### PR TITLE
[9.5] [Fleet] Add policy_base_id field to fleet-agents and fleet-policies index templates (#154521)

### DIFF
--- a/docs/changelog/154521.yaml
+++ b/docs/changelog/154521.yaml
@@ -1,0 +1,6 @@
+area: Infra/Plugins
+issues: []
+pr: 154521
+summary: "[Fleet] Add `policy_base_id` field to fleet-agents and fleet-policies index\
+  \ templates"
+type: enhancement

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -236,6 +236,9 @@
         "agent_policy_id": {
           "type": "keyword"
         },
+        "policy_base_id": {
+          "type": "keyword"
+        },
         "policy_output_permissions_hash": {
           "type": "keyword"
         },

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-policies.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-policies.json
@@ -26,6 +26,9 @@
         "policy_id": {
           "type": "keyword"
         },
+        "policy_base_id": {
+          "type": "keyword"
+        },
         "revision_idx": {
           "type": "integer"
         },

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -72,10 +72,10 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 10;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 11;
     private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 3;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
-    private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;
+    private static final int FLEET_POLICIES_MAPPINGS_VERSION = 3;
     private static final int FLEET_POLICIES_LEADER_MAPPINGS_VERSION = 1;
     private static final int FLEET_SERVERS_MAPPINGS_VERSION = 1;
     private static final int FLEET_ARTIFACTS_MAPPINGS_VERSION = 1;


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Fleet] Add policy_base_id field to fleet-agents and fleet-policies index templates (#154521)