### PR TITLE
feat(columnar): add per-stage JMH benchmarks

### DIFF
--- a/benchmarks/AGENTS.md
+++ b/benchmarks/AGENTS.md
@@ -10,6 +10,20 @@ cd benchmarks
 ../gradlew run --args "org.elasticsearch.benchmark._nightly.BytesBuilderBenchmark -pdata=1000_ints -pimpl=paged -poperation=write -rf json -rff build/jmh-result.json" | tee /tmp/bench/paged_write
 ```
 
+## ColumNAR transform benchmarks
+
+```
+cd benchmarks
+../gradlew run --args="EncodeBlockTransformBenchmark" | tee /tmp/bench/encode_transform
+../gradlew run --args="DecodeBlockTransformBenchmark" | tee /tmp/bench/decode_transform
+
+# Single stage + pattern
+../gradlew run --args="EncodeBlockTransformBenchmark -p stage=splitDelta -p pattern=TSDB_SPLIT" | tee /tmp/bench/encode_splitdelta_tsdb
+
+# Quick smoke
+../gradlew run --args="EncodeBlockTransformBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1 -p stage=delta -p pattern=MONOTONIC_TIMESTAMPS"
+```
+
 ## Self-test
 
 Never skip the self-test. Do not pass `-DskipSelfTest=true` or `--test` to `run.sh`. The

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
@@ -125,7 +125,7 @@ public abstract class BlockTransformBenchmark {
         "NEAR_CONSTANT_OUTLIERS" })
     protected String pattern;
 
-    @Param({ "512" })
+    @Param({ "512", "8192" })
     protected int blockSize;
 
     /**

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.columnar;
+
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.columnar.numeric.AlpDoubleTransform;
+import org.elasticsearch.columnar.numeric.BlockTransform;
+import org.elasticsearch.columnar.numeric.DeltaTransform;
+import org.elasticsearch.columnar.numeric.ForTerminal;
+import org.elasticsearch.columnar.numeric.GcdTransform;
+import org.elasticsearch.columnar.numeric.NumericBlockEncoder;
+import org.elasticsearch.columnar.numeric.NumericPipeline;
+import org.elasticsearch.columnar.numeric.OffsetTransform;
+import org.elasticsearch.columnar.numeric.SplitDeltaTransform;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
+
+/**
+ * Shared state and configuration for {@link EncodeBlockTransformBenchmark} and
+ * {@link DecodeBlockTransformBenchmark}.
+ *
+ * <p>Each stage entry in {@link #PIPELINE_FACTORIES} is the single source of truth for the
+ * available stages. The {@code stage} {@link Param} must list the same keys; {@link #encoderFor}
+ * enforces this at setup time by throwing for any unknown value.
+ *
+ * <h2>Stages</h2>
+ *
+ * <p>Each single-stage entry pairs the named transform with a {@link RawTerminal} (raw 8-byte
+ * longs, no bit-packing), so the throughput score reflects only that stage's work. {@code for}
+ * runs the FOR bit-packer alone with no preceding transform. The composed pipeline cost is
+ * covered by the end-to-end benchmarks ({@code ColumnarNumericIngestBenchmark}).
+ *
+ * <ul>
+ *   <li>{@code delta} - DeltaTransform + raw terminal</li>
+ *   <li>{@code offset} - OffsetTransform + raw terminal</li>
+ *   <li>{@code gcd} - GcdTransform + raw terminal</li>
+ *   <li>{@code splitDelta} - SplitDeltaTransform + raw terminal</li>
+ *   <li>{@code alp} - AlpDoubleTransform + raw terminal</li>
+ *   <li>{@code for} - FOR bit-packing alone</li>
+ * </ul>
+ *
+ * <h2>Patterns</h2>
+ * <ul>
+ *   <li>{@code MONOTONIC_TIMESTAMPS} - strictly increasing timestamps (delta applies)</li>
+ *   <li>{@code COUNTER_STEADY} - linear counter (delta + gcd apply)</li>
+ *   <li>{@code GAUGE} - non-monotonic oscillation around a centre (delta skips, offset applies)</li>
+ *   <li>{@code TSDB_SPLIT} - four descending runs with upward jumps (splitDelta applies)</li>
+ *   <li>{@code SENSOR_DOUBLES} - sortable longs for one-decimal IEEE doubles (alp applies)</li>
+ *   <li>{@code RANDOM_FULL} - full-width random longs (most stages skip)</li>
+ *   <li>{@code CONSTANT} - all values identical (delta→0, gcd→max, FOR needs 1 bit; collapse baseline)</li>
+ *   <li>{@code DECREASING} - strictly descending values (delta produces all-negative deltas)</li>
+ *   <li>{@code GCD_FRIENDLY} - random multiples of 1 000 000 (gcd applies strongly)</li>
+ *   <li>{@code NEAR_CONSTANT_OUTLIERS} - base value with ~5% wide outliers (offset applies)</li>
+ * </ul>
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public abstract class BlockTransformBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    // NOTE: ALP metadata is at most e/f (2B) + vint count (5B) + exceptions * 10B. ALP fires only
+    // when bestExceptions <= bitsSaved * blockSize / 160, so the theoretical maximum is well below
+    // blockSize * 10. For the current workloads SENSOR_DOUBLES produces 0 ALP exceptions and every
+    // other pattern causes ALP to decline, making 1024 B sufficient across all supported block sizes.
+    static final int EXTRA_METADATA_SIZE = 1024;
+
+    /**
+     * Maps each stage name to a factory that builds the corresponding pipeline given a block size.
+     * This is the single source of truth for available stages; the {@code stage} {@link Param}
+     * must list the same keys.
+     */
+    private static final Map<String, IntFunction<NumericPipeline>> PIPELINE_FACTORIES;
+    static {
+        PIPELINE_FACTORIES = new LinkedHashMap<>();
+        PIPELINE_FACTORIES.put("delta", bs -> new NumericPipeline(new BlockTransform[] { DeltaTransform.INSTANCE }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put("offset", bs -> new NumericPipeline(new BlockTransform[] { OffsetTransform.INSTANCE }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put("gcd", bs -> new NumericPipeline(new BlockTransform[] { GcdTransform.INSTANCE }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put("splitDelta", bs -> new NumericPipeline(new BlockTransform[] { new SplitDeltaTransform() }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put("alp", bs -> new NumericPipeline(new BlockTransform[] { new AlpDoubleTransform(bs) }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put("for", bs -> new NumericPipeline(new BlockTransform[] {}, new ForTerminal(bs)));
+    }
+
+    // keep in sync with PIPELINE_FACTORIES.keySet()
+    @Param({ "delta", "offset", "gcd", "splitDelta", "alp", "for" })
+    protected String stage;
+
+    @Param({
+        "MONOTONIC_TIMESTAMPS",
+        "COUNTER_STEADY",
+        "GAUGE",
+        "LOW_CARDINALITY",
+        "SMALL_INTS",
+        "TSDB_SPLIT",
+        "SENSOR_DOUBLES",
+        "RANDOM_FULL",
+        "CONSTANT",
+        "DECREASING",
+        "GCD_FRIENDLY",
+        "NEAR_CONSTANT_OUTLIERS" })
+    protected String pattern;
+
+    @Param({ "512" })
+    protected int blockSize;
+
+    /**
+     * Number of blocks encoded or decoded per JMH invocation.
+     *
+     * <p>The value is a deliberate balance between two opposing forces. Too few blocks and the
+     * per-invocation overhead (the JMH measurement loop, {@code Blackhole} consumption, the
+     * pre-invocation copy and cursor-reset) becomes a significant fraction of measured time,
+     * inflating noise and making small regressions invisible. Too many blocks and the combined
+     * input and output arrays exceed cache capacity, causing the score to reflect
+     * memory-bandwidth pressure rather than the transform's compute cost.
+     *
+     * <p>At 100 blocks and the default block size of 512 longs, the combined input and output
+     * working set is approximately 900 KB, which targets L3 on typical benchmark hardware. This
+     * matches the value used in the TSDB per-stage benchmarks. A smaller value (e.g. {@code 8})
+     * keeps data in L2 and isolates pure compute throughput at the cost of less stable scores.
+     */
+    @Param({ "100" })
+    protected int blocksPerInvocation;
+
+    protected NumericBlockEncoder blockEncoder;
+
+    static NumericBlockEncoder encoderFor(String stage, int blockSize) {
+        IntFunction<NumericPipeline> factory = PIPELINE_FACTORIES.get(stage);
+        if (factory == null) {
+            throw new IllegalArgumentException("Unknown stage '" + stage + "'; valid stages: " + PIPELINE_FACTORIES.keySet());
+        }
+        return new NumericBlockEncoder(factory.apply(blockSize), blockSize);
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/BlockTransformBenchmark.java
@@ -99,9 +99,15 @@ public abstract class BlockTransformBenchmark {
     static {
         PIPELINE_FACTORIES = new LinkedHashMap<>();
         PIPELINE_FACTORIES.put("delta", bs -> new NumericPipeline(new BlockTransform[] { DeltaTransform.INSTANCE }, RawTerminal.INSTANCE));
-        PIPELINE_FACTORIES.put("offset", bs -> new NumericPipeline(new BlockTransform[] { OffsetTransform.INSTANCE }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put(
+            "offset",
+            bs -> new NumericPipeline(new BlockTransform[] { OffsetTransform.INSTANCE }, RawTerminal.INSTANCE)
+        );
         PIPELINE_FACTORIES.put("gcd", bs -> new NumericPipeline(new BlockTransform[] { GcdTransform.INSTANCE }, RawTerminal.INSTANCE));
-        PIPELINE_FACTORIES.put("splitDelta", bs -> new NumericPipeline(new BlockTransform[] { new SplitDeltaTransform() }, RawTerminal.INSTANCE));
+        PIPELINE_FACTORIES.put(
+            "splitDelta",
+            bs -> new NumericPipeline(new BlockTransform[] { new SplitDeltaTransform() }, RawTerminal.INSTANCE)
+        );
         PIPELINE_FACTORIES.put("alp", bs -> new NumericPipeline(new BlockTransform[] { new AlpDoubleTransform(bs) }, RawTerminal.INSTANCE));
         PIPELINE_FACTORIES.put("for", bs -> new NumericPipeline(new BlockTransform[] {}, new ForTerminal(bs)));
     }
@@ -110,19 +116,21 @@ public abstract class BlockTransformBenchmark {
     @Param({ "delta", "offset", "gcd", "splitDelta", "alp", "for" })
     protected String stage;
 
-    @Param({
-        "MONOTONIC_TIMESTAMPS",
-        "COUNTER_STEADY",
-        "GAUGE",
-        "LOW_CARDINALITY",
-        "SMALL_INTS",
-        "TSDB_SPLIT",
-        "SENSOR_DOUBLES",
-        "RANDOM_FULL",
-        "CONSTANT",
-        "DECREASING",
-        "GCD_FRIENDLY",
-        "NEAR_CONSTANT_OUTLIERS" })
+    @Param(
+        {
+            "MONOTONIC_TIMESTAMPS",
+            "COUNTER_STEADY",
+            "GAUGE",
+            "LOW_CARDINALITY",
+            "SMALL_INTS",
+            "TSDB_SPLIT",
+            "SENSOR_DOUBLES",
+            "RANDOM_FULL",
+            "CONSTANT",
+            "DECREASING",
+            "GCD_FRIENDLY",
+            "NEAR_CONSTANT_OUTLIERS" }
+    )
     protected String pattern;
 
     @Param({ "512", "8192" })

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/DecodeBlockTransformBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/DecodeBlockTransformBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.columnar;
+
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.ByteArrayDataOutput;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+
+/**
+ * Per-stage decode benchmark for the ColumNAR pipeline.
+ *
+ * <p>Mirror of {@link EncodeBlockTransformBenchmark} on the read path. Encodes one block at
+ * setup time and measures the cost of decoding it repeatedly. Each invocation resets
+ * {@code blocksPerInvocation} pre-allocated {@link ByteArrayDataInput} objects to the start of
+ * the same encoded payload, then decodes into pre-allocated output arrays. Resetting the read
+ * cursor rather than allocating a new input object avoids per-invocation GC pressure while
+ * still presenting the decoder with a fresh byte sequence on every call, preventing the JIT
+ * from eliding the decode work. The cursor-reset adds a constant, structurally fixed overhead
+ * per block. Because that overhead is identical between any two runs of the same benchmark,
+ * any observed difference in throughput score comes exclusively from changes to the decode
+ * path itself.
+ *
+ * <p>See {@link BlockTransformBenchmark} for the list of stages and block shapes.
+ *
+ * <h2>Ready to run</h2>
+ *
+ * <pre>{@code
+ * # Full stage x pattern matrix
+ * ./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark"
+ *
+ * # Single stage across all patterns
+ * ./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark -p stage=splitDelta"
+ *
+ * # Compare stages on the TSDB split pattern
+ * ./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark -p pattern=TSDB_SPLIT"
+ *
+ * # Quick smoke
+ * ./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1 -p stage=delta -p pattern=MONOTONIC_TIMESTAMPS"
+ * }</pre>
+ */
+public class DecodeBlockTransformBenchmark extends BlockTransformBenchmark {
+
+    private byte[] encodedBlock;
+    private ByteArrayDataInput[] inputs;
+    private long[][] outputs;
+
+    @Setup(Level.Trial)
+    public void setupTrial() throws IOException {
+        final long[] template = NumericData.generate(pattern, blockSize);
+        blockEncoder = encoderFor(stage, blockSize);
+
+        final byte[] scratch = new byte[Long.BYTES * blockSize + EXTRA_METADATA_SIZE];
+        final ByteArrayDataOutput out = new ByteArrayDataOutput(scratch);
+        final long[] encodeBuffer = new long[blockSize];
+        System.arraycopy(template, 0, encodeBuffer, 0, blockSize);
+        blockEncoder.encode(encodeBuffer, blockSize, out);
+        final int encodedLength = out.getPosition();
+        encodedBlock = new byte[encodedLength];
+        System.arraycopy(scratch, 0, encodedBlock, 0, encodedLength);
+
+        inputs = new ByteArrayDataInput[blocksPerInvocation];
+        outputs = new long[blocksPerInvocation][blockSize];
+        for (int i = 0; i < blocksPerInvocation; i++) {
+            inputs[i] = new ByteArrayDataInput(encodedBlock);
+        }
+    }
+
+    @Benchmark
+    public void decode(final Blackhole bh) throws IOException {
+        for (int i = 0; i < blocksPerInvocation; i++) {
+            inputs[i].reset(encodedBlock);
+            blockEncoder.decode(inputs[i], blockSize, outputs[i]);
+            bh.consume(outputs[i][0]);
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/EncodeBlockTransformBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/EncodeBlockTransformBenchmark.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.columnar;
+
+import org.apache.lucene.store.ByteArrayDataOutput;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+
+/**
+ * Per-stage encode benchmark for the ColumNAR pipeline.
+ *
+ * <p>Each invocation copies the template into {@code blocksPerInvocation} pre-allocated input
+ * arrays and resets a pre-allocated output buffer before calling the encoder. Separate input
+ * arrays per block prevent the JIT from eliminating the encode work via alias analysis or
+ * dead-code elimination: a shared array would let the JIT observe that the encoder overwrites
+ * the same memory on every call and hoist or elide it entirely. The copy and buffer-reset add
+ * a constant overhead per block. Because that overhead is structurally identical between any
+ * two runs of the same benchmark, any observed difference in throughput score comes exclusively
+ * from changes to the encode path itself.
+ *
+ * <p>See {@link BlockTransformBenchmark} for the list of stages and block shapes.
+ *
+ * <h2>Ready to run</h2>
+ *
+ * <pre>{@code
+ * # Full stage x pattern matrix
+ * ./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark"
+ *
+ * # Single stage across all patterns
+ * ./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -p stage=splitDelta"
+ *
+ * # Compare stages on the TSDB split pattern
+ * ./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -p pattern=TSDB_SPLIT"
+ *
+ * # Allocation rate
+ * ./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -p stage=alp -p pattern=SENSOR_DOUBLES -prof gc"
+ *
+ * # Quick smoke
+ * ./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1 -p stage=delta -p pattern=MONOTONIC_TIMESTAMPS"
+ * }</pre>
+ */
+public class EncodeBlockTransformBenchmark extends BlockTransformBenchmark {
+
+    private long[][] inputs;
+    private long[] template;
+    private byte[][] outputBuffers;
+    private ByteArrayDataOutput[] outputs;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        template = NumericData.generate(pattern, blockSize);
+
+        inputs = new long[blocksPerInvocation][blockSize];
+        outputBuffers = new byte[blocksPerInvocation][Long.BYTES * blockSize + EXTRA_METADATA_SIZE];
+        outputs = new ByteArrayDataOutput[blocksPerInvocation];
+        for (int i = 0; i < blocksPerInvocation; i++) {
+            outputs[i] = new ByteArrayDataOutput(outputBuffers[i]);
+        }
+
+        blockEncoder = encoderFor(stage, blockSize);
+    }
+
+    @Benchmark
+    public void encode(final Blackhole bh) throws IOException {
+        for (int i = 0; i < blocksPerInvocation; i++) {
+            System.arraycopy(template, 0, inputs[i], 0, blockSize);
+            outputs[i].reset(outputBuffers[i]);
+            blockEncoder.encode(inputs[i], blockSize, outputs[i]);
+            bh.consume(outputs[i].getPosition());
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/NumericData.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/NumericData.java
@@ -17,8 +17,6 @@ final class NumericData {
 
     private NumericData() {}
 
-    static final String[] WORKLOADS = { "MONOTONIC_TIMESTAMPS", "COUNTER_STEADY", "GAUGE", "LOW_CARDINALITY", "SMALL_INTS", "RANDOM_FULL" };
-
     private static final long[] LOW_CARDINALITY_CODES = { 3, 7, 11, 42, 99, 128, 256, 999, 4096, 5000, 65535, 100000, 1, 2, 8, 16 };
 
     static long[] generate(String workload, int count) {
@@ -37,6 +35,17 @@ final class NumericData {
                 case "LOW_CARDINALITY" -> LOW_CARDINALITY_CODES[rng.nextInt(LOW_CARDINALITY_CODES.length)];
                 case "SMALL_INTS" -> rng.nextInt(256);
                 case "RANDOM_FULL" -> rng.nextLong();
+                case "TSDB_SPLIT" -> {
+                    int runsOf = Math.max(1, count / 4);
+                    int run = i / runsOf;
+                    int posInRun = i % runsOf;
+                    yield 1_700_000_000_000L + (long) run * 100_000L - (long) posInRun * 1_000L;
+                }
+                case "SENSOR_DOUBLES" -> Double.doubleToRawLongBits(20.0 + (i % 1000) * 0.1);
+                case "CONSTANT" -> 1_700_000_000_000L;
+                case "DECREASING" -> 1_700_000_000_000L - (long) i * 1_000L;
+                case "GCD_FRIENDLY" -> ((long) rng.nextInt(1000) + 1) * 1_000_000L;
+                case "NEAR_CONSTANT_OUTLIERS" -> rng.nextInt(20) == 0 ? rng.nextInt(1_000_000_000) : 1_700_000_000_000L;
                 default -> throw new IllegalArgumentException("Unknown workload: " + workload);
             };
         }
@@ -51,6 +60,12 @@ final class NumericData {
             case "LOW_CARDINALITY" -> 4L;
             case "SMALL_INTS" -> 5L;
             case "RANDOM_FULL" -> 6L;
+            case "TSDB_SPLIT" -> 7L;
+            case "SENSOR_DOUBLES" -> 8L;
+            case "CONSTANT" -> 9L;
+            case "DECREASING" -> 10L;
+            case "GCD_FRIENDLY" -> 11L;
+            case "NEAR_CONSTANT_OUTLIERS" -> 12L;
             default -> throw new IllegalArgumentException("Unknown workload: " + workload);
         };
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/NumericData.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/NumericData.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.benchmark.index.codec.columnar;
 
+import org.apache.lucene.util.NumericUtils;
+
 /**
  * Deterministic numeric data shapes for the ColumNAR benchmarks. A given workload always produces the
  * same values, so every format sees identical input.
@@ -41,7 +43,7 @@ final class NumericData {
                     int posInRun = i % runsOf;
                     yield 1_700_000_000_000L + (long) run * 100_000L - (long) posInRun * 1_000L;
                 }
-                case "SENSOR_DOUBLES" -> Double.doubleToRawLongBits(20.0 + (i % 1000) * 0.1);
+                case "SENSOR_DOUBLES" -> NumericUtils.doubleToSortableLong(20.0 + (i % 1000) * 0.1);
                 case "CONSTANT" -> 1_700_000_000_000L;
                 case "DECREASING" -> 1_700_000_000_000L - (long) i * 1_000L;
                 case "GCD_FRIENDLY" -> ((long) rng.nextInt(1000) + 1) * 1_000_000L;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/RawTerminal.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/columnar/RawTerminal.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.index.codec.columnar;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.elasticsearch.columnar.numeric.BlockTerminal;
+
+import java.io.IOException;
+
+/**
+ * Benchmark-only terminal that serializes a block as raw 8-byte longs, with no bit-packing.
+ * Used to isolate individual {@link org.elasticsearch.columnar.numeric.BlockTransform} stages
+ * from the cost of FOR bit-packing when measuring per-stage encode/decode throughput.
+ */
+final class RawTerminal implements BlockTerminal {
+
+    static final RawTerminal INSTANCE = new RawTerminal();
+
+    private RawTerminal() {}
+
+    @Override
+    public byte id() {
+        return (byte) 0x7F;
+    }
+
+    @Override
+    public void encode(long[] block, int valueCount, DataOutput out) throws IOException {
+        for (int i = 0; i < valueCount; i++) {
+            out.writeLong(block[i]);
+        }
+    }
+
+    @Override
+    public void decode(DataInput in, int valueCount, long[] block) throws IOException {
+        for (int i = 0; i < valueCount; i++) {
+            block[i] = in.readLong();
+        }
+    }
+}

--- a/libs/columnar/docs/BENCHMARKS.md
+++ b/libs/columnar/docs/BENCHMARKS.md
@@ -1,21 +1,67 @@
 # Benchmarks
 
 ColumNAR's JMH benchmarks live in the shared `:benchmarks` module, package
-`org.elasticsearch.benchmark.index.codec.columnar`, so they can compare ColumNAR
-against the numeric codecs it aims to reach parity with. Each takes a `format`
-param (`COLUMNAR`, `ES819`, `ES95`) and drives all formats over identical data
-through plain Lucene (`IndexWriter`, `IndexSearcher`).
+`org.elasticsearch.benchmark.index.codec.columnar`.
+
+## End-to-end benchmarks
+
+These drive the full stack through plain Lucene (`IndexWriter`, `IndexSearcher`) and compare
+ColumNAR against the numeric codecs it aims to reach parity with. Each takes a `format`
+param (`COLUMNAR`, `ES819`, `ES95`).
 
 - `ColumnarNumericIngestBenchmark` — ingest cost and storage. `merge` selects no merges, natural
   merges, or a force-merge; secondary counters report bytes on disk and total bytes written.
 - `ColumnarNumericRangeSlicingBenchmark` — range-query latency under
   `DataPartitioning.DOC` slicing.
 
-Run (JMH args after the class regex):
+```
+./gradlew :benchmarks:run --args="ColumnarNumericIngestBenchmark -p format=COLUMNAR,ES819,ES95"
+./gradlew :benchmarks:run --args="ColumnarNumericRangeSlicingBenchmark -p format=COLUMNAR,ES819 -p workload=RANDOM_FULL"
+```
+
+## Per-stage encode/decode benchmarks
+
+These measure encode and decode throughput for each `BlockTransform` stage in isolation,
+without Lucene IO overhead. Use them to freeze per-stage throughput baselines, identify
+the dominant stage in a composed pipeline, and catch regressions in a specific encoding.
+
+- `EncodeBlockTransformBenchmark` — encode throughput. `stage` selects the transform
+  (`delta`, `offset`, `gcd`, `splitDelta`, `alp`, `for`); `pattern` selects the block shape.
+- `DecodeBlockTransformBenchmark` — decode throughput. Same parameters.
+
+Every entry pairs the named transform with a `RawTerminal` (raw 8-byte longs, no bit-packing),
+so the throughput score reflects only that stage's work. `for` runs the FOR bit-packer alone
+with no preceding transform. The composed pipeline cost is covered by the end-to-end benchmarks.
+
+Block shapes and the stage each one exercises most:
+
+| Pattern | Primary stage |
+|---|---|
+| `MONOTONIC_TIMESTAMPS` | delta |
+| `COUNTER_STEADY` | delta + gcd |
+| `GAUGE` | offset |
+| `TSDB_SPLIT` | splitDelta |
+| `SENSOR_DOUBLES` | alp |
+| `RANDOM_FULL` | none (skip baseline) |
+| `CONSTANT` | all stages collapse (FOR needs 1 bit; collapse baseline) |
+| `DECREASING` | delta (all-negative deltas) |
+| `GCD_FRIENDLY` | gcd (random multiples of 1 000 000) |
+| `NEAR_CONSTANT_OUTLIERS` | offset (~5% wide outliers over a fixed base) |
 
 ```
-./gradlew :benchmarks:run --args="ColumnarNumericRangeSlicingBenchmark -p format=COLUMNAR,ES819 -p workload=RANDOM_FULL"
-./gradlew :benchmarks:run --args="ColumnarNumericIngestBenchmark -p format=COLUMNAR,ES819,ES95"
+./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark"
+./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark"
+
+# Single stage across all patterns
+./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -p stage=splitDelta"
+
+# Quick smoke
+./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1 -p stage=delta -p pattern=MONOTONIC_TIMESTAMPS"
 ```
+
+**Practice:** when adding a new `BlockTransform`, add the stage to both benchmarks. Add a
+block shape to `NumericData` only if no existing shape exercises the new stage.
+
+## General
 
 No results are committed — these are for investigation, run on demand.

--- a/libs/columnar/docs/PLAN.md
+++ b/libs/columnar/docs/PLAN.md
@@ -33,6 +33,9 @@ The direction, the decisions that constrain it, and the build order. Update as d
 - Tests: round-trip, fast-path + skipper vs brute force, end-to-end range query, multi-segment merge.
 - `SplitDeltaTransform` (frozen id 3) and `AlpDoubleTransform` (frozen id 4) registered in
   `NumericPipeline.Registry`; both available for use once per-field pipeline selection lands.
+- Per-stage encode/decode JMH benchmarks (`EncodeBlockTransformBenchmark`,
+  `DecodeBlockTransformBenchmark`) covering Delta, Offset, GCD, SplitDelta, ALP, and FOR
+  across ten block shapes.
 
 ## Next
 
@@ -62,4 +65,7 @@ The direction, the decisions that constrain it, and the build order. Update as d
 - Small self-contained changes proceed directly; anything touching on-disk framing, a frozen id, or
   the read contract is discussed first.
 - Every format change ships with correctness tests.
+- Every new `BlockTransform` ships with encode and decode entries in
+  `EncodeBlockTransformBenchmark` and `DecodeBlockTransformBenchmark`. Add a block shape to
+  `NumericData` only if no existing shape exercises the new stage. See `docs/BENCHMARKS.md`.
 - Server-tier work (mapping, the binary bridge, synthetic source) lives in other modules.


### PR DESCRIPTION
## TL;DR

Adds per-stage encode and decode JMH benchmarks for every `BlockTransform` in the ColumNAR numeric pipeline, and extends `NumericData` with ten deterministic block shapes that each target at least one stage's apply path.

## Summary

The ColumNAR numeric pipeline composes up to four stages (delta, offset, gcd, and the new splitDelta and alp transforms from #155248) before writing packed integers with the FOR terminal. Until now there was no way to isolate the throughput contribution of a single stage, which makes it hard to detect regressions or quantify the improvement from a new encoding.

**`EncodeBlockTransformBenchmark`** and **`DecodeBlockTransformBenchmark`** fill that gap. Every stage entry pairs the named transform with a benchmark-local `RawTerminal` that writes raw 8-byte longs, so the throughput score reflects only that transform's work with no FOR bit-packing overhead. `for` runs the FOR bit-packer alone with no preceding transform. The composed pipeline cost is already covered by `ColumnarNumericIngestBenchmark`.

Both benchmarks follow the TSDB benchmark pattern for JMH correctness. The per-invocation overhead (input copy on encode, cursor reset on decode) is structurally fixed between runs, so any throughput difference between a before and after measurement comes exclusively from the encode or decode path.

**`NumericData`** is extended from six to ten block shapes. The four additions each target a stage that had no dedicated shape:

| Pattern | Stage targeted |
|---|---|
| `CONSTANT` | collapse baseline (delta->0, gcd->max, FOR needs 1 bit) |
| `DECREASING` | delta (all-negative deltas) |
| `GCD_FRIENDLY` | gcd (random multiples of 1 000 000) |
| `NEAR_CONSTANT_OUTLIERS` | offset (~5% wide outliers over a fixed base) |

A working agreement is added to `PLAN.md`: every new `BlockTransform` ships encode and decode benchmark entries. A new block shape is added to `NumericData` only if no existing shape exercises the new stage, keeping the set lean while ensuring every stage has coverage.

This PR is stacked on #155248 (SplitDelta + ALP transforms). The benchmarks include entries for `splitDelta` and `alp` stages but those are only meaningful once the transforms are registered, which happens in the base PR.

## Testing

```
./gradlew :benchmarks:compileJava

# Full stage x pattern matrix
./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark"
./gradlew :benchmarks:run --args="DecodeBlockTransformBenchmark"

# Quick smoke
./gradlew :benchmarks:run --args="EncodeBlockTransformBenchmark -wi 1 -i 1 -f 1 -w 1 -r 1 -p stage=delta -p pattern=MONOTONIC_TIMESTAMPS"
```
