### PR TITLE
[9.5] Prevent setting frozen_after on failure store lifecycle (#155251)

### DIFF
--- a/docs/changelog/155251.yaml
+++ b/docs/changelog/155251.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 155251
+summary: Prevent setting `frozen_after` on failure store lifecycle policy both directly and via templates as this is not supported by the DLM lifecycle service
+type: bug

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/rest/RestPutDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/rest/RestPutDataStreamOptionsAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.admin.indices.RestPutComponentTemplateAction;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -31,7 +32,10 @@ import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 @ServerlessScope(Scope.PUBLIC)
 public class RestPutDataStreamOptionsAction extends BaseRestHandler {
 
-    private static final Set<String> CAPABILITIES = Set.of(RestGetDataStreamsAction.FAILURES_LIFECYCLE_API_CAPABILITY);
+    private static final Set<String> CAPABILITIES = Set.of(
+        RestGetDataStreamsAction.FAILURES_LIFECYCLE_API_CAPABILITY,
+        RestPutComponentTemplateAction.FAILURE_STORE_LIFECYCLE_REJECTS_FROZEN_AFTER
+    );
 
     @Override
     public String getName() {

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/230_data_stream_options.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/230_data_stream_options.yml
@@ -92,6 +92,24 @@ teardown:
   - is_false: data_streams.0.options
 
 ---
+"Setting frozen_after on failure store lifecycle via options API is rejected":
+  - requires:
+      reason: "Failure store lifecycle rejecting frozen_after was added in 9.5.1+"
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /_data_stream/{target}/_options
+          capabilities: [ 'failure_store.lifecycle.frozen_after_rejected' ]
+  - do:
+      indices.put_data_stream_options:
+        name: "failure-data-stream"
+        body:
+          failure_store:
+            lifecycle:
+              frozen_after: 30d
+      catch: '/Failure store lifecycle does not support freezing/'
+
+---
 "Test resetting data stream options in template composition":
   - do:
       cluster.put_component_template:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
@@ -205,6 +205,27 @@
   - match: {component_templates.0.component_template.template.lifecycle.frozen_after: "10d"}
 
 ---
+"Setting frozen_after on failure store lifecycle in component template is rejected":
+  - requires:
+      capabilities:
+        - method: PUT
+          path: /_component_template/{name}
+          capabilities: [ "failure_store.lifecycle.frozen_after_rejected" ]
+      test_runner_features: [ "capabilities" ]
+      reason: "Failure store lifecycle rejecting frozen_after was added in 9.5.1+"
+
+  - do:
+      cluster.put_component_template:
+        name: test-failure-lifecycle
+        body:
+          template:
+            data_stream_options:
+              failure_store:
+                lifecycle:
+                  frozen_after: "30d"
+      catch: '/Failure store lifecycle does not support freezing/'
+
+---
 "Get data stream lifecycle with default rollover":
   - requires:
       cluster_features: ["gte_v8.11.0"]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
@@ -263,3 +263,26 @@
   - match: {index_templates.0.index_template.template.lifecycle.enabled: true}
   - match: {index_templates.0.index_template.template.lifecycle.data_retention: "30d"}
   - match: {index_templates.0.index_template.template.lifecycle.frozen_after: "10d"}
+
+---
+"Setting frozen_after on failure store lifecycle in index template is rejected":
+  - requires:
+      capabilities:
+        - method: PUT
+          path: /_index_template/{name}
+          capabilities: [ "failure_store.lifecycle.frozen_after_rejected" ]
+      test_runner_features: [ "capabilities" ]
+      reason: "Failure store lifecycle rejecting frozen_after was added in 9.5.1+"
+
+  - do:
+      indices.put_index_template:
+        name: test-failure-lifecycle
+        body:
+          index_patterns: frozen-failure-*
+          data_stream: {}
+          template:
+            data_stream_options:
+              failure_store:
+                lifecycle:
+                  frozen_after: "30d"
+      catch: '/Failure store lifecycle does not support freezing/'

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutComponentTemplateAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 import java.util.List;
@@ -110,6 +111,19 @@ public class PutComponentTemplateAction extends ActionType<AcknowledgedResponse>
                         validationException
                     );
                 }
+            }
+            TimeValue failureStoreFrozenAfter = Optional.ofNullable(componentTemplate.template())
+                .map(Template::dataStreamOptions)
+                .map(dataStreamOptions -> dataStreamOptions.failureStore().get())
+                .map(failureStore -> failureStore.lifecycle().get())
+                .map(DataStreamLifecycle.Template::frozenAfter)
+                .map(ResettableValue::get)
+                .orElse(null);
+            if (failureStoreFrozenAfter != null) {
+                validationException = addValidationError(
+                    DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE,
+                    validationException
+                );
             }
             return validationException;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -228,7 +229,19 @@ public class TransportPutComposableIndexTemplateAction extends AcknowledgedTrans
                         );
                     }
                 }
-
+                TimeValue failureStoreFrozenAfter = Optional.ofNullable(indexTemplate.template())
+                    .map(Template::dataStreamOptions)
+                    .map(dataStreamOptions -> dataStreamOptions.failureStore().get())
+                    .map(failureStore -> failureStore.lifecycle().get())
+                    .map(DataStreamLifecycle.Template::frozenAfter)
+                    .map(ResettableValue::get)
+                    .orElse(null);
+                if (failureStoreFrozenAfter != null) {
+                    validationException = addValidationError(
+                        DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE,
+                        validationException
+                    );
+                }
             }
             return validationException;
         }

--- a/server/src/main/java/org/elasticsearch/action/datastreams/PutDataStreamOptionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/PutDataStreamOptionsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -108,6 +109,14 @@ public class PutDataStreamOptionsAction {
             ActionRequestValidationException validationException = null;
             if (options.failureStore() == null) {
                 validationException = addValidationError("At least one option needs to be provided", validationException);
+            }
+            if (options.failureStore() != null
+                && options.failureStore().lifecycle() != null
+                && options.failureStore().lifecycle().frozenAfter() != null) {
+                validationException = addValidationError(
+                    DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE,
+                    validationException
+                );
             }
             return validationException;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -75,6 +75,8 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
     public static final Tuple<TimeValue, RetentionSource> INFINITE_RETENTION = Tuple.tuple(null, RetentionSource.DATA_STREAM_CONFIGURATION);
     private static final String DOWNSAMPLING_NOT_SUPPORTED_ERROR_MESSAGE =
         "Failure store lifecycle does not support downsampling, please remove the downsampling configuration.";
+    public static final String FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE =
+        "Failure store lifecycle does not support freezing, please remove the frozen_after configuration.";
     public static final String DOWNSAMPLING_METHOD_WITHOUT_ROUNDS_ERROR =
         "Downsampling method can only be set when there is at least one downsampling round.";
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
@@ -34,12 +34,14 @@ public class RestPutComponentTemplateAction extends BaseRestHandler {
     private static final String COMPONENT_TEMPLATE_TRACKING_INFO = "component_template_tracking_info";
     public static final String SUPPORTS_DOWNSAMPLING_METHOD = "dlm.downsampling_method";
     public static final String SUPPORTS_FROZEN_AFTER = "dlm.frozen_after";
+    public static final String FAILURE_STORE_LIFECYCLE_REJECTS_FROZEN_AFTER = "failure_store.lifecycle.frozen_after_rejected";
     private static final Set<String> CAPABILITIES = Set.of(
         SUPPORTS_FAILURE_STORE,
         SUPPORTS_FAILURE_STORE_LIFECYCLE,
         COMPONENT_TEMPLATE_TRACKING_INFO,
         SUPPORTS_DOWNSAMPLING_METHOD,
-        SUPPORTS_FROZEN_AFTER
+        SUPPORTS_FROZEN_AFTER,
+        FAILURE_STORE_LIFECYCLE_REJECTS_FROZEN_AFTER
     );
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
+import static org.elasticsearch.rest.action.admin.indices.RestPutComponentTemplateAction.FAILURE_STORE_LIFECYCLE_REJECTS_FROZEN_AFTER;
 import static org.elasticsearch.rest.action.admin.indices.RestPutComponentTemplateAction.SUPPORTS_DOWNSAMPLING_METHOD;
 import static org.elasticsearch.rest.action.admin.indices.RestPutComponentTemplateAction.SUPPORTS_FAILURE_STORE;
 import static org.elasticsearch.rest.action.admin.indices.RestPutComponentTemplateAction.SUPPORTS_FAILURE_STORE_LIFECYCLE;
@@ -40,7 +41,8 @@ public class RestPutComposableIndexTemplateAction extends BaseRestHandler {
         SUPPORTS_FAILURE_STORE_LIFECYCLE,
         INDEX_TEMPLATE_TRACKING_INFO,
         SUPPORTS_DOWNSAMPLING_METHOD,
-        SUPPORTS_FROZEN_AFTER
+        SUPPORTS_FROZEN_AFTER,
+        FAILURE_STORE_LIFECYCLE_REJECTS_FROZEN_AFTER
     );
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComponentTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComponentTemplateRequestTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.template.put;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.ResettableValue;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PutComponentTemplateRequestTests extends ESTestCase {
+
+    public void testValidateRejectsFrozenAfterOnFailureStoreLifecycle() {
+        DataStreamLifecycle.Template failureLifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .frozenAfter(new TimeValue(30, TimeUnit.DAYS))
+            .buildTemplate();
+        DataStreamFailureStore.Template failureStore = DataStreamFailureStore.builder()
+            .lifecycle(ResettableValue.create(failureLifecycle))
+            .buildTemplate();
+        DataStreamOptions.Template dataStreamOptions = new DataStreamOptions.Template(ResettableValue.create(failureStore));
+        Template template = new Template(null, null, null, null, dataStreamOptions);
+        ComponentTemplate componentTemplate = new ComponentTemplate(template, null, null);
+
+        PutComponentTemplateAction.Request request = new PutComponentTemplateAction.Request("test");
+        request.componentTemplate(componentTemplate);
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertNotNull(validationException);
+        assertThat(
+            validationException.getMessage(),
+            containsString(DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE)
+        );
+    }
+
+    public void testValidateAcceptsExplicitFrozenAfterResetOnFailureStoreLifecycle() {
+        DataStreamLifecycle.Template failureLifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .frozenAfter(ResettableValue.reset())
+            .buildTemplate();
+        DataStreamFailureStore.Template failureStore = DataStreamFailureStore.builder()
+            .lifecycle(ResettableValue.create(failureLifecycle))
+            .buildTemplate();
+        DataStreamOptions.Template dataStreamOptions = new DataStreamOptions.Template(ResettableValue.create(failureStore));
+        Template template = new Template(null, null, null, null, dataStreamOptions);
+        ComponentTemplate componentTemplate = new ComponentTemplate(template, null, null);
+
+        PutComponentTemplateAction.Request request = new PutComponentTemplateAction.Request("test");
+        request.componentTemplate(componentTemplate);
+
+        assertThat(request.validate(), nullValue());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutComposableIndexTemplateRequestTests.java
@@ -12,18 +12,26 @@ package org.elasticsearch.action.admin.indices.template.put;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplateTests;
+import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ResettableValue;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializingTestCase<
     TransportPutComposableIndexTemplateAction.Request> {
@@ -107,5 +115,53 @@ public class PutComposableIndexTemplateRequestTests extends AbstractWireSerializ
             ComposableIndexTemplate.builder().indexPatterns(Collections.singletonList("*")).template(new Template(null, null, null)).build()
         );
         assertNull(req.validate());
+    }
+
+    public void testValidateRejectsFrozenAfterOnFailureStoreLifecycle() {
+        DataStreamLifecycle.Template failureLifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .frozenAfter(new TimeValue(30, TimeUnit.DAYS))
+            .buildTemplate();
+        DataStreamFailureStore.Template failureStore = DataStreamFailureStore.builder()
+            .lifecycle(ResettableValue.create(failureLifecycle))
+            .buildTemplate();
+        DataStreamOptions.Template dataStreamOptions = new DataStreamOptions.Template(ResettableValue.create(failureStore));
+        Template template = new Template(null, null, null, (DataStreamLifecycle.Template) null, dataStreamOptions);
+        ComposableIndexTemplate indexTemplate = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("logs-*"))
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .template(template)
+            .build();
+
+        TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request("test");
+        request.indexTemplate(indexTemplate);
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertThat(validationException, is(notNullValue()));
+        assertThat(
+            validationException.getMessage(),
+            containsString(DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE)
+        );
+    }
+
+    public void testValidateAcceptsExplicitFrozenAfterResetOnFailureStoreLifecycle() {
+        DataStreamLifecycle.Template failureLifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .frozenAfter(ResettableValue.reset())
+            .buildTemplate();
+        DataStreamFailureStore.Template failureStore = DataStreamFailureStore.builder()
+            .lifecycle(ResettableValue.create(failureLifecycle))
+            .buildTemplate();
+        DataStreamOptions.Template dataStreamOptions = new DataStreamOptions.Template(ResettableValue.create(failureStore));
+        Template template = new Template(null, null, null, (DataStreamLifecycle.Template) null, dataStreamOptions);
+        ComposableIndexTemplate indexTemplate = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("logs-*"))
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .template(template)
+            .build();
+
+        TransportPutComposableIndexTemplateAction.Request request = new TransportPutComposableIndexTemplateAction.Request("test");
+        request.indexTemplate(indexTemplate);
+
+        assertThat(request.validate(), nullValue());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/datastreams/PutDataStreamOptionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/PutDataStreamOptionsActionTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.datastreams;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PutDataStreamOptionsActionTests extends ESTestCase {
+
+    public void testValidateRejectsFrozenAfterOnFailureStoreLifecycle() {
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .frozenAfter(new TimeValue(30, TimeUnit.DAYS))
+            .build();
+        DataStreamFailureStore failureStore = new DataStreamFailureStore(null, lifecycle);
+        PutDataStreamOptionsAction.Request request = new PutDataStreamOptionsAction.Request(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            new String[] { "my-data-stream" },
+            failureStore
+        );
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertNotNull(validationException);
+        assertThat(
+            validationException.getMessage(),
+            containsString(DataStreamLifecycle.FROZEN_AFTER_NOT_SUPPORTED_ON_FAILURES_ERROR_MESSAGE)
+        );
+    }
+
+    public void testValidateAcceptsFailureStoreLifecycleWithoutFrozenAfter() {
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.failuresLifecycleBuilder()
+            .dataRetention(new TimeValue(30, TimeUnit.DAYS))
+            .build();
+        DataStreamFailureStore failureStore = new DataStreamFailureStore(null, lifecycle);
+        PutDataStreamOptionsAction.Request request = new PutDataStreamOptionsAction.Request(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            new String[] { "my-data-stream" },
+            failureStore
+        );
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertThat(validationException, nullValue());
+    }
+
+    public void testValidateAcceptsOptionsWithNoLifecycle() {
+        DataStreamOptions options = DataStreamOptions.EMPTY;
+        PutDataStreamOptionsAction.Request request = new PutDataStreamOptionsAction.Request(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            new String[] { "my-data-stream" },
+            options
+        );
+
+        ActionRequestValidationException validationException = request.validate();
+
+        assertNotNull(validationException);
+        assertThat(validationException.getMessage(), containsString("At least one option needs to be provided"));
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Prevent setting frozen_after on failure store lifecycle (#155251)