### PR TITLE
Return allowed tag names in TaggedProjectCustom

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -153,7 +153,7 @@ public class Metadata implements Diffable<Metadata>, ChunkedToXContent {
     public interface TaggedProjectCustom extends ProjectCustom {
 
         /** Returns a set of project tag names that are allowed for this {@link ProjectCustom}. */
-        Set<String> allowedTags();
+        Set<String> allowedTagsNames();
 
         String tagPrefix();
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.crossproject.ProjectTags;
 import org.elasticsearch.xcontent.NamedObjectNotFoundException;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
@@ -152,7 +151,9 @@ public class Metadata implements Diffable<Metadata>, ChunkedToXContent {
     public interface ProjectCustom extends MetadataCustom<ProjectCustom> {}
 
     public interface TaggedProjectCustom extends ProjectCustom {
-        ProjectTags tags();
+
+        /** Returns a set of project tag names that are allowed for this {@link ProjectCustom}. */
+        Set<String> allowedTags();
 
         String tagPrefix();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
@@ -212,7 +212,7 @@ public class AnalyzerContext {
                 .filter(Metadata.TaggedProjectCustom.class::isInstance)
                 .map(Metadata.TaggedProjectCustom.class::cast)
                 .forEach(x -> {
-                    for (String tagName : x.allowedTags()) {
+                    for (String tagName : x.allowedTagsNames()) {
                         result.add(x.tagPrefix() + tagName);
                     }
                 });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/AnalyzerContext.java
@@ -212,8 +212,7 @@ public class AnalyzerContext {
                 .filter(Metadata.TaggedProjectCustom.class::isInstance)
                 .map(Metadata.TaggedProjectCustom.class::cast)
                 .forEach(x -> {
-                    Set<String> tagNames = x.tags().tags().keySet();
-                    for (String tagName : tagNames) {
+                    for (String tagName : x.allowedTags()) {
                         result.add(x.tagPrefix() + tagName);
                     }
                 });


### PR DESCRIPTION
This PR reduces the scope of the `TaggedProjectCustom` interface: it now returns just a set of allowed tag names, and not complete `ProjectTags` instances. The values of `ProjectTags` aren't used from this interface (only through concrete classes in the serverless
`ProjectRoutingResolver` implementation), and for the `ProjectCustom`s that store information about >1 project they make no sense anyway.
