### PR TITLE
[Test] Fix flaky `StatelessReshardIT::testExplainApi`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -559,9 +559,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
   issue: https://github.com/elastic/elasticsearch/issues/155173
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
-  method: testExplainApi
-  issue: https://github.com/elastic/elasticsearch/issues/155193
 - class: org.elasticsearch.client.RestClientSingleHostIntegTests
   method: testRequestResetAndAbort
   issue: https://github.com/elastic/elasticsearch/issues/155213

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.explain;
 
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.get.GetResult;
@@ -179,5 +180,10 @@ public class ExplainResponse extends ActionResponse implements ToXContentObject 
     @Override
     public int hashCode() {
         return Objects.hash(index, id, explanation, getResult.isExists(), getResult.sourceAsMap(), getResult.getFields());
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.datastreams.CreateDataStreamAction;
 import org.elasticsearch.action.datastreams.GetDataStreamAction;
+import org.elasticsearch.action.explain.ExplainResponse;
 import org.elasticsearch.action.explain.TransportExplainAction;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetItemResponse;
@@ -78,6 +79,7 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.support.BlobMetadata;
@@ -4234,13 +4236,13 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
             .setQuery(QueryBuilders.matchQuery("field", "source_value"))
             .setFetchSource(true)
             .get(SAFE_AWAIT_TIMEOUT);
-        assertEquals(sourceShardReferenceResponse, sourceShardHandoffResponse);
+        assertSameExplainResult(sourceShardReferenceResponse, sourceShardHandoffResponse);
         var targetShardHandoffResponse = client(coordinator).prepareExplain(indexName, id2)
             .setRouting(shard1RoutingValue)
             .setQuery(QueryBuilders.matchQuery("field", "target_value"))
             .setFetchSource(true)
             .get(SAFE_AWAIT_TIMEOUT);
-        assertEquals(targetShardReferenceResponse, targetShardHandoffResponse);
+        assertSameExplainResult(targetShardReferenceResponse, targetShardHandoffResponse);
 
         splitBlocked.countDown();
         safeAwait(attemptingDone);
@@ -4251,13 +4253,13 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
                 .setQuery(QueryBuilders.matchQuery("field", "source_value"))
                 .setFetchSource(true)
                 .get(SAFE_AWAIT_TIMEOUT);
-            assertEquals(sourceShardReferenceResponse, sourceShardSplitResponse);
+            assertSameExplainResult(sourceShardReferenceResponse, sourceShardSplitResponse);
             var targetShardSplitResponse = client(coordinator).prepareExplain(indexName, id2)
                 .setRouting(shard1RoutingValue)
                 .setQuery(QueryBuilders.matchQuery("field", "target_value"))
                 .setFetchSource(true)
                 .get(SAFE_AWAIT_TIMEOUT);
-            assertEquals(targetShardReferenceResponse, targetShardSplitResponse);
+            assertSameExplainResult(targetShardReferenceResponse, targetShardSplitResponse);
         } finally {
             doneBlocked.countDown();
         }
@@ -5137,5 +5139,21 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
     private void waitForReshardCompletion(String indexName) {
         awaitClusterState((state) -> state.projectState().metadata().index(indexName).getReshardingMetadata() == null);
+    }
+
+    /// Asserts that two [ExplainResponse]s describe the same result, without requiring them to be identical.
+    ///
+    /// Two responses taken either side of a split are only identical for as long as no merge has run. An explanation embeds the
+    /// collection statistics of whichever shard copy served the request, plus the per-segment doc ID of the explained document, and both
+    /// change once a merge reclaims the unowned documents that the split target hard-deleted. That merge is expected but its timing is
+    /// not ours to control, so compare only the parts that resharding has to preserve.
+    private void assertSameExplainResult(ExplainResponse expected, ExplainResponse actual) {
+        var message = Strings.format("expected [%s] but was [%s]", expected, actual);
+        assertEquals(message, expected.getIndex(), actual.getIndex());
+        assertEquals(message, expected.getId(), actual.getId());
+        assertEquals(message, expected.isExists(), actual.isExists());
+        assertEquals(message, expected.isMatch(), actual.isMatch());
+        assertEquals(message, expected.getGetResult().sourceAsMap(), actual.getGetResult().sourceAsMap());
+        assertThat(message, actual.getExplanation().getValue().doubleValue(), greaterThan(0.0));
     }
 }


### PR DESCRIPTION
Fix flaky `StatelessReshardIT#testExplainApi`
---

`testExplainApi` calls `_explain` on two documents before a resharding split,
keeps the responses as references, then freezes the split at two checkpoints
and asserts the responses are still *exactly equal*.

That assertion is over-specified. An explain response embeds two things that a
merge can change:

- the BM25 collection statistics of whichever shard copy served it, and
- the per-segment doc ID of the explained document, in the
  `weight(field:value in N)` description.

During a split the target shard is handed a physical copy of all of the source
shard's documents and then hard-deletes the ones it does not own. In Lucene
those documents keep contributing to term statistics until a merge reclaims
them. Deleting one of two documents leaves the segment 50% deleted, well past
`index.merge.policy.deletes_pct_allowed` (default 20%), so a merge is expected
— it just usually doesn't finish inside the few milliseconds the test holds the
split frozen. That timing coin-flip is the flake.

## How we confirmed it

The reported failure was unreadable (`expected:<...ExplainResponse@3182e5cf>`),
so this PR also adds a `toString()` to `ExplainResponse`.

With that in place, forcing the merge at the point where the test does its
final explain calls reproduced the CI failure on the first run:

```
before merge: DocStats{count=1, deleted=1}
              CollectionStatistics[docCount=2, sumTotalTermFreq=2, sumDocFreq=2]
after merge:  DocStats{count=1, deleted=0}
              CollectionStatistics[docCount=1, sumTotalTermFreq=1, sumDocFreq=1]

expected: "value":0.6931471, "weight(field:target_value in 1)", idf from n=1, N=2
actual:   "value":0.2876821, "weight(field:target_value in 0)", idf from n=1, N=1
```

## The fix

Compare the parts resharding has to preserve — index, id, exists, matched and
the source — instead of the whole object. This is what `testTermVectorsApi` and
`testExplainApiStaleRequest` in the same file already do; `testExplainApi` was
the only test comparing whole responses.

Each assertion carries both full responses in its failure message, so if this
test ever fails again it says which field diverged and shows the surrounding
context.

assisted by Cursor, but makes sense to me, let me know if i'm missing something!

Closes #155193