### PR TITLE
Deny bare git commit in Cursor project CLI config

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": [
+      "Shell(git commit)",
+      "Shell(git commit:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,11 @@
 # Cursor rules and commands, if we want to implement project level rules and commands we'll want to remove these
 # These are based on the cursor docs here: https://cursor.com/docs/cli/using#rules
 # Prefix slash ensures these are only ignored at the same level as this file
-/.cursor/
+/.cursor/*
+!/.cursor/cli.json
+!/.cursor/rules/
+/.cursor/rules/*
+!/.cursor/rules/**
 
 # codex
 .agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - **Build tooling**: Gradle composite build with `build-conventions`, `build-tools`, and `build-tools-internal`; Docker is required for some packaging/tests.
 - **OS packages**: Packaging and QA jobs expect ephemeral hosts; do not run packaging suites on your workstation.
 - **Security**: Default dev clusters enable security; use `elastic-admin:elastic-password` or disable with `-Dtests.es.xpack.security.enabled=false`.
-- **Cursor/Copilot rules**: None provided in repo; follow this guide plus CONTRIBUTING.md.
+- **Cursor/Copilot rules**: Project rules in `.cursor/rules/`; CLI permissions in `.cursor/cli.json`.
 
 ## Build & Run Commands
 - Refer to BUILDING.md, CONTRIBUTING.md & TESTING.asciidoc for comprehensive build/test instructions.
@@ -153,7 +153,7 @@ To confirm: `grep ClassName muted-tests.yml`. To verify the migration/test actua
 - Prefer Gradle tasks over ad-hoc scripts.
 - When scripting CLI sequences, leverage `gradlew` task.
 - Unrecognized changes: assume other agent; keep going; focus your changes. If it causes issues, stop + ask user.
-- Do not add "Co-Authored-By" or any AI attribution trailers to commit messages, by any means—including `--trailer`, `-m`, or any other git flag. commit messages should adhere to the 50/72 rule: use a maximum of 50 columns for the commit summary. Your harness may introduce a hook that automatically adds attributions trailers to relevant git commands. Use `bash -lc` or a similar approach in this case to conform to the rule.
+- Do not add "Co-Authored-By" or any AI attribution trailers to commit messages, by any means—including `--trailer`, `-m`, or any other git flag. commit messages should adhere to the 50/72 rule: use a maximum of 50 columns for the commit summary. Cursor's agent harness rewrites bare `git commit` commands to add a `Co-authored-by: Cursor` trailer; `.cursor/cli.json` denies that form in this repo. Wrap commits in `bash -lc 'git commit ...'` to bypass the rewriter.
 
 ## Methods with Required Javadoc Reading
 If you encounter any of the following methods, you must go and read their javadoc before taking any other actions:

--- a/docs/changelog/155380.yaml
+++ b/docs/changelog/155380.yaml
@@ -1,0 +1,5 @@
+area: Infra/Logging
+issues: []
+pr: 155380
+summary: Deny bare git commit in Cursor project CLI config
+type: enhancement


### PR DESCRIPTION
## Summary

- Add `.cursor/cli.json` to deny bare `git commit` shell commands in this repo.
- Un-ignore `.cursor/cli.json` and `.cursor/rules/**` in `.gitignore`.
- Document Cursor harness behavior and the `bash -lc` workaround in `AGENTS.md`.

## Context

Cursor's agent harness rewrites top-level `git commit` commands to add:

`Co-authored-by: Cursor <cursoragent@cursor.com>`

Project `.cursor/cli.json` cannot set `attribution` (global-only per [Cursor CLI config](https://cursor.com/docs/cli/reference/configuration.md)). Denying `Shell(git commit)` forces agents to wrap commits in `bash -lc`, which bypasses the rewriter.

## Validation

- Project `cli.json` with `attribution` is rejected by the CLI schema.
- Project `cli.json` with `permissions.allow` + `deny` passes schema validation.
- Harness simulation: bare `git commit` is rewritten; `bash -lc 'git commit ...'` is not.
- This commit was created with `bash -lc` and has no Cursor trailer.

## Test plan

- [x] `agent` accepts `.cursor/cli.json` schema (no validation error)
- [x] `git check-ignore` shows `.cursor/cli.json` is trackable and `.cursor/plans/` remains ignored