### PR TITLE
Fix double RecoveryStats.sourceRecoveryCompleted on relocation

### DIFF
--- a/docs/changelog/155270.yaml
+++ b/docs/changelog/155270.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 155150
+pr: 155270
+summary: Fix double `RecoveryStats.sourceRecoveryCompleted` on relocation
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -693,9 +693,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/155149
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/155150
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/155152

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
@@ -82,6 +82,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -354,6 +355,10 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
 
         indexShard.recoveryStats().sourceRecoveryStarted();
         recoverySchedulingListeners.onRecoveryStarted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
+        // Guards against sourceRecoveryCompleted() being called twice: once in the normal success path
+        // (compoundHandoffListener.onResponse) and again via the outer failure handler if
+        // IndexShard.relocated()'s verifyRelocatingState throws after the handoff RPC already succeeded.
+        final var sourceRecoveryFinished = new AtomicBoolean(false);
 
         // Flushing before blocking operations because we expect this to reduce the amount of work done by the flush that happens while
         // operations are blocked. NB the flush has force=false so may do nothing.
@@ -373,8 +378,10 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
 
         final RelocationSourceMetrics.Builder relocationSourceMetricsBuilder = new RelocationSourceMetrics.Builder();
         preFlushStep.addListener(listener.delegateResponse((l, e) -> {
-            indexShard.recoveryStats().sourceRecoveryCompleted();
-            recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
+            if (sourceRecoveryFinished.compareAndSet(false, true)) {
+                indexShard.recoveryStats().sourceRecoveryCompleted();
+                recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
+            }
             l.onFailure(e);
         }).delegateFailureAndWrap((listener0, preFlushResult) -> {
             final var initialFlushDuration = getTimeSince(beforeInitialFlush);
@@ -525,8 +532,10 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
 
                         try {
                             handoffCompleteListener.onResponse(null);
-                            indexShard.recoveryStats().sourceRecoveryCompleted();
-                            recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
+                            if (sourceRecoveryFinished.compareAndSet(false, true)) {
+                                indexShard.recoveryStats().sourceRecoveryCompleted();
+                                recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
+                            }
                         } finally {
                             handoffResultListener.onResponse(null);
                         }


### PR DESCRIPTION
There was an issue with double execution of `indexShard.recoveryStats().sourceRecoveryCompleted();` in the `org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrimaryRelocationAction` (introduced [here](github.com/elastic/elasticsearch/pull/151355/))

There were two races, visible in the issue.

1. Assertion Error (-1), when the `sourceRecoveryCompleted()` being called twice just decrement the counter to -1. https://gradle-enterprise.elastic.co/s/o3ua3uajovq36 - reproduced locally.
2. A hang (never reaching green state) - most probably, when [.onFailure()](https://github.com/elastic/elasticsearch/blob/406574dcf4ec54979328862bad8bd12cd5d282f1/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java#L385) is not called (I could not reproduce it locally, unfortunately)

I've added a guard, that checks that we make a single call only and it fixed the issue on my local env.

Closes: https://github.com/elastic/elasticsearch/issues/155150

