### PR TITLE
Skip InputIndexUtilsTests on unsupported platforms

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -18,8 +18,8 @@ import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.elasticsearch.common.lucene.store.DirectAccessIndexInput;
 import org.elasticsearch.core.DirectAccessInput;
+import org.elasticsearch.simdvec.AbstractVectorTestCase;
 import org.elasticsearch.simdvec.IndexInputUtils;
-import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.not;
  * {@link DirectAccessInput} (byte-buffer), and plain {@link IndexInput}
  * (heap-copy fallback).
  */
-public class IndexInputUtilsTests extends ESTestCase {
+public class IndexInputUtilsTests extends AbstractVectorTestCase {
 
     private static final String FILE_NAME = "test.bin";
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -391,18 +391,6 @@ tests:
 - class: org.elasticsearch.exponentialhistogram.ExponentialHistogramMergerTests
   method: testDifferenceForCumulativeHistos
   issue: https://github.com/elastic/elasticsearch/issues/153665
-- class: org.elasticsearch.simdvec.internal.IndexInputUtilsTests
-  method: testES92ConstructorRejectsUnwrappedFilterIndexInput
-  issue: https://github.com/elastic/elasticsearch/issues/153738
-- class: org.elasticsearch.simdvec.internal.IndexInputUtilsTests
-  method: testES92ConstructorAcceptsMMapInput
-  issue: https://github.com/elastic/elasticsearch/issues/153739
-- class: org.elasticsearch.simdvec.internal.IndexInputUtilsTests
-  method: testES92ConstructorAcceptsDirectAccessInput
-  issue: https://github.com/elastic/elasticsearch/issues/153740
-- class: org.elasticsearch.simdvec.internal.IndexInputUtilsTests
-  method: testES92ConstructorAcceptsPlainInput
-  issue: https://github.com/elastic/elasticsearch/issues/153741
 - class: org.elasticsearch.xpack.esql.parser.ParamsParserTests
   method: testMixedSingleDoubleParams
   issue: https://github.com/elastic/elasticsearch/issues/153746


### PR DESCRIPTION
`AbstractVectorTestCase` contains logic to skip the tests where not supported, changing the base class inherits that logic. Several test failures on windows will be fixed by this change. 

Closes #153741, #153740, #153739, #153738