### PR TITLE
Allow GC of closed search contexts in ES|QL

### DIFF
--- a/docs/changelog/155418.yaml
+++ b/docs/changelog/155418.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155418
+summary: Allow GC of closed search contexts in ES|QL
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
@@ -7,10 +7,13 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
 
 import java.util.Arrays;
 import java.util.List;
@@ -53,8 +56,15 @@ class AcquiredSearchContexts implements Releasable {
         checkNotClosed();
         var startingIndex = nextAddIndex;
         for (var cse : searchContexts) {
-            allContexts[nextAddIndex] = new ComputeSearchContext(nextAddIndex, cse);
-            nextAddIndex++;
+            final int idx = nextAddIndex++;
+            cse.addReleasable(() -> {
+                synchronized (AcquiredSearchContexts.this) {
+                    // Allow GC of closed search contexts as soon as they are released.
+                    // noinspection resource
+                    allContexts[idx] = new AlreadyReleasedComputeSearchContext(idx);
+                }
+            });
+            allContexts[idx] = new ComputeSearchContext(idx, cse);
         }
         return new SubRanged<>(allContexts, startingIndex, nextAddIndex);
     }
@@ -198,6 +208,32 @@ class AcquiredSearchContexts implements Releasable {
         @Override
         public <U> IndexedByShardId<U> map(Function<S, U> anotherMapper) {
             return new Mapped<>(this, cache.length, offset, anotherMapper);
+        }
+    }
+
+    private static class AlreadyReleasedComputeSearchContext extends ComputeSearchContext {
+        AlreadyReleasedComputeSearchContext(int index) {
+            super(index, null);
+        }
+
+        @Override
+        public SearchContext searchContext() {
+            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
+        }
+
+        @Override
+        EsPhysicalOperationProviders.ShardContext newDetachedShardContext() {
+            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
+        }
+
+        @Override
+        EsPhysicalOperationProviders.ShardContext shardContext(QueryWarnings queryWarnings) {
+            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
+        }
+
+        @Override
+        public void close() {
+            // no-op
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
@@ -7,13 +7,10 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
-import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
-import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
 
 import java.util.Arrays;
 import java.util.List;
@@ -59,9 +56,11 @@ class AcquiredSearchContexts implements Releasable {
             final int idx = nextAddIndex++;
             cse.addReleasable(() -> {
                 synchronized (AcquiredSearchContexts.this) {
-                    // Allow GC of closed search contexts as soon as they are released.
-                    // noinspection resource
-                    allContexts[idx] = new AlreadyReleasedComputeSearchContext(idx);
+                    ComputeSearchContext ctx = allContexts[idx];
+                    if (ctx != null) {
+                        // Allow GC of closed search contexts as soon as they are released.
+                        allContexts[idx] = ctx.tombstone();
+                    }
                 }
             });
             allContexts[idx] = new ComputeSearchContext(idx, cse);
@@ -208,32 +207,6 @@ class AcquiredSearchContexts implements Releasable {
         @Override
         public <U> IndexedByShardId<U> map(Function<S, U> anotherMapper) {
             return new Mapped<>(this, cache.length, offset, anotherMapper);
-        }
-    }
-
-    private static class AlreadyReleasedComputeSearchContext extends ComputeSearchContext {
-        AlreadyReleasedComputeSearchContext(int index) {
-            super(index, null);
-        }
-
-        @Override
-        public SearchContext searchContext() {
-            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
-        }
-
-        @Override
-        EsPhysicalOperationProviders.ShardContext newDetachedShardContext() {
-            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
-        }
-
-        @Override
-        EsPhysicalOperationProviders.ShardContext shardContext(QueryWarnings queryWarnings) {
-            throw new AlreadyClosedException("ComputeSearchContext at index [" + index() + "] was already released");
-        }
-
-        @Override
-        public void close() {
-            // no-op
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.core.Releasable;
@@ -14,6 +15,8 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.DefaultShardContext;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
+
+import java.util.Objects;
 
 /**
  * Search and shard context used as entries in {@link org.elasticsearch.compute.lucene.IndexedByShardId}. These are shared by both the data
@@ -43,7 +46,23 @@ class ComputeSearchContext implements Releasable {
 
     ComputeSearchContext(int index, SearchContext searchContext) {
         this.index = index;
-        this.searchContext = searchContext;
+        this.searchContext = Objects.requireNonNull(searchContext);
+    }
+
+    private ComputeSearchContext(int index) {
+        this.index = index;
+        this.searchContext = null;
+    }
+
+    /** Tombstone with no {@link SearchContext}, so the closed search context can be GC'd. */
+    ComputeSearchContext tombstone() {
+        return new ComputeSearchContext(index);
+    }
+
+    private void ensureNotTombstone() {
+        if (searchContext == null) {
+            throw new AlreadyClosedException("ComputeSearchContext for index [" + index + "] was already closed");
+        }
     }
 
     public int index() {
@@ -58,6 +77,7 @@ class ComputeSearchContext implements Releasable {
     }
 
     public SearchContext searchContext() {
+        ensureNotTombstone();
         return searchContext;
     }
 
@@ -74,6 +94,7 @@ class ComputeSearchContext implements Releasable {
     }
 
     private ShardContext createShardContext(Releasable releasable, QueryWarnings queryWarnings) {
+        ensureNotTombstone();
         EsqlSearchExecutionContext searchExecutionContext = new EsqlSearchExecutionContext(
             searchContext.getSearchExecutionContext(),
             queryWarnings

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.compute.querydsl.query.QueryWarnings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.internal.SearchContext;
@@ -41,6 +42,7 @@ import java.util.Objects;
  */
 class ComputeSearchContext implements Releasable {
     private final int index;
+    @Nullable
     private final SearchContext searchContext;
     private final SetOnce<ShardContext> shardContext = new SetOnce<>();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
@@ -61,6 +61,7 @@ class ComputeSearchContext implements Releasable {
 
     private void ensureNotTombstone() {
         if (searchContext == null) {
+            assert false : "ComputeSearchContext for index [" + index + "] was already closed";
             throw new AlreadyClosedException("ComputeSearchContext for index [" + index + "] was already closed");
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -1427,9 +1427,6 @@ public class ComputeService {
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);
-
-            List<SearchExecutionContext> localContexts = new ArrayList<>();
-            context.searchExecutionContexts().iterable().forEach(localContexts::add);
             boolean hasExternalSource = plan.anyMatch(
                 p -> p instanceof ExternalSourceExec
                     || (p instanceof FragmentExec f && f.fragment().anyMatch(ExternalRelation.class::isInstance))
@@ -1437,6 +1434,8 @@ public class ComputeService {
             PhysicalPlan localPlan;
             final String logicalPlanString;
             if (localPhysicalOptimization == LocalPhysicalOptimization.ENABLED) {
+                List<SearchExecutionContext> localContexts = new ArrayList<>();
+                context.searchExecutionContexts().iterable().forEach(localContexts::add);
                 if (hasExternalSource) {
                     localPlan = PlannerUtils.localPlan(
                         plannerSettings,


### PR DESCRIPTION
 ES|QL already closes search contexts as soon as compute no longer needs them. However, AcquiredSearchContexts kept those closed contexts in its global array, so their in-memory Lucene/codec structures could not be GCed. Queries target many shards could therefore retain a large amount of memory and even OOM.

Relates #139693