### PR TITLE
[8.19] Unmute KeystoreManagementTests docker tests (#155192)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -226,7 +226,6 @@ public class KeystoreManagementTests extends PackagingTestCase {
      * Check that we can mount a password-protected keystore to a docker image
      * and provide a password via an environment variable.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/76124")
     public void test40DockerEnvironmentVariablePassword() throws Exception {
         assumeTrue(distribution().isDocker());
 
@@ -238,6 +237,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
             builder().volume(localConfigDir.resolve("config"), installation.config)
                 .envVar("KEYSTORE_PASSWORD", KEYSTORE_PASSWORD)
                 .envVar("ELASTIC_PASSWORD", ELASTIC_PASSWORD)
+                .envVar("discovery.type", "single-node")
         );
         waitForElasticsearch(installation, "elastic", ELASTIC_PASSWORD);
         runElasticsearchTestsAsElastic(ELASTIC_PASSWORD);
@@ -247,7 +247,6 @@ public class KeystoreManagementTests extends PackagingTestCase {
      * Check that we can mount a password-protected keystore to a docker image
      * and provide a password via a file, pointed at from an environment variable.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/76124")
     public void test41DockerEnvironmentVariablePasswordFromFile() throws Exception {
         assumeTrue(distribution().isDocker());
 
@@ -268,6 +267,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
                     .volume(tempDir, "/run/secrets")
                     .envVar("KEYSTORE_PASSWORD_FILE", "/run/secrets/" + passwordFilename)
                     .envVar("ELASTIC_PASSWORD", ELASTIC_PASSWORD)
+                    .envVar("discovery.type", "single-node")
             );
 
             waitForElasticsearch(installation, "elastic", ELASTIC_PASSWORD);
@@ -283,7 +283,6 @@ public class KeystoreManagementTests extends PackagingTestCase {
      * Check that if we provide the wrong password for a mounted and password-protected
      * keystore, Elasticsearch doesn't start.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/76124")
     public void test42DockerEnvironmentVariableBadPassword() throws Exception {
         assumeTrue(distribution().isDocker());
 
@@ -299,6 +298,14 @@ public class KeystoreManagementTests extends PackagingTestCase {
 
     public void test50CreateKeystoreManually() throws Exception {
         // Run this test last so that removing the existing keystore doesn't make subsequent tests fail
+        // This class reuses a single container across test methods, and the docker tests above leave it in a
+        // state this test cannot use: test42 leaves it stopped, because Elasticsearch deliberately fails to
+        // start there, and test40/test41 leave it running with a config directory bind-mounted from the host.
+        // Start a fresh container so the keystore is created in the image's own config directory.
+        if (distribution().isDocker()) {
+            installation = runContainer(distribution());
+        }
+
         rmKeystoreIfExists();
         createKeystore(null);
 
@@ -368,7 +375,13 @@ public class KeystoreManagementTests extends PackagingTestCase {
         sh.run("bash " + dockerTemp.resolve("set-pass.sh"));
 
         // copy keystore to temp file to make it available to docker host
-        sh.run("cp -arf" + dockerKeystore + " " + dockerTemp);
+        sh.run("cp -arf " + dockerKeystore + " " + dockerTemp);
+
+        // Security auto-configuration ran when the source container first started, and it pinned
+        // cluster.initial_master_nodes to that container's hostname. The copied config directory is
+        // remounted into a new container with a different hostname, so remove the setting and let the
+        // callers boot a single-node cluster instead (see the equivalent handling in DockerTests).
+        ServerUtils.removeSettingFromExistingConfiguration(tempDirectory.resolve("config"), "cluster.initial_master_nodes");
         return tempDirectory;
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Unmute KeystoreManagementTests docker tests (#155192)](https://github.com/elastic/elasticsearch/pull/155192)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)