### PR TITLE
ESQL:DS: Correct federation release to 9.5

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -25,7 +25,7 @@ public class Clusters {
      * release constants, so the boundary is converted from the server constant instead of being spelled out again. The
      * qualified name disambiguates the two {@code Version} types this file needs.
      */
-    private static final Version FEDERATION_SETTING_VERSION = Version.fromString(org.elasticsearch.Version.V_9_6_0.toString());
+    private static final Version FEDERATION_SETTING_VERSION = Version.fromString(org.elasticsearch.Version.V_9_5_0.toString());
 
     public static ElasticsearchCluster mixedVersionCluster() {
         return mixedVersionCluster(CsvTestUtils.createCsvDataDirectory(), false);

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/Clusters.java
@@ -231,13 +231,13 @@ public class Clusters {
     }
 
     /**
-     * Whether a cluster of this version accepts the ES|QL federation setting, which exists as of 9.6.0. A node that
+     * Whether a cluster of this version accepts the ES|QL federation setting, which exists as of 9.5.0. A node that
      * predates it rejects an unknown setting and never starts, and it has federation registered unconditionally, so
      * leaving the setting off matches how it behaves in production. Suites that depend on driving the setting skip
      * against such a cluster on the {@code FEDERATION_ENABLED_SETTING} capability.
      */
     private static boolean knowsFederationSetting(org.elasticsearch.Version version) {
-        return version.onOrAfter(org.elasticsearch.Version.V_9_6_0);
+        return version.onOrAfter(org.elasticsearch.Version.V_9_5_0);
     }
 
     public static org.elasticsearch.Version bwcVersion() {


### PR DESCRIPTION
This adjusts the version claimed to release federated data from 9.6 (needed for initial 9.5 backport) to 9.5, the actual version given in the backport (#155354).
