### PR TITLE
Unmute CoreWithSecurityClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -334,12 +334,6 @@ tests:
 - class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
   method: testDuel
   issue: https://github.com/elastic/elasticsearch/issues/154243
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_byte_quantized_bfloat16/Knn search with mip}
-  issue: https://github.com/elastic/elasticsearch/issues/154356
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=tsdb/40_search/aggs by index_mode}
-  issue: https://github.com/elastic/elasticsearch/issues/154375
 - class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_bbq_flat_bfloat16/Vector rescoring has same scoring as exact search for kNN section}
   issue: https://github.com/elastic/elasticsearch/issues/154656
@@ -358,9 +352,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/154916
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search/161_exists_query_within_nested_query/Test exists query within nested query on mapped geo_point field}
-  issue: https://github.com/elastic/elasticsearch/issues/155025
 - class: org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilderIT
   method: testRRFRetrieverPartialSearchErrorsTrue
   issue: https://github.com/elastic/elasticsearch/issues/155068


### PR DESCRIPTION
Tests were muted due to a single timeout failure.
For now just unmute the tests. If they start failing again, then we can extend the timeout.

Fixes #154356
Fixes #154375
Fixes #155025