### PR TITLE
[9.5] Return 400 for sorts on unsortable fields (#154433)

### DIFF
--- a/docs/changelog/154433.yaml
+++ b/docs/changelog/154433.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 154354
+pr: 154433
+summary: Return 400 for sorts on unsortable fields
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapper.java
@@ -245,7 +245,7 @@ public class ProvidedIdFieldMapper extends IdFieldMapper {
             int bucketSize,
             BucketedSort.ExtraData extra
         ) {
-            throw new UnsupportedOperationException("can't sort on the [" + CONTENT_TYPE + "] field");
+            throw new IllegalArgumentException("Can't sort on the [" + CONTENT_TYPE + "] field");
         }
 
         private static LeafFieldData wrap(LeafFieldData in) {

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -43,7 +43,14 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
         this.rawSortValues = rawSortValues;
         this.formattedSortValues = new Object[rawSortValues.length];
         for (int i = 0; i < rawSortValues.length; ++i) {
-            final Object v = sortValueFormats[i].formatSortValue(rawSortValues[i]);
+            final Object v;
+            try {
+                v = sortValueFormats[i].formatSortValue(rawSortValues[i]);
+            } catch (UnsupportedOperationException e) {
+                throw new IllegalArgumentException(
+                    "Field with doc value format [" + sortValueFormats[i].getWriteableName() + "] does not support sorting"
+                );
+            }
             assert v == null || v instanceof String || v instanceof Number || v instanceof Boolean || v instanceof Map
                 : v + " was not formatted";
             formattedSortValues[i] = v;

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
@@ -30,19 +30,28 @@ public class SearchSortValuesAndFormats implements Writeable {
         this.formattedSortValues = Arrays.copyOf(rawSortValues, rawSortValues.length);
         for (int i = 0; i < rawSortValues.length; ++i) {
             Object sortValue = rawSortValues[i];
-            if (sortValue instanceof BytesRef) {
-                this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
-            } else if (sortValue instanceof Long) {
-                this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
-            } else if (sortValue instanceof Double) {
-                this.formattedSortValues[i] = sortValueFormats[i].format((double) sortValue);
-            } else if (sortValue instanceof Float || sortValue instanceof Integer) {
-                // sort by _score or _doc
-                this.formattedSortValues[i] = sortValue;
-            } else {
-                assert sortValue == null
-                    : "Sort values must be a BytesRef, Long, Integer, Double or Float, but got " + sortValue.getClass() + ": " + sortValue;
-                this.formattedSortValues[i] = sortValue;
+            try {
+                if (sortValue instanceof BytesRef) {
+                    this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
+                } else if (sortValue instanceof Long) {
+                    this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
+                } else if (sortValue instanceof Double) {
+                    this.formattedSortValues[i] = sortValueFormats[i].format((double) sortValue);
+                } else if (sortValue instanceof Float || sortValue instanceof Integer) {
+                    // sort by _score or _doc
+                    this.formattedSortValues[i] = sortValue;
+                } else {
+                    assert sortValue == null
+                        : "Sort values must be a BytesRef, Long, Integer, Double or Float, but got "
+                            + sortValue.getClass()
+                            + ": "
+                            + sortValue;
+                    this.formattedSortValues[i] = sortValue;
+                }
+            } catch (UnsupportedOperationException e) {
+                throw new IllegalArgumentException(
+                    "Field with doc value format [" + sortValueFormats[i].getWriteableName() + "] does not support sorting"
+                );
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
@@ -19,9 +19,12 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceProvider;
+import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,6 +75,19 @@ public class ProvidedIdFieldMapperTests extends MapperServiceTestCase {
         ft.fielddataBuilder(FieldDataContext.noRuntimeFields(idFieldDataEnabled, "index", "test")).build(null, null);
         assertWarnings(ProvidedIdFieldMapper.ID_FIELD_DATA_DEPRECATION_MESSAGE);
         assertTrue(ft.isAggregatable(idFieldDataEnabled));
+    }
+
+    // Regular sorting on _id is supported, but bucketed sorting (e.g. top_metrics) is not and must be a 400, not a 500.
+    public void testBucketedSortOnIdThrowsIllegalArgument() {
+        var fieldData = ProvidedIdFieldMapper.COLUMNAR_ID.fieldType()
+            .fielddataBuilder(FieldDataContext.noRuntimeFields("index", "test"))
+            .build(null, null);
+        assertNotNull(fieldData.sortField(null, MultiValueMode.MIN, null, false));
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> fieldData.newBucketedSort(null, null, MultiValueMode.MIN, null, SortOrder.ASC, DocValueFormat.RAW, 1, null)
+        );
+        assertThat(e.getMessage(), containsString("_id"));
     }
 
     public void testFetchIdFieldValue() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -20,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class SearchSortValuesAndFormatsTests extends AbstractWireSerializingTestCase<SearchSortValuesAndFormats> {
     private NamedWriteableRegistry namedWriteableRegistry;
@@ -67,6 +70,64 @@ public class SearchSortValuesAndFormatsTests extends AbstractWireSerializingTest
             case 5 -> randomDouble();
             default -> throw new UnsupportedOperationException();
         };
+    }
+
+    public void testUnformattableLongSortValueThrowsIllegalArgument() {
+        DocValueFormat noNumericFormat = new DocValueFormat() {
+            @Override
+            public String getWriteableName() {
+                return "test_no_numeric_format";
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {}
+            // format(long) and format(double) are not overridden, inheriting the UnsupportedOperationException defaults
+        };
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SearchSortValuesAndFormats(new Object[] { randomLong() }, new DocValueFormat[] { noNumericFormat })
+        );
+        assertThat(e.getMessage(), containsString("test_no_numeric_format"));
+        assertThat(e.getMessage(), containsString("does not support sorting"));
+    }
+
+    public void testUnformattableDoubleSortValueThrowsIllegalArgument() {
+        DocValueFormat noNumericFormat = new DocValueFormat() {
+            @Override
+            public String getWriteableName() {
+                return "test_no_numeric_format";
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {}
+        };
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SearchSortValuesAndFormats(new Object[] { randomDouble() }, new DocValueFormat[] { noNumericFormat })
+        );
+        assertThat(e.getMessage(), containsString("test_no_numeric_format"));
+        assertThat(e.getMessage(), containsString("does not support sorting"));
+    }
+
+    public void testUnformattableBytesSortValueThrowsIllegalArgument() {
+        DocValueFormat noBytesFormat = new DocValueFormat() {
+            @Override
+            public String getWriteableName() {
+                return "test_no_bytes_format";
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {}
+        };
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SearchSortValuesAndFormats(
+                new Object[] { new BytesRef(randomAlphaOfLength(5)) },
+                new DocValueFormat[] { noBytesFormat }
+            )
+        );
+        assertThat(e.getMessage(), containsString("test_no_bytes_format"));
+        assertThat(e.getMessage(), containsString("does not support sorting"));
     }
 
     public static SearchSortValuesAndFormats randomInstance() {

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.LuceneTests;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
@@ -23,6 +24,8 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.Arrays;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class SearchSortValuesTests extends AbstractXContentSerializingTestCase<SearchSortValues> {
 
@@ -117,6 +120,25 @@ public class SearchSortValuesTests extends AbstractXContentSerializingTestCase<S
             builder.endObject();
             assertEquals("{}", Strings.toString(builder));
         }
+    }
+
+    public void testUnformattableBytesRefSortValueThrowsIllegalArgument() {
+        DocValueFormat noByteFormat = new DocValueFormat() {
+            @Override
+            public String getWriteableName() {
+                return "test_no_bytes_format";
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {}
+            // format(BytesRef) is not overridden, so it inherits the UnsupportedOperationException default
+        };
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new SearchSortValues(new Object[] { new BytesRef("val") }, new DocValueFormat[] { noByteFormat })
+        );
+        assertThat(e.getMessage(), containsString("test_no_bytes_format"));
+        assertThat(e.getMessage(), containsString("does not support sorting"));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -632,14 +632,16 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
                             ctx -> load(ctx).getAggregateMetricValues()
                         );
                     }
-                    throw new UnsupportedOperationException(
-                        "["
+                    throw new IllegalArgumentException(
+                        "Sorting by field ["
+                            + name()
+                            + "] of type ["
                             + CONTENT_TYPE
-                            + "] supports sorting if it has configured a single metric or the metrics ["
+                            + "] is not supported unless it has configured a single metric or the ["
                             + Metric.sum
                             + ", "
                             + Metric.value_count
-                            + "]"
+                            + "] metrics"
                     );
                 }
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.lucene.search.function.ScriptScoreQuery;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -27,6 +28,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.DocReader;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.DoubleScriptFieldRangeQuery;
 import org.elasticsearch.search.runtime.DoubleScriptFieldTermQuery;
@@ -39,9 +41,11 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.subfieldName;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -65,6 +69,45 @@ public class AggregateMetricDoubleFieldTypeTests extends FieldTypeTestCase {
             metricFields.put(m, subfield);
         }
         return new AggregateMetricDoubleFieldType(name, null, metricFields, meta);
+    }
+
+    private IndexFieldData<?> buildFieldData(AggregateMetricDoubleFieldType fieldType) {
+        return fieldType.fielddataBuilder(
+            new FieldDataContext("test", null, () -> null, s -> Set.of(), () -> false, MappedFieldType.FielddataOperation.SEARCH)
+        ).build(null, null);
+    }
+
+    // Sorting on a multi-metric field without [sum, value_count] must fail with a 400, not a 500.
+    public void testSortFieldWithMultipleMetricsThrowsIllegalArgument() {
+        AggregateMetricDoubleFieldType fieldType = createFieldType("field", Collections.emptyMap(), Metric.min, Metric.max);
+        IndexFieldData<?> fieldData = buildFieldData(fieldType);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> fieldData.sortField(null, MultiValueMode.MIN, null, false)
+        );
+        assertThat(e.getMessage(), containsString("Sorting by field [field]"));
+    }
+
+    // A single-metric field is still sortable.
+    public void testSortFieldWithSingleMetricSucceeds() {
+        Metric singleMetric = randomFrom(Metric.values());
+        AggregateMetricDoubleFieldType fieldType = createFieldType("field", Collections.emptyMap(), singleMetric);
+        IndexFieldData<?> fieldData = buildFieldData(fieldType);
+        assertNotNull(fieldData.sortField(null, MultiValueMode.MIN, null, false));
+    }
+
+    // A field with both [sum, value_count] is sortable via the computed average.
+    public void testSortFieldWithSumAndValueCountSucceeds() {
+        AggregateMetricDoubleFieldType fieldType = createFieldType("field", Collections.emptyMap(), Metric.sum, Metric.value_count);
+        IndexFieldData<?> fieldData = buildFieldData(fieldType);
+        assertNotNull(fieldData.sortField(null, MultiValueMode.MIN, null, false));
+    }
+
+    // A multi-metric field with only one of [sum, value_count] is not sortable.
+    public void testSortFieldWithSumButNotValueCountThrowsIllegalArgument() {
+        AggregateMetricDoubleFieldType fieldType = createFieldType("field", Collections.emptyMap(), Metric.sum, Metric.min);
+        IndexFieldData<?> fieldData = buildFieldData(fieldType);
+        expectThrows(IllegalArgumentException.class, () -> fieldData.sortField(null, MultiValueMode.MIN, null, false));
     }
 
     public void testTermQuery() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/10_basic.yml
@@ -316,6 +316,35 @@ setup:
           sort: [ { metric.value_count: desc } ]
 
 ---
+"Sort on multi-metric field without sum and value_count returns 400":
+  - do:
+      indices.create:
+        index: unsortable_amd
+        body:
+          mappings:
+            properties:
+              metric:
+                type: aggregate_metric_double
+                metrics: [min, max]
+
+  - do:
+      index:
+        index: unsortable_amd
+        id: "1"
+        body:
+          metric:
+            min: 1.0
+            max: 10.0
+        refresh: true
+
+  - do:
+      catch: /Sorting by field \[metric\] of type \[aggregate_metric_double\] is not supported/
+      search:
+        index: unsortable_amd
+        body:
+          sort: metric
+
+---
 "Test fields api":
   - do:
       allowed_warnings:


### PR DESCRIPTION
Backport of #154433 to `9.5`.