### PR TITLE
Use short desc instead of nodeId() in cache capacity decider's canAllocate

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/SharedCacheCapacityAllocationDecider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/SharedCacheCapacityAllocationDecider.java
@@ -164,7 +164,12 @@ public class SharedCacheCapacityAllocationDecider extends AllocationDecider {
         assert nodeCacheSizeAndCommitments != null;
         final NodeCacheSizeAndCommitments nodeCommitments = nodeCacheSizeAndCommitments.get(node.nodeId());
         if (nodeCommitments == null) {
-            return allocation.decision(Decision.YES, NAME, "no cache size and commitment data available for node [%s]", node.nodeId());
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                "no cache size and commitment data available for node [%s]",
+                node.getShortNodeDescription()
+            );
         }
 
         // Snapshot the accounting mode once so a concurrent settings update can't mix boosted and total values within a single decision.
@@ -178,7 +183,7 @@ public class SharedCacheCapacityAllocationDecider extends AllocationDecider {
             if (isDebugEnabled || allocation.debugDecision()) {
                 final String message = Strings.format(
                     "node [%s] cache commitment [%d] bytes already exceeds the low watermark [%d] bytes (accounting mode [%s])",
-                    node.nodeId(),
+                    node.getShortNodeDescription(),
                     currentCommitmentBytes,
                     thresholdBytes,
                     accountingMode
@@ -203,7 +208,7 @@ public class SharedCacheCapacityAllocationDecider extends AllocationDecider {
                 "no cache requirement data available for shard [%s], node [%s] cache commitment [%d] bytes is below the low watermark "
                     + "[%d] bytes",
                 shardRouting.shardId(),
-                node.nodeId(),
+                node.getShortNodeDescription(),
                 currentCommitmentBytes,
                 thresholdBytes
             );
@@ -218,7 +223,7 @@ public class SharedCacheCapacityAllocationDecider extends AllocationDecider {
                     "allocating shard [%s] to node [%s] would raise its cache commitment from [%d] to [%d] bytes, exceeding the low "
                         + "watermark [%d] bytes (accounting mode [%s])",
                     shardRouting.shardId(),
-                    node.nodeId(),
+                    node.getShortNodeDescription(),
                     currentCommitmentBytes,
                     newCommitmentBytes,
                     thresholdBytes,
@@ -239,7 +244,7 @@ public class SharedCacheCapacityAllocationDecider extends AllocationDecider {
             "allocating shard [%s] to node [%s] would raise its cache commitment from [%d] to [%d] bytes, which remains below the low "
                 + "watermark [%d] bytes (accounting mode [%s])",
             shardRouting.shardId(),
-            node.nodeId(),
+            node.getShortNodeDescription(),
             currentCommitmentBytes,
             newCommitmentBytes,
             thresholdBytes,

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/SharedCacheCapacityAllocationDeciderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/SharedCacheCapacityAllocationDeciderTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.TestShardRouting;
@@ -45,6 +46,10 @@ public class SharedCacheCapacityAllocationDeciderTests extends ESAllocationTestC
     static final String SEARCH_NODE_ID = "search-node";
     static final String OTHER_SEARCH_NODE_ID = "other-" + SEARCH_NODE_ID;
     static final String INDEX_NODE_ID = "index-node";
+
+    private static final String SEARCH_NODE_NAME = "search-node-name";
+    private static final String OTHER_SEARCH_NODE_NAME = "other-" + SEARCH_NODE_NAME;
+    private static final String INDEX_NODE_NAME = "index-node-name";
 
     private static final long CACHE_SIZE_IN_BYTES = 1000L;
     private static final long NO_COMMITMENT_BYTES = 0L;
@@ -95,16 +100,13 @@ public class SharedCacheCapacityAllocationDeciderTests extends ESAllocationTestC
 
         final ClusterInfo clusterInfo = createClusterInfo(Map.of(), Map.of());
         final RoutingAllocation routingAllocation = createRoutingAllocation(decider, shardRouting, clusterInfo);
+        final RoutingNode searchNode = routingAllocation.routingNodes().node(SEARCH_NODE_ID);
 
-        final Decision decision = decider.canAllocate(
-            shardRouting,
-            routingAllocation.routingNodes().node(SEARCH_NODE_ID),
-            routingAllocation
-        );
+        final Decision decision = decider.canAllocate(shardRouting, searchNode, routingAllocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
         assertThat(
             decision.getExplanation(),
-            containsString("no cache size and commitment data available for node [" + SEARCH_NODE_ID + "]")
+            containsString("no cache size and commitment data available for node [" + searchNode.getShortNodeDescription() + "]")
         );
     }
 
@@ -119,18 +121,15 @@ public class SharedCacheCapacityAllocationDeciderTests extends ESAllocationTestC
             Map.of()
         );
         final RoutingAllocation routingAllocation = createRoutingAllocation(decider, shardRouting, clusterInfo);
+        final RoutingNode searchNode = routingAllocation.routingNodes().node(SEARCH_NODE_ID);
 
-        final Decision decision = decider.canAllocate(
-            shardRouting,
-            routingAllocation.routingNodes().node(SEARCH_NODE_ID),
-            routingAllocation
-        );
+        final Decision decision = decider.canAllocate(shardRouting, searchNode, routingAllocation);
         assertThat(decision.type(), equalTo(Decision.Type.NOT_PREFERRED));
         assertThat(
             decision.getExplanation(),
             containsString(
                 "node ["
-                    + SEARCH_NODE_ID
+                    + searchNode.getShortNodeDescription()
                     + "] cache commitment ["
                     + overWatermarkCommitmentBytes
                     + "] bytes already exceeds the low "
@@ -278,17 +277,14 @@ public class SharedCacheCapacityAllocationDeciderTests extends ESAllocationTestC
             HIGH_WATERMARK_PERCENT
         );
         final RoutingAllocation totalAllocation = createRoutingAllocation(totalDecider, shardRouting, clusterInfo);
-        final Decision totalDecision = totalDecider.canAllocate(
-            shardRouting,
-            totalAllocation.routingNodes().node(SEARCH_NODE_ID),
-            totalAllocation
-        );
+        final RoutingNode totalSearchNode = totalAllocation.routingNodes().node(SEARCH_NODE_ID);
+        final Decision totalDecision = totalDecider.canAllocate(shardRouting, totalSearchNode, totalAllocation);
         assertThat(totalDecision.type(), equalTo(Decision.Type.NOT_PREFERRED));
         assertThat(
             totalDecision.getExplanation(),
             containsString(
                 "node ["
-                    + SEARCH_NODE_ID
+                    + totalSearchNode.getShortNodeDescription()
                     + "] cache commitment ["
                     + totalCommitmentBytes
                     + "] bytes already exceeds the low watermark "
@@ -431,8 +427,8 @@ public class SharedCacheCapacityAllocationDeciderTests extends ESAllocationTestC
 
     private static DiscoveryNodes.Builder nodesBuilder() {
         return DiscoveryNodes.builder()
-            .add(newNode(SEARCH_NODE_ID, Set.of(DiscoveryNodeRole.SEARCH_ROLE)))
-            .add(newNode(OTHER_SEARCH_NODE_ID, Set.of(DiscoveryNodeRole.SEARCH_ROLE)))
-            .add(newNode(INDEX_NODE_ID, Set.of(DiscoveryNodeRole.INDEX_ROLE)));
+            .add(newNode(SEARCH_NODE_NAME, SEARCH_NODE_ID, Set.of(DiscoveryNodeRole.SEARCH_ROLE)))
+            .add(newNode(OTHER_SEARCH_NODE_NAME, OTHER_SEARCH_NODE_ID, Set.of(DiscoveryNodeRole.SEARCH_ROLE)))
+            .add(newNode(INDEX_NODE_NAME, INDEX_NODE_ID, Set.of(DiscoveryNodeRole.INDEX_ROLE)));
     }
 }


### PR DESCRIPTION
Use short desc instead of nodeId() in cache capacity decider's canAllocate

- Update unit tests
- Closes https://github.com/elastic/elasticsearch-team/issues/4612