### PR TITLE
[9.5] Fix assertion race in ProgressListenableActionFuture split (#153119)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -385,15 +385,9 @@ tests:
 - class: org.elasticsearch.datastreams.lifecycle.ExplainDataStreamLifecycleIT
   method: testExplainFailuresLifecycle
   issue: https://github.com/elastic/elasticsearch/issues/151602
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
-  method: testCleanUpMigratedSystemIndexAfterIndicesAreDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/151732
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=aggregations/terms/Double test}
   issue: https://github.com/elastic/elasticsearch/issues/151793
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.blob.SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests
-  method: testCleanUpAfterIndicesAreDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/151819
 - class: org.elasticsearch.cluster.ClusterInfoServiceIT
   method: testMaxQueueLatenciesInClusterInfo
   issue: https://github.com/elastic/elasticsearch/issues/151837

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
 /**
@@ -55,7 +56,6 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
     private List<PositionAndListener> listeners;
     private long progress;
     private volatile boolean completed;
-    private volatile boolean success;
 
     /**
      * Creates a {@link ProgressListenableActionFuture} that accepts the progression
@@ -87,7 +87,6 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
         this.end = end;
         this.progress = start;
         this.completed = false;
-        this.success = false;
         this.unconditionalProgressConsumer = unconditionalProgressConsumer;
         this.progressConsumer = progressConsumer;
         assert invariant();
@@ -99,8 +98,8 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
      * <ul>
      *   <li>Lower's byte-level progress is forwarded unconditionally to this future.</li>
      *   <li>Upper's progress is forwarded once lower has completed.</li>
-     *   <li>When lower completes, this future advances to upper's current progress (at least {@code splitPoint})
-     *       via {@link #onProgressAtLeast}, catching up to any progress upper made while lower was pending.</li>
+     *   <li>When lower completes, this future advances to upper's current progress (at least {@code splitPoint}),
+     *       catching up to any progress upper made while lower was pending.</li>
      *   <li>When both halves complete, this future completes; on failure the failure propagates.</li>
      * </ul>
      */
@@ -109,25 +108,36 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
         assert splitPoint < end : splitPoint + " >= " + end;
 
         final LongConsumer originalProgressConsumer = this.progressConsumer;
+        // Splitting turns this future into a multi-producer sink fed by lower, the catch-up below, and upper. Delivery is
+        // serialized so that the strict onProgress contract still holds on the forwards: lower forwards until it completes,
+        // then the catch-up forwards upper's current progress to this future and only afterwards opens the gate
+        // (lowerForwarding) that allows upper to forward. The single value that both the catch-up and upper could deliver
+        // (upper's progress at catch-up time) is delivered only by the catch-up; upper skips it and forwards only beyond it.
         final ProgressListenableActionFuture lower = new ProgressListenableActionFuture(
             start,
             splitPoint,
             this::onProgress,
             originalProgressConsumer
         );
-        final ProgressListenableActionFuture upper = new ProgressListenableActionFuture(
-            splitPoint,
-            end,
-            p -> { if (lower.success) onProgress(p); },
-            originalProgressConsumer == null ? null : p -> {
-                if (lower.success) originalProgressConsumer.accept(p);
+        final long lowerForwardingUnassigned = Long.MIN_VALUE;
+        final var lowerForwarding = new AtomicLong(lowerForwardingUnassigned);
+        final ProgressListenableActionFuture upper = new ProgressListenableActionFuture(splitPoint, end, p -> {
+            final long captured = lowerForwarding.get();
+            if (captured != lowerForwardingUnassigned && p != captured) {
+                onProgress(p);
             }
-        );
+        }, originalProgressConsumer == null ? null : p -> {
+            if (lowerForwarding.get() != lowerForwardingUnassigned) originalProgressConsumer.accept(p);
+        });
 
-        // When lower completes we catch up to wherever upper has already progressed, not just splitPoint.
-        // upper.progress is always < upper.end (onProgress(end) returns early without updating the field),
-        // so passing it to onProgressAtLeast is always within the valid [start+1, end-1] range.
-        lower.addListener(ActionListener.wrap(ignored -> onProgressAtLeast(upper.getProgress()), e -> {}), splitPoint);
+        lower.addListener(ActionListener.wrap(ignored -> {
+            // Catch up to wherever upper has already progressed, not just splitPoint. So far only
+            // lower has forwarded (< splitPoint), while upperProgress is in [splitPoint, end-1] (onProgress(end) is a no-op,
+            // so upper.progress never reaches end). Delivering before opening the gate keeps upper's later forwards ordered.
+            final long upperProgress = upper.getProgress();
+            onProgress(upperProgress);
+            lowerForwarding.set(upperProgress);
+        }, e -> {}), splitPoint);
         try (var bothFiredRef = new RefCountingListener(ActionListener.wrap(v -> onResponse(end), this::onFailure))) {
             lower.addListener(bothFiredRef.acquire(l -> {}), splitPoint);
             upper.addListener(bothFiredRef.acquire(l -> {}), end);
@@ -155,27 +165,6 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
      * @param progressValue the new progress value; must be strictly greater than the current progress
      */
     public void onProgress(final long progressValue) {
-        doOnProgress(progressValue, true);
-    }
-
-    /**
-     * Like {@link #onProgress(long)} but a no-op if progress has already advanced to or past {@code progressValue}.
-     * Unlike {@link #onProgress}, this method is safe to call concurrently with other progress updates that may
-     * have already advanced past the given value — it simply returns without asserting ordering.
-     */
-    void onProgressAtLeast(final long progressValue) {
-        assert progressValue < end;
-        doOnProgress(progressValue, false);
-    }
-
-    /**
-     * Shared implementation for {@link #onProgress} and {@link #onProgressAtLeast}.
-     *
-     * @param strict if {@code true} the current progress must be strictly less than {@code progressValue} (normal
-     *               {@link #onProgress} contract); if {@code false} the method is a no-op when progress has already
-     *               advanced to or past {@code progressValue}, without asserting ordering.
-     */
-    private void doOnProgress(final long progressValue, final boolean strict) {
         ensureNotCompleted();
         if (progressValue <= start) {
             assert false : progressValue + " <= " + start;
@@ -191,11 +180,7 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
 
         List<ActionListener<Long>> listenersToExecute = null;
         synchronized (this) {
-            if (strict) {
-                assert this.progress < progressValue : this.progress + " < " + progressValue;
-            } else if (this.progress >= progressValue) {
-                return;
-            }
+            assert this.progress < progressValue : this.progress + " < " + progressValue;
             this.progress = progressValue;
 
             final List<PositionAndListener> listenersCopy = this.listeners;
@@ -254,8 +239,6 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
     @Override
     protected void done(boolean success) {
         super.done(success);
-        assert this.success == false : "success cannot be set twice";
-        this.success = success;
         final List<PositionAndListener> listenersToExecute;
         assert invariant();
         synchronized (this) {

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -616,8 +616,8 @@ public class SparseFileTracker {
     }
 
     private void updateCompletePointer(long value) {
-        // Use MAX rather than asserting monotonicity: when a split catch-up fires onProgressAtLeast with
-        // upper.progress, adjacent range merging in onGapSuccess may have already advanced complete further.
+        // Use MAX rather than asserting monotonicity: when a split catch-up advances to upper.progress,
+        // adjacent range merging in onGapSuccess may have already advanced complete further.
         synchronized (ranges) {
             if (value > complete) {
                 complete = value;

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/ProgressListenableActionFutureTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/ProgressListenableActionFutureTests.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -357,13 +359,13 @@ public class ProgressListenableActionFutureTests extends ESTestCase {
                 listenerInLower.actionGet(),
                 greaterThanOrEqualTo(thresholdInLower)
             );
-            // listenerAtSplit fires at upper.progress (>= splitPoint), caught up via onProgressAtLeast
+            // listenerAtSplit fires at upper.progress (>= splitPoint), reached via the catch-up when lower completes
             assertThat(
                 "listener at split fires when lower completes, at or above splitPoint",
                 listenerAtSplit.actionGet(),
                 greaterThanOrEqualTo(splitPoint)
             );
-            // Both halves now done: listener in upper fires via onProgressAtLeast catch-up or via onResponse(end)
+            // Both halves now done: listener in upper fires via the catch-up or via onResponse(end)
             assertThat(
                 "listener in upper fires at or above its threshold",
                 listenerInUpper.actionGet(),
@@ -400,7 +402,7 @@ public class ProgressListenableActionFutureTests extends ESTestCase {
         future.addListener(listener, upperMid);
         assertFalse("listener must not fire before lower completes", listener.isDone());
 
-        // Complete lower — onProgressAtLeast must catch up to upper.progress (= upperMid), firing the listener
+        // Complete lower — the catch-up must advance to upper.progress (= upperMid), firing the listener
         lower.onResponse(splitPoint);
         assertTrue("listener must fire when lower completes after upper already reached its threshold", listener.isDone());
         assertFalse("outer future must not be done until upper also completes", future.isDone());
@@ -409,41 +411,105 @@ public class ProgressListenableActionFutureTests extends ESTestCase {
         assertTrue(future.isDone());
     }
 
-    public void testOnProgressAtLeastFiresListeners() {
-        final ProgressListenableActionFuture future = randomFuture();
-        assertTrue("randomFuture must produce a range of at least 2", future.end - future.start >= 2);
+    // Test that a race between lower completing and upper forwarding progress to the parent does not cause assertion errors.
+    public void testConcurrentSplitProgressForwardingIsIdempotent() throws Exception {
+        final int iterations = 100;
+        for (int i = 0; i < iterations; i++) {
+            final long end = 2000L;
+            final long splitPoint = 1000L;
+            final ProgressListenableActionFuture future = new ProgressListenableActionFuture(0L, end, null);
+            final ProgressListenableActionFuture[] parts = future.split(splitPoint);
+            final ProgressListenableActionFuture lower = parts[0];
+            final ProgressListenableActionFuture upper = parts[1];
 
-        final long threshold = randomLongBetween(future.start + 1L, future.end - 1L);
-        final PlainActionFuture<Long> listener = new PlainActionFuture<>();
-        future.addListener(listener, threshold);
-        assertFalse(listener.isDone());
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+            final AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        future.onProgressAtLeast(randomLongBetween(threshold, future.end - 1L));
-        assertTrue("onProgressAtLeast should fire listener once threshold is reached", listener.isDone());
+            final Thread upperThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    // Sweep upper across its whole range so that lower's completion is likely to land in the tiny window
+                    // between "upper.progress := p" and upper forwarding p to the parent.
+                    for (long p = splitPoint + 1L; p < end; p++) {
+                        upper.onProgress(p);
+                    }
+                    upper.onResponse(end);
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "upper-" + i);
+
+            final Thread lowerThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    lower.onResponse(splitPoint);
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "lower-" + i);
+
+            upperThread.start();
+            lowerThread.start();
+            upperThread.join();
+            lowerThread.join();
+
+            final Throwable t = failure.get();
+            assertThat("Split progress forwarding should cause assertion errors", t, nullValue());
+        }
     }
 
-    public void testOnProgressAtLeastIsNoOpWhenAlreadyAdvanced() {
-        final ProgressListenableActionFuture future = randomFuture();
-        assertTrue("randomFuture must produce a range of at least 3", future.end - future.start >= 3);
+    // Recursive split: lower is itself split into lowerLower/lowerUpper.
+    public void testConcurrentNestedSplitProgressForwardingIsIdempotent() throws Exception {
+        final int iterations = 100;
+        for (int i = 0; i < iterations; i++) {
+            final long end = 3000L;
+            final long parentSplit = 2000L;
+            final long lowerSplit = 1000L;
+            final ProgressListenableActionFuture future = new ProgressListenableActionFuture(0L, end, null);
+            final ProgressListenableActionFuture[] parts = future.split(parentSplit);
+            final ProgressListenableActionFuture lower = parts[0];
+            final ProgressListenableActionFuture upper = parts[1];
+            final ProgressListenableActionFuture[] lowerParts = lower.split(lowerSplit);
+            final ProgressListenableActionFuture lowerLower = lowerParts[0];
+            final ProgressListenableActionFuture lowerUpper = lowerParts[1];
 
-        // Advance to some mid-point
-        final long mid = randomLongBetween(future.start + 1L, future.end - 2L);
-        future.onProgress(mid);
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+            final AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        // Add a listener above the current progress — it should NOT fire via onProgressAtLeast below
-        final long aboveThreshold = randomLongBetween(mid + 1L, future.end - 1L);
-        final PlainActionFuture<Long> listener = new PlainActionFuture<>();
-        future.addListener(listener, aboveThreshold);
-        assertFalse(listener.isDone());
+            final Thread lowerUpperThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    // Sweep lowerUpper across its whole range so its forwards to lower (once ungated by lowerLower's
+                    // completion) race with lower's catch-up forwarding to the parent.
+                    for (long p = lowerSplit + 1L; p < parentSplit; p++) {
+                        lowerUpper.onProgress(p);
+                    }
+                    lowerUpper.onResponse(parentSplit);
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "lower-upper-" + i);
 
-        // onProgressAtLeast with a value <= current progress is a no-op
-        future.onProgressAtLeast(randomLongBetween(future.start + 1L, mid));
-        assertFalse("onProgressAtLeast must be a no-op when progress already advanced past the value", listener.isDone());
+            final Thread lowerLowerThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    lowerLower.onResponse(lowerSplit);
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "lower-lower-" + i);
 
-        future.onProgress(future.end);
-        future.onResponse(future.end);
+            lowerUpperThread.start();
+            lowerLowerThread.start();
+            lowerUpperThread.join();
+            lowerLowerThread.join();
 
-        assertTrue(listener.isDone());
+            assertThat("nested split progress forwarding tripped a concurrency bug", failure.get(), nullValue());
+
+            // Complete the outer upper half so the whole future can complete cleanly.
+            upper.onResponse(end);
+            assertTrue(future.isDone());
+        }
     }
 
     private static ProgressListenableActionFuture randomFuture() {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix assertion race in ProgressListenableActionFuture split (#153119)