### PR TITLE
Add an automation rule to perform a daily merge of lucene_snapshot to lucene_snapshot_11

### DIFF
--- a/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
+++ b/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
@@ -3,6 +3,8 @@ steps:
     label: Trigger pipeline to build lucene snapshot
     key: lucene-build
     if: build.env("LUCENE_BUILD_ID") == null || build.env("LUCENE_BUILD_ID") == ""
+    build:
+      branch: "${LUCENE_BRANCH:-branch_10x}"
   - wait
   - label: Upload and update lucene snapshot
     command: .buildkite/scripts/lucene-snapshot/upload-snapshot.sh

--- a/.buildkite/pipelines/lucene-snapshot/update-branch.yml
+++ b/.buildkite/pipelines/lucene-snapshot/update-branch.yml
@@ -7,3 +7,9 @@ steps:
     build:
       branch: "${BUILDKITE_BRANCH}"
     async: true
+  - trigger: "elasticsearch-lucene-snapshot-update-branch"
+    label: Update lucene_snapshot_11 branch
+    if: build.branch == "lucene_snapshot"
+    build:
+      branch: "lucene_snapshot_11"
+    async: true

--- a/.buildkite/scripts/lucene-snapshot/update-branch.sh
+++ b/.buildkite/scripts/lucene-snapshot/update-branch.sh
@@ -2,17 +2,25 @@
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot"* ]]; then
-  echo "Error: This script should only be run on lucene_snapshot branches"
-  exit 1
-fi
+case "$BUILDKITE_BRANCH" in
+  lucene_snapshot)
+    UPSTREAM="main"
+    ;;
+  lucene_snapshot_11)
+    UPSTREAM="lucene_snapshot"
+    ;;
+  *)
+    echo "Error: no upstream branch configured for [$BUILDKITE_BRANCH]"
+    exit 1
+    ;;
+esac
 
-echo --- Updating "$BUILDKITE_BRANCH" branch with main
+echo --- Updating "$BUILDKITE_BRANCH" branch with "$UPSTREAM"
 
 git config --global user.name elasticsearchmachine
 git config --global user.email 'infra-root+elasticsearchmachine@elastic.co'
 
 git checkout "$BUILDKITE_BRANCH"
-git fetch origin main
-git merge --no-edit origin/main
+git fetch origin "$UPSTREAM"
+git merge --no-edit "origin/$UPSTREAM"
 git push origin "$BUILDKITE_BRANCH"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -183,7 +183,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-elasticsearch-lucene-snapshot-build
-  description: Builds a new lucene snapshot, uploads, updates the lucene_snapshot branch in ES, runs tests
+  description: Builds a new lucene snapshot, uploads, updates the matching lucene_snapshot branch in ES, runs tests
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/elasticsearch-lucene-snapshot-build
@@ -204,7 +204,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#lucene-ci"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
-      branch_configuration: lucene_snapshot
+      branch_configuration: lucene_snapshot lucene_snapshot_11
       default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
@@ -220,14 +220,22 @@ spec:
         Periodically on lucene_snapshot:
           branch: lucene_snapshot
           cronline: "0 2 * * * America/New_York"
-          message: "Builds a new lucene snapshot 1x per day"
+          message: "Builds a new lucene 10 snapshot 1x per day"
+          env:
+            LUCENE_BRANCH: branch_10x
+        Periodically on lucene_snapshot_11:
+          branch: lucene_snapshot_11
+          cronline: "0 2 * * * America/New_York"
+          message: "Builds a new lucene 11 snapshot 1x per day"
+          env:
+            LUCENE_BRANCH: main
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-elasticsearch-lucene-snapshot-update-branch
-  description: Merge main into the lucene_snapshot branch, and run tests
+  description: Merge upstream branches into the lucene_snapshot branches, and run tests
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/elasticsearch-lucene-snapshot-update-branch
@@ -239,7 +247,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      description: ":elasticsearch: Merges main into lucene_snapshot branch and runs tests"
+      description: ":elasticsearch: Merges main into lucene_snapshot, then lucene_snapshot into lucene_snapshot_11, and runs tests"
       name: elasticsearch / lucene-snapshot / update-branch
     spec:
       repository: elastic/elasticsearch
@@ -282,7 +290,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      description: ":elasticsearch: Runs tests against lucene_snapshot branch"
+      description: ":elasticsearch: Runs tests against lucene_snapshot branches"
       name: elasticsearch / lucene-snapshot / tests
     spec:
       repository: elastic/elasticsearch
@@ -291,7 +299,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#lucene-ci"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
-      branch_configuration: lucene_snapshot
+      branch_configuration: lucene_snapshot lucene_snapshot_11
       default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
@@ -308,6 +316,10 @@ spec:
           branch: lucene_snapshot
           cronline: "0 9,12,15,18 * * * America/New_York"
           message: "Runs tests against lucene_snapshot branch several times per day"
+        Periodically on lucene_snapshot_11:
+          branch: lucene_snapshot_11
+          cronline: "0 9,12,15,18 * * * America/New_York"
+          message: "Runs tests against lucene_snapshot_11 branch several times per day"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
We want to start working on Lucene 11 integration. 

- [x] Create lucene_snapshot_11
- [ ] Add automation: main -> lucene_snapshot -> lucene_snapshot_11 <----- WE ARE HERE
- [ ] When automation configs are merged into main an lucene_snapshot is updated, merge lucene_snapshot -> lucene_snapshot_11 manually
- [ ] Update JDK to 25 in lucene-build-snapshot (where?)

The lucene_snapshot branch uses Lucene 10.6 and contains many (~300) commits so it's closer to Lucene 11 than main. The lucene_snapshot_11 has been created from the current lucene_snapshot. It's updated from main every day. This automation adds lucene_snapshot -> lucene_snapshot_11 code propagation.