### PR TITLE
Revert "Extend doc_values index setting defaults to all object-form"

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -126,6 +126,13 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "match_only_text";
 
+    private static FieldMapper.DocValuesParameter.Values defaultDocValuesParameters(IndexMode indexMode) {
+        // Strictly columnar indices read field values from doc values, so enable doc values by default for match_only_text in that mode.
+        return indexMode.isStrictColumnar()
+            ? FieldMapper.DocValuesParameter.Values.ENABLED_HIGH_CARDINALITY
+            : FieldMapper.DocValuesParameter.Values.DISABLED_HIGH_CARDINALITY;
+    }
+
     public static class Defaults {
         public static final FieldType FIELD_TYPE;
 
@@ -152,7 +159,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         private final boolean storedFieldInBinaryFormat;
         private final boolean usesBinaryDocValuesForFallbackFields;
         private final IndexMode indexMode;
-        private final IndexSettings indexSettings;
 
         private Builder(
             String name,
@@ -161,7 +167,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             boolean storedFieldInBinaryFormat,
             boolean isWithinMultiField,
             boolean usesBinaryDocValuesForFallbackFields,
-            IndexSettings indexSettings
+            IndexMode indexMode
         ) {
             super(name, indexCreatedVersion, isWithinMultiField);
 
@@ -175,16 +181,12 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             );
             this.storedFieldInBinaryFormat = storedFieldInBinaryFormat;
             this.usesBinaryDocValuesForFallbackFields = usesBinaryDocValuesForFallbackFields;
-            this.indexSettings = indexSettings;
-            this.indexMode = indexSettings.getMode();
+            this.indexMode = indexMode;
             this.docValuesParameters = FieldMapper.DocValuesParameter.of(
-                FieldMapper.DocValuesParameter.defaultValues(
-                    indexSettings,
-                    FieldMapper.DocValuesParameter.Values.DISABLED_HIGH_CARDINALITY,
-                    FieldMapper.DocValuesParameter.Values.Cardinality.HIGH
-                ),
+                () -> defaultDocValuesParameters(indexMode),
+                defaultDocValuesParameters(indexMode),
                 m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters,
-                indexSettings.getMode().isStrictColumnar()
+                indexMode.isStrictColumnar()
             );
         }
 
@@ -196,7 +198,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 isSyntheticSourceStoredFieldInBinaryFormat(context.indexVersionCreated()),
                 context.isWithinMultiField(),
                 usesBinaryDocValuesForFallbackFields(context.getIndexSettings()),
-                context.getIndexSettings()
+                context.getIndexSettings().getMode()
             );
         }
 
@@ -1127,7 +1129,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private final DocValuesFieldFactory dvFactory;
     private final boolean indexed;
     private final IndexMode indexMode;
-    private final IndexSettings indexSettings;
     // The companion ".offsets" field used to reconstruct array order and null positions in strict-columnar mode; null otherwise.
     private final String offsetsFieldName;
 
@@ -1154,7 +1155,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         this.dvFactory = new DocValuesFieldFactory(this.docValuesParameters.multiValue(), false, this.indexCreatedVersion);
         this.indexed = builder.indexed.get();
         this.indexMode = builder.indexMode;
-        this.indexSettings = builder.indexSettings;
         this.offsetsFieldName = builder.offsetsFieldName;
     }
 
@@ -1182,7 +1182,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             storedFieldInBinaryFormat,
             fieldType().isWithinMultiField(),
             usesBinaryDocValuesForFallbackFields,
-            indexSettings
+            indexMode
         ).init(this);
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -87,6 +87,14 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return (ScaledFloatFieldMapper) in;
     }
 
+    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
+        true,
+        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+        true,
+        true,
+        FieldMapper.DocValuesParameter.Values.OnFailure.FAIL
+    );
+
     public static class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> indexed;
@@ -136,11 +144,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         public Builder(String name, IndexSettings indexSettings) {
             super(name);
             this.docValuesParameters = FieldMapper.DocValuesParameter.of(
-                FieldMapper.DocValuesParameter.defaultValues(
-                    indexSettings,
-                    FieldMapper.DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW
-                ),
+                DEFAULT_DOC_VALUES_PARAMS,
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -45,6 +45,14 @@ public class TokenCountFieldMapper extends FieldMapper {
         return (TokenCountFieldMapper) in;
     }
 
+    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
+        true,
+        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+        true,
+        true,
+        FieldMapper.DocValuesParameter.Values.OnFailure.FAIL
+    );
+
     public static class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).index, true);
@@ -76,11 +84,7 @@ public class TokenCountFieldMapper extends FieldMapper {
             super(name);
             this.indexSettings = indexSettings;
             this.docValuesParameters = FieldMapper.DocValuesParameter.of(
-                FieldMapper.DocValuesParameter.defaultValues(
-                    indexSettings,
-                    FieldMapper.DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW
-                ),
+                DEFAULT_DOC_VALUES_PARAMS,
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldData;
@@ -58,6 +59,12 @@ import java.util.Map;
 public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "icu_collation_keyword";
+
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexMode indexMode) {
+        return indexMode.isStrictColumnar()
+            ? DocValuesParameter.Values.ENABLED_HIGH_CARDINALITY
+            : DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+    }
 
     public static final class CollationFieldType extends StringFieldType {
         private final Collator collator;
@@ -276,20 +283,22 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         );
         final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toType(m).nullValue, null).acceptsNull();
 
-        private final IndexSettings indexSettings;
+        private final boolean indexDisabledByDefault;
+        private final IndexMode indexMode;
 
         public Builder(String name, IndexSettings indexSettings) {
+            this(name, indexSettings.getMode(), indexSettings.isIndexDisabledByDefault());
+        }
+
+        public Builder(String name, IndexMode indexMode, boolean indexDisabledByDefault) {
             super(name);
-            this.indexSettings = indexSettings;
-            indexed = Parameter.indexParam(m -> toType(m).indexed, indexSettings.isIndexDisabledByDefault() == false);
+            indexed = Parameter.indexParam(m -> toType(m).indexed, indexDisabledByDefault == false);
+            this.indexDisabledByDefault = indexDisabledByDefault;
+            this.indexMode = indexMode;
             this.docValuesPameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.HIGH
-                ),
+                defaultDocValuesParameters(indexMode),
                 m -> toType(m).docValuesParams(),
-                indexSettings.getMode().isStrictColumnar()
+                indexMode.isStrictColumnar()
             );
         }
 
@@ -385,7 +394,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
                 builderParams(this, context),
                 collator,
                 this,
-                indexSettings
+                indexMode
             );
         }
     }
@@ -511,7 +520,8 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     private final boolean indexed;
     private final String indexOptions;
     private final DocValuesParameter.Values docValuesParams;
-    private final IndexSettings indexSettings;
+    private final boolean indexDisabledByDefault;
+    private final IndexMode indexMode;
 
     protected ICUCollationKeywordFieldMapper(
         String simpleName,
@@ -520,7 +530,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         BuilderParams builderParams,
         Collator collator,
         Builder builder,
-        IndexSettings indexSettings
+        IndexMode indexMode
     ) {
         super(simpleName, mappedFieldType, builderParams);
         assert collator.isFrozen();
@@ -532,7 +542,8 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         this.indexed = builder.indexed.getValue();
         this.indexOptions = builder.indexOptions.getValue();
         this.docValuesParams = builder.docValuesPameters.getValue();
-        this.indexSettings = indexSettings;
+        this.indexDisabledByDefault = builder.indexDisabledByDefault;
+        this.indexMode = indexMode;
     }
 
     public DocValuesParameter.Values docValuesParams() {
@@ -561,7 +572,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(leafName(), indexSettings).init(this);
+        return new Builder(leafName(), indexMode, indexDisabledByDefault).init(this);
     }
 
     @Override

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldTypeTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldTypeTests.java
@@ -9,10 +9,9 @@
 
 package org.elasticsearch.plugin.analysis.icu;
 
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
-import org.elasticsearch.test.IndexSettingsModule;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,25 +20,22 @@ public class ICUCollationKeywordFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
 
-        ICUCollationKeywordFieldMapper mapper = new ICUCollationKeywordFieldMapper.Builder(
-            "field",
-            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY)
-        ).build(MapperBuilderContext.root(false, false));
+        ICUCollationKeywordFieldMapper mapper = new ICUCollationKeywordFieldMapper.Builder("field", IndexMode.STANDARD, false).build(
+            MapperBuilderContext.root(false, false)
+        );
         assertEquals(List.of("42"), fetchSourceValue(mapper.fieldType(), 42L));
         assertEquals(List.of("true"), fetchSourceValue(mapper.fieldType(), true));
 
-        ICUCollationKeywordFieldMapper ignoreAboveMapper = new ICUCollationKeywordFieldMapper.Builder(
-            "field",
-            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY)
-        ).ignoreAbove(4).build(MapperBuilderContext.root(false, false));
+        ICUCollationKeywordFieldMapper ignoreAboveMapper = new ICUCollationKeywordFieldMapper.Builder("field", IndexMode.STANDARD, false)
+            .ignoreAbove(4)
+            .build(MapperBuilderContext.root(false, false));
         assertEquals(List.of(), fetchSourceValue(ignoreAboveMapper.fieldType(), "value"));
         assertEquals(List.of("42"), fetchSourceValue(ignoreAboveMapper.fieldType(), 42L));
         assertEquals(List.of("true"), fetchSourceValue(ignoreAboveMapper.fieldType(), true));
 
-        ICUCollationKeywordFieldMapper nullValueMapper = new ICUCollationKeywordFieldMapper.Builder(
-            "field",
-            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY)
-        ).nullValue("NULL").build(MapperBuilderContext.root(false, false));
+        ICUCollationKeywordFieldMapper nullValueMapper = new ICUCollationKeywordFieldMapper.Builder("field", IndexMode.STANDARD, false)
+            .nullValue("NULL")
+            .build(MapperBuilderContext.root(false, false));
         assertEquals(List.of("NULL"), fetchSourceValue(nullValueMapper.fieldType(), null));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -78,6 +78,17 @@ public class BooleanFieldMapper extends FieldMapper {
         return (BooleanFieldMapper) in;
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+        }
+
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.LOW, multiValue, nullability, onFailure);
+    }
+
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final DocValuesParameter docValuesParameters;
@@ -113,11 +124,7 @@ public class BooleanFieldMapper extends FieldMapper {
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);
             this.indexSettings = Objects.requireNonNull(indexSettings);
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.LOW
-                ),
+                defaultDocValuesParameters(indexSettings),
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -257,6 +257,17 @@ public final class DateFieldMapper extends FieldMapper {
         return (DateFieldMapper) in;
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+        }
+
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.LOW, multiValue, nullability, onFailure);
+    }
+
     public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> index;
@@ -312,11 +323,7 @@ public final class DateFieldMapper extends FieldMapper {
             this.indexCreatedVersion = indexSettings.getIndexVersionCreated();
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.LOW
-                ),
+                defaultDocValuesParameters(indexSettings),
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1670,21 +1670,6 @@ public abstract class FieldMapper extends Mapper {
             return new DocValuesParameter(defaultValueSupplier, subParameterDefaults, initializer, supportsExtendedDocValues);
         }
 
-        /**
-         * Computes the default {@link Values} for a field given the index settings. Outside strict-columnar mode returns
-         * {@code nonColumnarDefault}; in strict-columnar mode returns enabled values with {@code columnarCardinality} and reads
-         * {@code multiValue}, {@code nullability}, and {@code onFailure} from the index-level settings.
-         */
-        public static Values defaultValues(IndexSettings indexSettings, Values nonColumnarDefault, Values.Cardinality columnarCardinality) {
-            if (indexSettings.getMode().isStrictColumnar() == false) {
-                return nonColumnarDefault;
-            }
-            boolean multiValue = DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
-            boolean nullability = DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
-            var onFailure = resolveOnFailureSetting(indexSettings.getSettings());
-            return new Values(true, columnarCardinality, multiValue, nullability, onFailure);
-        }
-
         private DocValuesParameter(Values defaultValue, Function<FieldMapper, Values> initializer, boolean supportsExtendedDocValues) {
             this(() -> defaultValue, defaultValue, initializer, supportsExtendedDocValues);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -86,6 +86,17 @@ public class IpFieldMapper extends FieldMapper {
         return (IpFieldMapper) in;
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+        }
+
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.HIGH, multiValue, nullability, onFailure);
+    }
+
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final Parameter<Boolean> indexed;
@@ -123,11 +134,7 @@ public class IpFieldMapper extends FieldMapper {
             this.script.precludesParameters(nullValue, ignoreMalformed);
 
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.HIGH
-                ),
+                defaultDocValuesParameters(indexSettings),
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -206,6 +206,17 @@ public final class KeywordFieldMapper extends FieldMapper {
         return textSearchInfo;
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+        }
+
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.HIGH, multiValue, nullability, onFailure);
+    }
+
     private static KeywordFieldMapper toType(FieldMapper in) {
         return (KeywordFieldMapper) in;
     }
@@ -302,11 +313,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.script.precludesParameters(nullValue);
 
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.HIGH
-                ),
+                defaultDocValuesParameters(indexSettings),
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );
@@ -384,23 +391,13 @@ public final class KeywordFieldMapper extends FieldMapper {
         @Deprecated()
         public Builder docValues(boolean hasDocValues) {
             this.docValuesParameters.setValue(
-                hasDocValues
-                    ? DocValuesParameter.defaultValues(
-                        indexSettings,
-                        DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                        DocValuesParameter.Values.Cardinality.HIGH
-                    )
-                    : DocValuesParameter.Values.DISABLED_LOW_CARDINALITY
+                hasDocValues ? defaultDocValuesParameters(indexSettings) : DocValuesParameter.Values.DISABLED_LOW_CARDINALITY
             );
             return this;
         }
 
         public Builder docValues(DocValuesParameter.Values.Cardinality cardinality) {
-            var defaultDocValues = DocValuesParameter.defaultValues(
-                indexSettings,
-                DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                DocValuesParameter.Values.Cardinality.HIGH
-            );
+            var defaultDocValues = defaultDocValuesParameters(indexSettings);
             this.docValuesParameters.setValue(
                 new DocValuesParameter.Values(
                     true,

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -113,6 +113,17 @@ public class NumberFieldMapper extends FieldMapper {
         return (NumberFieldMapper) in;
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.ENABLED_LOW_CARDINALITY;
+        }
+
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.LOW, multiValue, nullability, onFailure);
+    }
+
     /**
      * Encodes an integer into the term used by the {@code index_terms} inverted index, such that
      * unsigned byte-wise (lexicographic) term order matches numeric order.
@@ -223,11 +234,7 @@ public class NumberFieldMapper extends FieldMapper {
             this.scriptCompiler = Objects.requireNonNull(compiler);
             this.indexSettings = Objects.requireNonNull(indexSettings);
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.LOW
-                ),
+                defaultDocValuesParameters(indexSettings),
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );
@@ -322,13 +329,7 @@ public class NumberFieldMapper extends FieldMapper {
         @Deprecated
         public Builder docValues(boolean hasDocValues) {
             this.docValuesParameters.setValue(
-                hasDocValues
-                    ? DocValuesParameter.defaultValues(
-                        indexSettings,
-                        DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                        DocValuesParameter.Values.Cardinality.LOW
-                    )
-                    : DocValuesParameter.Values.DISABLED_LOW_CARDINALITY
+                hasDocValues ? defaultDocValuesParameters(indexSettings) : DocValuesParameter.Values.DISABLED_LOW_CARDINALITY
             );
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -263,6 +263,18 @@ public final class TextFieldMapper extends FieldMapper {
         return new FielddataFrequencyFilter(minFrequency, maxFrequency, minSegmentSize);
     }
 
+    private static DocValuesParameter.Values defaultDocValuesParameters(IndexSettings indexSettings) {
+        if (indexSettings.getMode().isStrictColumnar() == false) {
+            return DocValuesParameter.Values.DISABLED_HIGH_CARDINALITY;
+        }
+
+        // Strictly columnar indices read field values from doc values, so enable doc values by default for text fields in that mode.
+        boolean multiValue = FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.get(indexSettings.getSettings());
+        boolean nullability = FieldMapper.DOC_VALUES_NULLABILITY_SETTING.get(indexSettings.getSettings());
+        var onFailure = FieldMapper.resolveOnFailureSetting(indexSettings.getSettings());
+        return new DocValuesParameter.Values(true, DocValuesParameter.Values.Cardinality.HIGH, multiValue, nullability, onFailure);
+    }
+
     public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Boolean> store;
@@ -318,11 +330,8 @@ public final class TextFieldMapper extends FieldMapper {
             super(name, indexSettings.getIndexVersionCreated(), isWithinMultiField);
             this.indexSettings = indexSettings;
             this.docValuesParameters = DocValuesParameter.of(
-                DocValuesParameter.defaultValues(
-                    indexSettings,
-                    DocValuesParameter.Values.DISABLED_HIGH_CARDINALITY,
-                    DocValuesParameter.Values.Cardinality.HIGH
-                ),
+                () -> defaultDocValuesParameters(indexSettings),
+                defaultDocValuesParameters(indexSettings),
                 m -> ((TextFieldMapper) m).docValuesParameters,
                 indexSettings.getMode().isStrictColumnar()
             );

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -85,6 +85,14 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     static final BigInteger BIGINTEGER_2_64_MINUS_ONE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE); // 2^64 -1
     private static final BigDecimal BIGDECIMAL_2_64_MINUS_ONE = new BigDecimal(BIGINTEGER_2_64_MINUS_ONE);
 
+    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
+        true,
+        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+        true,
+        true,
+        FieldMapper.DocValuesParameter.Values.OnFailure.FAIL
+    );
+
     private static UnsignedLongFieldMapper toType(FieldMapper in) {
         return (UnsignedLongFieldMapper) in;
     }
@@ -114,11 +122,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         public Builder(String name, IndexSettings indexSettings) {
             super(name);
             this.docValuesParameters = FieldMapper.DocValuesParameter.of(
-                FieldMapper.DocValuesParameter.defaultValues(
-                    indexSettings,
-                    FieldMapper.DocValuesParameter.Values.ENABLED_LOW_CARDINALITY,
-                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW
-                ),
+                DEFAULT_DOC_VALUES_PARAMS,
                 m -> toType(m).docValuesParameters(),
                 indexSettings.getMode().isStrictColumnar()
             );


### PR DESCRIPTION
This reverts #155198, it has BWC issues.

Introduced in: https://github.com/elastic/elasticsearch/pull/155198