### PR TITLE
[8.19] Reserve regexp automaton memory on the circuit breaker before building it (#155076)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/query/regexp/RegexpNfaRamEstimatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/query/regexp/RegexpNfaRamEstimatorBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.search.query.regexp;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.lucene.search.cost.RegexpNfaRamEstimator;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares {@link RegexpNfaRamEstimator}'s cheap, AST-only estimate against the real heap of the NFA that
+ * {@link RegExp#toAutomaton()} actually builds, so we can see how tightly the estimate tracks reality and
+ * confirm it over-estimates (never under-estimates) across the patterns that matter.
+ * <p>
+ * The measured baseline is the real built {@link Automaton}'s own {@link Automaton#ramBytesUsed()} — the
+ * retained size of a real object, not a model. The estimate is deliberately a slight over-estimate of the
+ * <em>peak</em> build heap (which additionally includes the transient {@link Operations#repeat} allocations),
+ * so a ratio comfortably above {@code 1.0} for the repetition-heavy patterns is the expected, healthy result.
+ * <p>
+ * The {@link RegexPattern} params are the important edge cases: literals and character classes (baseline),
+ * unbounded/optional/union operators, and — most importantly — the bounded repetitions ({@code a{n}},
+ * {@code a{n,}}, {@code a{n,m}}, nested and over character classes) and intersections whose multiplicative
+ * blow-up is exactly what caused the incident OOM. Repetition counts are kept large enough to be
+ * representative yet small enough that the real NFA builds without OOMing this benchmark JVM.
+ * <p>
+ * The {@link Metrics} aux counters are JMH {@code EVENTS}, scaled by the iteration count, so divide each by
+ * {@code Cnt} to recover absolute bytes.
+ */
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@SuppressWarnings("unused") // invoked by JMH
+public class RegexpNfaRamEstimatorBenchmark {
+
+    /**
+     * Real regex patterns exercising every branch of {@link RegexpNfaRamEstimator}. Each is a valid Lucene
+     * {@link RegExp} whose NFA can be built in memory, so the measured side is a real {@link Automaton}.
+     */
+    public enum RegexPattern {
+        LITERAL("elasticsearch"),
+        CHAR_CLASS("[a-z0-9]"),
+        STAR("[a-z0-9]*"),
+        OPTIONAL("(elastic)?"),
+        UNION("(cat|dog|bird|fish|horse|snake|lizard|turtle)"),
+        // Bounded repetitions: the multiplicative blow-up that motivated the pre-build breaker charge.
+        REPEAT_EXACT("a{10000}"),
+        REPEAT_RANGE("a{100,10000}"),
+        REPEAT_MIN("a{10000,}"),
+        NESTED_REPEAT("(ab){5000}"),
+        CLASS_REPEAT("[a-z]{10000}"),
+        UNION_REPEAT("(cat|dog|bird){3000}"),
+        // Intersection is a product construction; the estimator multiplies the two sides.
+        INTERSECTION("[a-z]{5,10}&.{7}"),
+        MIXED("(ab|cd){2000}(ef)?[0-9]{50}");
+
+        private final String pattern;
+
+        RegexPattern(String pattern) {
+            this.pattern = pattern;
+        }
+    }
+
+    @Param
+    public RegexPattern regex;
+
+    private RegExp parsed;
+    private long precomputedEstimate;
+    private long precomputedMeasured;
+    private double precomputedRatio;
+
+    @AuxCounters(AuxCounters.Type.EVENTS)
+    @State(Scope.Thread)
+    public static class Metrics {
+        public double estimatedBytes;
+        public double measuredBytes;
+        public double estimateOverMeasuredRatio;
+    }
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        parsed = new RegExp(regex.pattern, RegExp.ALL, 0);
+        precomputedEstimate = RegexpNfaRamEstimator.estimateRamBytes(parsed);
+        precomputedMeasured = parsed.toAutomaton().ramBytesUsed();
+        precomputedRatio = precomputedMeasured == 0 ? 0.0 : (double) precomputedEstimate / (double) precomputedMeasured;
+    }
+
+    @Benchmark
+    public long estimate(Metrics metrics) {
+        publish(metrics);
+        return RegexpNfaRamEstimator.estimateRamBytes(parsed);
+    }
+
+    @Benchmark
+    public long build(Metrics metrics) {
+        publish(metrics);
+        // Build the real NFA and return its measured retained size so the timed work is the real construction.
+        return parsed.toAutomaton().ramBytesUsed();
+    }
+
+    private void publish(Metrics metrics) {
+        metrics.estimatedBytes = precomputedEstimate;
+        metrics.measuredBytes = precomputedMeasured;
+        metrics.estimateOverMeasuredRatio = precomputedRatio;
+    }
+}

--- a/docs/changelog/155076.yaml
+++ b/docs/changelog/155076.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 155076
+summary: Reserve regexp automaton memory on the circuit breaker before building it
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -14,10 +14,13 @@ import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.MinimizationOperations;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.lucene.search.cost.RegexpNfaRamEstimator;
 import org.elasticsearch.lucene.util.automaton.CircuitBreakingOperations;
 
 import java.util.ArrayList;
@@ -108,8 +111,11 @@ public class AutomatonQueries {
     }
 
     /**
-     * Build a deterministic automaton from a regular expression, checking a circuit breaker
-     * during determinization to prevent OOM from huge automatons.
+     * Build a deterministic automaton from a regular expression, using the circuit breaker to avoid running
+     * out of memory on huge patterns. Two steps can use a lot of heap and are each guarded:
+     * - Building the NFA ({@link #buildRegexpNfa}), which can blow up while expanding bounded repetitions
+     * - Determinizing it into a DFA ({@link CircuitBreakingOperations#determinize}), which accounts for the DFA as it grows.
+     * If either step would exceed the breaker's budget the query is rejected with a {@code CircuitBreakingException}.
      */
     public static Automaton toRegexpAutomaton(
         Term term,
@@ -118,8 +124,56 @@ public class AutomatonQueries {
         int maxDeterminizedStates,
         CircuitBreaker circuitBreaker
     ) {
-        Automaton nfa = new RegExp(term.text(), syntaxFlags, matchFlags).toAutomaton();
+        Automaton nfa = buildRegexpNfa(term.text(), syntaxFlags, matchFlags, circuitBreaker, term.field());
         return CircuitBreakingOperations.determinize(nfa, maxDeterminizedStates, circuitBreaker, "regexp:" + term.field());
+    }
+
+    /**
+     * Build a {@link ByteRunAutomaton} from a regular expression for the doc-values / script paths. This is the
+     * same idea as {@link #toRegexpAutomaton(Term, int, int, int, CircuitBreaker)} but with one extra step, so
+     * when a breaker is supplied three steps are guarded: building the NFA, determinizing it, and converting the
+     * DFA into a {@code ByteRunAutomaton} (which expands it to UTF-8 and determinizes again).
+     */
+    public static ByteRunAutomaton toRegexpByteRunAutomaton(
+        String field,
+        String pattern,
+        int syntaxFlags,
+        int matchFlags,
+        int maxDeterminizedStates,
+        @Nullable CircuitBreaker circuitBreaker
+    ) {
+        Automaton nfa = buildRegexpNfa(pattern, syntaxFlags, matchFlags, circuitBreaker, field);
+        if (circuitBreaker == null) {
+            return new ByteRunAutomaton(Operations.determinize(nfa, maxDeterminizedStates));
+        }
+
+        Automaton dfa = CircuitBreakingOperations.determinize(nfa, maxDeterminizedStates, circuitBreaker, "regexp:" + field);
+        return new ByteRunAutomaton(dfa);
+    }
+
+    /**
+     * Parse {@code pattern} into an NFA via {@link RegExp#toAutomaton()}, reserving a slight over-estimate of
+     * the build's peak heap on {@code circuitBreaker} beforehand and releasing it once the NFA is built. When
+     * {@code circuitBreaker} is {@code null} the NFA is built without accounting.
+     */
+    private static Automaton buildRegexpNfa(
+        String pattern,
+        int syntaxFlags,
+        int matchFlags,
+        @Nullable CircuitBreaker circuitBreaker,
+        String field
+    ) {
+        RegExp re = new RegExp(pattern, syntaxFlags, matchFlags);
+        if (circuitBreaker == null) {
+            return re.toAutomaton();
+        }
+        final long reservation = RegexpNfaRamEstimator.estimateRamBytes(re);
+        circuitBreaker.addEstimateBytesAndMaybeBreak(reservation, "regexp:" + field);
+        try {
+            return re.toAutomaton();
+        } finally {
+            circuitBreaker.addWithoutBreaking(-reservation);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -972,7 +972,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                     indexedValueForSearch(value).utf8ToString(),
                     syntaxFlags,
                     matchFlags,
-                    maxDeterminizedStates
+                    maxDeterminizedStates,
+                    context.getCircuitBreaker()
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordScriptFieldType.java
@@ -197,7 +197,8 @@ public final class KeywordScriptFieldType extends AbstractScriptFieldType<String
             value,
             syntaxFlags,
             matchFlags,
-            maxDeterminizedStates
+            maxDeterminizedStates,
+            context.getCircuitBreaker()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/search/cost/RegexpNfaRamEstimator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/cost/RegexpNfaRamEstimator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search.cost;
+
+import org.apache.lucene.util.automaton.RegExp;
+
+import java.util.Objects;
+
+/**
+ * Estimates how much heap {@link RegExp#toAutomaton()} will use to build a regexp's NFA, without building it.
+ */
+public final class RegexpNfaRamEstimator {
+
+    private RegexpNfaRamEstimator() {}
+
+    static final long ESTIMATED_BYTES_PER_STATE = 32L;
+
+    /** Estimates the NFA build cost, in bytes, for {@code pattern}. */
+    public static long estimateRamBytes(String pattern, int syntaxFlags, int matchFlags) {
+        return estimateRamBytes(new RegExp(pattern, syntaxFlags, matchFlags));
+    }
+
+    /** Estimates the NFA build cost, in bytes, for the already-parsed {@code re}, saturating to {@link Long#MAX_VALUE}. */
+    public static long estimateRamBytes(RegExp re) {
+        Objects.requireNonNull(re, "re must not be null");
+        return multiplySaturating(estimateStates(re), ESTIMATED_BYTES_PER_STATE);
+    }
+
+    /** Upper bound on the number of NFA states, mirroring how {@link RegExp#toAutomaton()} composes them. */
+    private static long estimateStates(RegExp re) {
+        switch (re.kind) {
+            case REGEXP_UNION:
+                return addSaturating(addSaturating(estimateStates(re.exp1), estimateStates(re.exp2)), 1L);
+            case REGEXP_CONCATENATION:
+                return addSaturating(estimateStates(re.exp1), estimateStates(re.exp2));
+            case REGEXP_INTERSECTION:
+                return multiplySaturating(estimateStates(re.exp1), estimateStates(re.exp2));
+            case REGEXP_OPTIONAL:
+            case REGEXP_REPEAT:
+                return addSaturating(estimateStates(re.exp1), 1L);
+            case REGEXP_REPEAT_MIN:
+                // a{n,}: n copies of the sub-expression plus a repeat.
+                return multiplySaturating(estimateStates(re.exp1), addSaturating(re.min, 1L));
+            case REGEXP_REPEAT_MINMAX:
+                // a{n,m}: up to m copies of the sub-expression. This multiplication is the blow-up we guard against.
+                return multiplySaturating(estimateStates(re.exp1), Math.max(1L, re.max));
+            case REGEXP_COMPLEMENT:
+                return estimateStates(re.exp1);
+            case REGEXP_STRING:
+                return re.s == null ? 2L : addSaturating(re.s.length(), 1L);
+            case REGEXP_CHAR:
+            case REGEXP_CHAR_RANGE:
+            case REGEXP_ANYCHAR:
+            case REGEXP_EMPTY:
+            case REGEXP_ANYSTRING:
+            case REGEXP_INTERVAL:
+            case REGEXP_AUTOMATON:
+            case REGEXP_PRE_CLASS:
+                return 2L;
+        }
+        throw new AssertionError("unexpected RegExp kind: " + re.kind);
+    }
+
+    private static long addSaturating(long a, long b) {
+        try {
+            return Math.addExact(a, b);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private static long multiplySaturating(long a, long b) {
+        try {
+            return Math.multiplyExact(a, b);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/runtime/StringScriptFieldRegexpQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/runtime/StringScriptFieldRegexpQuery.java
@@ -9,8 +9,9 @@
 
 package org.elasticsearch.search.runtime;
 
-import org.apache.lucene.util.automaton.ByteRunAutomaton;
-import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.StringFieldScript;
 
@@ -28,13 +29,21 @@ public class StringScriptFieldRegexpQuery extends AbstractStringScriptFieldAutom
         String pattern,
         int syntaxFlags,
         int matchFlags,
-        int maxDeterminizedStates
+        int maxDeterminizedStates,
+        @Nullable CircuitBreaker circuitBreaker
     ) {
         super(
             script,
             leafFactory,
             fieldName,
-            new ByteRunAutomaton(new RegExp(Objects.requireNonNull(pattern), syntaxFlags, matchFlags).toAutomaton(maxDeterminizedStates))
+            AutomatonQueries.toRegexpByteRunAutomaton(
+                fieldName,
+                Objects.requireNonNull(pattern),
+                syntaxFlags,
+                matchFlags,
+                maxDeterminizedStates,
+                circuitBreaker
+            )
         );
         this.pattern = pattern;
         this.syntaxFlags = syntaxFlags;

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
@@ -9,11 +9,15 @@
 
 package org.elasticsearch.common.lucene.search;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Locale;
@@ -155,6 +159,24 @@ public class AutomatonQueriesTests extends ESTestCase {
 
     private static void assertCollapsed(String input, String expected) {
         assertEquals(expected, AutomatonQueries.collapseConsecutiveQuantifiers(input));
+    }
+
+    public void testToRegexpAutomatonReservesAndReleasesBreakerMemory() {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofGb(1));
+        Term term = new Term("field", "a{100}b?c*");
+        Automaton dfa = AutomatonQueries.toRegexpAutomaton(term, RegExp.ALL, 0, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, breaker);
+        assertTrue(dfa.isDeterministic());
+        assertEquals("all reserved memory should be released after a successful build", 0, breaker.getUsed());
+    }
+
+    public void testToRegexpAutomatonTripsBreakerForHugeRepetitionBeforeBuild() {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(500));
+        Term term = new Term("field", "a{10000000}");
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> AutomatonQueries.toRegexpAutomaton(term, RegExp.ALL, 0, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, breaker)
+        );
+        assertEquals("no memory should remain reserved after the breaker trips", 0, breaker.getUsed());
     }
 
     private static void assertCollapsedAndLanguagePreserved(String pattern, String collapsed) {

--- a/server/src/test/java/org/elasticsearch/lucene/search/cost/RegexpNfaRamEstimatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/cost/RegexpNfaRamEstimatorTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search.cost;
+
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class RegexpNfaRamEstimatorTests extends ESTestCase {
+
+    public void testIsPositiveForSimplePatterns() {
+        assertThat(RegexpNfaRamEstimator.estimateRamBytes("", RegExp.ALL, 0), greaterThan(0L));
+        assertThat(RegexpNfaRamEstimator.estimateRamBytes("abc", RegExp.ALL, 0), greaterThan(0L));
+    }
+
+    public void testGrowsWithRepetition() {
+        long small = RegexpNfaRamEstimator.estimateRamBytes("a{10}", RegExp.ALL, 0);
+        long large = RegexpNfaRamEstimator.estimateRamBytes("a{100000}", RegExp.ALL, 0);
+        assertThat(large, greaterThan(small));
+    }
+
+    public void testSaturatesForPathologicalPattern() {
+        assertThat(RegexpNfaRamEstimator.estimateRamBytes("a{100000000}", RegExp.ALL, 0), greaterThan(ByteSizeValue.ofGb(5).getBytes()));
+        assertThat(RegexpNfaRamEstimator.estimateRamBytes("(a{2000000000}){2000000000}", RegExp.ALL, 0), equalTo(Long.MAX_VALUE));
+    }
+
+    public void testIgnoresLiteralBraces() {
+        long unescaped = RegexpNfaRamEstimator.estimateRamBytes("a{100000000}", RegExp.ALL, 0);
+        long escaped = RegexpNfaRamEstimator.estimateRamBytes("a\\{100000000\\}", RegExp.ALL, 0);
+        assertThat(escaped, greaterThan(0L));
+        assertThat(unescaped, greaterThan(escaped));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/runtime/StringScriptFieldRegexpQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/runtime/StringScriptFieldRegexpQueryTests.java
@@ -14,6 +14,9 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.script.Script;
 
 import java.util.List;
@@ -22,6 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptFieldQueryTestCase<StringScriptFieldRegexpQuery> {
+
     @Override
     protected StringScriptFieldRegexpQuery createTestInstance() {
         int matchFlags = randomBoolean() ? 0 : RegExp.ASCII_CASE_INSENSITIVE;
@@ -32,7 +36,8 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             randomAlphaOfLength(6),
             randomInt(RegExp.ALL),
             matchFlags,
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
     }
 
@@ -45,7 +50,8 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             orig.pattern(),
             orig.syntaxFlags(),
             orig.matchFlags(),
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
     }
 
@@ -71,7 +77,8 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             pattern,
             syntaxFlags,
             matchFlags,
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
     }
 
@@ -84,7 +91,8 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             "a.+b",
             0,
             0,
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
         BytesRefBuilder scratch = new BytesRefBuilder();
         assertTrue(query.matches(List.of("astuffb"), scratch));
@@ -102,7 +110,8 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             "a.+b",
             0,
             RegExp.ASCII_CASE_INSENSITIVE,
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
         assertTrue(ciQuery.matches(List.of("astuffB"), scratch));
         assertTrue(ciQuery.matches(List.of("Astuffb", "fffff"), scratch));
@@ -122,10 +131,29 @@ public class StringScriptFieldRegexpQueryTests extends AbstractStringScriptField
             "a.+b",
             0,
             0,
-            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+            null
         );
         ByteRunAutomaton automaton = visitForSingleAutomata(query);
         BytesRef term = new BytesRef("astuffb");
         assertThat(automaton.run(term.bytes, term.offset, term.length), is(true));
+    }
+
+    public void testCircuitBreakerTripsForHugeRepetition() {
+        CircuitBreaker tinyBreaker = newLimitedBreaker(ByteSizeValue.ofMb(100));
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> new StringScriptFieldRegexpQuery(
+                randomScript(),
+                leafFactory,
+                "test",
+                "a{100000000}",
+                RegExp.ALL,
+                0,
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                tinyBreaker
+            )
+        );
+        assertEquals("no memory should remain reserved after the breaker trips", 0, tinyBreaker.getUsed());
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Reserve regexp automaton memory on the circuit breaker before building it (#155076)](https://github.com/elastic/elasticsearch/pull/155076)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)