### PR TITLE
[9.5] Update ironbank base image from 9.7 to 9.8 (#155395)

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
@@ -20,7 +20,7 @@
 
 ARG BASE_REGISTRY=registry1.dso.mil
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.7
+ARG BASE_TAG=9.8
 
 ################################################################################
 # Build stage 1 `builder`:

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -11,7 +11,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "9.7"
+  BASE_TAG: "9.8"
 # Docker image labels
 labels:
   org.opencontainers.image.title: "elasticsearch"


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Update ironbank base image from 9.7 to 9.8 (#155395)