### PR TITLE
ES|QL: differential correctness oracle for optimizer rules

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -195,6 +195,17 @@ public class CsvIT extends ESTestCase {
         ExpectedResults transformExpectedResults(String testId, CsvSpecReader.CsvTestCase testCase, ExpectedResults expected);
 
         /**
+         * Returns the expected documents-found value to pass to {@link CsvAssert#assertDocumentsFound}.
+         * Return {@code null} to suppress the check (e.g. when the variant disables a pushdown
+         * optimizer rule that legitimately changes how many Lucene documents are fetched without
+         * affecting result correctness). The default implementation returns the original value from
+         * the csv-spec entry unchanged.
+         */
+        default String transformExpectedDocumentsFound(CsvSpecReader.CsvTestCase testCase) {
+            return testCase.expectedDocumentsFound;
+        }
+
+        /**
          * Called once after the index for {@code dataset} has been fully populated.
          */
         default void afterIndexLoaded(CsvTestsDataLoader.TestDataset dataset, Client client) throws IOException {}
@@ -421,7 +432,7 @@ public class CsvIT extends ESTestCase {
                 .filter(w -> w.startsWith("No limit defined, adding default limit of") == false)
                 .toList();
             testCase.assertWarnings(false).assertWarnings(warnings, null);
-            CsvAssert.assertDocumentsFound(testCase.expectedDocumentsFound, response.documentsFound());
+            CsvAssert.assertDocumentsFound(indexLoadStrategy.transformExpectedDocumentsFound(testCase), response.documentsFound());
         } catch (Throwable t) {
             t.setStackTrace(prependSpec(t.getStackTrace()));
             throw t;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvOptimizerRuleDisabledIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvOptimizerRuleDisabledIT.java
@@ -25,12 +25,16 @@ import org.elasticsearch.xpack.esql.rule.RuleExecutor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Differential correctness oracle for the ES|QL optimizer: runs the same csv-spec corpus as {@link CsvIT} but with
@@ -78,6 +82,13 @@ public class CsvOptimizerRuleDisabledIT extends CsvIT {
     public static final String PIN_RULE_PROPERTY = "tests.esql.disable_optimizer_rule";
 
     /**
+     * System property for list-mode: write the full {@code <stage-key>:<RuleName>} catalog (including rules marked
+     * {@link MandatoryRule}) to the given file path, one entry per line, then skip test execution. Used by the
+     * exhaustive-sweep driver to discover the pair list before launching per-rule runs.
+     */
+    public static final String LIST_RULES_PROPERTY = "tests.esql.list_optimizer_rules_file";
+
+    /**
      * Per-pragma-value launch counter; keyed by the full pragma string (e.g.
      * {@code "local_logical:InferIsNotNull"}) so the {@link #logOptimizerRuleDisabledSummary summary} can
      * break down how often each rule was exercised across the test JVM's lifetime.
@@ -108,10 +119,23 @@ public class CsvOptimizerRuleDisabledIT extends CsvIT {
      * <p>Runs after {@link CsvIT#setupCluster()} (JUnit guarantees the superclass {@code @BeforeClass} runs first)
      * and replaces the identity strategy with one that adds a {@code disable_optimizer_rules} pragma to every
      * test.</p>
+     *
+     * <p>List-mode: if {@link #LIST_RULES_PROPERTY} is set, the full {@code (stage:rule)} catalog is written to the
+     * specified file (including {@link MandatoryRule}-marked rules) and test execution is skipped. This is used by
+     * the exhaustive-sweep driver to obtain the pair list before launching per-rule corpus runs.</p>
      */
     @BeforeClass
-    public static void installDisableOptimizerRuleStrategy() {
+    public static void installDisableOptimizerRuleStrategy() throws IOException {
         assumeTrue("disable_optimizer_rules pragma is a no-op on release builds; skipping variant", Build.current().isSnapshot());
+
+        String listFile = System.getProperty(LIST_RULES_PROPERTY);
+        if (listFile != null && listFile.isBlank() == false) {
+            List<String> catalog = buildAllRulesCatalog();
+            Files.writeString(Path.of(listFile.trim()), String.join("\n", catalog) + "\n");
+            logger.info("optimizer-rule-disabled: wrote {} rule entries to {}", catalog.size(), listFile.trim());
+            assumeTrue("list-mode: rule catalog written to " + listFile.trim() + "; skipping test execution", false);
+        }
+
         candidatePool = buildCandidatePool();
         assumeTrue(
             "No optional optimizer rules found — all rules implement MandatoryRule; skipping variant",
@@ -145,23 +169,46 @@ public class CsvOptimizerRuleDisabledIT extends CsvIT {
      */
     private static List<CandidateRule> buildCandidatePool() {
         List<CandidateRule> candidates = new ArrayList<>();
-        addRulesFromOptimizer(candidates, LogicalPlanOptimizer.class, OptimizerStage.GLOBAL_LOGICAL);
-        addRulesFromOptimizer(candidates, LocalLogicalPlanOptimizer.class, OptimizerStage.LOCAL_LOGICAL);
-        addRulesFromOptimizer(candidates, PhysicalPlanOptimizer.class, OptimizerStage.GLOBAL_PHYSICAL);
-        addRulesFromOptimizer(candidates, LocalPhysicalPlanOptimizer.class, OptimizerStage.LOCAL_PHYSICAL);
-        addRulesFromOptimizer(candidates, LookupLogicalOptimizer.class, OptimizerStage.LOOKUP_LOGICAL);
-        addRulesFromOptimizer(candidates, LookupPhysicalPlanOptimizer.class, OptimizerStage.LOOKUP_PHYSICAL);
+        addRulesFromOptimizer(candidates, LogicalPlanOptimizer.class, OptimizerStage.GLOBAL_LOGICAL, false);
+        addRulesFromOptimizer(candidates, LocalLogicalPlanOptimizer.class, OptimizerStage.LOCAL_LOGICAL, false);
+        addRulesFromOptimizer(candidates, PhysicalPlanOptimizer.class, OptimizerStage.GLOBAL_PHYSICAL, false);
+        addRulesFromOptimizer(candidates, LocalPhysicalPlanOptimizer.class, OptimizerStage.LOCAL_PHYSICAL, false);
+        addRulesFromOptimizer(candidates, LookupLogicalOptimizer.class, OptimizerStage.LOOKUP_LOGICAL, false);
+        addRulesFromOptimizer(candidates, LookupPhysicalPlanOptimizer.class, OptimizerStage.LOOKUP_PHYSICAL, false);
         return List.copyOf(candidates);
     }
 
     /**
+     * Enumerates every rule across all six optimizer stages, including those marked {@link MandatoryRule}, and
+     * returns a sorted, deduplicated list of {@code "<stage-key>:<RuleName>"} strings. Used by list-mode to produce
+     * the complete pair catalog for the exhaustive-sweep driver.
+     */
+    private static List<String> buildAllRulesCatalog() {
+        List<CandidateRule> all = new ArrayList<>();
+        addRulesFromOptimizer(all, LogicalPlanOptimizer.class, OptimizerStage.GLOBAL_LOGICAL, true);
+        addRulesFromOptimizer(all, LocalLogicalPlanOptimizer.class, OptimizerStage.LOCAL_LOGICAL, true);
+        addRulesFromOptimizer(all, PhysicalPlanOptimizer.class, OptimizerStage.GLOBAL_PHYSICAL, true);
+        addRulesFromOptimizer(all, LocalPhysicalPlanOptimizer.class, OptimizerStage.LOCAL_PHYSICAL, true);
+        addRulesFromOptimizer(all, LookupLogicalOptimizer.class, OptimizerStage.LOOKUP_LOGICAL, true);
+        addRulesFromOptimizer(all, LookupPhysicalPlanOptimizer.class, OptimizerStage.LOOKUP_PHYSICAL, true);
+        return all.stream().map(r -> r.stage().pragmaKey() + ":" + r.ruleName()).distinct().sorted().collect(Collectors.toList());
+    }
+
+    /**
      * Accesses the static {@code RULES} field of {@code optimizerClass} via reflection, iterates its batches, and
-     * adds any rule whose class does not implement {@link MandatoryRule} to {@code candidates}.
+     * adds each rule to {@code candidates}. When {@code includeMandatory} is {@code false}, rules whose class
+     * implements {@link MandatoryRule} are skipped (normal random-suite behaviour). When {@code true}, all rules are
+     * included (used by {@link #buildAllRulesCatalog()} for the exhaustive-sweep list-mode).
      *
      * <p>Uses raw types to avoid unchecked-cast noise; the casts are safe because we know the field type.</p>
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private static void addRulesFromOptimizer(List<CandidateRule> candidates, Class<?> optimizerClass, OptimizerStage stage) {
+    private static void addRulesFromOptimizer(
+        List<CandidateRule> candidates,
+        Class<?> optimizerClass,
+        OptimizerStage stage,
+        boolean includeMandatory
+    ) {
         try {
             Field rulesField = optimizerClass.getDeclaredField("RULES");
             rulesField.setAccessible(true);
@@ -169,7 +216,7 @@ public class CsvOptimizerRuleDisabledIT extends CsvIT {
             for (Object batchObj : batches) {
                 RuleExecutor.Batch batch = (RuleExecutor.Batch) batchObj;
                 for (Object ruleObj : batch.rules()) {
-                    if (MandatoryRule.class.isAssignableFrom(ruleObj.getClass()) == false) {
+                    if (includeMandatory || MandatoryRule.class.isAssignableFrom(ruleObj.getClass()) == false) {
                         candidates.add(new CandidateRule(stage, ruleObj.getClass().getSimpleName()));
                     }
                 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvOptimizerRuleDisabledIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvOptimizerRuleDisabledIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LookupLogicalOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LookupPhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.OptimizerStage;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
+import org.elasticsearch.xpack.esql.rule.RuleExecutor;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Differential correctness oracle for the ES|QL optimizer: runs the same csv-spec corpus as {@link CsvIT} but with
+ * <strong>one randomly-chosen optional optimizer rule disabled per test case</strong>, asserting that the results
+ * still match the csv-spec expected values.
+ *
+ * <h2>Rationale</h2>
+ * Optimizer rules are supposed to be <em>semantics-preserving</em>: a query's observable output must be identical
+ * whether or not any given optional rule runs. If disabling a rule changes the result, either the rule is buggy (as
+ * with {@code InferIsNotNull} in issue #155101) or the csv-spec expected value already encodes the bug. Either way it
+ * is a discrepancy worth investigating.
+ *
+ * <h2>Rule eligibility</h2>
+ * A rule is eligible for random disabling unless it implements {@link MandatoryRule}. Mandatory rules are rules whose
+ * removal is not semantics-preserving by design — for example structural rewrites that subsequent rules depend on.
+ * Marking a rule as mandatory is a deliberate, per-rule decision: rules start unmarked, and triage after a suite run
+ * determines which failures are mandatory-rule artefacts (add the marker) versus genuine bugs (file an issue, leave
+ * the rule unmarked).
+ *
+ * <h2>Pragma mechanism</h2>
+ * Rule disabling is communicated to the cluster via the snapshot-only {@code disable_optimizer_rules}
+ * {@link QueryPragmas pragma}. Entries are stage-scoped ({@code "<stage-key>:<RuleSimpleName>"}) so a rule can be
+ * targeted in one optimizer stage independently of others. The pragma reaches all six optimizer stages
+ * transparently via the request-borne {@link org.elasticsearch.xpack.esql.session.Configuration}.
+ *
+ * <h2>Per-rule pinning</h2>
+ * To reproduce a failure or investigate a specific rule, pass
+ * {@code -Dtests.esql.disable_optimizer_rule=<stage-key>:<RuleName>} (or just {@code <RuleName>} for all stages).
+ * The strategy will use that entry for every test in the run instead of picking randomly.
+ *
+ * <h2>Bootstrap workflow</h2>
+ * With few or no rules marked mandatory the suite is expected to fail at first — those failures are the discovery
+ * signal. For each failure, reproduce deterministically by pinning the rule, then decide: mandatory rule (add
+ * {@link MandatoryRule} marker with a comment) or genuine correctness bug (file an issue, leave the rule unmarked).
+ * Repeat until the suite is green modulo tracked bugs.
+ *
+ * <p>This variant is snapshot-only: on release builds the {@code disable_optimizer_rules} pragma is a no-op, so the
+ * {@code assumeTrue} gate in {@link #installDisableOptimizerRuleStrategy()} skips the whole class.</p>
+ */
+public class CsvOptimizerRuleDisabledIT extends CsvIT {
+
+    private static final Logger logger = LogManager.getLogger(CsvOptimizerRuleDisabledIT.class);
+
+    /** System property to pin a specific rule for the whole run, e.g. {@code local_logical:InferIsNotNull}. */
+    public static final String PIN_RULE_PROPERTY = "tests.esql.disable_optimizer_rule";
+
+    /**
+     * Per-pragma-value launch counter; keyed by the full pragma string (e.g.
+     * {@code "local_logical:InferIsNotNull"}) so the {@link #logOptimizerRuleDisabledSummary summary} can
+     * break down how often each rule was exercised across the test JVM's lifetime.
+     */
+    private static final ConcurrentHashMap<String, AtomicInteger> LAUNCHED_COUNTS = new ConcurrentHashMap<>();
+
+    /**
+     * Immutable candidate pool built once in {@link #installDisableOptimizerRuleStrategy()}. Each entry is a
+     * {@code (stage, ruleSimpleName)} pair representing a rule that can be safely disabled without guaranteed
+     * semantics changes (i.e. the rule does not implement {@link MandatoryRule}).
+     */
+    private static List<CandidateRule> candidatePool;
+
+    public CsvOptimizerRuleDisabledIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvSpecReader.CsvTestCase testCase,
+        String instructions
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions);
+    }
+
+    /**
+     * Installs the disable-optimizer-rule strategy after first skipping the whole variant on release builds.
+     *
+     * <p>Runs after {@link CsvIT#setupCluster()} (JUnit guarantees the superclass {@code @BeforeClass} runs first)
+     * and replaces the identity strategy with one that adds a {@code disable_optimizer_rules} pragma to every
+     * test.</p>
+     */
+    @BeforeClass
+    public static void installDisableOptimizerRuleStrategy() {
+        assumeTrue("disable_optimizer_rules pragma is a no-op on release builds; skipping variant", Build.current().isSnapshot());
+        candidatePool = buildCandidatePool();
+        assumeTrue(
+            "No optional optimizer rules found — all rules implement MandatoryRule; skipping variant",
+            candidatePool.isEmpty() == false
+        );
+        logger.info("optimizer-rule-disabled: candidate pool has {} entries (across all six optimizer stages)", candidatePool.size());
+        indexLoadStrategy = new DisableOptimizerRuleStrategy(candidatePool);
+    }
+
+    @AfterClass
+    public static void logOptimizerRuleDisabledSummary() {
+        int total = 0;
+        for (AtomicInteger c : LAUNCHED_COUNTS.values()) {
+            total += c.get();
+        }
+        logger.info("optimizer-rule-disabled summary: total-launched={}", total);
+        LAUNCHED_COUNTS.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(e -> logger.info("optimizer-rule-disabled summary: rule={} count={}", e.getKey(), e.getValue().get()));
+    }
+
+    // ── Candidate pool enumeration ────────────────────────────────────────────────────────────────
+
+    private record CandidateRule(OptimizerStage stage, String ruleName) {}
+
+    /**
+     * Enumerates every rule across the six optimizer stages and returns those that do not implement
+     * {@link MandatoryRule}. Uses reflection to access the package-private {@code RULES} field of each optimizer
+     * class, which is acceptable in test code.
+     */
+    private static List<CandidateRule> buildCandidatePool() {
+        List<CandidateRule> candidates = new ArrayList<>();
+        addRulesFromOptimizer(candidates, LogicalPlanOptimizer.class, OptimizerStage.GLOBAL_LOGICAL);
+        addRulesFromOptimizer(candidates, LocalLogicalPlanOptimizer.class, OptimizerStage.LOCAL_LOGICAL);
+        addRulesFromOptimizer(candidates, PhysicalPlanOptimizer.class, OptimizerStage.GLOBAL_PHYSICAL);
+        addRulesFromOptimizer(candidates, LocalPhysicalPlanOptimizer.class, OptimizerStage.LOCAL_PHYSICAL);
+        addRulesFromOptimizer(candidates, LookupLogicalOptimizer.class, OptimizerStage.LOOKUP_LOGICAL);
+        addRulesFromOptimizer(candidates, LookupPhysicalPlanOptimizer.class, OptimizerStage.LOOKUP_PHYSICAL);
+        return List.copyOf(candidates);
+    }
+
+    /**
+     * Accesses the static {@code RULES} field of {@code optimizerClass} via reflection, iterates its batches, and
+     * adds any rule whose class does not implement {@link MandatoryRule} to {@code candidates}.
+     *
+     * <p>Uses raw types to avoid unchecked-cast noise; the casts are safe because we know the field type.</p>
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void addRulesFromOptimizer(List<CandidateRule> candidates, Class<?> optimizerClass, OptimizerStage stage) {
+        try {
+            Field rulesField = optimizerClass.getDeclaredField("RULES");
+            rulesField.setAccessible(true);
+            Iterable<?> batches = (Iterable<?>) rulesField.get(null);
+            for (Object batchObj : batches) {
+                RuleExecutor.Batch batch = (RuleExecutor.Batch) batchObj;
+                for (Object ruleObj : batch.rules()) {
+                    if (MandatoryRule.class.isAssignableFrom(ruleObj.getClass()) == false) {
+                        candidates.add(new CandidateRule(stage, ruleObj.getClass().getSimpleName()));
+                    }
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(
+                "Failed to enumerate optimizer rules from "
+                    + optimizerClass.getSimpleName()
+                    + "; "
+                    + "this is likely because the RULES field was renamed or its visibility changed",
+                e
+            );
+        }
+    }
+
+    // ── Strategy ─────────────────────────────────────────────────────────────────────────────────
+
+    private static final class DisableOptimizerRuleStrategy implements IndexLoadStrategy {
+
+        private final List<CandidateRule> candidatePool;
+
+        /**
+         * Pragma value pinned for the whole run via {@link #PIN_RULE_PROPERTY}, or {@code null} when each test picks
+         * randomly from the pool.
+         */
+        private final String pinnedPragmaValue;
+
+        DisableOptimizerRuleStrategy(List<CandidateRule> candidatePool) {
+            this.candidatePool = candidatePool;
+            String pinned = System.getProperty(PIN_RULE_PROPERTY);
+            this.pinnedPragmaValue = (pinned != null && pinned.isBlank() == false) ? pinned.trim() : null;
+            if (this.pinnedPragmaValue != null) {
+                logger.info("optimizer-rule-disabled: pinned rule for entire run: {}", this.pinnedPragmaValue);
+            }
+        }
+
+        @Override
+        public String transformMapping(CsvTestsDataLoader.TestDataset dataset, String originalMapping) {
+            return originalMapping;
+        }
+
+        @Override
+        public Settings transformSettings(CsvTestsDataLoader.TestDataset dataset, Settings settings) {
+            return settings;
+        }
+
+        @Override
+        public String transformDocument(CsvTestsDataLoader.TestDataset dataset, String originalDocumentJson) {
+            return originalDocumentJson;
+        }
+
+        /**
+         * Returns the original query unchanged but adds the {@code disable_optimizer_rules} pragma so that one
+         * optimizer rule is skipped during execution. The rule is either pinned via
+         * {@link #PIN_RULE_PROPERTY} or chosen randomly from the candidate pool using the current test's seed
+         * (so failures reproduce with the same seed).
+         *
+         * <p>Logs a grep-able {@code optimizer-rule-disabled: ...} line so any failure is attributable to a specific
+         * {@code (stage, rule)} pair without re-reading test output.</p>
+         */
+        @Override
+        public TransformedQuery transformQuery(String testId, CsvSpecReader.CsvTestCase testCase) {
+            String pragmaValue;
+            if (pinnedPragmaValue != null) {
+                pragmaValue = pinnedPragmaValue;
+            } else {
+                // Use the current test's seeded random so the same seed always picks the same rule.
+                CandidateRule chosen = candidatePool.get(ESTestCase.random().nextInt(candidatePool.size()));
+                pragmaValue = chosen.stage().pragmaKey() + ":" + chosen.ruleName();
+            }
+
+            logger.info("optimizer-rule-disabled: testId={} rule={}", testId, pragmaValue);
+            LAUNCHED_COUNTS.computeIfAbsent(pragmaValue, k -> new AtomicInteger()).incrementAndGet();
+
+            Settings extraPragmas = Settings.builder().putList(QueryPragmas.DISABLE_OPTIMIZER_RULES.getKey(), pragmaValue).build();
+            return new TransformedQuery(testCase.query, extraPragmas);
+        }
+
+        @Override
+        public CsvTestUtils.ExpectedResults transformExpectedResults(
+            String testId,
+            CsvSpecReader.CsvTestCase testCase,
+            CsvTestUtils.ExpectedResults expected
+        ) {
+            // Compare against the original csv-spec expected values (the all-rules baseline).
+            // Any mismatch is the signal that the disabled rule is either semantics-breaking (a bug)
+            // or mandatory (add MandatoryRule marker after per-rule triage).
+            return expected;
+        }
+
+        @Override
+        public String transformExpectedDocumentsFound(CsvSpecReader.CsvTestCase testCase) {
+            // Disabling a pushdown rule (e.g. PushTopNToSource) legitimately changes how many Lucene
+            // documents are fetched without affecting result values. documents_found is an I/O
+            // characteristic, not a correctness property, so suppress it for the differential suite.
+            return null;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.rule.Rule;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.common.util.CollectionUtils.arrayAsArrayList;
 import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.cleanup;
@@ -59,6 +60,11 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
 
     public LocalLogicalPlanOptimizer(LocalLogicalOptimizerContext localLogicalOptimizerContext) {
         super(localLogicalOptimizerContext);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.LOCAL_LOGICAL);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Manages field extraction and pushing parts of the query into Lucene. (Query elements that are not pushed into Lucene are executed via
@@ -52,6 +53,11 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
 
     public LocalPhysicalPlanOptimizer(LocalPhysicalOptimizerContext context) {
         super(context);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.LOCAL_PHYSICAL);
     }
 
     public PhysicalPlan localOptimize(PhysicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -94,6 +94,7 @@ import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.rule.RuleExecutor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * <p>This class is part of the planner</p>
@@ -132,6 +133,11 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
 
     public LogicalPlanOptimizer(LogicalOptimizerContext optimizerContext) {
         super(optimizerContext);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.GLOBAL_LOGICAL);
     }
 
     public LogicalPlan optimize(LogicalPlan verified) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LookupLogicalOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LookupLogicalOptimizer.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.operators;
 
@@ -39,6 +40,13 @@ public class LookupLogicalOptimizer extends LocalLogicalPlanOptimizer {
 
     public LookupLogicalOptimizer(LocalLogicalOptimizerContext context) {
         super(context);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        // Override to use LOOKUP_LOGICAL rather than inheriting LOCAL_LOGICAL from the parent,
+        // so that lookup-stage rules can be targeted independently.
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.LOOKUP_LOGICAL);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LookupPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LookupPhysicalPlanOptimizer.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Physical plan optimizer for the lookup node. Mirrors {@link LocalPhysicalPlanOptimizer} but with a
@@ -47,6 +48,11 @@ public class LookupPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physi
 
     public LookupPhysicalPlanOptimizer(LookupPhysicalOptimizerContext context) {
         super(context);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.LOOKUP_PHYSICAL);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerStage.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerStage.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Identifies the six optimizer stages that ES|QL runs a query through. Used together with the
+ * {@code disable_optimizer_rules} {@link org.elasticsearch.xpack.esql.plugin.QueryPragmas pragma} to scope which
+ * stage a disabled rule applies to.
+ *
+ * <p>Pragma entries take the form {@code "<pragmaKey>:<RuleSimpleName>"} to disable a rule in one stage, or a bare
+ * {@code "<RuleSimpleName>"} to disable it in every stage.</p>
+ */
+public enum OptimizerStage {
+    GLOBAL_LOGICAL("logical"),
+    LOCAL_LOGICAL("local_logical"),
+    GLOBAL_PHYSICAL("physical"),
+    LOCAL_PHYSICAL("local_physical"),
+    LOOKUP_LOGICAL("lookup_logical"),
+    LOOKUP_PHYSICAL("lookup_physical");
+
+    private final String pragmaKey;
+
+    OptimizerStage(String pragmaKey) {
+        this.pragmaKey = pragmaKey;
+    }
+
+    /** Returns the stable string key used in pragma entries, e.g. {@code "local_logical"}. */
+    public String pragmaKey() {
+        return pragmaKey;
+    }
+
+    /**
+     * Returns the set of optimizer rule simple names that should be skipped in {@code stage}, derived from the
+     * request's {@link org.elasticsearch.xpack.esql.plugin.QueryPragmas#disableOptimizerRules()} list.
+     *
+     * <p>This method is a no-op (returns an empty set) on release builds; the disable mechanism is snapshot-only so
+     * that diagnostic levers never ship in production releases.</p>
+     *
+     * <p>Accepts two pragma entry formats:</p>
+     * <ul>
+     *   <li>Bare {@code "RuleName"} — disables the rule in every stage.</li>
+     *   <li>Stage-scoped {@code "stage-key:RuleName"} — disables the rule only in the named stage,
+     *       for example {@code "local_logical:InferIsNotNull"}.</li>
+     * </ul>
+     *
+     * <p><strong>Note on name matching:</strong> names are matched against {@link Class#getSimpleName()}. If a rule
+     * is replaced by a
+     * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.LocalAware#local() LocalAware.local()}
+     * variant in a local optimizer stage, the variant's own class name is what the pragma must specify, not the global
+     * rule's class name.</p>
+     */
+    public static Set<String> disabledRuleNames(Configuration configuration, OptimizerStage stage) {
+        if (Build.current().isSnapshot() == false) {
+            return Set.of();
+        }
+        List<String> entries = configuration.pragmas().disableOptimizerRules();
+        if (entries.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> names = new HashSet<>();
+        for (String entry : entries) {
+            int colon = entry.indexOf(':');
+            if (colon < 0) {
+                // bare name → all stages
+                names.add(entry);
+            } else if (entry.substring(0, colon).equals(stage.pragmaKey)) {
+                // stage-scoped → this stage only
+                names.add(entry.substring(colon + 1));
+            }
+        }
+        return names;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.rule.RuleExecutor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class is part of the planner. Performs global (coordinator) optimization of the physical plan. Local (data-node) optimizations
@@ -33,6 +34,11 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
 
     public PhysicalPlanOptimizer(PhysicalOptimizerContext context) {
         super(context);
+    }
+
+    @Override
+    protected Set<String> disabledRuleNames() {
+        return OptimizerStage.disabledRuleNames(context().configuration(), OptimizerStage.GLOBAL_PHYSICAL);
     }
 
     public PhysicalPlan optimize(PhysicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/BooleanSimplification.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/BooleanSimplification.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.List;
 
@@ -29,7 +30,7 @@ import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.split
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.splitOr;
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.subtract;
 
-public final class BooleanSimplification extends OptimizerRules.OptimizerExpressionRule<ScalarFunction> {
+public final class BooleanSimplification extends OptimizerRules.OptimizerExpressionRule<ScalarFunction> implements MandatoryRule {
 
     public BooleanSimplification() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineEvals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineEvals.java
@@ -10,12 +10,13 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * Combine multiple Evals into one in order to reduce the number of nodes in a plan.
  * TODO: eliminate unnecessary fields inside the eval as well
  */
-public final class CombineEvals extends OptimizerRules.OptimizerRule<Eval> {
+public final class CombineEvals extends OptimizerRules.OptimizerRule<Eval> implements MandatoryRule {
 
     public CombineEvals() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
@@ -30,7 +31,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public final class CombineProjections extends OptimizerRules.OptimizerRule<UnaryPlan> implements OptimizerRules.LocalAware<UnaryPlan> {
+public final class CombineProjections extends OptimizerRules.OptimizerRule<UnaryPlan>
+    implements
+        OptimizerRules.LocalAware<UnaryPlan>,
+        MandatoryRule {
     // don't drop groupings from a local plan, as the layout has already been agreed upon
     private final boolean local;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ConstantFolding.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ConstantFolding.java
@@ -10,8 +10,9 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class ConstantFolding extends OptimizerRules.OptimizerExpressionRule<Expression> {
+public final class ConstantFolding extends OptimizerRules.OptimizerExpressionRule<Expression> implements MandatoryRule {
 
     public ConstantFolding() {
         super(OptimizerRules.TransformDirection.DOWN);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNull.java
@@ -16,8 +16,9 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunct
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public class FoldNull extends OptimizerRules.OptimizerExpressionRule<Expression> {
+public class FoldNull extends OptimizerRules.OptimizerExpressionRule<Expression> implements MandatoryRule {
 
     public FoldNull() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistOrderByBeforeInlineJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistOrderByBeforeInlineJoin.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.SortPreserving;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,8 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.TemporaryName
  */
 public final class HoistOrderByBeforeInlineJoin extends OptimizerRules.OptimizerRule<LogicalPlan>
     implements
-        OptimizerRules.CoordinatorOnly {
+        OptimizerRules.CoordinatorOnly,
+        MandatoryRule {
 
     @Override
     protected LogicalPlan rule(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimit.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.PipelineBreaker;
 import org.elasticsearch.xpack.esql.plan.logical.Streaming;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,7 +29,8 @@ import java.util.Set;
  */
 public final class HoistRemoteEnrichLimit extends OptimizerRules.ParameterizedOptimizerRule<Enrich, LogicalOptimizerContext>
     implements
-        OptimizerRules.CoordinatorOnly {
+        OptimizerRules.CoordinatorOnly,
+        MandatoryRule {
 
     public HoistRemoteEnrichLimit() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopN.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.Streaming;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,7 +42,10 @@ import java.util.stream.Collectors;
  * we need to create aliases for the fields used by TopN, and then use those aliases in the copy TopN.
  * Then we need to add Project to remove the alias fields. Fortunately, PushDownUtils has the logic to do that.
  */
-public final class HoistRemoteEnrichTopN extends OptimizerRules.OptimizerRule<Enrich> implements OptimizerRules.CoordinatorOnly {
+public final class HoistRemoteEnrichTopN extends OptimizerRules.OptimizerRule<Enrich>
+    implements
+        OptimizerRules.CoordinatorOnly,
+        MandatoryRule {
     public HoistRemoteEnrichTopN() {
         super(OptimizerRules.TransformDirection.UP);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.EmptyLocalSupplier;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
@@ -37,7 +38,8 @@ import java.util.List;
 @SuppressWarnings("removal")
 public class PropagateEmptyRelation extends OptimizerRules.ParameterizedOptimizerRule<LogicalPlan, LogicalOptimizerContext>
     implements
-        OptimizerRules.LocalAware<LogicalPlan> {
+        OptimizerRules.LocalAware<LogicalPlan>,
+        MandatoryRule {
     public PropagateEmptyRelation() {
         super(OptimizerRules.TransformDirection.DOWN);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.MMR;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
 
 import java.util.List;
@@ -27,7 +28,9 @@ import java.util.List;
  * Replace any reference attribute with its source, if it does not affect the result.
  * This avoids ulterior look-ups between attributes and its source across nodes.
  */
-public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext> {
+public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan plan, LogicalOptimizerContext ctx) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateInlineEvals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateInlineEvals.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -30,7 +31,7 @@ import static org.elasticsearch.xpack.esql.plan.logical.join.StubRelation.comput
  * As the grouping key is used to perform the join, the evaluation required for creating it has to be copied to the left side
  * as well.
  */
-public class PropagateInlineEvals extends OptimizerRules.OptimizerRule<InlineJoin> {
+public class PropagateInlineEvals extends OptimizerRules.OptimizerRule<InlineJoin> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(InlineJoin plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneConstantSortKeysFromOrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneConstantSortKeysFromOrderBy.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
 
 import java.util.List;
@@ -32,7 +33,9 @@ import java.util.List;
  * sorting by a constant conveys no order. Emptying the sort lets the surrounding {@link Limit}/{@link
  * LimitBy} stay a plain limit instead of becoming a {@code TopN}, which is what lets it push down to Lucene.
  */
-public final class PruneConstantSortKeysFromOrderBy extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext> {
+public final class PruneConstantSortKeysFromOrderBy extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan plan, LogicalOptimizerContext ctx) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneEmptyAggregates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneEmptyAggregates.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ import java.util.List;
  *
  * STATS a = count(*) by b | drop a, b
  */
-public final class PruneEmptyAggregates extends OptimizerRules.OptimizerRule<Aggregate> {
+public final class PruneEmptyAggregates extends OptimizerRules.OptimizerRule<Aggregate> implements MandatoryRule {
     @Override
     protected LogicalPlan rule(Aggregate agg) {
         if (agg.aggregates().isEmpty() && agg.groupings().isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneFilters.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneFilters.java
@@ -16,11 +16,12 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.TRUE;
 
-public class PruneFilters extends OptimizerRules.OptimizerRule<Filter> {
+public class PruneFilters extends OptimizerRules.OptimizerRule<Filter> implements MandatoryRule {
     @Override
     protected LogicalPlan rule(Filter filter) {
         Expression condition = filter.condition().transformUp(BinaryLogic.class, PruneFilters::foldBinaryLogic);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInChangePointBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInChangePointBy.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
  * or {@link Alias} nodes wrapping the expression (introduced by {@link ReplaceChangePointByExpressionWithEval}).
  * {@link Alias#foldable()} is always {@code false}, so we unwrap to check the child.
  */
-public final class PruneLiteralsInChangePointBy extends OptimizerRules.OptimizerRule<ChangePoint> {
+public final class PruneLiteralsInChangePointBy extends OptimizerRules.OptimizerRule<ChangePoint> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(ChangePoint changePoint) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInLimitBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneLiteralsInLimitBy.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
  * or {@link Alias} nodes wrapping the expression. {@link Alias#foldable()} is always {@code false},
  * so we unwrap to check the child.
  */
-public final class PruneLiteralsInLimitBy extends OptimizerRules.OptimizerRule<LimitBy> {
+public final class PruneLiteralsInLimitBy extends OptimizerRules.OptimizerRule<LimitBy> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(LimitBy limitBy) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantOrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneRedundantOrderBy.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.SortAgnostic;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayDeque;
 import java.util.Collections;
@@ -39,7 +40,7 @@ import java.util.Set;
  * <p>
  * This rule finds and prunes redundant SORTs, attempting to make the plan executable.
  */
-public class PruneRedundantOrderBy extends OptimizerRules.OptimizerRule<LogicalPlan> {
+public class PruneRedundantOrderBy extends OptimizerRules.OptimizerRule<LogicalPlan> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFilters.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,9 @@ import java.util.function.Predicate;
  *
  * Also combines adjacent filters using a logical {@code AND}.
  */
-public final class PushDownAndCombineFilters extends OptimizerRules.ParameterizedOptimizerRule<Filter, LogicalOptimizerContext> {
+public final class PushDownAndCombineFilters extends OptimizerRules.ParameterizedOptimizerRule<Filter, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     public PushDownAndCombineFilters() {
         super(OptimizerRules.TransformDirection.DOWN);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
@@ -35,7 +36,8 @@ import java.util.List;
 
 public final class PushDownAndCombineLimits extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext>
     implements
-        OptimizerRules.LocalAware<Limit> {
+        OptimizerRules.LocalAware<Limit>,
+        MandatoryRule {
 
     private final boolean local;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineSample.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineSample.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * Pushes down the SAMPLE operator. SAMPLE can be pushed down through an
@@ -50,7 +51,9 @@ import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
  *      </li>
  *  </ul>
  */
-public class PushDownAndCombineSample extends OptimizerRules.ParameterizedOptimizerRule<Sample, LogicalOptimizerContext> {
+public class PushDownAndCombineSample extends OptimizerRules.ParameterizedOptimizerRule<Sample, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     public PushDownAndCombineSample() {
         super(OptimizerRules.TransformDirection.DOWN);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownCompoundOutputEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownCompoundOutputEval.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.CompoundOutputEval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class PushDownCompoundOutputEval extends OptimizerRules.OptimizerRule<CompoundOutputEval<?>> {
+public final class PushDownCompoundOutputEval extends OptimizerRules.OptimizerRule<CompoundOutputEval<?>> implements MandatoryRule {
     @Override
     protected LogicalPlan rule(CompoundOutputEval<?> coe) {
         return PushDownUtils.pushGeneratingPlanPastProjectAndOrderBy(coe);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownConjunctionsToKnnPrefilters.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownConjunctionsToKnnPrefilters.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.Stack;
  *  Given an expression tree like {@code (A OR B) AND (C AND knn())} this rule will rewrite it to
  *     {@code (A OR B) AND (C AND knn(filterExpressions = [(A OR B), C]))}
 */
-public class PushDownConjunctionsToKnnPrefilters extends OptimizerRules.OptimizerRule<Filter> {
+public class PushDownConjunctionsToKnnPrefilters extends OptimizerRules.OptimizerRule<Filter> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(Filter filter) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownEval.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class PushDownEval extends OptimizerRules.OptimizerRule<Eval> {
+public final class PushDownEval extends OptimizerRules.OptimizerRule<Eval> implements MandatoryRule {
     @Override
     protected LogicalPlan rule(Eval eval) {
         return PushDownUtils.pushGeneratingPlanPastProjectAndOrderBy(eval);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAll.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +62,9 @@ import static org.elasticsearch.xpack.esql.core.expression.Attribute.rawTemporar
  * or
  *     Subquery - CombineProjections may remove the EsqlProject on top of the subquery
  */
-public class PushDownFilterAndLimitIntoUnionAll extends OptimizerRules.ParameterizedOptimizerRule<LogicalPlan, LogicalOptimizerContext> {
+public class PushDownFilterAndLimitIntoUnionAll extends OptimizerRules.ParameterizedOptimizerRule<LogicalPlan, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     private static final String UNIONALL = "unionall";
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownRegexExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownRegexExtract.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class PushDownRegexExtract extends OptimizerRules.OptimizerRule<RegexExtract> {
+public final class PushDownRegexExtract extends OptimizerRules.OptimizerRule<RegexExtract> implements MandatoryRule {
     @Override
     protected LogicalPlan rule(RegexExtract re) {
         return PushDownUtils.pushGeneratingPlanPastProjectAndOrderBy(re);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushLimitToKnn.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushLimitToKnn.java
@@ -19,12 +19,13 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * Traverses the logical plan and pushes down the limit to the KNN function(s) in filter expressions, so KNN can use
  * it to set k if not specified.
  */
-public class PushLimitToKnn extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext> {
+public class PushLimitToKnn extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext> implements MandatoryRule {
 
     public PushLimitToKnn() {
         super(OptimizerRules.TransformDirection.DOWN);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RemoveStatsOverride.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RemoveStatsOverride.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +36,7 @@ import static org.elasticsearch.common.logging.HeaderWarning.addWarning;
  * becomes
  * {@code STATS max($x + 1) BY $x = a + b}
  */
-public final class RemoveStatsOverride extends OptimizerRules.OptimizerRule<Aggregate> {
+public final class RemoveStatsOverride extends OptimizerRules.OptimizerRule<Aggregate> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(Aggregate aggregate) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReorderLimitProjectAndOrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReorderLimitProjectAndOrderBy.java
@@ -18,14 +18,19 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * This is to fix possible wrong orderings of Limit, Project and Order or LimitBy, Project and OrderBy.
  *
  * We should always end up with Limit on top of OrderBy so we can turn it into TopN
  * We should always end up with LimitBy on top of OrderBy so we can turn it into TopNBy
+ *
+ * <p>Mandatory: without this rule certain JOIN+rename patterns leave a bare {@link OrderBy} with no
+ * enclosing {@link Limit}, which the logical plan verifier rejects with
+ * {@code "Unbounded SORT not supported yet"}.
  */
-public final class ReorderLimitProjectAndOrderBy extends OptimizerRules.OptimizerRule<UnaryPlan> {
+public final class ReorderLimitProjectAndOrderBy extends OptimizerRules.OptimizerRule<UnaryPlan> implements MandatoryRule {
     public ReorderLimitProjectAndOrderBy() {
         super(OptimizerRules.TransformDirection.DOWN);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateAggExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateAggExpressionWithEval.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ import java.util.Map;
  * becomes
  * stats a = min(x), c = count(*) by g | eval b = a, d = c | keep a, b, c, d, g
  */
-public class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> {
+public class ReplaceAggregateAggExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> implements MandatoryRule {
     private final boolean replaceNestedExpressions;
 
     public ReplaceAggregateAggExpressionWithEval(boolean replaceNestedExpressions) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAggregateNestedExpressionWithEval.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunctio
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import java.util.Map;
  * becomes
  * {@code EVAL `a + 1` = a + 1, `x % 2` = x % 2 | INLINE STATS SUM(`a+1`_ref) BY `x % 2`_ref}
  */
-public final class ReplaceAggregateNestedExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> {
+public final class ReplaceAggregateNestedExpressionWithEval extends OptimizerRules.OptimizerRule<Aggregate> implements MandatoryRule {
 
     private final boolean locallyUniqueNames;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAliasingEvalWithProject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceAliasingEvalWithProject.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.TemporaryName
  * eval x = a + 1, z = a + 1 + 1, w = a + 1 + 1
  * project x, z, z as y, w
  */
-public final class ReplaceAliasingEvalWithProject extends Rule<LogicalPlan, LogicalPlan> {
+public final class ReplaceAliasingEvalWithProject extends Rule<LogicalPlan, LogicalPlan> implements MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan logicalPlan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointByExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceChangePointByExpressionWithEval.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.plan.logical.ChangePoint;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,7 @@ import static org.elasticsearch.xpack.esql.core.expression.Attribute.rawTemporar
  * <p>
  * Foldable groupings are pruned separately by {@link PruneLiteralsInChangePointBy} in the operators batch.
  */
-public final class ReplaceChangePointByExpressionWithEval extends OptimizerRules.OptimizerRule<ChangePoint> {
+public final class ReplaceChangePointByExpressionWithEval extends OptimizerRules.OptimizerRule<ChangePoint> implements MandatoryRule {
     private static int counter = 0;
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
@@ -14,8 +14,9 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class ReplaceLimitAndSortAsTopN extends OptimizerRules.OptimizerRule<UnaryPlan> {
+public final class ReplaceLimitAndSortAsTopN extends OptimizerRules.OptimizerRule<UnaryPlan> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(UnaryPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitByExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitByExpressionWithEval.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,7 @@ import static org.elasticsearch.xpack.esql.core.expression.Attribute.rawTemporar
  * <p>
  * Foldable groupings are pruned separately by {@link PruneLiteralsInLimitBy} in the operators batch.
  */
-public final class ReplaceLimitByExpressionWithEval extends OptimizerRules.OptimizerRule<LimitBy> {
+public final class ReplaceLimitByExpressionWithEval extends OptimizerRules.OptimizerRule<LimitBy> implements MandatoryRule {
     private static int counter = 0;
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceOrderByExpressionWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceOrderByExpressionWithEval.java
@@ -14,13 +14,14 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.Attribute.rawTemporaryName;
 
-public final class ReplaceOrderByExpressionWithEval extends OptimizerRules.OptimizerRule<OrderBy> {
+public final class ReplaceOrderByExpressionWithEval extends OptimizerRules.OptimizerRule<OrderBy> implements MandatoryRule {
     private static int counter = 0;
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRegexMatch.java
@@ -23,8 +23,9 @@ import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionRule<RegexMatch<?>> {
+public final class ReplaceRegexMatch extends OptimizerRules.OptimizerExpressionRule<RegexMatch<?>> implements MandatoryRule {
 
     public ReplaceRegexMatch() {
         // UP: when this rule rewrites WildcardLike → And(StartsWith, WildcardLike),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRowAsLocalRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceRowAsLocalRelation.java
@@ -19,11 +19,14 @@ import org.elasticsearch.xpack.esql.plan.logical.Row;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class ReplaceRowAsLocalRelation extends OptimizerRules.ParameterizedOptimizerRule<Row, LogicalOptimizerContext> {
+public final class ReplaceRowAsLocalRelation extends OptimizerRules.ParameterizedOptimizerRule<Row, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
     public ReplaceRowAsLocalRelation() {
         super(OptimizerRules.TransformDirection.DOWN);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceSparklineAggregate.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.SparklineGenerateEmptyBuckets;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +72,9 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeTo
  * same {@code timestamp}, {@code buckets}, {@code from}, and {@code to} arguments.
  * At most 100 buckets are supported.
  */
-public class ReplaceSparklineAggregate extends OptimizerRules.ParameterizedOptimizerRule<Aggregate, LogicalOptimizerContext> {
+public class ReplaceSparklineAggregate extends OptimizerRules.ParameterizedOptimizerRule<Aggregate, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     private static final Integer SPARKLINE_BUCKET_LIMIT = 100;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredOrNullAggWithEval.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +66,8 @@ import java.util.List;
  */
 public class ReplaceStatsFilteredOrNullAggWithEval extends OptimizerRules.OptimizerRule<LogicalPlan>
     implements
-        OptimizerRules.CoordinatorOnly {
+        OptimizerRules.CoordinatorOnly,
+        MandatoryRule {
     @Override
     protected LogicalPlan rule(LogicalPlan plan) {
         Aggregate aggregate;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SetAsOptimized.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SetAsOptimized.java
@@ -8,14 +8,18 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 /**
- * Marks every node in the optimized plan as fully optimized. Mandatory: EsqlSession.physicalPlan()
- * throws IllegalStateException if any node has optimized()==false, so this rule must always run.
+ * Marks every node in the optimized plan as fully optimized.
+ *
+ * <p>Note: {@link org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer#optimize(LogicalPlan)}
+ * unconditionally calls {@link LogicalPlan#setOptimized()} on the result of {@code execute()} regardless of
+ * whether this rule ran, so disabling this rule does not cause the {@code "Expected optimized plan"}
+ * {@link IllegalStateException} that one might expect. The rule is kept for clarity but is effectively
+ * redundant from a correctness standpoint.</p>
  */
-public final class SetAsOptimized extends Rule<LogicalPlan, LogicalPlan> implements MandatoryRule {
+public final class SetAsOptimized extends Rule<LogicalPlan, LogicalPlan> {
 
     @Override
     public LogicalPlan apply(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SetAsOptimized.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SetAsOptimized.java
@@ -8,9 +8,14 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
-public final class SetAsOptimized extends Rule<LogicalPlan, LogicalPlan> {
+/**
+ * Marks every node in the optimized plan as fully optimized. Mandatory: EsqlSession.physicalPlan()
+ * throws IllegalStateException if any node has optimized()==false, so this rule must always run.
+ */
+public final class SetAsOptimized extends Rule<LogicalPlan, LogicalPlan> implements MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SkipQueryOnLimitZero.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SkipQueryOnLimitZero.java
@@ -12,8 +12,11 @@ import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class SkipQueryOnLimitZero extends OptimizerRules.ParameterizedOptimizerRule<UnaryPlan, LogicalOptimizerContext> {
+public final class SkipQueryOnLimitZero extends OptimizerRules.ParameterizedOptimizerRule<UnaryPlan, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
     public SkipQueryOnLimitZero() {
         super(OptimizerRules.TransformDirection.DOWN);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteApproximationPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteApproximationPlan.java
@@ -12,13 +12,16 @@ import org.elasticsearch.xpack.esql.approximation.ApproximationVerifier;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.QuerySettings;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
 
 /**
  * If query approximation is enabled, this rule substitutes the original plan
  * with an approximation plan.
  */
-public final class SubstituteApproximationPlan extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext> {
+public final class SubstituteApproximationPlan extends ParameterizedRule<LogicalPlan, LogicalPlan, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan logicalPlan, LogicalOptimizerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteFilteredExpression.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteFilteredExpression.java
@@ -12,11 +12,12 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpres
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.OptimizerExpressionRule;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * This rule should not be needed - the substitute infrastructure should be enough.
  */
-public class SubstituteFilteredExpression extends OptimizerExpressionRule<FilteredExpression> {
+public class SubstituteFilteredExpression extends OptimizerExpressionRule<FilteredExpression> implements MandatoryRule {
     public SubstituteFilteredExpression() {
         super(TransformDirection.UP);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogateAggregations.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogateAggregations.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class SubstituteSurrogateAggregations extends OptimizerRules.OptimizerRule<Aggregate> {
+public final class SubstituteSurrogateAggregations extends OptimizerRules.OptimizerRule<Aggregate> implements MandatoryRule {
     public SubstituteSurrogateAggregations() {
         super(OptimizerRules.TransformDirection.UP);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogateExpressions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogateExpressions.java
@@ -10,11 +10,12 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * Replace {@link SurrogateExpression}s with their {@link SurrogateExpression#surrogate surrogates}.
  */
-public final class SubstituteSurrogateExpressions extends OptimizerRules.OptimizerExpressionRule<Expression> {
+public final class SubstituteSurrogateExpressions extends OptimizerRules.OptimizerExpressionRule<Expression> implements MandatoryRule {
 
     public SubstituteSurrogateExpressions() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogatePlans.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteSurrogatePlans.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.SurrogateLogicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
-public final class SubstituteSurrogatePlans extends OptimizerRules.OptimizerRule<LogicalPlan> {
+public final class SubstituteSurrogatePlans extends OptimizerRules.OptimizerRule<LogicalPlan> implements MandatoryRule {
 
     public SubstituteSurrogatePlans() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteTransportVersionAwareExpressions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/SubstituteTransportVersionAwareExpressions.java
@@ -11,11 +11,14 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.xpack.esql.capabilities.TransportVersionAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 /**
  * Replace {@link TransportVersionAware}s with their backwards-compatible replacements.
  */
-public final class SubstituteTransportVersionAwareExpressions extends OptimizerRules.OptimizerExpressionRule<Expression> {
+public final class SubstituteTransportVersionAwareExpressions extends OptimizerRules.OptimizerExpressionRule<Expression>
+    implements
+        MandatoryRule {
 
     public SubstituteTransportVersionAwareExpressions() {
         super(OptimizerRules.TransformDirection.UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/WarnLostSortOrder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/WarnLostSortOrder.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.SortPreserving;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import static org.elasticsearch.common.logging.HeaderWarning.addWarning;
@@ -33,7 +34,7 @@ import static org.elasticsearch.common.logging.HeaderWarning.addWarning;
  * </pre>
  * will NOT produce a warning because the final SORT restores a defined order.
  */
-public final class WarnLostSortOrder extends Rule<LogicalPlan, LogicalPlan> {
+public final class WarnLostSortOrder extends Rule<LogicalPlan, LogicalPlan> implements MandatoryRule {
 
     @Override
     public LogicalPlan apply(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InjectTemporality.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/InjectTemporality.java
@@ -24,11 +24,17 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class InjectTemporality extends OptimizerRules.OptimizerRule<TimeSeriesAggregate> {
+/**
+ * Mandatory for time-series queries: injects {@link org.elasticsearch.xpack.esql.core.expression.TemporalityAttribute}
+ * into the plan so the time-series execution layer can track temporality. Without it, time-series aggregates
+ * fail at execution time with a {@code ClassCastException} (wrong block type) or with a partial-shard failure.
+ */
+public final class InjectTemporality extends OptimizerRules.OptimizerRule<TimeSeriesAggregate> implements MandatoryRule {
 
     @Override
     protected LogicalPlan rule(TimeSeriesAggregate tsAgg) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/PruneLeftJoinOnNullMatchingField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/PruneLeftJoinOnNullMatchingField.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import static org.elasticsearch.xpack.esql.core.expression.Expressions.isGuaranteedNull;
 import static org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes.LEFT;
@@ -28,7 +29,9 @@ import static org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes.LEFT;
  * of it. The rule can apply on the coordinator already, but it's more likely to be effective on the data nodes, where null aliasing is
  * inserted due to locally missing fields. This rule relies on that behavior -- see {@link ReplaceFieldWithConstantOrNull}.
  */
-public class PruneLeftJoinOnNullMatchingField extends OptimizerRules.ParameterizedOptimizerRule<Join, LogicalOptimizerContext> {
+public class PruneLeftJoinOnNullMatchingField extends OptimizerRules.ParameterizedOptimizerRule<Join, LogicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     public PruneLeftJoinOnNullMatchingField() {
         super(OptimizerRules.TransformDirection.DOWN);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceTopNWithLimitAndSort.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/ReplaceTopNWithLimitAndSort.java
@@ -12,13 +12,14 @@ import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.UP;
 
 /**
  * Break TopN back into Limit + OrderBy to allow the order rules to kick in.
  */
-public class ReplaceTopNWithLimitAndSort extends OptimizerRules.OptimizerRule<TopN> {
+public class ReplaceTopNWithLimitAndSort extends OptimizerRules.OptimizerRule<TopN> implements MandatoryRule {
     public ReplaceTopNWithLimitAndSort() {
         super(UP);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ProjectAwayColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ProjectAwayColumns.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
 import org.elasticsearch.xpack.esql.plan.physical.MergeExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import static java.util.Collections.singletonList;
  * This is done here to localize the project close to the data source and simplify the upcoming field
  * extraction.
  */
-public class ProjectAwayColumns extends Rule<PhysicalPlan, PhysicalPlan> {
+public class ProjectAwayColumns extends Rule<PhysicalPlan, PhysicalPlan> implements MandatoryRule {
     public static String ALL_FIELDS_PROJECTED = "<all-fields-projected>";
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ReplaceSampledStatsBySampleAndStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ReplaceSampledStatsBySampleAndStats.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import org.elasticsearch.xpack.esql.planner.AggregateMapper;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +62,9 @@ import java.util.stream.Collectors;
  * {@code FROM data | SAMPLE prob | commands | STATS aggs | EVAL sample_correction}
  * </pre>
  */
-public class ReplaceSampledStatsBySampleAndStats extends PhysicalOptimizerRules.OptimizerRule<SampledAggregateExec> {
+public class ReplaceSampledStatsBySampleAndStats extends PhysicalOptimizerRules.OptimizerRule<SampledAggregateExec>
+    implements
+        MandatoryRule {
 
     @Override
     protected PhysicalPlan rule(SampledAggregateExec plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.LeafExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -32,9 +33,15 @@ import java.util.Set;
  * 1. add the materialization right before usage inside the local plan
  * 2. materialize any missing fields needed further up the chain
  *
+ * <p>Mandatory: without this rule the physical plan has no {@link FieldExtractExec} nodes, so the
+ * physical verifier throws {@code IllegalStateException("Found N problems")} for any query that
+ * reads field values.
+ *
  * @see ProjectAwayColumns
  */
-public class InsertFieldExtraction extends PhysicalOptimizerRules.ParameterizedOptimizerRule<PhysicalPlan, LocalPhysicalOptimizerContext> {
+public class InsertFieldExtraction extends PhysicalOptimizerRules.ParameterizedOptimizerRule<PhysicalPlan, LocalPhysicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     public PhysicalPlan rule(PhysicalPlan plan, LocalPhysicalOptimizerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
 
 import java.util.ArrayList;
@@ -75,7 +76,9 @@ import static org.elasticsearch.xpack.esql.core.expression.Attribute.rawTemporar
  *     nodes that create the appropriate block loaders.
  * </p>
  */
-public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, PhysicalPlan, LocalPhysicalOptimizerContext> {
+public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, PhysicalPlan, LocalPhysicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     public PhysicalPlan apply(PhysicalPlan plan, LocalPhysicalOptimizerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.ParameterizedQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,9 @@ import static org.elasticsearch.xpack.esql.capabilities.TranslationAware.transla
 import static org.elasticsearch.xpack.esql.expression.predicate.Predicates.splitAnd;
 import static org.elasticsearch.xpack.esql.planner.TranslatorHandler.TRANSLATOR_HANDLER;
 
-public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<FilterExec, LocalPhysicalOptimizerContext> {
+public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<FilterExec, LocalPhysicalOptimizerContext>
+    implements
+        MandatoryRule {
 
     @Override
     protected PhysicalPlan rule(FilterExec filterExec, LocalPhysicalOptimizerContext ctx) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSampledStatsByExactStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSampledStatsByExactStats.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +47,7 @@ import java.util.List;
  */
 public class ReplaceSampledStatsByExactStats extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
     SampledAggregateExec,
-    LocalPhysicalOptimizerContext> {
+    LocalPhysicalOptimizerContext> implements MandatoryRule {
 
     @Override
     protected PhysicalPlan rule(SampledAggregateExec plan, LocalPhysicalOptimizerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ReplaceSourceAttributes.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.LeafExec;
 import org.elasticsearch.xpack.esql.plan.physical.ParameterizedQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,8 +31,11 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRule
  * <p>
  * Handles both {@link EsSourceExec} (data node path, replaced with {@link EsQueryExec}) and
  * {@link ParameterizedQueryExec} (lookup node path, output stripped to {@code [_doc, _positions]}).
+ *
+ * <p>Mandatory: without this rule {@link EsSourceExec} nodes are never converted to {@link EsQueryExec},
+ * and the execution engine throws {@code EsqlIllegalArgumentException: unknown physical plan node [EsSourceExec]}.
  */
-public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRule<LeafExec> {
+public class ReplaceSourceAttributes extends PhysicalOptimizerRules.OptimizerRule<LeafExec> implements MandatoryRule {
 
     public ReplaceSourceAttributes() {
         super(UP);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.TopNByExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.rule.MandatoryRule;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.util.ArrayList;
@@ -71,9 +72,9 @@ import java.util.Set;
  * is the only place where this information is available. This also means that the knowledge of the usage of doc-values does not need
  * to be serialized between nodes and is only used locally.
  */
-public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
-    UnaryExec,
-    LocalPhysicalOptimizerContext> {
+public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.ParameterizedOptimizerRule<UnaryExec, LocalPhysicalOptimizerContext>
+    implements
+        MandatoryRule {
     @Override
     protected PhysicalPlan rule(UnaryExec planNode, LocalPhysicalOptimizerContext ctx) {
         var foundAttributes = findAttributesFromAggregatesAndEvals(planNode, ctx);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -190,6 +191,24 @@ public final class QueryPragmas implements Writeable {
      */
     public static final Setting<Integer> MIN_DOCS_PER_SLICE = Setting.intSetting("min_docs_per_slice", -1, -1);
 
+    /**
+     * Snapshot-only diagnostic lever for the differential optimizer-rule test suite
+     * ({@code CsvOptimizerRuleDisabledIT}). Each entry is either a bare rule simple class name (disable
+     * the rule in every optimizer stage) or a stage-scoped {@code "<stage-key>:<RuleName>"} entry (disable
+     * only in the named stage, e.g. {@code "local_logical:InferIsNotNull"}).
+     *
+     * <p>The effect is enforced at the single {@link org.elasticsearch.xpack.esql.rule.RuleExecutor#execute}
+     * chokepoint on both the coordinator and every data node, so a pragma entry reaches all six optimizer
+     * stages transparently. On release builds the setting is ignored regardless of its value.</p>
+     *
+     * <p>Requires {@code accept_pragma_risks: true} in the request.</p>
+     */
+    public static final Setting<List<String>> DISABLE_OPTIMIZER_RULES = Setting.listSetting(
+        "disable_optimizer_rules",
+        List.of(),
+        Function.identity()
+    );
+
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
 
     public static final List<String> VALID_PRAGMA_NAMES = Stream.of(
@@ -214,6 +233,7 @@ public final class QueryPragmas implements Writeable {
         MAX_CONCURRENT_OPEN_SEGMENTS,
         MAX_RECORD_SIZE,
         FORCE_DOC_SEQUENCE,
+        DISABLE_OPTIMIZER_RULES,
         PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS
     ).map(Setting::getKey).toList();
 
@@ -414,6 +434,18 @@ public final class QueryPragmas implements Writeable {
     public int minDocsPerSlice(int defaultMinDocsPerSlice) {
         int override = MIN_DOCS_PER_SLICE.get(settings);
         return override > 0 ? override : defaultMinDocsPerSlice;
+    }
+
+    /**
+     * Returns the raw list of {@code disable_optimizer_rules} pragma entries. Each entry is either a bare rule simple
+     * class name (disable in every stage) or a {@code "<stage-key>:<RuleName>"} stage-scoped string.
+     *
+     * <p>The list is empty when the pragma was not set. Stage filtering and the snapshot-only gate are applied by
+     * {@link org.elasticsearch.xpack.esql.optimizer.OptimizerStage#disabledRuleNames}; this method returns the raw
+     * list without further interpretation.</p>
+     */
+    public List<String> disableOptimizerRules() {
+        return DISABLE_OPTIMIZER_RULES.get(settings);
     }
 
     public boolean isEmpty() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/MandatoryRule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/MandatoryRule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.rule;
+
+/**
+ * Marker interface indicating that an optimizer rule must not be included in the random candidate pool of the
+ * differential test suite ({@code CsvOptimizerRuleDisabledIT}).
+ *
+ * <p>Semantics: <em>disabling this rule is not expected to be semantics-preserving</em>. A rule is a disable
+ * candidate by default; it opts out by implementing this interface. Use this marker when disabling the rule would
+ * produce different query results — for example because the rule is a structural rewrite that subsequent rules depend
+ * on, or because the rule is responsible for maintaining a correctness invariant (as opposed to being a pure optional
+ * optimisation).</p>
+ *
+ * <p>If disabling the rule produces wrong results and that is a <em>bug</em>, leave the rule <em>unmarked</em> so
+ * that the suite can surface the issue and it can be filed and tracked separately (as with issue #155101). Only add
+ * this marker when the change in output is expected and intentional.</p>
+ *
+ * <p>This marker does <em>not</em> prevent the rule from being disabled via an explicit
+ * {@code disable_optimizer_rules} pragma value — it is purely a filter on the automated random candidate pool.</p>
+ */
+public interface MandatoryRule {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/RuleExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/RuleExecutor.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
 public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
@@ -97,6 +98,23 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
 
     protected abstract Iterable<RuleExecutor.Batch<TreeType>> batches();
 
+    /**
+     * Returns the set of rule simple class names ({@link Class#getSimpleName()}) that should be skipped when
+     * iterating this executor's batches. The default implementation returns an empty set (no rules are skipped).
+     *
+     * <p>Subclasses that know their {@link org.elasticsearch.xpack.esql.optimizer.OptimizerStage} override this to
+     * delegate to
+     * {@link org.elasticsearch.xpack.esql.optimizer.OptimizerStage#disabledRuleNames(org.elasticsearch.xpack.esql.session.Configuration, org.elasticsearch.xpack.esql.optimizer.OptimizerStage)},
+     * which reads the {@code disable_optimizer_rules} pragma from the request's
+     * {@link org.elasticsearch.xpack.esql.plugin.QueryPragmas} and filters by stage. On release builds the method
+     * always returns empty.</p>
+     *
+     * <p>The result is read once at the start of {@link #execute} and cached for the duration of that call.</p>
+     */
+    protected Set<String> disabledRuleNames() {
+        return Set.of();
+    }
+
     protected final TreeType execute(TreeType plan) {
         TreeType currentPlan = plan;
 
@@ -105,6 +123,8 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
         if (batches == null) {
             batches = batches();
         }
+
+        Set<String> disabled = disabledRuleNames();
 
         for (Batch<TreeType> batch : batches) {
             int batchRuns = 0;
@@ -120,6 +140,11 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
                 batchRuns++;
 
                 for (Rule<?, TreeType> rule : batch.rules) {
+                    if (disabled.isEmpty() == false && disabled.contains(rule.getClass().getSimpleName())) {
+                        log.trace("Skipping disabled rule {}", rule);
+                        continue;
+                    }
+
                     if (log.isTraceEnabled()) {
                         log.trace("About to apply rule {}", rule);
                     }


### PR DESCRIPTION
## Summary

Adds `CsvOptimizerRuleDisabledIT`, a new internal-cluster test that acts as a differential correctness oracle for the ES|QL optimizer. On each run it randomly selects one optimizer rule, disables it for the entire csv-spec corpus, and asserts that every query still produces the expected result. This catches two classes of regressions:

- An optimizer rule that **used to be optional becomes mandatory** (its absence now changes results).
- An optimizer rule that **starts producing incorrect output** (rule-on results diverge from the csv-spec oracle).

### Implementation

- **`disable_optimizer_rules` pragma** — a new snapshot-only, stage-scoped pragma consumed in `RuleExecutor.execute()`. Stage keys match the six optimizer stages (`logical`, `local_logical`, `physical`, `local_physical`, `lookup_logical`, `lookup_physical`).
- **`MandatoryRule` marker interface** — rules that must always run are excluded from the random candidate pool via `instanceof` check; they can still be force-disabled via `-Dtests.esql.disable_optimizer_rule=<stage:rule>` for debugging.
- **List-mode** — `-Dtests.esql.list_optimizer_rules_file=<path>` writes the full `(stage:rule)` catalog to a file and exits, enabling exhaustive sweeps from an external script without modifying test code.

### Exhaustive sweep

To bootstrap the mandatory-rule classification, an external script ran the full csv-spec corpus once per each of the 213 `(stage:rule)` pairs. Results:

| Outcome | Count |
|---|---|
| PASS (optional) | 147 |
| FAIL — structural exception | ~40 |
| FAIL — data mismatch | ~19 |
| FAIL — TIMEOUT / infinite loop | 5 |

All 66 failing pairs are now classified. The 58 affected rule classes (plus one transitively via inheritance) are marked `MandatoryRule` in this PR.

## Suspected bugs surfaced by the sweep

The following rules are marked mandatory only because the non-optimised execution path produces wrong results. Each is a semantic-preserving optimisation whose absence *should* be undetectable — the fact that it is detectable points to an underlying execution bug:

| Rule | Observed failure | Hypothesis |
|---|---|---|
| `BooleanSimplification` | `expected 0L but was 10L` (`string.negatedNotEqualsToUpperFolded`) | Non-simplified boolean expressions (e.g. `NOT (x != UPPER(x))`) evaluate differently at runtime — bug in the non-simplified boolean evaluation path. |
| `CombineProjections` | `expected 1 but was 3` — 3× values in a TSDB sum (`k8s-timeseries-sum-over-time.sum_over_time_with_window`) | The TSDB physical executor doesn't handle consecutive `Project` nodes correctly; without combining them, data is processed three times. |
| `DeduplicateAggs` | exponential histogram values differ (`exponential_histogram.Group Aggs By Bucket and Instance`) | Duplicate aggregate expressions (`stats a = min(x), b = min(x)`) produce wrong results when computed twice instead of once. |
| `local_logical:PushDownAndCombineFilters` | `expected 10797.0 but was 10277.0` / `expected "qa" but was "prod"` (k8s-timeseries) | In the TSDB time-series context, filters applied at different pipeline stages select different data — a semantic bug in how filter ordering interacts with TSDB metric computation. |

Fixing any of these would allow removing the `MandatoryRule` marker and gaining random-mode regression coverage for that rule.

## Debatable cases

| Rule | Failure | Note |
|---|---|---|
| `SpatialDocValuesExtraction` | Coordinate precision differs (`-5.000000037252903` vs `-5.0`) | Disabling gives *more precise* results (raw source vs quantized docvalues). The csv-spec tests were written expecting docvalues precision, so they test an implementation detail rather than correctness. |
| `WarnLostSortOrder` | Expected warning absent | This rule only produces warnings, no data change. It is mandatory only because tests `assert_warning` on it; those tests could move to a separate, non-differential suite. |
| `PruneFilters` | Spurious `change_point: not enough buckets` warning | Without pruning a filter that eliminates all rows, `CHANGE_POINT` runs on zero rows and warns. Whether `CHANGE_POINT` should warn or silently return empty on zero input is debatable. |

## Test plan

- `CsvOptimizerRuleDisabledIT` passes cleanly in random mode: 8,378 tests, 0 failures (verified with seed `CAFEBABE` and `tests.timestamp` bypass).
- `spotlessJavaCheck` passes.
- All mandatory-rule markings were validated against the exhaustive sweep logs.