### PR TITLE
[9.5] ES|QL|DS: Add esql.federation.enabled, off by default (#155199)

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ExternalClusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/ExternalClusters.java
@@ -34,6 +34,8 @@ class ExternalClusters {
      */
     static ElasticsearchCluster buildExternalCluster(Supplier<String> s3EndpointSupplier) {
         return Clusters.buildClusterSpec()
+            // This suite registers data sources and reads them, so it needs the opt-in federation setting.
+            .setting("esql.federation.enabled", "true")
             // Pin the request-breaker limit so the suite reliably trips it regardless of the
             // base cluster's heap size (which varies between the standard and serverless configs).
             // Kept low to leave headroom for untracked S3/Netty allocations.

--- a/x-pack/plugin/esql-datasource-azure/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/azure/AzureAksManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql-datasource-azure/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/azure/AzureAksManagedIdentityAuthIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
 import org.elasticsearch.test.fixtures.tls.TestTrustStore;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -110,6 +111,7 @@ public class AzureAksManagedIdentityAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("esql.datasource.managed_identity.enabled", "true")
         // Operator-managed symlink that the Azure SDK is pointed at via tokenFilePath().
         .configFile("esql-datasource-azure/azure-federated-token", Resource.fromString(fixture.getFederatedToken()))

--- a/x-pack/plugin/esql-datasource-azure/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/azure/AzureManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql-datasource-azure/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/azure/AzureManagedIdentityAuthIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.fixtures.tls.TestTlsCertificate;
 import org.elasticsearch.test.fixtures.tls.TestTrustStore;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -110,6 +111,7 @@ public class AzureManagedIdentityAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         // Open the workload identity gate so the validator accepts auth=managed_identity.
         .setting("esql.datasource.managed_identity.enabled", "true")
         // Redirect the Azure IMDS endpoint to our fixture so ManagedIdentityCredential resolves a

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/Clusters.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/Clusters.java
@@ -52,6 +52,9 @@ public class Clusters {
             // Basic cluster settings
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            // Federation is opt-in for users; every suite here queries external data. This default is a supplier rather
+            // than a plain value so that a per-node override added later still wins: explicit settings beat suppliers.
+            .setting(Federation.FEDERATION_ENABLED.getKey(), () -> "true")
             // Disable ML to avoid native code loading issues in some environments
             .setting("xpack.ml.enabled", "false")
             // Allow the LOCAL storage backend to read fixture files from the test resources directory.
@@ -116,18 +119,17 @@ public class Clusters {
     }
 
     /**
-     * A split-role two-node cluster (coordinator-only node 0, master+data node 1) that boots the data node
-     * with the ES|QL federation kill switch engaged ({@code es.esql.register_federation_feature=false}) while
-     * the coordinator stays enabled. This reproduces the mixed / rolling-restart window the data-node backstop
-     * in {@code LocalExecutionPlanner.planExternalSource} guards: the enabled coordinator resolves
-     * {@code FROM <dataset>} into an external scan and dispatches it to the disabled data node, which must
-     * refuse it at operator build rather than reading external storage. The property is a static, read-once
-     * lever, so it must be supplied per node at boot rather than toggled at runtime.
+     * A split-role two-node cluster (coordinator-only node 0, master+data node 1) that boots the data node with
+     * federation turned off while the coordinator keeps it on. This reproduces the rolling-restart window the data-node
+     * backstop in {@code LocalExecutionPlanner.planExternalSource} guards: the enabled coordinator resolves
+     * {@code FROM <dataset>} into an external scan and dispatches it to the data node, which must refuse it at operator
+     * build rather than reading external storage. Federation is read once at boot, so the override is supplied per node
+     * rather than toggled at runtime.
      */
     public static ElasticsearchCluster multiNodeCoordinatorEnabledDataNodeDisabledCluster(Supplier<String> s3EndpointSupplier) {
         return baseBuilder(s3EndpointSupplier, config -> {}).withNode(node -> node.name("coordinator").setting("node.roles", "[]"))
             .withNode(node -> node.name("data-node").setting("node.roles", "[master, data]"))
-            .systemProperty(Federation.REGISTER_PROPERTY, () -> "false", nodeSpec -> "data-node".equals(nodeSpec.getName()))
+            .setting(Federation.FEDERATION_ENABLED.getKey(), () -> "false", nodeSpec -> "data-node".equals(nodeSpec.getName()))
             .build();
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/FederationDataNodeBackstopRestIT.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/FederationDataNodeBackstopRestIT.java
@@ -37,20 +37,27 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Exercises the federation kill switch's data-node backstop ({@code LocalExecutionPlanner.planExternalSource})
- * at its call site, which the pure-unit {@code FederationTests} cannot: that helper test drives
- * {@code Federation.ensureEnabled(boolean)} directly, so deleting the backstop call from the planner would not
- * make it fail.
+ * Pins the end-to-end behavior a node without federation owes an enabled coordinator: it refuses the external scan
+ * and reads nothing. The pure-unit {@code FederationTests} cannot show this, since it drives
+ * {@code Federation.ensureEnabled(boolean)} directly rather than through any call site.
  *
  * <p>The cluster splits roles across two JVMs: node 0 is coordinating-only with federation <em>enabled</em>,
- * node 1 is master+data with federation <em>suppressed</em> at boot. This is the mixed / rolling-restart window
- * the backstop guards. All requests target the enabled coordinator, which registers a local-file CSV data
- * source and dataset (the create actions still work through the suppressed master because the transport actions
- * stay registered), then runs {@code FROM <dataset>}. The coordinator resolves the dataset and dispatches the
- * external scan to the disabled data node, which must refuse it at operator build with a {@code 400}
- * ({@code external data sources are not available}) rather than reading the file. With the backstop removed the
- * data node would scan the CSV and the query would succeed, so this test goes red exactly when the wiring is
- * lost.
+ * node 1 is master+data with {@code esql.federation.enabled} turned <em>off</em> at boot. This is the
+ * rolling-restart window the refusal guards. All requests target the enabled coordinator, which registers a
+ * local-file CSV data source and dataset (the create actions still work through the disabled master because the
+ * transport actions stay registered), then runs {@code FROM <dataset>}. The coordinator resolves the dataset and
+ * dispatches the external scan to the disabled data node, which must answer {@code 400}
+ * ({@code external data sources are not available}) rather than reading the file.
+ *
+ * <p>Two independent mechanisms produce that answer, and this suite deliberately does not distinguish them: the
+ * request-entry gate in {@code DataNodeComputeHandler.handleExternalSourceRequest} refuses first, and the operator
+ * build backstop in {@code LocalExecutionPlanner.planExternalSource} would refuse the same query if the gate were
+ * gone. So removing either one alone leaves this test green; what goes red is losing both, i.e. the data node
+ * actually serving external data. Each mechanism has its own narrower test:
+ * {@code LocalExecutionPlannerTests.testExternalSourceRefusedWhenFederationIsNotAvailable} for the backstop, and
+ * for the gate the shapes only it can catch, an ungrouped aggregate that {@code PushStatsToExternalSource} answers
+ * from split statistics and folds to a {@code LocalSourceExec}, which local CSV cannot produce because it carries
+ * no statistics.
  */
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class FederationDataNodeBackstopRestIT extends ESRestTestCase {
@@ -100,14 +107,14 @@ public class FederationDataNodeBackstopRestIT extends ESRestTestCase {
         assumeTrue("LOCAL fixtures unavailable (packaged in a JAR)", localFixturesPath != null);
         String uri = localFixturesPath.resolve("standalone/employees.csv").toUri().toString();
         // Register a local-file data source + dataset over the fixture. The create requests go through the
-        // suppressed master node: they succeed because the federation transport actions stay registered even
-        // when the switch is engaged (only the REST handlers are unregistered).
+        // disabled master node: they succeed because the federation transport actions stay registered even when
+        // federation is off (only the REST handlers are unregistered).
         DatasetRegistry.ensureDataSource(client(), LOCAL_DATA_SOURCE, "local", Map.of());
         DatasetRegistry.ensureDataset(client(), DATASET, LOCAL_DATA_SOURCE, uri, "{ \"multi_value_syntax\": \"brackets\" }");
 
         Request request = new Request("POST", "/_query");
         // external_distribution=round_robin forces the scan onto the data node (the adaptive default might run a
-        // single small split locally on the coordinator), so the disabled data node's backstop is the path under test.
+        // single small split locally on the coordinator), so the disabled data node is the one that has to refuse.
         request.setJsonEntity(
             "{\"query\":\"FROM " + DATASET + " | STATS c = COUNT(*)\",\"pragma\":{\"external_distribution\":\"round_robin\"}}"
         );

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvDataSourcePlugin.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
@@ -90,9 +91,14 @@ public class CsvDataSourcePlugin extends Plugin implements DataSourcePlugin {
         return Set.of(FormatSpec.of("csv", ".csv", FORMAT_CONFIG_KEYS), FormatSpec.of("tsv", ".tsv", FORMAT_CONFIG_KEYS));
     }
 
+    /**
+     * The CSV read path only exists for external data sources, so this knob follows the federation feature: an
+     * operator who unregistered the feature does not accept configuration for it, and a node whose
+     * {@code elasticsearch.yml} carries the key fails to start with the standard {@code unknown setting} error.
+     */
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(CSV_DIRECT_BLOCK_ENABLED);
+        return Federation.isRegistered() ? List.of(CSV_DIRECT_BLOCK_ENABLED) : List.of();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-gcs/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/gcs/GcsManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/gcs/GcsManagedIdentityAuthIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -84,6 +85,7 @@ public class GcsManagedIdentityAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         // Open the workload identity gate so the validator accepts auth=managed_identity.
         .setting("esql.datasource.managed_identity.enabled", "true")
         // Redirect the GCE metadata server to our fixture so ComputeEngineCredentials.refresh()

--- a/x-pack/plugin/esql-datasource-grpc/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/grpc/Clusters.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/grpc/Clusters.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.qa.grpc;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 
 /**
  * Cluster configuration for Arrow Flight (gRPC) integration tests.
@@ -21,6 +22,7 @@ class Clusters {
             .shared(true)
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             .setting("xpack.ml.enabled", "false")
             .jvmArg("--add-opens=java.base/java.nio=ALL-UNNAMED")
             .jvmArg("-Darrow.allocation.manager.type=Unsafe")

--- a/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/Clusters.java
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/Clusters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.qa.iceberg;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 
 import java.util.function.Supplier;
 
@@ -39,6 +40,7 @@ public class Clusters {
             // Basic cluster settings
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             // Disable ML to avoid native code loading issues in some environments
             .setting("xpack.ml.enabled", "false")
             // S3 client configuration for accessing the S3HttpFixture

--- a/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/InteractiveFixtureManual.java
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/InteractiveFixtureManual.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3HttpFixture;
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.S3RequestLog;
@@ -95,6 +96,10 @@ public class InteractiveFixtureManual extends ESRestTestCase {
         // Basic cluster settings
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        // This runner builds its own cluster rather than going through Clusters, so it needs the federation opt-in that
+        // the shared builder applies; without it the data source and dataset routes this fixture exists to drive by hand
+        // are never registered.
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         // Disable ML to avoid native code loading issues in some environments
         .setting("xpack.ml.enabled", "false")
         // S3 client configuration for accessing the S3HttpFixture

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/Clusters.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/Clusters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.qa.ndjson;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
 import java.util.function.Supplier;
@@ -47,6 +48,7 @@ public class Clusters {
             // Basic cluster settings
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             // Disable ML to avoid native code loading issues in some environments
             .setting("xpack.ml.enabled", "false")
             // Allow the LOCAL storage backend to read fixture files from the test resources directory.

--- a/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/orc/Clusters.java
+++ b/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/orc/Clusters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.qa.orc;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
 import java.util.function.Supplier;
@@ -31,6 +32,7 @@ public class Clusters {
             .module("repository-gcs")
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             .setting("xpack.ml.enabled", "false")
             .setting("path.repo", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))
             .setting("esql.datasource.local_allowed_paths", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))

--- a/x-pack/plugin/esql-datasource-parquet-rs/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
+++ b/x-pack/plugin/esql-datasource-parquet-rs/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.qa.parquet;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
 import java.util.function.Supplier;
@@ -32,6 +33,7 @@ public class Clusters {
             .module("repository-gcs")
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             .setting("xpack.ml.enabled", "false")
             .setting("path.repo", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))
             .setting("esql.datasource.local_allowed_paths", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.qa.parquet;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
 import java.util.function.Supplier;
@@ -48,6 +49,7 @@ public class Clusters {
             .module("repository-gcs")
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             .setting("xpack.ml.enabled", "false")
             .setting("path.repo", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))
             .setting("esql.datasource.local_allowed_paths", FixtureUtils.pathRepoRootForIcebergFixtures(Clusters.class))
@@ -68,6 +70,7 @@ public class Clusters {
             // Basic cluster settings
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             // Disable ML to avoid native code loading issues in some environments
             .setting("xpack.ml.enabled", "false")
             // Allow the LOCAL storage backend to read fixture files from the test resources directory.

--- a/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/IrsaCredentialsReloadIT.java
+++ b/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/IrsaCredentialsReloadIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -94,6 +95,7 @@ public class IrsaCredentialsReloadIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("esql.datasource.managed_identity.enabled", "true")
         // Start with a token that does NOT match what the STS fixture expects, so the initial query
         // fails; the test then rewrites this file to the valid value at runtime.

--- a/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/IrsaManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/IrsaManagedIdentityAuthIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -100,6 +101,7 @@ public class IrsaManagedIdentityAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("esql.datasource.managed_identity.enabled", "true")
         // The plugin requires the operator to symlink the EKS-injected web-identity token to a
         // fixed location under config; the cluster builder writes the token bytes there directly.

--- a/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/PodIdentityManagedIdentityAuthIT.java
+++ b/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/PodIdentityManagedIdentityAuthIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -93,6 +94,7 @@ public class PodIdentityManagedIdentityAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("esql.datasource.managed_identity.enabled", "true")
         // Operator-managed symlink the plugin redirects the AWS SDK at via JVM sysprop.
         .configFile("esql-datasource-s3/eks-pod-identity-token", Resource.fromString(AUTH_TOKEN_FILE_CONTENTS))

--- a/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/S3ManagedIdentityBrokenAuthIT.java
+++ b/x-pack/plugin/esql-datasource-s3/src/javaRestTest/java/org/elasticsearch/xpack/esql/datasource/s3/qa/S3ManagedIdentityBrokenAuthIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -83,6 +84,7 @@ public class S3ManagedIdentityBrokenAuthIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("esql.datasource.managed_identity.enabled", "true")
         .configFile(WEB_IDENTITY_TOKEN_FILE_LOCATION, Resource.fromString(ON_DISK_TOKEN))
         .systemProperty("org.elasticsearch.xpack.esql.datasource.s3.stsEndpointOverride", stsHttpFixture::getAddress)

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.datasources.EsqlDataSourcesCapabilities;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.Before;
 import org.junit.ClassRule;
 
@@ -69,6 +70,8 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
+        // Federation is opt-in for users; the data source and dataset authorization tests here need it on.
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .rolesFile(Resource.fromClasspath("roles.yml"))
         .user("test-admin", "x-pack-test-password", "test-admin", true)
         .user("user1", "x-pack-test-password", "user1", false)

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -25,7 +25,7 @@ public class Clusters {
      * release constants, so the boundary is converted from the server constant instead of being spelled out again. The
      * qualified name disambiguates the two {@code Version} types this file needs.
      */
-    private static final Version FEDERATION_SETTING_VERSION = Version.fromString(org.elasticsearch.Version.V_9_6_0.toString());
+    private static final Version FEDERATION_SETTING_VERSION = Version.fromString(org.elasticsearch.Version.V_9_5_0.toString());
 
     public static ElasticsearchCluster mixedVersionCluster() {
         return mixedVersionCluster(CsvTestUtils.createCsvDataDirectory(), false);

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -8,14 +8,25 @@
 package org.elasticsearch.xpack.esql.qa.mixed;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalNodeSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 
 import java.nio.file.Path;
 
 public class Clusters {
+
+    private static final String FEDERATION_ENABLED_SETTING = Federation.FEDERATION_ENABLED.getKey();
+    /**
+     * The version {@link #FEDERATION_ENABLED_SETTING} exists as of. Node specs take a {@link Version}, which carries no
+     * release constants, so the boundary is converted from the server constant instead of being spelled out again. The
+     * qualified name disambiguates the two {@code Version} types this file needs.
+     */
+    private static final Version FEDERATION_SETTING_VERSION = Version.fromString(org.elasticsearch.Version.V_9_6_0.toString());
+
     public static ElasticsearchCluster mixedVersionCluster() {
         return mixedVersionCluster(CsvTestUtils.createCsvDataDirectory(), false);
     }
@@ -26,10 +37,10 @@ public class Clusters {
         boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
         var cluster = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .withNode(node -> node.version(oldVersionString, isDetachedVersion))
-            .withNode(node -> node.version(Version.CURRENT).setting("esql.datasource.local_allowed_paths", csvDataPath::toString))
-            .withNode(node -> node.version(oldVersionString, isDetachedVersion))
-            .withNode(node -> node.version(Version.CURRENT).setting("esql.datasource.local_allowed_paths", csvDataPath::toString))
+            .withNode(node -> oldVersionNode(node, oldVersionString, isDetachedVersion, oldVersion))
+            .withNode(node -> currentVersionNode(node, csvDataPath))
+            .withNode(node -> oldVersionNode(node, oldVersionString, isDetachedVersion, oldVersion))
+            .withNode(node -> currentVersionNode(node, csvDataPath))
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
             .setting("path.repo", csvDataPath::toString)
@@ -53,6 +64,41 @@ public class Clusters {
             cluster.shared(true);
         }
         return cluster.build();
+    }
+
+    /**
+     * Configures a current-version node with the settings that do not exist on every version in the mixed cluster: a node
+     * that does not know a setting rejects it and fails to start, so the local-disk allowlist and the federation opt-in
+     * are set per node rather than cluster-wide.
+     */
+    private static void currentVersionNode(LocalNodeSpecBuilder node, Path csvDataPath) {
+        node.version(Version.CURRENT)
+            .setting("esql.datasource.local_allowed_paths", csvDataPath::toString)
+            .setting(FEDERATION_ENABLED_SETTING, "true");
+    }
+
+    /**
+     * Configures an old-version node, opting it into federation when it knows the setting. Any node can coordinate a
+     * query and federation has to agree across the cluster, so every node that reads the setting gets it; a build that
+     * predates the setting registers federation unconditionally and has it on without one.
+     */
+    private static void oldVersionNode(LocalNodeSpecBuilder node, String versionString, boolean detached, Version version) {
+        node.version(versionString, detached);
+        if (knowsFederationSetting(version, detached)) {
+            node.setting(FEDERATION_ENABLED_SETTING, "true");
+        }
+    }
+
+    /**
+     * Whether the old node accepts the federation setting. A node that does not know it rejects it as an unknown setting
+     * and never starts.
+     *
+     * @param detached whether the node is built from a git ref rather than resolved from a release. Such a build reports
+     *        the version it will become, which says nothing about which commits it contains, so the setting is left off:
+     *        the ref can point at a main commit from before the setting was introduced.
+     */
+    private static boolean knowsFederationSetting(Version version, boolean detached) {
+        return detached == false && version.onOrAfter(FEDERATION_SETTING_VERSION);
     }
 
     private static boolean supportRetryOnShardFailures(Version version) {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/build.gradle
@@ -53,22 +53,25 @@ tasks.named("bwcTest").configure {
   }
 }
 
-// The federation kill-switch remote-dataset gate is a current-to-current CCS test (it registers a dataset while
-// enabled, then bounces the remote with the switch off). The base javaRestTest task is disabled by the bwc-test
-// plugin and every other javaRestTest class here is bwc-only, so this class gets its own current-to-current runner
-// wired into `check`.
-def federationKillSwitchTest = tasks.register("v${currentVersion}#federationKillSwitchTest", StandaloneRestIntegTestTask) {
+// The federation remote-dataset gates drive the federation setting on one of the two clusters: one registers a dataset
+// on the remote while federation is enabled there and then bounces the remote with federation off, the other keeps the
+// remote enabled and runs against a local cluster that has federation off. Both skip on a cluster whose version does
+// not report the federation setting capability, so the BWC tasks below cover the directions that can run. The base
+// javaRestTest task is disabled by the bwc-test plugin, so they get their own current-to-current runner wired into
+// `check` for the configuration that always applies.
+def federationGateTestPattern = "org.elasticsearch.xpack.esql.ccq.Federation*GateRestIT"
+def federationRemoteDatasetGateTest = tasks.register("v${currentVersion}#federationRemoteDatasetGateTest", StandaloneRestIntegTestTask) {
   systemProperty("tests.version.remote_cluster", currentVersion)
   systemProperty("tests.version.local_cluster", currentVersion)
   maxParallelForks = 1
   testClassesDirs = sourceSets.javaRestTest.output.classesDirs
   classpath = sourceSets.javaRestTest.runtimeClasspath
   filter {
-    includeTestsMatching "org.elasticsearch.xpack.esql.ccq.FederationRemoteDatasetGateRestIT"
+    includeTestsMatching federationGateTestPattern
   }
 }
 tasks.named("check").configure {
-  dependsOn federationKillSwitchTest
+  dependsOn federationRemoteDatasetGateTest
 }
 
 def supportedVersion = bwcVersion -> {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
@@ -30,16 +30,15 @@ public class Clusters {
     }
 
     /**
-     * @param registerFederationFeature supplier for the ES|QL federation kill-switch system property
-     *        ({@value org.elasticsearch.xpack.esql.datasources.Federation#REGISTER_PROPERTY}), re-read on every
-     *        (re)start so a test can create federation state while enabled and then bounce the remote with the
-     *        switch off. {@code null} leaves the property unset (federation enabled by default).
+     * @param federationEnabled supplier for the ES|QL federation setting, re-read on every (re)start so a test can
+     *        create federation state while enabled and then bounce the remote with federation off. {@code null}
+     *        enables federation, which the dataset-bearing suites need.
      */
     static ElasticsearchCluster remoteCluster(
         Path csvDataPath,
         Map<String, String> additionalSettings,
         boolean shared,
-        Supplier<String> registerFederationFeature
+        Supplier<String> federationEnabled
     ) {
         Version version = distributionVersion("tests.version.remote_cluster");
         var cluster = ElasticsearchCluster.local()
@@ -63,8 +62,8 @@ public class Clusters {
         if (remoteClusterVersion().onOrAfter(org.elasticsearch.Version.V_9_5_0)) {
             cluster.setting("esql.datasource.local_allowed_paths", csvDataPath.toString());
         }
-        if (registerFederationFeature != null) {
-            cluster.systemProperty(Federation.REGISTER_PROPERTY, registerFederationFeature);
+        if (knowsFederationSetting(remoteClusterVersion())) {
+            cluster.setting(Federation.FEDERATION_ENABLED.getKey(), federationEnabled == null ? () -> "true" : federationEnabled);
         }
         for (Map.Entry<String, String> entry : additionalSettings.entrySet()) {
             cluster.setting(entry.getKey(), entry.getValue());
@@ -84,12 +83,12 @@ public class Clusters {
     }
 
     /**
-     * A remote cluster whose ES|QL federation kill switch is driven by {@code registerFederationFeature}, re-read on
-     * every (re)start. Used by the federation kill-switch tests to create dataset state while enabled and then bounce
-     * the remote with the switch engaged.
+     * A remote cluster whose ES|QL federation setting is driven by {@code federationEnabled}, re-read on every
+     * (re)start. Used by the federation gate tests to create dataset state while enabled and then bounce the remote
+     * with federation off.
      */
-    public static ElasticsearchCluster remoteCluster(Supplier<String> registerFederationFeature) {
-        return remoteCluster(CsvTestUtils.createCsvDataDirectory(), emptyMap(), false, registerFederationFeature);
+    public static ElasticsearchCluster remoteCluster(Supplier<String> federationEnabled) {
+        return remoteCluster(CsvTestUtils.createCsvDataDirectory(), emptyMap(), false, federationEnabled);
     }
 
     public static ElasticsearchCluster localCluster(ElasticsearchCluster remoteCluster) {
@@ -128,6 +127,22 @@ public class Clusters {
         Map<String, String> additionalSettings,
         boolean shared
     ) {
+        return localCluster(csvDataPath, remoteCluster, skipUnavailable, additionalSettings, shared, "true");
+    }
+
+    /**
+     * @param federationEnabled value for the ES|QL federation setting. It is only written on a version that has the
+     *        setting, so a suite that depends on the value it passes has to skip when the cluster does not report the
+     *        {@code FEDERATION_ENABLED_SETTING} capability.
+     */
+    public static ElasticsearchCluster localCluster(
+        Path csvDataPath,
+        ElasticsearchCluster remoteCluster,
+        Boolean skipUnavailable,
+        Map<String, String> additionalSettings,
+        boolean shared,
+        String federationEnabled
+    ) {
         Version version = distributionVersion("tests.version.local_cluster");
         var cluster = ElasticsearchCluster.local()
             .name(LOCAL_CLUSTER_NAME)
@@ -152,9 +167,14 @@ public class Clusters {
         if (localClusterVersion().onOrAfter(org.elasticsearch.Version.V_9_5_0)) {
             cluster.setting("esql.datasource.local_allowed_paths", csvDataPath.toString());
         }
+        if (knowsFederationSetting(localClusterVersion())) {
+            cluster.setting(Federation.FEDERATION_ENABLED.getKey(), federationEnabled);
+        }
         if (localClusterSupportsInferenceTestService()) {
             cluster.plugin("inference-service-test");
         }
+        // Applied to whichever version this cluster runs, so a caller may only pass settings that every BWC version
+        // in the matrix knows; anything newer has to go behind a version check like the block above.
         if (additionalSettings != null && additionalSettings.isEmpty() == false) {
             for (Map.Entry<String, String> entry : additionalSettings.entrySet()) {
                 cluster.setting(entry.getKey(), entry.getValue());
@@ -193,6 +213,10 @@ public class Clusters {
         if (localClusterVersion().onOrAfter(org.elasticsearch.Version.V_9_5_0)) {
             cluster.setting("esql.datasource.local_allowed_paths", csvDataPath.toString());
         }
+        if (knowsFederationSetting(localClusterVersion())) {
+            // The local coordinator only asks its remotes to resolve datasets when federation is available here.
+            cluster.setting(Federation.FEDERATION_ENABLED.getKey(), "true");
+        }
         return cluster.build();
     }
 
@@ -204,6 +228,16 @@ public class Clusters {
     public static org.elasticsearch.Version remoteClusterVersion() {
         String prop = System.getProperty("tests.version.remote_cluster");
         return prop != null ? org.elasticsearch.Version.fromString(prop) : org.elasticsearch.Version.CURRENT;
+    }
+
+    /**
+     * Whether a cluster of this version accepts the ES|QL federation setting, which exists as of 9.6.0. A node that
+     * predates it rejects an unknown setting and never starts, and it has federation registered unconditionally, so
+     * leaving the setting off matches how it behaves in production. Suites that depend on driving the setting skip
+     * against such a cluster on the {@code FEDERATION_ENABLED_SETTING} capability.
+     */
+    private static boolean knowsFederationSetting(org.elasticsearch.Version version) {
+        return version.onOrAfter(org.elasticsearch.Version.V_9_6_0);
     }
 
     public static org.elasticsearch.Version bwcVersion() {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
@@ -231,13 +231,13 @@ public class Clusters {
     }
 
     /**
-     * Whether a cluster of this version accepts the ES|QL federation setting, which exists as of 9.6.0. A node that
-     * predates it rejects an unknown setting and never starts, and it has federation registered unconditionally, so
-     * leaving the setting off matches how it behaves in production. Suites that depend on driving the setting skip
-     * against such a cluster on the {@code FEDERATION_ENABLED_SETTING} capability.
+     * Whether a cluster of this version accepts the ES|QL federation setting, which on this branch exists as of 9.5.0. A
+     * node that predates it rejects an unknown setting and never starts, and it has federation registered
+     * unconditionally, so leaving the setting off matches how it behaves in production. Suites that depend on driving
+     * the setting skip against such a cluster on the {@code FEDERATION_ENABLED_SETTING} capability.
      */
     private static boolean knowsFederationSetting(org.elasticsearch.Version version) {
-        return version.onOrAfter(org.elasticsearch.Version.V_9_6_0);
+        return version.onOrAfter(org.elasticsearch.Version.V_9_5_0);
     }
 
     public static org.elasticsearch.Version bwcVersion() {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/FederationOutgoingDatasetGateRestIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/FederationOutgoingDatasetGateRestIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.ccq;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.http.HttpHost;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Build;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.CsvTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.datasources.DatasetRegistry;
+import org.elasticsearch.xpack.esql.datasources.EsqlDataSourcesCapabilities;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.xpack.esql.ccq.Clusters.REMOTE_CLUSTER_NAME;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Exercises the outgoing half of federation's remote-dataset gate: a coordinator without federation must not ask its
+ * remotes to resolve datasets ({@code EsqlResolveFieldsAction} sets {@code resolveDatasets} from its own availability).
+ * Without that, a remote that does have federation answers a qualified name that happens to be one of its datasets with
+ * {@code RemoteDatasetNotSupportedException}, which names the dataset and so advertises a feature the local deployment
+ * has turned off.
+ *
+ * <p>The local cluster therefore boots with {@code esql.federation.enabled} off while the remote keeps it on and holds a
+ * real dataset in its cluster state. {@code FROM <remote>:<dataset>} must fail as a plain missing index, exactly like a
+ * nonexistent name. Removing the gate flips the error to the dataset-naming one, so this goes red exactly when the
+ * wiring is lost. The complementary incoming half (remote federation off) is covered by
+ * {@link FederationRemoteDatasetGateRestIT}.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class FederationOutgoingDatasetGateRestIT extends ESRestTestCase {
+
+    private static final Path DATA_PATH = CsvTestUtils.createCsvDataDirectory();
+
+    static ElasticsearchCluster remoteCluster = Clusters.remoteCluster(DATA_PATH, emptyMap(), false);
+    static ElasticsearchCluster localCluster = Clusters.localCluster(DATA_PATH, remoteCluster, false, emptyMap(), false, "false");
+
+    @ClassRule
+    public static TestRule clusterRule = RuleChain.outerRule(remoteCluster).around(localCluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return localCluster.getHttpAddresses();
+    }
+
+    public void testDisabledLocalResolvesRemoteDatasetAsMissingIndex() throws Exception {
+        assumeTrue("datasources are only available in snapshot builds", Build.current().isSnapshot());
+        // The premise is a local cluster with federation off, which only holds where the setting exists: a node without
+        // it has federation on and would ask the remote to resolve datasets. The remote has to expose the CRUD routes
+        // for the dataset this test registers there.
+        assumeTrue(
+            "the local cluster has to read the federation setting",
+            clusterHasCapability("POST", "/_query", List.of(), List.of(EsqlCapabilities.Cap.FEDERATION_ENABLED_SETTING.capabilityName()))
+                .orElse(false)
+        );
+        try (RestClient capabilityClient = remoteClusterClient()) {
+            assumeTrue(
+                "the remote cluster has to expose the data source routes",
+                clusterHasCapability(
+                    capabilityClient,
+                    "PUT",
+                    "/_query/data_source/{name}",
+                    List.of(),
+                    List.of(EsqlDataSourcesCapabilities.DATA_SOURCES)
+                ).orElse(false)
+            );
+        }
+
+        final String dataSource = "outgoing_gate_ds";
+        final String dataset = "outgoing_gate_dataset";
+        final String qualified = REMOTE_CLUSTER_NAME + ":" + dataset;
+
+        // A valid local CSV the dataset points at. The dataset is never actually read (the query fails during
+        // resolution), but a real file under the allowlisted path keeps registration from tripping on the resource.
+        Path csv = DATA_PATH.resolve("outgoing_gate.csv");
+        Files.writeString(csv, "id\n1\n2\n");
+
+        try (RestClient remoteClient = remoteClusterClient()) {
+            DatasetRegistry.putDataSource(remoteClient, dataSource, "local", Map.of());
+            DatasetRegistry.putDataset(remoteClient, dataset, dataSource, csv.toUri().toString(), Map.of());
+            // Guard against a false green: without the dataset in the remote's cluster state the query would fall
+            // through to "Unknown index" even with the gate removed.
+            assertThat(datasetNames(remoteClient), hasItem(dataset));
+        }
+
+        Request query = new Request("POST", "/_query");
+        query.setJsonEntity("{\"query\":\"FROM " + qualified + "\"}");
+        ResponseException error = expectThrows(ResponseException.class, () -> client().performRequest(query));
+        String body = EntityUtils.toString(error.getResponse().getEntity());
+        assertThat(error.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(body, containsString("Unknown index [" + qualified + "]"));
+        assertThat(body, not(containsString("remote datasets are not supported")));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> datasetNames(RestClient client) throws IOException {
+        Map<String, Object> body = entityAsMap(client.performRequest(new Request("GET", "/_query/dataset")));
+        return ((List<Map<String, Object>>) body.get("datasets")).stream().map(h -> (String) h.get("name")).toList();
+    }
+
+    private RestClient remoteClusterClient() throws IOException {
+        HttpHost[] remoteHosts = parseClusterHosts(remoteCluster.getHttpAddresses()).toArray(HttpHost[]::new);
+        return buildClient(restClientSettings(), remoteHosts);
+    }
+}

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/FederationRemoteDatasetGateRestIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/FederationRemoteDatasetGateRestIT.java
@@ -42,19 +42,20 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 /**
- * Exercises the federation kill switch's remote-dataset gate in {@code EsqlResolveFieldsAction} at its call site,
- * which the pure-unit {@code FederationTests} cannot: that helper test drives {@code Federation.ensureEnabled(boolean)}
- * directly, so deleting the {@code && Federation.isAvailable()} guard from the resolve action would not make it fail.
+ * Exercises the incoming half of federation's remote-dataset gate in {@code EsqlResolveFieldsAction} at its call site,
+ * which the pure-unit {@code FederationTests} cannot: that helper test drives {@code Federation.ensureEnabled} directly,
+ * so deleting the guard that makes a remote report no datasets would not make it fail. The outgoing half (a coordinator
+ * without federation not asking its remotes for datasets) is covered by {@link FederationOutgoingDatasetGateRestIT}.
  *
  * <p>The gate only runs on a remote cluster (the {@code resolveDatasets} option is set only on the request the
- * originating cluster sends to a remote), and to go red on removal the disabled remote must still hold a dataset in
- * its cluster state. A dataset can only be created while federation is enabled (the REST route is gone once the switch
- * is engaged), so this test creates the dataset on the remote while enabled, then bounces the remote with the switch
- * off. Because a remote restart lands on new ports, the remote connection is configured dynamically through the
- * cluster settings API (see {@link Clusters#localClusterForDynamicRemote}) so the seed can be re-pointed after the
- * bounce.
+ * originating cluster sends to a remote), and to go red on removal the remote must still hold a dataset in its cluster
+ * state while federation is off there. A dataset can only be created while federation is available (the REST route is
+ * gone otherwise), so this test creates the dataset on the remote while enabled, then bounces the remote with
+ * {@code esql.federation.enabled} set back to {@code false}. Because a remote restart lands on new ports, the remote
+ * connection is configured dynamically through the cluster settings API (see
+ * {@link Clusters#localClusterForDynamicRemote}) so the seed can be re-pointed after the bounce.
  *
- * <p>With the switch engaged the remote reports no datasets, so {@code FROM <remote>:<dataset>} falls through to normal
+ * <p>With federation off the remote reports no datasets, so {@code FROM <remote>:<dataset>} falls through to normal
  * remote index resolution and fails as a plain missing index, exactly like a nonexistent name. If the gate were
  * removed the still-present dataset would instead surface a {@code RemoteDatasetNotSupportedException} naming it, so
  * the phase-2 assertions go red exactly when the wiring is lost.
@@ -64,9 +65,9 @@ public class FederationRemoteDatasetGateRestIT extends ESRestTestCase {
 
     private static final Path DATA_PATH = org.elasticsearch.xpack.esql.CsvTestUtils.createCsvDataDirectory();
 
-    private static final AtomicReference<String> remoteRegisterFederationFeature = new AtomicReference<>("true");
+    private static final AtomicReference<String> remoteFederationEnabled = new AtomicReference<>("true");
 
-    static ElasticsearchCluster remoteCluster = Clusters.remoteCluster(DATA_PATH, emptyMap(), false, remoteRegisterFederationFeature::get);
+    static ElasticsearchCluster remoteCluster = Clusters.remoteCluster(DATA_PATH, emptyMap(), false, remoteFederationEnabled::get);
     static ElasticsearchCluster localCluster = Clusters.localClusterForDynamicRemote(DATA_PATH);
 
     @ClassRule
@@ -86,15 +87,26 @@ public class FederationRemoteDatasetGateRestIT extends ESRestTestCase {
 
     public void testDisabledRemoteResolvesDatasetAsMissingIndex() throws Exception {
         assumeTrue("datasources are only available in snapshot builds", Build.current().isSnapshot());
-        // The remote-dataset gate needs the federation kill switch on both nodes: the coordinator sends the
-        // resolveDatasets option to the remote, and the remote honors the switch by dropping its datasets. Older nodes
-        // predate the feature and do not report the capability, so a mixed cluster correctly skips this scenario.
-        List<String> killSwitchCapability = List.of(EsqlCapabilities.Cap.REGISTER_FEDERATION_FEATURE.capabilityName());
+        // The remote-dataset gate needs federation on both clusters: the coordinator only sends the resolveDatasets
+        // option to the remote when federation is available locally, and the remote honors its own state by dropping its
+        // datasets. Phase 2 turns the remote off through the setting, so the remote also has to be a version that reads
+        // it; one that only has the operator kill switch cannot be turned off per node and skips here.
         try (RestClient capabilityClient = remoteClusterClient()) {
             assumeTrue(
-                "federation kill switch requires the feature on both clusters",
-                clusterHasCapability("POST", "/_query", List.of(), killSwitchCapability).orElse(false)
-                    && clusterHasCapability(capabilityClient, "POST", "/_query", List.of(), killSwitchCapability).orElse(false)
+                "the remote-dataset gate requires the feature locally and the federation setting on the remote",
+                clusterHasCapability(
+                    "POST",
+                    "/_query",
+                    List.of(),
+                    List.of(EsqlCapabilities.Cap.REGISTER_FEDERATION_FEATURE.capabilityName())
+                ).orElse(false)
+                    && clusterHasCapability(
+                        capabilityClient,
+                        "POST",
+                        "/_query",
+                        List.of(),
+                        List.of(EsqlCapabilities.Cap.FEDERATION_ENABLED_SETTING.capabilityName())
+                    ).orElse(false)
             );
         }
 
@@ -127,13 +139,13 @@ public class FederationRemoteDatasetGateRestIT extends ESRestTestCase {
         assertThat(enabledBody, containsString("remote datasets are not supported"));
         assertThat(enabledBody, containsString(dataset));
 
-        // Suppress federation on the remote and bounce it so it re-reads the property, then re-point the seed at the
+        // Turn federation off on the remote and bounce it so it re-reads the setting, then re-point the seed at the
         // remote's new transport port.
-        remoteRegisterFederationFeature.set("false");
+        remoteFederationEnabled.set("false");
         remoteCluster.restart(false);
         configureRemoteConnection(remoteCluster.getTransportEndpoint(0));
 
-        // Phase 2: remote federation disabled. The remote reports no datasets (the gate), so the qualified name falls
+        // Phase 2: federation off on the remote. The remote reports no datasets (the gate), so the qualified name falls
         // through to normal remote index resolution and fails as a plain missing index, the same error a nonexistent
         // name gives. Removing the gate would instead surface RemoteDatasetNotSupportedException for the still-present
         // dataset, so both assertions below go red exactly when the wiring is lost.

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/Clusters.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 
 import java.nio.file.Path;
 
@@ -29,6 +30,8 @@ public class Clusters {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("path.repo", csvDataPath::toString)
             .setting("esql.datasource.local_allowed_paths", csvDataPath::toString)
+            // Federation is opt-in for users; the EXTERNAL and dataset specs run here need it on.
+            .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
             .configFile("user-agent/custom-regexes.yml", Resource.fromClasspath("custom-regexes.yml"))
             .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
             .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedClusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedClusters.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.qa.multi_node;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
 
 import java.util.function.Supplier;
@@ -38,6 +39,9 @@ public class ExternalDistributedClusters {
             spec.feature(FeatureFlag.ESQL_EXTERNAL_AZURE);
             spec.feature(FeatureFlag.ESQL_EXTERNAL_ORC);
             spec.feature(FeatureFlag.ESQL_EXTERNAL_PARQUET_RS);
+            // This suite reads external sources, so it needs the opt-in federation setting. It is set here rather
+            // than relying on Clusters, which serverless substitutes with a builder that only defines node shape.
+            spec.setting(Federation.FEDERATION_ENABLED.getKey(), "true");
             spec.plugin("inference-service-test");
             spec.module("repository-s3");
             spec.module("repository-gcs");

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractFederationRestartRestTestCase.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractFederationRestartRestTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.Federation;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * End-to-end REST coverage for turning federation off on a live deployment: a node boots with federation available, a
+ * data source and dataset are created, then one of the two levers is turned off and the node is restarted. This is the
+ * realistic "flip it and bounce" flow (both levers are read once at startup), and it is the only way to observe the
+ * unavailable behavior against <em>pre-existing</em> federation state, which a cluster that boots without federation
+ * cannot create.
+ *
+ * <p>Both levers must produce the same surface, so subclasses share this flow and differ only in
+ * {@link #turnFederationOff()}. Values reach the node through a mutable holder that the cluster spec reads on every
+ * (re)start; after {@link ElasticsearchCluster#restart(boolean)} the REST client is rebuilt because the node's ports may
+ * change.
+ *
+ * <p>Asserted after federation is off (it must look like it never existed):
+ * <ul>
+ *   <li>PUT, GET, and DELETE of data sources and datasets all return HTTP 400 {@code no handler found for uri} (the
+ *       routes are unregistered), even though the pre-existing state is still in cluster state;</li>
+ *   <li>executing {@code FROM <dataset>} against the pre-existing dataset fails as {@code Unknown index} (HTTP 400),
+ *       the same error a nonexistent index gives, so the dataset is never resolved or accessed.</li>
+ * </ul>
+ */
+public abstract class AbstractFederationRestartRestTestCase extends ESRestTestCase {
+
+    /**
+     * The suite's own cluster, which this flow restarts. Each subclass declares its own {@code @ClassRule} because the
+     * two levers are supplied to the node differently.
+     */
+    protected abstract ElasticsearchCluster cluster();
+
+    /**
+     * Sets this suite's lever to off. The value is only picked up by the restart that follows.
+     */
+    protected abstract void turnFederationOff();
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        // The cluster is restarted mid-test and is ephemeral for this class; skip the shared-cluster wipe. The
+        // federation routes are unregistered after the restart, so the created state cannot be cleaned up over REST
+        // anyway.
+        return true;
+    }
+
+    public void testFeatureLooksAbsentAfterRestart() throws Exception {
+        final String source = "restart_source";
+        final String dataset = "restart_dataset";
+
+        // Phase 1: federation available. Create the state the unavailable phase will act on.
+        putDataSource(source, Map.of("region", "us-east-1", "auth", "anonymous"));
+        putDataset(dataset, source, "s3://bucket/x/*.parquet");
+        assertThat(datasourceNames(), contains(source));
+        assertThat(datasetNames(), contains(dataset));
+
+        turnFederationOff();
+        cluster().restart(false);
+        closeClients();
+        initClient();
+
+        // All six routes are gone: PUT/GET/DELETE for both data sources and datasets return the standard no-handler 400,
+        // even though the pre-existing state is still in cluster state.
+        assertRouteUnregistered("PUT", "/_query/data_source/late_source", "{\"type\":\"s3\",\"settings\":{\"auth\":\"anonymous\"}}");
+        assertRouteUnregistered("GET", "/_query/data_source", null);
+        assertRouteUnregistered("DELETE", "/_query/data_source/" + source, null);
+        assertRouteUnregistered("PUT", "/_query/dataset/late_dataset", "{\"data_source\":\"" + source + "\",\"resource\":\"s3://b/*\"}");
+        assertRouteUnregistered("GET", "/_query/dataset", null);
+        assertRouteUnregistered("DELETE", "/_query/dataset/" + dataset, null);
+
+        // FROM <pre-existing dataset> is never resolved as a dataset: the name flows into normal index resolution with
+        // resolveDatasets=false, so it matches no concrete index and errors as Unknown index, the same 400 a nonexistent
+        // index name gives. The dataset is not accessed and neither lever must leak into the message.
+        Request query = new Request("POST", "/_query");
+        query.setJsonEntity("{\"query\": \"FROM " + dataset + "\"}");
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(query));
+        String body = EntityUtils.toString(ex.getResponse().getEntity());
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(body, containsString("Unknown index [" + dataset + "]"));
+        assertNoLeverNamed(body);
+    }
+
+    /**
+     * Asserts the given route behaves like an endpoint that was never registered: HTTP 400 with a
+     * {@code no handler found for uri} body that does not name either lever.
+     */
+    private static void assertRouteUnregistered(String method, String path, String jsonBody) throws IOException {
+        Request req = new Request(method, path);
+        if (jsonBody != null) {
+            req.setJsonEntity(jsonBody);
+        }
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(req));
+        String body = EntityUtils.toString(ex.getResponse().getEntity());
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(body, containsString("no handler found for uri"));
+        assertNoLeverNamed(body);
+    }
+
+    private static void assertNoLeverNamed(String body) {
+        assertThat(body, not(containsString(Federation.REGISTER_PROPERTY)));
+        assertThat(body, not(containsString(Federation.FEDERATION_ENABLED.getKey())));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> datasourceNames() throws IOException {
+        Response r = client().performRequest(new Request("GET", "/_query/data_source"));
+        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
+        return ((List<Map<String, Object>>) entityAsMap(r).get("data_sources")).stream().map(h -> (String) h.get("name")).toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> datasetNames() throws IOException {
+        Response r = client().performRequest(new Request("GET", "/_query/dataset"));
+        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
+        return ((List<Map<String, Object>>) entityAsMap(r).get("datasets")).stream().map(h -> (String) h.get("name")).toList();
+    }
+
+    private static void putDataSource(String name, Map<String, Object> settings) throws IOException {
+        Request req = new Request("PUT", "/_query/data_source/" + name);
+        try (XContentBuilder b = jsonBuilder()) {
+            b.startObject().field("type", "s3").field("settings", settings).endObject();
+            req.setJsonEntity(Strings.toString(b));
+        }
+        assertThat(client().performRequest(req).getStatusLine().getStatusCode(), equalTo(200));
+    }
+
+    private static void putDataset(String name, String dataSource, String resource) throws IOException {
+        Request req = new Request("PUT", "/_query/dataset/" + name);
+        try (XContentBuilder b = jsonBuilder()) {
+            b.startObject().field("data_source", dataSource).field("resource", resource).endObject();
+            req.setJsonEntity(Strings.toString(b));
+        }
+        assertThat(client().performRequest(req).getStatusLine().getStatusCode(), equalTo(200));
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractFederationUnavailableRestTestCase.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractFederationUnavailableRestTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.Federation;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * REST coverage shared by every deployment shape in which federation is not available: the six data source and dataset
+ * routes must be unregistered, so PUT, GET and DELETE all return the framework's standard
+ * {@code no handler found for uri} ({@code 400}), exactly as if the feature never existed, and no response names either
+ * of the two levers. Subclasses differ only in which lever they turn off.
+ *
+ * <p>Behavior against <em>pre-existing</em> federation state (executing {@code FROM <dataset>} against an existing
+ * dataset) cannot be exercised here, because a node that boots without federation cannot create that state; it is
+ * covered by {@link FederationKillSwitchRestartRestIT} and {@link FederationSettingRestartRestIT}, which create state
+ * while enabled and then restart the node with one lever off. The complementary enabled-path CRUD coverage lives in
+ * {@link DataSourceCrudRestIT}.
+ */
+public abstract class AbstractFederationUnavailableRestTestCase extends ESRestTestCase {
+
+    public void testPutDataSourceRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("PUT", "/_query/data_source/blocked_ds", "{\"type\":\"s3\",\"settings\":{\"auth\":\"anonymous\"}}");
+    }
+
+    public void testGetDataSourceRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("GET", "/_query/data_source", null);
+    }
+
+    public void testDeleteDataSourceRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("DELETE", "/_query/data_source/blocked_ds", null);
+    }
+
+    public void testPutDatasetRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("PUT", "/_query/dataset/blocked_dataset", "{\"data_source\":\"some_parent\",\"resource\":\"s3://b/*\"}");
+    }
+
+    public void testGetDatasetRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("GET", "/_query/dataset", null);
+    }
+
+    public void testDeleteDatasetRouteIsUnregistered() throws IOException {
+        assertRouteUnregistered("DELETE", "/_query/dataset/blocked_dataset", null);
+    }
+
+    /**
+     * A name that would be a dataset on a cluster with federation reads as a plain missing index here. No dataset can
+     * exist on this cluster (the routes that create one are gone), so this pins the error shape rather than the gate
+     * itself: the message must be the ordinary {@code Unknown index} and must not mention datasets or either lever.
+     */
+    public void testFromDatasetNameLooksLikeMissingIndex() throws IOException {
+        Request query = new Request("POST", "/_query");
+        query.setJsonEntity("{\"query\": \"FROM blocked_dataset\"}");
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(query));
+        String body = EntityUtils.toString(ex.getResponse().getEntity());
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(body, containsString("Unknown index [blocked_dataset]"));
+        assertNoLeverNamed(body);
+    }
+
+    /**
+     * Asserts the given route behaves like an endpoint that was never registered: HTTP 400 with a
+     * {@code no handler found for uri} body. The body must not name either lever, so the feature reads as absent
+     * rather than merely disabled.
+     */
+    private void assertRouteUnregistered(String method, String path, String jsonBody) throws IOException {
+        Request req = new Request(method, path);
+        if (jsonBody != null) {
+            req.setJsonEntity(jsonBody);
+        }
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(req));
+        String body = EntityUtils.toString(ex.getResponse().getEntity());
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(body, containsString("no handler found for uri"));
+        assertNoLeverNamed(body);
+    }
+
+    private static void assertNoLeverNamed(String body) {
+        assertThat(body, not(containsString(Federation.REGISTER_PROPERTY)));
+        assertThat(body, not(containsString(Federation.FEDERATION_ENABLED.getKey())));
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.xpack.esql.CsvTestUtils;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 
 import java.nio.file.Path;
 
@@ -42,21 +43,48 @@ public class Clusters {
     }
 
     public static ElasticsearchCluster testCluster(Path csvDataPath, LocalClusterConfigProvider configProvider, boolean shared) {
+        return testCluster(csvDataPath, configProvider, shared, true);
+    }
+
+    /**
+     * A cluster for the suites that unregister the federation feature on the node JVM with
+     * {@link Federation#REGISTER_PROPERTY}. It leaves the federation settings out entirely rather than setting them to
+     * a harmless value, because an unregistered feature registers no settings: a node whose {@code elasticsearch.yml}
+     * carries one of those keys does not start. A suite that needs the setting for part of its run supplies it itself,
+     * as {@link FederationKillSwitchRestartRestIT} does for the phase before the feature is unregistered.
+     */
+    public static ElasticsearchCluster clusterWithFederationUnregistered(LocalClusterConfigProvider configProvider) {
+        return testCluster(CsvTestUtils.createCsvDataDirectory(), configProvider, false, false);
+    }
+
+    private static ElasticsearchCluster testCluster(
+        Path csvDataPath,
+        LocalClusterConfigProvider configProvider,
+        boolean shared,
+        boolean federationSettings
+    ) {
         boolean securityEnabled = Booleans.parseBoolean(System.getProperty(SECURITY_ENABLED_PROPERTY, "false"));
         var builder = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
             .setting("xpack.security.enabled", Boolean.toString(securityEnabled))
             .setting("xpack.license.self_generated.type", "trial")
             .setting("path.repo", csvDataPath::toString)
-            .setting("esql.datasource.local_allowed_paths", csvDataPath::toString)
             .keystore("cluster.state.encryption.password." + ENCRYPTION_PASSWORD_ID, ENCRYPTION_PASSWORD)
             .keystore("cluster.state.encryption.active_password_id", ENCRYPTION_PASSWORD_ID)
             .configFile("user-agent/custom-regexes.yml", Resource.fromClasspath("custom-regexes.yml"))
             .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
             .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))
             .configFile("ingest-geoip/GeoLite2-ASN.mmdb", Resource.fromClasspath("GeoLite2-ASN.mmdb"))
-            .setting("ingest.geoip.downloader.enabled", "false")
-            .apply(() -> configProvider);
+            .setting("ingest.geoip.downloader.enabled", "false");
+        if (federationSettings) {
+            // Federation is opt-in for users; the data source and dataset suites here need it on. A test that wants the
+            // default-off surface turns it back off through the config provider applied below. This default is a
+            // supplier, not a plain value, so that a config provider can override it with either form: explicit
+            // settings win over suppliers regardless of order, and among suppliers the last one applied wins.
+            builder.setting(Federation.FEDERATION_ENABLED.getKey(), () -> "true")
+                .setting("esql.datasource.local_allowed_paths", csvDataPath::toString);
+        }
+        builder.apply(() -> configProvider);
         if (securityEnabled) {
             builder.user(ADMIN_USER, ADMIN_PASSWORD, "superuser", true);
         }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationDisabledRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationDisabledRestIT.java
@@ -9,83 +9,57 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.Federation;
+import org.elasticsearch.xpack.esql.datasources.datasource.DataSourceService;
 import org.junit.ClassRule;
 
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 
 /**
- * End-to-end REST coverage for a node that boots with federation suppressed
- * ({@code -Des.esql.register_federation_feature=false}), the always-off deployment shape. Proves the six
- * data-source/dataset routes are unregistered: PUT, GET, and DELETE all return the framework's standard
- * {@code no handler found for uri} ({@code 400}), exactly as if the feature never existed. The switch is read
- * once at node startup, so this needs a dedicated cluster with the system property set on the node JVM (see the
- * {@code @ClassRule}).
- *
- * <p>Behavior against <em>pre-existing</em> federation state (executing {@code FROM <dataset>} against an existing
- * dataset) cannot be exercised here, because a boot-disabled node cannot create that state; it is covered by
- * {@link FederationKillSwitchRestartRestIT}, which creates state while enabled and then restarts the node with the
- * switch off. The complementary enabled-path CRUD coverage lives in {@link DataSourceCrudRestIT}.
+ * End-to-end REST coverage for a node whose operator unregistered federation
+ * ({@code -Des.esql.register_federation_feature=false}), the always-off deployment shape. The property is read once at
+ * node startup, so this needs a dedicated cluster with it set on the node JVM (see the {@code @ClassRule}), and that
+ * cluster carries no federation setting: an unregistered feature does not accept its own settings, which
+ * {@link FederationSettingRejectedWhenUnregisteredRestIT} covers.
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-public class FederationDisabledRestIT extends ESRestTestCase {
+public class FederationDisabledRestIT extends AbstractFederationUnavailableRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.systemProperty(Federation.REGISTER_PROPERTY, "false"));
+    public static ElasticsearchCluster cluster = Clusters.clusterWithFederationUnregistered(
+        spec -> spec.systemProperty(Federation.REGISTER_PROPERTY, "false")
+    );
 
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
     }
 
-    public void testPutDataSourceRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("PUT", "/_query/data_source/blocked_ds", "{\"type\":\"s3\",\"settings\":{\"auth\":\"anonymous\"}}");
-    }
-
-    public void testGetDataSourceRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("GET", "/_query/data_source", null);
-    }
-
-    public void testDeleteDataSourceRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("DELETE", "/_query/data_source/blocked_ds", null);
-    }
-
-    public void testPutDatasetRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("PUT", "/_query/dataset/blocked_dataset", "{\"data_source\":\"some_parent\",\"resource\":\"s3://b/*\"}");
-    }
-
-    public void testGetDatasetRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("GET", "/_query/dataset", null);
-    }
-
-    public void testDeleteDatasetRouteIsUnregistered() throws IOException {
-        assertRouteUnregistered("DELETE", "/_query/dataset/blocked_dataset", null);
-    }
-
     /**
-     * Asserts the given route behaves like an endpoint that was never registered: HTTP 400 with a
-     * {@code no handler found for uri} body. The body must not name the kill-switch property, so the feature
-     * reads as absent rather than merely disabled.
+     * The unregistered feature owns no settings, so the cluster settings API rejects them the same way it rejects a
+     * misspelled key. This is the counterpart of the accepted update in {@link FederationNotEnabledRestIT}: merely leaving
+     * the feature disabled keeps its settings configurable, unregistering it takes them away.
      */
-    private void assertRouteUnregistered(String method, String path, String jsonBody) throws IOException {
-        Request req = new Request(method, path);
-        if (jsonBody != null) {
-            req.setJsonEntity(jsonBody);
-        }
-        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(req));
-        String body = EntityUtils.toString(ex.getResponse().getEntity());
-        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
-        assertThat(body, containsString("no handler found for uri"));
-        assertThat(body, not(containsString(Federation.REGISTER_PROPERTY)));
+    public void testFederationSettingsAreRejectedOverRest() throws IOException {
+        assertRejected(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED.getKey(), "true");
+        assertRejected(DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING.getKey(), "7");
+    }
+
+    private static void assertRejected(String key, String value) throws IOException {
+        Request update = new Request("PUT", "/_cluster/settings");
+        update.setJsonEntity(Strings.format("""
+            {"persistent": {"%s": %s}}""", key, value));
+        ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(update));
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(e.getMessage(), containsString("persistent setting [" + key + "], not recognized"));
     }
 }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationKillSwitchRestartRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationKillSwitchRestartRestIT.java
@@ -9,153 +9,50 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
-import org.apache.http.util.EntityUtils;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.test.cluster.MutableSettingsProvider;
 import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.junit.ClassRule;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-
 /**
- * End-to-end REST coverage for suppressing federation on a live deployment: a node boots with federation enabled, a
- * data source and dataset are created, then the node is restarted with
- * {@code -Des.esql.register_federation_feature=false}. This is the realistic "flip the switch and bounce" flow (the
- * switch is read once at startup), and it is the only way to observe the suppressed behavior against
- * <em>pre-existing</em> federation state, which a boot-disabled cluster cannot create.
+ * The operator lever of {@link AbstractFederationRestartRestTestCase}: federation is unregistered with
+ * {@code -Des.esql.register_federation_feature=false} and the node bounced.
  *
- * <p>The property is supplied to the node JVM through a mutable holder ({@link #registerFederationFeature}); the test
- * flips it and calls {@link ElasticsearchCluster#restart(boolean)}, which re-reads the supplier. After the restart the
- * REST client is rebuilt because the node's ports may change.
- *
- * <p>Asserted after the switch is engaged (federation must look like it never existed):
- * <ul>
- *   <li>PUT, GET, and DELETE of data sources and datasets all return HTTP 400 {@code no handler found for uri} (the
- *       routes are unregistered), even though the pre-existing state is still in cluster state;</li>
- *   <li>executing {@code FROM <dataset>} against the pre-existing dataset fails as {@code Unknown index} (HTTP 400),
- *       the same error a nonexistent index gives, so the dataset is never resolved or accessed.</li>
- * </ul>
+ * <p>Turning the lever off drops {@link Federation#FEDERATION_ENABLED} from the node's yml along with it, so the
+ * restarted node is the shape an operator actually deploys. An unregistered feature registers no settings, so a node
+ * that still carried the key would not start at all, which is what
+ * {@link FederationSettingRejectedWhenUnregisteredRestIT} covers.
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-public class FederationKillSwitchRestartRestIT extends ESRestTestCase {
+public class FederationKillSwitchRestartRestIT extends AbstractFederationRestartRestTestCase {
 
     private static final AtomicReference<String> registerFederationFeature = new AtomicReference<>("true");
+    private static final MutableSettingsProvider federationSettings = new MutableSettingsProvider();
+    static {
+        federationSettings.put(Federation.FEDERATION_ENABLED.getKey(), "true");
+    }
 
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(
-        spec -> spec.systemProperty(Federation.REGISTER_PROPERTY, registerFederationFeature::get)
+    public static ElasticsearchCluster cluster = Clusters.clusterWithFederationUnregistered(
+        spec -> spec.systemProperty(Federation.REGISTER_PROPERTY, registerFederationFeature::get).settings(federationSettings)
     );
+
+    @Override
+    protected ElasticsearchCluster cluster() {
+        return cluster;
+    }
+
+    @Override
+    protected void turnFederationOff() {
+        registerFederationFeature.set("false");
+        federationSettings.remove(Federation.FEDERATION_ENABLED.getKey());
+    }
 
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
-    }
-
-    @Override
-    protected boolean preserveClusterUponCompletion() {
-        // The cluster is restarted mid-test and is ephemeral for this class; skip the shared-cluster wipe. The
-        // federation routes are unregistered after the restart, so the created state cannot be cleaned up over REST
-        // anyway.
-        return true;
-    }
-
-    public void testFeatureLooksAbsentAfterRestart() throws Exception {
-        final String source = "restart_source";
-        final String dataset = "restart_dataset";
-
-        // Phase 1: federation enabled. Create the state the suppressed phase will act on.
-        putDataSource(source, Map.of("region", "us-east-1", "auth", "anonymous"));
-        putDataset(dataset, source, "s3://bucket/x/*.parquet");
-        assertThat(datasourceNames(), contains(source));
-        assertThat(datasetNames(), contains(dataset));
-
-        // Suppress federation and bounce the node so it reads the new value.
-        registerFederationFeature.set("false");
-        cluster.restart(false);
-        closeClients();
-        initClient();
-
-        // All six routes are gone: PUT/GET/DELETE for both data sources and datasets return the standard no-handler 400,
-        // even though the pre-existing state is still in cluster state.
-        assertRouteUnregistered("PUT", "/_query/data_source/late_source", "{\"type\":\"s3\",\"settings\":{\"auth\":\"anonymous\"}}");
-        assertRouteUnregistered("GET", "/_query/data_source", null);
-        assertRouteUnregistered("DELETE", "/_query/data_source/" + source, null);
-        assertRouteUnregistered("PUT", "/_query/dataset/late_dataset", "{\"data_source\":\"" + source + "\",\"resource\":\"s3://b/*\"}");
-        assertRouteUnregistered("GET", "/_query/dataset", null);
-        assertRouteUnregistered("DELETE", "/_query/dataset/" + dataset, null);
-
-        // FROM <pre-existing dataset> is never resolved as a dataset: the name flows into normal index resolution with
-        // resolveDatasets=false, so it matches no concrete index and errors as Unknown index, the same 400 a nonexistent
-        // index name gives. The dataset is not accessed and the kill-switch property must not leak into the message.
-        Request query = new Request("POST", "/_query");
-        query.setJsonEntity("{\"query\": \"FROM " + dataset + "\"}");
-        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(query));
-        String body = EntityUtils.toString(ex.getResponse().getEntity());
-        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
-        assertThat(body, containsString("Unknown index [" + dataset + "]"));
-        assertThat(body, not(containsString(Federation.REGISTER_PROPERTY)));
-    }
-
-    /**
-     * Asserts the given route behaves like an endpoint that was never registered: HTTP 400 with a
-     * {@code no handler found for uri} body that does not name the kill-switch property.
-     */
-    private static void assertRouteUnregistered(String method, String path, String jsonBody) throws IOException {
-        Request req = new Request(method, path);
-        if (jsonBody != null) {
-            req.setJsonEntity(jsonBody);
-        }
-        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(req));
-        String body = EntityUtils.toString(ex.getResponse().getEntity());
-        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
-        assertThat(body, containsString("no handler found for uri"));
-        assertThat(body, not(containsString(Federation.REGISTER_PROPERTY)));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<String> datasourceNames() throws IOException {
-        Response r = client().performRequest(new Request("GET", "/_query/data_source"));
-        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
-        return ((List<Map<String, Object>>) entityAsMap(r).get("data_sources")).stream().map(h -> (String) h.get("name")).toList();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<String> datasetNames() throws IOException {
-        Response r = client().performRequest(new Request("GET", "/_query/dataset"));
-        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
-        return ((List<Map<String, Object>>) entityAsMap(r).get("datasets")).stream().map(h -> (String) h.get("name")).toList();
-    }
-
-    private static void putDataSource(String name, Map<String, Object> settings) throws IOException {
-        Request req = new Request("PUT", "/_query/data_source/" + name);
-        try (XContentBuilder b = jsonBuilder()) {
-            b.startObject().field("type", "s3").field("settings", settings).endObject();
-            req.setJsonEntity(Strings.toString(b));
-        }
-        assertThat(client().performRequest(req).getStatusLine().getStatusCode(), equalTo(200));
-    }
-
-    private static void putDataset(String name, String dataSource, String resource) throws IOException {
-        Request req = new Request("PUT", "/_query/dataset/" + name);
-        try (XContentBuilder b = jsonBuilder()) {
-            b.startObject().field("data_source", dataSource).field("resource", resource).endObject();
-            req.setJsonEntity(Strings.toString(b));
-        }
-        assertThat(client().performRequest(req).getStatusLine().getStatusCode(), equalTo(200));
     }
 }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationNotEnabledRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationNotEnabledRestIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
+import org.elasticsearch.xpack.esql.datasources.Federation;
+import org.elasticsearch.xpack.esql.datasources.datasource.DataSourceService;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+/**
+ * End-to-end REST coverage for the default deployment shape: the feature is registered, but nobody enabled it, so it is
+ * unavailable and looks exactly like the operator-unregistered case in {@link FederationDisabledRestIT}. The shared
+ * cluster builder turns the setting on for the other suites in this project, so this cluster turns it back off, which
+ * is equivalent to leaving it out of {@code elasticsearch.yml}.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class FederationNotEnabledRestIT extends AbstractFederationUnavailableRestTestCase {
+
+    private static final String FEDERATED_IDENTITY = ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED.getKey();
+    private static final String MAX_DISCOVERED_FILES = ExternalSourceSettings.MAX_DISCOVERED_FILES.getKey();
+    private static final String MAX_DATA_SOURCES = DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING.getKey();
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(
+        spec -> spec.setting(Federation.FEDERATION_ENABLED.getKey(), "false")
+    );
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    /**
+     * Only availability is off here, not registration, so the rest of the federation settings still exist and the cluster
+     * settings API accepts them. A deployment can therefore configure the feature before opting in, or without ever
+     * opting in. This assertion belongs to this suite rather than the shared base because the same request must be
+     * rejected on the operator-unregistered node of {@link FederationDisabledRestIT}, where those settings do not exist.
+     */
+    public void testFederationSettingsAreStillUpdatableOverRest() throws IOException {
+        Request update = new Request("PUT", "/_cluster/settings");
+        update.setJsonEntity(Strings.format("""
+            {"persistent": {"%s": true, "%s": 42, "%s": 7}}""", FEDERATED_IDENTITY, MAX_DISCOVERED_FILES, MAX_DATA_SOURCES));
+        Response response = client().performRequest(update);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+
+        Request get = new Request("GET", "/_cluster/settings");
+        get.addParameter("flat_settings", "true");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> persistent = (Map<String, Object>) entityAsMap(client().performRequest(get)).get("persistent");
+        assertThat(persistent, hasEntry(FEDERATED_IDENTITY, "true"));
+        assertThat(persistent, hasEntry(MAX_DISCOVERED_FILES, "42"));
+        assertThat(persistent, hasEntry(MAX_DATA_SOURCES, "7"));
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationSettingRejectedWhenUnregisteredRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationSettingRejectedWhenUnregisteredRestIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.LogType;
+import org.elasticsearch.test.cluster.MutableSettingsProvider;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.Federation;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * A node whose operator unregistered federation does not merely ignore {@link Federation#FEDERATION_ENABLED}, it
+ * refuses to start with it: an unregistered feature registers none of its settings, so the key is unknown and settings
+ * validation rejects it exactly as it rejects a misspelled one.
+ *
+ * <p>The node boots with the feature registered and the setting on, then only the system property flips and the node is
+ * restarted, which is the upgrade-shaped path into the combination: an operator adds the kill switch to a deployment
+ * that had opted in. The restart must fail, and the reason must name the setting in the node log rather than leaving an
+ * operator to guess.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class FederationSettingRejectedWhenUnregisteredRestIT extends ESRestTestCase {
+
+    private static final AtomicReference<String> registerFederationFeature = new AtomicReference<>("true");
+    private static final MutableSettingsProvider federationSettings = new MutableSettingsProvider();
+    static {
+        federationSettings.put(Federation.FEDERATION_ENABLED.getKey(), "true");
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.clusterWithFederationUnregistered(
+        spec -> spec.systemProperty(Federation.REGISTER_PROPERTY, registerFederationFeature::get).settings(federationSettings)
+    );
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        // The cluster is dead once the restart below fails, so its state cannot be wiped over REST.
+        return true;
+    }
+
+    public void testNodeDoesNotStartWithTheSettingWhenFeatureIsUnregistered() throws IOException {
+        registerFederationFeature.set("false");
+        expectThrows(
+            Exception.class,
+            "the node came up with ["
+                + Federation.FEDERATION_ENABLED.getKey()
+                + "] configured while the federation feature was unregistered, so the setting is still being registered "
+                + "and settings validation accepted configuration for a feature that is not there",
+            () -> cluster.restart(false)
+        );
+
+        AtomicBoolean found = new AtomicBoolean(false);
+        for (int i = 0; i < cluster.getNumNodes(); i++) {
+            try (InputStream log = cluster.getNodeLog(i, LogType.SERVER)) {
+                Streams.readAllLines(log, line -> {
+                    if (line.contains("unknown setting [" + Federation.FEDERATION_ENABLED.getKey() + "]")) {
+                        found.set(true);
+                    }
+                });
+            }
+        }
+        assertThat(
+            "the node refused to start, but its log does not name ["
+                + Federation.FEDERATION_ENABLED.getKey()
+                + "] as an unknown setting, so it failed for some other reason",
+            found.get(),
+            is(true)
+        );
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationSettingRestartRestIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/FederationSettingRestartRestIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.single_node;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xpack.esql.datasources.Federation;
+import org.junit.ClassRule;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The user lever of {@link AbstractFederationRestartRestTestCase}: {@code esql.federation.enabled} is set back to
+ * {@code false} and the node bounced, which is how a user opts out again after opting in.
+ */
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
+public class FederationSettingRestartRestIT extends AbstractFederationRestartRestTestCase {
+
+    private static final AtomicReference<String> federationEnabled = new AtomicReference<>("true");
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(
+        spec -> spec.setting(Federation.FEDERATION_ENABLED.getKey(), federationEnabled::get)
+    );
+
+    @Override
+    protected ElasticsearchCluster cluster() {
+        return cluster;
+    }
+
+    @Override
+    protected void turnFederationOff() {
+        federationEnabled.set("false");
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+}

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/AbstractEsqlClientYamlIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 import org.elasticsearch.test.rest.yaml.section.IsFalseAssertion;
 import org.elasticsearch.xcontent.XContentLocation;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -32,6 +33,8 @@ abstract class AbstractEsqlClientYamlIT extends ESClientYamlSuiteTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        // Federation is opt-in for users; the data source and dataset YAML suites need it on.
+        .setting(Federation.FEDERATION_ENABLED.getKey(), "true")
         .setting("ingest.geoip.downloader.enabled", "false")
         .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
         .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -29,6 +29,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.datasource.TestEncryptionServicePlugin;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.inference.InferenceSettings;
@@ -157,6 +158,9 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(EsqlPlugin.QUERY_ALLOW_PARTIAL_RESULTS.getKey(), false)
+            // Federation is opt-in for users; enable it for every ES|QL integration test so the external data source and
+            // dataset suites run. The default-off surface is covered by the federation REST ITs.
+            .put(Federation.FEDERATION_ENABLED.getKey(), true)
             .build();
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterDatasetIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
 import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
 import org.elasticsearch.xpack.esql.datasources.metadata.DataSourceSetting;
@@ -85,6 +86,13 @@ public class CrossClusterDatasetIT extends AbstractCrossClusterTestCase {
         ) {
             return datasetSettings == null ? Map.of() : new HashMap<>(datasetSettings);
         }
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        // Both the local and the remote nodes need federation on: the remote reports its datasets during field
+        // resolution only when it is available there, and the local coordinator only asks when it is available here.
+        return Settings.builder().put(super.nodeSettings()).put(Federation.FEDERATION_ENABLED.getKey(), true).build();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2783,13 +2783,22 @@ public class EsqlCapabilities {
         DATA_SOURCES_SERVERLESS_SCOPE,
 
         /**
-         * Signals that this node honors the federation kill switch (see {@code Federation}): when suppressed it reports
-         * no datasets during remote field resolution, so a {@code FROM <remote>:<dataset>} falls through to normal index
-         * resolution instead of surfacing a {@code RemoteDatasetNotSupportedException}. Old nodes in a mixed cluster
-         * predate the switch and will not report this capability via {@code /_capabilities}, so any mixed cluster
-         * containing such a node correctly returns {@code supported=false}.
+         * Signals that this node reports no datasets during remote field resolution whenever federation is unavailable
+         * (see {@code Federation}), whether because the operator property suppressed it or because the setting leaves it
+         * off, so a {@code FROM <remote>:<dataset>} falls through to normal index resolution instead of surfacing a
+         * {@code RemoteDatasetNotSupportedException}. Old nodes in a mixed cluster predate this behavior and will not
+         * report the capability via {@code /_capabilities}, so any mixed cluster containing such a node correctly
+         * returns {@code supported=false}.
          */
         REGISTER_FEDERATION_FEATURE,
+
+        /**
+         * Signals that this node reads the {@code esql.federation.enabled} setting (see {@code Federation}), so
+         * federation is off unless a deployment opts in. Nodes that only have the operator kill switch report
+         * {@link #REGISTER_FEDERATION_FEATURE} but not this, and they have federation on with no way to turn it off
+         * per node, so a test that drives the setting has to skip against them.
+         */
+        FEDERATION_ENABLED_SETTING,
 
         /**
          * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantAggregateGroupings} rebuilds a pruned

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResolveFieldsAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResolveFieldsAction.java
@@ -60,6 +60,7 @@ public class EsqlResolveFieldsAction extends HandledTransportAction<FieldCapabil
     private final ViewResolutionService viewResolutionService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ProjectResolver projectResolver;
+    private final boolean federationAvailable;
 
     @Inject
     public EsqlResolveFieldsAction(
@@ -77,6 +78,7 @@ public class EsqlResolveFieldsAction extends HandledTransportAction<FieldCapabil
         this.viewResolutionService = new ViewResolutionService(indexNameExpressionResolver);
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.projectResolver = projectResolver;
+        this.federationAvailable = Federation.isAvailable(clusterService.getSettings());
     }
 
     @Override
@@ -89,10 +91,10 @@ public class EsqlResolveFieldsAction extends HandledTransportAction<FieldCapabil
         List<String> remoteViews = abstractionOptions.resolveViews()
             ? qualify(request.clusterAlias(), getViews(request.indices(), request.indicesOptions(), request.getResolvedIndexExpressions()))
             : List.of();
-        // When federation is suppressed this node reports no datasets, so a FROM <remote:name> falls through to normal
+        // When federation is not available this node reports no datasets, so a FROM <remote:name> falls through to normal
         // remote index resolution and the node is indistinguishable from one that never shipped the feature, rather than
         // failing with a RemoteDatasetNotSupportedException that names pre-existing datasets still in cluster state.
-        List<String> remoteDatasets = abstractionOptions.resolveDatasets() && Federation.isAvailable()
+        List<String> remoteDatasets = abstractionOptions.resolveDatasets() && federationAvailable
             ? qualify(request.clusterAlias(), getDatasets(request.indices(), request.indicesOptions()))
             : List.of();
         boolean hasRemoteViews = remoteViews.isEmpty() == false;
@@ -121,12 +123,15 @@ public class EsqlResolveFieldsAction extends HandledTransportAction<FieldCapabil
                 FieldCapabilitiesRequest remoteRequest,
                 ActionListenerResponseHandler<FieldCapabilitiesResponse> responseHandler
             ) {
+                // A node without federation does not ask its remotes for datasets either, so a remote that has the feature on
+                // cannot make FROM <remote>:<name> fail here with an error naming datasets; the name falls through to normal
+                // remote index resolution instead.
                 remoteRequest.indicesOptions(
                     IndicesOptions.builder(remoteRequest.indicesOptions())
                         .indexAbstractionOptions(
                             IndicesOptions.IndexAbstractionOptions.builder(remoteRequest.indicesOptions().indexAbstractionOptions())
                                 .resolveViews(true)
-                                .resolveDatasets(true)
+                                .resolveDatasets(federationAvailable)
                         )
                         .build()
                 );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetResolver.java
@@ -48,11 +48,17 @@ public class DatasetResolver {
     private final Client client;
     private final Executor executor;
     private final CrossProjectModeDecider crossProjectModeDecider;
+    private final boolean federationAvailable;
 
-    public DatasetResolver(Client client, Executor executor, CrossProjectModeDecider crossProjectModeDecider) {
+    /**
+     * Federation availability is resolved once by the caller (see {@link Federation#isAvailable}) rather than per query:
+     * it is fixed for the lifetime of the node, since both of its levers are read at startup.
+     */
+    public DatasetResolver(Client client, Executor executor, CrossProjectModeDecider crossProjectModeDecider, boolean federationAvailable) {
         this.client = client;
         this.executor = executor;
         this.crossProjectModeDecider = crossProjectModeDecider;
+        this.federationAvailable = federationAvailable;
     }
 
     /**
@@ -60,28 +66,14 @@ public class DatasetResolver {
      * Authorization failures (DLS/FLS, and the {@code Unknown index} a rewrite raises for an explicit unauthorized
      * dataset) propagate as-is.
      *
-     * <p>When federation is suppressed (see {@link Federation}) the rewrite is skipped entirely: the plan is returned
+     * <p>When federation is not available (see {@link Federation}) the rewrite is skipped entirely: the plan is returned
      * untouched, so a {@code FROM <dataset>} name flows into normal index resolution and errors as {@code Unknown index},
      * exactly as a nonexistent index would. No dataset lookup and no {@link EsqlResolveDatasetAction} dispatch happen.
      */
     public void replaceDatasets(LogicalPlan parsed, ProjectMetadata projectMetadata, ActionListener<LogicalPlan> listener) {
-        replaceDatasets(parsed, projectMetadata, listener, Federation.isAvailable());
-    }
-
-    /**
-     * Package-private overload that accepts the federation-enabled state as a parameter, allowing unit tests to exercise
-     * the kill-switch branch without relying on the {@code static final} field in {@link Federation}.
-     */
-    void replaceDatasets(
-        LogicalPlan parsed,
-        ProjectMetadata projectMetadata,
-        ActionListener<LogicalPlan> listener,
-        boolean federationEnabled
-    ) {
-        // Federation suppressed: do not attempt any dataset resolution, so the feature is indistinguishable from one
-        // that was never registered (the FROM <dataset> name resolves as an unknown index). The EsqlResolveDatasetAction
-        // is also unregistered in this mode, so dispatching it here would fail; skipping is both correct and required.
-        if (federationEnabled == false) {
+        // Federation not available: do not attempt any dataset resolution, so the feature is indistinguishable from one
+        // that was never registered (the FROM <dataset> name resolves as an unknown index).
+        if (federationAvailable == false) {
             listener.onResponse(parsed);
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/Federation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/Federation.java
@@ -8,49 +8,77 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheSettings;
+import org.elasticsearch.xpack.esql.datasources.dataset.DatasetService;
+import org.elasticsearch.xpack.esql.datasources.datasource.DataSourceService;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 /**
- * Kill switch for the ES|QL federation feature (external data sources and datasets). The feature is
- * registered by default; an operator suppresses it by setting the system property
- * {@value #REGISTER_PROPERTY} to {@code false}.
- *
- * <p>This is a deliberately coarse, static lever, not a dynamic setting: the value is read once at
- * class initialization (forced at node startup by {@code EsqlPlugin}), so changing it requires
- * restarting the node. That trade-off is intentional for an emergency lever that is expected to be
- * used rarely, and it keeps the mechanism simple (a dynamic enabler would be considerably more
- * complex). Cloud/GovCloud can set system properties on any deployment.
- *
- * <p>When suppressed, the goal is that the feature looks like it never existed rather than being
- * present-but-forbidden:
+ * The availability gate for the ES|QL federation feature (external data sources and datasets). Two
+ * levers decide it, and the feature is available only when both agree:
  * <ul>
- *   <li>{@code EsqlPlugin} does not register the federation REST handlers or transport actions
- *       (create/get/delete data source and dataset, plus the {@code FROM <dataset>} resolve action),
- *       so their endpoints return the framework's standard {@code no handler found for uri}
- *       ({@code 400}), identical to a feature that was never shipped.</li>
+ *   <li>the system property {@value #REGISTER_PROPERTY} decides whether the feature is
+ *       <em>registered</em> on this node at all. It defaults to {@code true}, and an operator
+ *       suppresses the feature by setting it to {@code false}. Cloud/GovCloud can set system
+ *       properties on any deployment.</li>
+ *   <li>the setting {@link #FEDERATION_ENABLED} decides whether a user has <em>enabled</em> the
+ *       registered feature. It defaults to {@code false}, so federation is off until it is turned
+ *       on in {@code elasticsearch.yml}.</li>
+ * </ul>
+ *
+ * <p>The two levers are not symmetric. An unregistered feature has no settings at all: {@link #settings()}
+ * returns nothing, so neither {@link #FEDERATION_ENABLED} nor any external data source knob is registered and a
+ * node whose {@code elasticsearch.yml} carries one of those keys fails to start with the framework's standard
+ * {@code unknown setting} error. Configuring a feature an operator removed is a misconfiguration, not something
+ * to tolerate, and the resulting error is the same one a misspelled key gives.
+ *
+ * <p>Both levers are deliberately coarse and static rather than dynamic: the property is read once at
+ * class initialization and the setting is read from the node's settings, so changing either requires
+ * restarting the node. The gates below include REST handler registration, which happens once at
+ * startup, so a dynamic value could not take effect without a restart anyway.
+ *
+ * <p>When federation is not available, the goal is that the feature looks like it never existed rather
+ * than being present-but-forbidden:
+ * <ul>
+ *   <li>{@code EsqlPlugin} does not register the federation REST handlers (create/get/delete data
+ *       source and dataset), so their endpoints return the framework's standard
+ *       {@code no handler found for uri} ({@code 400}), identical to a feature that was never
+ *       shipped. The corresponding transport actions stay registered, so a caller with transport
+ *       privileges can still read and write data source and dataset cluster state.</li>
  *   <li>{@code DatasetResolver} skips the {@code FROM <dataset>} rewrite entirely, so a dataset name
  *       falls through to normal index resolution and errors as {@code Unknown index}, the same error
  *       a nonexistent index gives.</li>
+ *   <li>{@code EsqlResolveFieldsAction} reports no datasets for an incoming remote field-caps request
+ *       and does not ask its own remotes to resolve datasets, so {@code FROM <remote>:<name>} falls
+ *       through to normal remote index resolution in both directions instead of failing with a
+ *       {@code RemoteDatasetNotSupportedException} that names datasets.</li>
+ *   <li>A data node refuses an external request on arrival
+ *       ({@code DataNodeComputeHandler.handleExternalSourceRequest}), before local planning runs. This closes
+ *       the data-node execution path: work shipped from an enabled coordinator (in CCS/CPS, or during a
+ *       rolling restart that has not yet reached this node) is refused whatever the plan turns into, including
+ *       an ungrouped {@code COUNT}/{@code MIN}/{@code MAX} that {@code PushStatsToExternalSource} would answer
+ *       from split stats without ever building a scanning operator.</li>
  *   <li>Every node keeps a backstop at the physical external-source operator build
- *       ({@code LocalExecutionPlanner.planExternalSource}) that throws {@link #notAvailableException()}.
- *       This closes the data-node execution path: an already-rewritten {@code ExternalSourceExec}
- *       shipped from an enabled coordinator (in CCS/CPS, or during a rolling restart that has not yet
- *       reached this node) is refused before it can build a scanning operator, so a disabled node runs
- *       no external scan. Coordinator-side work (the {@code FROM <dataset>} rewrite) is closed
- *       separately by the {@code DatasetResolver} gate above; the snapshot-only inline {@code EXTERNAL}
- *       command bypasses that gate and is only stopped here at operator build, so on a disabled
- *       coordinator its planning-time source resolution and split discovery can still touch external
- *       storage before this backstop fires.</li>
+ *       ({@code LocalExecutionPlanner.planExternalSource}) that throws {@link #notAvailableException()}, which
+ *       also covers plans built outside the data-node request path above. Coordinator-side work (the
+ *       {@code FROM <dataset>} rewrite) is closed separately by the {@code DatasetResolver} gate above; the
+ *       snapshot-only inline {@code EXTERNAL} command bypasses that gate and is only stopped here at operator
+ *       build, so on a coordinator without federation its planning-time source resolution and split discovery
+ *       can still touch external storage before this backstop fires.</li>
  * </ul>
  *
  * <p>Because any node can be the coordinating node for a query and any node can receive a data
- * source / dataset create request, the property must be set on <em>all</em> nodes for a complete
- * kill.
+ * source / dataset create request, both levers must be set on <em>all</em> nodes for a consistent
+ * result.
  */
 public final class Federation {
 
@@ -58,25 +86,61 @@ public final class Federation {
 
     public static final String REGISTER_PROPERTY = "es.esql.register_federation_feature";
 
-    private static final boolean ENABLED = readEnabled(System::getProperty);
+    /**
+     * Enables the ES|QL federation feature (external data sources and datasets) on this node. Defaults
+     * to {@code false}: federation is opt-in. The value is read from the node's settings rather than
+     * from cluster state and gates REST handler registration, so a change takes effect only after a
+     * restart. It is registered only when the feature is registered, so on a node where an operator set
+     * {@value #REGISTER_PROPERTY} to {@code false} this key is unknown and rejected at startup.
+     */
+    public static final Setting<Boolean> FEDERATION_ENABLED = Setting.boolSetting(
+        "esql.federation.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
 
-    static {
-        // Mirror FeatureFlag: surface the effective state in the node log so an operator can confirm
-        // the switch after a bounce. Only log the exceptional (disabled) state to avoid noise. Because
-        // the read and this log run in the static initializer, EsqlPlugin forces class initialization
-        // at boot rather than deferring it to the first federation operation.
-        if (ENABLED == false) {
-            logger.info("ES|QL federation (external data sources) is not registered ([{}]=false)", REGISTER_PROPERTY);
-        }
-    }
+    private static final boolean REGISTERED = readRegistered(System::getProperty);
 
     private Federation() {}
 
     /**
-     * Parses the enabled state from the given property source. Defaults to enabled when the property
-     * is absent; an unparseable value fails fast (matching {@code FeatureFlag}).
+     * Whether the feature is registered on this node, i.e. whether an operator left {@value #REGISTER_PROPERTY}
+     * alone. Callers that only need to know if federation can be used should use {@link #isAvailable(Settings)};
+     * this is for the registration-time decisions that cannot consult a setting, because the settings themselves
+     * are what is being registered.
      */
-    static boolean readEnabled(Function<String, String> getProperty) {
+    public static boolean isRegistered() {
+        return REGISTERED;
+    }
+
+    /**
+     * The node settings that exist only while the feature is registered: the {@link #FEDERATION_ENABLED} gate, every
+     * external data source and dataset knob, and the ceilings on how many data sources and datasets a project may
+     * hold. A plugin must add these to its own {@code Plugin#getSettings()} rather than registering the groups
+     * directly, so that unregistering the feature takes its whole configuration surface with it.
+     */
+    public static List<Setting<?>> settings() {
+        return settings(REGISTERED);
+    }
+
+    static List<Setting<?>> settings(boolean registered) {
+        if (registered == false) {
+            return List.of();
+        }
+        List<Setting<?>> settings = new ArrayList<>();
+        settings.add(FEDERATION_ENABLED);
+        settings.addAll(ExternalSourceSettings.settings());
+        settings.addAll(ExternalSourceCacheSettings.settings());
+        settings.add(DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING);
+        settings.add(DatasetService.MAX_DATASETS_COUNT_SETTING);
+        return List.copyOf(settings);
+    }
+
+    /**
+     * Parses the registered state from the given property source. Defaults to registered when the
+     * property is absent; an unparseable value fails fast (matching {@code FeatureFlag}).
+     */
+    static boolean readRegistered(Function<String, String> getProperty) {
         final String value = getProperty.apply(REGISTER_PROPERTY);
         try {
             return Booleans.parseBoolean(value, true);
@@ -86,17 +150,17 @@ public final class Federation {
     }
 
     /**
-     * Whether the federation feature is available on this node. Read by {@code EsqlPlugin} at startup to
-     * decide whether to register the federation REST handlers and transport actions, and by
-     * {@code DatasetResolver} to decide whether to attempt the {@code FROM <dataset>} rewrite.
+     * Whether the federation feature is available on this node, which requires both that it is registered
+     * and that {@link #FEDERATION_ENABLED} is set. Takes the node settings rather than caching an
+     * effective value, because settings are per-node state and several nodes share one JVM in tests.
      */
-    public static boolean isAvailable() {
-        return ENABLED;
+    public static boolean isAvailable(Settings settings) {
+        return REGISTERED && FEDERATION_ENABLED.get(settings);
     }
 
-    /** No-op when federation is available; throws {@link #notAvailableException()} when the kill switch is engaged. */
-    public static void ensureEnabled() {
-        ensureEnabled(isAvailable());
+    /** No-op when federation is available on this node; throws {@link #notAvailableException()} otherwise. */
+    public static void ensureEnabled(Settings settings) {
+        ensureEnabled(isAvailable(settings));
     }
 
     static void ensureEnabled(boolean enabled) {
@@ -106,11 +170,33 @@ public final class Federation {
     }
 
     /**
-     * The {@code 400} thrown by the data-node backstop when an external-source plan reaches a node that has
-     * federation suppressed. The message deliberately omits the property name so it reads as a plain
-     * "feature not present" error rather than a configuration hint.
+     * Surfaces the effective state in the node log at startup so an operator can confirm both levers after a
+     * bounce. Only a state an operator asked for reaches {@code INFO}: federation being off is the default on
+     * every node, so that one is logged at {@code DEBUG} and confirming it takes raising the level for this
+     * class. An unregistered node cannot also have the setting on, because it does not accept the setting at
+     * all, so there is no combination to warn about.
      */
-    static ElasticsearchStatusException notAvailableException() {
+    public static void logEffectiveState(Settings settings) {
+        logEffectiveState(REGISTERED, FEDERATION_ENABLED.get(settings));
+    }
+
+    static void logEffectiveState(boolean registered, boolean enabled) {
+        if (registered == false) {
+            logger.info("ES|QL federation (external data sources) is not registered ([{}]=[false])", REGISTER_PROPERTY);
+        } else if (enabled) {
+            logger.info("ES|QL federation (external data sources) is enabled ([{}]=[true])", FEDERATION_ENABLED.getKey());
+        } else {
+            logger.debug("ES|QL federation (external data sources) is disabled ([{}]=[false])", FEDERATION_ENABLED.getKey());
+        }
+    }
+
+    /**
+     * The {@code 400} raised when external-source work reaches a node that does not have federation available,
+     * either at the data node's external-request entry point or at the operator-build backstop. The message
+     * deliberately omits the property and setting names so it reads as a plain "feature not present" error
+     * rather than a configuration hint.
+     */
+    public static ElasticsearchStatusException notAvailableException() {
         return new ElasticsearchStatusException("external data sources are not available", RestStatus.BAD_REQUEST);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/dataset/DatasetService.java
@@ -69,7 +69,10 @@ public class DatasetService {
             Priority.NORMAL,
             new SequentialAckingBatchedTaskExecutor<>()
         );
-        clusterService.getClusterSettings().initializeAndWatch(MAX_DATASETS_COUNT_SETTING, v -> this.maxDatasetsCount = v);
+        // The ceiling is watched while the setting exists, which is while the federation feature is registered (see
+        // Federation#settings). Where the feature is unregistered the ceiling is the setting's default and cannot be
+        // changed, which no request observes because the CRUD REST routes are not registered either.
+        clusterService.getClusterSettings().initializeAndWatchIfRegistered(MAX_DATASETS_COUNT_SETTING, v -> this.maxDatasetsCount = v);
     }
 
     protected DatasetMetadata getMetadata(ProjectMetadata projectMetadata) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/datasource/DataSourceService.java
@@ -84,7 +84,11 @@ public class DataSourceService {
             Priority.NORMAL,
             new SequentialAckingBatchedTaskExecutor<>()
         );
-        clusterService.getClusterSettings().initializeAndWatch(MAX_DATA_SOURCES_COUNT_SETTING, v -> this.maxDataSourcesCount = v);
+        // The ceiling is watched while the setting exists, which is while the federation feature is registered (see
+        // Federation#settings). Where the feature is unregistered the ceiling is the setting's default and cannot be
+        // changed, which no request observes because the CRUD REST routes are not registered either.
+        clusterService.getClusterSettings()
+            .initializeAndWatchIfRegistered(MAX_DATA_SOURCES_COUNT_SETTING, v -> this.maxDataSourcesCount = v);
     }
 
     protected DataSourceMetadata getMetadata(ProjectMetadata projectMetadata) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1837,13 +1837,16 @@ public class LocalExecutionPlanner {
      * @return the physical operation
      */
     private PhysicalOperation planExternalSource(ExternalSourceExec externalSource, LocalExecutionPlannerContext context) {
-        // Federation kill switch, data-node backstop. This is where an external source becomes a running operator, so
-        // enforcing here refuses any already-rewritten ExternalSourceExec that reaches a disabled node regardless of who
-        // planned the query: an enabled coordinator, a remote cluster in CCS/CPS, or an enabled coordinator during a
-        // rolling restart that has not yet reached this node. The coordinator FROM <dataset> path is closed earlier by
-        // the DatasetResolver gate; the snapshot-only inline EXTERNAL command bypasses that gate and is stopped only
-        // here, after its planning-time source resolution and split discovery have run.
-        Federation.ensureEnabled();
+        // Federation gate, operator-build backstop. This is where an external source becomes a running operator, so
+        // enforcing here refuses any already-rewritten ExternalSourceExec that reaches a node without federation
+        // regardless of who planned the query: an enabled coordinator, a remote cluster in CCS/CPS, or an enabled
+        // coordinator during a rolling restart that has not yet reached this node. An external request arriving at a
+        // data node is already refused earlier, in DataNodeComputeHandler.handleExternalSourceRequest, which also
+        // covers the plans this backstop cannot see because local planning folded the source away. The coordinator
+        // FROM <dataset> path is closed earlier by the DatasetResolver gate; the snapshot-only inline EXTERNAL command
+        // bypasses that gate and is stopped only here, after its planning-time source resolution and split discovery
+        // have run.
+        Federation.ensureEnabled(settings);
 
         Layout.Builder layout = new Layout.Builder();
         layout.append(externalSource.output());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -51,6 +51,7 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
@@ -89,6 +90,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
     private final ExchangeService exchangeService;
     private final Executor searchExecutor;
     private final ThreadPool threadPool;
+    /**
+     * Resolved once: {@link Federation#FEDERATION_ENABLED} is node scoped and takes effect only after a restart, so
+     * every external request on this node gets the same answer.
+     */
+    private final boolean federationAvailable;
 
     DataNodeComputeHandler(
         ComputeService computeService,
@@ -107,6 +113,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         this.exchangeService = exchangeService;
         this.searchExecutor = searchExecutor;
         this.threadPool = transportService.getThreadPool();
+        this.federationAvailable = Federation.isAvailable(clusterService.getSettings());
         transportService.registerRequestHandler(ComputeService.DATA_ACTION_NAME, searchExecutor, DataNodeRequest::new, this);
     }
 
@@ -844,14 +851,38 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         );
     }
 
+    /**
+     * Rejects an external request that never got as far as building a driver. The coordinator opened the exchange before
+     * sending the request, so a sink handler is already registered here; it has to be failed explicitly or the
+     * coordinator's exchange source only learns of the refusal through task cancellation and this node holds an
+     * unfinished sink until the inactive-sinks reaper runs.
+     */
+    private void failWithoutStarting(DataNodeRequest request, ActionListener<DataNodeComputeResponse> listener, Exception failure) {
+        exchangeService.finishSinkHandler(request.sessionId(), failure);
+        listener.onFailure(failure);
+    }
+
     private void handleExternalSourceRequest(
         DataNodeRequest request,
         CancellableTask task,
         ActionListener<DataNodeComputeResponse> listener,
         PlanTimeProfile planTimeProfile
     ) {
+        // Federation gate for the whole external request, not just the operators it ends up building. The backstop in
+        // LocalExecutionPlanner.planExternalSource only fires for a plan that still contains an ExternalSourceExec, and
+        // localPlan() below can consume it: PushStatsToExternalSource answers an ungrouped COUNT/MIN/MAX from the split
+        // stats the coordinator discovered and leaves a LocalSourceExec behind. Refusing on entry means a node without
+        // federation serves no external data whatever the aggregate shape.
+        if (federationAvailable == false) {
+            failWithoutStarting(request, listener, Federation.notAvailableException());
+            return;
+        }
         if (request.plan() instanceof ExchangeSinkExec == false) {
-            listener.onFailure(new IllegalStateException("expected exchange sink for external compute; got " + request.plan()));
+            failWithoutStarting(
+                request,
+                listener,
+                new IllegalStateException("expected exchange sink for external compute; got " + request.plan())
+            );
             return;
         }
         ExchangeSinkExec sinkExec = (ExchangeSinkExec) request.plan();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -156,7 +156,6 @@ import org.elasticsearch.xpack.esql.view.ViewResolver;
 import org.elasticsearch.xpack.esql.view.ViewService;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -374,13 +373,10 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
             .flatMap(p -> p.checkers(services.projectResolver(), services.clusterService()).stream())
             .toList();
 
-        // Force Federation to initialize now so the kill-switch property is validated (fail fast on an invalid value)
-        // and the disabled state is logged at startup, rather than lazily on the first federation operation.
-        try {
-            MethodHandles.publicLookup().ensureInitialized(Federation.class);
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException("Failed to initialize " + Federation.class.getName(), e);
-        }
+        // Report the effective federation state at startup rather than lazily on the first federation operation. Logging
+        // is all this call does: an invalid value for the operator property is rejected when Federation#REGISTERED is
+        // initialized, which getSettings() has already triggered by reading FEDERATION_ENABLED off the class.
+        Federation.logEffectiveState(services.clusterService().getSettings());
 
         // Discover DataSourcePlugin implementations via SPI (META-INF/services)
         // This discovers built-in plugins from this plugin's classloader
@@ -402,24 +398,34 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         DataSourceCredentials dataSourceCredentials = new DataSourceCredentials(encryptionService);
 
         boolean isStateless = DiscoveryNode.isStateless(settings);
+        // The external source settings are registered only while the federation feature is registered (see
+        // Federation#settings), so an unregistered node has neither a configured value to start from nor an update
+        // consumer to attach: ClusterSettings rejects a consumer for a setting it does not know. The credential gates
+        // below are therefore off outright rather than resolved from settings, which states the invariant here instead
+        // of resting on startup validation having already rejected the keys.
+        boolean federationRegistered = Federation.isRegistered();
+
         // Read through MANAGED_IDENTITY_ENABLED, which falls back to the deprecated workload_identity key, so a
         // pre-rename operator config is still honored. Its update consumer fires on changes to either key because the
         // setting's raw value resolves the fallback.
         AtomicBoolean managedIdentityEnabled = new AtomicBoolean(
-            isStateless == false && ExternalSourceSettings.MANAGED_IDENTITY_ENABLED.get(settings)
+            federationRegistered && isStateless == false && ExternalSourceSettings.MANAGED_IDENTITY_ENABLED.get(settings)
         );
-        services.clusterService()
-            .getClusterSettings()
-            .addSettingsUpdateConsumer(
-                ExternalSourceSettings.MANAGED_IDENTITY_ENABLED,
-                v -> managedIdentityEnabled.set(isStateless == false && v)
-            );
-
-        // Disabled by default; an operator can enable it dynamically;
-        AtomicBoolean federatedIdentityEnabled = new AtomicBoolean(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED.get(settings));
-        services.clusterService()
-            .getClusterSettings()
-            .addSettingsUpdateConsumer(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED, federatedIdentityEnabled::set);
+        // Disabled by default; while the feature is registered an operator can enable it dynamically.
+        AtomicBoolean federatedIdentityEnabled = new AtomicBoolean(
+            federationRegistered && ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED.get(settings)
+        );
+        if (federationRegistered) {
+            services.clusterService()
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                    ExternalSourceSettings.MANAGED_IDENTITY_ENABLED,
+                    v -> managedIdentityEnabled.set(isStateless == false && v)
+                );
+            services.clusterService()
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED, federatedIdentityEnabled::set);
+        }
 
         // Local-disk gate: parsed once at startup (NodeScope setting — no update consumer needed).
         LocalFileAccess localFileAccess = LocalFileAccess.create(settings);
@@ -463,9 +469,11 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
             );
 
         ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings);
-        services.clusterService()
-            .getClusterSettings()
-            .addSettingsUpdateConsumer(ExternalSourceCacheSettings.CACHE_ENABLED, cacheService::setEnabled);
+        if (federationRegistered) {
+            services.clusterService()
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(ExternalSourceCacheSettings.CACHE_ENABLED, cacheService::setEnabled);
+        }
 
         // Build the format metadata the dataset CRUD validator uses to (a) accept format-specific
         // fields (e.g. CSV's "delimiter") so they persist in cluster state and reach the format reader
@@ -613,8 +621,6 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
                 ViewService.MAX_VIEWS_COUNT_SETTING,
                 ViewService.MAX_VIEW_LENGTH_SETTING,
                 ViewResolver.MAX_VIEW_DEPTH_SETTING,
-                DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING,
-                DatasetService.MAX_DATASETS_COUNT_SETTING,
                 GROK_WATCHDOG_MAX_EXECUTION_TIME
             )
         );
@@ -623,11 +629,11 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
         // Inference command settings
         settings.addAll(InferenceSettings.getSettings());
 
-        // External source rate limiting settings
-        settings.addAll(ExternalSourceSettings.settings());
-
-        // External source cache settings
-        settings.addAll(ExternalSourceCacheSettings.settings());
+        // The federation gate, every external source knob below it, and the data source / dataset count ceilings,
+        // registered only while an operator leaves the feature registered. On a node where the feature is
+        // unregistered these keys are unknown, so carrying one in elasticsearch.yml fails startup instead of
+        // configuring a feature that is not there.
+        settings.addAll(Federation.settings());
 
         return Collections.unmodifiableList(settings);
     }
@@ -679,10 +685,10 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
                 new RestGetViewAction()
             )
         );
-        // Federation (external data sources) REST handlers are registered only when the feature is on. When
-        // suppressed the routes are unregistered, so PUT/GET/DELETE of data sources and datasets return the
+        // Federation (external data sources) REST handlers are registered only when the feature is on. When it is
+        // not available the routes are unregistered, so PUT/GET/DELETE of data sources and datasets return the
         // framework's standard "no handler found for uri" (400), as if the feature never existed.
-        if (Federation.isAvailable()) {
+        if (Federation.isAvailable(restHandlersServices.settings())) {
             handlers.add(new RestPutDataSourceAction());
             handlers.add(new RestGetDataSourceAction());
             handlers.add(new RestDeleteDataSourceAction());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.esql.core.async.AsyncTaskManagementService;
 import org.elasticsearch.xpack.esql.core.expression.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.datasources.DatasetResolver;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.enrich.AbstractLookupService;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
@@ -150,7 +151,12 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         this.clusterService = clusterService;
         this.viewResolver = viewResolver;
         this.requestExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
-        this.datasetResolver = new DatasetResolver(client, requestExecutor, crossProjectModeDecider);
+        this.datasetResolver = new DatasetResolver(
+            client,
+            requestExecutor,
+            crossProjectModeDecider,
+            Federation.isAvailable(clusterService.getSettings())
+        );
         exchangeService.registerTransportHandler(transportService);
         this.exchangeService = exchangeService;
         this.enrichPolicyResolver = new EnrichPolicyResolver(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetResolverTests.java
@@ -128,17 +128,16 @@ public class DatasetResolverTests extends ESTestCase {
         assertEquals("no datasets registered → no dispatch", 0, localCalls.get());
     }
 
-    public void testFederationDisabledReturnsPlanUnchanged() {
+    public void testFederationUnavailableReturnsPlanUnchanged() {
         AtomicInteger localCalls = new AtomicInteger();
-        DatasetResolver resolver = resolver(crossProjectEnabled(true), localCalls);
+        DatasetResolver resolver = resolver(crossProjectEnabled(true), localCalls, false);
 
-        // The kill switch suppresses all dataset resolution: the plan is returned untouched and no
+        // A node without federation performs no dataset resolution at all: the plan is returned untouched and no
         // EsqlResolveDatasetAction dispatch happens, even though datasets are registered in project state.
         UnresolvedRelation relation = relationOf(DATASET_NAME);
-        PlainActionFuture<LogicalPlan> future = new PlainActionFuture<>();
-        resolver.replaceDatasets(relation, project(), future, false);
-        assertSame(relation, future.actionGet());
-        assertEquals("federation disabled → no dispatch", 0, localCalls.get());
+        LogicalPlan rewritten = replaceDatasets(resolver, relation);
+        assertSame(relation, rewritten);
+        assertEquals("federation unavailable, so no dispatch", 0, localCalls.get());
     }
 
     // --- harness ---
@@ -154,7 +153,11 @@ public class DatasetResolverTests extends ESTestCase {
     }
 
     private DatasetResolver resolver(CrossProjectModeDecider decider, AtomicInteger localCalls) {
-        return new DatasetResolver(localActionClient(localCalls), EsExecutors.DIRECT_EXECUTOR_SERVICE, decider);
+        return resolver(decider, localCalls, true);
+    }
+
+    private DatasetResolver resolver(CrossProjectModeDecider decider, AtomicInteger localCalls, boolean federationAvailable) {
+        return new DatasetResolver(localActionClient(localCalls), EsExecutors.DIRECT_EXECUTOR_SERVICE, decider, federationAvailable);
     }
 
     private static CrossProjectModeDecider crossProjectEnabled(boolean enabled) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FederationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FederationTests.java
@@ -7,19 +7,38 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheSettings;
+import org.elasticsearch.xpack.esql.datasources.dataset.DatasetService;
+import org.elasticsearch.xpack.esql.datasources.datasource.DataSourceService;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
 /**
- * Unit tests for {@link Federation}, the federation (external data sources) kill switch. The live state is a
- * {@code static final} read once at class load and cannot be flipped in-JVM, so the property parsing and the
- * enforcement branch are exercised through the package-private {@link Federation#readEnabled} /
- * {@link Federation#ensureEnabled(boolean)} seams, which take their input as a parameter. The registered-vs-suppressed
- * behavior at the REST and transport surface is covered end-to-end by the single-node REST ITs.
+ * Unit tests for {@link Federation}, the availability gate for external data sources and datasets. The registered state
+ * comes from a system property read into a {@code static final} at class load and cannot be flipped in-JVM, so property
+ * parsing, the enforcement branch, the set of registered settings, and the startup logging are exercised through the
+ * package-private {@link Federation#readRegistered}, {@link Federation#ensureEnabled(boolean)},
+ * {@link Federation#settings(boolean)} and {@link Federation#logEffectiveState(boolean, boolean)} seams, which take
+ * their inputs as parameters. The end-to-end behavior of both levers at the REST and transport surface is covered by the
+ * federation REST ITs.
  */
 public class FederationTests extends ESTestCase {
 
@@ -27,25 +46,49 @@ public class FederationTests extends ESTestCase {
         return Map.of(Federation.REGISTER_PROPERTY, value)::get;
     }
 
-    public void testEnabledByDefaultWhenPropertyAbsent() {
-        assertTrue(Federation.readEnabled(key -> null));
+    private static Settings enabled(boolean enabled) {
+        return Settings.builder().put(Federation.FEDERATION_ENABLED.getKey(), enabled).build();
     }
 
-    public void testEnabledByDefaultWhenBlank() {
-        assertTrue(Federation.readEnabled(property("   ")));
+    public void testRegisteredByDefaultWhenPropertyAbsent() {
+        assertTrue(Federation.readRegistered(key -> null));
     }
 
-    public void testEnabledWhenTrue() {
-        assertTrue(Federation.readEnabled(property("true")));
+    public void testRegisteredByDefaultWhenBlank() {
+        assertTrue(Federation.readRegistered(property("   ")));
     }
 
-    public void testDisabledWhenFalse() {
-        assertFalse(Federation.readEnabled(property("false")));
+    public void testRegisteredWhenTrue() {
+        assertTrue(Federation.readRegistered(property("true")));
+    }
+
+    public void testNotRegisteredWhenFalse() {
+        assertFalse(Federation.readRegistered(property("false")));
     }
 
     public void testInvalidValueFailsFast() {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> Federation.readEnabled(property("maybe")));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> Federation.readRegistered(property("maybe")));
         assertTrue(e.getMessage().contains(Federation.REGISTER_PROPERTY));
+    }
+
+    public void testDisabledByDefault() {
+        assertFalse(Federation.FEDERATION_ENABLED.get(Settings.EMPTY));
+    }
+
+    public void testNotAvailableWhenSettingAbsent() {
+        assertFalse(Federation.isAvailable(Settings.EMPTY));
+    }
+
+    public void testNotAvailableWhenSettingFalse() {
+        assertFalse(Federation.isAvailable(enabled(false)));
+    }
+
+    public void testAvailableWhenRegisteredAndSettingTrue() {
+        assumeTrue(
+            "the test JVM must not unregister the feature",
+            System.getProperty(Federation.REGISTER_PROPERTY) == null || Federation.readRegistered(System::getProperty)
+        );
+        assertTrue(Federation.isAvailable(enabled(true)));
     }
 
     public void testEnsureEnabledIsNoopWhenEnabled() {
@@ -62,5 +105,108 @@ public class FederationTests extends ESTestCase {
         ElasticsearchStatusException e = Federation.notAvailableException();
         assertEquals(RestStatus.BAD_REQUEST, e.status());
         assertEquals("external data sources are not available", e.getMessage());
+    }
+
+    public void testNoSettingsWhenNotRegistered() {
+        assertThat(Federation.settings(false), empty());
+    }
+
+    /**
+     * The whole configuration surface of the feature travels with the registration lever, not just the gate: an
+     * operator who unregistered the feature must not be able to configure any part of it.
+     */
+    public void testSettingsCoverTheGateAndEveryExternalSourceKnob() {
+        List<String> keys = Federation.settings(true).stream().map(Setting::getKey).toList();
+        assertThat(keys, hasItem(Federation.FEDERATION_ENABLED.getKey()));
+        for (Setting<?> setting : ExternalSourceSettings.settings()) {
+            assertThat(keys, hasItem(setting.getKey()));
+        }
+        for (Setting<?> setting : ExternalSourceCacheSettings.settings()) {
+            assertThat(keys, hasItem(setting.getKey()));
+        }
+        assertThat(keys, hasItem(DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING.getKey()));
+        assertThat(keys, hasItem(DatasetService.MAX_DATASETS_COUNT_SETTING.getKey()));
+        assertThat(keys, hasSize(3 + ExternalSourceSettings.settings().size() + ExternalSourceCacheSettings.settings().size()));
+    }
+
+    /**
+     * Registration follows the operator property alone, never {@link Federation#FEDERATION_ENABLED}: with the feature
+     * registered but not enabled, the rest of the settings are still registered and still updatable, so a deployment can
+     * ship its federation configuration before opting in, or without ever opting in. Exercised against a real
+     * {@link ClusterSettings}, which is what the cluster settings API validates an update against, so this covers the
+     * dynamic keys reaching their consumers as well as the update being accepted at all.
+     */
+    public void testSettingsStayUpdatableWhileFederationIsNotEnabled() {
+        Settings nodeSettings = enabled(false);
+        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, Set.copyOf(Federation.settings(true)));
+
+        AtomicBoolean federatedIdentity = new AtomicBoolean();
+        clusterSettings.addSettingsUpdateConsumer(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED, federatedIdentity::set);
+        AtomicInteger maxDiscoveredFiles = new AtomicInteger();
+        clusterSettings.addSettingsUpdateConsumer(ExternalSourceSettings.MAX_DISCOVERED_FILES, maxDiscoveredFiles::set);
+        AtomicBoolean cacheEnabled = new AtomicBoolean(true);
+        clusterSettings.addSettingsUpdateConsumer(ExternalSourceCacheSettings.CACHE_ENABLED, cacheEnabled::set);
+        AtomicInteger maxDataSources = new AtomicInteger();
+        clusterSettings.addSettingsUpdateConsumer(DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING, maxDataSources::set);
+
+        Settings update = Settings.builder()
+            .put(ExternalSourceSettings.FEDERATED_IDENTITY_ENABLED.getKey(), true)
+            .put(ExternalSourceSettings.MAX_DISCOVERED_FILES.getKey(), 42)
+            .put(ExternalSourceCacheSettings.CACHE_ENABLED.getKey(), false)
+            .put(DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING.getKey(), 7)
+            .build();
+        clusterSettings.validate(update, true);
+        clusterSettings.applySettings(update);
+
+        assertTrue("federated identity must be settable while federation is off", federatedIdentity.get());
+        assertEquals(42, maxDiscoveredFiles.get());
+        assertFalse(cacheEnabled.get());
+        assertEquals(7, maxDataSources.get());
+    }
+
+    public void testLogsNotRegisteredAtInfo() {
+        MockLog.assertThatLogger(
+            () -> Federation.logEffectiveState(false, false),
+            Federation.class,
+            new MockLog.SeenEventExpectation(
+                "not registered",
+                Federation.class.getCanonicalName(),
+                Level.INFO,
+                "*not registered*" + Federation.REGISTER_PROPERTY + "*"
+            ),
+            new MockLog.UnseenEventExpectation("no warning", Federation.class.getCanonicalName(), Level.WARN, "*")
+        );
+    }
+
+    public void testLogsEnabledAtInfo() {
+        MockLog.assertThatLogger(
+            () -> Federation.logEffectiveState(true, true),
+            Federation.class,
+            new MockLog.SeenEventExpectation(
+                "enabled",
+                Federation.class.getCanonicalName(),
+                Level.INFO,
+                "*is enabled*" + Federation.FEDERATION_ENABLED.getKey() + "*"
+            ),
+            new MockLog.UnseenEventExpectation("no warning", Federation.class.getCanonicalName(), Level.WARN, "*")
+        );
+    }
+
+    @TestLogging(
+        value = "org.elasticsearch.xpack.esql.datasources.Federation:DEBUG",
+        reason = "federation being off is the default state, so it is logged at DEBUG"
+    )
+    public void testLogsDefaultOffAtDebug() {
+        MockLog.assertThatLogger(
+            () -> Federation.logEffectiveState(true, false),
+            Federation.class,
+            new MockLog.SeenEventExpectation(
+                "disabled",
+                Federation.class.getCanonicalName(),
+                Level.DEBUG,
+                "*is disabled*" + Federation.FEDERATION_ENABLED.getKey() + "*"
+            ),
+            new MockLog.UnseenEventExpectation("no warning", Federation.class.getCanonicalName(), Level.WARN, "*")
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MaxCountSettingsRegistrationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MaxCountSettingsRegistrationTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.encryption.spi.EncryptedData;
+import org.elasticsearch.xpack.encryption.spi.EncryptionService;
+import org.elasticsearch.xpack.esql.datasources.dataset.DatasetService;
+import org.elasticsearch.xpack.esql.datasources.datasource.DataSourceService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The ceilings on how many data sources and datasets a project may hold travel with the federation feature, so on a node
+ * where an operator unregistered it (see {@link Federation#settings}) those settings do not exist. {@link DataSourceService}
+ * and {@link DatasetService} are built on every node regardless, because the CRUD transport actions inject them, so each
+ * must come up against cluster settings that do not know its ceiling rather than taking the node down at startup.
+ */
+public class MaxCountSettingsRegistrationTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void startThreadPool() {
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void stopThreadPool() {
+        terminate(threadPool);
+    }
+
+    public void testServicesStartWithoutTheirCeilingSettings() {
+        try (ClusterService clusterService = clusterService(Set.of())) {
+            new DataSourceService(clusterService, Map.of(), new PassThroughEncryptionService());
+            new DatasetService(clusterService, Map.of());
+        }
+    }
+
+    public void testServicesStartWithTheirCeilingSettings() {
+        try (ClusterService clusterService = clusterService(Set.copyOf(Federation.settings(true)))) {
+            new DataSourceService(clusterService, Map.of(), new PassThroughEncryptionService());
+            new DatasetService(clusterService, Map.of());
+        }
+    }
+
+    /**
+     * Where the settings exist they stay live: a ceiling reaches its consumer on registration and again on every update.
+     * Asserted through a consumer of this test's own rather than the services' private field, which also pins what the
+     * services rely on, namely that both ceilings are dynamic. A ceiling that stopped being dynamic would quietly become
+     * a start-up-only value instead of failing.
+     */
+    public void testRegisteredCeilingsAreWatched() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Set.copyOf(Federation.settings(true)));
+        assertCeilingIsWatched(clusterSettings, DataSourceService.MAX_DATA_SOURCES_COUNT_SETTING, 7);
+        assertCeilingIsWatched(clusterSettings, DatasetService.MAX_DATASETS_COUNT_SETTING, 13);
+    }
+
+    private static void assertCeilingIsWatched(ClusterSettings clusterSettings, Setting<Integer> ceiling, int updated) {
+        AtomicInteger observed = new AtomicInteger();
+        clusterSettings.initializeAndWatchIfRegistered(ceiling, observed::set);
+        assertEquals(
+            "[" + ceiling.getKey() + "] must be initialized to its default",
+            ceiling.getDefault(Settings.EMPTY).intValue(),
+            observed.get()
+        );
+
+        clusterSettings.applySettings(Settings.builder().put(ceiling.getKey(), updated).build());
+        assertEquals("[" + ceiling.getKey() + "] must follow an update", updated, observed.get());
+    }
+
+    private ClusterService clusterService(Set<Setting<?>> esqlSettings) {
+        // The built-in settings are what ClusterService itself watches; the federation settings are the ones under test.
+        Set<Setting<?>> settings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        settings.addAll(esqlSettings);
+        return ClusterServiceUtils.createClusterService(threadPool, new ClusterSettings(Settings.EMPTY, settings));
+    }
+
+    /**
+     * The services only hold on to the encryption service, so an implementation that hands the bytes back is enough here.
+     * The encrypt transform itself is covered by {@code DataSourceServiceEncryptionTests}.
+     */
+    private static class PassThroughEncryptionService implements EncryptionService {
+        @Override
+        public EncryptedData encrypt(byte[] bytes) {
+            return new EncryptedData("test-key", bytes.clone());
+        }
+
+        @Override
+        public byte[] decrypt(EncryptedData encryptedData) {
+            return encryptedData.payload();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -48,6 +49,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
@@ -63,6 +65,7 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
+import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
@@ -377,6 +380,43 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             notNullValue()
         );
         assertThat(captured.get().sliceQueue().totalSlices(), equalTo(1));
+    }
+
+    /**
+     * The data-node backstop: building the operator for an external source is refused on a node that does not have
+     * federation, whoever planned the query. An already-rewritten {@link ExternalSourceExec} can arrive from an
+     * enabled coordinator, from a remote cluster, or from a rolling restart that has not reached this node yet.
+     */
+    public void testExternalSourceRefusedWhenFederationIsNotAvailable() throws IOException {
+        SourceOperatorFactoryProvider provider = capturingProvider(new AtomicReference<>());
+        OperatorFactoryRegistry operatorFactoryRegistry = new OperatorFactoryRegistry(Map.of(), Map.of("file", provider), Runnable::run);
+
+        List<Attribute> attrs = List.of(
+            new FieldAttribute(Source.EMPTY, "a", new EsField("a", DataType.INTEGER, Map.of(), true, EsField.TimeSeriesFieldType.NONE))
+        );
+        ExternalSourceExec exec = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://bucket/data.ndjson",
+            "file",
+            attrs,
+            Map.of(),
+            Map.of(),
+            null,
+            10
+        );
+
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> planner(operatorFactoryRegistry, false).plan(
+                "test",
+                FoldContext.small(),
+                PlannerSettings.DEFAULTS,
+                exec,
+                EmptyIndexedByShardId.instance()
+            )
+        );
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(), equalTo("external data sources are not available"));
     }
 
     /**
@@ -801,6 +841,10 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
     }
 
     private LocalExecutionPlanner planner(OperatorFactoryRegistry operatorFactoryRegistry) throws IOException {
+        return planner(operatorFactoryRegistry, true);
+    }
+
+    private LocalExecutionPlanner planner(OperatorFactoryRegistry operatorFactoryRegistry, boolean federationEnabled) throws IOException {
         List<EsPhysicalOperationProviders.ShardContext> shardContexts = createShardContexts();
         return new LocalExecutionPlanner(
             "test",
@@ -811,6 +855,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             Settings.builder()
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "dev-cluster")
                 .put(Node.NODE_NAME_SETTING.getKey(), "node-1")
+                // several tests here plan an ExternalSourceExec, which the federation gate refuses unless it is enabled
+                .put(Federation.FEDERATION_ENABLED.getKey(), federationEnabled)
                 .build(),
             config(),
             null,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -651,7 +651,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
      * executor, or the cross-project remote leg — nulls are never dereferenced.
      */
     private static DatasetResolver noDatasetsResolver() {
-        return new DatasetResolver(null, null, CrossProjectModeDecider.NOOP);
+        return new DatasetResolver(null, null, CrossProjectModeDecider.NOOP, true);
     }
 
     private List<FieldCapabilitiesIndexResponse> indexFieldCapabilities(String[] indices) {

--- a/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/yamlRestTest/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -38,6 +38,12 @@ public class XPackRestIT extends AbstractXPackRestTest {
         .setting("xpack.security.transport.ssl.verification_mode", "certificate")
         .setting("xpack.security.audit.enabled", "true")
         .setting("xpack.license.self_generated.type", "trial")
+        // Federation is opt-in for users; this suite runs the ES|QL data source and dataset YAML tests, which are
+        // skipped when their REST routes are unregistered. Known limitation: dropping this setting silently skips
+        // those tests rather than failing them. Their capability gate cannot be tightened into a hard failure because
+        // other runners of the same YAML files legitimately have federation off. Spelled out rather than taken from
+        // Federation.FEDERATION_ENABLED because this source set does not have the ES|QL plugin on its classpath.
+        .setting("esql.federation.enabled", "true")
         // disable ILM history, since it disturbs tests using _all
         .setting("indices.lifecycle.history_index_enabled", "false")
         .keystore("bootstrap.password", "x-pack-test-password")

--- a/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
@@ -41,6 +41,12 @@ public class XpackWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProj
         .setting("xpack.security.transport.ssl.verification_mode", "certificate")
         .setting("xpack.security.audit.enabled", "true")
         .setting("xpack.license.self_generated.type", "trial")
+        // Federation is opt-in for users; this suite runs the ES|QL data source and dataset YAML tests, which are
+        // skipped when their REST routes are unregistered. Known limitation: dropping this setting silently skips
+        // those tests rather than failing them. Their capability gate cannot be tightened into a hard failure because
+        // other runners of the same YAML files legitimately have federation off. Spelled out rather than taken from
+        // Federation.FEDERATION_ENABLED because this source set does not have the ES|QL plugin on its classpath.
+        .setting("esql.federation.enabled", "true")
         // disable ILM history, since it disturbs tests using _all
         .setting("indices.lifecycle.history_index_enabled", "false")
         .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")


### PR DESCRIPTION
Backports the following commits to 9.5:

- ES|QL|DS: Add esql.federation.enabled, off by default (#155199)

The cherry-pick was not clean; two adaptations were needed.

`ExternalErrorSurfaceIT` does not exist on this branch, so the source
commit's modify conflicted with the delete. The change to it was only the
federation opt-in on its test cluster, so the file is dropped rather than
reintroduced. Nothing on 9.5 references it.

The version gate is retargeted from 9.6.0 to 9.5.0, in its own commit.
`Version.V_9_6_0` does not exist here — the server `Version` class tops
out at `V_9_5_0` — so the source form does not compile. Both gates mean
"the version the setting first ships in", which on this branch is 9.5.0,
not yet released. The gates otherwise keep their original form, so the only
difference from the source commit is the constant.


Verified locally: both touched sourcesets compile and `spotlessJavaCheck`
passes on each.
