### PR TITLE
[8.19] Fix OperatorTestCase small input size

### DIFF
--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
@@ -73,7 +73,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
     }
 
     protected int smallInputSize() {
-        return randomIntBetween(1, 100);
+        return randomIntBetween(10, 100);
     }
 
     /**


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/136982 to 8.19

Closes https://github.com/elastic/elasticsearch/issues/155330 and https://github.com/elastic/elasticsearch/issues/155325