### PR TITLE
Make system descriptor assertion mapping-version aware

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -447,8 +447,9 @@ public class MetadataCreateIndexService {
         }
         // There may be no descriptor on the request, in which case return the latest descriptor and the assertion should fail
         // with an appropriate message
-        return request.systemIndexDescriptor() != null
-            ? descriptorForIndex.getDescriptorCompatibleWith(request.systemIndexDescriptor().getMappingsVersion())
+        final var requestDescriptor = request.systemIndexDescriptor();
+        return requestDescriptor != null
+            ? descriptorForIndex.getDescriptorCompatibleWith(requestDescriptor.getMappingsVersion())
             : descriptorForIndex;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -445,9 +445,9 @@ public class MetadataCreateIndexService {
         if (descriptorForIndex == null) {
             return null;
         }
-        // If the request has a managed system index descriptor on it, use the mapping version from that
+        // If the expected descriptor is automatically managed, try and adjust it to the mapping version on the request descriptor
         final var requestDescriptor = request.systemIndexDescriptor();
-        return requestDescriptor != null && requestDescriptor.isAutomaticallyManaged()
+        return requestDescriptor != null && descriptorForIndex.isAutomaticallyManaged() && requestDescriptor.isAutomaticallyManaged()
             ? descriptorForIndex.getDescriptorCompatibleWith(requestDescriptor.getMappingsVersion())
             : descriptorForIndex;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -445,8 +445,7 @@ public class MetadataCreateIndexService {
         if (descriptorForIndex == null) {
             return null;
         }
-        // There may be no descriptor on the request, in which case return the latest descriptor and the assertion should fail
-        // with an appropriate message. Also, unmanaged indices have no mappings or version.
+        // If the request has a managed system index descriptor on it, use the mapping version from that
         final var requestDescriptor = request.systemIndexDescriptor();
         return requestDescriptor != null && requestDescriptor.isAutomaticallyManaged()
             ? descriptorForIndex.getDescriptorCompatibleWith(requestDescriptor.getMappingsVersion())

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -446,9 +446,9 @@ public class MetadataCreateIndexService {
             return null;
         }
         // There may be no descriptor on the request, in which case return the latest descriptor and the assertion should fail
-        // with an appropriate message
+        // with an appropriate message. Also, unmanaged indices have no mappings or version.
         final var requestDescriptor = request.systemIndexDescriptor();
-        return requestDescriptor != null
+        return requestDescriptor != null && requestDescriptor.isAutomaticallyManaged()
             ? descriptorForIndex.getDescriptorCompatibleWith(requestDescriptor.getMappingsVersion())
             : descriptorForIndex;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -390,7 +390,11 @@ public class MetadataCreateIndexService {
         final CreateIndexClusterStateUpdateRequest request,
         final ActionListener<ShardsAcknowledgedResponse> listener
     ) {
-        assert systemIndices.findMatchingDescriptor(request.index()) == request.systemIndexDescriptor();
+        assert descriptorForRequestIndexAndMappingVersion(request) == request.systemIndexDescriptor()
+            : "Expected system index descriptor "
+                + descriptorForRequestIndexAndMappingVersion(request)
+                + " but got "
+                + request.systemIndexDescriptor();
         assert request.dataStreamName() == null
             || systemIndices.findMatchingDataStreamDescriptor(request.dataStreamName()) == request.systemDataStreamDescriptor();
 
@@ -431,6 +435,21 @@ public class MetadataCreateIndexService {
                 }
             })
         );
+    }
+
+    /**
+     * Get the expected system index descriptor for the index name and mapping version on the request
+     */
+    private SystemIndexDescriptor descriptorForRequestIndexAndMappingVersion(CreateIndexClusterStateUpdateRequest request) {
+        final var descriptorForIndex = systemIndices.findMatchingDescriptor(request.index());
+        if (descriptorForIndex == null) {
+            return null;
+        }
+        // There may be no descriptor on the request, in which case return the latest descriptor and the assertion should fail
+        // with an appropriate message
+        return request.systemIndexDescriptor() != null
+            ? descriptorForIndex.getDescriptorCompatibleWith(request.systemIndexDescriptor().getMappingsVersion())
+            : descriptorForIndex;
     }
 
     private void onlyCreateIndex(


### PR DESCRIPTION
The assertion that checks the system descriptor in the `MetadataCreateIndexService` assumed the descriptor would be the one for the mapping version on the master node.

In a mixed cluster scenario the system descriptor will be the one for the minimum cluster mapping version. I loosened the assertion so that it checks that the system index descriptor is consistent with the index name, and the mapping version specified in the request.

I believe this started failing because
- This assertion was merged on 2026-06-08 (#149892) 
- We merged a prior version for the `.tasks` index on 2026-07-09 (#147736)
- 💥 

Fixes #154381