### PR TITLE
EQL: `stringContains` returns null instead of failing when the substring argument is null

### DIFF
--- a/docs/changelog/155301.yaml
+++ b/docs/changelog/155301.yaml
@@ -1,0 +1,6 @@
+pr: 155301
+summary: "EQL: `stringContains` returns null instead of failing when the substring argument is null"
+area: EQL
+type: bug
+issues:
+ - 155300

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessor.java
@@ -52,6 +52,11 @@ public class StringContainsFunctionProcessor implements Processor {
         }
 
         throwIfNotString(string);
+
+        if (substring == null) {
+            return null;
+        }
+
         throwIfNotString(substring);
 
         String strString = string.toString();

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessorTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/StringContainsFunctionProcessorTests.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.xpack.eql.expression.function.scalar.string;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 
 import java.util.Locale;
 import java.util.concurrent.Callable;
 
 import static org.elasticsearch.xpack.eql.expression.function.scalar.string.StringContainsFunctionProcessor.doProcess;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class StringContainsFunctionProcessorTests extends ESTestCase {
 
@@ -37,22 +37,17 @@ public class StringContainsFunctionProcessorTests extends ESTestCase {
             }
             final String string = str;
 
-            // The string parameter can be null. Expect exception if any of other parameters is null.
-            if (string != null && substring == null) {
-                EqlIllegalArgumentException e = expectThrows(
-                    EqlIllegalArgumentException.class,
-                    () -> doProcess(string, substring, insensitive)
-                );
-                assertThat(e.getMessage(), equalTo("A string/char is required; received [null]"));
+            // Either parameter can be null. A null in either argument yields a null result rather than an exception,
+            // matching the lenient null handling of the other EQL string functions (e.g. endsWith, indexOf).
+            if (string == null || substring == null) {
+                assertThat(doProcess(string, substring, insensitive), nullValue());
             } else {
-                assertThat(doProcess(string, substring, insensitive), equalTo(string == null ? null : true));
+                assertThat(doProcess(string, substring, insensitive), equalTo(true));
 
                 // deliberately make the test return "false/true" by lowercasing or uppercasing the substring in a in/sensitive scenario
-                if (substring != null) {
-                    String subsChanged = randomBoolean() ? substring.toLowerCase(Locale.ROOT) : substring.toUpperCase(Locale.ROOT);
-                    if (substring.equals(subsChanged) == false) {
-                        assertThat(doProcess(string, subsChanged, insensitive), equalTo(string == null ? null : insensitive));
-                    }
+                String subsChanged = randomBoolean() ? substring.toLowerCase(Locale.ROOT) : substring.toUpperCase(Locale.ROOT);
+                if (substring.equals(subsChanged) == false) {
+                    assertThat(doProcess(string, subsChanged, insensitive), equalTo(insensitive));
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Related Issues:
Fixes #155300
Related to https://github.com/elastic/detection-rules/pull/6512


## Problem

EQL string functions are documented to handle missing/null field values leniently,
and most of them do — `EndsWithFunctionProcessor` and `IndexOfFunctionProcessor`
null-check both arguments and return `null`.

`StringContainsFunctionProcessor.doProcess` only null-checked its first argument
(`string`). When the second argument (`substring`) resolved to `null` at runtime —
i.e. a missing field in a document — `throwIfNotString(substring)` threw:

```
eql_illegal_argument_exception: A string/char is required; received [null]
```

Because this happens inside the compiled Painless script, the exception fails the
whole shard, and the EQL search returns only partial results
("The EQL event query was only executed on the available shards").

For Elastic Security this manifests as silent partial coverage loss. The prebuilt
rule Potential Computer Account NTLM Relay Activity uses
`not stringContains(string(host.ip), string(source.ip))`; on documents where
`source.ip` is absent, the shard fails.

## Fix

Add a `null` check for the `substring` argument (after validating `string`),
returning `null` — mirroring the lenient null handling already present in
`EndsWithFunctionProcessor` and `IndexOfFunctionProcessor`.

```java
public static Object doProcess(Object string, Object substring, boolean caseInsensitive) {
    if (string == null) {
        return null;
    }

    throwIfNotString(string);

    if (substring == null) {
        return null;
    }

    throwIfNotString(substring);

    String strString = string.toString();
    String strSubstring = substring.toString();

    return StringUtils.stringContains(strString, strSubstring, caseInsensitive);
}
```

With this change, `stringContains(a, b)` where `b` is null now returns `null`
(the row is simply excluded from `where` matches) instead of failing the shard —
symmetric with the already-lenient behaviour when the first argument is null.

## Testing

```
./gradlew :x-pack:plugin:eql:test \
  --tests "org.elasticsearch.xpack.eql.expression.function.scalar.string.StringContainsFunctionProcessorTests"
```

`BUILD SUCCESSFUL` — the randomized `testStringContains` (20 runs/invocation)
now exercises the null-substring path and passes.


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
