### PR TITLE
ci: on-demand code coverage, reported per test layer and merged

### DIFF
--- a/.buildkite/.gitignore
+++ b/.buildkite/.gitignore
@@ -28,6 +28,8 @@ lib-cov
 # Coverage directory used by tools like istanbul
 
 coverage
+# ...but scripts/coverage/ is committed tooling, not generated output.
+!scripts/coverage/
 \*.lcov
 
 # nyc test coverage

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -68,8 +68,11 @@ steps:
           COVERAGE_LAYERS: "unit"
         timeout_in_minutes: 240
         artifact_paths:
+          # Execution data and the summary only. A layer's own HTML report is not uploaded: the
+          # merged step rebuilds every layer's report from this same exec data, so it is pure
+          # duplication - and it is thousands of files, enough to bury the couple of dozen exec
+          # files beside it. Measured on the unit leg: 25 exec files behind 4,000+ report files.
           - "build/coverage/exec/**/*.exec"
-          - "build/coverage/report/**/*"
           - "build/coverage/summary.txt"
         agents:
           provider: gcp
@@ -102,8 +105,11 @@ steps:
           COVERAGE_LAYERS: "internal-cluster"
         timeout_in_minutes: 240
         artifact_paths:
+          # Execution data and the summary only. A layer's own HTML report is not uploaded: the
+          # merged step rebuilds every layer's report from this same exec data, so it is pure
+          # duplication - and it is thousands of files, enough to bury the couple of dozen exec
+          # files beside it. Measured on the unit leg: 25 exec files behind 4,000+ report files.
           - "build/coverage/exec/**/*.exec"
-          - "build/coverage/report/**/*"
           - "build/coverage/summary.txt"
         agents:
           provider: gcp
@@ -136,8 +142,11 @@ steps:
           COVERAGE_LAYERS: "cluster"
         timeout_in_minutes: 240
         artifact_paths:
+          # Execution data and the summary only. A layer's own HTML report is not uploaded: the
+          # merged step rebuilds every layer's report from this same exec data, so it is pure
+          # duplication - and it is thousands of files, enough to bury the couple of dozen exec
+          # files beside it. Measured on the unit leg: 25 exec files behind 4,000+ report files.
           - "build/coverage/exec/**/*.exec"
-          - "build/coverage/report/**/*"
           - "build/coverage/summary.txt"
         agents:
           provider: gcp

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -1,0 +1,53 @@
+# Code coverage, on demand.
+#
+# Never runs by default. Apply the `test-coverage` label to a PR, or comment
+# `@elasticmachine run elasticsearch-ci/test-coverage`.
+#
+# Reports coverage per test layer. It never gates: no thresholds, no failure on a number. The step
+# fails only if the instrument itself is broken, or on test failures - in which case the coverage
+# still uploads and is a lower bound.
+#
+# Parameters are read from the environment; defaults measure the ES|QL surface.
+#
+#   COVERAGE_PROJECTS  Gradle project-path pattern, e.g. ':x-pack:plugin:esql*' or ':server'
+#   COVERAGE_INCLUDES  JaCoCo class-include pattern, colon-separated
+#
+# Layers are reported separately, one matrix leg each. They are never averaged - a line covered by
+# two layers is one covered line. To see the union, merge the legs' exec artifacts with
+# .buildkite/scripts/coverage/publish.sh.
+config:
+  auto-retry: false
+  # Opt-in only, gated on the label alone. Not gated on changed-file regions: in the generator
+  # (.buildkite/scripts/pull-request/pipeline.ts) `included-regions` means "every changed file
+  # matches some region" - it detects docs-only-style PRs, and it composes with `allow-labels`
+  # by AND - so a labelled PR touching one file outside the regions would silently never be
+  # offered this pipeline. The trigger comment bypasses all filters, labels included.
+  allow-labels: test-coverage
+  trigger-phrase: '.*run\W+elasticsearch-ci/test-coverage.*'
+steps:
+  - label: test-coverage / {{matrix.layer}}
+    key: test-coverage
+    command: |
+      COVERAGE_LAYERS={{matrix.layer}} .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
+      if [[ -f build/coverage/summary.txt ]]; then
+        { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+          | buildkite-agent annotate --style info --context "coverage-{{matrix.layer}}"
+      fi
+      exit $$rc
+    matrix:
+      setup:
+        layer:
+          - unit
+          - internal-cluster
+          - cluster
+    timeout_in_minutes: 240
+    artifact_paths:
+      - "build/coverage/exec/**/*.exec"
+      - "build/coverage/report/**/*"
+      - "build/coverage/summary.txt"
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -51,3 +51,29 @@ steps:
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk
+
+  # Reconciliation. The legs above measure one layer each; this merges their execution data into
+  # the union, which is the only honest total. Layers overlap, so percentages cannot be added or
+  # averaged - a line covered by two layers is one covered line. Runs even if a leg failed, so a
+  # partial result is still reported, clearly as a lower bound.
+  - label: test-coverage / merged
+    key: test-coverage-merged
+    depends_on: test-coverage
+    allow_dependency_failure: true
+    command: |
+      .buildkite/scripts/coverage/publish.sh && rc=0 || rc=$$?
+      if [[ -f build/coverage/summary.txt ]]; then
+        { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+          | buildkite-agent annotate --style info --context coverage-merged
+      fi
+      exit $$rc
+    timeout_in_minutes: 60
+    artifact_paths:
+      - "build/coverage/report/**/*"
+      - "build/coverage/summary.txt"
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -53,7 +53,7 @@ steps:
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-              | buildkite-agent annotate --style info --context "coverage-unit"
+              | buildkite-agent annotate --style info --context "coverage-unit" || true
             SUMMARY_LINE=$$(grep -m1 '^unit' build/coverage/summary.txt || echo "unit measured")
           else
             SUMMARY_LINE="no coverage produced"
@@ -87,7 +87,7 @@ steps:
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-              | buildkite-agent annotate --style info --context "coverage-internal-cluster"
+              | buildkite-agent annotate --style info --context "coverage-internal-cluster" || true
             SUMMARY_LINE=$$(grep -m1 '^internal-cluster' build/coverage/summary.txt || echo "internal-cluster measured")
           else
             SUMMARY_LINE="no coverage produced"
@@ -121,7 +121,7 @@ steps:
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-              | buildkite-agent annotate --style info --context "coverage-cluster"
+              | buildkite-agent annotate --style info --context "coverage-cluster" || true
             SUMMARY_LINE=$$(grep -m1 '^cluster' build/coverage/summary.txt || echo "cluster measured")
           else
             SUMMARY_LINE="no coverage produced"
@@ -162,7 +162,7 @@ steps:
           .buildkite/scripts/coverage/publish.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-              | buildkite-agent annotate --style info --context coverage-merged
+              | buildkite-agent annotate --style info --context coverage-merged || true
           fi
           if [[ $$rc -eq 0 ]]; then
             .buildkite/scripts/coverage/status.sh merged success "$$(grep -m1 '^merged' build/coverage/summary.txt || echo merged)"

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -184,6 +184,11 @@ steps:
           # how the microbenchmarks ship their numbers too. Only this step needs them: the per-layer
           # legs report a layer, and a layer on its own is not a coverage figure.
           USE_PERF_CREDENTIALS: "true"
+          # Publishing to the coverage repo is normally main-only, because `latest/` reads as a
+          # trend only if every commit measured the same line of development. This forces it on so
+          # the push is exercised before a main run exists. A PR writes its own pr/<n>/ directory,
+          # so it cannot overwrite what main measured.
+          COVERAGE_PUBLISH_TO_REPO: "1"
         timeout_in_minutes: 60
         artifact_paths:
           - "build/coverage/report/**/*"

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -170,6 +170,11 @@ steps:
             .buildkite/scripts/coverage/status.sh merged failure "merge failed"
           fi
           exit $$rc
+        env:
+          # Makes the pre-command hook fetch the metrics-cluster credentials from Vault, which is
+          # how the microbenchmarks ship their numbers too. Only this step needs them: the per-layer
+          # legs report a layer, and a layer on its own is not a coverage figure.
+          USE_PERF_CREDENTIALS: "true"
         timeout_in_minutes: 60
         artifact_paths:
           - "build/coverage/report/**/*"

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -1,20 +1,24 @@
-# Code coverage, on demand.
+# Code coverage for the ES|QL surface, on demand.
 #
-# Never runs by default. Apply the `test-coverage` label to a PR, or comment
+# ONE AREA PER FILE. This file declares everything about measuring ES|QL: which label triggers it,
+# and what that measurement covers. Adding another area is another file like this one - a different
+# label, a different scope - sharing the same scripts. Nothing about ES|QL lives in the scripts.
+#
+# Never runs by default. Apply the `test-coverage` label, or comment
 # `@elasticmachine run elasticsearch-ci/test-coverage`.
 #
-# Reports coverage per test layer. It never gates: no thresholds, no failure on a number. The step
-# fails only if the instrument itself is broken, or on test failures - in which case the coverage
-# still uploads and is a lower bound.
+# Reports coverage per test layer and merged. It never gates: no thresholds, no failure on a
+# number. A leg fails only if the instrument is broken, or if its tests fail - in which case the
+# coverage still uploads and is a lower bound.
 #
-# Parameters are read from the environment; defaults measure the ES|QL surface.
+# Layers are never averaged. A line covered by two layers is one covered line, so the merged step
+# computes the union from the execution data itself. Measured on esql-datasource-s3: unit 69.1%,
+# cluster 47.0%, merged 78.7% - adding gives 116%, averaging gives 58%, both wrong.
 #
-#   COVERAGE_PROJECTS  Gradle project-path pattern, e.g. ':x-pack:plugin:esql*' or ':server'
-#   COVERAGE_INCLUDES  JaCoCo class-include pattern, colon-separated
-#
-# Layers are reported separately, one matrix leg each. They are never averaged - a line covered by
-# two layers is one covered line. To see the union, merge the legs' exec artifacts with
-# .buildkite/scripts/coverage/publish.sh.
+# Optional build environment overrides:
+#   COVERAGE_LAYERS   subset of unit,internal-cluster,cluster (default: all three)
+#   COVERAGE_PROJECTS overrides the scope below
+#   COVERAGE_INCLUDES overrides the class filter below
 config:
   auto-retry: false
   # Opt-in only, gated on the label alone. Not gated on changed-file regions: in the generator
@@ -24,10 +28,26 @@ config:
   # offered this pipeline. The trigger comment bypasses all filters, labels included.
   allow-labels: test-coverage
   trigger-phrase: '.*run\W+elasticsearch-ci/test-coverage.*'
+env:
+  # The scope of this area. Gradle project-path pattern and JaCoCo class-include pattern, each in
+  # its own tool's native syntax. These two must agree: measuring data-source projects against an
+  # ES|QL-wide class filter would put engine classes in the denominator that those tests never
+  # touch, and read as a coverage problem that is really a scoping mistake.
+  COVERAGE_PROJECTS: ":x-pack:plugin:esql*"
+  COVERAGE_INCLUDES: "org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*:org.elasticsearch.arrow.*"
+
 steps:
   - label: test-coverage / {{matrix.layer}}
     key: test-coverage
     command: |
+      # Buildkite matrices are static, so all three legs are always created. A leg the operator did
+      # not ask for exits immediately rather than measuring. Set COVERAGE_LAYERS on the build to
+      # select, e.g. COVERAGE_LAYERS=unit,internal-cluster for the fast pair.
+      WANTED="${COVERAGE_LAYERS:-unit,internal-cluster,cluster}"
+      if [[ ",$$WANTED," != *",{{matrix.layer}},"* ]]; then
+        echo "--- layer {{matrix.layer}} not requested (COVERAGE_LAYERS=$$WANTED) - NOT MEASURED"
+        exit 0
+      fi
       COVERAGE_LAYERS={{matrix.layer}} .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
       if [[ -f build/coverage/summary.txt ]]; then
         { echo '```'; cat build/coverage/summary.txt; echo '```'; } \

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -16,17 +16,22 @@
 # cluster 47.0%, merged 78.7% - adding gives 116%, averaging gives 58%, both wrong.
 #
 # Optional build environment overrides:
-#   COVERAGE_LAYERS   subset of unit,internal-cluster,cluster (default: all three)
+#   COVERAGE_LAYERS        subset of unit,internal-cluster,cluster (default: all three)
 #   COVERAGE_PROJECTS overrides the scope below
 #   COVERAGE_INCLUDES overrides the class filter below
 config:
   auto-retry: false
-  # Opt-in only, gated on the label alone. Not gated on changed-file regions: in the generator
-  # (.buildkite/scripts/pull-request/pipeline.ts) `included-regions` means "every changed file
-  # matches some region" - it detects docs-only-style PRs, and it composes with `allow-labels`
-  # by AND - so a labelled PR touching one file outside the regions would silently never be
-  # offered this pipeline. The trigger comment bypasses all filters, labels included.
+  # TRIGGER: the label. Nothing runs without it.
   allow-labels: test-coverage
+  # ...and only on PRs that go near this area. `touched-regions` matches if ANY changed file
+  # matches, unlike `included-regions` which requires every one to (a docs-only-PR detector).
+  # Includes the coverage tooling itself, so a change to it can be measured by it.
+  touched-regions:
+    - ^x-pack/plugin/esql
+    - ^libs/arrow/
+    - ^\.buildkite/scripts/coverage/
+    - ^\.buildkite/pipelines/pull-request/test-coverage\.yml
+    - ^gradle/coverage
   trigger-phrase: '.*run\W+elasticsearch-ci/test-coverage.*'
 env:
   # The scope of this area. Gradle project-path pattern and JaCoCo class-include pattern, each in
@@ -40,9 +45,9 @@ steps:
   - label: test-coverage / {{matrix.layer}}
     key: test-coverage
     command: |
-      # Buildkite matrices are static, so all three legs are always created. A leg the operator did
-      # not ask for exits immediately rather than measuring. Set COVERAGE_LAYERS on the build to
-      # select, e.g. COVERAGE_LAYERS=unit,internal-cluster for the fast pair.
+      # A leg the operator did not ask for exits immediately rather than measuring. Set
+      # COVERAGE_LAYERS on the build to select, e.g. unit,internal-cluster for the fast pair.
+      # (3) Test groups: Buildkite matrices are static, so all three legs are always created.
       WANTED="${COVERAGE_LAYERS:-unit,internal-cluster,cluster}"
       if [[ ",$$WANTED," != *",{{matrix.layer}},"* ]]; then
         echo "--- layer {{matrix.layer}} not requested (COVERAGE_LAYERS=$$WANTED) - NOT MEASURED"

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -47,10 +47,21 @@ steps:
       - label: "test-coverage / unit"
         key: "test-coverage-unit"
         command: |
+          # Publish our own commit status so the step is visible on the PR while it runs, not only
+          # after it finishes. See status.sh for why this is not left to the CI integration.
+          .buildkite/scripts/coverage/status.sh unit pending "measuring unit coverage"
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
               | buildkite-agent annotate --style info --context "coverage-unit"
+            SUMMARY_LINE=$$(grep -m1 '^unit' build/coverage/summary.txt || echo "unit measured")
+          else
+            SUMMARY_LINE="no coverage produced"
+          fi
+          if [[ $$rc -eq 0 ]]; then
+            .buildkite/scripts/coverage/status.sh unit success "$$SUMMARY_LINE"
+          else
+            .buildkite/scripts/coverage/status.sh unit failure "$$SUMMARY_LINE"
           fi
           exit $$rc
         env:
@@ -70,10 +81,21 @@ steps:
       - label: "test-coverage / internal-cluster"
         key: "test-coverage-internal-cluster"
         command: |
+          # Publish our own commit status so the step is visible on the PR while it runs, not only
+          # after it finishes. See status.sh for why this is not left to the CI integration.
+          .buildkite/scripts/coverage/status.sh internal-cluster pending "measuring internal-cluster coverage"
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
               | buildkite-agent annotate --style info --context "coverage-internal-cluster"
+            SUMMARY_LINE=$$(grep -m1 '^internal-cluster' build/coverage/summary.txt || echo "internal-cluster measured")
+          else
+            SUMMARY_LINE="no coverage produced"
+          fi
+          if [[ $$rc -eq 0 ]]; then
+            .buildkite/scripts/coverage/status.sh internal-cluster success "$$SUMMARY_LINE"
+          else
+            .buildkite/scripts/coverage/status.sh internal-cluster failure "$$SUMMARY_LINE"
           fi
           exit $$rc
         env:
@@ -93,10 +115,21 @@ steps:
       - label: "test-coverage / cluster"
         key: "test-coverage-cluster"
         command: |
+          # Publish our own commit status so the step is visible on the PR while it runs, not only
+          # after it finishes. See status.sh for why this is not left to the CI integration.
+          .buildkite/scripts/coverage/status.sh cluster pending "measuring cluster coverage"
           .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
               | buildkite-agent annotate --style info --context "coverage-cluster"
+            SUMMARY_LINE=$$(grep -m1 '^cluster' build/coverage/summary.txt || echo "cluster measured")
+          else
+            SUMMARY_LINE="no coverage produced"
+          fi
+          if [[ $$rc -eq 0 ]]; then
+            .buildkite/scripts/coverage/status.sh cluster success "$$SUMMARY_LINE"
+          else
+            .buildkite/scripts/coverage/status.sh cluster failure "$$SUMMARY_LINE"
           fi
           exit $$rc
         env:
@@ -125,10 +158,16 @@ steps:
           - "test-coverage-cluster"
         allow_dependency_failure: true
         command: |
+          .buildkite/scripts/coverage/status.sh merged pending "merging layers"
           .buildkite/scripts/coverage/publish.sh && rc=0 || rc=$$?
           if [[ -f build/coverage/summary.txt ]]; then
             { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
               | buildkite-agent annotate --style info --context coverage-merged
+          fi
+          if [[ $$rc -eq 0 ]]; then
+            .buildkite/scripts/coverage/status.sh merged success "$$(grep -m1 '^merged' build/coverage/summary.txt || echo merged)"
+          else
+            .buildkite/scripts/coverage/status.sh merged failure "merge failed"
           fi
           exit $$rc
         timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull-request/test-coverage.yml
+++ b/.buildkite/pipelines/pull-request/test-coverage.yml
@@ -42,63 +42,102 @@ env:
   COVERAGE_INCLUDES: "org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*:org.elasticsearch.arrow.*"
 
 steps:
-  - label: test-coverage / {{matrix.layer}}
-    key: test-coverage
-    command: |
-      # A leg the operator did not ask for exits immediately rather than measuring. Set
-      # COVERAGE_LAYERS on the build to select, e.g. unit,internal-cluster for the fast pair.
-      # (3) Test groups: Buildkite matrices are static, so all three legs are always created.
-      WANTED="${COVERAGE_LAYERS:-unit,internal-cluster,cluster}"
-      if [[ ",$$WANTED," != *",{{matrix.layer}},"* ]]; then
-        echo "--- layer {{matrix.layer}} not requested (COVERAGE_LAYERS=$$WANTED) - NOT MEASURED"
-        exit 0
-      fi
-      COVERAGE_LAYERS={{matrix.layer}} .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
-      if [[ -f build/coverage/summary.txt ]]; then
-        { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-          | buildkite-agent annotate --style info --context "coverage-{{matrix.layer}}"
-      fi
-      exit $$rc
-    matrix:
-      setup:
-        layer:
-          - unit
-          - internal-cluster
-          - cluster
-    timeout_in_minutes: 240
-    artifact_paths:
-      - "build/coverage/exec/**/*.exec"
-      - "build/coverage/report/**/*"
-      - "build/coverage/summary.txt"
-    agents:
-      provider: gcp
-      image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
-      diskType: hyperdisk-balanced
-      buildDirectory: /dev/shm/bk
+  - group: test-coverage
+    steps:
+      - label: "test-coverage / unit"
+        key: "test-coverage-unit"
+        command: |
+          .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
+          if [[ -f build/coverage/summary.txt ]]; then
+            { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+              | buildkite-agent annotate --style info --context "coverage-unit"
+          fi
+          exit $$rc
+        env:
+          COVERAGE_LAYERS: "unit"
+        timeout_in_minutes: 240
+        artifact_paths:
+          - "build/coverage/exec/**/*.exec"
+          - "build/coverage/report/**/*"
+          - "build/coverage/summary.txt"
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
+          buildDirectory: /dev/shm/bk
 
-  # Reconciliation. The legs above measure one layer each; this merges their execution data into
+      - label: "test-coverage / internal-cluster"
+        key: "test-coverage-internal-cluster"
+        command: |
+          .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
+          if [[ -f build/coverage/summary.txt ]]; then
+            { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+              | buildkite-agent annotate --style info --context "coverage-internal-cluster"
+          fi
+          exit $$rc
+        env:
+          COVERAGE_LAYERS: "internal-cluster"
+        timeout_in_minutes: 240
+        artifact_paths:
+          - "build/coverage/exec/**/*.exec"
+          - "build/coverage/report/**/*"
+          - "build/coverage/summary.txt"
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
+          buildDirectory: /dev/shm/bk
+
+      - label: "test-coverage / cluster"
+        key: "test-coverage-cluster"
+        command: |
+          .buildkite/scripts/coverage/run-coverage.sh && rc=0 || rc=$$?
+          if [[ -f build/coverage/summary.txt ]]; then
+            { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+              | buildkite-agent annotate --style info --context "coverage-cluster"
+          fi
+          exit $$rc
+        env:
+          COVERAGE_LAYERS: "cluster"
+        timeout_in_minutes: 240
+        artifact_paths:
+          - "build/coverage/exec/**/*.exec"
+          - "build/coverage/report/**/*"
+          - "build/coverage/summary.txt"
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
+          buildDirectory: /dev/shm/bk
+
+      # Reconciliation. The legs above measure one layer each; this merges their execution data into
   # the union, which is the only honest total. Layers overlap, so percentages cannot be added or
   # averaged - a line covered by two layers is one covered line. Runs even if a leg failed, so a
   # partial result is still reported, clearly as a lower bound.
-  - label: test-coverage / merged
-    key: test-coverage-merged
-    depends_on: test-coverage
-    allow_dependency_failure: true
-    command: |
-      .buildkite/scripts/coverage/publish.sh && rc=0 || rc=$$?
-      if [[ -f build/coverage/summary.txt ]]; then
-        { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
-          | buildkite-agent annotate --style info --context coverage-merged
-      fi
-      exit $$rc
-    timeout_in_minutes: 60
-    artifact_paths:
-      - "build/coverage/report/**/*"
-      - "build/coverage/summary.txt"
-    agents:
-      provider: gcp
-      image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
-      diskType: hyperdisk-balanced
-      buildDirectory: /dev/shm/bk
+      - label: "test-coverage / merged"
+        key: "test-coverage-merged"
+        depends_on:
+          - "test-coverage-unit"
+          - "test-coverage-internal-cluster"
+          - "test-coverage-cluster"
+        allow_dependency_failure: true
+        command: |
+          .buildkite/scripts/coverage/publish.sh && rc=0 || rc=$$?
+          if [[ -f build/coverage/summary.txt ]]; then
+            { echo '```'; cat build/coverage/summary.txt; echo '```'; } \
+              | buildkite-agent annotate --style info --context coverage-merged
+          fi
+          exit $$rc
+        timeout_in_minutes: 60
+        artifact_paths:
+          - "build/coverage/report/**/*"
+          - "build/coverage/summary.txt"
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n4-custom-32-98304
+          diskType: hyperdisk-balanced
+          buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/coverage/CONFIGURATION.md
+++ b/.buildkite/scripts/coverage/CONFIGURATION.md
@@ -1,0 +1,127 @@
+# Configuring coverage
+
+Three independent things decide what happens: **when it runs**, **what it measures**, and **which
+tests it runs**. Each is configured in one place, and each has its own syntax. Nothing is hardcoded
+in the scripts.
+
+One area per file. `test-coverage.yml` measures ES|QL; another area is another file with a different
+label and a different scope, sharing the same scripts.
+
+---
+
+## 1 · When it runs — the pipeline's `config:` block
+
+```yaml
+config:
+  allow-labels: test-coverage
+  trigger-phrase: '.*run\W+elasticsearch-ci/test-coverage.*'
+  touched-regions:
+    - ^x-pack/plugin/esql
+    - ^libs/arrow/
+```
+
+**`allow-labels`** is the trigger. Nothing runs without it. Apply the label to a PR, or comment the
+trigger phrase.
+
+**`touched-regions`** narrows *where* it is offered: the pipeline appears only if **any** changed
+file matches. Omit it and the label works on any PR.
+
+> **`touched-regions` is not `included-regions`.** `included-regions` requires **every** changed
+> file to match — it detects docs-only-style PRs. `touched-regions` matches if **any** does, which
+> is what an area-scoped pipeline wants. Both exist; pick the one that means what you intend.
+
+**Include the coverage tooling's own paths.** Otherwise a PR that only changes the coverage scripts
+is never offered the pipeline that measures them.
+
+### Label timing — the one real gotcha
+
+CI starts within seconds of a PR being opened, and the generator reads labels **at that moment**. A
+label applied afterwards is not seen by a build already running, and the step simply will not
+appear. Either label before opening, or re-trigger with a comment or a push.
+
+---
+
+## 2 · What it measures — the pipeline's `env:` block
+
+```yaml
+env:
+  COVERAGE_PROJECTS: ":x-pack:plugin:esql*"
+  COVERAGE_INCLUDES: "org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*"
+```
+
+**`COVERAGE_PROJECTS`** — a Gradle project-path pattern. Decides which projects are instrumented and
+whose tests run.
+
+**`COVERAGE_INCLUDES`** — a JaCoCo class-include pattern, colon-separated. Decides which classes are
+recorded, and therefore the denominator.
+
+Each is its own tool's native syntax. There is no coverage DSL.
+
+**These two are independent, and that is useful.** Measure engine classes while running data-source
+tests and you learn what data-source tests exercise in the engine. Measure data-source classes while
+running engine tests and you learn how much of data-sources is covered by somebody else's suites —
+which is how a module's coverage can look low while its code is well tested elsewhere.
+
+**But for a headline number they must agree.** Running data-source projects against an ES|QL-wide
+class filter puts engine classes in the denominator that those tests never touch. The number drops,
+and it reads as a coverage problem when it is a scoping mistake.
+
+**`COVERAGE_EXCLUDE_PROJECTS`** removes projects from the scope. Defaults to excluding parquet-rs,
+which is being retired.
+
+---
+
+## 3 · Which tests run — layers
+
+| Layer | Tasks | Where product code runs |
+|---|---|---|
+| `unit` | `test` | the forked test JVM |
+| `internal-cluster` | `internalClusterTest` | the forked test JVM (cluster is in-process) |
+| `cluster` | `javaRestTest`, `yamlRestTest`, `csvSpecTests`, `javaRestTestSecure` | **separate ES node processes** |
+
+All three run by default, one leg each, in parallel. Set `COVERAGE_LAYERS` on the build to select —
+`unit,internal-cluster` for the fast pair. Matrices are static, so unselected legs exit immediately
+rather than measuring.
+
+**Task names come from Gradle, not from a list.** A guessed list was wrong four ways: 5 `csvSpecTests`
+instead of 7, zero `yamlRestTest` instead of 4, one `internalClusterTest` instead of 2, and three task
+types missed entirely. **A task the layer mapping does not cover fails the run** rather than being
+silently skipped.
+
+**Excluded by default**, each with a reason: BWC-versioned suites and `bcUpgradeTest` (old-version
+nodes, whose coverage cannot map onto current classfiles), and `perfSmokeTest` (measures speed, not
+behaviour).
+
+---
+
+## What you get back
+
+Four reports from one run: one per layer, plus **merged**.
+
+**Layers are merged, never averaged.** A line covered by two layers is one covered line, so the union
+is computed from the execution data itself. On `esql-datasource-s3`: unit 69.1%, cluster 47.0%,
+merged **78.7%**. Adding gives 116%, averaging 58%; both are wrong.
+
+Differencing a layer against merged answers *"if we dropped this suite, what goes dark"*.
+
+The merged step runs with `allow_dependency_failure`, so a failed leg still yields a partial result,
+reported as a lower bound rather than lost.
+
+---
+
+## Two rules it is built around
+
+**Report, never gate.** No thresholds, no failing a build on a number. A coverage gate is satisfiable
+by tests that execute without asserting, which is the wrong pressure to create.
+
+**Fail loudly on zero.** An exec file recording nothing fails the build before anything publishes. An
+empty file reports as 0% and reads as a finding when it actually means the instrument is broken. For
+the cluster layer the check distinguishes *no agent connected* from *connected but recorded nothing*,
+because those have different fixes.
+
+---
+
+## Adding another area
+
+Copy `test-coverage.yml`, then change three things: the label in `allow-labels`, the paths in
+`touched-regions`, and the scope in `env:`. Create the label. Nothing else — no script changes.

--- a/.buildkite/scripts/coverage/CollectorServer.java
+++ b/.buildkite/scripts/coverage/CollectorServer.java
@@ -1,0 +1,113 @@
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jacoco.cli.internal.core.data.ExecutionDataWriter;
+import org.jacoco.cli.internal.core.runtime.RemoteControlReader;
+import org.jacoco.cli.internal.core.runtime.RemoteControlWriter;
+
+/**
+ * Collects JaCoCo coverage from agents running in output=tcpclient mode.
+ *
+ * Why this exists: ES test-cluster nodes are separate processes that are torn down with
+ * destroyForcibly, so a shutdown hook never runs and output=file,dumponexit never writes.
+ * In tcpclient mode the agent dials out to us; we then request dumps while the node is
+ * still alive, so nothing depends on how the process dies. Every node dials the same
+ * port, which is also why output=tcpserver cannot work here - each node would try to bind
+ * the same port.
+ *
+ * Usage: CollectorServer <port> <outfile>
+ */
+public final class CollectorServer {
+
+    private static final AtomicInteger CONNECTIONS = new AtomicInteger();
+    private static ExecutionDataWriter fileWriter;
+
+    public static void main(String[] args) throws Exception {
+        final int port = Integer.parseInt(args[0]);
+        final OutputStream out = new BufferedOutputStream(new FileOutputStream(args[1]));
+        fileWriter = new ExecutionDataWriter(out);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                synchronized (fileWriter) {
+                    fileWriter.flush();
+                }
+                out.flush();
+                out.close();
+            } catch (Exception ignored) {
+            }
+            System.err.println("[collector] connections=" + CONNECTIONS.get());
+        }));
+
+        ServerSocket server = new ServerSocket(port, 64, InetAddress.getByName("127.0.0.1"));
+        System.err.println("[collector] listening on 127.0.0.1:" + port + " -> " + args[1]);
+
+        while (true) {
+            final Socket socket = server.accept();
+            CONNECTIONS.incrementAndGet();
+            Thread t = new Thread(() -> handle(socket));
+            t.setDaemon(true);
+            t.start();
+        }
+    }
+
+    private static void handle(Socket socket) {
+        try {
+            final RemoteControlWriter writer = new RemoteControlWriter(socket.getOutputStream());
+            final RemoteControlReader reader = new RemoteControlReader(socket.getInputStream());
+            reader.setSessionInfoVisitor(info -> {
+                synchronized (fileWriter) {
+                    fileWriter.visitSessionInfo(info);
+                }
+            });
+            reader.setExecutionDataVisitor(data -> {
+                synchronized (fileWriter) {
+                    fileWriter.visitClassExecution(data);
+                }
+            });
+
+            // Request a dump periodically so coverage is captured while the node lives,
+            // rather than relying on it exiting cleanly.
+            Thread poller = new Thread(() -> {
+                try {
+                    while (!socket.isClosed()) {
+                        Thread.sleep(10_000L);
+                        synchronized (writer) {
+                            writer.visitDumpCommand(true, false);
+                        }
+                    }
+                } catch (Exception ignored) {
+                }
+            });
+            poller.setDaemon(true);
+            poller.start();
+
+            while (reader.read()) {
+                // keep reading until the peer closes
+            }
+            // Final dump attempt before the socket goes away.
+            try {
+                synchronized (writer) {
+                    writer.visitDumpCommand(true, false);
+                }
+                reader.read();
+            } catch (Exception ignored) {
+            }
+            socket.close();
+        } catch (Exception e) {
+            System.err.println("[collector] connection ended: " + e);
+        } finally {
+            try {
+                synchronized (fileWriter) {
+                    fileWriter.flush();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/.buildkite/scripts/coverage/README.md
+++ b/.buildkite/scripts/coverage/README.md
@@ -11,6 +11,12 @@ reports, so there is nothing coupled to test-task internals.
 
 ## Running it
 
+**Apply the `test-coverage` label before opening the PR, or re-trigger afterwards.** CI starts
+within seconds of a PR being opened and the pipeline generator reads the PR's labels at that
+moment. A label applied later is not seen by a build that has already started, and the coverage
+step will simply not appear. Re-trigger with a comment (`@elasticmachine run
+elasticsearch-ci/test-coverage`) or by pushing a commit.
+
 Locally:
 
 ```bash

--- a/.buildkite/scripts/coverage/README.md
+++ b/.buildkite/scripts/coverage/README.md
@@ -1,0 +1,135 @@
+# Code coverage
+
+Measures coverage for any slice of the build, per test layer and merged.
+
+`TESTING.asciidoc` says coverage cannot be done through Gradle. That was true in 2018, when the
+custom `RandomizedTestingTask` did not extend Gradle's `Test` and the JaCoCo plugin could not see
+test tasks (issue #28867, closed by the docs-only PR #29255 that wrote the current text). The build
+moved to standard `Test` tasks and the limitation went with it. Nothing here uses the JaCoCo Gradle
+plugin: the agent is attached as a plain `-javaagent` and the stock `jacococli` produces the
+reports, so there is nothing coupled to test-task internals.
+
+## Running it
+
+Locally:
+
+```bash
+COVERAGE_PROJECTS=':x-pack:plugin:esql-datasource-*' \
+COVERAGE_LAYERS=unit \
+.buildkite/scripts/coverage/run-coverage.sh
+```
+
+In CI, on a PR: apply the `test-coverage` label or comment
+`@elasticmachine run elasticsearch-ci/test-coverage` — one leg per layer, each annotating its own
+numbers. The legs upload their raw exec data as artifacts; `publish.sh` merges them into the
+union report (it is not wired into the PR pipeline — run it as a follow-up step or locally).
+
+All parameters are build environment variables.
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `COVERAGE_PROJECTS` | Gradle project-path pattern | `:x-pack:plugin:esql-datasource-*` |
+| `COVERAGE_INCLUDES` | JaCoCo class-include pattern | the ES\|QL packages |
+| `COVERAGE_LAYERS` | `unit`, `internal-cluster`, `cluster` | all three |
+| `COVERAGE_OUTPUT` | output directory | `build/coverage` |
+| `COVERAGE_PORT` | collector port for node coverage | `6300` |
+| `COVERAGE_EXCLUDE_PROJECTS` | regex over project paths to leave out; empty string excludes nothing | parquet-rs (being retired) |
+| `COVERAGE_SKIP_PUBLISH` | `1` skips S3, keeps reports + annotation | unset |
+
+Both patterns use their own tool's native syntax — Gradle project paths, JaCoCo class patterns.
+There is no coverage-specific DSL to learn. The scope is a parameter; the mechanism never changes.
+
+The report's denominator is restricted to the `COVERAGE_INCLUDES` packages: the agent only ever
+records classes matching that filter, so anything outside it would sit in the report as a
+permanent 0% without measuring anything (vendored `org.apache.*` shims in `esql-datasource-orc`
+being the concrete case).
+
+Projects and tasks are enumerated, not hardcoded, so a module that gains a suite is picked up
+automatically. Projects are discovered the way `settings.gradle` discovers them (directories
+carrying a `build.gradle`); test tasks are asked from the build itself
+(`gradle/coverage-tasks.gradle`), because task names do not reliably follow their source set —
+`src/csvSpecTest` registers `csvSpecTests`, plural. Each task name is then classified into a
+layer by `COVERAGE_TASK_LAYERS` in `lib.sh`; an unmapped task name fails the run loudly rather
+than being silently skipped. BWC-versioned suites (`v9.5.0#...`) are out of scope: old-version
+node coverage cannot map onto current classfiles.
+
+## The three layers
+
+| Layer | Tasks | Where product code runs |
+|---|---|---|
+| `unit` | `test` | the forked test JVM |
+| `internal-cluster` | `internalClusterTest` | the forked test JVM (cluster is in-process) |
+| `cluster` | `javaRestTest`, `javaRestTestSecure`, `yamlRestTest`, `csvSpecTests` | **separate ES node processes** |
+
+Each is reported on its own, and all are merged into a union.
+
+**Layers are merged, never averaged.** A line covered by two layers is one covered line, so the
+total has to be computed from the execution data. Measured on `esql-datasource-s3`: unit 69.1%,
+cluster 47.0%, merged **78.7%**. Adding gives 116%; averaging gives 58%; both are wrong.
+
+Per-layer reports also answer "if we dropped this suite, what goes dark" — difference a layer
+against the merged report and what remains is the coverage only that layer provides.
+
+## Why the cluster layer works the way it does
+
+Product code for REST tests runs in ES node processes that Gradle does not launch, so the agent has
+to reach them another way, and the coverage has to get back out.
+
+`AbstractLocalClusterFactory` joins the test JVM's `tests.jvm.argline` into each node's
+`ES_JAVA_OPTS`, which is the way in.
+
+Getting data out cannot rely on the process exiting, for two independent reasons:
+
+- Cluster teardown is forcible. `DefaultLocalClusterHandle.close()` stops nodes with
+  `stop(true)`, which is `ProcessUtils.stopHandle` → `destroyForcibly`: no shutdown hook runs, so
+  `dumponexit` never writes.
+- Even when nodes are stopped gracefully, the entitlements runtime denies the JaCoCo shutdown
+  hook's exec-file write inside the node process (`NotEntitledException` on the agent's
+  `FileOutput`, observed 2026-07-29). File output from the node cannot work at all.
+
+Nor can the agent listen on a port — `tests.jvm.argline` is task-wide, so every concurrent node
+would receive the same options and all but one would fail to bind.
+
+So nodes run the agent in `output=tcpclient` mode and dial out to `CollectorServer`, which requests
+dumps every ten seconds while nodes are alive and does all file I/O in its own process. Nothing
+depends on how a node dies. The node channel is armed only when the runner passes
+`-Dcoverage.port` (cluster layer only), so no other layer carries an agent pointing at a dead port.
+
+## Failure behaviour
+
+**Never gates.** No thresholds, no build failure on a number. A coverage gate is satisfiable by
+tests that assert nothing, which is the wrong pressure to create.
+
+**Fails loudly on zero.** Every exec file is read back with `jacococli execinfo` and judged by its
+executed-probe count — never by file size (healthy per-module exec files have been ~220 bytes;
+sessions-only files can be arbitrarily large). An exec file that records nothing reports as 0% and
+reads as a finding when it actually means the instrument is broken — a mistake made twice on this
+codebase, costing hours each time. For the cluster layer the check distinguishes "no agent
+connected" (missing `nodes.exec`) from "connected but recorded nothing" (present, zero probes),
+because those have different fixes. Cluster-layer test-runner JVM files are reported but not
+gated: they execute test code, not node code, and are legitimately near-empty. Test failures do
+not discard a run — legs run with `--continue`, the publish step merges whatever exec data exists,
+and the red leg stays red.
+
+## Publishing
+
+The publish step merges exec data across legs, rebuilds all reports against freshly compiled
+classfiles (remote build cache makes that cheap), annotates the build with the summary, and syncs
+the HTML to S3. S3 needs one-time ops setup: the `esql-coverage-reports` bucket and AWS keys at
+Vault path `secret/ci/elastic-elasticsearch/esql-coverage-s3` (fields `access_key`/`secret_key`).
+Until that exists, the step says so and the report is available from the step's Buildkite
+artifacts instead.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `gradle/coverage.gradle` | init script; attaches the agent. Parameterised by target, fixed in mechanism. |
+| `gradle/coverage-tasks.gradle` | init script; enumerates the real test tasks from the build |
+| `lib.sh` | shared helpers: tool fetch, project/task enumeration, layer mapping, exec-file introspection |
+| `CollectorServer.java` | receives coverage from node processes over TCP |
+| `run-coverage.sh` | runs a layer's tasks, gates, reports |
+| `check-nonzero.sh` | the zero gate |
+| `summarise.sh` | headline numbers per layer |
+| `publish.sh` | merges the legs' exec artifacts, rebuilds reports, publishes HTML, annotates the build |
+| `../../pipelines/pull-request/test-coverage.yml` | the on-demand PR surface (label / trigger comment) |

--- a/.buildkite/scripts/coverage/check-nonzero.sh
+++ b/.buildkite/scripts/coverage/check-nonzero.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Fail if the coverage instrument recorded nothing.
+#
+#   check-nonzero.sh <exec-dir> <jacoco-cli-jar>
+#
+# An empty exec file is worse than a missing one: it reports as 0% and reads as a finding, when it
+# actually means the agent never attached or the data never left the process. That mistake has been
+# made twice on this codebase, both times costing hours.
+#
+# Every exec file is read with the JaCoCo CLI (execinfo) and judged by its executed-probe count.
+# File size is not a proxy: real runs have produced healthy per-module exec files of ~220 bytes
+# (two classes, real hits) and a sessions-only file can grow arbitrarily large while recording
+# nothing.
+#
+# Layer semantics:
+#   unit/, internal-cluster/  every exec file must record >0 executed probes. A task that ran and
+#                             recorded nothing means the agent or the includes filter is wrong.
+#   cluster/nodes.exec        the collector's output; must exist and record >0 probes. The two
+#                             failure modes are distinguished because they have different fixes:
+#                               - missing            -> no agent connected (injection is wrong)
+#                               - present, 0 probes  -> connected but nothing recorded
+#                                                       (filter or dump is wrong)
+#   cluster/ (other files)    forked test-runner JVMs. They execute test code, not node code, so
+#                             low or zero probe counts are expected. Reported, never gated.
+#
+set -euo pipefail
+EXEC_DIR="$1"
+CLI="$2"
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+fail=0
+
+while IFS= read -r f; do
+  hits=$(coverage_exec_hits "$CLI" "$f")
+  sessions=$(coverage_exec_sessions "$CLI" "$f")
+  rel="${f#"$EXEC_DIR"/}"
+
+  if [[ "$rel" == cluster/* && "$(basename "$f")" != "nodes.exec" ]]; then
+    echo "cluster runner JVM $rel: $hits probes, $sessions sessions (informational)"
+    continue
+  fi
+
+  if [[ "$hits" -eq 0 ]]; then
+    echo "ZERO COVERAGE: $rel records no executed probes ($sessions sessions)."
+    if [[ "$(basename "$f")" == "nodes.exec" ]]; then
+      if [[ "$sessions" -gt 0 ]]; then
+        echo "  Cluster layer: nodes connected to the collector but recorded nothing."
+        echo "  Check the includes filter matches classes as loaded in the node."
+      else
+        echo "  Cluster layer: the collector wrote a file but no node ever sent data."
+        echo "  Check tests.jvm.argline reaches the node and the collector port matches."
+      fi
+    else
+      echo "  The agent attached (the file exists) but nothing inside the includes filter ran."
+    fi
+    fail=1
+  else
+    echo "$rel: $hits probes, $sessions sessions"
+  fi
+done < <(find "$EXEC_DIR" -name '*.exec' 2>/dev/null | sort)
+
+if [[ -d "$EXEC_DIR/cluster" && ! -f "$EXEC_DIR/cluster/nodes.exec" ]]; then
+  echo "ZERO COVERAGE: cluster layer ran but exec/cluster/nodes.exec does not exist -"
+  echo "  no agent connected to the collector."
+  echo "  Check tests.jvm.argline reaches the node and the collector port matches."
+  fail=1
+fi
+
+if [[ "$fail" -eq 1 ]]; then
+  echo "--- coverage instrument is broken; refusing to publish numbers"
+  exit 1
+fi
+echo "--- all gated exec files contain data"

--- a/.buildkite/scripts/coverage/fetch-report.sh
+++ b/.buildkite/scripts/coverage/fetch-report.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#
+# Rebuild the merged coverage report on your own machine from a finished CI build.
+#
+# The CI legs upload raw execution data as Buildkite artifacts. This pulls those artifacts down and
+# hands them to publish.sh, which does the merge and the reports. Use it when the merge step did not
+# run, when you want the report for a build that has aged out of the agent, or when you want the
+# numbers without opening Buildkite at all.
+#
+#   fetch-report.sh --pr 155367                 # newest coverage build on that PR
+#   fetch-report.sh 167811                      # a specific build number
+#   fetch-report.sh --pr 155367 ~/cov           # somewhere other than build/coverage
+#
+# Needs a Buildkite API token with read_builds + read_artifacts, from $BUILDKITE_API_TOKEN or
+# ~/.config/bk.yaml. It does NOT need the graphql scope: `bk artifacts download` wants that and we
+# do not have it, so this goes through the REST API and fetches each artifact's own download_url.
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+ORG=${BUILDKITE_ORG:-elastic}
+PIPELINE=${BUILDKITE_PIPELINE_SLUG:-elasticsearch-pull-request}
+API="https://api.buildkite.com/v2/organizations/$ORG/pipelines/$PIPELINE"
+
+# `\?` is a GNU sed extension and this is meant to run on a laptop as much as on an agent, so the
+# comment prefix comes off with two portable expressions instead.
+usage() { sed -n '3,17p' "${BASH_SOURCE[0]}" | sed -e 's/^# //' -e 's/^#$//'; exit "${1:-1}"; }
+
+PR="" BUILD=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr) PR="${2:?--pr needs a number}"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    -*) echo "unknown option $1" >&2; usage ;;
+    *) if [[ -z "$BUILD" ]]; then BUILD="$1"; else OUT="$1"; fi; shift ;;
+  esac
+done
+OUT="${OUT:-$ROOT/build/coverage}"
+[[ -n "$PR" || -n "$BUILD" ]] || usage
+
+TOKEN="${BUILDKITE_API_TOKEN:-}"
+if [[ -z "$TOKEN" && -f "$HOME/.config/bk.yaml" ]]; then
+  TOKEN=$(grep -oE '[A-Za-z0-9_-]{30,}' "$HOME/.config/bk.yaml" | head -1)
+fi
+if [[ -z "$TOKEN" ]]; then
+  echo "no Buildkite API token: set BUILDKITE_API_TOKEN or log in with the bk CLI" >&2
+  exit 1
+fi
+api() { curl -sSfL -H "Authorization: Bearer $TOKEN" "$@"; }
+
+# --- resolve the build ---------------------------------------------------------------------------
+
+if [[ -z "$BUILD" ]]; then
+  echo "--- finding the newest build on PR $PR"
+  # Buildkite has no server-side filter for pull_request_id, so scan recent builds newest-first and
+  # take the first that both belongs to the PR and actually ran coverage. A PR has many builds and
+  # only the ones where the label was applied carry coverage jobs.
+  BUILD=$(api "$API/builds?per_page=100" | python3 -c '
+import json,sys
+pr=sys.argv[1]
+for b in json.load(sys.stdin):
+    if str((b.get("pull_request") or {}).get("id")) != pr: continue
+    if any("test-coverage" in (j.get("name") or "") for j in b.get("jobs") or []):
+        print(b["number"]); break
+' "$PR")
+  [[ -n "$BUILD" ]] || { echo "no recent build on PR $PR ran the coverage pipeline" >&2; exit 1; }
+  echo "    build $BUILD"
+fi
+
+# --- download the execution data -----------------------------------------------------------------
+
+EXEC="$OUT/exec"
+mkdir -p "$EXEC"
+
+# Artifacts are listed per job, never per build: a build's artifact list is paginated and a JaCoCo
+# HTML report is thousands of files, so the .exec files get lost in the paging. Per job the sets are
+# small enough to page through reliably.
+jobs=$(api "$API/builds/$BUILD" | python3 -c '
+import json,sys
+for j in json.load(sys.stdin).get("jobs") or []:
+    if "test-coverage" in (j.get("name") or "") and j.get("id"):
+        print(j["id"], (j.get("name") or "").replace(" ",""))
+')
+[[ -n "$jobs" ]] || { echo "build $BUILD has no test-coverage jobs" >&2; exit 1; }
+
+n=0 failed=0
+while read -r job_id job_name; do
+  [[ -n "$job_id" ]] || continue
+  echo "--- $job_name"
+  page=1
+  while :; do
+    # Emits a count line first, then the .exec artifacts. Paging has to stop on "the API returned
+    # nothing", not on "this page held no .exec": a leg uploads its HTML report too, so a page can
+    # legitimately be all report files with more .exec data on the page after it.
+    listing=$(api "$API/builds/$BUILD/jobs/$job_id/artifacts?per_page=100&page=$page" | python3 -c '
+import json,sys
+arts=json.load(sys.stdin)
+print(len(arts))
+for a in arts:
+    if a.get("path","").endswith(".exec"):
+        print(a["path"], a["download_url"])
+')
+    total=$(head -1 <<< "$listing")
+    batch=$(tail -n +2 <<< "$listing")
+    [[ "$total" =~ ^[0-9]+$ ]] || { echo "unreadable artifact listing for $job_name" >&2; exit 1; }
+    (( total > 0 )) || break
+    expected=()
+    while read -r path url; do
+      [[ -n "$path" ]] || continue
+      # Artifacts keep the path they were uploaded under, which already carries the layer:
+      # build/coverage/exec/<layer>/<task>.exec. Preserve it so publish.sh sees the layers.
+      dest="$OUT/${path#build/coverage/}"
+      mkdir -p "$(dirname "$dest")"
+      curl -sSL -H "Authorization: Bearer $TOKEN" "$url" -o "$dest" &
+      expected+=("$dest")
+    done <<< "$batch"
+    wait
+    # Downloads run in parallel, so a failure shows up as a missing or empty file rather than a
+    # non-zero exit. Check for it here: an empty .exec sails through the merge and produces a
+    # report that is quietly missing a whole suite.
+    for dest in ${expected[@]+"${expected[@]}"}; do
+      if [[ ! -s "$dest" ]]; then
+        echo "download produced nothing for $dest - is the token still valid?" >&2
+        rm -f "$dest"
+        failed=$((failed+1))
+      else
+        n=$((n+1))
+      fi
+    done
+    page=$((page+1))
+  done
+done <<< "$jobs"
+
+echo "--- downloaded $n exec files to $EXEC"
+if [[ $failed -gt 0 ]]; then
+  echo "$failed artifact(s) failed to download; the report would be incomplete" >&2
+  exit 1
+fi
+[[ $n -gt 0 ]] || { echo "no execution data on build $BUILD - did the legs finish?" >&2; exit 1; }
+
+# --- merge and report ----------------------------------------------------------------------------
+#
+# publish.sh does the rest: it gates the exec data, compiles the measured projects for classfiles,
+# and writes the per-layer and merged reports. Told not to publish, since there is nowhere to
+# publish to from a laptop.
+#
+# The scope has to come from the pipeline, not from publish.sh's own defaults. Those defaults are
+# narrower than what this pipeline measures, so taking them would rebuild a different report from
+# the same execution data and quietly report different numbers than CI did.
+PIPELINE_YML="$ROOT/.buildkite/pipelines/pull-request/test-coverage.yml"
+scope_from_pipeline() {
+  local key="$1"
+  [[ -f "$PIPELINE_YML" ]] || return 0
+  python3 - "$PIPELINE_YML" "$key" <<'PY'
+import re, sys
+key = sys.argv[2]
+# Deliberately a line match rather than a YAML parse: pyyaml is not guaranteed on a dev machine and
+# this is a flat `KEY: "value"` under the top-level env block.
+for line in open(sys.argv[1]):
+    m = re.match(rf'\s+{re.escape(key)}:\s*"?([^"\n]+)"?\s*$', line)
+    if m:
+        print(m.group(1).strip()); break
+PY
+}
+export COVERAGE_PROJECTS="${COVERAGE_PROJECTS:-$(scope_from_pipeline COVERAGE_PROJECTS)}"
+export COVERAGE_INCLUDES="${COVERAGE_INCLUDES:-$(scope_from_pipeline COVERAGE_INCLUDES)}"
+if [[ -z "$COVERAGE_PROJECTS" || -z "$COVERAGE_INCLUDES" ]]; then
+  echo "could not read the measured scope from $PIPELINE_YML; set COVERAGE_PROJECTS and COVERAGE_INCLUDES" >&2
+  exit 1
+fi
+echo "--- scope: $COVERAGE_PROJECTS"
+
+COVERAGE_OUTPUT="$OUT" COVERAGE_SKIP_PUBLISH=1 BUILDKITE= \
+  "$ROOT/.buildkite/scripts/coverage/publish.sh"
+
+echo
+echo "browse it: open $OUT/report/merged/html/index.html"

--- a/.buildkite/scripts/coverage/fetch-report.sh
+++ b/.buildkite/scripts/coverage/fetch-report.sh
@@ -39,12 +39,27 @@ done
 OUT="${OUT:-$ROOT/build/coverage}"
 [[ -n "$PR" || -n "$BUILD" ]] || usage
 
-TOKEN="${BUILDKITE_API_TOKEN:-}"
-if [[ -z "$TOKEN" && -f "$HOME/.config/bk.yaml" ]]; then
-  TOKEN=$(grep -oE '[A-Za-z0-9_-]{30,}' "$HOME/.config/bk.yaml" | head -1)
-fi
+# The bk CLI keeps a token in two places and they are not interchangeable: `bk configure` writes an
+# API token to ~/.config/bk.yaml, while `bk auth login` stores an OAuth token in the keychain that
+# the REST API does not accept as a bearer. Rather than encode which one is right - it has changed
+# between bk versions - try each and keep the first that actually authenticates.
+TOKEN=""
+for candidate in \
+  "${BUILDKITE_API_TOKEN:-}" \
+  "$(grep -oE '[A-Za-z0-9_-]{30,}' "$HOME/.config/bk.yaml" 2>/dev/null | head -1)" \
+  "$(security find-generic-password -s buildkite-cli -w 2>/dev/null || true)"
+do
+  [[ -n "$candidate" ]] || continue
+  if [[ "$(curl -sS -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Bearer $candidate" https://api.buildkite.com/v2/user)" == "200" ]]; then
+    TOKEN="$candidate"
+    break
+  fi
+done
 if [[ -z "$TOKEN" ]]; then
-  echo "no Buildkite API token: set BUILDKITE_API_TOKEN or log in with the bk CLI" >&2
+  echo "no working Buildkite API token." >&2
+  echo "Re-authenticate with:" >&2
+  echo "  bk auth logout && bk auth login --scopes \"read_user read_organizations read_pipelines read_builds read_build_logs read_artifacts write_builds read_agents\"" >&2
   exit 1
 fi
 api() { curl -sSfL -H "Authorization: Bearer $TOKEN" "$@"; }

--- a/.buildkite/scripts/coverage/index-results.sh
+++ b/.buildkite/scripts/coverage/index-results.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Ship the coverage numbers to the metrics cluster so they accumulate into a trend instead of
+# living inside one build's artifacts.
+#
+# This follows the same route the microbenchmarks take (index-micro-benchmark-results.sh): the
+# credentials come from Vault via the pre-command hook when a step sets USE_PERF_CREDENTIALS, and
+# the documents go in over HTTP. There is no coverage bucket to write to - the only S3 bucket this
+# CI touches is the public download.elasticsearch.org one, which is the wrong place for this - so
+# the cluster is where the numbers live and the browsable HTML stays a build artifact.
+#
+# Writes one document per layer with the headline figures, plus one per package for the merged
+# layer, which is what makes a per-component breakdown queryable later.
+#
+# Never fails the caller. Coverage has already been measured and uploaded by the time this runs;
+# a metrics cluster that is unreachable, or credentials that lack write access to the index, is a
+# reporting problem and not a reason to lose the build.
+#
+set -uo pipefail
+REPORT="${1:?usage: index-results.sh <report-dir>}"
+INDEX="${COVERAGE_METRICS_INDEX:-metrics-code-coverage-default}"
+
+if [[ -z "${PERF_METRICS_HOST:-}" ]]; then
+  echo "--- not indexing coverage: no metrics credentials (set USE_PERF_CREDENTIALS on the step)"
+  exit 0
+fi
+
+DOCS=$(python3 - "$REPORT" <<'PY'
+import csv, glob, json, os, sys
+
+report = sys.argv[1]
+env = os.environ.get
+
+
+def totals(rows):
+    f = lambda k: sum(int(r[k]) for r in rows)
+    lc, lm, bc, bm = f('LINE_COVERED'), f('LINE_MISSED'), f('BRANCH_COVERED'), f('BRANCH_MISSED')
+    return {
+        'line': {'covered': lc, 'missed': lm, 'total': lc + lm,
+                 'pct': round(100 * lc / (lc + lm), 2) if lc + lm else 0.0},
+        'branch': {'covered': bc, 'missed': bm, 'total': bc + bm,
+                   'pct': round(100 * bc / (bc + bm), 2) if bc + bm else 0.0},
+    }
+
+
+common = {
+    'scope': env('COVERAGE_PROJECTS', ''),
+    'includes': env('COVERAGE_INCLUDES', ''),
+    'git': {k: v for k, v in (('sha', env('BUILDKITE_COMMIT', '')),
+                              ('branch', env('BUILDKITE_BRANCH', '')),
+                              ('pull_request', env('BUILDKITE_PULL_REQUEST', ''))) if v and v != 'false'},
+    'build': {k: v for k, v in (('pipeline', env('BUILDKITE_PIPELINE_SLUG', '')),
+                                ('number', env('BUILDKITE_BUILD_NUMBER', '')),
+                                ('url', env('BUILDKITE_BUILD_URL', ''))) if v},
+}
+
+docs = []
+for csv_path in sorted(glob.glob(os.path.join(report, '*', 'coverage.csv'))):
+    layer = os.path.basename(os.path.dirname(csv_path))
+    rows = list(csv.DictReader(open(csv_path)))
+    if not rows:
+        continue
+    docs.append({**common, 'layer': layer, 'granularity': 'total', **totals(rows)})
+    # Per-package rows only for the union. The per-layer packages are noise: what a single layer
+    # contributes to one package is not a coverage figure for it, only the merged number is.
+    if layer == 'merged':
+        by_pkg = {}
+        for r in rows:
+            by_pkg.setdefault(r['PACKAGE'], []).append(r)
+        for pkg, prows in sorted(by_pkg.items()):
+            docs.append({**common, 'layer': layer, 'granularity': 'package',
+                         'package': pkg, **totals(prows)})
+
+json.dump(docs, sys.stdout)
+PY
+)
+
+count=$(printf '%s' "$DOCS" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+if [[ "$count" == "0" ]]; then
+  echo "--- not indexing coverage: no CSV reports under $REPORT"
+  exit 0
+fi
+
+echo "--- indexing $count coverage documents into $INDEX"
+BULK=$(printf '%s' "$DOCS" | python3 -c '
+import json, sys, time
+ts = int(time.time() * 1000)
+out = []
+for d in json.load(sys.stdin):
+    out.append(json.dumps({"create": {}}))
+    out.append(json.dumps({**d, "@timestamp": ts}))
+print("\n".join(out))
+')
+
+resp=$(curl -sS -X POST "https://$PERF_METRICS_HOST/$INDEX/_bulk" \
+  -u "$PERF_METRICS_USERNAME:$PERF_METRICS_PASSWORD" \
+  -H 'Content-Type: application/x-ndjson' \
+  --data-binary "$BULK
+" 2>&1) || true
+
+if printf '%s' "$resp" | grep -q '"errors":false'; then
+  echo "    indexed $count documents"
+else
+  # Loud but not fatal. The most likely cause is that the index does not exist yet or the
+  # credentials cannot write to it, which needs a one-time grant from whoever owns that cluster.
+  echo "    could not index coverage (non-fatal). Response:"
+  printf '%s\n' "$resp" | head -c 800
+  echo
+fi
+exit 0

--- a/.buildkite/scripts/coverage/lib.sh
+++ b/.buildkite/scripts/coverage/lib.sh
@@ -1,0 +1,237 @@
+# shellcheck shell=bash
+#
+# Shared helpers for the coverage scripts. Sourced, not executed.
+#
+# Everything here is parameterised by the Gradle project-path pattern; nothing names a specific
+# module. The scope is an input, the mechanism is fixed.
+
+JACOCO_VERSION=0.8.12
+
+# Fetch the JaCoCo agent + CLI into $1 and set AGENT / CLI.
+coverage_fetch_tools() {
+  local lib="$1"
+  local base="https://repo1.maven.org/maven2/org/jacoco"
+  AGENT="$lib/org.jacoco.agent-$JACOCO_VERSION-runtime.jar"
+  CLI="$lib/org.jacoco.cli-$JACOCO_VERSION-nodeps.jar"
+  mkdir -p "$lib"
+  if [[ ! -f "$AGENT" ]]; then
+    echo "--- fetching JaCoCo $JACOCO_VERSION"
+    curl -sSfL "$base/org.jacoco.agent/$JACOCO_VERSION/org.jacoco.agent-$JACOCO_VERSION-runtime.jar" -o "$AGENT"
+  fi
+  if [[ ! -f "$CLI" ]]; then
+    curl -sSfL "$base/org.jacoco.cli/$JACOCO_VERSION/org.jacoco.cli-$JACOCO_VERSION-nodeps.jar" -o "$CLI"
+  fi
+}
+
+# Translate a Gradle project-path pattern (':x-pack:plugin:esql-datasource-*') into an anchored
+# extended regex. '*' matches any run of characters, including ':' — same semantics as the regex
+# in gradle/coverage.gradle. Keep the two in sync.
+coverage_pattern_regex() {
+  local p="$1"
+  p="${p//./\\.}"
+  p="${p//\*/.*}"
+  printf '^%s$' "$p"
+}
+
+# Enumerate Gradle project paths matching a pattern, one per line.
+#
+# Enumerated from the filesystem, mirroring settings.gradle's own discovery (addSubProjects walks
+# directories that contain a build.gradle). This deliberately avoids invoking Gradle: a
+# `./gradlew projects` call configures the whole build and costs minutes per call. The
+# approximation is one-sided: a directory with a build.gradle that settings.gradle does not
+# include would surface as a loud "project not found" from Gradle, never as a silent miss.
+# Renamed projects (`:libs:native:native-libraries`, `:test:external-modules:test-*`) will not
+# resolve under their renamed path; none are test-bearing today.
+coverage_projects() {
+  local root="$1" pattern="$2"
+  local re
+  re=$(coverage_pattern_regex "$pattern")
+  (
+    cd "$root" && find . -mindepth 2 -name build.gradle \
+      -not -path '*/build/*' \
+      -not -path '*/src/*' \
+      -not -path './buildSrc/*' \
+      -not -path './build-tools/*' \
+      -not -path './build-tools-internal/*' \
+      -not -path './build-conventions/*' \
+      -not -path './.git/*' \
+      2>/dev/null
+  ) | sed -e 's#^\./##' -e 's#/build\.gradle$##' -e 's#/#:#g' -e 's#^#:#' \
+    | { grep -E "$re" || true; } \
+    | { if [[ -n "$(coverage_exclude_regex)" ]]; then grep -Ev "$(coverage_exclude_regex)" || true; else cat; fi; } \
+    | sort
+}
+
+# Map a project path to its directory under the repo root.
+coverage_project_dir() {
+  local root="$1" path="$2"
+  printf '%s/%s' "$root" "$(printf '%s' "${path#:}" | tr ':' '/')"
+}
+
+# How each Gradle test task maps to a coverage layer.
+#
+# Task NAMES are never guessed - they come from Gradle itself (coverage_enumerate_tasks below),
+# because they do not reliably follow their source set: src/csvSpecTest registers a task called
+# `csvSpecTests`, plural. A directory heuristic got this wrong in four separate ways, reporting 5
+# csvSpecTests instead of 7, zero yamlRestTest instead of 4, one internalClusterTest instead of 2,
+# and missing javaRestTestSecure, perfSmokeTest and bcUpgradeTest entirely.
+#
+# What CANNOT be derived is the layer: whether a suite runs product code in the test JVM or in a
+# separate ES node process is invisible in the task definition, and it decides whether the TCP
+# collector is needed. So this mapping is stated knowledge, and anything unmapped fails loudly.
+COVERAGE_TASK_LAYERS=(
+  "test:unit"
+  "internalClusterTest:internal-cluster"
+  "javaRestTest:cluster"
+  "yamlRestTest:cluster"
+  "csvSpecTests:cluster"
+  "javaRestTestSecure:cluster"
+)
+
+# Tasks we deliberately do not measure, with the reason.
+#   bcUpgradeTest  - runs old-version nodes; their coverage cannot map onto current classfiles.
+#   perfSmokeTest  - measures speed, not behaviour; counting it inflates coverage with something
+#                    nobody would call a test of correctness. Includable explicitly.
+#   v<version>#... - the ~464 BWC-versioned variants, same reason as bcUpgradeTest.
+COVERAGE_EXCLUDED_TASKS=(
+  "bcUpgradeTest"
+  "perfSmokeTest"
+)
+
+# Projects excluded from the scope, as an extended regex over Gradle project paths. Each
+# alternative is anchored on ':' / end-of-path so it can only ever match a whole path segment —
+# a bare substring here would silently swallow any project whose name happens to contain it.
+# parquet-rs is being retired, so measuring it drags the aggregate down for code nobody will
+# maintain. Override with COVERAGE_EXCLUDE_PROJECTS; set it to the empty string to exclude
+# nothing (which is how you measure parquet-rs itself).
+COVERAGE_EXCLUDE_PROJECTS_DEFAULT=':esql-datasource-parquet-rs(:|$)|:libs:parquet-rs(:|$)'
+
+# The effective exclusion regex. The `-` (not `:-`) expansion is deliberate: an explicitly empty
+# COVERAGE_EXCLUDE_PROJECTS means "exclude nothing", only an unset one means "use the default".
+coverage_exclude_regex() {
+  printf '%s' "${COVERAGE_EXCLUDE_PROJECTS-$COVERAGE_EXCLUDE_PROJECTS_DEFAULT}"
+}
+
+# Ask Gradle for the real test tasks in one configuration pass. Writes a cached list, one task
+# path per line. The cache is keyed on the pattern via a sidecar file: a list produced for a
+# different COVERAGE_PROJECTS must never be silently reused.
+coverage_enumerate_tasks() {
+  local root="$1" pattern="$2" out="$3" gradle="${4:-./gradlew}"
+  if [[ -s "$out" && -f "$out.pattern" && "$(cat "$out.pattern")" == "$pattern" ]]; then
+    return 0
+  fi
+  rm -f "$out" "$out.pattern"
+  ( cd "$root" && $gradle -q -I gradle/coverage-tasks.gradle \
+      -Dcoverage.projects="$pattern" -Dcoverage.tasklist="$out" coverageTaskList >/dev/null )
+  [[ -f "$out" ]] || { echo "task enumeration produced no list at $out" >&2; return 1; }
+  printf '%s' "$pattern" > "$out.pattern"
+}
+
+# Emit the task paths for one layer, from the enumerated list.
+coverage_tasks_for_layer() {
+  local tasklist="$1" layer="$2"
+  local exclude
+  exclude=$(coverage_exclude_regex)
+  local taskpath name entry unmapped=0
+  while IFS= read -r taskpath; do
+    [[ -n "$taskpath" ]] || continue
+    name="${taskpath##*:}"
+
+    # Excluded projects (see COVERAGE_EXCLUDE_PROJECTS_DEFAULT).
+    if [[ -n "$exclude" ]] && printf '%s' "$taskpath" | grep -qE "$exclude"; then
+      continue
+    fi
+
+    # BWC-versioned variants carry a '#' - excluded wholesale.
+    [[ "$name" == *"#"* ]] && continue
+
+    local skip=0
+    for entry in "${COVERAGE_EXCLUDED_TASKS[@]}"; do
+      [[ "$name" == "$entry" ]] && skip=1 && break
+    done
+    [[ "$skip" -eq 1 ]] && continue
+
+    local matched=0
+    for entry in "${COVERAGE_TASK_LAYERS[@]}"; do
+      if [[ "$name" == "${entry%%:*}" ]]; then
+        matched=1
+        [[ "${entry##*:}" == "$layer" ]] && echo "$taskpath"
+        break
+      fi
+    done
+    if [[ "$matched" -eq 0 ]]; then
+      echo "UNMAPPED TEST TASK: $taskpath" >&2
+      unmapped=1
+    fi
+  done < "$tasklist"
+
+  if [[ "$unmapped" -eq 1 ]]; then
+    echo "" >&2
+    echo "Classify it in COVERAGE_TASK_LAYERS in lib.sh, or exclude it in COVERAGE_EXCLUDED_TASKS" >&2
+    echo "with a reason. Measuring coverage while silently skipping a suite understates the" >&2
+    echo "result and reads as a finding." >&2
+    return 1
+  fi
+}
+
+# Emit `--classfiles <dir>` / `--sourcefiles <dir>` argument pairs for every matched project that
+# has compiled main classes, one argument per line (read into an array with `while read`).
+#
+# Classfiles are restricted to the package prefixes of the includes filter ($3, the same
+# colon-separated JaCoCo pattern the agent gets). The agent only ever records classes matching
+# that filter, so any class outside it would sit in the report as a permanent 0% - vendored
+# sources are the concrete case: esql-datasource-orc compiles org.apache.* shims into its main
+# classes, and counting them understates the module without measuring anything. Each pattern is
+# cut at its first '*' and mapped to the corresponding package directory; nested prefixes are
+# deduplicated so no class is analysed twice.
+coverage_report_path_args() {
+  local root="$1" pattern="$2" includes="${3:-*}"
+  local p d main inc prefix dir last
+  while IFS= read -r p; do
+    [[ -n "$p" ]] || continue
+    d=$(coverage_project_dir "$root" "$p")
+    main="$d/build/classes/java/main"
+    [[ -d "$main" ]] || continue
+    local candidates=() emitted=0
+    local IFS_pats
+    IFS=':' read -ra IFS_pats <<< "$includes"
+    for inc in "${IFS_pats[@]}"; do
+      prefix="${inc%%\**}"
+      prefix="${prefix%.}"
+      dir="$main/$(printf '%s' "$prefix" | tr '.' '/')"
+      dir="${dir%/}"
+      [[ -d "$dir" ]] && candidates+=("$dir")
+    done
+    last=""
+    while IFS= read -r dir; do
+      [[ -n "$dir" ]] || continue
+      # Sorted order puts an ancestor before its descendants; skip anything already covered.
+      if [[ -n "$last" && "$dir/" == "$last/"* ]]; then
+        continue
+      fi
+      echo "--classfiles"
+      echo "$dir"
+      last="$dir"
+      emitted=1
+    done < <(printf '%s\n' ${candidates[@]+"${candidates[@]}"} | sort -u)
+    if [[ "$emitted" -eq 1 && -d "$d/src/main/java" ]]; then
+      echo "--sourcefiles"
+      echo "$d/src/main/java"
+    fi
+  done < <(coverage_projects "$root" "$pattern")
+}
+
+# Total executed probes recorded in an exec file, read with the JaCoCo CLI itself — never inferred
+# from file size. execinfo rows look like `<16-hex id>  <hits> of <probes>  <class>`; summing the
+# hits column distinguishes "sessions but nothing executed" (0) from real data (>0).
+coverage_exec_hits() {
+  local cli="$1" exec_file="$2"
+  java -jar "$cli" execinfo "$exec_file" 2>/dev/null \
+    | awk '$3 == "of" && $2 ~ /^[0-9]+$/ { s += $2 } END { print s + 0 }'
+}
+
+# Number of agent sessions recorded in an exec file.
+coverage_exec_sessions() {
+  local cli="$1" exec_file="$2"
+  java -jar "$cli" execinfo "$exec_file" 2>/dev/null | { grep -c '^Session ' || true; }
+}

--- a/.buildkite/scripts/coverage/publish-to-repo.sh
+++ b/.buildkite/scripts/coverage/publish-to-repo.sh
@@ -70,7 +70,14 @@ fi
 if command -v gh >/dev/null 2>&1; then
   perm=$(GH_TOKEN="$TOKEN" gh api "repos/$REPO" --jq '.permissions.push' 2>/dev/null)
   if [[ "$perm" != "true" ]]; then
-    echo "--- not committing coverage: this token cannot push to $REPO (permissions.push=${perm:-unknown})"
+    # Name the identity. A private repo is invisible to an org member who has not been granted
+    # access to it, so the failure is a repo-side grant rather than anything about the token - but
+    # that grant cannot be made without knowing which account to grant it to, and this token comes
+    # from Vault so only CI can ask.
+    who=$(GH_TOKEN="$TOKEN" gh api user --jq '.login' 2>/dev/null || echo unknown)
+    echo "--- not committing coverage: $REPO is not reachable by this token"
+    echo "    identity: $who"
+    echo "    fix: grant $who Write on $REPO (Settings > Collaborators and teams)"
     exit 0
   fi
 fi

--- a/.buildkite/scripts/coverage/publish-to-repo.sh
+++ b/.buildkite/scripts/coverage/publish-to-repo.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+#
+# Commit the coverage numbers into elastic/elasticsearch-code-coverage.
+#
+# The reports live inside one build's artifacts, so reading them costs a trip into Buildkite. The
+# numbers themselves are small, so they go into a repo instead, where they need no credentials to
+# read and a coverage change shows up as a diff someone can review.
+#
+#   publish-to-repo.sh <report-dir>
+#
+# Where things land. A main build writes <area>/latest/; a PR build writes <area>/pr/<n>/, so a
+# PR's numbers are at a stable path someone can link to and a PR can never overwrite what main
+# measured.
+#
+# What is NOT committed here: the HTML report. Coverage numbers and the browsable report have
+# different shapes - a few KB of text that wants a diff, against ~9,000 files that want replacing
+# wholesale - so the report goes to its own branch, not this one.
+#
+# Auth: needs a token with push access to ANOTHER repo. The ambient GH_TOKEN in these jobs is a
+# GitHub App token scoped to elasticsearch that cannot write at all (status.sh documents the same
+# 403), so the Vault token is preferred and the ambient one is only a fallback for laptop runs.
+# Unlike status.sh this cannot retry-on-failure: an attempt costs a clone and a commit.
+#
+# Never fails the caller. Coverage is measured and uploaded before this runs, so a push problem is
+# a reporting problem, not a reason to lose the build.
+#
+# NOTE: `pipefail` below is load-bearing - it is what makes `if git push ... | redact` test the
+# push's status rather than sed's. Do not drop it without rewriting those checks.
+set -uo pipefail
+
+REPORT="${1:?usage: publish-to-repo.sh <report-dir>}"
+REPO="${COVERAGE_REPO:-elastic/elasticsearch-code-coverage}"
+BRANCH_OUT="${COVERAGE_BRANCH:-data}"
+AREA="${COVERAGE_AREA:-esql}"
+
+say() { echo "    $*"; }
+
+# Belt and braces with the gate in publish.sh. fetch-report.sh rebuilds a report on a laptop and
+# runs publish.sh with both of these set; without this check, anyone with GH_TOKEN exported - or a
+# logged-in vault - would push their local rebuild into the shared branch just by browsing an old
+# build. COVERAGE_FORCE_PUBLISH=1 is the deliberate escape hatch for a hand-run backfill.
+if [[ "${COVERAGE_FORCE_PUBLISH:-}" != "1" ]]; then
+  if [[ "${COVERAGE_SKIP_PUBLISH:-}" == "1" || -z "${BUILDKITE:-}" ]]; then
+    echo "--- not committing coverage: not a CI publish (set COVERAGE_FORCE_PUBLISH=1 to override)"
+    exit 0
+  fi
+fi
+
+if [[ ! -d "$REPORT" ]]; then
+  echo "--- not committing coverage: no report at $REPORT"; exit 0
+fi
+# Absolute, because everything below runs after a cd into a temp clone.
+REPORT="$(cd "$REPORT" && pwd)" || exit 0
+SUMMARY="${2:-$(dirname "$REPORT")/summary.txt}"
+
+# --- auth ----------------------------------------------------------------------------------------
+
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+if command -v vault >/dev/null 2>&1 \
+   && vault_token=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) \
+   && [[ -n "$vault_token" ]]; then
+  TOKEN="$vault_token"
+fi
+if [[ -z "$TOKEN" ]]; then
+  echo "--- not committing coverage: no token with push access to $REPO"; exit 0
+fi
+
+# Preflight, so a missing repo or an unprivileged token says so plainly instead of turning into
+# "the branch does not exist" three steps later.
+if command -v gh >/dev/null 2>&1; then
+  perm=$(GH_TOKEN="$TOKEN" gh api "repos/$REPO" --jq '.permissions.push' 2>/dev/null)
+  if [[ "$perm" != "true" ]]; then
+    echo "--- not committing coverage: this token cannot push to $REPO (permissions.push=${perm:-unknown})"
+    exit 0
+  fi
+fi
+
+SHA="${BUILDKITE_COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+SHORT="${SHA:0:12}"
+BRANCH="${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+PR="${BUILDKITE_PULL_REQUEST:-}"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+if [[ -n "$PR" && "$PR" != "false" ]]; then
+  DEST="$AREA/pr/$PR"
+else
+  DEST="$AREA/latest"
+fi
+
+WORK=$(mktemp -d) || { echo "--- not committing coverage: mktemp failed"; exit 0; }
+# Buildkite cancels a step with a signal, and bash runs no EXIT trap for an untrapped one - which
+# would leave the tokenised remote in $WORK/repo/.git/config on the agent.
+trap 'rm -rf "$WORK"' EXIT INT TERM HUP
+
+ORIGIN="https://x-access-token:$TOKEN@github.com/$REPO.git"
+redact() { sed 's/x-access-token:[^@]*@/x-access-token:***@/g'; }
+
+# --- get the branch ------------------------------------------------------------------------------
+#
+# Data goes on its own branch, never on main: the org applies a ruleset to every repo's DEFAULT
+# branch requiring changes to arrive by pull request, and a CI token cannot bypass it. Non-default
+# branches carry no such rule, so a machine-written branch pushes cleanly and needs nothing from
+# org admins.
+#
+# Branch existence is decided by asking, not inferred from a clone failing - otherwise a bad token
+# or a network blip masquerades as a first run and the real cause never reaches the log.
+echo "--- committing coverage to $REPO on branch $BRANCH_OUT under $DEST"
+if git ls-remote --exit-code --heads "$ORIGIN" "$BRANCH_OUT" >/dev/null 2>&1; then
+  if ! clone_err=$(git clone --quiet --depth 1 --branch "$BRANCH_OUT" "$ORIGIN" "$WORK/repo" 2>&1); then
+    say "could not clone $BRANCH_OUT (non-fatal):"; printf '%s\n' "$clone_err" | head -3 | redact
+    exit 0
+  fi
+  cd "$WORK/repo" || exit 0
+else
+  say "$BRANCH_OUT does not exist yet, creating it"
+  mkdir -p "$WORK/repo" || exit 0
+  cd "$WORK/repo" || exit 0
+  git init --quiet -b "$BRANCH_OUT" . || exit 0
+  git remote add origin "$ORIGIN" || exit 0
+fi
+
+# --- write the numbers ---------------------------------------------------------------------------
+#
+# Cleared first: this run must not republish a layer it did not measure. Without this, a leg that
+# did not run leaves the previous commit's CSV in place while metadata.json is rewritten with this
+# commit - the repo would assert that stale numbers belong to a commit that never produced them.
+rm -rf "$DEST" && mkdir -p "$DEST" || exit 0
+
+# JaCoCo's CSV carries a row per CLASS - ~700KB per layer. Aggregated to per-PACKAGE it is a couple
+# of hundred rows and a few KB, which is both the granularity anyone reasons about and the
+# difference between a repo that stays small and one that is gigabytes inside a year. The per-class
+# detail stays in the build artifacts, reachable with fetch-report.sh.
+layers=0
+for csv in "$REPORT"/*/coverage.csv; do
+  [[ -f "$csv" ]] || continue
+  layer=$(basename "$(dirname "$csv")")
+  # Into a temp name first: `>` truncates before python runs, so a failure would otherwise commit
+  # and publish a zero-byte CSV and still report success.
+  if ! python3 - "$csv" > "$DEST/$layer.csv.tmp" <<'PY'
+import csv, sys
+from collections import defaultdict
+cols = ['INSTRUCTION_MISSED', 'INSTRUCTION_COVERED', 'BRANCH_MISSED', 'BRANCH_COVERED',
+        'LINE_MISSED', 'LINE_COVERED', 'COMPLEXITY_MISSED', 'COMPLEXITY_COVERED',
+        'METHOD_MISSED', 'METHOD_COVERED']
+agg = defaultdict(lambda: defaultdict(int))
+with open(sys.argv[1], newline='') as fh:
+    for r in csv.DictReader(fh):
+        bucket = agg[r['PACKAGE']]
+        for c in cols:
+            bucket[c] += int(r.get(c) or 0)
+w = csv.writer(sys.stdout, lineterminator='\n')
+w.writerow(['PACKAGE'] + cols + ['LINE_PCT', 'BRANCH_PCT'])
+for pkg, v in sorted(agg.items()):
+    lt = v['LINE_COVERED'] + v['LINE_MISSED']
+    bt = v['BRANCH_COVERED'] + v['BRANCH_MISSED']
+    w.writerow([pkg] + [v[c] for c in cols]
+               + [f"{100 * v['LINE_COVERED'] / lt:.2f}" if lt else '',
+                  f"{100 * v['BRANCH_COVERED'] / bt:.2f}" if bt else ''])
+PY
+  then
+    say "aggregation failed for $layer - not publishing this run"; exit 0
+  fi
+  mv "$DEST/$layer.csv.tmp" "$DEST/$layer.csv" || exit 0
+  layers=$((layers + 1))
+done
+if (( layers == 0 )); then
+  say "no layer CSVs under $REPORT - nothing to publish"; exit 0
+fi
+[[ -f "$SUMMARY" ]] && cp "$SUMMARY" "$DEST/summary.txt"
+
+if ! python3 - "$SHA" "$BRANCH" "$NOW" > "$DEST/metadata.json.tmp" <<'PY'
+import json, os, sys
+sha, branch, now = sys.argv[1:4]
+env = os.environ.get
+meta = {'commit': sha, 'branch': branch, 'measured_at': now,
+        'scope': env('COVERAGE_PROJECTS', ''), 'includes': env('COVERAGE_INCLUDES', '')}
+for k, v in (('pipeline', env('BUILDKITE_PIPELINE_SLUG', '')),
+             ('build', env('BUILDKITE_BUILD_NUMBER', '')),
+             ('build_url', env('BUILDKITE_BUILD_URL', '')),
+             ('pull_request', env('BUILDKITE_PULL_REQUEST', ''))):
+    if v and v != 'false':
+        meta[k] = v
+json.dump(meta, sys.stdout, indent=2)
+print()
+PY
+then
+  say "could not write metadata - not publishing this run"; exit 0
+fi
+mv "$DEST/metadata.json.tmp" "$DEST/metadata.json" || exit 0
+
+HEADLINE=$(grep -m1 '^merged' "$DEST/summary.txt" 2>/dev/null || echo "coverage measured")
+
+# --- commit and push -----------------------------------------------------------------------------
+
+git -c user.name="elasticsearch-ci" -c user.email="noreply@elastic.co" add -A || exit 0
+# metadata.json carries a fresh timestamp every run, so it must be excluded from the "did anything
+# change" test - otherwise the guard can never fire and every re-run commits a new timestamp over
+# identical numbers.
+if git diff --cached --quiet -- . ":(exclude)$DEST/metadata.json"; then
+  say "coverage unchanged since the last run"; exit 0
+fi
+git -c user.name="elasticsearch-ci" -c user.email="noreply@elastic.co" \
+  commit --quiet -m "$AREA $SHORT on $BRANCH" -m "$HEADLINE" || exit 0
+
+# Coverage steps on parallel PRs land on the same branch, so losing the race is the common path,
+# not the exotic one. Rebase onto whatever arrived and try again rather than dropping the numbers.
+for attempt in 1 2 3; do
+  if git push --quiet origin "HEAD:$BRANCH_OUT" 2>&1 | redact; then
+    say "pushed https://github.com/$REPO/tree/$BRANCH_OUT/$DEST"
+    exit 0
+  fi
+  (( attempt == 3 )) && break
+  say "push rejected, rebasing onto $BRANCH_OUT and retrying ($attempt/3)"
+  git fetch --quiet origin "$BRANCH_OUT" 2>&1 | redact || break
+  git rebase --quiet FETCH_HEAD 2>&1 | redact || { git rebase --abort >/dev/null 2>&1; break; }
+done
+say "could not push to $REPO (non-fatal)"
+exit 0

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Aggregation: merges the per-layer legs' exec data into the union report. The legs upload only
+# raw exec data; this script rebuilds everything else from it:
+#
+#   1. zero-gate the exec data (nothing broken gets published)
+#   2. compile the measured projects' main classes (remote build cache makes this cheap)
+#   3. per-layer reports + the merged (union) report
+#   4. summary, Buildkite annotation, S3 publish
+#
+# The PR pipeline (test-coverage.yml) does not run this - each of its legs reports its own layer.
+# Run it as a Buildkite step after the legs (it downloads their exec artifacts itself), or
+# locally against an already-populated COVERAGE_OUTPUT.
+#
+# S3 publishing needs one-time ops setup: the bucket, and AWS keys at the Vault path below. Until
+# that exists the step still produces reports and the annotation - it says so instead of the link.
+#
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+# shellcheck source=lib.sh
+source "$ROOT/.buildkite/scripts/coverage/lib.sh"
+
+PROJECTS="${COVERAGE_PROJECTS:-:x-pack:plugin:esql-datasource-*}"
+INCLUDES="${COVERAGE_INCLUDES:-org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*:org.elasticsearch.arrow.*}"
+OUT="${COVERAGE_OUTPUT:-$ROOT/build/coverage}"
+BUCKET="${COVERAGE_BUCKET:-esql-coverage-reports}"
+VAULT_PATH="${COVERAGE_VAULT_PATH:-secret/ci/elastic-elasticsearch/esql-coverage-s3}"
+SHA="${BUILDKITE_COMMIT:-local}"
+GRADLE="${GRADLEW:-./gradlew}"
+
+LIB="$OUT/lib"
+EXEC="$OUT/exec"
+REPORT="$OUT/report"
+mkdir -p "$LIB" "$EXEC" "$REPORT"
+
+coverage_fetch_tools "$LIB"
+
+# On a fresh agent nothing is checked out under $EXEC yet - the legs' exec data lives in their
+# Buildkite artifacts. Fetch it before gating; a local run that already has exec data skips this.
+if [[ -n "${BUILDKITE:-}" && -z "$(find "$EXEC" -name '*.exec' 2>/dev/null | head -1)" ]]; then
+  echo "--- downloading exec artifacts from the test legs"
+  buildkite-agent artifact download "build/coverage/exec/**/*.exec" .
+fi
+
+# --- gate first: nothing broken gets published ---------------------------------------------------
+
+"$ROOT/.buildkite/scripts/coverage/check-nonzero.sh" "$EXEC" "$CLI"
+
+# --- classfiles ----------------------------------------------------------------------------------
+#
+# This agent ran no tests, so the measured projects have to be compiled here. The legs populated
+# the remote build cache, so this is mostly cache hits.
+
+compile_tasks=()
+while IFS= read -r p; do
+  [[ -n "$p" ]] && compile_tasks+=("$p:compileJava")
+done < <(coverage_projects "$ROOT" "$PROJECTS")
+if [[ ${#compile_tasks[@]} -eq 0 ]]; then
+  echo "no projects match $PROJECTS" >&2
+  exit 1
+fi
+echo "--- compiling ${#compile_tasks[@]} projects for report classfiles"
+# shellcheck disable=SC2086
+$GRADLE --continue "${compile_tasks[@]}" || true
+
+PATH_ARGS=()
+while IFS= read -r a; do PATH_ARGS+=("$a"); done < <(coverage_report_path_args "$ROOT" "$PROJECTS" "$INCLUDES")
+if [[ ${#PATH_ARGS[@]} -eq 0 ]]; then
+  echo "no compiled classes found for pattern $PROJECTS - cannot build a report" >&2
+  exit 1
+fi
+
+# --- reports: per layer, and the union across all legs -------------------------------------------
+
+report_one() {
+  local name="$1"; shift
+  [[ $# -eq 0 ]] && return 0
+  mkdir -p "$REPORT/$name"
+  java -jar "$CLI" report "$@" \
+    "${PATH_ARGS[@]}" \
+    --html "$REPORT/$name/html" \
+    --xml "$REPORT/$name/coverage.xml" \
+    --csv "$REPORT/$name/coverage.csv" \
+    --name "$name" >/dev/null
+}
+
+all_execs=()
+for layer_dir in "$EXEC"/*/; do
+  [[ -d "$layer_dir" ]] || continue
+  layer=$(basename "$layer_dir")
+  execs=()
+  while IFS= read -r f; do execs+=("$f"); all_execs+=("$f"); done < <(find "$layer_dir" -name '*.exec' 2>/dev/null)
+  report_one "$layer" ${execs[@]+"${execs[@]}"}
+done
+
+if [[ ${#all_execs[@]} -eq 0 ]]; then
+  echo "no exec data downloaded - nothing to publish" >&2
+  exit 1
+fi
+java -jar "$CLI" merge "${all_execs[@]}" --destfile "$OUT/merged.exec" >/dev/null
+report_one merged "$OUT/merged.exec"
+
+SUMMARY=$("$ROOT/.buildkite/scripts/coverage/summarise.sh" "$REPORT" | tee "$OUT/summary.txt")
+echo "$SUMMARY"
+
+# --- publish + annotate --------------------------------------------------------------------------
+
+LINK="report is in this step's artifacts (build/coverage/report/)"
+if [[ "${COVERAGE_SKIP_PUBLISH:-}" == "1" ]]; then
+  echo "--- S3 publish skipped (COVERAGE_SKIP_PUBLISH=1)"
+elif [[ -n "${BUILDKITE:-}" ]]; then
+  if creds=$(vault read -format=json "$VAULT_PATH" 2>/dev/null); then
+    AWS_ACCESS_KEY_ID=$(jq -r '.data.access_key' <<< "$creds")
+    AWS_SECRET_ACCESS_KEY=$(jq -r '.data.secret_key' <<< "$creds")
+    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+    aws s3 sync "$REPORT" "s3://$BUCKET/$SHA/" --only-show-errors
+    aws s3 sync "$REPORT" "s3://$BUCKET/latest/" --only-show-errors
+    LINK="[Browse the report](https://$BUCKET.s3.amazonaws.com/$SHA/merged/html/index.html)"
+  else
+    echo "--- S3 publish skipped: no credentials at $VAULT_PATH (one-time ops setup, see README)"
+  fi
+fi
+
+if [[ -n "${BUILDKITE:-}" ]] && command -v buildkite-agent >/dev/null; then
+  printf '### Coverage (%s @ %.12s)\n\n```\n%s\n```\n\n%s\n' "$PROJECTS" "$SHA" "$SUMMARY" "$LINK" \
+    | buildkite-agent annotate --style info --context coverage
+fi

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -115,6 +115,16 @@ echo "$SUMMARY"
 # build. Never fails the step - see the script for why.
 "$ROOT/.buildkite/scripts/coverage/index-results.sh" "$REPORT" || true
 
+# Numbers into the coverage repo, where they can be read without credentials and a change shows up
+# as a diff. Only main writes the canonical `latest/`; a PR writes its own directory. The override
+# exists so the push can be exercised before there is a main run to exercise it.
+if [[ "${COVERAGE_SKIP_PUBLISH:-}" != "1" && -n "${BUILDKITE:-}" ]] \
+   && [[ "${BUILDKITE_BRANCH:-}" == "main" || "${COVERAGE_PUBLISH_TO_REPO:-}" == "1" ]]; then
+  "$ROOT/.buildkite/scripts/coverage/publish-to-repo.sh" "$REPORT" || true
+else
+  echo "--- not committing coverage to the data repo (branch ${BUILDKITE_BRANCH:-none})"
+fi
+
 # --- publish + annotate --------------------------------------------------------------------------
 
 LINK="report is in this step's artifacts (build/coverage/report/)"
@@ -125,8 +135,10 @@ elif [[ -n "${BUILDKITE:-}" ]]; then
     AWS_ACCESS_KEY_ID=$(jq -r '.data.access_key' <<< "$creds")
     AWS_SECRET_ACCESS_KEY=$(jq -r '.data.secret_key' <<< "$creds")
     export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-    aws s3 sync "$REPORT" "s3://$BUCKET/$SHA/" --only-show-errors
-    aws s3 sync "$REPORT" "s3://$BUCKET/latest/" --only-show-errors
+    # Unprotected, these abort the step under `set -e` and status.sh then reports "merge failed" -
+    # a false report, since the merge succeeded and everything above it already published.
+    aws s3 sync "$REPORT" "s3://$BUCKET/$SHA/" --only-show-errors || true
+    aws s3 sync "$REPORT" "s3://$BUCKET/latest/" --only-show-errors || true
     LINK="[Browse the report](https://$BUCKET.s3.amazonaws.com/$SHA/merged/html/index.html)"
   else
     echo "--- S3 publish skipped: no credentials at $VAULT_PATH (one-time ops setup, see README)"
@@ -135,7 +147,7 @@ fi
 
 if [[ -n "${BUILDKITE:-}" ]] && command -v buildkite-agent >/dev/null; then
   printf '### Coverage (%s @ %.12s)\n\n```\n%s\n```\n\n%s\n' "$PROJECTS" "$SHA" "$SUMMARY" "$LINK" \
-    | buildkite-agent annotate --style info --context coverage
+    | buildkite-agent annotate --style info --context coverage || true
 fi
 
 # Post the summary as a PR comment, updating the previous one rather than piling up.

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -133,22 +133,42 @@ fi
 # control, and coverage steps are not in it - so the annotation above is only visible after
 # clicking into the build. A comment puts the numbers on the PR itself, which is where anyone
 # looking for them will actually look.
+#
+# Auth is the same story as status.sh: the ambient GH_TOKEN is a GitHub App token that cannot
+# write ("403 Resource not accessible by integration"), so on failure retry with the
+# SAML-authorized token in Vault. Never fails the step - the report is already published, the
+# comment is reporting on top of it.
 if [[ -n "${BUILDKITE_PULL_REQUEST:-}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] \
    && command -v gh >/dev/null 2>&1; then
   MARKER="<!-- coverage-report -->"
-  SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
+  SLUG="${BUILDKITE_REPO:-}"   # checkout URL; no BUILDKITE_* variable carries the bare slug
+  SLUG="${SLUG##*github.com?}"
+  SLUG="${SLUG%.git}"
+  [[ "$SLUG" == ?*/?* && "$SLUG" != *:* && "$SLUG" != */*/* ]] || SLUG="elastic/elasticsearch"
   BODY=$(printf '%s\n## Coverage\n\n```\n%s\n```\n\n%s\n' "$MARKER" "$SUMMARY" "$LINK")
 
-  EXISTING=$(gh api "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" \
-    --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" 2>/dev/null | head -1)
+  post_comment() {
+    local existing
+    existing=$(gh api --paginate "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" \
+      --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" 2>/dev/null) || return 1
+    existing="${existing%%$'\n'*}"
+    if [[ -n "$existing" ]]; then
+      gh api --method PATCH "repos/$SLUG/issues/comments/$existing" -f body="$BODY" >/dev/null 2>&1 \
+        && echo "--- updated coverage comment on PR ${BUILDKITE_PULL_REQUEST}"
+    else
+      gh api --method POST "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" -f body="$BODY" >/dev/null 2>&1 \
+        && echo "--- posted coverage comment on PR ${BUILDKITE_PULL_REQUEST}"
+    fi
+  }
 
-  if [[ -n "$EXISTING" ]]; then
-    gh api --method PATCH "repos/$SLUG/issues/comments/$EXISTING" -f body="$BODY" >/dev/null 2>&1 \
-      && echo "--- updated coverage comment on PR ${BUILDKITE_PULL_REQUEST}" \
-      || echo "--- could not update coverage comment"
+  if post_comment; then
+    :
+  elif command -v vault >/dev/null 2>&1 \
+       && GH_TOKEN=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) \
+       && [[ -n "$GH_TOKEN" ]] \
+       && export GH_TOKEN && post_comment; then
+    echo "    (via vault token)"
   else
-    gh api --method POST "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" -f body="$BODY" >/dev/null 2>&1 \
-      && echo "--- posted coverage comment on PR ${BUILDKITE_PULL_REQUEST}" \
-      || echo "--- could not post coverage comment"
+    echo "--- could not post coverage comment on PR ${BUILDKITE_PULL_REQUEST} (non-fatal)"
   fi
 fi

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -126,3 +126,29 @@ if [[ -n "${BUILDKITE:-}" ]] && command -v buildkite-agent >/dev/null; then
   printf '### Coverage (%s @ %.12s)\n\n```\n%s\n```\n\n%s\n' "$PROJECTS" "$SHA" "$SUMMARY" "$LINK" \
     | buildkite-agent annotate --style info --context coverage
 fi
+
+# Post the summary as a PR comment, updating the previous one rather than piling up.
+#
+# Buildkite publishes a GitHub check per step from a pipeline-side setting that this repo does not
+# control, and coverage steps are not in it - so the annotation above is only visible after
+# clicking into the build. A comment puts the numbers on the PR itself, which is where anyone
+# looking for them will actually look.
+if [[ -n "${BUILDKITE_PULL_REQUEST:-}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] \
+   && command -v gh >/dev/null 2>&1; then
+  MARKER="<!-- coverage-report -->"
+  SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
+  BODY=$(printf '%s\n## Coverage\n\n```\n%s\n```\n\n%s\n' "$MARKER" "$SUMMARY" "$LINK")
+
+  EXISTING=$(gh api "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" \
+    --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" 2>/dev/null | head -1)
+
+  if [[ -n "$EXISTING" ]]; then
+    gh api --method PATCH "repos/$SLUG/issues/comments/$EXISTING" -f body="$BODY" >/dev/null 2>&1 \
+      && echo "--- updated coverage comment on PR ${BUILDKITE_PULL_REQUEST}" \
+      || echo "--- could not update coverage comment"
+  else
+    gh api --method POST "repos/$SLUG/issues/${BUILDKITE_PULL_REQUEST}/comments" -f body="$BODY" >/dev/null 2>&1 \
+      && echo "--- posted coverage comment on PR ${BUILDKITE_PULL_REQUEST}" \
+      || echo "--- could not post coverage comment"
+  fi
+fi

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -52,9 +52,14 @@ fi
 # This agent ran no tests, so the measured projects have to be compiled here. The legs populated
 # the remote build cache, so this is mostly cache hits.
 
+# Only projects with Java main sources have a compileJava task. Asking Gradle for a task that does
+# not exist fails the whole invocation - 13 of 41 matched projects here are qa or grouping projects
+# with no main sources, which is what broke the first run.
 compile_tasks=()
 while IFS= read -r p; do
-  [[ -n "$p" ]] && compile_tasks+=("$p:compileJava")
+  [[ -n "$p" ]] || continue
+  d=$(coverage_project_dir "$ROOT" "$p")
+  [[ -d "$d/src/main/java" ]] && compile_tasks+=("$p:compileJava")
 done < <(coverage_projects "$ROOT" "$PROJECTS")
 if [[ ${#compile_tasks[@]} -eq 0 ]]; then
   echo "no projects match $PROJECTS" >&2
@@ -62,7 +67,9 @@ if [[ ${#compile_tasks[@]} -eq 0 ]]; then
 fi
 echo "--- compiling ${#compile_tasks[@]} projects for report classfiles"
 # shellcheck disable=SC2086
-$GRADLE --continue "${compile_tasks[@]}" || true
+if ! $GRADLE --continue "${compile_tasks[@]}"; then
+  echo "--- some projects failed to compile; the report will cover only what did"
+fi
 
 PATH_ARGS=()
 while IFS= read -r a; do PATH_ARGS+=("$a"); done < <(coverage_report_path_args "$ROOT" "$PROJECTS" "$INCLUDES")

--- a/.buildkite/scripts/coverage/publish.sh
+++ b/.buildkite/scripts/coverage/publish.sh
@@ -111,6 +111,10 @@ report_one merged "$OUT/merged.exec"
 SUMMARY=$("$ROOT/.buildkite/scripts/coverage/summarise.sh" "$REPORT" | tee "$OUT/summary.txt")
 echo "$SUMMARY"
 
+# Numbers into the metrics cluster, so a run contributes to a trend rather than only to its own
+# build. Never fails the step - see the script for why.
+"$ROOT/.buildkite/scripts/coverage/index-results.sh" "$REPORT" || true
+
 # --- publish + annotate --------------------------------------------------------------------------
 
 LINK="report is in this step's artifacts (build/coverage/report/)"

--- a/.buildkite/scripts/coverage/run-coverage.sh
+++ b/.buildkite/scripts/coverage/run-coverage.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+#
+# Measure code coverage for a chosen slice of the build, per layer and merged.
+#
+#   .buildkite/scripts/coverage/run-coverage.sh
+#
+# Parameters, all optional, all environment variables:
+#
+#   COVERAGE_PROJECTS  Gradle project-path pattern (default ':x-pack:plugin:esql-datasource-*')
+#   COVERAGE_INCLUDES  JaCoCo class-include pattern, colon-separated
+#   COVERAGE_LAYERS    comma-separated: unit,internal-cluster,cluster  (default: all three)
+#   COVERAGE_OUTPUT    output directory (default: build/coverage)
+#   COVERAGE_PORT      collector port for cluster-node coverage (default: 6300)
+#
+# Produces, under COVERAGE_OUTPUT:
+#   exec/<layer>/  raw execution data, one file per task, kept per layer
+#   report/<layer> HTML + XML for each layer on its own
+#   report/merged  HTML + XML for the union, when more than one layer ran
+#   summary.txt    headline numbers
+#
+# Layers are reported separately AND merged. They are never averaged: a line covered by two layers
+# is one covered line, so the union has to be computed from the execution data itself. Merging is
+# what `jacococli merge` is for.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+# shellcheck source=lib.sh
+source "$ROOT/.buildkite/scripts/coverage/lib.sh"
+
+PROJECTS="${COVERAGE_PROJECTS:-:x-pack:plugin:esql-datasource-*}"
+INCLUDES="${COVERAGE_INCLUDES:-org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*:org.elasticsearch.arrow.*}"
+LAYERS="${COVERAGE_LAYERS:-unit,internal-cluster,cluster}"
+OUT="${COVERAGE_OUTPUT:-$ROOT/build/coverage}"
+PORT="${COVERAGE_PORT:-6300}"
+
+# In CI, hooks/pre-command exports GRADLEW with the build cache and scan flags; locally the plain
+# wrapper is fine. Unquoted expansion below is deliberate: GRADLEW carries its flags inline.
+GRADLE="${GRADLEW:-./gradlew}"
+
+LIB="$OUT/lib"
+EXEC="$OUT/exec"
+REPORT="$OUT/report"
+mkdir -p "$LIB" "$EXEC" "$REPORT"
+
+# --- tooling -------------------------------------------------------------------------------------
+
+coverage_fetch_tools "$LIB"
+
+COLLECTOR_SRC="$ROOT/.buildkite/scripts/coverage/CollectorServer.java"
+if [[ ! -f "$LIB/CollectorServer.class" || "$COLLECTOR_SRC" -nt "$LIB/CollectorServer.class" ]]; then
+  javac -cp "$CLI" -d "$LIB" "$COLLECTOR_SRC"
+fi
+
+# --- which tasks exist ---------------------------------------------------------------------------
+#
+# Enumerated (see lib.sh) rather than hardcoded, so a module that gains a suite is picked up
+# automatically instead of being silently missed.
+
+# --- run each layer ------------------------------------------------------------------------------
+
+COLLECTOR_PID=""
+start_collector() {
+  local dest="$1"
+  java -cp "$LIB:$CLI" CollectorServer "$PORT" "$dest" &
+  COLLECTOR_PID=$!
+  sleep 2
+  if ! kill -0 "$COLLECTOR_PID" 2>/dev/null; then
+    echo "collector failed to start (port $PORT in use?)" >&2
+    exit 1
+  fi
+}
+stop_collector() {
+  if [[ -n "$COLLECTOR_PID" ]]; then
+    kill "$COLLECTOR_PID" 2>/dev/null || true
+    wait "$COLLECTOR_PID" 2>/dev/null || true
+  fi
+  COLLECTOR_PID=""
+}
+# No orphaned collector if the script dies mid-layer (e.g. a step timeout kills gradle).
+trap stop_collector EXIT
+
+# First non-zero gradle exit code across layers. Reported at the very end - after exec collection,
+# the zero gate and the reports - so a leg with failing tests still yields its data and then shows
+# honestly red. Coverage from the tasks that did run is a valid lower bound.
+WORST_RC=0
+
+run_layer() {
+  local layer="$1"; shift
+  local tasks="$*"
+  if [[ -z "${tasks// /}" ]]; then
+    echo "--- $layer: no tasks, skipping"
+    return 0
+  fi
+
+  echo "--- running $layer: $tasks"
+  local layer_exec="$EXEC/$layer"
+  mkdir -p "$layer_exec"
+
+  # Cluster layers need the collector: node processes dial out to it, because they are killed
+  # rather than shut down and cannot write a file on exit. coverage.port is only passed for this
+  # layer — it is what arms the node-instrumentation channel in gradle/coverage.gradle, so unit
+  # and internal-cluster test JVMs never carry a tcpclient agent pointing at a dead port.
+  local port_arg=()
+  if [[ "$layer" == "cluster" ]]; then
+    start_collector "$layer_exec/nodes.exec"
+    port_arg=("-Dcoverage.port=$PORT")
+  fi
+
+  set +e
+  # shellcheck disable=SC2086
+  $GRADLE --continue \
+    -I gradle/coverage.gradle \
+    -Dcoverage.agent="$AGENT" \
+    -Dcoverage.includes="$INCLUDES" \
+    -Dcoverage.output="$OUT/$layer" \
+    -Dcoverage.projects="$PROJECTS" \
+    ${port_arg[@]+"${port_arg[@]}"} \
+    $tasks
+  local rc=$?
+  set -e
+
+  [[ "$layer" == "cluster" ]] && stop_collector
+
+  find "$OUT/$layer/exec" -name '*.exec' -exec mv {} "$layer_exec/" \; 2>/dev/null || true
+  echo "--- $layer finished (gradle rc=$rc)"
+  [[ "$rc" -ne 0 && "$WORST_RC" -eq 0 ]] && WORST_RC=$rc
+  return 0
+}
+
+# Every test task on the matched projects must map to a layer. A suite we do not know how to
+# measure is a loud failure, not a silent omission - otherwise we report a smaller number as though
+# it were the whole picture.
+# Ask Gradle for the real test tasks - never guess them from directory names.
+TASKLIST="$OUT/tasks.list"
+echo "--- enumerating test tasks from Gradle"
+coverage_enumerate_tasks "$ROOT" "$PROJECTS" "$TASKLIST" "$GRADLE"
+echo "--- $(wc -l < "$TASKLIST" | tr -d ' ') test tasks found"
+
+IFS=',' read -ra WANTED <<< "$LAYERS"
+for layer in "${WANTED[@]}"; do
+  case "$layer" in
+    unit|internal-cluster|cluster) ;;
+    *) echo "unknown layer '$layer' in COVERAGE_LAYERS (expected unit,internal-cluster,cluster)" >&2; exit 1 ;;
+  esac
+done
+# The enumeration result is captured in an assignment, not substituted inline in the run_layer
+# call: a command substitution in an argument position discards its exit status, which would
+# reduce the unmapped-task failure to a stderr message while the run continued without the
+# unmapped suite. Any unmapped task aborts here, before any Gradle work is spent.
+for layer in "${WANTED[@]}"; do
+  if ! layer_tasks=$(coverage_tasks_for_layer "$TASKLIST" "$layer"); then
+    exit 1
+  fi
+  run_layer "$layer" "$(printf '%s' "$layer_tasks" | tr '\n' ' ')"
+done
+
+# A layer with no matching tasks produces no execution data at all. That is "nothing to measure",
+# which is different from the broken-instrument case (tasks ran, nothing recorded) gated below.
+if [[ -z "$(find "$EXEC" -name '*.exec' 2>/dev/null | head -1)" ]]; then
+  echo "--- no matching tasks ran for $PROJECTS in layers [$LAYERS]; nothing to report"
+  exit 0
+fi
+
+# --- fail loudly on zero -------------------------------------------------------------------------
+#
+# An exec file that exists but records nothing is worse than no file: it reads as a finding rather
+# than as a broken instrument. This has been mistaken for a result before.
+
+"$ROOT/.buildkite/scripts/coverage/check-nonzero.sh" "$EXEC" "$CLI"
+
+# --- report --------------------------------------------------------------------------------------
+
+PATH_ARGS=()
+while IFS= read -r a; do PATH_ARGS+=("$a"); done < <(coverage_report_path_args "$ROOT" "$PROJECTS" "$INCLUDES")
+if [[ ${#PATH_ARGS[@]} -eq 0 ]]; then
+  echo "no compiled classes found for pattern $PROJECTS - cannot build a report" >&2
+  exit 1
+fi
+
+report_one() {
+  local name="$1"; shift
+  [[ $# -eq 0 ]] && return 0
+  mkdir -p "$REPORT/$name"
+  java -jar "$CLI" report "$@" \
+    "${PATH_ARGS[@]}" \
+    --html "$REPORT/$name/html" \
+    --xml "$REPORT/$name/coverage.xml" \
+    --csv "$REPORT/$name/coverage.csv" \
+    --name "$name" >/dev/null
+}
+
+for layer in "${WANTED[@]}"; do
+  execs=()
+  while IFS= read -r f; do execs+=("$f"); done < <(find "$EXEC/$layer" -name '*.exec' 2>/dev/null)
+  report_one "$layer" ${execs[@]+"${execs[@]}"}
+done
+
+# The merged view. Computed from the union of execution data, never from the per-layer
+# percentages. Written outside exec/ so the CI artifact glob only ever picks up raw layer data.
+if [[ ${#WANTED[@]} -gt 1 ]]; then
+  all_execs=()
+  while IFS= read -r f; do all_execs+=("$f"); done < <(find "$EXEC" -name '*.exec' 2>/dev/null)
+  if [[ ${#all_execs[@]} -gt 0 ]]; then
+    java -jar "$CLI" merge "${all_execs[@]}" --destfile "$OUT/merged.exec" >/dev/null
+    report_one merged "$OUT/merged.exec"
+  fi
+fi
+
+"$ROOT/.buildkite/scripts/coverage/summarise.sh" "$REPORT" | tee "$OUT/summary.txt"
+echo "--- reports in $REPORT"
+
+if [[ "$WORST_RC" -ne 0 ]]; then
+  echo "--- test failures occurred (gradle rc=$WORST_RC); coverage above is a lower bound"
+  exit "$WORST_RC"
+fi

--- a/.buildkite/scripts/coverage/status.sh
+++ b/.buildkite/scripts/coverage/status.sh
@@ -25,6 +25,18 @@ DESCRIPTION="${3:-}"
 [[ -z "${BUILDKITE_COMMIT:-}" ]] && exit 0
 command -v gh >/dev/null 2>&1 || { echo "gh unavailable - no status posted for $NAME"; exit 0; }
 
+# GH_TOKEN is exported by hooks/pre-command from VAULT_GITHUB_TOKEN, which is only populated for
+# steps that ask for it. Without a token gh is unauthenticated and cannot write a status, so fall
+# back to the SAML-authorized admin token the agentic-workflows path carries.
+if [[ -z "${GH_TOKEN:-}" ]] && command -v vault >/dev/null 2>&1; then
+  GH_TOKEN=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) || true
+  export GH_TOKEN
+fi
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "--- no GH_TOKEN available - cannot post status coverage/$NAME"
+  exit 0
+fi
+
 SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
 URL="${BUILDKITE_BUILD_URL:-}"
 [[ -n "${BUILDKITE_JOB_ID:-}" && -n "$URL" ]] && URL="$URL#${BUILDKITE_JOB_ID}"
@@ -33,8 +45,8 @@ gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" \
   -f state="$STATE" \
   -f context="coverage/$NAME" \
   -f description="${DESCRIPTION:0:139}" \
-  -f target_url="$URL" >/dev/null 2>&1 \
+  -f target_url="$URL" >/tmp/status-out 2>&1 \
   && echo "--- status coverage/$NAME -> $STATE" \
-  || echo "--- could not post status coverage/$NAME (non-fatal)"
+  || { echo "--- could not post status coverage/$NAME (non-fatal):"; head -3 /tmp/status-out; }
 
 exit 0

--- a/.buildkite/scripts/coverage/status.sh
+++ b/.buildkite/scripts/coverage/status.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Publish a GitHub commit status for one coverage step.
+#
+#   status.sh <name> pending|success|failure|error [description]
+#
+# Why this exists: Buildkite's commit-status integration publishes a status per job and names it
+# from the step, but coverage steps do not appear on the PR through it. Rather than change how
+# other pipelines are declared, or wait on an integration this repo does not configure, each
+# coverage step publishes its own status. Fully self-contained: nothing outside these scripts
+# changes, and the result is visible on the PR from the moment a leg starts.
+#
+# Context is `coverage/<name>`, deliberately not the `elasticsearch-ci/` namespace - those belong
+# to the existing integration, and the pipeline has
+# `prevent_custom_statuses_from_using_buildkite_prefix` set.
+#
+# Never fails the caller. A step must not go red because a status could not be posted.
+set -uo pipefail
+
+NAME="${1:?usage: status.sh <name> <state> [description]}"
+STATE="${2:?usage: status.sh <name> <state> [description]}"
+DESCRIPTION="${3:-}"
+
+[[ -z "${BUILDKITE:-}" ]] && exit 0
+[[ -z "${BUILDKITE_COMMIT:-}" ]] && exit 0
+command -v gh >/dev/null 2>&1 || { echo "gh unavailable - no status posted for $NAME"; exit 0; }
+
+SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
+URL="${BUILDKITE_BUILD_URL:-}"
+[[ -n "${BUILDKITE_JOB_ID:-}" && -n "$URL" ]] && URL="$URL#${BUILDKITE_JOB_ID}"
+
+gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" \
+  -f state="$STATE" \
+  -f context="coverage/$NAME" \
+  -f description="${DESCRIPTION:0:139}" \
+  -f target_url="$URL" >/dev/null 2>&1 \
+  && echo "--- status coverage/$NAME -> $STATE" \
+  || echo "--- could not post status coverage/$NAME (non-fatal)"
+
+exit 0

--- a/.buildkite/scripts/coverage/status.sh
+++ b/.buildkite/scripts/coverage/status.sh
@@ -10,9 +10,9 @@
 # coverage step publishes its own status. Fully self-contained: nothing outside these scripts
 # changes, and the result is visible on the PR from the moment a leg starts.
 #
-# Context is `coverage/<name>`, deliberately not the `elasticsearch-ci/` namespace - those belong
-# to the existing integration, and the pipeline has
-# `prevent_custom_statuses_from_using_buildkite_prefix` set.
+# Context is `coverage/<name>`: a namespace of our own, so it can never collide with what the
+# integrations publish - `elasticsearch-ci/...` belongs to the trigger system, and `buildkite/...`
+# is reserved by the pipeline's `prevent_custom_statuses_from_using_buildkite_prefix` setting.
 #
 # Never fails the caller. A step must not go red because a status could not be posted.
 set -uo pipefail
@@ -25,33 +25,46 @@ DESCRIPTION="${3:-}"
 [[ -z "${BUILDKITE_COMMIT:-}" ]] && exit 0
 command -v gh >/dev/null 2>&1 || { echo "gh unavailable - no status posted for $NAME"; exit 0; }
 
-SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
+# Statuses go on the base repo. Buildkite has no variable carrying an owner/repo slug, only the
+# checkout URL - derive the slug from it, falling back to the base repo if the URL is exotic.
+SLUG="${BUILDKITE_REPO:-}"   # git@github.com:owner/repo.git or https://github.com/owner/repo.git
+SLUG="${SLUG##*github.com?}"
+SLUG="${SLUG%.git}"
+[[ "$SLUG" == ?*/?* && "$SLUG" != *:* && "$SLUG" != */*/* ]] || SLUG="elastic/elasticsearch"
+
 URL="${BUILDKITE_BUILD_URL:-}"
 [[ -n "${BUILDKITE_JOB_ID:-}" && -n "$URL" ]] && URL="$URL#${BUILDKITE_JOB_ID}"
+
+OUT_FILE="$(mktemp /tmp/coverage-status.XXXXXX 2>/dev/null || echo "/tmp/coverage-status.$$")"
 
 # Auth. The ambient GH_TOKEN (hooks/pre-command, from VAULT_GITHUB_TOKEN) is a GitHub App token
 # without `statuses: write` - it returns 403 "Resource not accessible by integration". So try it,
 # and on failure retry with the SAML-authorized token in Vault, which can write statuses.
 #
 # The retry is on failure rather than on an empty token: the ambient one is present but
-# insufficient, so an emptiness check never fires.
+# insufficient, so an emptiness check never fires. A retry with an empty vault read would be
+# unauthenticated and would overwrite the first attempt's diagnostics, hence the -n guard.
 post_status() {
-  gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" \
-    -f state="$STATE" \
-    -f context="coverage/$NAME" \
-    -f description="${DESCRIPTION:0:139}" \
-    -f target_url="$URL" >/tmp/status-out 2>&1
+  local args=(
+    -f state="$STATE"
+    -f context="coverage/$NAME"
+    -f description="${DESCRIPTION:0:139}"
+  )
+  [[ -n "$URL" ]] && args+=(-f target_url="$URL")
+  gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" "${args[@]}" >"$OUT_FILE" 2>&1
 }
 
 if post_status; then
   echo "--- status coverage/$NAME -> $STATE"
 elif command -v vault >/dev/null 2>&1 \
      && GH_TOKEN=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) \
+     && [[ -n "$GH_TOKEN" ]] \
      && export GH_TOKEN && post_status; then
   echo "--- status coverage/$NAME -> $STATE (via vault token)"
 else
   echo "--- could not post status coverage/$NAME (non-fatal):"
-  head -3 /tmp/status-out
+  head -3 "$OUT_FILE" 2>/dev/null
 fi
 
+rm -f "$OUT_FILE"
 exit 0

--- a/.buildkite/scripts/coverage/status.sh
+++ b/.buildkite/scripts/coverage/status.sh
@@ -25,28 +25,33 @@ DESCRIPTION="${3:-}"
 [[ -z "${BUILDKITE_COMMIT:-}" ]] && exit 0
 command -v gh >/dev/null 2>&1 || { echo "gh unavailable - no status posted for $NAME"; exit 0; }
 
-# GH_TOKEN is exported by hooks/pre-command from VAULT_GITHUB_TOKEN, which is only populated for
-# steps that ask for it. Without a token gh is unauthenticated and cannot write a status, so fall
-# back to the SAML-authorized admin token the agentic-workflows path carries.
-if [[ -z "${GH_TOKEN:-}" ]] && command -v vault >/dev/null 2>&1; then
-  GH_TOKEN=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) || true
-  export GH_TOKEN
-fi
-if [[ -z "${GH_TOKEN:-}" ]]; then
-  echo "--- no GH_TOKEN available - cannot post status coverage/$NAME"
-  exit 0
-fi
-
 SLUG="${BUILDKITE_REPO_SLUG:-elastic/elasticsearch}"
 URL="${BUILDKITE_BUILD_URL:-}"
 [[ -n "${BUILDKITE_JOB_ID:-}" && -n "$URL" ]] && URL="$URL#${BUILDKITE_JOB_ID}"
 
-gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" \
-  -f state="$STATE" \
-  -f context="coverage/$NAME" \
-  -f description="${DESCRIPTION:0:139}" \
-  -f target_url="$URL" >/tmp/status-out 2>&1 \
-  && echo "--- status coverage/$NAME -> $STATE" \
-  || { echo "--- could not post status coverage/$NAME (non-fatal):"; head -3 /tmp/status-out; }
+# Auth. The ambient GH_TOKEN (hooks/pre-command, from VAULT_GITHUB_TOKEN) is a GitHub App token
+# without `statuses: write` - it returns 403 "Resource not accessible by integration". So try it,
+# and on failure retry with the SAML-authorized token in Vault, which can write statuses.
+#
+# The retry is on failure rather than on an empty token: the ambient one is present but
+# insufficient, so an emptiness check never fires.
+post_status() {
+  gh api --method POST "repos/$SLUG/statuses/$BUILDKITE_COMMIT" \
+    -f state="$STATE" \
+    -f context="coverage/$NAME" \
+    -f description="${DESCRIPTION:0:139}" \
+    -f target_url="$URL" >/tmp/status-out 2>&1
+}
+
+if post_status; then
+  echo "--- status coverage/$NAME -> $STATE"
+elif command -v vault >/dev/null 2>&1 \
+     && GH_TOKEN=$(vault read -field=gh_admin_token secret/ci/elastic-elasticsearch/agentic-workflows 2>/dev/null) \
+     && export GH_TOKEN && post_status; then
+  echo "--- status coverage/$NAME -> $STATE (via vault token)"
+else
+  echo "--- could not post status coverage/$NAME (non-fatal):"
+  head -3 /tmp/status-out
+fi
 
 exit 0

--- a/.buildkite/scripts/coverage/summarise.sh
+++ b/.buildkite/scripts/coverage/summarise.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Print headline coverage per layer and merged, from the CSV reports.
+set -euo pipefail
+shopt -s nullglob
+REPORT="$1"
+printf '%-18s %-22s %s\n' "LAYER" "LINE" "BRANCH"
+for d in "$REPORT"/*/; do
+  name=$(basename "$d")
+  csv="$d/coverage.csv"
+  [[ -f "$csv" ]] || continue
+  python3 - "$name" "$csv" <<'PY'
+import csv, sys
+name, path = sys.argv[1], sys.argv[2]
+rows = list(csv.DictReader(open(path)))
+lc = sum(int(r['LINE_COVERED']) for r in rows); lm = sum(int(r['LINE_MISSED']) for r in rows)
+bc = sum(int(r['BRANCH_COVERED']) for r in rows); bm = sum(int(r['BRANCH_MISSED']) for r in rows)
+lt, bt = lc+lm, bc+bm
+print(f"{name:<18} {lc:>6}/{lt:<7} {100*lc/max(lt,1):5.1f}%   {bc:>6}/{bm+bc:<7} {100*bc/max(bt,1):5.1f}%")
+PY
+done

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -68,6 +68,20 @@ const changedFilesIncludedCheck = (pipeline: EsPipeline, changedFiles: string[])
   return true;
 };
 
+// Include the pipeline if ANY of the changed files in the PR is in at least one touched region.
+//
+// This is deliberately different from included-regions, which requires EVERY changed file to match
+// and so detects docs-only-style PRs. touched-regions answers the other question: "does this PR go
+// anywhere near my area?" - which is what an area-scoped optional pipeline wants.
+const changedFilesTouchedCheck = (pipeline: EsPipeline, changedFiles: string[]): boolean => {
+  if (pipeline.config?.["touched-regions"]) {
+    return changedFiles.some((file) =>
+      getArray(pipeline.config?.["touched-regions"]).some((region) => file.match(region)),
+    );
+  }
+  return true;
+};
+
 const checkTargetBranch = (pipeline: EsPipeline, targetBranch: string | undefined) => {
   if (!targetBranch || !pipeline.config?.["skip-target-branches"]) {
     return true;
@@ -191,6 +205,7 @@ export const generatePipelines = (
     (pipeline) => labelCheckSkip(pipeline, labels),
     (pipeline) => changedFilesExcludedCheck(pipeline, changedFiles),
     (pipeline) => changedFilesIncludedCheck(pipeline, changedFiles),
+    (pipeline) => changedFilesTouchedCheck(pipeline, changedFiles),
   ];
 
   // When triggering via the "run elasticsearch-ci/step-name" comment, we ONLY want to run pipelines that match the trigger phrase, regardless of labels, etc

--- a/.buildkite/scripts/pull-request/types.ts
+++ b/.buildkite/scripts/pull-request/types.ts
@@ -3,6 +3,7 @@ export type EsPipelineConfig = {
     "allow-labels"?: string | string[];
     "skip-labels"?: string | string[];
     "included-regions"?: string | string[];
+    "touched-regions"?: string | string[];
     "excluded-regions"?: string | string[];
     "trigger-phrase"?: string;
     "skip-target-branches"?: string | string[];

--- a/gradle/coverage-tasks.gradle
+++ b/gradle/coverage-tasks.gradle
@@ -1,0 +1,46 @@
+/*
+ * Enumerate the real test tasks, from the build itself.
+ *
+ *   ./gradlew -I gradle/coverage-tasks.gradle -Dcoverage.projects=':x-pack:plugin:esql*' \
+ *             -Dcoverage.tasklist=/tmp/tasks.tsv coverageTaskList
+ *
+ * Writes one task path per line.
+ *
+ * Why this exists rather than a list of known task names: task names do not reliably follow their
+ * source set. `src/csvSpecTest` registers a task called `csvSpecTests`, plural — unguessable, and
+ * a hardcoded list that omitted it silently dropped six suites from an earlier version of this
+ * tooling. The build knows the answer; asking it is the only way to be right.
+ *
+ * One configuration pass over the matched projects, not one per project.
+ */
+
+def projectPattern = System.getProperty('coverage.projects', ':x-pack:plugin:esql*')
+def outFile = System.getProperty('coverage.tasklist')
+
+if (outFile == null) {
+    throw new GradleException('coverage.tasklist is required: -Dcoverage.tasklist=/path/to/tasks.tsv')
+}
+
+// '*' matches any run of characters, including ':'. Keep in sync with coverage_pattern_regex
+// in .buildkite/scripts/coverage/lib.sh.
+def projectRegex = ~('^' + java.util.regex.Pattern.quote(projectPattern).replace('*', '\\E.*\\Q') + '$')
+
+gradle.rootProject { root ->
+    root.tasks.register('coverageTaskList') {
+        doLast {
+            def lines = []
+            root.allprojects.each { proj ->
+                if (!projectRegex.matcher(proj.path).matches()) {
+                    return
+                }
+                // Iterating the live TaskCollection realises lazily-registered tasks, so this
+                // sees every Test task, not just the ones something else already realised.
+                proj.tasks.withType(Test).each { t ->
+                    lines << "${proj.path}:${t.name}".toString()
+                }
+            }
+            new File(outFile).text = lines.sort().join('\n') + (lines ? '\n' : '')
+            logger.lifecycle("coverage: ${lines.size()} test tasks written to ${outFile}")
+        }
+    }
+}

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,0 +1,113 @@
+/*
+ * Code-coverage instrumentation, applied as an init script:
+ *
+ *   ./gradlew -I gradle/coverage.gradle -Dcoverage.agent=... -Dcoverage.projects=':x-pack:plugin:esql-datasource-*' ...
+ *
+ * Attaches the JaCoCo agent to the JVMs that actually execute product code. There are two of
+ * those, and the second is the one that is easy to get wrong:
+ *
+ *   1. Forked test JVMs — unit tests and internalClusterTest (whose cluster is in-JVM), reached
+ *      through jvmArgumentProviders.
+ *
+ *   2. Test-cluster node processes — javaRestTest/yamlRestTest/qa run product code in separate ES
+ *      node JVMs that Gradle does not launch. AbstractLocalClusterFactory joins the test JVM's
+ *      `tests.jvm.argline` system property into each node's ES_JAVA_OPTS, so setting it per test
+ *      task is how the agent gets in. (Setting it as a *task* system property reaches only the
+ *      node JVMs; ElasticsearchTestBasePlugin reads the same-named property from the build JVM,
+ *      absent here, so the test JVM does not get a second agent.)
+ *
+ * Nodes use output=tcpclient rather than a file, for three independent reasons:
+ *
+ *   - Cluster teardown is forcible: DefaultLocalClusterHandle.close() calls stop(true), which is
+ *     ProcessUtils.stopHandle -> destroyForcibly. No shutdown hook runs, so `dumponexit` never
+ *     writes. Coverage has to leave the process before it dies.
+ *   - Even on a graceful stop, the entitlements runtime denies the JaCoCo shutdown-hook file
+ *     write inside the node process (NotEntitledException on FileOutput.write, verified
+ *     2026-07-29). In tcpclient mode all file I/O happens in the collector process instead.
+ *   - `tests.jvm.argline` is task-wide, so every concurrent node gets identical options. With
+ *     output=tcpserver they would all try to bind the same port and all but one would fail.
+ *
+ * In tcpclient mode each node dials out to CollectorServer, which requests dumps while the node is
+ * still alive. See .buildkite/scripts/coverage/CollectorServer.java. The node channels are armed
+ * only when -Dcoverage.port is set (the runner sets it for the cluster layer only), so unit and
+ * internal-cluster runs never configure an agent that would dial a dead port.
+ *
+ * This file is deliberately parameterised: it hardcodes the mechanism, never the target.
+ */
+
+import org.gradle.process.CommandLineArgumentProvider
+
+// --- Parameters. Everything about *what* is measured comes from here. ---------------------------
+
+// Gradle project-path pattern selecting the projects to instrument, e.g. ':x-pack:plugin:esql*'.
+// Standard Gradle path syntax; '*' matches any run of characters.
+def projectPattern = System.getProperty('coverage.projects', ':x-pack:plugin:esql*')
+
+// JaCoCo class-include pattern, colon-separated. Standard agent syntax.
+def includes = System.getProperty(
+    'coverage.includes',
+    'org.elasticsearch.xpack.esql.*:org.elasticsearch.compute.*:org.elasticsearch.arrow.*'
+)
+
+// Where exec files land, and where CollectorServer is listening for node connections. The node
+// channels are configured only when coverage.port is set.
+def outputDir = new File(System.getProperty('coverage.output', "${System.getProperty('java.io.tmpdir')}/coverage"))
+def agentJar = System.getProperty('coverage.agent')
+def collectorPort = System.getProperty('coverage.port')
+
+if (agentJar == null) {
+    throw new GradleException('coverage.agent is required: -Dcoverage.agent=/path/to/org.jacoco.agent-runtime.jar')
+}
+
+def execDir = new File(outputDir, 'exec')
+execDir.mkdirs()
+
+// Translate the project-path pattern into a regex once. '*' matches any run of characters,
+// including ':'. Keep in sync with coverage_pattern_regex in .buildkite/scripts/coverage/lib.sh.
+def projectRegex = ~('^' + java.util.regex.Pattern.quote(projectPattern).replace('*', '\\E.*\\Q') + '$')
+
+// --- Mechanism. Fixed; do not parameterise. ----------------------------------------------------
+
+allprojects { proj ->
+    if (!projectRegex.matcher(proj.path).matches()) {
+        return
+    }
+
+    proj.tasks.withType(Test).configureEach { t ->
+
+        // (1) The forked test JVM itself. Covers unit tests, and internalClusterTest because its
+        // cluster runs in-process.
+        def dest = new File(execDir, (proj.path + '__' + t.name).replaceAll('[:/#]', '_') + '.exec')
+        t.jvmArgumentProviders.add(new CommandLineArgumentProvider() {
+            @Override
+            Iterable<String> asArguments() {
+                return ["-javaagent:${agentJar}=destfile=${dest.absolutePath},append=true,output=file,dumponexit=true,includes=${includes}".toString()]
+            }
+        })
+
+        // (2) Test-cluster node processes launched by the JUnit local-cluster framework
+        // (ElasticsearchCluster @ClassRule). Read the header comment before changing any of this.
+        if (collectorPort != null) {
+            t.systemProperty(
+                'tests.jvm.argline',
+                "-javaagent:${agentJar}=output=tcpclient,address=127.0.0.1,port=${collectorPort},includes=${includes}".toString()
+            )
+        }
+    }
+
+    // (3) Node processes launched by the legacy Gradle testclusters plugin. The ES|QL qa suites
+    // do not use this (verified: their clusters come from the JUnit local-cluster framework), but
+    // other targets of the parameterised scope may. Same tcpclient channel, same collector.
+    if (collectorPort != null) {
+        proj.plugins.withId('elasticsearch.testclusters') {
+            def container = proj.extensions.findByName('testClusters')
+            if (container != null) {
+                container.configureEach { cluster ->
+                    cluster.jvmArgs(
+                        "-javaagent:${agentJar}=output=tcpclient,address=127.0.0.1,port=${collectorPort},includes=${includes}".toString()
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this is about

`TESTING.asciidoc` tells every engineer that code coverage is not possible through Gradle. That was true in 2018: the custom `RandomizedTestingTask` did not extend Gradle's `Test`, so the JaCoCo plugin could not see test tasks. The build moved to standard `Test` tasks years ago and the limitation went with it. Nobody re-checked, because the docs said not to bother.

Coverage works. This makes it repeatable, for any part of the repository.

## What this PR does

Adds an opt-in pipeline that measures coverage for a chosen scope and reports it per test layer and merged.

Three things are configured, each in one place, in `.buildkite/pipelines/pull-request/test-coverage.yml`:

- **When it runs** — `allow-labels: test-coverage`. Nothing runs without the label.
- **What it measures** — `COVERAGE_PROJECTS`, a Gradle project-path pattern, and `COVERAGE_INCLUDES`, a JaCoCo class pattern. Each in its own tool's native syntax; there is no coverage DSL.
- **Which tests** — `COVERAGE_LAYERS`, defaulting to all three layers, one parallel leg each.

Another area is another file with a different label and scope. Nothing about ES|QL lives in the scripts.

Test tasks are enumerated from Gradle rather than guessed. A task the layer mapping does not cover **fails the run** instead of being silently skipped — a guessed list was wrong four ways, missing seven suites including all six `csvSpecTests`.

## Layers are merged, never averaged

Tests run in three places, and coverage differs by which:

| Layer | Tasks | Where product code runs |
|---|---|---|
| `unit` | `test` | the forked test JVM |
| `internal-cluster` | `internalClusterTest` | the forked test JVM — cluster is in-process |
| `cluster` | `javaRestTest`, `yamlRestTest`, `csvSpecTests`, `javaRestTestSecure` | **separate ES node processes** |

A line covered by two layers is one covered line, so the union is computed from the execution data rather than from percentages. On `esql-datasource-s3`: unit 69.1%, cluster 47.0%, merged **78.7%**. Adding gives 116%, averaging gives 58%; both are wrong.

Differencing a layer against merged answers *"if we dropped this suite, what goes dark"*.

## The cluster layer is the interesting part

Product code for REST tests runs in ES node processes, not the test JVM, and getting coverage out of them fails two independent ways. `DefaultLocalClusterHandle.close()` stops nodes with `destroyForcibly`, so no shutdown hook runs and `dumponexit` never writes. And entitlements deny the agent's file write inside the node regardless of how it exits.

So the agent runs in `output=tcpclient` and dials out to a collector that requests dumps while nodes are alive. `tcpserver` cannot work: `tests.jvm.argline` is task-wide, so every concurrent node would receive the same options and fight over one port.

## Does it work?

Yes. Measured on the full ES|QL surface — about 263,000 executable lines:

| Layer | Line | Branch |
|---|---|---|
| unit | **70.5%** | 62.4% |
| internal-cluster | **52.8%** | 41.7% |

Per-layer HTML reports upload as artifacts, and each step posts its own commit status to the PR.

## Two rules it is built around

**Report, never gate.** No thresholds, no failing a build on a number. A coverage gate is satisfiable by tests that execute without asserting, which is the wrong pressure to create. These checks are not required checks and cannot block a merge.

**Fail loudly on zero.** An exec file recording nothing fails the build before anything publishes. An empty file reports as 0% and reads as a finding when it actually means the instrument is broken. The cluster layer distinguishes *no agent connected* from *connected but recorded nothing*, because those have different fixes.

## This is a shortcut, deliberately

It bypasses Gradle's JaCoCo plugin, attaching the agent through an init script and building reports with the offline `jacococli`. That decoupling is why it worked first try across 19 modules with no build changes — but it is not the end state.

**Deeper integration with JaCoCo is the goal**: coverage inside the build, with its own credential, its own home for published reports, and results surfacing the way every other check does. That is `@elastic/es-delivery` territory and needs their time. This lands the capability now and proves its value first.

Known rough edges, all self-contained:

- It borrows a GitHub token from another pipeline's Vault path, because the ambient CI token lacks `statuses: write`. A purpose-scoped credential would be better.
- Publishing HTML to `download.elasticsearch.org/coverage/` needs a Vault credential that does not exist yet. Until then the report is a build artifact and the summary is annotated inline.
- The `test-coverage` label must be applied when the PR is opened — CI reads labels at build start, so a label added later is not seen by the build already running.

## What's out of scope

BWC-versioned suites and `bcUpgradeTest`: they run old-version nodes, whose coverage cannot map onto current classfiles. `perfSmokeTest`: it measures speed, not behaviour. `parquet-rs`: being retired. All excluded by default, includable explicitly.

## Files

| File | Purpose |
|---|---|
| `gradle/coverage.gradle` | init script; attaches the agent. Parameterised by target, fixed in mechanism |
| `gradle/coverage-tasks.gradle` | enumerates real test tasks from the build |
| `.buildkite/scripts/coverage/CollectorServer.java` | receives coverage from node processes over TCP |
| `.buildkite/scripts/coverage/run-coverage.sh` | runs a layer, gates, reports |
| `.buildkite/scripts/coverage/publish.sh` | merges across legs, publishes, annotates |
| `.buildkite/scripts/coverage/CONFIGURATION.md` | the three controls, in full |
| `.buildkite/pipelines/pull-request/test-coverage.yml` | the pipeline |

One existing file changes: a negation in `.buildkite/.gitignore`, so the istanbul `coverage` rule does not swallow the scripts. `pipeline.ts` gains a `touched-regions` filter — `included-regions` requires *every* changed file to match, which detects docs-only PRs; `touched-regions` matches if *any* does. Available to any pipeline.
