### PR TITLE
Unmute SmokeTestMultiNodeClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -475,9 +475,6 @@ tests:
 - class: org.elasticsearch.upgrades.TokenBackwardsCompatibilityIT
   method: testTokensStayInvalidatedInUpgradedCluster
   issue: https://github.com/elastic/elasticsearch/issues/154627
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=indices.create/10_basic/Create index with write aliases}
-  issue: https://github.com/elastic/elasticsearch/issues/154659
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/154058
@@ -532,9 +529,6 @@ tests:
 - class: org.elasticsearch.foreign.DefaultMethodHandleResolverTests
   method: testDefaultResolverBuildsWorkingMethodHandle
   issue: https://github.com/elastic/elasticsearch/issues/155012
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search/160_exists_query/Test exists query on object inner field in empty index}
-  issue: https://github.com/elastic/elasticsearch/issues/155016
 - class: org.elasticsearch.xpack.transform.integration.TransformDestIndexIT
   method: testUnattendedTransformDestIndexCreatedDuringUpdate_EmptySourceIndex_NoDeferValidation
   issue: https://github.com/elastic/elasticsearch/issues/152599
@@ -556,12 +550,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.BulkArrowAggregationTests
   method: testSumIntOverArrowBufferMasked
   issue: https://github.com/elastic/elasticsearch/issues/153586
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search.inner_hits/10_basic/Inner hits with disabled _source}
-  issue: https://github.com/elastic/elasticsearch/issues/155041
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search/350_point_in_time/delete invalid PIT returns error}
-  issue: https://github.com/elastic/elasticsearch/issues/155066
 - class: org.elasticsearch.xpack.stateless.objectstore.gc.StaleTranslogsGCIT
   method: testIsolatedNodeDoesNotDeleteTranslogs
   issue: https://github.com/elastic/elasticsearch/issues/155130


### PR DESCRIPTION
Test failures are due to timeouts, and the timeout was extended in elastic/elasticsearch#155247.

Fixes #154659
Fixes #155016
Fixes #155041
Fixes #155066
