### PR TITLE
[9.5] Skip InputIndexUtilsTests on unsupported platforms (#155274)

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.lucene.store.DirectAccessIndexInput;
 import org.elasticsearch.core.DirectAccessInput;
 import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.simdvec.AbstractVectorTestCase;
-import org.elasticsearch.simdvec.IndexInputUtils;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -19,7 +19,8 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.elasticsearch.common.lucene.store.DirectAccessIndexInput;
 import org.elasticsearch.core.DirectAccessInput;
 import org.elasticsearch.nativeaccess.NativeAccess;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.simdvec.AbstractVectorTestCase;
+import org.elasticsearch.simdvec.IndexInputUtils;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -35,7 +36,7 @@ import static org.hamcrest.Matchers.not;
  * {@link DirectAccessInput} (byte-buffer), and plain {@link IndexInput}
  * (heap-copy fallback).
  */
-public class IndexInputUtilsTests extends ESTestCase {
+public class IndexInputUtilsTests extends AbstractVectorTestCase {
 
     private static final String FILE_NAME = "test.bin";
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Skip InputIndexUtilsTests on unsupported platforms (#155274)](https://github.com/elastic/elasticsearch/pull/155274)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)