### PR TITLE
[Inference API] Cleaning up status code check

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
@@ -78,11 +78,13 @@ public abstract class BaseResponseHandler implements ResponseHandler {
 
     @Override
     public void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result) {
-        checkForFailureStatusCode(outboundRequest, result);
+        if (result.isSuccessfulResponse() == false) {
+            handleFailureStatusCode(outboundRequest, result);
+        }
         checkForEmptyBody(throttlerManager, logger, outboundRequest, result);
     }
 
-    protected abstract void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result);
+    protected abstract void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result);
 
     protected ElasticsearchException buildError(String message, OutboundRequest outboundRequest, HttpResult result) {
         var errorEntityMsg = errorParseFunction.apply(result);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchResponseHandler.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.alibabacloudsearch;
 
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
@@ -25,18 +24,16 @@ public class AlibabaCloudSearchResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
-        if (RestStatus.isSuccessful(statusCode)) {
-            return;
-        }
 
         // handle error codes
         if (statusCode >= 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandler.java
@@ -58,7 +58,8 @@ public class AnthropicResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * The Anthropic API error codes are documented <a href="https://docs.anthropic.com/en/api/errors">here</a>.
      * @param outboundRequest The originating request
@@ -66,11 +67,7 @@ public class AnthropicResponseHandler extends BaseResponseHandler {
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.azureopenai.response;
 
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
@@ -21,13 +20,11 @@ import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
-import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiStreamingProcessor;
 
 import java.util.concurrent.Flow;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForEmptyBody;
 import static org.elasticsearch.xpack.inference.external.http.retry.ResponseHandlerUtils.getFirstHeaderOrUnknown;
 
 /**
@@ -63,13 +60,6 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result)
-        throws RetryException {
-        checkForFailureStatusCode(outboundRequest, result);
-        checkForEmptyBody(throttlerManager, logger, outboundRequest, result);
-    }
-
-    @Override
     public boolean canHandleStreamingResponses() {
         return canHandleStreamingResponses;
     }
@@ -84,11 +74,7 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
         return new StreamingChatCompletionResults(openAiProcessor);
     }
 
-    public void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    public void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandler.java
@@ -49,18 +49,15 @@ public class CohereResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandler.java
@@ -24,11 +24,7 @@ public class ContextualAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomResponseHandler.java
@@ -64,11 +64,8 @@ public class CustomResponseHandler extends BaseResponseHandler {
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
-        if (statusCode >= 200 && statusCode < 300) {
-            return;
-        }
 
         // handle error codes
         if (statusCode >= 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
@@ -30,11 +30,7 @@ public class ElasticInferenceServiceResponseHandler extends BaseResponseHandler 
     }
 
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         throw buildRetryException(outboundRequest, result);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandler.java
@@ -26,11 +26,7 @@ public class FireworksAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // Handle error status codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandler.java
@@ -46,7 +46,8 @@ public class GoogleAiStudioResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code and throws a RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * The Google AI Studio error codes are documented <a href="https://ai.google.dev/gemini-api/docs/troubleshooting">here</a>.
      * @param outboundRequest The originating request
@@ -54,11 +55,7 @@ public class GoogleAiStudioResponseHandler extends BaseResponseHandler {
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandler.java
@@ -40,11 +40,7 @@ public class GoogleVertexAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandler.java
@@ -22,7 +22,8 @@ public class HuggingFaceResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code and throws a RetryException if it is not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * The Hugging Face error codes are loosely defined <a href="https://huggingface.co/docs/api-inference/faq">here</a>.
      * @param outboundRequest the http request
@@ -30,11 +31,7 @@ public class HuggingFaceResponseHandler extends BaseResponseHandler {
      * @throws RetryException thrown if status code is {@code >= 300 or < 200}
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 503 || statusCode == 502 || statusCode == 429) {
             throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxResponseHandler.java
@@ -20,7 +20,8 @@ public class IbmWatsonxResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code and throws a RetryException if it is not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * The IBM Cloud error codes for text_embedding are loosely
      * defined <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">here</a>.
@@ -29,11 +30,7 @@ public class IbmWatsonxResponseHandler extends BaseResponseHandler {
      * @throws RetryException thrown if status code is {@code >= 300 or < 200}
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
             throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandler.java
@@ -27,18 +27,15 @@ public class JinaAIResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
@@ -58,7 +58,8 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * The OpenAI API error codes are documented <a href="https://platform.openai.com/docs/guides/error-codes/api-errors">here</a>.
      * @param outboundRequest The originating request
@@ -66,11 +67,7 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    public void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    public void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandler.java
@@ -27,18 +27,15 @@ public class VoyageAIResponseHandler extends BaseResponseHandler {
     }
 
     /**
-     * Validates the status code throws an RetryException if not in the range [200, 300).
+     * Handles failure status codes by throwing a RetryException.
+     * Only called when the HTTP response status code is not in the range [200, 300).
      *
      * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
-        if (result.isSuccessfulResponse()) {
-            return;
-        }
-
+    protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseE
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler.toRestStatus;
 import static org.hamcrest.core.Is.is;
@@ -39,6 +40,64 @@ public class BaseResponseHandlerTests extends ESTestCase {
 
     public void testToRestStatus_ReturnsBadRequest_WhenStatusIsUnknown() {
         assertThat(toRestStatus(1000), is(RestStatus.BAD_REQUEST));
+    }
+
+    public void testValidateResponse_SkipsHandleFailureStatusCode_WhenResponseIsSuccessful() {
+        var handler = new BaseResponseHandler(
+            "test",
+            (OutboundRequest outboundRequest, HttpResult result) -> null,
+            ErrorMessageResponseEntity::fromResponse
+        ) {
+            @Override
+            protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) {
+                throw new RetryException(false, new RuntimeException("should not be called"));
+            }
+        };
+
+        var response = mock200Response();
+        var request = mock(OutboundRequest.class);
+        when(request.getInferenceEntityId()).thenReturn("test-id");
+
+        // 200 → handleFailureStatusCode must not be called
+        handler.validateResponse(
+            mock(ThrottlerManager.class),
+            mock(Logger.class),
+            request,
+            new HttpResult(response, "{}".getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    public void testValidateResponse_CallsHandleFailureStatusCode_WhenResponseIsNotSuccessful() {
+        var handlerCalled = new AtomicBoolean(false);
+        var handler = new BaseResponseHandler(
+            "test",
+            (OutboundRequest outboundRequest, HttpResult result) -> null,
+            ErrorMessageResponseEntity::fromResponse
+        ) {
+            @Override
+            protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) {
+                handlerCalled.set(true);
+                throw new RetryException(false, new RuntimeException("failure"));
+            }
+        };
+
+        var statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(500);
+        var response = mock(HttpResponse.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        var request = mock(OutboundRequest.class);
+        when(request.getInferenceEntityId()).thenReturn("test-id");
+
+        expectThrows(
+            RetryException.class,
+            () -> handler.validateResponse(
+                mock(ThrottlerManager.class),
+                mock(Logger.class),
+                request,
+                new HttpResult(response, "{}".getBytes(StandardCharsets.UTF_8))
+            )
+        );
+        assertTrue(handlerCalled.get());
     }
 
     public void testValidateResponse_DoesNotThrowAnExceptionWhenStatus200_AndNoErrorObject() {
@@ -155,7 +214,7 @@ public class BaseResponseHandlerTests extends ESTestCase {
             ErrorMessageResponseEntity::fromResponse
         ) {
             @Override
-            protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) {}
+            protected void handleFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) {}
         };
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandlerTests.java
@@ -27,12 +27,8 @@ import static org.mockito.Mockito.when;
 
 public class AnthropicResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor500_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -41,8 +37,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor529_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(529, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor529_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(529, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -53,8 +49,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(505, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(505, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -63,8 +59,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -77,7 +73,7 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_ShouldRetry_RetrievesFieldsFromHeaders() {
+    public void testHandleFailureStatusCode_ThrowsFor429_ShouldRetry_RetrievesFieldsFromHeaders() {
         int statusCode = 429;
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
@@ -117,8 +113,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         );
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(403, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(403, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -127,8 +123,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.FORBIDDEN));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -137,8 +133,8 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(425, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(425, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -147,7 +143,7 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String inferenceEntityId) {
+    private static void callHandleFailureStatusCode(int statusCode, String inferenceEntityId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -162,7 +158,7 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new AnthropicResponseHandler("", (request, result) -> null, false);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureAndOpenAiExternalResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureAndOpenAiExternalResponseHandlerTests.java
@@ -50,12 +50,9 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
             false
         );
 
-        // 200 ok
-        when(statusLine.getStatusCode()).thenReturn(200);
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
         // 503
         when(statusLine.getStatusCode()).thenReturn(503);
-        var retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        var retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -64,7 +61,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 501
         when(statusLine.getStatusCode()).thenReturn(501);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -73,7 +70,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 500
         when(statusLine.getStatusCode()).thenReturn(500);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -82,27 +79,27 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 429
         when(statusLine.getStatusCode()).thenReturn(429);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a rate limit status code."));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
         // 413
         when(statusLine.getStatusCode()).thenReturn(413);
-        retryException = expectThrows(ContentTooLargeException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(ContentTooLargeException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
         // 400 content too large
         retryException = expectThrows(
             ContentTooLargeException.class,
-            () -> handler.checkForFailureStatusCode(mockRequest, createContentTooLargeResult(400))
+            () -> handler.handleFailureStatusCode(mockRequest, createContentTooLargeResult(400))
         );
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 400 generic bad request should not be marked as a content too large
         when(statusLine.getStatusCode()).thenReturn(400);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -111,10 +108,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 400 is not flagged as a content too large when the error message is different
         when(statusLine.getStatusCode()).thenReturn(400);
-        retryException = expectThrows(
-            RetryException.class,
-            () -> handler.checkForFailureStatusCode(mockRequest, createResult(400, "blah"))
-        );
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, createResult(400, "blah")));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -123,7 +117,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 401
         when(statusLine.getStatusCode()).thenReturn(401);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -132,7 +126,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.UNAUTHORIZED));
         // 300
         when(statusLine.getStatusCode()).thenReturn(300);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -141,7 +135,7 @@ public class AzureAndOpenAiExternalResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
         // 402
         when(statusLine.getStatusCode()).thenReturn(402);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandlerTests.java
@@ -30,12 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CohereResponseHandlerTests extends ESTestCase {
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor503() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -44,8 +40,8 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -54,8 +50,8 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -64,8 +60,8 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(400, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor400() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(400, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -74,10 +70,10 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400_TextsTooLarge() {
+    public void testHandleFailureStatusCode_ThrowsFor400_TextsTooLarge() {
         var exception = expectThrows(
             RetryException.class,
-            () -> callCheckForFailureStatusCode(400, "invalid request: total number of texts must be at most 96 - received 100", "id")
+            () -> callHandleFailureStatusCode(400, "invalid request: total number of texts must be at most 96 - received 100", "id")
         );
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
@@ -87,8 +83,8 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor401() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(401, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor401() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(401, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -99,8 +95,8 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.UNAUTHORIZED));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor300() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor300() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -109,11 +105,11 @@ public class CohereResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
-        callCheckForFailureStatusCode(statusCode, null, modelId);
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
+        callHandleFailureStatusCode(statusCode, null, modelId);
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -134,6 +130,6 @@ public class CohereResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new CohereResponseHandler("", (request, result) -> null, false);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandlerTests.java
@@ -31,13 +31,9 @@ import static org.mockito.Mockito.when;
 
 public class ContextualAiResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode_StatusCode200_DoesNotThrow() {
-        callCheckForFailureStatusCode(200, null);
-    }
-
-    public void testCheckForFailureStatusCode_StatusCode500_ThrowsRetryableServerError() {
+    public void testHandleFailureStatusCode_StatusCode500_ThrowsRetryableServerError() {
         var errorBody = "Internal server error: service unavailable";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, errorBody));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -52,9 +48,9 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_StatusCode503_ThrowsRetryableServerError() {
+    public void testHandleFailureStatusCode_StatusCode503_ThrowsRetryableServerError() {
         var errorBody = "Service temporarily unavailable";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, errorBody));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -69,9 +65,9 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_StatusCode429_ThrowsRetryableRateLimitError() {
+    public void testHandleFailureStatusCode_StatusCode429_ThrowsRetryableRateLimitError() {
         var errorBody = "Rate limit exceeded, please retry later";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, errorBody));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -86,9 +82,9 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_StatusCode401_ThrowsAuthenticationError() {
+    public void testHandleFailureStatusCode_StatusCode401_ThrowsAuthenticationError() {
         var errorBody = "Invalid API key provided";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(401, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(401, errorBody));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -103,9 +99,9 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.UNAUTHORIZED));
     }
 
-    public void testCheckForFailureStatusCode_StatusCode400_ThrowsUnsuccessfulError() {
+    public void testHandleFailureStatusCode_StatusCode400_ThrowsUnsuccessfulError() {
         var errorBody = "Invalid request: missing required field";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(400, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(400, errorBody));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -120,9 +116,9 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_StatusCode300_ThrowsRedirectionError() {
+    public void testHandleFailureStatusCode_StatusCode300_ThrowsRedirectionError() {
         var errorBody = "Resource has been moved";
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, errorBody));
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, errorBody));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -134,7 +130,7 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, @Nullable String errorMessage) {
+    private static void callHandleFailureStatusCode(int statusCode, @Nullable String errorMessage) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -149,6 +145,6 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : errorMessage.getBytes(StandardCharsets.UTF_8));
         var handler = new ContextualAiResponseHandler("", (request, result) -> null, false);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandlerTests.java
@@ -133,15 +133,10 @@ public class ElasticInferenceServiceResponseHandlerTests extends ESTestCase {
         );
     }
 
-    public void testCheckForFailureStatusCode_Throws_WithErrorMessage() {
+    public void testHandleFailureStatusCode_Throws_WithErrorMessage() {
         var exception = expectThrows(
             RetryException.class,
-            () -> callCheckForFailureStatusCode(
-                failureTestCase.inputStatusCode,
-                failureTestCase.errorMessage,
-                "id",
-                failureTestCase.headers
-            )
+            () -> callHandleFailureStatusCode(failureTestCase.inputStatusCode, failureTestCase.errorMessage, "id", failureTestCase.headers)
         );
         assertThat(exception.shouldRetry(), is(failureTestCase.shouldRetry));
         assertThat(exception.getCause().getMessage(), containsString(failureTestCase.errorMessage));
@@ -151,15 +146,11 @@ public class ElasticInferenceServiceResponseHandlerTests extends ESTestCase {
         }
     }
 
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, null, "id", Map.of());
-    }
-
-    public void testCheckForFailureStatusCode_AlwaysAppliesRetryAfterHeaderWhenPresent() {
+    public void testHandleFailureStatusCode_AlwaysAppliesRetryAfterHeaderWhenPresent() {
         final String retryAfter = String.valueOf(randomIntBetween(1, 1000));
         var exception = expectThrows(
             RetryException.class,
-            () -> callCheckForFailureStatusCode(
+            () -> callHandleFailureStatusCode(
                 randomIntBetween(300, 599),
                 randomAlphaOfLength(10),
                 "id",
@@ -169,7 +160,7 @@ public class ElasticInferenceServiceResponseHandlerTests extends ESTestCase {
         assertCauseHasRetryHeader(exception, retryAfter);
     }
 
-    private static void callCheckForFailureStatusCode(
+    private static void callHandleFailureStatusCode(
         int statusCode,
         @Nullable String errorMessage,
         String modelId,
@@ -192,7 +183,7 @@ public class ElasticInferenceServiceResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new ElasticInferenceServiceResponseHandler("", (request, result) -> null);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 
     private static void givenResponseHasHeaders(HttpResponse httpResponse, Map<String, String> headersMap) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandlerTests.java
@@ -30,12 +30,8 @@ import static org.mockito.Mockito.when;
 
 public class FireworksAiResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -44,8 +40,8 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor503_WithShouldRetryFalse() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503_WithShouldRetryFalse() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -54,8 +50,8 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -64,8 +60,8 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor401_WithShouldRetryFalse() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(401, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor401_WithShouldRetryFalse() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(401, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -76,8 +72,8 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.UNAUTHORIZED));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400_WithShouldRetryFalse() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(400, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor400_WithShouldRetryFalse() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(400, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -86,8 +82,8 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor300_WithShouldRetryFalse() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor300_WithShouldRetryFalse() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -96,11 +92,11 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
-        callCheckForFailureStatusCode(statusCode, null, modelId);
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
+        callHandleFailureStatusCode(statusCode, null, modelId);
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
         when(statusLine.toString()).thenReturn("HTTP/1.1 " + statusCode + " Error");
@@ -116,6 +112,6 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : errorMessage.getBytes(StandardCharsets.UTF_8));
         var handler = new FireworksAiResponseHandler("", (request, result) -> null, false);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandlerTests.java
@@ -26,12 +26,8 @@ import static org.mockito.Mockito.when;
 
 public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor500_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -40,8 +36,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor503_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -52,8 +48,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(505, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(505, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -62,8 +58,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -72,8 +68,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor404_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(404, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor404_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(404, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -82,8 +78,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.NOT_FOUND));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(403, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(403, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -92,8 +88,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.FORBIDDEN));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -102,8 +98,8 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(425, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(425, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -112,7 +108,7 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -127,7 +123,7 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new GoogleAiStudioResponseHandler("", (request, result) -> null);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandlerTests.java
@@ -26,12 +26,8 @@ import static org.mockito.Mockito.when;
 
 public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode_DoesNotThrowFor200() {
-        callCheckForFailureStatusCode(200, "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor500_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -40,8 +36,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor503_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -52,8 +48,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(505, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor505_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(505, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -62,8 +58,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_ShouldRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_ShouldRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -72,8 +68,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor404_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(404, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor404_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(404, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -82,8 +78,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.NOT_FOUND));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(403, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor403_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(403, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -92,8 +88,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.FORBIDDEN));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(300, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor300_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(300, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -102,8 +98,8 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(425, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor425_ShouldNotRetry() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(425, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -112,7 +108,7 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -127,6 +123,6 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new GoogleVertexAiResponseHandler("", (request, result) -> null);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandlerTests.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 public class HuggingFaceResponseHandlerTests extends ESTestCase {
 
-    public void testCheckForFailureStatusCode() {
+    public void testHandleFailureStatusCode() {
         var statusLine = mock(StatusLine.class);
 
         var httpResponse = mock(HttpResponse.class);
@@ -36,12 +36,9 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
 
         var handler = new HuggingFaceResponseHandler("", (request, result) -> null);
 
-        // 200 ok
-        when(statusLine.getStatusCode()).thenReturn(200);
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
         // 503
         when(statusLine.getStatusCode()).thenReturn(503);
-        var retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        var retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -50,7 +47,7 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 502
         when(statusLine.getStatusCode()).thenReturn(502);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -59,7 +56,7 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 429
         when(statusLine.getStatusCode()).thenReturn(429);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -68,13 +65,13 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
         // 413
         when(statusLine.getStatusCode()).thenReturn(413);
-        retryException = expectThrows(ContentTooLargeException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(ContentTooLargeException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
         // 401
         when(statusLine.getStatusCode()).thenReturn(401);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -83,7 +80,7 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.UNAUTHORIZED));
         // 300
         when(statusLine.getStatusCode()).thenReturn(300);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -92,7 +89,7 @@ public class HuggingFaceResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
         // 402
         when(statusLine.getStatusCode()).thenReturn(402);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandlerTests.java
@@ -29,12 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class JinaAIResponseHandlerTests extends ESTestCase {
-    public void testCheckForFailureStatusCode_DoesNotThrowForStatusCodesBetween200And299() {
-        callCheckForFailureStatusCode(randomIntBetween(200, 299), "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor503() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -43,8 +39,8 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -53,8 +49,8 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -63,8 +59,8 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(400, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor400() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(400, "id"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -73,10 +69,10 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400_InputsTooLarge() {
+    public void testHandleFailureStatusCode_ThrowsFor400_InputsTooLarge() {
         var exception = expectThrows(
             RetryException.class,
-            () -> callCheckForFailureStatusCode(400, "\"input\" length 2049 is larger than the largest allowed size 2048", "id")
+            () -> callHandleFailureStatusCode(400, "\"input\" length 2049 is larger than the largest allowed size 2048", "id")
         );
         assertFalse(exception.shouldRetry());
         assertThat(
@@ -86,8 +82,8 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor401() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(401, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor401() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(401, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         assertThat(
             exception.getCause().getMessage(),
@@ -98,18 +94,18 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.UNAUTHORIZED));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor402() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(402, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor402() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(402, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         assertThat(exception.getCause().getMessage(), containsString("Payment required"));
         assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.PAYMENT_REQUIRED));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
-        callCheckForFailureStatusCode(statusCode, null, modelId);
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
+        callHandleFailureStatusCode(statusCode, null, modelId);
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -132,6 +128,6 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new JinaAIResponseHandler("", (request, result) -> null);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/embeddings/NvidiaEmbeddingsResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/embeddings/NvidiaEmbeddingsResponseHandlerTests.java
@@ -44,7 +44,7 @@ public class NvidiaEmbeddingsResponseHandlerTests extends ESTestCase {
         when(statusLine.getStatusCode()).thenReturn(413);
         RetryException retryException = expectThrows(
             ContentTooLargeException.class,
-            () -> responseHandler.checkForFailureStatusCode(mockRequest, httpResult)
+            () -> responseHandler.handleFailureStatusCode(mockRequest, httpResult)
         );
         assertThat(retryException.shouldRetry(), is(true));
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
@@ -56,7 +56,7 @@ public class NvidiaEmbeddingsResponseHandlerTests extends ESTestCase {
         // 400 content too large
         var retryException = expectThrows(
             ContentTooLargeException.class,
-            () -> responseHandler.checkForFailureStatusCode(mockRequest, createContentTooLargeResult400())
+            () -> responseHandler.handleFailureStatusCode(mockRequest, createContentTooLargeResult400())
         );
         assertThat(retryException.shouldRetry(), is(true));
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
@@ -72,7 +72,7 @@ public class NvidiaEmbeddingsResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         // 400 generic bad request should not be marked as a content too large
         when(statusLine.getStatusCode()).thenReturn(400);
-        var retryException = expectThrows(RetryException.class, () -> responseHandler.checkForFailureStatusCode(mockRequest, httpResult));
+        var retryException = expectThrows(RetryException.class, () -> responseHandler.handleFailureStatusCode(mockRequest, httpResult));
         assertThat(retryException.shouldRetry(), is(false));
         assertThat(
             retryException.getCause().getMessage(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiChatCompletionResponseHandlerTests.java
@@ -53,7 +53,7 @@ public class OpenAiChatCompletionResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, responseBodyStream.readAllBytes());
         var handler = new OpenAiChatCompletionResponseHandler("", (request, result) -> null);
 
-        var retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        var retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
 
         assertFalse(retryException.shouldRetry());
         assertThat(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandlerTests.java
@@ -47,12 +47,9 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new OpenAiResponseHandler("", (request, result) -> null, false);
 
-        // 200 ok
-        when(statusLine.getStatusCode()).thenReturn(200);
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
         // 503
         when(statusLine.getStatusCode()).thenReturn(503);
-        var retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        var retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -61,7 +58,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 501
         when(statusLine.getStatusCode()).thenReturn(501);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -70,7 +67,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 500
         when(statusLine.getStatusCode()).thenReturn(500);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -79,27 +76,27 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 429
         when(statusLine.getStatusCode()).thenReturn(429);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a rate limit status code. Token limit"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
         // 413
         when(statusLine.getStatusCode()).thenReturn(413);
-        retryException = expectThrows(ContentTooLargeException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(ContentTooLargeException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
         // 400 content too large
         retryException = expectThrows(
             ContentTooLargeException.class,
-            () -> handler.checkForFailureStatusCode(mockRequest, createContentTooLargeResult(400))
+            () -> handler.handleFailureStatusCode(mockRequest, createContentTooLargeResult(400))
         );
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 400 generic bad request should not be marked as a content too large
         when(statusLine.getStatusCode()).thenReturn(400);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -108,10 +105,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 400 is not flagged as a content too large when the error message is different
         when(statusLine.getStatusCode()).thenReturn(400);
-        retryException = expectThrows(
-            RetryException.class,
-            () -> handler.checkForFailureStatusCode(mockRequest, createResult(400, "blah"))
-        );
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, createResult(400, "blah")));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -120,7 +114,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 401
         when(statusLine.getStatusCode()).thenReturn(401);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -129,7 +123,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.UNAUTHORIZED));
         // 300
         when(statusLine.getStatusCode()).thenReturn(300);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -138,7 +132,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.MULTIPLE_CHOICES));
         // 402
         when(statusLine.getStatusCode()).thenReturn(402);
-        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        retryException = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
@@ -173,7 +167,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new OpenAiResponseHandler("", (request, result) -> null, false);
 
-        var exception = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(mockRequest, httpResult));
+        var exception = expectThrows(RetryException.class, () -> handler.handleFailureStatusCode(mockRequest, httpResult));
         return new FailureResult(mockRequest, exception);
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandlerTests.java
@@ -30,12 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class VoyageAIResponseHandlerTests extends ESTestCase {
-    public void testCheckForFailureStatusCode_DoesNotThrowForStatusCodesBetween200And299() {
-        callCheckForFailureStatusCode(randomIntBetween(200, 299), "id");
-    }
-
-    public void testCheckForFailureStatusCode_ThrowsFor503() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(503, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor503() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(503, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -44,8 +40,8 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(500, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor500_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(500, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -54,8 +50,8 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(429, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor429_WithShouldRetryTrue() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(429, "id"));
         assertTrue(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -64,8 +60,8 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(400, "id"));
+    public void testHandleFailureStatusCode_ThrowsFor400() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(400, "id"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -74,10 +70,10 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor400_InputsTooLarge() {
+    public void testHandleFailureStatusCode_ThrowsFor400_InputsTooLarge() {
         var exception = expectThrows(
             RetryException.class,
-            () -> callCheckForFailureStatusCode(400, "\"input\" length 2049 is larger than the largest allowed size 2048", "id")
+            () -> callHandleFailureStatusCode(400, "\"input\" length 2049 is larger than the largest allowed size 2048", "id")
         );
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
@@ -87,8 +83,8 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.BAD_REQUEST));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor401() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(401, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor401() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(401, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(
             exception.getCause().getMessage(),
@@ -99,18 +95,18 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.UNAUTHORIZED));
     }
 
-    public void testCheckForFailureStatusCode_ThrowsFor402() {
-        var exception = expectThrows(RetryException.class, () -> callCheckForFailureStatusCode(402, "inferenceEntityId"));
+    public void testHandleFailureStatusCode_ThrowsFor402() {
+        var exception = expectThrows(RetryException.class, () -> callHandleFailureStatusCode(402, "inferenceEntityId"));
         assertFalse(exception.shouldRetry());
         MatcherAssert.assertThat(exception.getCause().getMessage(), containsString("Payment required"));
         MatcherAssert.assertThat(((ElasticsearchStatusException) exception.getCause()).status(), is(RestStatus.PAYMENT_REQUIRED));
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, String modelId) {
-        callCheckForFailureStatusCode(statusCode, null, modelId);
+    private static void callHandleFailureStatusCode(int statusCode, String modelId) {
+        callHandleFailureStatusCode(statusCode, null, modelId);
     }
 
-    private static void callCheckForFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
+    private static void callHandleFailureStatusCode(int statusCode, @Nullable String errorMessage, String modelId) {
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
 
@@ -133,6 +129,6 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new VoyageAIResponseHandler("", (request, result) -> null);
 
-        handler.checkForFailureStatusCode(mockRequest, httpResult);
+        handler.handleFailureStatusCode(mockRequest, httpResult);
     }
 }


### PR DESCRIPTION
This PR refactors the status code checks to remove some duplicate code. We can perform the success check in the base class and skip the status code check if we have a success.