### PR TITLE
Harden buildExpanded assertion in LegacyYamlRestTestPluginFuncTest

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
@@ -139,7 +139,10 @@ class LegacyYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
         def result = gradleRunner("yamlRestTest", "--console", 'plain').buildAndFail()
 
         then:
-        result.task(":distribution:archives:integ-test-zip:buildExpanded").outcome == TaskOutcome.SUCCESS
+        def buildExpandedTask = result.task(":distribution:archives:integ-test-zip:buildExpanded")
+        assert buildExpandedTask != null : "buildExpanded missing from execution graph. " +
+            "Executed tasks: ${result.tasks*.path}\nOutput:\n${result.getOutput()}"
+        buildExpandedTask.outcome == TaskOutcome.SUCCESS
         result.getOutput().contains(expectedInstallLog)
 
         where:


### PR DESCRIPTION
## Summary

`LegacyYamlRestTestPluginFuncTest."#type projects are wired into test cluster setup"`
(the "plugin" data point) has failed intermittently in CI with an opaque
`NullPointerException`:

```
result.task(":distribution:archives:integ-test-zip:buildExpanded").outcome == TaskOutcome.SUCCESS
|      |                                                           |
|      null                                                        java.lang.NullPointerException
```

`result.task(...)` returns `null` because `buildExpanded` never appears in
the TestKit build result, and Groovy's power-assert then NPEs trying to read
`.outcome` off `null` — a useless failure signature for triage.

## Investigation

Traced the wiring chain the assertion depends on
(`ElasticsearchNode` distribution list population → `LegacyRestTestBasePlugin`
task realization → `TestClustersAware.useCluster()`'s explicit `dependsOn` →
`InternalDistributionDownloadPlugin`'s `local-build` resolution) and confirmed
there is no reachable configuration-order race: the `testClusters {}` DSL
block is fully evaluated, and `ElasticsearchNode`'s distribution list
populated, before task realization/`dependsOn` wiring runs, and that wiring
is an explicit `dependsOn` in addition to the `@InputFiles`-inferred one.

I also confirmed this data point is unrelated to #150984 (the sibling
"module" data point in the same test method, fixed in #154170): that was a
genuine configuration-cache serialization bug in
`ElasticsearchCluster.module(TaskProvider<Sync>)`. The "plugin" path exercised
here (`ElasticsearchCluster.plugin(TaskProvider<Zip>)`) already uses the
CC-safe `flatMap(AbstractArchiveTask::getArchiveFile)` pattern that fix
mirrored, so configuration cache stays enabled for this test — there's no
evidence of a CC defect on this path to work around.

Given the failure hasn't reproduced locally or under CI reproduction attempts
despite investigation, this is most consistent with intermittent CI
infrastructure flakiness rather than a build-logic defect. Ran the test
repeatedly locally (fresh seeds, `--rerun`, configuration cache enabled) with
no failures.

## Change

Minimally invasive: harden the assertion so a future recurrence is
diagnosable instead of opaque. Replaces the bare outcome comparison with a
null-safe check that reports the full executed task list and build output on
failure:

```groovy
def buildExpandedTask = result.task(":distribution:archives:integ-test-zip:buildExpanded")
assert buildExpandedTask != null : "buildExpanded missing from execution graph. " +
    "Executed tasks: ${result.tasks*.path}\nOutput:\n${result.getOutput()}"
buildExpandedTask.outcome == TaskOutcome.SUCCESS
```

No production build-logic code is touched.

Relates #148014