### PR TITLE
ESQL: Re-enables TS * when we have views

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -1276,6 +1276,26 @@ c:long | cluster:keyword
 5      | staging
 ;
 
+// Wildcard patterns that match views are silently excluded from TS commands.
+// view_k8s_* matches several loaded views but none is a concrete name in the pattern,
+// so they are skipped and the result is identical to plain TS k8s.
+tsWildcardSkipsViews
+required_capability: views_crud_as_index_actions
+required_capability: ts_command_v0
+required_capability: subquery_with_ts
+required_capability: ts_command_wildcards_skip_views
+
+TS k8s, view_k8s_*
+| STATS max_bytes = max(to_long(network.total_bytes_in)) BY cluster
+| SORT max_bytes DESC
+;
+
+max_bytes:long | cluster:keyword
+10797          | qa
+10277          | prod
+7403           | staging
+;
+
 tsViewAndIndexPatternWithStats
 required_capability: subquery_in_from_command
 required_capability: views_with_no_branching

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1538,6 +1538,14 @@ public class EsqlCapabilities {
         FIX_TS_MIXED_WITH_NON_TS_SOURCES,
 
         /**
+         * Wildcard patterns in {@code TS} commands silently skip matching views — the relation is
+         * returned unchanged so field-caps' {@code _index_mode:time_series} filter excludes them
+         * naturally. Concrete view names in {@code TS} patterns are still rejected with a
+         * {@code VerificationException}.
+         */
+        TS_COMMAND_WILDCARDS_SKIP_VIEWS,
+
+        /**
          * Support for the {@code leading_zeros} named parameter.
          */
         TO_IP_LEADING_ZEROS,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -476,13 +476,22 @@ public class ViewResolver {
             // Views are a stored subquery, and TS command already rejects explicit subqueries
             // (see LogicalPlanBuilder#visitRelation) because time-series semantics (_tsid,
             // bucketing, etc.) assume every row comes directly from a time-series index. A view's
-            // output never satisfies that, so reject it here too, once view resolution has told us
-            // whether the pattern actually matched a view - the parser can't know this up front.
+            // output never satisfies that, so reject concrete view names in TS commands.
+            // Wildcard patterns are allowed: field-caps carries an _index_mode:time_series filter
+            // that naturally excludes views (which are not real indices), so we return the relation
+            // unchanged and let field-caps handle it.
             if (unresolvedRelation.indexMode() == IndexMode.TIME_SERIES) {
-                throw new VerificationException(
-                    "Views are not supported in TS command, found view(s) [{}]",
-                    Arrays.stream(response.views()).map(View::name).collect(Collectors.joining(", "))
-                );
+                Set<String> patternSet = new HashSet<>(Arrays.asList(patterns));
+                String concreteViewNames = Arrays.stream(response.views())
+                    .map(View::name)
+                    .filter(patternSet::contains)
+                    .collect(Collectors.joining(", "));
+                if (concreteViewNames.isEmpty() == false) {
+                    throw new VerificationException("Views are not supported in TS command, found view(s) [{}]", concreteViewNames);
+                }
+                // Only wildcard-matched views reached here; skip expansion and return unchanged.
+                listener.onResponse(unresolvedRelation);
+                return;
             }
 
             final HashMap<String, ViewPlan> resolvedViews = new HashMap<>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -990,6 +990,29 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
     }
 
     /**
+     * Views matched only via wildcards are silently skipped in TS commands — the relation is
+     * returned unchanged so field-caps' {@code _index_mode:time_series} filter excludes them
+     * naturally. Concrete view names in TS patterns are still rejected (see
+     * {@link #testViewNotSupportedAsSoleTsSource} and friends).
+     */
+    public void testTsWildcardSkipsViews() {
+        assumeTrue("Requires TS wildcard skipping views", EsqlCapabilities.Cap.TS_COMMAND_WILDCARDS_SKIP_VIEWS.isEnabled());
+        addView("view_a", "FROM emp");
+        assertThat(replaceViews(query("TS *")), matchesPlan(query("TS *")));
+    }
+
+    /**
+     * Exclusion wildcards (e.g. {@code -.*}) in a TS pattern are not concrete view names, so they
+     * must not trigger a rejection either. The plan is returned unchanged; field-caps handles the
+     * exclusion on real indices.
+     */
+    public void testTsWildcardWithExclusionSkipsViews() {
+        assumeTrue("Requires TS wildcard skipping views", EsqlCapabilities.Cap.TS_COMMAND_WILDCARDS_SKIP_VIEWS.isEnabled());
+        addView("view_a", "FROM emp");
+        assertThat(replaceViews(query("TS *,-.*")), matchesPlan(query("TS *,-.*")));
+    }
+
+    /**
      * Reproduces https://github.com/elastic/elasticsearch/issues/146665
      * FORK queries that reference no views should succeed even when circular views exist on the cluster.
      */


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/149619 gated `TS` to not be able to use views in it.

Unfortunately this broke `TS *` because that will pull in views and fail with `Views are not supported in TS command` in view resolution.


## Fix
Now we fail only if the view resolution query source command is `TS` and we include concrete views. Field caps filters anything that is not a time series naturally otherwise (and that was the behaviour before https://github.com/elastic/elasticsearch/issues/149619)

This means when using `TS index, view` that will still fail (we already had tests for that in `InMemoryViewServiceTests`, but when you use `TS *` they will get filtered out.

## Alternative
We considered excluding only views that contained `FROM`. That wouldn't work. Even if we define `view` as `TS index`,  it doesn't have time series mode nowadays, so if we allowed this:

```
TS index, view
| STATS MAX(last_over_time(event))
```

it would still fail complaining with: `optimized incorrectly due to missing references [_tsid{m}#663, _timeseries{f}#662]"}]`

