### PR TITLE
[9.5] Fix double sourceRecoveryCompleted in relocation (#154872)

### DIFF
--- a/docs/changelog/154872.yaml
+++ b/docs/changelog/154872.yaml
@@ -1,0 +1,7 @@
+area: Recovery
+issues:
+ - 151861
+ - 151884
+pr: 154872
+summary: Fix double `sourceRecoveryCompleted` in relocation
+type: bug

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -89,7 +89,6 @@ import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
@@ -814,14 +813,6 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         assertHitCount(client().prepareSearch(clusterInfo.indexName).setSize(0).setTrackTotalHits(true), clusterInfo.numDocs + moreDocs);
     }
 
-    @TestLogging(value = "org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrimaryRelocationAction:TRACE", reason = """
-        We have seen flakes in this test where assertRequestsFinished() fails during test teardown.
-        See https://github.com/elastic/elasticsearch/issues/151861 for details.
-        In the instance captured there, an internal:index/shard/recovery/stateless_primary_relocation/start task is running during teardown.
-        It seems likely that the race between the index close and the relocation that hollows shards is leaving some asynchronous process
-        hanging so that it never completes its listener chain. This would be a genuine race condition.
-        By enabling trace logging on TransportStatelessPrimaryRelocationAction, we should get more detail about where that task got to.
-        """)
     public void testCloseWhileShardsAreHollowed() throws Exception {
         startMasterOnlyNode();
         final var indexNodeSettings = Settings.builder()

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
@@ -371,10 +371,9 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
         logger.debug("[{}] completed the flush, waiting to upload", request.shardId());
 
         final RelocationSourceMetrics.Builder relocationSourceMetricsBuilder = new RelocationSourceMetrics.Builder();
-        preFlushStep.addListener(listener.delegateResponse((l, e) -> {
+        preFlushStep.addListener(ActionListener.runAfter(listener, () -> {
             indexShard.recoveryStats().sourceRecoveryCompleted();
             recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
-            l.onFailure(e);
         }).delegateFailureAndWrap((listener0, preFlushResult) -> {
             final var initialFlushDuration = getTimeSince(beforeInitialFlush);
             final long beforeAcquiringPermits = threadPool.relativeTimeInMillis();
@@ -524,8 +523,6 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
 
                         try {
                             handoffCompleteListener.onResponse(null);
-                            indexShard.recoveryStats().sourceRecoveryCompleted();
-                            recoverySchedulingListeners.onRecoveryCompleted(RecoverySource.Type.PEER, RecoveryRole.SOURCE);
                         } finally {
                             handoffResultListener.onResponse(null);
                         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix double sourceRecoveryCompleted in relocation (#154872)](https://github.com/elastic/elasticsearch/pull/154872)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)