### PR TITLE
[8.19] Verify test cluster distribution copy integrity (#154257)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -21,7 +21,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -29,6 +31,13 @@ public final class IOUtils {
     private static final Logger LOGGER = LogManager.getLogger(IOUtils.class);
     private static final int RETRY_DELETE_MILLIS = OS.current() == OS.WINDOWS ? 500 : 0;
     private static final int MAX_RETRY_DELETE_TIMES = OS.current() == OS.WINDOWS ? 15 : 0;
+
+    /**
+     * Marker prefixed to every log line and error message emitted by the distribution-copy self-heal in
+     * {@link #syncMaybeWithLinks(Path, Path)}. Grep for this token when diagnosing incomplete test-cluster
+     * distribution copies (see https://github.com/elastic/elasticsearch/issues/149129).
+     */
+    static final String SELF_HEAL_MARKER = "[distribution-copy-self-heal]";
 
     private IOUtils() {}
 
@@ -73,13 +82,104 @@ public final class IOUtils {
             // Note does not work for network drives, e.g. Vagrant
             LOGGER.info("Failed to sync using hard links. Falling back to copy.", e);
             // ensure we get a clean copy
-            try {
-                deleteWithRetry(destinationRoot);
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-            syncWithCopy(sourceRoot, destinationRoot);
+            cleanCopy(sourceRoot, destinationRoot);
         }
+
+        verifyDistributionCopyComplete(sourceRoot, destinationRoot);
+    }
+
+    /**
+     * Verifies that {@code destinationRoot} contains every file present under {@code sourceRoot} and, when it does not,
+     * self-heals with a clean copy. An incomplete distribution copy otherwise manifests much later as a cryptic failure
+     * that is very hard to triage, e.g. a CLI tool such as {@code elasticsearch-keystore.bat} failing with a
+     * {@code ClassNotFoundException} because a jar was silently dropped from its classpath
+     * (see https://github.com/elastic/elasticsearch/issues/149129).
+     * <p>
+     * Every log line and the failure message are tagged with {@link #SELF_HEAL_MARKER} so they are trivial to grep for
+     * when diagnosing distribution-copy issues.
+     *
+     * @throws UncheckedIOException if files are still missing after a clean copy (i.e. the source itself is incomplete)
+     */
+    static void verifyDistributionCopyComplete(Path sourceRoot, Path destinationRoot) {
+        List<String> missing = findMissingFiles(sourceRoot, destinationRoot);
+        if (missing.isEmpty()) {
+            return;
+        }
+
+        LOGGER.warn(
+            "{} incomplete distribution copy detected from [{}] to [{}]: {} file(s) missing, self-healing with a clean copy. "
+                + "Missing files: {}",
+            SELF_HEAL_MARKER,
+            sourceRoot,
+            destinationRoot,
+            missing.size(),
+            missing
+        );
+        cleanCopy(sourceRoot, destinationRoot);
+        missing = findMissingFiles(sourceRoot, destinationRoot);
+        if (missing.isEmpty() == false) {
+            throw new UncheckedIOException(
+                new IOException(
+                    SELF_HEAL_MARKER
+                        + " self-heal FAILED: incomplete distribution copy from "
+                        + sourceRoot
+                        + " to "
+                        + destinationRoot
+                        + "; "
+                        + missing.size()
+                        + " file(s) still missing after a clean copy: "
+                        + missing
+                )
+            );
+        }
+        LOGGER.warn(
+            "{} self-heal succeeded: distribution copy to [{}] is now complete after a clean copy.",
+            SELF_HEAL_MARKER,
+            destinationRoot
+        );
+    }
+
+    /** Deletes {@code destinationRoot} if present and re-populates it with a full content copy of {@code sourceRoot}. */
+    private static void cleanCopy(Path sourceRoot, Path destinationRoot) {
+        try {
+            deleteWithRetry(destinationRoot);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        syncWithCopy(sourceRoot, destinationRoot);
+    }
+
+    /**
+     * Returns the source-relative paths of all regular files present under {@code sourceRoot} but absent from
+     * {@code destinationRoot}. Transient JVM artifacts (e.g. {@code .attach_pid} files) are ignored since they are
+     * not part of the distribution and may appear or vanish between walks.
+     */
+    static List<String> findMissingFiles(Path sourceRoot, Path destinationRoot) {
+        List<String> missing = new ArrayList<>();
+        try {
+            Files.walkFileTree(sourceRoot, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path source, BasicFileAttributes attrs) {
+                    Path relative = sourceRoot.relativize(source);
+                    if (relative.toString().contains(".attach_pid")) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    if (Files.exists(destinationRoot.resolve(relative)) == false) {
+                        missing.add(relative.toString());
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    // Ignore files that disappear mid-walk (e.g. JVM .attach_pid files); they aren't part of the distribution.
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException("Can't walk source " + sourceRoot, e);
+        }
+        return missing;
     }
 
     /**

--- a/test/test-clusters/src/test/java/org/elasticsearch/test/cluster/util/IOUtilsTests.java
+++ b/test/test-clusters/src/test/java/org/elasticsearch/test/cluster/util/IOUtilsTests.java
@@ -9,6 +9,14 @@
 
 package org.elasticsearch.test.cluster.util;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -16,8 +24,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
@@ -53,6 +64,114 @@ public class IOUtilsTests {
         if (OS.current() != OS.WINDOWS) {
             assertThat("Expected 2 hard links", Files.getAttribute(path, "unix:nlink"), is(2));
         }
+    }
+
+    @Test
+    public void testSyncMaybeWithLinksCopiesAllFiles() throws IOException {
+        // given
+        Path sourceDir = Files.createTempDirectory("sourceDir");
+        Files.createFile(sourceDir.resolve("file1.txt"));
+        Files.createDirectory(sourceDir.resolve("lib"));
+        Files.createDirectory(sourceDir.resolve("lib").resolve("java-version-checker"));
+        Files.createFile(sourceDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar"));
+
+        Path baseDestinationDir = Files.createTempDirectory("baseDestinationDir");
+        Path destinationDir = baseDestinationDir.resolve("destinationDir");
+
+        // when
+        IOUtils.syncMaybeWithLinks(sourceDir, destinationDir);
+
+        // then
+        assertFileExists(destinationDir.resolve("file1.txt"));
+        assertFileExists(destinationDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar"));
+    }
+
+    /**
+     * The integrity check underpinning the self-heal in {@link IOUtils#syncMaybeWithLinks}: it must report exactly the
+     * source-relative files that are absent from the destination. This is what catches a hard-link sync that silently
+     * dropped a jar from the classpath, as observed on Windows in #149129.
+     */
+    @Test
+    public void testFindMissingFilesDetectsIncompleteCopy() throws IOException {
+        // given a source tree and a destination missing a nested file
+        Path sourceDir = Files.createTempDirectory("sourceDir");
+        Files.createFile(sourceDir.resolve("file1.txt"));
+        Files.createDirectory(sourceDir.resolve("lib"));
+        Files.createDirectory(sourceDir.resolve("lib").resolve("java-version-checker"));
+        Files.createFile(sourceDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar"));
+
+        Path destinationDir = Files.createTempDirectory("destinationDir");
+        Files.copy(sourceDir.resolve("file1.txt"), destinationDir.resolve("file1.txt"));
+
+        // when / then the nested missing file is reported
+        assertThat(
+            IOUtils.findMissingFiles(sourceDir, destinationDir),
+            is(List.of(Path.of("lib", "java-version-checker", "checker.jar").toString()))
+        );
+
+        // and once the file is present, nothing is reported as missing
+        Files.createDirectory(destinationDir.resolve("lib"));
+        Files.createDirectory(destinationDir.resolve("lib").resolve("java-version-checker"));
+        Files.copy(
+            sourceDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar"),
+            destinationDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar")
+        );
+        assertThat(IOUtils.findMissingFiles(sourceDir, destinationDir), is(List.of()));
+    }
+
+    /**
+     * When a copy is incomplete, {@link IOUtils#verifyDistributionCopyComplete} must recover the missing files with a
+     * clean copy and emit explicit, greppable log lines (tagged with the self-heal marker) so the recovery is easy to
+     * find when diagnosing distribution-copy issues such as #149129.
+     */
+    @Test
+    public void testVerifyDistributionCopyCompleteSelfHealsAndLogs() throws IOException {
+        // given a source tree and an incomplete destination (missing the nested jar)
+        Path sourceDir = Files.createTempDirectory("sourceDir");
+        Files.createFile(sourceDir.resolve("file1.txt"));
+        Files.createDirectory(sourceDir.resolve("lib"));
+        Files.createDirectory(sourceDir.resolve("lib").resolve("java-version-checker"));
+        Files.createFile(sourceDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar"));
+
+        Path destinationDir = Files.createTempDirectory("destinationDir");
+        Files.copy(sourceDir.resolve("file1.txt"), destinationDir.resolve("file1.txt"));
+
+        // when, while capturing log output from IOUtils
+        List<String> logMessages = new CopyOnWriteArrayList<>();
+        AbstractAppender appender = new AbstractAppender("self-heal-capture", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                logMessages.add(event.getMessage().getFormattedMessage());
+            }
+        };
+        appender.start();
+        // With no log4j configuration the default root level is ERROR, which would filter the WARN self-heal lines,
+        // so attach the capturing appender and lower the level on the relevant logger config for the capture window,
+        // restoring both afterwards.
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(IOUtils.class.getName());
+        Level previousLevel = loggerConfig.getLevel();
+        config.addAppender(appender);
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        loggerConfig.setLevel(Level.WARN);
+        ctx.updateLoggers();
+        try {
+            IOUtils.verifyDistributionCopyComplete(sourceDir, destinationDir);
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            loggerConfig.setLevel(previousLevel);
+            ctx.updateLoggers();
+            appender.stop();
+        }
+
+        // then the missing file has been recovered (via a full copy, so no hard-link count assertion here)
+        Path recovered = destinationDir.resolve("lib").resolve("java-version-checker").resolve("checker.jar");
+        assertThat("Expected " + recovered + " to be recovered", Files.isRegularFile(recovered), is(true));
+
+        // and the self-heal is explicitly logged with the marker (detection + success)
+        assertThat(logMessages, hasItem(containsString(IOUtils.SELF_HEAL_MARKER + " incomplete distribution copy detected")));
+        assertThat(logMessages, hasItem(containsString(IOUtils.SELF_HEAL_MARKER + " self-heal succeeded")));
     }
 
     @Test


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Verify test cluster distribution copy integrity (#154257)