### PR TITLE
Stream safe wildcard source excludes

### DIFF
--- a/docs/changelog/155289.yaml
+++ b/docs/changelog/155289.yaml
@@ -1,0 +1,5 @@
+area: CRUD
+issues: []
+pr: 155289
+summary: Stream safe wildcard source excludes
+type: enhancement

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
@@ -33,8 +33,6 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         null,
         false,
         true,
-        false,
-        false,
         false
     );
 
@@ -45,9 +43,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
     final FilterPath[] excludes;
     final boolean filtersMatchFieldNamesWithDots;
     final boolean includeSourceOnError;
-    final boolean sourceFilterSemantics;
-    final boolean wildcardExcludes;
-    final boolean dottedPathExcludes;
+    final boolean sourceFilterWildcardSemantics;
 
     private XContentParserConfigurationImpl(
         NamedXContentRegistry registry,
@@ -57,9 +53,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         FilterPath[] excludes,
         boolean filtersMatchFieldNamesWithDots,
         boolean includeSourceOnError,
-        boolean sourceFilterSemantics,
-        boolean wildcardExcludes,
-        boolean dottedPathExcludes
+        boolean sourceFilterWildcardSemantics
     ) {
         this.registry = registry;
         this.deprecationHandler = deprecationHandler;
@@ -68,9 +62,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         this.excludes = excludes;
         this.filtersMatchFieldNamesWithDots = filtersMatchFieldNamesWithDots;
         this.includeSourceOnError = includeSourceOnError;
-        this.sourceFilterSemantics = sourceFilterSemantics;
-        this.wildcardExcludes = wildcardExcludes;
-        this.dottedPathExcludes = dottedPathExcludes;
+        this.sourceFilterWildcardSemantics = sourceFilterWildcardSemantics;
     }
 
     private XContentParserConfigurationImpl copy(boolean includeSourceOnError) {
@@ -82,9 +74,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             excludes,
             filtersMatchFieldNamesWithDots,
             includeSourceOnError,
-            sourceFilterSemantics,
-            wildcardExcludes,
-            dottedPathExcludes
+            sourceFilterWildcardSemantics
         );
     }
 
@@ -111,9 +101,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             excludes,
             filtersMatchFieldNamesWithDots,
             includeSourceOnError,
-            sourceFilterSemantics,
-            wildcardExcludes,
-            dottedPathExcludes
+            sourceFilterWildcardSemantics
         );
     }
 
@@ -130,9 +118,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             excludes,
             filtersMatchFieldNamesWithDots,
             includeSourceOnError,
-            sourceFilterSemantics,
-            wildcardExcludes,
-            dottedPathExcludes
+            sourceFilterWildcardSemantics
         );
     }
 
@@ -149,9 +135,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             excludes,
             filtersMatchFieldNamesWithDots,
             includeSourceOnError,
-            sourceFilterSemantics,
-            wildcardExcludes,
-            dottedPathExcludes
+            sourceFilterWildcardSemantics
         );
     }
 
@@ -177,12 +161,15 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
     }
 
     @Override
-    public XContentParserConfiguration withSourceFilterFiltering(
+    public XContentParserConfiguration withSourceFilterWildcardFiltering(
         String prefixPath,
         Set<String> includeStrings,
         Set<String> excludeStrings,
         boolean filtersMatchFieldNamesWithDots
     ) {
+        if (includeStrings != null && includeStrings.isEmpty() == false) {
+            throw new IllegalArgumentException("source wildcard filtering only supports exclude-only patterns");
+        }
         return buildFilteringConfiguration(prefixPath, includeStrings, excludeStrings, filtersMatchFieldNamesWithDots, true);
     }
 
@@ -191,22 +178,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         Set<String> includeStrings,
         Set<String> excludeStrings,
         boolean filtersMatchFieldNamesWithDots,
-        boolean sourceFilterSemantics
+        boolean sourceFilterWildcardSemantics
     ) {
         FilterPath[] includePaths = FilterPath.compile(includeStrings);
         FilterPath[] excludePaths = FilterPath.compile(excludeStrings);
-        boolean wildcardExcludes = false;
-        boolean dottedPathExcludes = false;
-        if (sourceFilterSemantics && excludeStrings != null) {
-            for (String exclude : excludeStrings) {
-                if (exclude != null && exclude.contains("*")) {
-                    wildcardExcludes = true;
-                }
-                if (exclude != null && exclude.contains(".")) {
-                    dottedPathExcludes = true;
-                }
-            }
-        }
 
         if (prefixPath != null) {
             if (includePaths != null) {
@@ -233,37 +208,16 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             excludePaths,
             filtersMatchFieldNamesWithDots,
             includeSourceOnError,
-            sourceFilterSemantics,
-            wildcardExcludes,
-            dottedPathExcludes
+            sourceFilterWildcardSemantics
         );
     }
 
     public JsonParser filter(JsonParser parser) {
         JsonParser filtered = parser;
         if (excludes != null) {
-            FilterPathBasedFilter excludeFilter;
-            if (sourceFilterSemantics) {
-                if (includes != null) {
-                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterWithIncludes(
-                        excludes,
-                        filtersMatchFieldNamesWithDots
-                    );
-                } else if (wildcardExcludes) {
-                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterExcludeOnlyWildcard(
-                        excludes,
-                        filtersMatchFieldNamesWithDots
-                    );
-                } else {
-                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterExcludeOnlyLiteral(
-                        excludes,
-                        filtersMatchFieldNamesWithDots,
-                        dottedPathExcludes
-                    );
-                }
-            } else {
-                excludeFilter = new FilterPathBasedFilter(excludes, false, filtersMatchFieldNamesWithDots);
-            }
+            FilterPathBasedFilter excludeFilter = sourceFilterWildcardSemantics
+                ? FilterPathBasedFilter.createSourceFilterExclusiveWildcardFilter(excludes, filtersMatchFieldNamesWithDots)
+                : new FilterPathBasedFilter(excludes, false, filtersMatchFieldNamesWithDots);
             filtered = new FilteringParserDelegate(filtered, excludeFilter, true, true);
         }
         if (includes != null) {

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
@@ -32,7 +32,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         null,
         null,
         false,
-        true
+        true,
+        false,
+        false,
+        false
     );
 
     final NamedXContentRegistry registry;
@@ -42,6 +45,9 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
     final FilterPath[] excludes;
     final boolean filtersMatchFieldNamesWithDots;
     final boolean includeSourceOnError;
+    final boolean sourceFilterSemantics;
+    final boolean wildcardExcludes;
+    final boolean dottedPathExcludes;
 
     private XContentParserConfigurationImpl(
         NamedXContentRegistry registry,
@@ -50,7 +56,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         FilterPath[] includes,
         FilterPath[] excludes,
         boolean filtersMatchFieldNamesWithDots,
-        boolean includeSourceOnError
+        boolean includeSourceOnError,
+        boolean sourceFilterSemantics,
+        boolean wildcardExcludes,
+        boolean dottedPathExcludes
     ) {
         this.registry = registry;
         this.deprecationHandler = deprecationHandler;
@@ -59,6 +68,24 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         this.excludes = excludes;
         this.filtersMatchFieldNamesWithDots = filtersMatchFieldNamesWithDots;
         this.includeSourceOnError = includeSourceOnError;
+        this.sourceFilterSemantics = sourceFilterSemantics;
+        this.wildcardExcludes = wildcardExcludes;
+        this.dottedPathExcludes = dottedPathExcludes;
+    }
+
+    private XContentParserConfigurationImpl copy(boolean includeSourceOnError) {
+        return new XContentParserConfigurationImpl(
+            registry,
+            deprecationHandler,
+            restApiVersion,
+            includes,
+            excludes,
+            filtersMatchFieldNamesWithDots,
+            includeSourceOnError,
+            sourceFilterSemantics,
+            wildcardExcludes,
+            dottedPathExcludes
+        );
     }
 
     @Override
@@ -71,15 +98,7 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         if (includeSourceOnError == this.includeSourceOnError) {
             return this;
         }
-        return new XContentParserConfigurationImpl(
-            registry,
-            deprecationHandler,
-            restApiVersion,
-            includes,
-            excludes,
-            filtersMatchFieldNamesWithDots,
-            includeSourceOnError
-        );
+        return copy(includeSourceOnError);
     }
 
     @Override
@@ -91,7 +110,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             includes,
             excludes,
             filtersMatchFieldNamesWithDots,
-            includeSourceOnError
+            includeSourceOnError,
+            sourceFilterSemantics,
+            wildcardExcludes,
+            dottedPathExcludes
         );
     }
 
@@ -107,7 +129,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             includes,
             excludes,
             filtersMatchFieldNamesWithDots,
-            includeSourceOnError
+            includeSourceOnError,
+            sourceFilterSemantics,
+            wildcardExcludes,
+            dottedPathExcludes
         );
     }
 
@@ -123,7 +148,10 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             includes,
             excludes,
             filtersMatchFieldNamesWithDots,
-            includeSourceOnError
+            includeSourceOnError,
+            sourceFilterSemantics,
+            wildcardExcludes,
+            dottedPathExcludes
         );
     }
 
@@ -145,8 +173,40 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
         Set<String> excludeStrings,
         boolean filtersMatchFieldNamesWithDots
     ) {
+        return buildFilteringConfiguration(prefixPath, includeStrings, excludeStrings, filtersMatchFieldNamesWithDots, false);
+    }
+
+    @Override
+    public XContentParserConfiguration withSourceFilterFiltering(
+        String prefixPath,
+        Set<String> includeStrings,
+        Set<String> excludeStrings,
+        boolean filtersMatchFieldNamesWithDots
+    ) {
+        return buildFilteringConfiguration(prefixPath, includeStrings, excludeStrings, filtersMatchFieldNamesWithDots, true);
+    }
+
+    private XContentParserConfiguration buildFilteringConfiguration(
+        String prefixPath,
+        Set<String> includeStrings,
+        Set<String> excludeStrings,
+        boolean filtersMatchFieldNamesWithDots,
+        boolean sourceFilterSemantics
+    ) {
         FilterPath[] includePaths = FilterPath.compile(includeStrings);
         FilterPath[] excludePaths = FilterPath.compile(excludeStrings);
+        boolean wildcardExcludes = false;
+        boolean dottedPathExcludes = false;
+        if (sourceFilterSemantics && excludeStrings != null) {
+            for (String exclude : excludeStrings) {
+                if (exclude != null && exclude.contains("*")) {
+                    wildcardExcludes = true;
+                }
+                if (exclude != null && exclude.contains(".")) {
+                    dottedPathExcludes = true;
+                }
+            }
+        }
 
         if (prefixPath != null) {
             if (includePaths != null) {
@@ -172,19 +232,39 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
             includePaths,
             excludePaths,
             filtersMatchFieldNamesWithDots,
-            includeSourceOnError
+            includeSourceOnError,
+            sourceFilterSemantics,
+            wildcardExcludes,
+            dottedPathExcludes
         );
     }
 
     public JsonParser filter(JsonParser parser) {
         JsonParser filtered = parser;
         if (excludes != null) {
-            filtered = new FilteringParserDelegate(
-                filtered,
-                new FilterPathBasedFilter(excludes, false, filtersMatchFieldNamesWithDots),
-                true,
-                true
-            );
+            FilterPathBasedFilter excludeFilter;
+            if (sourceFilterSemantics) {
+                if (includes != null) {
+                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterWithIncludes(
+                        excludes,
+                        filtersMatchFieldNamesWithDots
+                    );
+                } else if (wildcardExcludes) {
+                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterExcludeOnlyWildcard(
+                        excludes,
+                        filtersMatchFieldNamesWithDots
+                    );
+                } else {
+                    excludeFilter = FilterPathBasedFilter.createSourceFilterExclusiveFilterExcludeOnlyLiteral(
+                        excludes,
+                        filtersMatchFieldNamesWithDots,
+                        dottedPathExcludes
+                    );
+                }
+            } else {
+                excludeFilter = new FilterPathBasedFilter(excludes, false, filtersMatchFieldNamesWithDots);
+            }
+            filtered = new FilteringParserDelegate(filtered, excludeFilter, true, true);
         }
         if (includes != null) {
             filtered = new FilteringParserDelegate(

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
@@ -47,13 +47,110 @@ public class FilterPathBasedFilter extends TokenFilter {
 
     private final boolean matchFieldNamesWithDots;
 
+    /**
+     * When {@code true}, empty objects whose contents were fully excluded are still emitted so a
+     * downstream inclusive filter (or implicit match-all includes) can keep them if they match an
+     * include pattern (map-filter parity).
+     */
+    private final boolean preserveEmptyObjectsForDownstreamIncludes;
+
+    /**
+     * When {@code true}, {@link #includeEmptyObject(boolean)} applies to the object value of an array
+     * element. Map filtering drops empty array elements, but keeps empty object fields nested inside
+     * an array element when an include matches the object path.
+     */
+    private final boolean arrayElementRoot;
+
+    /**
+     * When {@code true}, empty arrays whose elements were fully excluded are still emitted. Used for
+     * source-filter exclude-only filtering where empty includes imply match-all (map-filter parity).
+     */
+    private final boolean preserveEmptyArraysForImplicitIncludeAll;
+
+    private final boolean deferIncompleteMatches;
+
     public FilterPathBasedFilter(FilterPath[] filters, boolean inclusive, boolean matchFieldNamesWithDots) {
+        this(filters, inclusive, matchFieldNamesWithDots, false, false, false, false);
+    }
+
+    /**
+     * Creates an exclusive filter for parser-based streaming.
+     */
+    public static FilterPathBasedFilter createParserExclusiveFilter(FilterPath[] filters, boolean matchFieldNamesWithDots) {
+        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, false, false, false, false);
+    }
+
+    /**
+     * Creates an exclusive filter for source-filter bytes filtering with map parity for exclude-only patterns.
+     */
+    /**
+     * Map-parity exclude filter for source filtering when includes are configured.
+     */
+    public static FilterPathBasedFilter createSourceFilterExclusiveFilterWithIncludes(
+        FilterPath[] filters,
+        boolean matchFieldNamesWithDots
+    ) {
+        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, true, false, false, false);
+    }
+
+    /**
+     * Map-parity exclude filter for exclude-only source filtering without wildcard excludes.
+     */
+    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyLiteral(
+        FilterPath[] filters,
+        boolean matchFieldNamesWithDots,
+        boolean dottedPathExcludes
+    ) {
+        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, dottedPathExcludes, false, dottedPathExcludes, false);
+    }
+
+    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyLiteral(
+        FilterPath[] filters,
+        boolean matchFieldNamesWithDots
+    ) {
+        return createSourceFilterExclusiveFilterExcludeOnlyLiteral(filters, matchFieldNamesWithDots, true);
+    }
+
+    /**
+     * Map-parity exclude filter for exclude-only source filtering with wildcard excludes.
+     */
+    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyWildcard(
+        FilterPath[] filters,
+        boolean matchFieldNamesWithDots
+    ) {
+        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, true, false, true, true);
+    }
+
+    public static FilterPathBasedFilter createSourceFilterExclusiveFilter(
+        FilterPath[] filters,
+        boolean matchFieldNamesWithDots,
+        boolean wildcardExcludes
+    ) {
+        if (wildcardExcludes) {
+            return createSourceFilterExclusiveFilterExcludeOnlyWildcard(filters, matchFieldNamesWithDots);
+        }
+        return createSourceFilterExclusiveFilterExcludeOnlyLiteral(filters, matchFieldNamesWithDots);
+    }
+
+    private FilterPathBasedFilter(
+        FilterPath[] filters,
+        boolean inclusive,
+        boolean matchFieldNamesWithDots,
+        boolean preserveEmptyObjectsForDownstreamIncludes,
+        boolean arrayElementRoot,
+        boolean preserveEmptyArraysForImplicitIncludeAll,
+        boolean deferIncompleteMatches
+    ) {
         if (filters == null || filters.length == 0) {
             throw new IllegalArgumentException("filters cannot be null or empty");
         }
         this.inclusive = inclusive;
         this.filters = filters;
         this.matchFieldNamesWithDots = matchFieldNamesWithDots;
+        this.preserveEmptyObjectsForDownstreamIncludes = preserveEmptyObjectsForDownstreamIncludes;
+        this.arrayElementRoot = arrayElementRoot;
+        this.preserveEmptyArraysForImplicitIncludeAll = preserveEmptyArraysForImplicitIncludeAll;
+        this.deferIncompleteMatches = deferIncompleteMatches;
     }
 
     public FilterPathBasedFilter(Set<String> filters, boolean inclusive) {
@@ -67,7 +164,7 @@ public class FilterPathBasedFilter extends TokenFilter {
         if (filterPaths != null) {
             List<FilterPath> nextFilters = new ArrayList<>();
             for (FilterPath filter : filterPaths) {
-                boolean matches = filter.matches(name, nextFilters, matchFieldNamesWithDots);
+                boolean matches = filter.matches(name, nextFilters, matchFieldNamesWithDots, deferIncompleteMatches);
                 if (matches) {
                     return MATCHING;
                 }
@@ -77,7 +174,11 @@ public class FilterPathBasedFilter extends TokenFilter {
                 return new FilterPathBasedFilter(
                     nextFilters.toArray(new FilterPath[nextFilters.size()]),
                     inclusive,
-                    matchFieldNamesWithDots
+                    matchFieldNamesWithDots,
+                    preserveEmptyObjectsForDownstreamIncludes,
+                    false,
+                    preserveEmptyArraysForImplicitIncludeAll,
+                    deferIncompleteMatches
                 );
             }
         }
@@ -94,6 +195,19 @@ public class FilterPathBasedFilter extends TokenFilter {
             return inclusive ? null : TokenFilter.INCLUDE_ALL;
         }
         return filter;
+    }
+
+    @Override
+    public TokenFilter includeElement(int index) {
+        return new FilterPathBasedFilter(
+            filters,
+            inclusive,
+            matchFieldNamesWithDots,
+            preserveEmptyObjectsForDownstreamIncludes,
+            true,
+            preserveEmptyArraysForImplicitIncludeAll,
+            deferIncompleteMatches
+        );
     }
 
     /**
@@ -118,17 +232,36 @@ public class FilterPathBasedFilter extends TokenFilter {
      */
     @Override
     public boolean includeEmptyArray(boolean contentsFiltered) {
-        return inclusive == false && contentsFiltered == false;
+        if (inclusive == false) {
+            if (contentsFiltered && preserveEmptyArraysForImplicitIncludeAll) {
+                return true;
+            }
+            return contentsFiltered == false;
+        }
+        return super.includeEmptyArray(contentsFiltered);
     }
 
     /**
      * This is overridden in order to keep empty objects in nested exclusions - see #109668.
      * <p>
-     * The same logic applies to this as to {@link #includeEmptyArray(boolean)}, only for nested objects instead of nested arrays.
+     * Map filtering keeps empty object fields when an include matches the object path, but drops
+     * empty objects from arrays when all of their properties are excluded.
      */
     @Override
     public boolean includeEmptyObject(boolean contentsFiltered) {
-        return inclusive == false && contentsFiltered == false;
+        if (inclusive == false) {
+            if (arrayElementRoot) {
+                return false;
+            }
+            if (contentsFiltered) {
+                if (preserveEmptyObjectsForDownstreamIncludes) {
+                    return true;
+                }
+                return false;
+            }
+            return true;
+        }
+        return super.includeEmptyObject(contentsFiltered);
     }
 
     @Override

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
@@ -79,10 +79,7 @@ public class FilterPathBasedFilter extends TokenFilter {
      * @param matchFieldNamesWithDots whether dots in field names are treated as path separators
      * @return an exclusive filter with wildcard backtracking and empty-container preservation
      */
-    public static FilterPathBasedFilter createSourceFilterExclusiveWildcardFilter(
-        FilterPath[] filters,
-        boolean matchFieldNamesWithDots
-    ) {
+    public static FilterPathBasedFilter createSourceFilterExclusiveWildcardFilter(FilterPath[] filters, boolean matchFieldNamesWithDots) {
         return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, true, false, true, true);
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/filtering/FilterPathBasedFilter.java
@@ -48,11 +48,10 @@ public class FilterPathBasedFilter extends TokenFilter {
     private final boolean matchFieldNamesWithDots;
 
     /**
-     * When {@code true}, empty objects whose contents were fully excluded are still emitted so a
-     * downstream inclusive filter (or implicit match-all includes) can keep them if they match an
-     * include pattern (map-filter parity).
+     * When {@code true}, empty object fields whose contents were fully excluded are still emitted to
+     * match exclude-only map filtering.
      */
-    private final boolean preserveEmptyObjectsForDownstreamIncludes;
+    private final boolean preserveEmptyObjectsForMapParity;
 
     /**
      * When {@code true}, {@link #includeEmptyObject(boolean)} applies to the object value of an array
@@ -74,69 +73,24 @@ public class FilterPathBasedFilter extends TokenFilter {
     }
 
     /**
-     * Creates an exclusive filter for parser-based streaming.
-     */
-    public static FilterPathBasedFilter createParserExclusiveFilter(FilterPath[] filters, boolean matchFieldNamesWithDots) {
-        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, false, false, false, false);
-    }
-
-    /**
-     * Creates an exclusive filter for source-filter bytes filtering with map parity for exclude-only patterns.
-     */
-    /**
-     * Map-parity exclude filter for source filtering when includes are configured.
-     */
-    public static FilterPathBasedFilter createSourceFilterExclusiveFilterWithIncludes(
-        FilterPath[] filters,
-        boolean matchFieldNamesWithDots
-    ) {
-        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, true, false, false, false);
-    }
-
-    /**
-     * Map-parity exclude filter for exclude-only source filtering without wildcard excludes.
-     */
-    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyLiteral(
-        FilterPath[] filters,
-        boolean matchFieldNamesWithDots,
-        boolean dottedPathExcludes
-    ) {
-        return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, dottedPathExcludes, false, dottedPathExcludes, false);
-    }
-
-    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyLiteral(
-        FilterPath[] filters,
-        boolean matchFieldNamesWithDots
-    ) {
-        return createSourceFilterExclusiveFilterExcludeOnlyLiteral(filters, matchFieldNamesWithDots, true);
-    }
-
-    /**
      * Map-parity exclude filter for exclude-only source filtering with wildcard excludes.
+     *
+     * @param filters compiled exclude paths
+     * @param matchFieldNamesWithDots whether dots in field names are treated as path separators
+     * @return an exclusive filter with wildcard backtracking and empty-container preservation
      */
-    public static FilterPathBasedFilter createSourceFilterExclusiveFilterExcludeOnlyWildcard(
+    public static FilterPathBasedFilter createSourceFilterExclusiveWildcardFilter(
         FilterPath[] filters,
         boolean matchFieldNamesWithDots
     ) {
         return new FilterPathBasedFilter(filters, false, matchFieldNamesWithDots, true, false, true, true);
     }
 
-    public static FilterPathBasedFilter createSourceFilterExclusiveFilter(
-        FilterPath[] filters,
-        boolean matchFieldNamesWithDots,
-        boolean wildcardExcludes
-    ) {
-        if (wildcardExcludes) {
-            return createSourceFilterExclusiveFilterExcludeOnlyWildcard(filters, matchFieldNamesWithDots);
-        }
-        return createSourceFilterExclusiveFilterExcludeOnlyLiteral(filters, matchFieldNamesWithDots);
-    }
-
     private FilterPathBasedFilter(
         FilterPath[] filters,
         boolean inclusive,
         boolean matchFieldNamesWithDots,
-        boolean preserveEmptyObjectsForDownstreamIncludes,
+        boolean preserveEmptyObjectsForMapParity,
         boolean arrayElementRoot,
         boolean preserveEmptyArraysForImplicitIncludeAll,
         boolean deferIncompleteMatches
@@ -147,7 +101,7 @@ public class FilterPathBasedFilter extends TokenFilter {
         this.inclusive = inclusive;
         this.filters = filters;
         this.matchFieldNamesWithDots = matchFieldNamesWithDots;
-        this.preserveEmptyObjectsForDownstreamIncludes = preserveEmptyObjectsForDownstreamIncludes;
+        this.preserveEmptyObjectsForMapParity = preserveEmptyObjectsForMapParity;
         this.arrayElementRoot = arrayElementRoot;
         this.preserveEmptyArraysForImplicitIncludeAll = preserveEmptyArraysForImplicitIncludeAll;
         this.deferIncompleteMatches = deferIncompleteMatches;
@@ -175,7 +129,7 @@ public class FilterPathBasedFilter extends TokenFilter {
                     nextFilters.toArray(new FilterPath[nextFilters.size()]),
                     inclusive,
                     matchFieldNamesWithDots,
-                    preserveEmptyObjectsForDownstreamIncludes,
+                    preserveEmptyObjectsForMapParity,
                     false,
                     preserveEmptyArraysForImplicitIncludeAll,
                     deferIncompleteMatches
@@ -203,7 +157,7 @@ public class FilterPathBasedFilter extends TokenFilter {
             filters,
             inclusive,
             matchFieldNamesWithDots,
-            preserveEmptyObjectsForDownstreamIncludes,
+            preserveEmptyObjectsForMapParity,
             true,
             preserveEmptyArraysForImplicitIncludeAll,
             deferIncompleteMatches
@@ -254,7 +208,7 @@ public class FilterPathBasedFilter extends TokenFilter {
                 return false;
             }
             if (contentsFiltered) {
-                if (preserveEmptyObjectsForDownstreamIncludes) {
+                if (preserveEmptyObjectsForMapParity) {
                     return true;
                 }
                 return false;

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParserConfiguration.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParserConfiguration.java
@@ -83,11 +83,10 @@ public interface XContentParserConfiguration {
     );
 
     /**
-     * Like {@link #withFiltering(String, Set, Set, boolean)} but configures exclude-only streaming to match
-     * map-based source filtering when includes are empty (implicit include-all). Used by source bytes filtering
-     * in the server module.
+     * Configures exclude-only wildcard filtering that preserves map-based source-filter semantics for empty containers and wildcard suffix
+     * matching. This specialized mode is used only for safe wildcard patterns selected by the server's source filter.
      */
-    XContentParserConfiguration withSourceFilterFiltering(
+    XContentParserConfiguration withSourceFilterWildcardFiltering(
         String prefixPath,
         Set<String> includeStrings,
         Set<String> excludeStrings,

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParserConfiguration.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParserConfiguration.java
@@ -81,4 +81,16 @@ public interface XContentParserConfiguration {
         Set<String> excludeStrings,
         boolean filtersMatchFieldNamesWithDots
     );
+
+    /**
+     * Like {@link #withFiltering(String, Set, Set, boolean)} but configures exclude-only streaming to match
+     * map-based source filtering when includes are empty (implicit include-all). Used by source bytes filtering
+     * in the server module.
+     */
+    XContentParserConfiguration withSourceFilterFiltering(
+        String prefixPath,
+        Set<String> includeStrings,
+        Set<String> excludeStrings,
+        boolean filtersMatchFieldNamesWithDots
+    );
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
@@ -92,7 +92,13 @@ public class FilterPath {
     }
 
     /**
-     * @param deferIncompleteMatches when {@code true}, enable map-parity suffix backtracking for source filtering
+     * Matches a field name while optionally retaining incomplete wildcard matches across nested objects.
+     *
+     * @param name field name to match
+     * @param nextFilters receives filters that may match child fields
+     * @param matchFieldNamesWithDots whether dots in field names are treated as path separators
+     * @param deferIncompleteMatches whether to enable map-parity suffix backtracking across nested objects
+     * @return {@code true} if the field name completes this filter path
      */
     public boolean matches(String name, List<FilterPath> nextFilters, boolean matchFieldNamesWithDots, boolean deferIncompleteMatches) {
         if (nextFilters == null) {
@@ -104,16 +110,17 @@ public class FilterPath {
             // contains dot and not the first or last char
             int dotIndex = name.indexOf('.');
             if ((dotIndex != -1) && (dotIndex != 0) && (dotIndex != name.length() - 1)) {
-                return matchFieldNamesWithDots(name, dotIndex, nextFilters, deferIncompleteMatches);
+                return matchFieldNamesWithDots(name, dotIndex, nextFilters);
             }
         }
         return matchSegment(name, nextFilters, deferIncompleteMatches);
     }
 
-    private boolean matchFieldNamesWithDots(String name, int dotIndex, List<FilterPath> nextFilters, boolean deferIncompleteMatches) {
+    private boolean matchFieldNamesWithDots(String name, int dotIndex, List<FilterPath> nextFilters) {
         String prefixName = name.substring(0, dotIndex);
         String suffixName = name.substring(dotIndex + 1);
         List<FilterPath> prefixFilterPath = new ArrayList<>();
+        // Defer only across nested object fields, not across segments of one field name containing dots.
         boolean prefixMatch = matches(prefixName, prefixFilterPath, true, false);
         // if prefixMatch return true(because prefix is a final FilterPath node)
         if (prefixMatch) {
@@ -158,22 +165,30 @@ public class FilterPath {
 
         if (isDoubleWildcard) {
             nextFilters.add(this);
-        } else if (deferIncompleteMatches
+        } else if (shouldDeferWildcardMatch(nextFilters, nextFiltersSizeBefore, deferIncompleteMatches)) {
+            nextFilters.add(this);
+        } else if (shouldDeferSuffixMatch(nextFilters, nextFiltersSizeBefore, deferIncompleteMatches)) {
+            nextFilters.add(this);
+        }
+
+        return false;
+    }
+
+    private boolean shouldDeferWildcardMatch(List<FilterPath> nextFilters, int nextFiltersSizeBefore, boolean deferIncompleteMatches) {
+        return deferIncompleteMatches
             && WILDCARD.equals(pattern)
             && isFinalNode == false
             && hasPendingChildren()
-            && nextFilters.size() == nextFiltersSizeBefore) {
-                nextFilters.add(this);
-            } else if (deferIncompleteMatches
-                && deferSuffixAcrossObjects
-                && isFinalNode == false
-                && pattern.isEmpty() == false
-                && hasPendingChildren()
-                && nextFilters.size() == nextFiltersSizeBefore) {
-                    nextFilters.add(this);
-                }
+            && nextFilters.size() == nextFiltersSizeBefore;
+    }
 
-        return false;
+    private boolean shouldDeferSuffixMatch(List<FilterPath> nextFilters, int nextFiltersSizeBefore, boolean deferIncompleteMatches) {
+        return deferIncompleteMatches
+            && deferSuffixAcrossObjects
+            && isFinalNode == false
+            && pattern.isEmpty() == false
+            && hasPendingChildren()
+            && nextFilters.size() == nextFiltersSizeBefore;
     }
 
     private boolean hasPendingChildren() {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/filtering/FilterPath.java
@@ -30,13 +30,25 @@ public class FilterPath {
     private final String pattern;
     private final boolean isDoubleWildcard;
     private final boolean isFinalNode;
+    /**
+     * When {@code true}, an incomplete suffix match on this node may still match at a deeper object nesting level. Set for nodes
+     * beneath a single-segment {@code *} wildcard (map parity); not set under {@code **}.
+     */
+    private final boolean deferSuffixAcrossObjects;
 
-    private FilterPath(String pattern, boolean isFinalNode, Map<String, FilterPath> termsChildren, FilterPath[] wildcardChildren) {
+    private FilterPath(
+        String pattern,
+        boolean isFinalNode,
+        Map<String, FilterPath> termsChildren,
+        FilterPath[] wildcardChildren,
+        boolean deferSuffixAcrossObjects
+    ) {
         this.pattern = pattern;
         this.isFinalNode = isFinalNode;
         this.termsChildren = Collections.unmodifiableMap(termsChildren);
         this.wildcardChildren = wildcardChildren;
         this.isDoubleWildcard = pattern.equals(DOUBLE_WILDCARD);
+        this.deferSuffixAcrossObjects = deferSuffixAcrossObjects;
     }
 
     public boolean hasDoubleWildcard() {
@@ -75,7 +87,14 @@ public class FilterPath {
      * @param matchFieldNamesWithDots support dot in field name or not
      * @return true if the name equal a final node, otherwise return false
      */
-    public boolean matches(String name, List<FilterPath> nextFilters, boolean matchFieldNamesWithDots) { // << here
+    public boolean matches(String name, List<FilterPath> nextFilters, boolean matchFieldNamesWithDots) {
+        return matches(name, nextFilters, matchFieldNamesWithDots, false);
+    }
+
+    /**
+     * @param deferIncompleteMatches when {@code true}, enable map-parity suffix backtracking for source filtering
+     */
+    public boolean matches(String name, List<FilterPath> nextFilters, boolean matchFieldNamesWithDots, boolean deferIncompleteMatches) {
         if (nextFilters == null) {
             return false;
         }
@@ -85,9 +104,38 @@ public class FilterPath {
             // contains dot and not the first or last char
             int dotIndex = name.indexOf('.');
             if ((dotIndex != -1) && (dotIndex != 0) && (dotIndex != name.length() - 1)) {
-                return matchFieldNamesWithDots(name, dotIndex, nextFilters);
+                return matchFieldNamesWithDots(name, dotIndex, nextFilters, deferIncompleteMatches);
             }
         }
+        return matchSegment(name, nextFilters, deferIncompleteMatches);
+    }
+
+    private boolean matchFieldNamesWithDots(String name, int dotIndex, List<FilterPath> nextFilters, boolean deferIncompleteMatches) {
+        String prefixName = name.substring(0, dotIndex);
+        String suffixName = name.substring(dotIndex + 1);
+        List<FilterPath> prefixFilterPath = new ArrayList<>();
+        boolean prefixMatch = matches(prefixName, prefixFilterPath, true, false);
+        // if prefixMatch return true(because prefix is a final FilterPath node)
+        if (prefixMatch) {
+            return true;
+        }
+        // if has prefixNextFilter, use them to match suffix
+        for (FilterPath filter : prefixFilterPath) {
+            boolean matches = filter.matches(suffixName, nextFilters, true, false);
+            if (matches) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Match one path segment against this node. When {@code deferIncompleteMatches} is {@code true}, keep this node active if
+     * the segment did not complete the pattern but the pattern suffix may still match at a deeper nesting level (map parity).
+     */
+    private boolean matchSegment(String name, List<FilterPath> nextFilters, boolean deferIncompleteMatches) {
+        int nextFiltersSizeBefore = nextFilters.size();
+
         FilterPath termNode = termsChildren.get(name);
         if (termNode != null) {
             if (termNode.isFinalNode()) {
@@ -110,28 +158,26 @@ public class FilterPath {
 
         if (isDoubleWildcard) {
             nextFilters.add(this);
-        }
+        } else if (deferIncompleteMatches
+            && WILDCARD.equals(pattern)
+            && isFinalNode == false
+            && hasPendingChildren()
+            && nextFilters.size() == nextFiltersSizeBefore) {
+                nextFilters.add(this);
+            } else if (deferIncompleteMatches
+                && deferSuffixAcrossObjects
+                && isFinalNode == false
+                && pattern.isEmpty() == false
+                && hasPendingChildren()
+                && nextFilters.size() == nextFiltersSizeBefore) {
+                    nextFilters.add(this);
+                }
 
         return false;
     }
 
-    private boolean matchFieldNamesWithDots(String name, int dotIndex, List<FilterPath> nextFilters) {
-        String prefixName = name.substring(0, dotIndex);
-        String suffixName = name.substring(dotIndex + 1);
-        List<FilterPath> prefixFilterPath = new ArrayList<>();
-        boolean prefixMatch = matches(prefixName, prefixFilterPath, true);
-        // if prefixMatch return true(because prefix is a final FilterPath node)
-        if (prefixMatch) {
-            return true;
-        }
-        // if has prefixNextFilter, use them to match suffix
-        for (FilterPath filter : prefixFilterPath) {
-            boolean matches = filter.matches(suffixName, nextFilters, true);
-            if (matches) {
-                return true;
-            }
-        }
-        return false;
+    private boolean hasPendingChildren() {
+        return termsChildren.isEmpty() == false || wildcardChildren.length > 0;
     }
 
     private static class FilterPathBuilder {
@@ -153,7 +199,7 @@ public class FilterPath {
         }
 
         FilterPath build() {
-            return buildPath("", root);
+            return buildPath("", root, false);
         }
 
         static void insertNode(String filter, BuildNode node, int depth) {
@@ -188,20 +234,32 @@ public class FilterPath {
             }
         }
 
-        static FilterPath buildPath(String segment, BuildNode node) {
+        static FilterPath buildPath(String segment, BuildNode node, boolean deferSuffixAcrossObjects) {
             Map<String, FilterPath> termsChildren = new HashMap<>();
             List<FilterPath> wildcardChildren = new ArrayList<>();
             for (Map.Entry<String, BuildNode> entry : node.children.entrySet()) {
                 String childName = entry.getKey();
                 BuildNode childNode = entry.getValue();
-                FilterPath childFilterPath = buildPath(childName, childNode);
+                boolean childDeferSuffixAcrossObjects = deferSuffixAcrossObjects;
+                if (WILDCARD.equals(childName)) {
+                    childDeferSuffixAcrossObjects = true;
+                } else if (DOUBLE_WILDCARD.equals(childName)) {
+                    childDeferSuffixAcrossObjects = false;
+                }
+                FilterPath childFilterPath = buildPath(childName, childNode, childDeferSuffixAcrossObjects);
                 if (childName.contains(WILDCARD)) {
                     wildcardChildren.add(childFilterPath);
                 } else {
                     termsChildren.put(childName, childFilterPath);
                 }
             }
-            return new FilterPath(segment, node.isFinalNode, termsChildren, wildcardChildren.toArray(new FilterPath[0]));
+            return new FilterPath(
+                segment,
+                node.isFinalNode,
+                termsChildren,
+                wildcardChildren.toArray(new FilterPath[0]),
+                deferSuffixAcrossObjects
+            );
         }
     }
 

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
@@ -25,6 +25,131 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class FilterPathTests extends ESTestCase {
+    public void testWildcardObj3PathMatching() {
+        FilterPath[] filterPaths = FilterPath.compile(singleton("*.obj3"));
+        List<FilterPath> nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("obj1", nextFilters, true, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterObj1 = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterObj1.matches("obj2", nextFilters, true, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterObj2 = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterObj2.matches("obj3", nextFilters, true, true), is(true));
+    }
+
+    public void testWildcardExcludeMatchesNestedLeaf() {
+        FilterPath[] filterPaths = FilterPath.compile(singleton("*.obj2"));
+        List<FilterPath> nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("obj1", nextFilters, true, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterObj1 = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterObj1.matches("obj2", nextFilters, true, true), is(true));
+        assertEquals(0, nextFilters.size());
+
+        filterPaths = FilterPath.compile(singleton("*.obj3"));
+        nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("obj1", nextFilters, true, true), is(false));
+        assertEquals(1, nextFilters.size());
+        afterObj1 = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterObj1.matches("obj2", nextFilters, true, true), is(false));
+        assertEquals(1, nextFilters.size());
+        FilterPath afterObj2 = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterObj2.matches("obj3", nextFilters, true, true), is(true));
+    }
+
+    public void testDeferredMatchStarFooBarAfterIntermediateSegment() {
+        assertTrue(matchesSegments("*.foo.bar", "b", "foo", "bar"));
+        assertFalse(matchesSegments("*.foo.bar", "b", "foo", "x"));
+
+        List<FilterPath> nextFilters = new ArrayList<>();
+        FilterPath[] filterPaths = FilterPath.compile(singleton("*.foo.bar"));
+        assertThat(filterPaths[0].matches("a", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterA = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterA.matches("foo", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterFoo = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterFoo.matches("inner", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterInner = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterInner.matches("foo", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterInnerFoo = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterInnerFoo.matches("bar", nextFilters, false, true), is(true));
+    }
+
+    public void testDeferredMatchStarWildcardSuffix() {
+        assertTrue(matchesSegments("*.obj*", "b", "obj2", "objX"));
+        assertTrue(matchesSegments("*.obj*", "a", "obj1"));
+
+        FilterPath[] filterPaths = FilterPath.compile(singleton("*.obj*"));
+        List<FilterPath> nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("a", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterA = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterA.matches("obj1", nextFilters, false, true), is(true));
+    }
+
+    public void testDeferredMatchFooStarBar() {
+        assertTrue(matchesSegments("foo.*.bar", "foo", "middle", "bar"));
+        assertFalse(matchesSegments("foo.*.bar", "foo", "middle", "baz"));
+
+        FilterPath[] filterPaths = FilterPath.compile(singleton("foo.*.bar"));
+        List<FilterPath> nextFilters = new ArrayList<>();
+        assertThat(filterPaths[0].matches("foo", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterFoo = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterFoo.matches("middle", nextFilters, false, true), is(false));
+        assertEquals(1, nextFilters.size());
+
+        FilterPath afterMiddle = nextFilters.get(0);
+        nextFilters = new ArrayList<>();
+        assertThat(afterMiddle.matches("bar", nextFilters, false, true), is(true));
+    }
+
+    private static boolean matchesSegments(String pattern, String... segments) {
+        FilterPath[] filterPaths = FilterPath.compile(singleton(pattern));
+        List<FilterPath> active = new ArrayList<>();
+        active.add(filterPaths[0]);
+        for (String segment : segments) {
+            List<FilterPath> next = new ArrayList<>();
+            boolean matched = false;
+            for (FilterPath filter : active) {
+                if (filter.matches(segment, next, false, true)) {
+                    matched = true;
+                }
+            }
+            if (matched) {
+                return true;
+            }
+            active = next;
+            if (active.isEmpty()) {
+                return false;
+            }
+        }
+        return false;
+    }
+
     public void testSimpleFilterPath() {
         final String input = "test";
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -38,6 +38,11 @@ public final class SourceFilter {
     private Function<Map<String, Object>, Map<String, Object>> mapFilter = null;
     private Function<Source, Source> bytesFilter = null;
 
+    /**
+     * Streaming bytes filtering is only used when parity with map filtering is established for the
+     * configured patterns. Wildcard excludes that do not contain a {@code .} segment (for example
+     * {@code array*}) can produce invalid JSON in the streaming filter and continue to use the map path.
+     */
     private final boolean canFilterBytes;
     private final boolean empty;
     private final String[] includes;
@@ -53,11 +58,29 @@ public final class SourceFilter {
     public SourceFilter(String[] includes, String[] excludes) {
         this.includes = includes == null ? Strings.EMPTY_ARRAY : includes;
         this.excludes = excludes == null ? Strings.EMPTY_ARRAY : excludes;
-        // TODO: Remove this once we upgrade to Jackson 2.14. There is currently a bug
-        // in exclude filtering if one of the excludes contains a wildcard '*'.
-        // see https://github.com/FasterXML/jackson-core/pull/729
-        this.canFilterBytes = CollectionUtils.isEmpty(excludes) || Arrays.stream(excludes).noneMatch(field -> field.contains("*"));
-        this.empty = CollectionUtils.isEmpty(this.includes) && CollectionUtils.isEmpty(this.excludes);
+        this.canFilterBytes = canFilterBytes(this.includes, this.excludes);
+        this.empty = this.includes.length == 0 && this.excludes.length == 0;
+    }
+
+    /**
+     * Returns whether bytes streaming can be used for this filter configuration.
+     */
+    static boolean canFilterBytes(String[] includes, String[] excludes) {
+        if (CollectionUtils.isEmpty(excludes)) {
+            return true;
+        }
+        if (includes.length > 0 && excludes.length > 0) {
+            return false;
+        }
+        for (String exclude : excludes) {
+            if (exclude.contains("**")) {
+                return false;
+            }
+            if (exclude.contains("*") && exclude.contains(".") == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public String[] getIncludes() {
@@ -160,7 +183,7 @@ public final class SourceFilter {
         if (canFilterBytes == false) {
             return this::filterMap;
         }
-        final XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withFiltering(
+        final XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withSourceFilterFiltering(
             null,
             Set.copyOf(Arrays.asList(includes)),
             Set.copyOf(Arrays.asList(excludes)),

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -69,15 +69,14 @@ public final class SourceFilter {
         if (CollectionUtils.isEmpty(excludes)) {
             return true;
         }
-        if (includes.length > 0 && excludes.length > 0) {
-            return false;
-        }
         for (String exclude : excludes) {
             if (exclude.contains("**")) {
                 return false;
             }
-            if (exclude.contains("*") && exclude.contains(".") == false) {
-                return false;
+            if (exclude.contains("*")) {
+                if (includes.length > 0 || exclude.contains(".") == false) {
+                    return false;
+                }
             }
         }
         return true;
@@ -183,12 +182,12 @@ public final class SourceFilter {
         if (canFilterBytes == false) {
             return this::filterMap;
         }
-        final XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withSourceFilterFiltering(
-            null,
-            Set.copyOf(Arrays.asList(includes)),
-            Set.copyOf(Arrays.asList(excludes)),
-            true
-        );
+        Set<String> includePaths = Set.copyOf(Arrays.asList(includes));
+        Set<String> excludePaths = Set.copyOf(Arrays.asList(excludes));
+        boolean hasWildcardExcludes = Arrays.stream(excludes).anyMatch(exclude -> exclude.contains("*"));
+        final XContentParserConfiguration parserConfig = hasWildcardExcludes
+            ? XContentParserConfiguration.EMPTY.withSourceFilterWildcardFiltering(null, includePaths, excludePaths, true)
+            : XContentParserConfiguration.EMPTY.withFiltering(null, includePaths, excludePaths, true);
         return in -> {
             try {
                 BytesStreamOutput streamOutput = new BytesStreamOutput(1024);

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -503,6 +503,29 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(((Map<String, Object>) filteredSource.get("obj")).size(), equalTo(0));
     }
 
+    @SuppressWarnings("unchecked")
+    public void testWildcardExcludeDeferredSuffixMapParity() {
+        Map<String, Object> doc = Map.of("a", Map.of("obj1", Map.of()), "b", Map.of("obj2", Map.of("objX", "v")));
+        Map<String, Object> filtered = XContentMapValues.filter(doc, Strings.EMPTY_ARRAY, new String[] { "*.obj*" });
+        assertThat(filtered, equalTo(Map.of("a", Map.of(), "b", Map.of())));
+
+        doc = Map.of("a", Map.of("foo", Map.of("x", 1)), "b", Map.of("foo", Map.of("bar", Map.of("v", 1))));
+        filtered = XContentMapValues.filter(doc, Strings.EMPTY_ARRAY, new String[] { "*.foo.bar" });
+        assertThat(filtered, equalTo(Map.of("a", Map.of("foo", Map.of("x", 1)), "b", Map.of("foo", Map.of()))));
+
+        doc = Map.of("foo", Map.of("middle", Map.of("bar", Map.of("v", 1))));
+        filtered = XContentMapValues.filter(doc, Strings.EMPTY_ARRAY, new String[] { "foo.*.bar" });
+        assertThat(filtered, equalTo(Map.of("foo", Map.of("middle", Map.of()))));
+
+        doc = Map.of("myArray", List.of(Map.of("myObject", Map.of("excluded", "x"))));
+        filtered = XContentMapValues.filter(doc, new String[] { "myArray.myObject" }, new String[] { "myArray.myObject.excluded" });
+        assertThat(filtered, equalTo(Map.of("myArray", List.of(Map.of("myObject", Map.of())))));
+
+        doc = Map.of("obj1", Map.of("obj2", Map.of("obj3", Map.of())));
+        filtered = XContentMapValues.filter(doc, Strings.EMPTY_ARRAY, new String[] { "*.obj3" });
+        assertThat(filtered, equalTo(Map.of("obj1", Map.of("obj2", Map.of()))));
+    }
+
     @SuppressWarnings({ "unchecked" })
     public void testNotOmittingObjectWithNestedExcludedObject() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -232,7 +233,7 @@ public class SourceFilterTests extends ESTestCase {
         assertTrue(SourceFilter.canFilterBytes(new String[] {}, new String[] { "*.obj3" }));
         assertFalse(SourceFilter.canFilterBytes(new String[] {}, new String[] { "array*" }));
         assertFalse(SourceFilter.canFilterBytes(new String[] { "meta.*" }, new String[] { "meta.other.*" }));
-        assertFalse(SourceFilter.canFilterBytes(new String[] { "myArray" }, new String[] { "myArray.myField" }));
+        assertTrue(SourceFilter.canFilterBytes(new String[] { "myArray" }, new String[] { "myArray.myField" }));
         assertFalse(SourceFilter.canFilterBytes(new String[] {}, new String[] { "**.field" }));
     }
 
@@ -250,6 +251,33 @@ public class SourceFilterTests extends ESTestCase {
         assertEquals(Map.of("obj1", Map.of("obj2", Map.of())), filtered.source());
     }
 
+    public void testWildcardIncludeExcludeUsesMap() {
+        Source s = new Source() {
+            @Override
+            public XContentType sourceContentType() {
+                return XContentType.JSON;
+            }
+
+            @Override
+            public Map<String, Object> source() {
+                return Map.of("obj1", Map.of("obj2", Map.of("obj3", Map.of())));
+            }
+
+            @Override
+            public BytesReference internalSourceRef() {
+                throw new AssertionError("SourceFilter with includes and wildcard excludes should filter on map");
+            }
+
+            @Override
+            public Source filter(SourceFilter sourceFilter) {
+                return sourceFilter.filterBytes(this);
+            }
+        };
+
+        Source filtered = s.filter(new SourceFilter(new String[] { "*.obj2" }, new String[] { "*.obj3" }));
+        assertEquals(Map.of("obj1", Map.of("obj2", Map.of())), filtered.source());
+    }
+
     public void testExcludeWithWildcardsUsesBytes() {
         Source s = new Source() {
             @Override
@@ -259,7 +287,7 @@ public class SourceFilterTests extends ESTestCase {
 
             @Override
             public Map<String, Object> source() {
-                throw new AssertionError("SourceFilter with dotted-path wildcard excludes should filter on bytes");
+                throw new AssertionError("SourceFilter with safe wildcard excludes should filter on bytes");
             }
 
             @Override
@@ -274,24 +302,11 @@ public class SourceFilterTests extends ESTestCase {
             }
         };
 
-        Source filtered = s.filter(new SourceFilter(new String[] {}, new String[] { "nested.drop" }));
+        Source filtered = s.filter(new SourceFilter(new String[] {}, new String[] { "*.drop" }));
         assertTrue(filtered.source().containsKey("field1"));
         assertTrue(filtered.source().containsKey("nested"));
         assertEquals("value3", ((Map<?, ?>) filtered.source().get("nested")).get("keep"));
         assertFalse(((Map<?, ?>) filtered.source().get("nested")).containsKey("drop"));
-    }
-
-    public void testFilterMapBytesParityIncludesAndExcludesPreserveEmptyObject() {
-        assertFilterMapBytesParity("""
-            {
-              "requests": { "count": 10, "foo": "bar" },
-              "meta": {
-                "name": "Some metric",
-                "description": "Some metric description",
-                "other": { "foo": "one", "baz": "two" }
-              }
-            }
-            """, new String[] { "*.count", "meta.*" }, new String[] { "meta.description", "meta.other.*" });
     }
 
     public void testFilterMapBytesParityExcludeOnlyEmptyNestedObject() {
@@ -303,19 +318,19 @@ public class SourceFilterTests extends ESTestCase {
     public void testFilterMapBytesParityExcludeOnlyEmptyArray() {
         assertFilterMapBytesParity("""
             { "myArray": [ { "myField": "v" } ] }
-            """, new String[] {}, new String[] { "myArray.myField" });
+            """, new String[] {}, new String[] { "*.myField" });
     }
 
     public void testFilterMapBytesParityNestedObjectInsideArrayElement() {
         assertFilterMapBytesParity("""
             { "myArray": [ { "myObject": { "excluded": "x" } } ] }
-            """, new String[] { "myArray.myObject" }, new String[] { "myArray.myObject.excluded" });
+            """, new String[] {}, new String[] { "*.excluded" });
     }
 
     public void testFilterMapBytesParityEmptyObjectArrayElement() {
         assertFilterMapBytesParity("""
             { "myArray": [ { "keep": 1 }, {} ] }
-            """, new String[] { "myArray" }, new String[] { "myArray.keep" });
+            """, new String[] {}, new String[] { "*.keep" });
     }
 
     public void testFilterMapBytesParityWildcardSuffixBacktracking() {
@@ -336,29 +351,13 @@ public class SourceFilterTests extends ESTestCase {
             """, new String[] {}, new String[] { "foo.*.bar" });
     }
 
-    public void testFilterMapBytesParityExcludeOnlySingleFieldObject() {
+    public void testFilterMapBytesParityMixedLiteralAndWildcardExcludes() {
         assertFilterMapBytesParity("""
-            { "foo": { "bar": "test" } }
-            """, new String[] {}, new String[] { "foo.bar" });
-    }
-
-    public void testFilterMapBytesParityRandomizedExcludeOnlyLiteralPaths() {
-        for (int i = 0; i < 10; i++) {
-            String field = randomAlphaOfLengthBetween(3, 8);
-            String nested = randomAlphaOfLengthBetween(3, 8);
-            String value = randomAlphaOfLengthBetween(1, 5);
-            assertFilterMapBytesParity(
-                """
-                    { "%s": { "%s": "%s" }, "%s": "%s" }
-                    """.formatted(field, nested, value, randomValueOtherField(field), randomAlphaOfLength(4)),
-                new String[] {},
-                new String[] { field + "." + nested }
-            );
-        }
-    }
-
-    private static String randomValueOtherField(String field) {
-        return field + "Other";
+            {
+              "http": { "secret": "x", "keep": "y" },
+              "meta": { "description": "drop", "keep": "keep" }
+            }
+            """, new String[] {}, new String[] { "http.*", "meta.description" });
     }
 
     private static void assertFilterMapBytesParity(String json, String[] includes, String[] excludes) {
@@ -371,6 +370,9 @@ public class SourceFilterTests extends ESTestCase {
 
     private static void assertFilterMapBytesParity(Source source, String[] includes, String[] excludes) {
         SourceFilter filter = new SourceFilter(includes, excludes);
+        assertTrue(SourceFilter.canFilterBytes(includes, excludes));
+        assertEquals(0, includes.length);
+        assertTrue(Arrays.stream(excludes).anyMatch(exclude -> exclude.contains("*")));
         Map<String, Object> mapFiltered = filter.filterMap(source).source();
         Map<String, Object> bytesFiltered = filter.filterBytes(source).source();
         assertEquals(mapFiltered, bytesFiltered);

--- a/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/SourceFilterTests.java
@@ -227,4 +227,152 @@ public class SourceFilterTests extends ESTestCase {
         assertTrue(new SourceFilter(null, new String[] { x }).isPathFiltered(x, false));
         assertFalse(new SourceFilter(null, new String[] { x }).isPathFiltered(y, false));
     }
+
+    public void testCanFilterBytesRequiresDottedWildcardExcludes() {
+        assertTrue(SourceFilter.canFilterBytes(new String[] {}, new String[] { "*.obj3" }));
+        assertFalse(SourceFilter.canFilterBytes(new String[] {}, new String[] { "array*" }));
+        assertFalse(SourceFilter.canFilterBytes(new String[] { "meta.*" }, new String[] { "meta.other.*" }));
+        assertFalse(SourceFilter.canFilterBytes(new String[] { "myArray" }, new String[] { "myArray.myField" }));
+        assertFalse(SourceFilter.canFilterBytes(new String[] {}, new String[] { "**.field" }));
+    }
+
+    public void testWildcardExcludeEmptyNestedObject() {
+        Source s = Source.fromBytes(new BytesArray("""
+            { "obj1": { "obj2": { "obj3": {} } } }"""), XContentType.JSON);
+        Source filtered = s.filter(new SourceFilter(new String[] {}, new String[] { "*.obj3" }));
+        assertEquals(Map.of("obj1", Map.of("obj2", Map.of())), filtered.source());
+    }
+
+    public void testWildcardIncludeExcludeEmptyNestedObject() {
+        Source s = Source.fromBytes(new BytesArray("""
+            { "obj1": { "obj2": { "obj3": {} } } }"""), XContentType.JSON);
+        Source filtered = s.filter(new SourceFilter(new String[] { "*.obj2" }, new String[] { "*.obj3" }));
+        assertEquals(Map.of("obj1", Map.of("obj2", Map.of())), filtered.source());
+    }
+
+    public void testExcludeWithWildcardsUsesBytes() {
+        Source s = new Source() {
+            @Override
+            public XContentType sourceContentType() {
+                return XContentType.JSON;
+            }
+
+            @Override
+            public Map<String, Object> source() {
+                throw new AssertionError("SourceFilter with dotted-path wildcard excludes should filter on bytes");
+            }
+
+            @Override
+            public BytesReference internalSourceRef() {
+                return new BytesArray("""
+                    { "field1" : "value1", "nested" : { "drop" : "value2", "keep" : "value3" } }""");
+            }
+
+            @Override
+            public Source filter(SourceFilter sourceFilter) {
+                return sourceFilter.filterBytes(this);
+            }
+        };
+
+        Source filtered = s.filter(new SourceFilter(new String[] {}, new String[] { "nested.drop" }));
+        assertTrue(filtered.source().containsKey("field1"));
+        assertTrue(filtered.source().containsKey("nested"));
+        assertEquals("value3", ((Map<?, ?>) filtered.source().get("nested")).get("keep"));
+        assertFalse(((Map<?, ?>) filtered.source().get("nested")).containsKey("drop"));
+    }
+
+    public void testFilterMapBytesParityIncludesAndExcludesPreserveEmptyObject() {
+        assertFilterMapBytesParity("""
+            {
+              "requests": { "count": 10, "foo": "bar" },
+              "meta": {
+                "name": "Some metric",
+                "description": "Some metric description",
+                "other": { "foo": "one", "baz": "two" }
+              }
+            }
+            """, new String[] { "*.count", "meta.*" }, new String[] { "meta.description", "meta.other.*" });
+    }
+
+    public void testFilterMapBytesParityExcludeOnlyEmptyNestedObject() {
+        assertFilterMapBytesParity("""
+            { "obj1": { "obj2": { "obj3": {} } } }
+            """, new String[] {}, new String[] { "*.obj3" });
+    }
+
+    public void testFilterMapBytesParityExcludeOnlyEmptyArray() {
+        assertFilterMapBytesParity("""
+            { "myArray": [ { "myField": "v" } ] }
+            """, new String[] {}, new String[] { "myArray.myField" });
+    }
+
+    public void testFilterMapBytesParityNestedObjectInsideArrayElement() {
+        assertFilterMapBytesParity("""
+            { "myArray": [ { "myObject": { "excluded": "x" } } ] }
+            """, new String[] { "myArray.myObject" }, new String[] { "myArray.myObject.excluded" });
+    }
+
+    public void testFilterMapBytesParityEmptyObjectArrayElement() {
+        assertFilterMapBytesParity("""
+            { "myArray": [ { "keep": 1 }, {} ] }
+            """, new String[] { "myArray" }, new String[] { "myArray.keep" });
+    }
+
+    public void testFilterMapBytesParityWildcardSuffixBacktracking() {
+        assertFilterMapBytesParity("""
+            {
+              "a": { "obj1": {} },
+              "b": { "obj2": { "objX": "v" } }
+            }
+            """, new String[] {}, new String[] { "*.obj*" });
+        assertFilterMapBytesParity("""
+            {
+              "a": { "foo": { "x": 1 } },
+              "b": { "foo": { "bar": { "v": 1 } } }
+            }
+            """, new String[] {}, new String[] { "*.foo.bar" });
+        assertFilterMapBytesParity("""
+            { "foo": { "middle": { "bar": { "v": 1 } } } }
+            """, new String[] {}, new String[] { "foo.*.bar" });
+    }
+
+    public void testFilterMapBytesParityExcludeOnlySingleFieldObject() {
+        assertFilterMapBytesParity("""
+            { "foo": { "bar": "test" } }
+            """, new String[] {}, new String[] { "foo.bar" });
+    }
+
+    public void testFilterMapBytesParityRandomizedExcludeOnlyLiteralPaths() {
+        for (int i = 0; i < 10; i++) {
+            String field = randomAlphaOfLengthBetween(3, 8);
+            String nested = randomAlphaOfLengthBetween(3, 8);
+            String value = randomAlphaOfLengthBetween(1, 5);
+            assertFilterMapBytesParity(
+                """
+                    { "%s": { "%s": "%s" }, "%s": "%s" }
+                    """.formatted(field, nested, value, randomValueOtherField(field), randomAlphaOfLength(4)),
+                new String[] {},
+                new String[] { field + "." + nested }
+            );
+        }
+    }
+
+    private static String randomValueOtherField(String field) {
+        return field + "Other";
+    }
+
+    private static void assertFilterMapBytesParity(String json, String[] includes, String[] excludes) {
+        assertFilterMapBytesParity(Source.fromBytes(new BytesArray(json), XContentType.JSON), includes, excludes);
+    }
+
+    private static void assertFilterMapBytesParity(Map<String, Object> doc, String[] includes, String[] excludes) {
+        assertFilterMapBytesParity(Source.fromMap(doc, XContentType.JSON), includes, excludes);
+    }
+
+    private static void assertFilterMapBytesParity(Source source, String[] includes, String[] excludes) {
+        SourceFilter filter = new SourceFilter(includes, excludes);
+        Map<String, Object> mapFiltered = filter.filterMap(source).source();
+        Map<String, Object> bytesFiltered = filter.filterBytes(source).source();
+        assertEquals(mapFiltered, bytesFiltered);
+    }
 }


### PR DESCRIPTION
## Summary

Use streaming `_source` filtering for safe exclude-only dotted wildcard patterns, while retaining map fallback for wildcard classes without proven parity.

The existing TODO suggested removing the fallback after upgrading Jackson. Simply removing it changes `_source` output: Jackson streaming and map filtering differ when exclusions leave empty objects or arrays, and for some nested wildcard matches. This change adds the required parity behavior and only enables the new streaming path for pattern classes covered by differential tests.

Existing literal and include+exclude configurations retain their previous streaming behavior. Excludes containing `**`, segment-only wildcards without a dotted path, or wildcards combined with non-empty includes continue using map filtering.

## Performance

JMH results for exclude-only `http.*`:

| Source | Streaming | Map | Speedup |
|---|---:|---:|---:|
| 300 B | 1.04 µs | 7.79 µs | 7.5× |
| 4 KB | 4.39 µs | 11.67 µs | 2.7× |
| 4 MB | 3.15 ms | 4.39 ms | 1.4× |

Measured with `FetchSourcePhaseBenchmark.filterSourceBytes` using `excludes=http.*`; this constructs and invokes the production `SourceFilter` path.

## Testing

- Full `:libs:x-content:test`
- `SourceFilterTests`
- `XContentSourceFilterTests`
- Map/streaming differential tests that assert production bytes routing
- Spotless checks

## Risk

The new behavior is limited to exclude-only dotted wildcard patterns. Complex wildcard classes retain map fallback, and pre-existing streaming configurations keep the generic parser path. No output changes are intended.