### PR TITLE
wip: add OTel Profiling datastreams

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-events.json
@@ -1,0 +1,89 @@
+{
+  "index_patterns": [
+    "profiling-otel-events*"
+  ],
+  "data_stream": {
+    "hidden": false
+  },
+  "template": {
+    "lifecycle": {
+      "data_retention": "60d"
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "ecs.version": {
+          "type": "keyword",
+          "index": true
+        },
+        "profiling.project.id": {
+          "type": "keyword"
+        },
+        "@timestamp": {
+          "type": "date_nanos",
+          "format": "strict_date_optional_time_nanos||epoch_second"
+        },
+        "host.id": {
+          "type": "keyword"
+        },
+        "Stacktrace.id": {
+          "type": "keyword",
+          "index": false
+        },
+        "orchestrator.resource.name": {
+          "type": "keyword"
+        },
+        "container.name": {
+          "type": "keyword"
+        },
+        "process.thread.name": {
+          "type": "keyword"
+        },
+        "process.executable.name": {
+          "type": "keyword"
+        },
+        "Stacktrace.count": {
+          "type": "short",
+          "index": false
+        },
+        "Stacktrace.sampling_frequency": {
+          "type": "long",
+          "index": false
+        },
+        "agent.version": {
+          "type": "keyword"
+        },
+        "host.ip": {
+          "type": "ip"
+        },
+        "host.name": {
+          "type": "keyword"
+        },
+        "os.kernel": {
+          "type": "keyword"
+        },
+        "tags": {
+          "type": "keyword"
+        },
+        "service.name": {
+          "type": "keyword"
+        },
+        "container.id": {
+          "type": "keyword"
+        },
+        "k8s.namespace.name": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "composed_of": [
+    "profiling-hot-tier"
+  ],
+  "priority": 100,
+  "_meta": {
+    "description": "OTel data stream template for profiling-otel-events",
+    "managed": true
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-executables.json
@@ -1,0 +1,46 @@
+{
+  "index_patterns": [
+    "profiling-otel-executables"
+  ],
+  "data_stream": {},
+  "template": {
+    "lifecycle": {
+      "data_retention": "60d"
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "ecs.version": {
+          "type": "keyword",
+          "index": true
+        },
+        "Executable.build.id": {
+          "type": "keyword",
+          "index": true
+        },
+        "Executable.file.name": {
+          "type": "keyword",
+          "index": true
+        },
+        "@timestamp": {
+          "type": "date",
+          "format": "epoch_second"
+        },
+        "Symbolization.next_time": {
+          "type": "date",
+          "format": "epoch_second",
+          "index": true
+        }
+      }
+    }
+  },
+  "composed_of": [
+    "profiling-hot-tier"
+  ],
+  "priority": 100,
+  "_meta": {
+    "description": "OTel data stream template for profiling-otel-executables",
+    "managed": true
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-hosts.json
@@ -1,0 +1,73 @@
+{
+  "index_patterns": [
+    "profiling-otel-hosts"
+  ],
+  "data_stream": {},
+  "template": {
+    "lifecycle": {
+      "data_retention": "60d"
+    },
+    "mappings": {
+      "_source": {
+        "enabled": true
+      },
+      "dynamic": false,
+      "properties": {
+        "ecs.version": {
+          "type": "keyword"
+        },
+        "@timestamp": {
+          "type": "date",
+          "format": "epoch_second"
+        },
+        "host": {
+          "properties": {
+            "arch": { "type": "keyword" },
+            "id": { "type": "keyword" },
+            "name": { "type": "keyword" },
+            "type": { "type": "keyword" }
+          }
+        },
+        "host.id": { "type": "keyword" },
+        "host.name": { "type": "keyword" },
+        "cloud": {
+          "properties": {
+            "provider": { "type": "keyword" },
+            "region": { "type": "keyword" }
+          }
+        },
+        "os": {
+          "properties": {
+            "type": { "type": "keyword" }
+          }
+        },
+        "profiling": {
+          "properties": {
+            "project.id": { "type": "keyword" },
+            "agent": {
+              "properties": {
+                "version": { "type": "version" },
+                "revision": { "type": "keyword" },
+                "build_timestamp": { "type": "date", "format": "epoch_second" },
+                "start_time": { "type": "date", "format": "epoch_millis" },
+                "protocol": { "type": "keyword" },
+                "config.probabilistic_interval": { "type": "keyword" },
+                "config.probabilistic_threshold": { "type": "unsigned_long" },
+                "config.sampling_frequency": { "type": "integer" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "composed_of": [
+    "profiling-hot-tier"
+  ],
+  "priority": 100,
+  "_meta": {
+    "description": "OTel data stream template for profiling-otel-hosts",
+    "managed": true
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-stackframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-stackframes.json
@@ -1,0 +1,58 @@
+{
+  "index_patterns": [
+    "profiling-otel-stackframes"
+  ],
+  "data_stream": {},
+  "template": {
+    "lifecycle": {
+      "data_retention": "60d"
+    },
+    "mappings": {
+      "_source": {
+        "enabled": true
+      },
+      "dynamic": false,
+      "properties": {
+        "ecs.version": {
+          "type": "keyword",
+          "index": true,
+          "doc_values": false,
+          "store": false
+        },
+        "Stackframe.line.number": {
+          "type": "integer",
+          "index": false,
+          "doc_values": false,
+          "store": false
+        },
+        "Stackframe.file.name": {
+          "type": "keyword",
+          "index": false,
+          "doc_values": false,
+          "store": false
+        },
+        "Stackframe.function.name": {
+          "type": "keyword",
+          "index": false,
+          "doc_values": false,
+          "store": false
+        },
+        "Stackframe.function.offset": {
+          "type": "integer",
+          "index": false,
+          "doc_values": false,
+          "store": false
+        }
+      }
+    }
+  },
+  "composed_of": [
+    "profiling-hot-tier"
+  ],
+  "priority": 100,
+  "_meta": {
+    "description": "OTel data stream template for profiling-otel-stackframes",
+    "managed": true
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-otel-stacktraces.json
@@ -1,0 +1,37 @@
+{
+  "index_patterns": [
+    "profiling-otel-stacktraces"
+  ],
+  "data_stream": {},
+  "template": {
+    "lifecycle": {
+      "data_retention": "60d"
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "ecs.version": {
+          "type": "keyword",
+          "index": true
+        },
+        "Stacktrace.frame.ids": {
+          "type": "keyword",
+          "index": false
+        },
+        "Stacktrace.frame.types": {
+          "type": "keyword",
+          "index": false
+        }
+      }
+    }
+  },
+  "composed_of": [
+    "profiling-hot-tier"
+  ],
+  "priority": 100,
+  "_meta": {
+    "description": "OTel data stream template for profiling-otel-stacktraces",
+    "managed": true
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -97,7 +97,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_CHECK_OUTDATED_INDICES, this::updateCheckOutdatedIndices);
 
         indexManager.set(new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get()));
-        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get()));
+        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get(), settings));
         // set initial value
         updateTemplatesEnabled(PROFILING_TEMPLATES_ENABLED.get(settings));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_TEMPLATES_ENABLED, this::updateTemplatesEnabled);

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -97,7 +97,9 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_CHECK_OUTDATED_INDICES, this::updateCheckOutdatedIndices);
 
         indexManager.set(new ProfilingIndexManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get()));
-        dataStreamManager.set(new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get(), settings));
+        dataStreamManager.set(
+            new ProfilingDataStreamManager(threadPool, client, clusterService, indexStateResolver.get(), registry.get(), settings)
+        );
         // set initial value
         updateTemplatesEnabled(PROFILING_TEMPLATES_ENABLED.get(settings));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_TEMPLATES_ENABLED, this::updateTemplatesEnabled);

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
@@ -58,7 +59,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     private static final Logger logger = LogManager.getLogger(ProfilingPlugin.class);
     public static final Setting<Boolean> PROFILING_TEMPLATES_ENABLED = Setting.boolSetting(
         "xpack.profiling.templates.enabled",
-        false,
+        true,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -102,7 +103,9 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(PROFILING_TEMPLATES_ENABLED, this::updateTemplatesEnabled);
         if (enabled) {
             registry.get().initialize();
-            indexManager.get().initialize();
+            if (DiscoveryNode.isStateless(settings) == false) {
+                indexManager.get().initialize();
+            }
             dataStreamManager.get().initialize();
         }
         return List.of(createLicenseChecker(), registry.get());

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/KvIndexResolver.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/KvIndexResolver.java
@@ -84,7 +84,11 @@ public class KvIndexResolver {
                 );
             }
             List<Index> dsIndices = otelDataStream.getIndices();
-            log.debug("Resolved [{}] to OTel data stream backing indices {}.", indexPattern, dsIndices.stream().map(Index::getName).toList());
+            log.debug(
+                "Resolved [{}] to OTel data stream backing indices {}.",
+                indexPattern,
+                dsIndices.stream().map(Index::getName).toList()
+            );
             return Collections.unmodifiableList(dsIndices);
         }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/KvIndexResolver.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/KvIndexResolver.java
@@ -9,14 +9,17 @@ package org.elasticsearch.xpack.profiling.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.rest.RestStatus;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -27,10 +30,20 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Resolves aliases that point to multiple key/value indices.
+ * Resolves aliases that point to multiple key/value indices or their OTel data stream counterpart.
+ *
+ * For each K/V index pattern such as {@code profiling-executables} the resolver first checks
+ * whether a corresponding OTel data stream ({@code profiling-otel-executables}) exists. If it does,
+ * its backing indices are returned directly. If both the OTel data stream and the legacy K/V alias
+ * exist simultaneously a {@link RestStatus#CONFLICT} exception is raised because mixed schemas are
+ * not supported. When no OTel data stream is present the resolver falls back to the existing
+ * time-range K/V logic.
  */
 public class KvIndexResolver {
     private static final Logger log = LogManager.getLogger(KvIndexResolver.class);
+
+    private static final String KV_PREFIX = "profiling-";
+    private static final String OTEL_PREFIX = "profiling-otel-";
 
     private final IndexNameExpressionResolver resolver;
     /**
@@ -45,19 +58,37 @@ public class KvIndexResolver {
     }
 
     /**
+     * Resolves the backing indices for a K/V index pattern.
      *
-     * Resolves aliases that point to multiple K/V indices. When resolving indices it sorts indices by their creation timestamp (or
-     * lifecycle origination date, if specified) and assumes that an index contains data from its creation until the creation of the next
-     * index plus an overlap that is controlled by <code>kvIndexOverlapPeriod</code>. It will only return matching indices within the
-     * specified time range.
+     * The OTel data stream is checked first. If found, its backing indices are returned. If both the
+     * OTel data stream and the legacy K/V alias exist a {@link RestStatus#CONFLICT} exception is
+     * thrown. Otherwise the resolver falls back to the time-range K/V logic.
      *
-     * @param clusterState The current cluster state.
-     * @param indexPattern An index pattern to match.
-     * @param eventStart The earliest point in time to consider
-     * @param eventEnd The latest point in time to consider
-     * @return A list of indices that match both the provided index pattern and the time range between event start and end.
+     * @param clusterState the current cluster state
+     * @param indexPattern a legacy K/V index pattern such as {@code profiling-executables}
+     * @param eventStart the earliest point in time to consider, used only on the K/V path
+     * @param eventEnd the latest point in time to consider, used only on the K/V path
+     * @return a list of indices that satisfy the query
      */
     public List<Index> resolve(ClusterState clusterState, String indexPattern, Instant eventStart, Instant eventEnd) {
+        String otelDsName = toOtelName(indexPattern);
+        DataStream otelDataStream = clusterState.metadata().getProject().dataStreams().get(otelDsName);
+
+        if (otelDataStream != null) {
+            if (clusterState.metadata().getProject().hasAlias(indexPattern)) {
+                throw new ElasticsearchStatusException(
+                    "Both K/V indices and an OTel data stream exist for ["
+                        + indexPattern
+                        + "]. Mixed schemas are not supported. Delete the legacy K/V indices to continue using the OTel data stream.",
+                    RestStatus.CONFLICT
+                );
+            }
+            List<Index> dsIndices = otelDataStream.getIndices();
+            log.debug("Resolved [{}] to OTel data stream backing indices {}.", indexPattern, dsIndices.stream().map(Index::getName).toList());
+            return Collections.unmodifiableList(dsIndices);
+        }
+
+        // K/V index path: filter by time range when multiple indices exist.
         Index[] indices = resolver.concreteIndices(clusterState, IndicesOptions.STRICT_EXPAND_OPEN, indexPattern);
         List<Index> matchingIndices = new ArrayList<>();
         // find matching index for the current time range (indices are non-overlapping)
@@ -79,7 +110,7 @@ public class KvIndexResolver {
                 }
                 indicesWithTime.add(Tuple.tuple(i, Instant.ofEpochMilli(creationDate)));
             }
-            // sort - newest index first, then work backwards to find overlaps
+            // sort newest index first, then work backwards to find overlaps
             indicesWithTime.sort((i1, i2) -> i2.v2().compareTo(i1.v2()));
             Instant intervalEnd = Instant.MAX;
             for (Tuple<Index, Instant> indexAndTime : indicesWithTime) {
@@ -111,5 +142,16 @@ public class KvIndexResolver {
             );
         }
         return Collections.unmodifiableList(matchingIndices);
+    }
+
+    /**
+     * Derives the OTel data stream name for a given legacy K/V index name.
+     * For example {@code profiling-executables} becomes {@code profiling-otel-executables}.
+     */
+    static String toOtelName(String kvIndexPattern) {
+        if (kvIndexPattern.startsWith(KV_PREFIX) == false) {
+            return OTEL_PREFIX + kvIndexPattern;
+        }
+        return OTEL_PREFIX + kvIndexPattern.substring(KV_PREFIX.length());
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
@@ -195,7 +195,12 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 if (sampleCount > 0) {
                     log.debug("Using OTel index [{}] with [{}] samples.", EventsIndex.OTEL_FULL_INDEX, sampleCount);
                     searchRandomSampledProfilingEvents(
-                        submitTask, client, request, submitListener, responseBuilder, EventsIndex.OTEL_FULL_INDEX
+                        submitTask,
+                        client,
+                        request,
+                        submitListener,
+                        responseBuilder,
+                        EventsIndex.OTEL_FULL_INDEX
                     );
                 } else {
                     log.debug("OTel index [{}] is empty, falling back to standard profiling indices.", EventsIndex.OTEL_FULL_INDEX);
@@ -203,7 +208,10 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 }
             }, e -> {
                 if (e instanceof IndexNotFoundException) {
-                    log.debug("OTel index [{}] not found, falling back to standard profiling indices.", EventsIndex.OTEL_FULL_INDEX.getName());
+                    log.debug(
+                        "OTel index [{}] not found, falling back to standard profiling indices.",
+                        EventsIndex.OTEL_FULL_INDEX.getName()
+                    );
                     searchStandardProfilingEvents(submitTask, client, request, submitListener, responseBuilder);
                 } else {
                     submitListener.onFailure(e);
@@ -318,30 +326,32 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
             .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
             .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))
             .addAggregation(randomSampler)
-            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, "profiling-hosts", searchResponse -> {
-                long totalSamples = 0;
-                SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
-                Terms stacktraces = sample.getAggregations().get("group_by");
+            .execute(
+                handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, "profiling-hosts", searchResponse -> {
+                    long totalSamples = 0;
+                    SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
+                    Terms stacktraces = sample.getAggregations().get("group_by");
 
-                // When we retrieve data for generic events, we need to adapt the handler similar to searchEventGroupedByStackTrace().
+                    // When we retrieve data for generic events, we need to adapt the handler similar to searchEventGroupedByStackTrace().
 
-                // aggregation
-                Map<TraceEventID, TraceEvent> stackTraceEvents = new HashMap<>();
-                for (Terms.Bucket stacktraceBucket : stacktraces.getBuckets()) {
-                    long count = stacktraceBucket.getDocCount();
-                    totalSamples += count;
+                    // aggregation
+                    Map<TraceEventID, TraceEvent> stackTraceEvents = new HashMap<>();
+                    for (Terms.Bucket stacktraceBucket : stacktraces.getBuckets()) {
+                        long count = stacktraceBucket.getDocCount();
+                        totalSamples += count;
 
-                    String stackTraceID = stacktraceBucket.getKeyAsString();
+                        String stackTraceID = stacktraceBucket.getKeyAsString();
 
-                    TraceEventID eventID = new TraceEventID("", "", "", stackTraceID, DEFAULT_SAMPLING_FREQUENCY);
-                    TraceEvent event = stackTraceEvents.computeIfAbsent(eventID, k -> new TraceEvent());
-                    event.count += count;
-                    subGroups.collectResults(stacktraceBucket, event);
-                }
-                responseBuilder.setTotalSamples(totalSamples);
-                log.debug("Found [{}] stacktrace events.", stackTraceEvents.size());
-                return stackTraceEvents;
-            }));
+                        TraceEventID eventID = new TraceEventID("", "", "", stackTraceID, DEFAULT_SAMPLING_FREQUENCY);
+                        TraceEvent event = stackTraceEvents.computeIfAbsent(eventID, k -> new TraceEvent());
+                        event.count += count;
+                        subGroups.collectResults(stacktraceBucket, event);
+                    }
+                    responseBuilder.setTotalSamples(totalSamples);
+                    log.debug("Found [{}] stacktrace events.", stackTraceEvents.size());
+                    return stackTraceEvents;
+                })
+            );
     }
 
     private void searchRandomSampledProfilingEvents(
@@ -431,106 +441,121 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                         )
                     )
             )
-            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, eventsIndex.hostsIndex(), searchResponse -> {
-                StopWatch watch = new StopWatch("createStackTraceEvents");
-                SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
-                InternalComposite stacktraces = sample.getAggregations().get("group_by");
-                RandomGenerator rng = new Random(rngSeed);
-                long indexSamplingFactor = Math.round(1 / eventsIndex.getSampleRate()); // for example, 5^2 = 25 for profiling-events-5pow02
-                int bucketCount = stacktraces.getBuckets().size();
-                long eventCount = sample.getDocCount();
-                long maxSamplingFrequency = getAggValueAsLong(searchResponse, "max_freq") <= 0
-                    ? (long) DEFAULT_SAMPLING_FREQUENCY
-                    : getAggValueAsLong(searchResponse, "max_freq");
+            .execute(
+                handleEventsGroupedByStackTrace(
+                    submitTask,
+                    client,
+                    responseBuilder,
+                    submitListener,
+                    eventsIndex.hostsIndex(),
+                    searchResponse -> {
+                        StopWatch watch = new StopWatch("createStackTraceEvents");
+                        SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
+                        InternalComposite stacktraces = sample.getAggregations().get("group_by");
+                        RandomGenerator rng = new Random(rngSeed);
+                        long indexSamplingFactor = Math.round(1 / eventsIndex.getSampleRate()); // for example, 5^2 = 25 for
+                                                                                                // profiling-events-5pow02
+                        int bucketCount = stacktraces.getBuckets().size();
+                        long eventCount = sample.getDocCount();
+                        long maxSamplingFrequency = getAggValueAsLong(searchResponse, "max_freq") <= 0
+                            ? (long) DEFAULT_SAMPLING_FREQUENCY
+                            : getAggValueAsLong(searchResponse, "max_freq");
 
-                log.debug(
-                    "Got {} events from {} buckets, indexSamplingFactor {}, upscaled events {}",
-                    eventCount,
-                    bucketCount,
-                    indexSamplingFactor,
-                    eventCount * indexSamplingFactor
-                );
+                        log.debug(
+                            "Got {} events from {} buckets, indexSamplingFactor {}, upscaled events {}",
+                            eventCount,
+                            bucketCount,
+                            indexSamplingFactor,
+                            eventCount * indexSamplingFactor
+                        );
 
-                // Since the random sampler aggregation does not support sampling rates between 0.5 and 1.0,
-                // we can have up to 2x more events in the response as requested by the user.
-                // In order to reduce latency for stacktrace and stackframe lookups, we add another sampling factor
-                // to reduce the number of events to match the user request (which reduces the number of unique stacktrace ids).
-                boolean needAdditionalDownsampling = eventCount > request.getSampleSize();
-                double downSamplingRate = needAdditionalDownsampling
-                    ? (double) request.getSampleSize() / eventCount
-                    : responseBuilder.getSamplingRate();
+                        // Since the random sampler aggregation does not support sampling rates between 0.5 and 1.0,
+                        // we can have up to 2x more events in the response as requested by the user.
+                        // In order to reduce latency for stacktrace and stackframe lookups, we add another sampling factor
+                        // to reduce the number of events to match the user request (which reduces the number of unique stacktrace ids).
+                        boolean needAdditionalDownsampling = eventCount > request.getSampleSize();
+                        double downSamplingRate = needAdditionalDownsampling
+                            ? (double) request.getSampleSize() / eventCount
+                            : responseBuilder.getSamplingRate();
 
-                eventCount = 0;
-                boolean mixedFrequency = false;
-                Map<TraceEventID, TraceEvent> stackTraceEvents = new HashMap<>(bucketCount);
-                for (InternalComposite.InternalBucket stacktraceBucket : stacktraces.getBuckets()) {
-                    long sampledCount;
-                    if (needAdditionalDownsampling) {
-                        sampledCount = downsampleEvents(rng, downSamplingRate, stacktraceBucket.getDocCount());
-                        if (sampledCount <= 0) {
-                            bucketCount--;
-                            continue; // skip bucket
-                        }
-                    } else {
-                        sampledCount = stacktraceBucket.getDocCount();
-                    }
-
-                    long count = roundWithRandom((sampledCount * indexSamplingFactor) / downSamplingRate, rng);
-                    eventCount += sampledCount;
-
-                    TraceEventID eventID = getTraceEventID(stacktraceBucket);
-                    stackTraceEvents.compute(eventID, (k, event) -> {
-                        if (event == null) {
-                            event = new TraceEvent(count);
-                        } else {
-                            event.count += count;
-                        }
-
-                        if (aggregationFields != null && aggregationFields.length > 0) {
-                            if (event.subGroups == null) {
-                                event.subGroups = SubGroup.root(aggregationFields[0]);
+                        eventCount = 0;
+                        boolean mixedFrequency = false;
+                        Map<TraceEventID, TraceEvent> stackTraceEvents = new HashMap<>(bucketCount);
+                        for (InternalComposite.InternalBucket stacktraceBucket : stacktraces.getBuckets()) {
+                            long sampledCount;
+                            if (needAdditionalDownsampling) {
+                                sampledCount = downsampleEvents(rng, downSamplingRate, stacktraceBucket.getDocCount());
+                                if (sampledCount <= 0) {
+                                    bucketCount--;
+                                    continue; // skip bucket
+                                }
+                            } else {
+                                sampledCount = stacktraceBucket.getDocCount();
                             }
 
-                            SubGroup parent = event.subGroups;
-                            for (String fieldName : aggregationFields) {
-                                Object o = stacktraceBucket.getKey().get(fieldName);
-                                String val = o == null ? "" : o.toString();
-                                parent.addCount(val, count);
-                                parent = parent.getSubGroup(val);
+                            long count = roundWithRandom((sampledCount * indexSamplingFactor) / downSamplingRate, rng);
+                            eventCount += sampledCount;
+
+                            TraceEventID eventID = getTraceEventID(stacktraceBucket);
+                            stackTraceEvents.compute(eventID, (k, event) -> {
+                                if (event == null) {
+                                    event = new TraceEvent(count);
+                                } else {
+                                    event.count += count;
+                                }
+
+                                if (aggregationFields != null && aggregationFields.length > 0) {
+                                    if (event.subGroups == null) {
+                                        event.subGroups = SubGroup.root(aggregationFields[0]);
+                                    }
+
+                                    SubGroup parent = event.subGroups;
+                                    for (String fieldName : aggregationFields) {
+                                        Object o = stacktraceBucket.getKey().get(fieldName);
+                                        String val = o == null ? "" : o.toString();
+                                        parent.addCount(val, count);
+                                        parent = parent.getSubGroup(val);
+                                    }
+                                }
+                                return event;
+                            });
+
+                            if (eventID.samplingFrequency() != DEFAULT_SAMPLING_FREQUENCY) {
+                                mixedFrequency = true;
                             }
                         }
-                        return event;
-                    });
 
-                    if (eventID.samplingFrequency() != DEFAULT_SAMPLING_FREQUENCY) {
-                        mixedFrequency = true;
-                    }
-                }
+                        AtomicLong upscaledEventCount = new AtomicLong(eventCount * indexSamplingFactor);
+                        if (mixedFrequency) {
+                            upscaledEventCount.set(0);
 
-                AtomicLong upscaledEventCount = new AtomicLong(eventCount * indexSamplingFactor);
-                if (mixedFrequency) {
-                    upscaledEventCount.set(0);
-
-                    // Events have different frequencies.
-                    // Scale the count up to the maximum sampling frequency.
-                    stackTraceEvents.forEach((eventID, event) -> {
-                        if (eventID.samplingFrequency() != maxSamplingFrequency) {
-                            double samplingFactor = maxSamplingFrequency / eventID.samplingFrequency();
-                            event.count = roundWithRandom(event.count * samplingFactor, rng);
+                            // Events have different frequencies.
+                            // Scale the count up to the maximum sampling frequency.
+                            stackTraceEvents.forEach((eventID, event) -> {
+                                if (eventID.samplingFrequency() != maxSamplingFrequency) {
+                                    double samplingFactor = maxSamplingFrequency / eventID.samplingFrequency();
+                                    event.count = roundWithRandom(event.count * samplingFactor, rng);
+                                }
+                                upscaledEventCount.addAndGet(event.count);
+                            });
                         }
-                        upscaledEventCount.addAndGet(event.count);
-                    });
-                }
 
-                log.debug(watch::report);
+                        log.debug(watch::report);
 
-                responseBuilder.setSamplingRate(downSamplingRate);
-                responseBuilder.setSamplingFrequency(maxSamplingFrequency);
-                responseBuilder.setTotalSamples(upscaledEventCount.get());
-                log.debug("Use [{}] events in [{}] buckets, upscaled to [{}] events).", eventCount, bucketCount, upscaledEventCount.get());
+                        responseBuilder.setSamplingRate(downSamplingRate);
+                        responseBuilder.setSamplingFrequency(maxSamplingFrequency);
+                        responseBuilder.setTotalSamples(upscaledEventCount.get());
+                        log.debug(
+                            "Use [{}] events in [{}] buckets, upscaled to [{}] events).",
+                            eventCount,
+                            bucketCount,
+                            upscaledEventCount.get()
+                        );
 
-                return stackTraceEvents;
-            }));
+                        return stackTraceEvents;
+                    }
+                )
+            );
     }
 
     private static long roundWithRandom(double value, RandomGenerator r) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStackTracesAction.java
@@ -185,6 +185,39 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         ActionListener<GetStackTracesResponse> submitListener,
         GetStackTracesResponseBuilder responseBuilder
     ) {
+        // Probe OTel full index first; fall back to standard indices if empty or missing.
+        client.prepareSearch(EventsIndex.OTEL_FULL_INDEX.getName())
+            .setSize(0)
+            .setQuery(request.getQuery())
+            .setTrackTotalHits(true)
+            .execute(ActionListener.wrap(searchResponse -> {
+                long sampleCount = searchResponse.getHits().getTotalHits().value();
+                if (sampleCount > 0) {
+                    log.debug("Using OTel index [{}] with [{}] samples.", EventsIndex.OTEL_FULL_INDEX, sampleCount);
+                    searchRandomSampledProfilingEvents(
+                        submitTask, client, request, submitListener, responseBuilder, EventsIndex.OTEL_FULL_INDEX
+                    );
+                } else {
+                    log.debug("OTel index [{}] is empty, falling back to standard profiling indices.", EventsIndex.OTEL_FULL_INDEX);
+                    searchStandardProfilingEvents(submitTask, client, request, submitListener, responseBuilder);
+                }
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    log.debug("OTel index [{}] not found, falling back to standard profiling indices.", EventsIndex.OTEL_FULL_INDEX.getName());
+                    searchStandardProfilingEvents(submitTask, client, request, submitListener, responseBuilder);
+                } else {
+                    submitListener.onFailure(e);
+                }
+            }));
+    }
+
+    private void searchStandardProfilingEvents(
+        CancellableTask submitTask,
+        Client client,
+        GetStackTracesRequest request,
+        ActionListener<GetStackTracesResponse> submitListener,
+        GetStackTracesResponseBuilder responseBuilder
+    ) {
         StopWatch watch = new StopWatch("getResampledIndex");
         EventsIndex mediumDownsampled = EventsIndex.MEDIUM_DOWNSAMPLED;
         client.prepareSearch(mediumDownsampled.getName())
@@ -285,7 +318,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
             .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
             .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))
             .addAggregation(randomSampler)
-            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, searchResponse -> {
+            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, "profiling-hosts", searchResponse -> {
                 long totalSamples = 0;
                 SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
                 Terms stacktraces = sample.getAggregations().get("group_by");
@@ -398,7 +431,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                         )
                     )
             )
-            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, searchResponse -> {
+            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, eventsIndex.hostsIndex(), searchResponse -> {
                 StopWatch watch = new StopWatch("createStackTraceEvents");
                 SingleBucketAggregation sample = searchResponse.getAggregations().get("sample");
                 InternalComposite stacktraces = sample.getAggregations().get("group_by");
@@ -542,6 +575,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         Client client,
         GetStackTracesResponseBuilder responseBuilder,
         ActionListener<GetStackTracesResponse> submitListener,
+        String hostsIndex,
         Function<SearchResponse, Map<TraceEventID, TraceEvent>> stacktraceCollector
     ) {
         StopWatch watch = new StopWatch("eventsGroupedByStackTrace");
@@ -556,7 +590,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 responseBuilder.setStart(Instant.ofEpochMilli(minTime));
                 responseBuilder.setEnd(Instant.ofEpochMilli(maxTime));
                 responseBuilder.setStackTraceEvents(stackTraceEvents);
-                retrieveStackTraces(submitTask, client, responseBuilder, submitListener);
+                retrieveStackTraces(submitTask, client, responseBuilder, submitListener, hostsIndex);
             } else {
                 submitListener.onResponse(responseBuilder.build());
             }
@@ -580,7 +614,8 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         CancellableTask submitTask,
         Client client,
         GetStackTracesResponseBuilder responseBuilder,
-        ActionListener<GetStackTracesResponse> submitListener
+        ActionListener<GetStackTracesResponse> submitListener,
+        String hostsIndex
     ) {
         if (submitTask.notifyIfCancelled(submitListener)) {
             return;
@@ -620,7 +655,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         }
 
         // Retrieve the host metadata in parallel. Assume low-cardinality and do not split the query.
-        client.prepareSearch("profiling-hosts")
+        client.prepareSearch(hostsIndex)
             .setTrackTotalHits(false)
             .setQuery(
                 QueryBuilders.boolQuery()

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java
@@ -147,17 +147,19 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         }
 
         private boolean isResourcesCreated(ClusterState state) {
+            boolean stateless = DiscoveryNode.isStateless(clusterService.getSettings());
             IndexStateResolver indexStateResolver = indexStateResolver(state);
             boolean templatesCreated = templateRegistry.isAllResourcesCreated(state, clusterService.getSettings());
-            boolean indicesCreated = ProfilingIndexManager.isAllResourcesCreated(state, indexStateResolver);
-            boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver);
+            boolean indicesCreated = stateless || ProfilingIndexManager.isAllResourcesCreated(state, indexStateResolver);
+            boolean dataStreamsCreated = ProfilingDataStreamManager.isAllResourcesCreated(state, indexStateResolver, stateless);
             return templatesCreated && indicesCreated && dataStreamsCreated;
         }
 
         private boolean isAnyPre891Data(ClusterState state) {
+            boolean stateless = DiscoveryNode.isStateless(clusterService.getSettings());
             IndexStateResolver indexStateResolver = indexStateResolver(state);
-            boolean indicesPre891 = ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
-            boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
+            boolean indicesPre891 = stateless == false && ProfilingIndexManager.isAnyResourceTooOld(state, indexStateResolver);
+            boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver, stateless);
             return indicesPre891 || dataStreamsPre891;
         }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/EventsIndex.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/EventsIndex.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 public final class EventsIndex {
     private static final String PREFIX = "profiling-events";
+    private static final String OTEL_PREFIX = "profiling-otel-events";
     private static final String ALL_EVENTS = PREFIX + "-all";
 
     private static final int SAMPLING_FACTOR = 5;
@@ -25,7 +26,10 @@ public final class EventsIndex {
 
     public static final EventsIndex FULL_INDEX = new EventsIndex(ALL_EVENTS, 1, 0);
 
+    public static final EventsIndex OTEL_FULL_INDEX = new EventsIndex(OTEL_PREFIX + "-all", 1, 0);
+
     // Start with counting the results in the index down-sampled by 5^6.
+
     // That is in the middle of our down-sampled indexes.
     public static final EventsIndex MEDIUM_DOWNSAMPLED = fromFactorAndExponent(SAMPLING_FACTOR, 6);
 
@@ -43,6 +47,14 @@ public final class EventsIndex {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the hosts data stream name that corresponds to this events index.
+     * OTel events use {@code profiling-otel-hosts}; legacy events use {@code profiling-hosts}.
+     */
+    public String hostsIndex() {
+        return name.startsWith(OTEL_PREFIX) ? "profiling-otel-hosts" : "profiling-hosts";
     }
 
     public int getExponent() {
@@ -90,10 +102,23 @@ public final class EventsIndex {
     }
 
     public static Collection<String> indexNames() {
+        return indexNamesForPrefix(PREFIX);
+    }
+
+    /**
+     * Returns the set of OTel event data stream names that mirror the downsampled structure of the
+     * legacy profiling-events streams. OTel streams use the {@code profiling-otel-events} prefix
+     * and are managed via DSL rather than ILM.
+     */
+    public static Collection<String> otelIndexNames() {
+        return indexNamesForPrefix(OTEL_PREFIX);
+    }
+
+    private static Collection<String> indexNamesForPrefix(String prefix) {
         Set<String> names = new HashSet<>();
-        names.add(EventsIndex.ALL_EVENTS);
+        names.add(prefix + "-all");
         for (int exp = MIN_EXPONENT; exp <= MAX_EXPONENT; exp++) {
-            names.add(indexName(SAMPLING_FACTOR, exp));
+            names.add(String.format(Locale.ROOT, "%s-%dpow%02d", prefix, SAMPLING_FACTOR, exp));
         }
         return Collections.unmodifiableSet(names);
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
@@ -17,7 +17,9 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -37,56 +39,68 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
  * Creates all data streams that are required for using Elastic Universal Profiling.
  */
 public class ProfilingDataStreamManager extends AbstractProfilingPersistenceManager<ProfilingDataStreamManager.ProfilingDataStream> {
+    public static final List<ProfilingDataStream> LEGACY_DATASTREAMS;
+    public static final List<ProfilingDataStream> OTEL_DATASTREAMS;
     public static final List<ProfilingDataStream> PROFILING_DATASTREAMS;
 
     static {
-        List<ProfilingDataStream> dataStreams = new ArrayList<>(
+        List<ProfilingDataStream> legacy = new ArrayList<>(
             EventsIndex.indexNames()
                 .stream()
                 .map(n -> ProfilingDataStream.withoutPreCreation(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
                 .toList()
         );
-        dataStreams.add(ProfilingDataStream.of("profiling-metrics", ProfilingIndexTemplateRegistry.PROFILING_METRICS_VERSION));
-        dataStreams.add(ProfilingDataStream.of("profiling-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION));
+        legacy.add(ProfilingDataStream.of("profiling-metrics", ProfilingIndexTemplateRegistry.PROFILING_METRICS_VERSION));
+        legacy.add(ProfilingDataStream.of("profiling-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION));
+        LEGACY_DATASTREAMS = Collections.unmodifiableList(legacy);
+
         // OTel data streams are auto-created on first ingest and managed here for rollover and mapping migrations.
-        dataStreams.addAll(
+        List<ProfilingDataStream> otel = new ArrayList<>(
             EventsIndex.otelIndexNames()
                 .stream()
                 .map(n -> ProfilingDataStream.withoutPreCreation(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
                 .toList()
         );
-        dataStreams.add(
+        otel.add(
             ProfilingDataStream.withoutPreCreation("profiling-otel-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION)
         );
-        dataStreams.add(
+        otel.add(
             ProfilingDataStream.withoutPreCreation(
                 "profiling-otel-executables",
                 ProfilingIndexTemplateRegistry.PROFILING_EXECUTABLES_VERSION
             )
         );
-        dataStreams.add(
+        otel.add(
             ProfilingDataStream.withoutPreCreation(
                 "profiling-otel-stacktraces",
                 ProfilingIndexTemplateRegistry.PROFILING_STACKTRACES_VERSION
             )
         );
-        dataStreams.add(
+        otel.add(
             ProfilingDataStream.withoutPreCreation(
                 "profiling-otel-stackframes",
                 ProfilingIndexTemplateRegistry.PROFILING_STACKFRAMES_VERSION
             )
         );
-        PROFILING_DATASTREAMS = Collections.unmodifiableList(dataStreams);
+        OTEL_DATASTREAMS = Collections.unmodifiableList(otel);
+
+        List<ProfilingDataStream> all = new ArrayList<>(LEGACY_DATASTREAMS);
+        all.addAll(OTEL_DATASTREAMS);
+        PROFILING_DATASTREAMS = Collections.unmodifiableList(all);
     }
+
+    private final boolean stateless;
 
     public ProfilingDataStreamManager(
         ThreadPool threadPool,
         Client client,
         ClusterService clusterService,
         IndexStateResolver indexStateResolver,
-        ProfilingIndexTemplateRegistry templateRegistry
+        ProfilingIndexTemplateRegistry templateRegistry,
+        Settings settings
     ) {
         super(threadPool, client, clusterService, indexStateResolver, templateRegistry);
+        this.stateless = DiscoveryNode.isStateless(settings);
     }
 
     @Override
@@ -116,7 +130,7 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
 
     @Override
     protected Iterable<ProfilingDataStream> getManagedIndices() {
-        return PROFILING_DATASTREAMS;
+        return stateless ? OTEL_DATASTREAMS : PROFILING_DATASTREAMS;
     }
 
     private void onDataStreamFailure(ProfilingDataStream dataStream, Exception ex) {
@@ -308,8 +322,13 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         }
     }
 
-    public static boolean isAllResourcesCreated(ClusterState state, IndexStateResolver indexStateResolver) {
-        for (ProfilingDataStream profilingDataStream : PROFILING_DATASTREAMS) {
+    public static boolean isAllResourcesCreated(
+        ClusterState state,
+        IndexStateResolver indexStateResolver,
+        boolean stateless
+    ) {
+        List<ProfilingDataStream> streams = stateless ? OTEL_DATASTREAMS : PROFILING_DATASTREAMS;
+        for (ProfilingDataStream profilingDataStream : streams) {
             IndexStatus status = indexStateResolver.getIndexState(state, profilingDataStream).getStatus();
             if (status == IndexStatus.UP_TO_DATE) {
                 continue;
@@ -323,8 +342,13 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         return true;
     }
 
-    public static boolean isAnyResourceTooOld(ClusterState state, IndexStateResolver indexStateResolver) {
-        for (ProfilingDataStream profilingDataStream : PROFILING_DATASTREAMS) {
+    public static boolean isAnyResourceTooOld(
+        ClusterState state,
+        IndexStateResolver indexStateResolver,
+        boolean stateless
+    ) {
+        List<ProfilingDataStream> streams = stateless ? OTEL_DATASTREAMS : PROFILING_DATASTREAMS;
+        for (ProfilingDataStream profilingDataStream : streams) {
             if (indexStateResolver.getIndexState(state, profilingDataStream).getStatus() == IndexStatus.TOO_OLD) {
                 return true;
             }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
@@ -43,11 +43,39 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         List<ProfilingDataStream> dataStreams = new ArrayList<>(
             EventsIndex.indexNames()
                 .stream()
-                .map(n -> ProfilingDataStream.of(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
+                .map(n -> ProfilingDataStream.withoutPreCreation(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
                 .toList()
         );
         dataStreams.add(ProfilingDataStream.of("profiling-metrics", ProfilingIndexTemplateRegistry.PROFILING_METRICS_VERSION));
         dataStreams.add(ProfilingDataStream.of("profiling-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION));
+        // OTel data streams are auto-created on first ingest and managed here for rollover and mapping migrations.
+        dataStreams.addAll(
+            EventsIndex.otelIndexNames()
+                .stream()
+                .map(n -> ProfilingDataStream.withoutPreCreation(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
+                .toList()
+        );
+        dataStreams.add(
+            ProfilingDataStream.withoutPreCreation("profiling-otel-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION)
+        );
+        dataStreams.add(
+            ProfilingDataStream.withoutPreCreation(
+                "profiling-otel-executables",
+                ProfilingIndexTemplateRegistry.PROFILING_EXECUTABLES_VERSION
+            )
+        );
+        dataStreams.add(
+            ProfilingDataStream.withoutPreCreation(
+                "profiling-otel-stacktraces",
+                ProfilingIndexTemplateRegistry.PROFILING_STACKTRACES_VERSION
+            )
+        );
+        dataStreams.add(
+            ProfilingDataStream.withoutPreCreation(
+                "profiling-otel-stackframes",
+                ProfilingIndexTemplateRegistry.PROFILING_STACKFRAMES_VERSION
+            )
+        );
         PROFILING_DATASTREAMS = Collections.unmodifiableList(dataStreams);
     }
 
@@ -69,7 +97,13 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
     ) {
         IndexStatus status = indexState.getStatus();
         switch (status) {
-            case NEEDS_CREATION -> createDataStream(indexState.getIndex(), listener);
+            case NEEDS_CREATION -> {
+                if (indexState.getIndex().requiresPreCreation()) {
+                    createDataStream(indexState.getIndex(), listener);
+                } else {
+                    listener.onResponse(null);
+                }
+            }
             case NEEDS_VERSION_BUMP -> rolloverDataStream(indexState.getIndex(), listener);
             case NEEDS_MAPPINGS_UPDATE -> applyMigrations(indexState, listener);
             default -> {
@@ -181,6 +215,7 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
     static class ProfilingDataStream implements ProfilingIndexAbstraction {
         private final String name;
         private final int version;
+        private final boolean requiresPreCreation;
         private final List<Migration> migrations;
 
         public static ProfilingDataStream of(String name, int version) {
@@ -189,17 +224,31 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
 
         public static ProfilingDataStream of(String name, int version, Migration.Builder builder) {
             List<Migration> migrations = builder != null ? builder.build(version) : null;
-            return new ProfilingDataStream(name, version, migrations);
+            return new ProfilingDataStream(name, version, true, migrations);
         }
 
-        private ProfilingDataStream(String name, int version, List<Migration> migrations) {
+        /**
+         * Creates a data stream entry that is tracked for rollover and migrations but never
+         * pre-created by the manager. ES auto-creates it on first document ingest via the
+         * installed index templates.
+         */
+        public static ProfilingDataStream withoutPreCreation(String name, int version) {
+            return new ProfilingDataStream(name, version, false, null);
+        }
+
+        private ProfilingDataStream(String name, int version, boolean requiresPreCreation, List<Migration> migrations) {
             this.name = name;
             this.version = version;
+            this.requiresPreCreation = requiresPreCreation;
             this.migrations = migrations;
         }
 
+        boolean requiresPreCreation() {
+            return requiresPreCreation;
+        }
+
         public ProfilingDataStream withVersion(int version) {
-            return new ProfilingDataStream(name, version, migrations);
+            return new ProfilingDataStream(name, version, requiresPreCreation, migrations);
         }
 
         @Override
@@ -261,9 +310,15 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
 
     public static boolean isAllResourcesCreated(ClusterState state, IndexStateResolver indexStateResolver) {
         for (ProfilingDataStream profilingDataStream : PROFILING_DATASTREAMS) {
-            if (indexStateResolver.getIndexState(state, profilingDataStream).getStatus() != IndexStatus.UP_TO_DATE) {
-                return false;
+            IndexStatus status = indexStateResolver.getIndexState(state, profilingDataStream).getStatus();
+            if (status == IndexStatus.UP_TO_DATE) {
+                continue;
             }
+            // OTel data streams are auto-created on first ingest; their absence does not block setup.
+            if (profilingDataStream.requiresPreCreation() == false && status == IndexStatus.NEEDS_CREATION) {
+                continue;
+            }
+            return false;
         }
         return true;
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingDataStreamManager.java
@@ -61,9 +61,7 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
                 .map(n -> ProfilingDataStream.withoutPreCreation(n, ProfilingIndexTemplateRegistry.PROFILING_EVENTS_VERSION))
                 .toList()
         );
-        otel.add(
-            ProfilingDataStream.withoutPreCreation("profiling-otel-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION)
-        );
+        otel.add(ProfilingDataStream.withoutPreCreation("profiling-otel-hosts", ProfilingIndexTemplateRegistry.PROFILING_HOSTS_VERSION));
         otel.add(
             ProfilingDataStream.withoutPreCreation(
                 "profiling-otel-executables",
@@ -322,11 +320,7 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         }
     }
 
-    public static boolean isAllResourcesCreated(
-        ClusterState state,
-        IndexStateResolver indexStateResolver,
-        boolean stateless
-    ) {
+    public static boolean isAllResourcesCreated(ClusterState state, IndexStateResolver indexStateResolver, boolean stateless) {
         List<ProfilingDataStream> streams = stateless ? OTEL_DATASTREAMS : PROFILING_DATASTREAMS;
         for (ProfilingDataStream profilingDataStream : streams) {
             IndexStatus status = indexStateResolver.getIndexState(state, profilingDataStream).getStatus();
@@ -342,11 +336,7 @@ public class ProfilingDataStreamManager extends AbstractProfilingPersistenceMana
         return true;
     }
 
-    public static boolean isAnyResourceTooOld(
-        ClusterState state,
-        IndexStateResolver indexStateResolver,
-        boolean stateless
-    ) {
+    public static boolean isAnyResourceTooOld(ClusterState state, IndexStateResolver indexStateResolver, boolean stateless) {
         List<ProfilingDataStream> streams = stateless ? OTEL_DATASTREAMS : PROFILING_DATASTREAMS;
         for (ProfilingDataStream profilingDataStream : streams) {
             if (indexStateResolver.getIndexState(state, profilingDataStream).getStatus() == IndexStatus.TOO_OLD) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -52,8 +53,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 13: Added 'container.id' keyword mapping to profiling-events
     // version 14: Stop using using _source.mode attribute in index templates
     // version 15: Use LogsDB mode for profiling-events-* (~30% smaller storage footprint)
-    // version 16: Added 'profiling.executable.name' keyword mapping to profiling-events
-    public static final int INDEX_TEMPLATE_VERSION = 15;
+    // version 16: Added OTel data stream templates for profiling-executables, profiling-stacktraces, profiling-stackframes
+    public static final int INDEX_TEMPLATE_VERSION = 16;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 6;
@@ -69,6 +70,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     public static final String PROFILING_TEMPLATE_VERSION_VARIABLE = "xpack.profiling.template.version";
 
     private volatile boolean templatesEnabled;
+    private final boolean stateless;
 
     public ProfilingIndexTemplateRegistry(
         Settings nodeSettings,
@@ -78,6 +80,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         NamedXContentRegistry xContentRegistry
     ) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        this.stateless = DiscoveryNode.isStateless(nodeSettings);
     }
 
     public void setTemplatesEnabled(boolean templatesEnabled) {
@@ -113,10 +116,24 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected List<LifecyclePolicy> getLifecyclePolicies() {
-        return templatesEnabled ? lifecyclePolicies : Collections.emptyList();
+        if (stateless || templatesEnabled == false) {
+            return Collections.emptyList();
+        }
+        return lifecyclePolicies;
     }
 
-    private final Map<String, ComponentTemplate> componentTemplates = parseComponentTemplates(
+    // Component templates shared by both legacy K/V and OTel paths
+    private final Map<String, ComponentTemplate> sharedComponentTemplates = parseComponentTemplates(
+        new IndexTemplateConfig(
+            "profiling-hot-tier",
+            "/profiling/component-template/profiling-hot-tier.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        )
+    );
+
+    // Component templates required only by the legacy K/V path (not used on serverless)
+    private final Map<String, ComponentTemplate> legacyComponentTemplates = parseComponentTemplates(
         new IndexTemplateConfig(
             "profiling-events",
             "/profiling/component-template/profiling-events.json",
@@ -134,12 +151,6 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
         new IndexTemplateConfig(
             "profiling-ilm",
             "/profiling/component-template/profiling-ilm.json",
-            INDEX_TEMPLATE_VERSION,
-            PROFILING_TEMPLATE_VERSION_VARIABLE
-        ),
-        new IndexTemplateConfig(
-            "profiling-hot-tier",
-            "/profiling/component-template/profiling-hot-tier.json",
             INDEX_TEMPLATE_VERSION,
             PROFILING_TEMPLATE_VERSION_VARIABLE
         ),
@@ -186,10 +197,53 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
-        return templatesEnabled ? componentTemplates : Collections.emptyMap();
+        if (templatesEnabled == false) {
+            return Collections.emptyMap();
+        }
+        if (stateless) {
+            return sharedComponentTemplates;
+        }
+        Map<String, ComponentTemplate> all = new java.util.HashMap<>(sharedComponentTemplates);
+        all.putAll(legacyComponentTemplates);
+        return Collections.unmodifiableMap(all);
     }
 
-    private final Map<String, ComposableIndexTemplate> composableIndexTemplates = parseComposableTemplates(
+    // OTel data stream templates are DSL managed and auto-created on first ingest
+    private final Map<String, ComposableIndexTemplate> otelComposableIndexTemplates = parseComposableTemplates(
+        new IndexTemplateConfig(
+            "profiling-otel-events",
+            "/profiling/index-template/profiling-otel-events.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            "profiling-otel-hosts",
+            "/profiling/index-template/profiling-otel-hosts.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            "profiling-otel-executables",
+            "/profiling/index-template/profiling-otel-executables.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            "profiling-otel-stacktraces",
+            "/profiling/index-template/profiling-otel-stacktraces.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+            "profiling-otel-stackframes",
+            "/profiling/index-template/profiling-otel-stackframes.json",
+            INDEX_TEMPLATE_VERSION,
+            PROFILING_TEMPLATE_VERSION_VARIABLE
+        )
+    );
+
+    // Legacy K/V and ILM-backed templates (not used on serverless)
+    private final Map<String, ComposableIndexTemplate> legacyComposableIndexTemplates = parseComposableTemplates(
         new IndexTemplateConfig(
             "profiling-events",
             "/profiling/index-template/profiling-events.json",
@@ -264,7 +318,15 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
 
     @Override
     protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
-        return templatesEnabled ? composableIndexTemplates : Collections.emptyMap();
+        if (templatesEnabled == false) {
+            return Collections.emptyMap();
+        }
+        if (stateless) {
+            return otelComposableIndexTemplates;
+        }
+        Map<String, ComposableIndexTemplate> all = new java.util.HashMap<>(otelComposableIndexTemplates);
+        all.putAll(legacyComposableIndexTemplates);
+        return Collections.unmodifiableMap(all);
     }
 
     @Override
@@ -299,19 +361,19 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
      * @return <code>true</code> if and only if all resources managed by this registry have been created and are current.
      */
     public boolean isAllResourcesCreated(ClusterState state, Settings settings) {
-        for (String name : componentTemplates.keySet()) {
+        for (String name : getComponentTemplateConfigs().keySet()) {
             ComponentTemplate componentTemplate = state.metadata().getProject().componentTemplates().get(name);
             if (componentTemplate == null || componentTemplate.version() < INDEX_TEMPLATE_VERSION) {
                 return false;
             }
         }
-        for (String name : composableIndexTemplates.keySet()) {
+        for (String name : getComposableTemplateConfigs().keySet()) {
             ComposableIndexTemplate composableIndexTemplate = state.metadata().getProject().templatesV2().get(name);
             if (composableIndexTemplate == null || composableIndexTemplate.version() < INDEX_TEMPLATE_VERSION) {
                 return false;
             }
         }
-        if (isDataStreamsLifecycleOnlyMode(settings) == false) {
+        if (stateless == false && isDataStreamsLifecycleOnlyMode(settings) == false) {
             IndexLifecycleMetadata ilmMetadata = state.metadata().getProject().custom(IndexLifecycleMetadata.TYPE);
             if (ilmMetadata == null) {
                 return false;


### PR DESCRIPTION
Adds new datastreams only for OTel Profiling: profiling-otel-events, profiling-otel-hosts, profiling-otel-stacktraces and profiling-otel-stackframes


In self-managed environments, non-OTel and OTel indices templates will be installed. In Serverless, only the OTel templates (datastreams, no ILM).

Flamegraph/Profiling queries will only work if one or the other backing indices are found, if both indices schemas/naming is found an `ElasticsearchStatusException` will be returned.