### PR TITLE
Periodic metrics for blob cache eviction policy

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCachePlugin.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.blobcache;
 
+import org.elasticsearch.blobcache.shared.BlobCachePeriodicMetrics;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.plugins.ExtensiblePlugin;
@@ -28,7 +29,8 @@ public class BlobCachePlugin extends Plugin implements ExtensiblePlugin {
             SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING,
             SharedBlobCacheService.SHARED_CACHE_MMAP,
             SharedBlobCacheService.SHARED_CACHE_COUNT_READS,
-            SharedBlobCacheService.SHARED_CACHE_CONCURRENT_EVICTIONS_SETTING
+            SharedBlobCacheService.SHARED_CACHE_CONCURRENT_EVICTIONS_SETTING,
+            BlobCachePeriodicMetrics.BLOB_CACHE_METRICS_INTERVAL_SETTING
         );
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetrics.java
@@ -103,7 +103,7 @@ public final class BlobCachePeriodicMetrics extends AbstractLifecycleComponent {
                 meterRegistry,
                 BLOB_CACHE_REGIONS_CURRENT,
                 "The number of occupied shared blob-cache regions, with additional attributes supplied by the active eviction policy",
-                "entries"
+                "regions"
             )
         );
         metricsTask.set(threadPool.scheduleWithFixedDelay(this::sample, metricsInterval, threadPool.generic()));

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetrics.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.telemetry.metric.ConsumingLongGaugeMetric;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Periodically samples shared blob-cache occupancy and publishes a consuming gauge.
+ * <p>
+ * The gauge value is the number of filled (occupied) regions. Additional attributes come from the
+ * active {@link EvictionPolicy#metricAttributes} implementation.
+ */
+public final class BlobCachePeriodicMetrics extends AbstractLifecycleComponent {
+
+    /**
+     * How often to sample blob-cache occupancy metrics. A value of {@link TimeValue#MINUS_ONE} disables sampling.
+     * Defaults to five minutes on stateless nodes and {@link TimeValue#MINUS_ONE} otherwise.
+     */
+    public static final Setting<TimeValue> BLOB_CACHE_METRICS_INTERVAL_SETTING = Setting.timeSetting(
+        "es.blob_cache.metrics_interval",
+        settings -> DiscoveryNode.isStateless(settings) ? TimeValue.timeValueMinutes(5) : TimeValue.MINUS_ONE,
+        TimeValue.MINUS_ONE,
+        Setting.Property.NodeScope
+    );
+
+    public static final String BLOB_CACHE_REGIONS_CURRENT = "es.blob_cache.regions.current";
+
+    private final SharedBlobCacheService<?> cacheService;
+    private final ThreadPool threadPool;
+    private final MeterRegistry meterRegistry;
+    private final TimeValue metricsInterval;
+    private final SetOnce<Scheduler.Cancellable> metricsTask = new SetOnce<>();
+    private final SetOnce<ConsumingLongGaugeMetric> regionsMetric = new SetOnce<>();
+
+    public BlobCachePeriodicMetrics(
+        SharedBlobCacheService<?> cacheService,
+        Settings settings,
+        ThreadPool threadPool,
+        MeterRegistry meterRegistry
+    ) {
+        this(cacheService, threadPool, meterRegistry, BLOB_CACHE_METRICS_INTERVAL_SETTING.get(settings));
+    }
+
+    /**
+     * For tests that configure a fixed interval.
+     */
+    BlobCachePeriodicMetrics(
+        SharedBlobCacheService<?> cacheService,
+        ThreadPool threadPool,
+        MeterRegistry meterRegistry,
+        TimeValue metricsInterval
+    ) {
+        this.cacheService = Objects.requireNonNull(cacheService);
+        this.threadPool = Objects.requireNonNull(threadPool);
+        this.meterRegistry = Objects.requireNonNull(meterRegistry);
+        this.metricsInterval = Objects.requireNonNull(metricsInterval);
+    }
+
+    private void sample() {
+        final ConsumingLongGaugeMetric metric = regionsMetric.get();
+        assert metric != null;
+        final int numRegions = cacheService.getStats().numberOfRegions();
+        if (numRegions == 0) {
+            return;
+        }
+        final long free = cacheService.freeRegionCount();
+        final long filled = numRegions - free;
+        metric.set(filled, attributesOf(cacheService, numRegions));
+    }
+
+    private static <KeyType extends SharedBlobCacheService.KeyBase> Map<String, Object> attributesOf(
+        SharedBlobCacheService<KeyType> cacheService,
+        int numRegions
+    ) {
+        return cacheService.getEvictionPolicy().metricAttributes(cacheService::iterateCachedRegions, numRegions);
+    }
+
+    @Override
+    protected void doStart() {
+        if (TimeValue.MINUS_ONE.equals(metricsInterval)) {
+            return;
+        }
+        regionsMetric.set(
+            ConsumingLongGaugeMetric.create(
+                meterRegistry,
+                BLOB_CACHE_REGIONS_CURRENT,
+                "The number of occupied shared blob-cache regions, with additional attributes supplied by the active eviction policy",
+                "entries"
+            )
+        );
+        metricsTask.set(threadPool.scheduleWithFixedDelay(this::sample, metricsInterval, threadPool.generic()));
+    }
+
+    @Override
+    protected void doStop() {
+        if (metricsTask.get() != null) {
+            metricsTask.get().cancel();
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {}
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/EvictionPolicy.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/EvictionPolicy.java
@@ -9,6 +9,9 @@ package org.elasticsearch.blobcache.shared;
 
 import org.elasticsearch.core.Releasable;
 
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -65,6 +68,20 @@ public interface EvictionPolicy<KeyType extends SharedBlobCacheService.KeyBase> 
      * have both been removed from the cache.
      */
     void onEvicted(CacheRegion<KeyType> region);
+
+    /**
+     * Policy-specific attributes for a periodic blob-cache metrics sample.
+     * <p>
+     * Implementations that need to inspect occupied regions should call {@code regions.accept(...)}
+     * at most once. This method must not perform I/O.
+     *
+     * @param regions    accepts a consumer of {@code (region, freq)} for each occupied initialized region
+     * @param numRegions cache capacity (total number of region slots), for percent attributes
+     * @return attribute map to attach to the occupancy gauge; empty by default
+     */
+    default Map<String, Object> metricAttributes(Consumer<BiConsumer<CacheRegion<KeyType>, Integer>> regions, int numRegions) {
+        return Map.of();
+    }
 
     /**
      * Called when the policy is closed so that it has a chance to perform any cleanup if needed. This is needed

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
@@ -934,8 +935,20 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         throw new UnsupportedOperationException("cache is not an LFUCache");
     }
 
-    // used by tests
-    EvictionPolicy<KeyType> getEvictionPolicy() {
+    /**
+     * Iterates occupied cache regions that have an assigned IO slot (fully initialized, not merely present in
+     * the key map while still initializing). The consumer receives the region and its current LFU frequency
+     * (may be stale if read without holding the cache monitor; acceptable for metrics).
+     */
+    public void iterateCachedRegions(BiConsumer<CacheRegion<KeyType>, Integer> consumer) {
+        if (cache instanceof LFUCache lfuCache) {
+            lfuCache.iterateCachedRegions(consumer);
+            return;
+        }
+        throw new UnsupportedOperationException("cache is not an LFUCache");
+    }
+
+    public EvictionPolicy<KeyType> getEvictionPolicy() {
         if (cache instanceof LFUCache lfuCache) {
             return lfuCache.evictionPolicy;
         }
@@ -946,9 +959,6 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         throw new AlreadyClosedException(message);
     }
 
-    /**
-     * NOTE: Method is package private mostly to allow checking the number of fee regions in tests.
-     */
     int freeRegionCount() {
         return freeRegions.size();
     }
@@ -2911,6 +2921,16 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                 }
             });
             return count[0];
+        }
+
+        void iterateCachedRegions(BiConsumer<CacheRegion<KeyType>, Integer> consumer) {
+            keyMapping.forEach((regionKey, entry) -> {
+                // Exclude still-initializing entries (no IO slot yet) so occupancy metrics cannot exceed capacity.
+                // freq is not volatile and may be stale without the monitor; acceptable for metrics sampling.
+                if (entry.chunk.isEvicted() == false && entry.chunk.volatileIO() != null) {
+                    consumer.accept(entry.chunk, entry.freq);
+                }
+            });
         }
 
         // used by tests

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetricsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetricsTests.java
@@ -17,13 +17,11 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.telemetry.InstrumentType;
-import org.elasticsearch.telemetry.Measurement;
 import org.elasticsearch.telemetry.RecordingMeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.function.Supplier;
 
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.equalTo;
@@ -55,15 +53,9 @@ public class BlobCachePeriodicMetricsTests extends ESTestCase {
             assertThat(recording.getLongGauge(BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT), notNullValue());
             taskQueue.runTasksUpToTimeInOrder(taskQueue.getCurrentTimeMillis() + interval.millis());
             recording.getRecorder().collect();
-            final var getLastMeasurement = new Supplier<Measurement>() {
-                @Override
-                public Measurement get() {
-                    return recording.getRecorder()
-                        .getMeasurements(InstrumentType.LONG_GAUGE, BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT)
-                        .getLast();
-                }
-            };
-            final var firstMeasurement = getLastMeasurement.get();
+            final var firstMeasurement = recording.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT)
+                .getLast();
             assertThat(firstMeasurement.getLong(), equalTo(0L));
             assertThat(firstMeasurement.attributes().isEmpty(), equalTo(true));
 

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetricsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/BlobCachePeriodicMetricsTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.blobcache.BlobCacheMetrics;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class BlobCachePeriodicMetricsTests extends ESTestCase {
+
+    public void testStartRegistersMetricAndPublishesFilledCount() throws IOException {
+        final int numRegions = randomIntBetween(4, 10);
+        final long regionSize = SharedBytes.PAGE_SIZE * 10L;
+        final Settings settings = cacheSettings(numRegions, regionSize);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final RecordingMeterRegistry recording = new RecordingMeterRegistry();
+        final TimeValue interval = TimeValue.timeValueMinutes(1);
+
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                new BlobCacheMetrics(recording)
+            );
+            var metrics = new BlobCachePeriodicMetrics(cacheService, taskQueue.getThreadPool(), recording, interval)
+        ) {
+            metrics.start();
+            assertThat(recording.getLongGauge(BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT), notNullValue());
+            taskQueue.runTasksUpToTimeInOrder(taskQueue.getCurrentTimeMillis() + interval.millis());
+            recording.getRecorder().collect();
+            final var getLastMeasurement = new Supplier<Measurement>() {
+                @Override
+                public Measurement get() {
+                    return recording.getRecorder()
+                        .getMeasurements(InstrumentType.LONG_GAUGE, BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT)
+                        .getLast();
+                }
+            };
+            final var firstMeasurement = getLastMeasurement.get();
+            assertThat(firstMeasurement.getLong(), equalTo(0L));
+            assertThat(firstMeasurement.attributes().isEmpty(), equalTo(true));
+
+            for (int i = 0; i < numRegions; i++) {
+                final var cacheKey = new TestCacheKey(new ShardId("index", randomUUID(), 0), "file-" + i);
+                SharedBlobCacheServiceTestUtils.cacheRegion(cacheService, cacheKey, regionSize - 1, 0);
+            }
+
+            taskQueue.runTasksUpToTimeInOrder(taskQueue.getCurrentTimeMillis() + interval.millis());
+            recording.getRecorder().collect();
+            final var lastMeasurement = recording.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT)
+                .getLast();
+            assertThat(lastMeasurement.getLong(), equalTo((long) numRegions));
+            assertThat(lastMeasurement.attributes().isEmpty(), equalTo(true));
+        }
+    }
+
+    public void testDisabledIntervalDoesNotRegisterMetric() throws IOException {
+        final Settings settings = cacheSettings(4, SharedBytes.PAGE_SIZE * 10L);
+        final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        final RecordingMeterRegistry recording = new RecordingMeterRegistry();
+        final Settings metricsSettings = Settings.builder()
+            .put(settings)
+            .put(BlobCachePeriodicMetrics.BLOB_CACHE_METRICS_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)
+            .build();
+
+        try (
+            NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
+            var cacheService = new SharedBlobCacheService<TestCacheKey>(
+                environment,
+                settings,
+                taskQueue.getThreadPool(),
+                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                new BlobCacheMetrics(recording)
+            );
+            var metrics = new BlobCachePeriodicMetrics(cacheService, metricsSettings, taskQueue.getThreadPool(), recording)
+        ) {
+            metrics.start();
+            assertThat(recording.getLongGauge(BlobCachePeriodicMetrics.BLOB_CACHE_REGIONS_CURRENT), nullValue());
+        }
+    }
+
+    public void testDefaultIntervalDependsOnStateless() {
+        assertThat(BlobCachePeriodicMetrics.BLOB_CACHE_METRICS_INTERVAL_SETTING.get(Settings.EMPTY), equalTo(TimeValue.MINUS_ONE));
+        assertThat(
+            BlobCachePeriodicMetrics.BLOB_CACHE_METRICS_INTERVAL_SETTING.get(
+                Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, false).build()
+            ),
+            equalTo(TimeValue.MINUS_ONE)
+        );
+        assertThat(
+            BlobCachePeriodicMetrics.BLOB_CACHE_METRICS_INTERVAL_SETTING.get(
+                Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build()
+            ),
+            equalTo(TimeValue.timeValueMinutes(5))
+        );
+    }
+
+    private static Settings cacheSettings(int numRegions, long regionSize) {
+        return Settings.builder()
+            .put(NODE_NAME_SETTING.getKey(), "node")
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(regionSize * numRegions))
+            .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(regionSize))
+            .put(SharedBlobCacheService.SHARED_CACHE_INITIAL_DECAYS_SETTING.getKey(), 0)
+            .put("path.home", createTempDir())
+            .build();
+    }
+
+    private record TestCacheKey(ShardId shardId, String file) implements SharedBlobCacheService.KeyBase {}
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
+import org.elasticsearch.blobcache.shared.BlobCachePeriodicMetrics;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -327,6 +328,9 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
             );
             this.frozenCacheService.set(sharedBlobCacheService);
             components.add(cacheService);
+            components.add(
+                new BlobCachePeriodicMetrics(sharedBlobCacheService, settings, threadPool, services.telemetryProvider().getMeterRegistry())
+            );
             final BlobStoreCacheService blobStoreCacheService = new BlobStoreCacheService(client, SNAPSHOT_BLOB_CACHE_INDEX);
             this.blobStoreCacheService.set(blobStoreCacheService);
             clusterService.addListener(

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.AutoCreateAction;
 import org.elasticsearch.action.termvectors.EnsureDocsSearchableAction;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
+import org.elasticsearch.blobcache.shared.BlobCachePeriodicMetrics;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -65,7 +66,6 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
@@ -795,6 +795,7 @@ public class StatelessPlugin extends Plugin
         );
         var sharedBlobCacheServiceSupplier = new SharedBlobCacheServiceSupplier(setAndGet(this.sharedBlobCacheService, cacheService));
         components.add(sharedBlobCacheServiceSupplier);
+        components.add(new BlobCachePeriodicMetrics(cacheService, settings, threadPool, services.telemetryProvider().getMeterRegistry()));
         var cacheBlobReaderService = setAndGet(
             this.cacheBlobReaderService,
             new CacheBlobReaderService(settings, cacheService, client, threadPool)
@@ -1231,7 +1232,8 @@ public class StatelessPlugin extends Plugin
         super.close();
         STATELESS_FEATURE.stopTracking(getLicenseState(), NAME);
 
-        // We should close the shared blob cache only after we made sure that all shards have been closed.
+        // Shared blob cache is a LifecycleComponent closed with other plugin components after IndicesService.
+        // Await shard close first so we can warn if anything is still open when the cache stops.
         try {
             if (indicesService.get().awaitClose(1, TimeUnit.MINUTES) == false) {
                 logger.warn("Closing the Stateless services while some shards are still open");
@@ -1239,7 +1241,6 @@ public class StatelessPlugin extends Plugin
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        Releasables.close(sharedBlobCacheService.get());
         IOUtils.close(reshardSearchFilters.get());
         try {
             IOUtils.close(blobStoreHealthIndicator.get());

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -66,6 +66,7 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
@@ -1232,8 +1233,7 @@ public class StatelessPlugin extends Plugin
         super.close();
         STATELESS_FEATURE.stopTracking(getLicenseState(), NAME);
 
-        // Shared blob cache is a LifecycleComponent closed with other plugin components after IndicesService.
-        // Await shard close first so we can warn if anything is still open when the cache stops.
+        // We should close the shared blob cache only after we made sure that all shards have been closed.
         try {
             if (indicesService.get().awaitClose(1, TimeUnit.MINUTES) == false) {
                 logger.warn("Closing the Stateless services while some shards are still open");
@@ -1241,6 +1241,7 @@ public class StatelessPlugin extends Plugin
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+        Releasables.close(sharedBlobCacheService.get());
         IOUtils.close(reshardSearchFilters.get());
         try {
             IOUtils.close(blobStoreHealthIndicator.get());

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
@@ -12,6 +12,8 @@ import org.elasticsearch.blobcache.shared.EvictionPolicy;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
@@ -19,7 +21,10 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /// Eviction policy that does not evict cache regions for shards present on this node whose content timestamp
@@ -43,21 +48,65 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
         Setting.Property.NodeScope
     );
 
+    public static final String PINNED_ATTRIBUTE_KEY = "pinned";
+    public static final String PINNED_PERCENT_ATTRIBUTE_KEY = "pinned_percent";
+    public static final String BACKFILL_IN_PROGRESS_ATTRIBUTE_KEY = "backfill";
+    public static final String BACKFILL_PERCENT_ATTRIBUTE_KEY = "backfill_percent";
+    public static final String UNKNOWN_TIMESTAMP_ATTRIBUTE_KEY = "unknown";
+    public static final String UNKNOWN_PERCENT_ATTRIBUTE_KEY = "unknown_percent";
+    public static final String MINIMAL_TIMESTAMP_ATTRIBUTE_KEY = "minimal";
+    public static final String MINIMAL_PERCENT_ATTRIBUTE_KEY = "minimal_percent";
+    /// Pinned regions at LFU frequency level 0 (least recently / about to be decayed).
+    public static final String FREQ_LOW_ATTRIBUTE_KEY = "freq_low";
+    public static final String FREQ_LOW_PERCENT_ATTRIBUTE_KEY = "freq_low_percent";
+    /// Pinned regions in the next ~20% of frequency levels (1...midBucketMaxInclusive(maxFreq)).
+    public static final String FREQ_MID_ATTRIBUTE_KEY = "freq_mid";
+    public static final String FREQ_MID_PERCENT_ATTRIBUTE_KEY = "freq_mid_percent";
+    /// Pinned regions in the remaining ~80% of frequency levels.
+    public static final String FREQ_HIGH_ATTRIBUTE_KEY = "freq_high";
+    public static final String FREQ_HIGH_PERCENT_ATTRIBUTE_KEY = "freq_high_percent";
+
     private final Predicate<ShardId> hasShardPredicate;
     private final ThreadPool threadPool;
+    private final int maxFreq;
 
     private volatile TimeValue pinnedWindowDuration;
 
-    private final Releasable releasePinnedWindowDurationUpdater;
+    @Nullable
+    private final Releasable releaseSettingsUpdaters;
 
     public PinnedWindowEvictionPolicy(ClusterSettings clusterSettings, ThreadPool threadPool, Predicate<ShardId> hasShardPredicate) {
         this.hasShardPredicate = Objects.requireNonNull(hasShardPredicate);
         this.threadPool = Objects.requireNonNull(threadPool);
+        Objects.requireNonNull(clusterSettings);
         this.pinnedWindowDuration = clusterSettings.get(PINNED_WINDOW_DURATION_SETTING);
-        this.releasePinnedWindowDurationUpdater = Releasables.releaseOnce(
-            Objects.requireNonNull(clusterSettings)
-                .addRemovableSettingsUpdateConsumer(PINNED_WINDOW_DURATION_SETTING, value -> this.pinnedWindowDuration = value)
+        this.maxFreq = clusterSettings.get(SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING);
+        this.releaseSettingsUpdaters = Releasables.releaseOnce(
+            clusterSettings.addRemovableSettingsUpdateConsumer(PINNED_WINDOW_DURATION_SETTING, value -> this.pinnedWindowDuration = value)
         );
+    }
+
+    /**
+     * For tests that configure a fixed pinned-window duration.
+     */
+    protected PinnedWindowEvictionPolicy(ThreadPool threadPool, Predicate<ShardId> hasShardPredicate, TimeValue pinnedWindowDuration) {
+        this(threadPool, hasShardPredicate, pinnedWindowDuration, SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING.get(Settings.EMPTY));
+    }
+
+    /**
+     * For tests that configure a fixed pinned-window duration and max LFU frequency.
+     */
+    protected PinnedWindowEvictionPolicy(
+        ThreadPool threadPool,
+        Predicate<ShardId> hasShardPredicate,
+        TimeValue pinnedWindowDuration,
+        int maxFreq
+    ) {
+        this.hasShardPredicate = Objects.requireNonNull(hasShardPredicate);
+        this.threadPool = Objects.requireNonNull(threadPool);
+        this.pinnedWindowDuration = pinnedWindowDuration;
+        this.maxFreq = maxFreq;
+        this.releaseSettingsUpdaters = null;
     }
 
     public TimeValue getPinnedWindowDuration() {
@@ -76,30 +125,28 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
     }
 
     /**
-     * Returns {@code true} if {@code timestampMillis} is within the pinned window relative to
-     * {@code pinnedWindowCutoffMillis}, inclusive of the window boundary.
+     * Returns {@code true} if {@code region} is currently protected from eviction by this policy based on its own
+     * state (independent of any incoming region).
      */
-    protected boolean isWithinPinnedWindow(long timestampMillis, long pinnedWindowCutoffMillis) {
+    boolean isProtected(CacheRegion<FileCacheKey> region, long pinnedWindowCutoffMillis) {
+        if (hasShard(region.key().shardId()) == false) {
+            return false;
+        }
+        final long timestampMillis = region.timestampMillis();
+        if (timestampMillis < 0) {
+            assert timestampMillis == SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP
+                || timestampMillis == SharedBlobCacheService.UNKNOWN_TIMESTAMP : "unexpected negative timestamp: " + timestampMillis;
+            return true;
+        }
+        // TODO: regions of unboosted shards, and of shards with a boost multiplier of less than 1, should be
+        // evicted irrespective of their timestamp.
         return timestampMillis >= pinnedWindowCutoffMillis;
     }
 
     @Override
     public Predicate<CacheRegion<FileCacheKey>> createPredicate(CacheRegion<FileCacheKey> incoming) {
         final long pinnedWindowCutoffMillis = currentTimeMillis() - pinnedWindowDuration.getMillis();
-        return region -> {
-            if (hasShard(region.key().shardId()) == false) {
-                return true;
-            }
-            final long timestampMillis = region.timestampMillis();
-            if (timestampMillis < 0) {
-                assert timestampMillis == SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP
-                    || timestampMillis == SharedBlobCacheService.UNKNOWN_TIMESTAMP : "unexpected negative timestamp: " + timestampMillis;
-                return false;
-            }
-            // TODO: regions of unboosted shards, and of shards with a boost multiplier of less than 1, should be
-            // evicted irrespective of their timestamp.
-            return isWithinPinnedWindow(timestampMillis, pinnedWindowCutoffMillis) == false;
-        };
+        return region -> isProtected(region, pinnedWindowCutoffMillis) == false;
     }
 
     @Override
@@ -109,8 +156,86 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
     public void onEvicted(CacheRegion<FileCacheKey> region) {}
 
     @Override
+    public Map<String, Object> metricAttributes(Consumer<BiConsumer<CacheRegion<FileCacheKey>, Integer>> regions, int numRegions) {
+        if (numRegions <= 0) {
+            return Map.of();
+        }
+        final int midBucketMaxInclusive = midBucketMaxInclusive(maxFreq);
+        final long[] pinned = new long[1];
+        final long[] backfillInProgress = new long[1];
+        final long[] unknownTimestamp = new long[1];
+        final long[] minimalTimestamp = new long[1];
+        final long[] freqLow = new long[1];
+        final long[] freqMid = new long[1];
+        final long[] freqHigh = new long[1];
+        final long pinnedWindowCutoffMillis = currentTimeMillis() - pinnedWindowDuration.getMillis();
+        regions.accept((region, freq) -> {
+            final long timestampMillis = region.timestampMillis();
+            if (timestampMillis == SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP) {
+                minimalTimestamp[0]++;
+            }
+            if (isProtected(region, pinnedWindowCutoffMillis) == false) {
+                return;
+            }
+            pinned[0]++;
+            if (timestampMillis == SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP) {
+                backfillInProgress[0]++;
+            } else if (timestampMillis == SharedBlobCacheService.UNKNOWN_TIMESTAMP) {
+                unknownTimestamp[0]++;
+            }
+            if (freq <= 0) {
+                freqLow[0]++;
+            } else if (freq <= midBucketMaxInclusive) {
+                freqMid[0]++;
+            } else {
+                freqHigh[0]++;
+            }
+        });
+        return Map.ofEntries(
+            Map.entry(PINNED_ATTRIBUTE_KEY, pinned[0]),
+            Map.entry(PINNED_PERCENT_ATTRIBUTE_KEY, toPercent(pinned[0], numRegions)),
+            Map.entry(BACKFILL_IN_PROGRESS_ATTRIBUTE_KEY, backfillInProgress[0]),
+            Map.entry(BACKFILL_PERCENT_ATTRIBUTE_KEY, toPercent(backfillInProgress[0], numRegions)),
+            Map.entry(UNKNOWN_TIMESTAMP_ATTRIBUTE_KEY, unknownTimestamp[0]),
+            Map.entry(UNKNOWN_PERCENT_ATTRIBUTE_KEY, toPercent(unknownTimestamp[0], numRegions)),
+            Map.entry(MINIMAL_TIMESTAMP_ATTRIBUTE_KEY, minimalTimestamp[0]),
+            Map.entry(MINIMAL_PERCENT_ATTRIBUTE_KEY, toPercent(minimalTimestamp[0], numRegions)),
+            Map.entry(FREQ_LOW_ATTRIBUTE_KEY, freqLow[0]),
+            Map.entry(FREQ_LOW_PERCENT_ATTRIBUTE_KEY, toPercent(freqLow[0], numRegions)),
+            Map.entry(FREQ_MID_ATTRIBUTE_KEY, freqMid[0]),
+            Map.entry(FREQ_MID_PERCENT_ATTRIBUTE_KEY, toPercent(freqMid[0], numRegions)),
+            Map.entry(FREQ_HIGH_ATTRIBUTE_KEY, freqHigh[0]),
+            Map.entry(FREQ_HIGH_PERCENT_ATTRIBUTE_KEY, toPercent(freqHigh[0], numRegions))
+        );
+    }
+
+    /**
+     * Upper inclusive frequency for the mid bucket: ~20% of levels after level 0.
+     * Levels are {@code [0, maxFreq)}. Level 0 is the low bucket; {@code 1..result} is mid; the rest is high.
+     */
+    static int midBucketMaxInclusive(int maxFreq) {
+        assert maxFreq >= 1 : maxFreq;
+        if (maxFreq == 1) {
+            // Only level 0 exists; mid/high buckets stay empty.
+            return 0;
+        }
+        return Math.max(1, (maxFreq - 1) * 20 / 100);
+    }
+
+    /**
+     * Converts a count to an integer percent of {@code numRegions}, rounding up so any non-zero count is at least
+     * {@code 1}. Caps at {@code 100} so label values' cardinality stays bounded.
+     */
+    static long toPercent(long count, int numRegions) {
+        assert numRegions > 0 : numRegions;
+        if (count <= 0L) {
+            return 0L;
+        }
+        return Math.min(100L, Math.max(1L, (count * 100L + numRegions - 1L) / numRegions));
+    }
+
+    @Override
     public void close() {
-        // Remove the pinned window duration updater from ClusterSettings registration
-        Releasables.close(releasePinnedWindowDurationUpdater);
+        Releasables.close(releaseSettingsUpdaters);
     }
 }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicy.java
@@ -12,8 +12,6 @@ import org.elasticsearch.blobcache.shared.EvictionPolicy;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
@@ -72,7 +70,6 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
 
     private volatile TimeValue pinnedWindowDuration;
 
-    @Nullable
     private final Releasable releaseSettingsUpdaters;
 
     public PinnedWindowEvictionPolicy(ClusterSettings clusterSettings, ThreadPool threadPool, Predicate<ShardId> hasShardPredicate) {
@@ -84,29 +81,6 @@ public class PinnedWindowEvictionPolicy implements EvictionPolicy<FileCacheKey> 
         this.releaseSettingsUpdaters = Releasables.releaseOnce(
             clusterSettings.addRemovableSettingsUpdateConsumer(PINNED_WINDOW_DURATION_SETTING, value -> this.pinnedWindowDuration = value)
         );
-    }
-
-    /**
-     * For tests that configure a fixed pinned-window duration.
-     */
-    protected PinnedWindowEvictionPolicy(ThreadPool threadPool, Predicate<ShardId> hasShardPredicate, TimeValue pinnedWindowDuration) {
-        this(threadPool, hasShardPredicate, pinnedWindowDuration, SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING.get(Settings.EMPTY));
-    }
-
-    /**
-     * For tests that configure a fixed pinned-window duration and max LFU frequency.
-     */
-    protected PinnedWindowEvictionPolicy(
-        ThreadPool threadPool,
-        Predicate<ShardId> hasShardPredicate,
-        TimeValue pinnedWindowDuration,
-        int maxFreq
-    ) {
-        this.hasShardPredicate = Objects.requireNonNull(hasShardPredicate);
-        this.threadPool = Objects.requireNonNull(threadPool);
-        this.pinnedWindowDuration = pinnedWindowDuration;
-        this.maxFreq = maxFreq;
-        this.releaseSettingsUpdaters = null;
     }
 
     public TimeValue getPinnedWindowDuration() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SwitchingEvictionPolicy.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SwitchingEvictionPolicy.java
@@ -19,7 +19,10 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -76,6 +79,11 @@ class SwitchingEvictionPolicy implements EvictionPolicy<FileCacheKey> {
     @Override
     public void onEvicted(CacheRegion<FileCacheKey> region) {
         delegate.onEvicted(region);
+    }
+
+    @Override
+    public Map<String, Object> metricAttributes(Consumer<BiConsumer<CacheRegion<FileCacheKey>, Integer>> regions, int numRegions) {
+        return delegate.metricAttributes(regions, numRegions);
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
@@ -40,7 +40,9 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP;
@@ -152,6 +154,49 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
         assertTrue(canEvict(policy, region(shardId, now - PINNED_WINDOW_DURATION.millis() - 1)));
     }
 
+    public void testMetricAttributesCountsPinnedAndTimestampBuckets() {
+        final long now = TimeValue.timeValueDays(365).millis() + randomLongBetween(0, TimeValue.timeValueDays(365).millis());
+        final ShardId shardId = new ShardId("index", randomUUID(), 0);
+        final var policy = fixedTimePolicy(now, PINNED_WINDOW_DURATION, shardId);
+        final long insideWindow = now - randomLongBetween(0, PINNED_WINDOW_DURATION.millis() / 2);
+        final long outsideWindow = now - PINNED_WINDOW_DURATION.millis() - 1;
+        final int numRegions = 10;
+
+        final Map<String, Object> attributes = policy.metricAttributes(consumer -> {
+            consumer.accept(region(shardId, insideWindow), 1);
+            consumer.accept(region(shardId, UNKNOWN_TIMESTAMP), 0);
+            consumer.accept(region(shardId, BACKFILL_IN_PROGRESS_TIMESTAMP), 50);
+            consumer.accept(region(shardId, SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP), 0);
+            consumer.accept(region(shardId, outsideWindow), 2);
+        }, numRegions);
+
+        // pinned: inside + unknown + backfill (minimal and outside are not pinned)
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.PINNED_ATTRIBUTE_KEY), equalTo(3L));
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.PINNED_PERCENT_ATTRIBUTE_KEY), equalTo(30L));
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.UNKNOWN_TIMESTAMP_ATTRIBUTE_KEY), equalTo(1L));
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.BACKFILL_IN_PROGRESS_ATTRIBUTE_KEY), equalTo(1L));
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.MINIMAL_TIMESTAMP_ATTRIBUTE_KEY), equalTo(1L));
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.FREQ_LOW_ATTRIBUTE_KEY), equalTo(1L)); // unknown at freq 0
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.FREQ_MID_ATTRIBUTE_KEY), equalTo(1L)); // inside at freq 1
+        assertThat(attributes.get(PinnedWindowEvictionPolicy.FREQ_HIGH_ATTRIBUTE_KEY), equalTo(1L)); // backfill at freq 50
+    }
+
+    public void testToPercentRoundsUpNonZeroCounts() {
+        assertThat(PinnedWindowEvictionPolicy.toPercent(0, 100), equalTo(0L));
+        assertThat(PinnedWindowEvictionPolicy.toPercent(1, 100), equalTo(1L));
+        assertThat(PinnedWindowEvictionPolicy.toPercent(1, 1000), equalTo(1L));
+        assertThat(PinnedWindowEvictionPolicy.toPercent(5, 100), equalTo(5L));
+        assertThat(PinnedWindowEvictionPolicy.toPercent(100, 100), equalTo(100L));
+        assertThat(PinnedWindowEvictionPolicy.toPercent(99, 100), equalTo(99L));
+    }
+
+    public void testMidBucketMaxInclusive() {
+        assertThat(PinnedWindowEvictionPolicy.midBucketMaxInclusive(1), equalTo(0));
+        assertThat(PinnedWindowEvictionPolicy.midBucketMaxInclusive(2), equalTo(1));
+        assertThat(PinnedWindowEvictionPolicy.midBucketMaxInclusive(5), equalTo(1));
+        assertThat(PinnedWindowEvictionPolicy.midBucketMaxInclusive(100), equalTo(19));
+    }
+
     public void testShrinkingPinnedWindowMakesRegionEvictable() {
         clusterSettings.applySettings(Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), PINNED_WINDOW_DURATION).build());
         final ShardId shardId = new ShardId("index", randomUUID(), 0);
@@ -160,7 +205,7 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
         final var policy = new PinnedWindowEvictionPolicy(
             clusterSettings,
             clusterService.threadPool(),
-            shardIdPredicate -> shardIdPredicate.equals(shardId)
+            candidate -> candidate.equals(shardId)
         );
         final var region = region(shardId, timestampMillis);
 
@@ -267,7 +312,7 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
     }
 
     private static final class FixedTimePinnedWindowEvictionPolicy extends PinnedWindowEvictionPolicy {
-        private final long fixedCurrentTimeMillis;
+        private final AtomicLong fixedCurrentTimeMillis;
 
         FixedTimePinnedWindowEvictionPolicy(
             ThreadPool threadPool,
@@ -275,19 +320,14 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
             long fixedCurrentTimeMillis,
             TimeValue pinnedWindowDuration
         ) {
-            super(createClusterSettingsWithPinnedWindowDuration(pinnedWindowDuration), threadPool, hasShardPredicate);
-            this.fixedCurrentTimeMillis = fixedCurrentTimeMillis;
+            super(threadPool, hasShardPredicate, pinnedWindowDuration);
+            this.fixedCurrentTimeMillis = new AtomicLong(fixedCurrentTimeMillis);
         }
 
         @Override
         protected long currentTimeMillis() {
-            return fixedCurrentTimeMillis;
+            return fixedCurrentTimeMillis.get();
         }
-    }
-
-    private static ClusterSettings createClusterSettingsWithPinnedWindowDuration(TimeValue pinnedWindowDuration) {
-        final Settings settings = Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), pinnedWindowDuration).build();
-        return new ClusterSettings(settings, Sets.union(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS, Set.of(PINNED_WINDOW_DURATION_SETTING)));
     }
 
     private static IndexMetadata indexMetadata(String indexName, String indexUuid) {
@@ -315,6 +355,7 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
     private static ClusterSettings createClusterSettings(Settings settings) {
         Set<Setting<?>> settingsSet = Sets.newHashSet(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         settingsSet.add(PINNED_WINDOW_DURATION_SETTING);
+        settingsSet.add(SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING);
         settingsSet.add(StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING);
         settingsSet.add(StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_EVICTION_POLICY_SEARCH_SETTING);
         return new ClusterSettings(settings, settingsSet);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP;
@@ -312,7 +311,7 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
     }
 
     private static final class FixedTimePinnedWindowEvictionPolicy extends PinnedWindowEvictionPolicy {
-        private final AtomicLong fixedCurrentTimeMillis;
+        private final long fixedCurrentTimeMillis;
 
         FixedTimePinnedWindowEvictionPolicy(
             ThreadPool threadPool,
@@ -320,14 +319,25 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
             long fixedCurrentTimeMillis,
             TimeValue pinnedWindowDuration
         ) {
-            super(threadPool, hasShardPredicate, pinnedWindowDuration);
-            this.fixedCurrentTimeMillis = new AtomicLong(fixedCurrentTimeMillis);
+            super(createClusterSettingsWithPinnedWindowDuration(pinnedWindowDuration), threadPool, hasShardPredicate);
+            this.fixedCurrentTimeMillis = fixedCurrentTimeMillis;
         }
 
         @Override
         protected long currentTimeMillis() {
-            return fixedCurrentTimeMillis.get();
+            return fixedCurrentTimeMillis;
         }
+    }
+
+    private static ClusterSettings createClusterSettingsWithPinnedWindowDuration(TimeValue pinnedWindowDuration) {
+        final Settings settings = Settings.builder().put(PINNED_WINDOW_DURATION_SETTING.getKey(), pinnedWindowDuration).build();
+        return new ClusterSettings(
+            settings,
+            Sets.union(
+                ClusterSettings.BUILT_IN_CLUSTER_SETTINGS,
+                Set.of(PINNED_WINDOW_DURATION_SETTING, SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING)
+            )
+        );
     }
 
     private static IndexMetadata indexMetadata(String indexName, String indexUuid) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheEvictionPolicyTypeTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/StatelessCacheEvictionPolicyTypeTests.java
@@ -125,6 +125,7 @@ public class StatelessCacheEvictionPolicyTypeTests extends ESTestCase {
     private static ClusterSettings createClusterSettings(Settings settings) {
         Set<Setting<?>> clusterSettings = Sets.newHashSet(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterSettings.add(PINNED_WINDOW_DURATION_SETTING);
+        clusterSettings.add(org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING);
         clusterSettings.add(STATELESS_CACHE_BOOST_PREFERENCE_EVICTION_POLICY_SEARCH_SETTING);
         return new ClusterSettings(settings, clusterSettings);
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SwitchingEvictionPolicyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SwitchingEvictionPolicyTests.java
@@ -117,6 +117,7 @@ public class SwitchingEvictionPolicyTests extends ESTestCase {
     private static ClusterSettings createClusterSettings(Settings settings) {
         var settingSet = Sets.newHashSet(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         settingSet.add(PINNED_WINDOW_DURATION_SETTING);
+        settingSet.add(org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_MAX_FREQ_SETTING);
         settingSet.add(STATELESS_CACHE_BOOST_PREFERENCE_EVICTION_POLICY_SEARCH_SETTING);
         return new ClusterSettings(settings, settingSet);
     }


### PR DESCRIPTION
New BlobCachePeriodicMetrics that exposes peridocially the filled regions of the cache, plus additionally any other attributes that the eviction policy calculates by iterating all active regions and their frequencies.

Used by PinnedWindowEvictionPolicy to expose several metrics around timestamps and pinned regions.

Relates elastic/elasticsearch-team#4589