### PR TITLE
[8.19] Bound numeric string length before parsing (#154689)

### DIFF
--- a/docs/changelog/154689.yaml
+++ b/docs/changelog/154689.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 154689
+summary: Bound numeric string length before parsing
+type: bug

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -123,11 +123,13 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Short.class);
-
-            double doubleValue = Double.parseDouble(text());
+            XContentString numericText = optimizedText();
+            checkNumericStringLength(numericText.stringLength());
+            String value = numericText.string();
+            double doubleValue = Double.parseDouble(value);
 
             if (doubleValue < Short.MIN_VALUE || doubleValue > Short.MAX_VALUE) {
-                throw new IllegalArgumentException("Value [" + text() + "] is out of range for a short");
+                throw new IllegalArgumentException("Value [" + value + "] is out of range for a short");
             }
 
             return (short) doubleValue;
@@ -149,10 +151,13 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Integer.class);
-            double doubleValue = Double.parseDouble(text());
+            XContentString numericText = optimizedText();
+            checkNumericStringLength(numericText.stringLength());
+            String value = numericText.string();
+            double doubleValue = Double.parseDouble(value);
 
             if (doubleValue < Integer.MIN_VALUE || doubleValue > Integer.MAX_VALUE) {
-                throw new IllegalArgumentException("Value [" + text() + "] is out of range for an integer");
+                throw new IllegalArgumentException("Value [" + value + "] is out of range for an integer");
             }
 
             return (int) doubleValue;
@@ -166,6 +171,18 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     private static final BigInteger LONG_MAX_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MAX_VALUE);
     private static final BigInteger LONG_MIN_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MIN_VALUE);
+
+    // Numeric strings longer than this are rejected before coercion, whose cost grows with the digit count;
+    // matches the unquoted JSON number-token limit. Mirrored by Numbers#MAX_NUMERIC_STRING_LENGTH. Keep in sync.
+    public static final int MAX_NUMERIC_STRING_LENGTH = 1000;
+
+    private static void checkNumericStringLength(int length) {
+        if (length > MAX_NUMERIC_STRING_LENGTH) {
+            throw new IllegalArgumentException(
+                "Numeric value length [" + length + "] exceeds the maximum of [" + MAX_NUMERIC_STRING_LENGTH + "]"
+            );
+        }
+    }
 
     /** Return the long that {@code stringValue} stores or throws an exception if the
      *  stored value cannot be converted to a long that stores the exact same
@@ -219,7 +236,9 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Long.class);
-            return toLong(text(), coerce);
+            XContentString numericText = optimizedText();
+            checkNumericStringLength(numericText.stringLength());
+            return toLong(numericText.string(), coerce);
         }
         long result = doLongValue();
         ensureNumberConversion(coerce, result, Long.class);
@@ -238,7 +257,9 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Float.class);
-            return Float.parseFloat(text());
+            XContentString numericText = optimizedText();
+            checkNumericStringLength(numericText.stringLength());
+            return Float.parseFloat(numericText.string());
         }
         return doFloatValue();
     }
@@ -255,7 +276,9 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Double.class);
-            return Double.parseDouble(text());
+            XContentString numericText = optimizedText();
+            checkNumericStringLength(numericText.stringLength());
+            return Double.parseDouble(numericText.string());
         }
         return doDoubleValue();
     }

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -12,8 +12,10 @@ package org.elasticsearch.xcontent;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xcontent.support.AbstractXContentParser;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -127,6 +129,40 @@ public class XContentParserTests extends ESTestCase {
                 assertFieldWithValue("maxNegativeExp", 0L, parser);
 
                 assertFieldWithInvalidLongValue("tooNegativeExp", parser);
+            }
+        }
+    }
+
+    public void testNumericCoercionBoundsStringLength() throws IOException {
+        String atLimit = "0".repeat(AbstractXContentParser.MAX_NUMERIC_STRING_LENGTH - 1) + "1";
+        String overLimit = "0".repeat(AbstractXContentParser.MAX_NUMERIC_STRING_LENGTH) + "1";
+        assertThat(atLimit.length(), equalTo(AbstractXContentParser.MAX_NUMERIC_STRING_LENGTH));
+        assertThat(overLimit.length(), equalTo(AbstractXContentParser.MAX_NUMERIC_STRING_LENGTH + 1));
+
+        for (CheckedConsumer<XContentParser, IOException> accessor : List.<CheckedConsumer<XContentParser, IOException>>of(
+            XContentParser::shortValue,
+            XContentParser::intValue,
+            XContentParser::longValue,
+            XContentParser::floatValue,
+            XContentParser::doubleValue
+        )) {
+            assertNumericAccessor(atLimit, accessor);
+            assertNumericAccessor(overLimit, parser -> {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> accessor.accept(parser));
+                assertThat(e.getMessage(), containsString("exceeds the maximum"));
+            });
+        }
+    }
+
+    private void assertNumericAccessor(String value, CheckedConsumer<XContentParser, IOException> assertion) throws IOException {
+        XContentType xContentType = randomFrom(XContentType.values());
+        try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.startObject().field("n", value).endObject();
+            try (XContentParser parser = createParser(xContentType.xContent(), BytesReference.bytes(builder))) {
+                assertThat(parser.nextToken(), is(XContentParser.Token.START_OBJECT));
+                assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
+                assertThat(parser.nextToken(), is(XContentParser.Token.VALUE_STRING));
+                assertion.accept(parser);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/Numbers.java
+++ b/server/src/main/java/org/elasticsearch/common/Numbers.java
@@ -121,6 +121,25 @@ public final class Numbers {
     private static BigDecimal BIGDECIMAL_GREATER_THAN_LONG_MAX_VALUE = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
     private static BigDecimal BIGDECIMAL_LESS_THAN_LONG_MIN_VALUE = BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE);
 
+    // Numeric strings longer than this are rejected before coercion, whose cost grows with the digit count;
+    // matches the unquoted JSON number-token limit. Mirrored by AbstractXContentParser#MAX_NUMERIC_STRING_LENGTH. Keep in sync.
+    public static final int MAX_NUMERIC_STRING_LENGTH = 1000;
+
+    /** Rejects numeric strings longer than {@link #MAX_NUMERIC_STRING_LENGTH}. */
+    public static void checkNumericStringLength(String value) {
+        if (value.length() > MAX_NUMERIC_STRING_LENGTH) {
+            throw new IllegalArgumentException(
+                "Numeric value length [" + value.length() + "] exceeds the maximum of [" + MAX_NUMERIC_STRING_LENGTH + "]"
+            );
+        }
+    }
+
+    /** Like {@code new BigDecimal(value)} but rejects strings longer than {@link #MAX_NUMERIC_STRING_LENGTH}. */
+    public static BigDecimal newBigDecimal(String value) {
+        checkNumericStringLength(value);
+        return new BigDecimal(value);
+    }
+
     /** Return the long that {@code stringValue} stores or throws an exception if the
      *  stored value cannot be converted to a long that stores the exact same
      *  value and {@code coerce} is false. */
@@ -133,7 +152,7 @@ public final class Numbers {
 
         final BigInteger bigIntegerValue;
         try {
-            BigDecimal bigDecimalValue = new BigDecimal(stringValue);
+            BigDecimal bigDecimalValue = newBigDecimal(stringValue);
             if (bigDecimalValue.compareTo(BIGDECIMAL_GREATER_THAN_LONG_MAX_VALUE) >= 0
                 || bigDecimalValue.compareTo(BIGDECIMAL_LESS_THAN_LONG_MIN_VALUE) <= 0) {
                 throw new IllegalArgumentException("Value [" + stringValue + "] is out of range for a long");

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1461,7 +1461,7 @@ public class NumberFieldMapper extends FieldMapper {
                     return false;
                 }
                 String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
-                BigDecimal bigDecimalValue = new BigDecimal(stringValue);
+                BigDecimal bigDecimalValue = Numbers.newBigDecimal(stringValue);
                 return bigDecimalValue.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0
                     || bigDecimalValue.compareTo(BigDecimal.valueOf(Long.MIN_VALUE)) < 0;
             }

--- a/server/src/test/java/org/elasticsearch/common/NumbersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/NumbersTests.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -58,6 +59,22 @@ public class NumbersTests extends ESTestCase {
             "For input string: \"t12345\"",
             expectThrows(IllegalArgumentException.class, () -> Numbers.toLong("t12345", false)).getMessage()
         );
+    }
+
+    public void testNewBigDecimalRejectsOversizedString() {
+        // A value at the limit parses normally; one character longer is rejected before construction.
+        String atLimit = "1".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        assertThat(Numbers.newBigDecimal(atLimit), equalTo(new BigDecimal(atLimit)));
+
+        String tooLong = "1".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
+        assertThat(
+            expectThrows(IllegalArgumentException.class, () -> Numbers.newBigDecimal(tooLong)).getMessage(),
+            containsString("exceeds the maximum")
+        );
+
+        // toLong routes string coercion through the same guard instead of parsing an unbounded number.
+        String oversizedDecimal = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(IllegalArgumentException.class, () -> Numbers.toLong(oversizedDecimal, true));
     }
 
     public void testToLongExact() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.Script;
@@ -101,6 +102,13 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
         assertThat(doc.rootDoc().getFields("field"), hasSize(1));
         doc = mapper.parse(source(b -> b.field("field", "-9223372036854775808.9")));
         assertThat(doc.rootDoc().getFields("field"), hasSize(1));
+    }
+
+    public void testLongIndexingRejectsOversizedString() throws Exception {
+        // A quoted numeric value long enough to be costly to parse is rejected instead of coerced.
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        String oversized = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> b.field("field", oversized))));
     }
 
     // This is the biggest long that double can represent exactly

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -34,6 +34,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.IndexSettings;
@@ -105,6 +106,13 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals(LongPoint.newSetQuery("field", 1), ft.termsQuery(Arrays.asList(1, 2.1), MOCK_CONTEXT));
         assertEquals(LongPoint.newSetQuery("field", 1), ft.termsQuery(Arrays.asList(1.0, 2.1), MOCK_CONTEXT));
         assertTrue(ft.termsQuery(Arrays.asList(1.1, 2.1), MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+    }
+
+    public void testLongTermQueryRejectsOversizedString() {
+        // A quoted numeric value long enough to be costly to parse is rejected rather than coerced.
+        MappedFieldType ft = new NumberFieldType("field", NumberType.LONG);
+        String oversized = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(IllegalArgumentException.class, () -> ft.termQuery(oversized, MOCK_CONTEXT));
     }
 
     public void testByteTermQueryWithDecimalPart() {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.core.type;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
@@ -348,6 +349,13 @@ public final class DataTypeConverter {
     }
 
     public static BigInteger safeToUnsignedLong(String x) {
+        if (x.length() > Numbers.MAX_NUMERIC_STRING_LENGTH) {
+            throw new InvalidArgumentException(
+                "Numeric value length [{}] exceeds the maximum of [{}]",
+                x.length(),
+                Numbers.MAX_NUMERIC_STRING_LENGTH
+            );
+        }
         BigInteger bi = new BigDecimal(x).toBigInteger();
         if (isUnsignedLong(bi) == false) {
             throw new InvalidArgumentException("[{}] out of [unsigned_long] range", x);

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.Tuple;
@@ -367,7 +368,19 @@ public final class StringUtils {
         return value;
     }
 
+    // Bounds the numeric string length before parsing, whose cost grows with the digit count.
+    private static void checkNumericStringLength(String string) {
+        if (string.length() > Numbers.MAX_NUMERIC_STRING_LENGTH) {
+            throw new InvalidArgumentException(
+                "Numeric value length [{}] exceeds the maximum of [{}]",
+                string.length(),
+                Numbers.MAX_NUMERIC_STRING_LENGTH
+            );
+        }
+    }
+
     public static long parseLong(String string) throws InvalidArgumentException {
+        checkNumericStringLength(string);
         try {
             return Long.parseLong(string);
         } catch (NumberFormatException nfe) {
@@ -386,6 +399,7 @@ public final class StringUtils {
     }
 
     public static Number parseIntegral(String string) throws InvalidArgumentException {
+        checkNumericStringLength(string);
         BigInteger bi;
         try {
             bi = new BigInteger(string);

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/StringUtilsTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/util/StringUtilsTests.java
@@ -7,13 +7,21 @@
 
 package org.elasticsearch.xpack.esql.core.util;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 
 import static org.elasticsearch.xpack.esql.core.util.StringUtils.luceneWildcardToRegExp;
 import static org.elasticsearch.xpack.esql.core.util.StringUtils.wildcardToJavaPattern;
 import static org.hamcrest.Matchers.is;
 
 public class StringUtilsTests extends ESTestCase {
+
+    public void testParseIntegralRejectsOversizedString() {
+        String oversized = "9".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
+        expectThrows(InvalidArgumentException.class, () -> StringUtils.parseIntegral(oversized));
+        expectThrows(InvalidArgumentException.class, () -> StringUtils.parseLong(oversized));
+    }
 
     public void testNoWildcard() {
         assertEquals("^fooBar$", wildcardToJavaPattern("fooBar", '\\'));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -67,10 +68,22 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
         );
         // random strings that don't look like an unsigned_long
         TestCaseSupplier.forUnaryStrings(suppliers, evaluatorName("String", "in"), DataType.UNSIGNED_LONG, bytesRef -> null, bytesRef -> {
+            String value = bytesRef.utf8ToString();
+            // Strings longer than the numeric limit are rejected before BigDecimal parsing, so the surfaced error differs.
+            if (value.length() > Numbers.MAX_NUMERIC_STRING_LENGTH) {
+                return List.of(
+                    "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
+                    "Line 1:1: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Numeric value length ["
+                        + value.length()
+                        + "] exceeds the maximum of ["
+                        + Numbers.MAX_NUMERIC_STRING_LENGTH
+                        + "]"
+                );
+            }
             // BigDecimal, used to parse unsigned_longs will throw NFEs with different messages depending on empty string, first
             // non-number character after a number-looking like prefix, or string starting with "e", maybe others -- safer to take
             // this shortcut here.
-            Exception e = expectThrows(NumberFormatException.class, () -> new BigDecimal(bytesRef.utf8ToString()));
+            Exception e = expectThrows(NumberFormatException.class, () -> new BigDecimal(value));
             return List.of(
                 "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.",
                 "Line 1:1: java.lang.NumberFormatException: " + e.getMessage()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverterTests.java
@@ -7,8 +7,10 @@
 
 package org.elasticsearch.xpack.esql.type;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.time.Instant;
@@ -50,6 +52,11 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.isString;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.commonType;
 
 public class EsqlDataTypeConverterTests extends ESTestCase {
+
+    public void testStringToUnsignedLongRejectsOversizedString() {
+        String oversized = "9".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
+        expectThrows(InvalidArgumentException.class, () -> EsqlDataTypeConverter.stringToUnsignedLong(oversized));
+    }
 
     public void testNanoTimeToString() {
         long expected = randomNonNegativeLong();

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -18,6 +18,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersion;
@@ -583,6 +584,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 }
             } else {
                 String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
+                Numbers.checkNumericStringLength(stringValue);
                 try {
                     return Long.parseUnsignedLong(stringValue);
                 } catch (NumberFormatException e) {
@@ -614,7 +616,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 return longValue;
             }
             String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
-            final BigDecimal bigDecimalValue = new BigDecimal(stringValue);  // throws an exception if it is an improper number
+            final BigDecimal bigDecimalValue = Numbers.newBigDecimal(stringValue);  // throws an exception if it is an improper number
             if (bigDecimalValue.compareTo(BigDecimal.ZERO) < 0) {
                 return 0L; // for values < 0, set lowerTerm to 0
             }
@@ -648,7 +650,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 return longValue;
             }
             String stringValue = (value instanceof BytesRef) ? ((BytesRef) value).utf8ToString() : value.toString();
-            final BigDecimal bigDecimalValue = new BigDecimal(stringValue);  // throws an exception if it is an improper number
+            final BigDecimal bigDecimalValue = Numbers.newBigDecimal(stringValue);  // throws an exception if it is an improper number
             int c = bigDecimalValue.compareTo(BigDecimal.ZERO);
             if (c < 0 || (c == 0 && include == false)) {
                 return null; // upperTerm is below minimum
@@ -855,7 +857,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             } catch (NumberFormatException ignored) {
                 final BigInteger bigInteger;
                 try {
-                    final BigDecimal bigDecimal = new BigDecimal(stringValue);
+                    final BigDecimal bigDecimal = Numbers.newBigDecimal(stringValue);
                     bigInteger = bigDecimal.toBigIntegerExact();
                 } catch (ArithmeticException e) {
                     throw new IllegalArgumentException("Value \"" + stringValue + "\" has a decimal part");

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.unsignedlong;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -111,6 +112,29 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
         IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
         assertEquals(9223372036854775807L, dvField.numericValue().longValue());
+    }
+
+    public void testIndexingOversizedStringIsRejected() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        String oversized = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> b.field("field", oversized))));
+    }
+
+    public void testRangeTermsRejectOversizedString() {
+        String oversized = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> UnsignedLongFieldMapper.UnsignedLongFieldType.parseLowerRangeTerm(oversized, true)
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> UnsignedLongFieldMapper.UnsignedLongFieldType.parseUpperRangeTerm(oversized, true)
+        );
+    }
+
+    public void testTermRejectsOversizedString() {
+        String oversized = "1." + "0".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH);
+        expectThrows(IllegalArgumentException.class, () -> UnsignedLongFieldMapper.UnsignedLongFieldType.parseTerm(oversized));
     }
 
     public void testNoDocValues() throws Exception {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DataTypeConverter.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DataTypeConverter.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ql.type;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
@@ -427,6 +428,13 @@ public final class DataTypeConverter {
     }
 
     public static BigInteger safeToUnsignedLong(String x) {
+        if (x.length() > Numbers.MAX_NUMERIC_STRING_LENGTH) {
+            throw new InvalidArgumentException(
+                "Numeric value length [{}] exceeds the maximum of [{}]",
+                x.length(),
+                Numbers.MAX_NUMERIC_STRING_LENGTH
+            );
+        }
         BigInteger bi = new BigDecimal(x).toBigInteger();
         if (isUnsignedLong(bi) == false) {
             throw new InvalidArgumentException("[{}] out of [unsigned_long] range", x);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -10,6 +10,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.Tuple;
@@ -323,7 +324,19 @@ public final class StringUtils {
         return value;
     }
 
+    // Bounds the numeric string length before parsing, whose cost grows with the digit count.
+    private static void checkNumericStringLength(String string) {
+        if (string.length() > Numbers.MAX_NUMERIC_STRING_LENGTH) {
+            throw new InvalidArgumentException(
+                "Numeric value length [{}] exceeds the maximum of [{}]",
+                string.length(),
+                Numbers.MAX_NUMERIC_STRING_LENGTH
+            );
+        }
+    }
+
     public static long parseLong(String string) throws InvalidArgumentException {
+        checkNumericStringLength(string);
         try {
             return Long.parseLong(string);
         } catch (NumberFormatException nfe) {
@@ -342,6 +355,7 @@ public final class StringUtils {
     }
 
     public static Number parseIntegral(String string) throws InvalidArgumentException {
+        checkNumericStringLength(string);
         BigInteger bi;
         try {
             bi = new BigInteger(string);

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/type/DataTypeConversionTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ql.type;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Literal;
@@ -37,6 +38,12 @@ import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
 import static org.elasticsearch.xpack.ql.type.DateUtils.asDateTime;
 
 public class DataTypeConversionTests extends ESTestCase {
+
+    public void testSafeToUnsignedLongRejectsOversizedString() {
+        // A numeric string long enough to be costly to parse is rejected before BigDecimal construction.
+        String oversized = "9".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
+        expectThrows(InvalidArgumentException.class, () -> DataTypeConverter.safeToUnsignedLong(oversized));
+    }
 
     public void testConversionToString() {
         DataType to = KEYWORD;

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
@@ -7,11 +7,19 @@
 
 package org.elasticsearch.xpack.ql.util;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 
 import static org.elasticsearch.xpack.ql.util.StringUtils.wildcardToJavaPattern;
 
 public class StringUtilsTests extends ESTestCase {
+
+    public void testParseIntegralRejectsOversizedString() {
+        String oversized = "9".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
+        expectThrows(InvalidArgumentException.class, () -> StringUtils.parseIntegral(oversized));
+        expectThrows(InvalidArgumentException.class, () -> StringUtils.parseLong(oversized));
+    }
 
     public void testNoWildcard() {
         assertEquals("^fooBar$", wildcardToJavaPattern("fooBar", '\\'));


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Bound numeric string length before parsing (#154689)
