### PR TITLE
ESQL: Unmute StSimplifyPreserveTopologyTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -86,45 +86,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
   method: testMonitorClusterHealth
   issue: https://github.com/elastic/elasticsearch/issues/148615
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[double].}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[float]. null in 1}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[integer]. null in 1}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[double]. null in 1}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[long]. null in 1 #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=<geo_shape>, <null>}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[integer]. #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[long]. null in 0}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[double]. null in 0 #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[float]. #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[float]. null in 0 #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[integer]. null in 0}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: "testEvaluateInManyThreads {TestCase=geo_shape with tolerance[long]. #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/150079
 - class: org.elasticsearch.compute.operator.exchange.ExchangeServiceTests
   method: testExchangeSourceContinueOnFailure
   issue: https://github.com/elastic/elasticsearch/issues/150552


### PR DESCRIPTION
The 13 `testEvaluateInManyThreads` mutes on this branch point at #150079, closed 2026-06-22. Its fix caps random test geometries at 100 vertices and reached 9.4 via backport #151836, but the unmute that #151554 asked for on backport was missed, so these parameterizations haven't run here in over five weeks.

Verified locally on this branch with the mutes removed: 1040 tests, 0 failures, and all 13 parameterizations confirmed executing. Re-ran with `-Dtests.iters=5` since the original failure was seed-dependent: 5200 tests, 0 failures. On `main`, where this method isn't muted, the class has been clean since 2026-06-22.

Closes #155407

Assisted by Claude
