### PR TITLE
Add Agent Builder SML component template

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2546,6 +2546,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case ".kibana-reporting":
             case "ai-index-idx":
             case "ai-index-ds":
+            case "ai-index-idx-sml-data":
                 return true;
             default:
                 return false;

--- a/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-idx-sml-data.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-idx-sml-data.json
@@ -1,0 +1,20 @@
+{
+  "index_patterns": ["${ai-index.idx.sml.index_pattern}"],
+  "priority": 600,
+  "composed_of": [
+    "ai-index@mappings",
+    "ai-index-sml@mappings"
+  ],
+  "template": {
+    "aliases": {
+      "ai-index-idx-sml-data": {
+        "is_write_index": true
+      }
+    }
+  },
+  "_meta": {
+    "description": "Template applied to the SML data index. Composes the shared ai-index@mappings base with SML-specific fields and provides the write alias.",
+    "managed": true
+  },
+  "version": ${xpack.stack.ai-index.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-sml@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-sml@mappings.json
@@ -1,0 +1,76 @@
+{
+  "template": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "tags": {
+          "type": "keyword",
+          "normalizer": "lowercase"
+        },
+        "origin": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "keyword"
+            }
+          }
+        },
+        "discovery_labels": {
+          "type": "nested",
+          "properties": {
+            "value": {
+              "type": "search_as_you_type"
+            },
+            "kind": {
+              "type": "keyword"
+            }
+          }
+        },
+        "extended_attrs": {
+          "type": "flattened"
+        },
+        "user_id": {
+          "type": "keyword"
+        },
+        "created_at": {
+          "type": "date"
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "spaces": {
+          "type": "keyword"
+        },
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "kibana": {
+              "type": "object",
+              "properties": {
+                "privileges": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ingestion_method": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "SML-specific field mappings, composed on top of ai-index@mappings for the SML data index.",
+    "managed": true
+  },
+  "version": ${xpack.stack.ai-index.template.version}
+}

--- a/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-sml@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index-sml@mappings.json
@@ -29,9 +29,6 @@
             }
           }
         },
-        "extended_attrs": {
-          "type": "flattened"
-        },
         "user_id": {
           "type": "keyword"
         },

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -294,8 +294,10 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
                 // AI index components
                 "ai-index-idx",
                 "ai-index-ds",
+                "ai-index-idx-sml-data",
                 "ai-index@mappings",
-                "ai-index@ds-settings"
+                "ai-index@ds-settings",
+                "ai-index-sml@mappings"
             )
         );
     }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
@@ -29,28 +29,34 @@ import java.util.Map;
  * ({@code ai-index-idx-*}) for persistent data requiring in-place updates, and data streams
  * ({@code ai-index-ds-*}) for time series data. Both share a common set of field mappings and compose it
  * with a type-specific settings component.
+ * ({@code ai-index-idx-sml-data-*}) defines Agent Builder SML-specific managed mappings and supplies the {@code ai-index-idx-sml-data}
+ * write alias.
  */
 public class AiIndexTemplateRegistry extends IndexTemplateRegistry {
 
     // This number must be incremented when we make changes to built-in templates.
-    static final int REGISTRY_VERSION = 1;
+    static final int REGISTRY_VERSION = 2;
 
     // The computed checksum of all templates and components that are registered in this registry.
-    static final String COMPUTED_CHECKSUM = "27635e19";
+    static final String COMPUTED_CHECKSUM = "8906a4d";
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.ai-index.template.version";
 
     public static final String AI_INDEX_IDX_PREFIX = "ai-index-idx-";
     public static final String AI_INDEX_DS_PREFIX = "ai-index-ds-";
+    public static final String AI_INDEX_IDX_SML_PREFIX = "ai-index-idx-sml-data-";
 
     public static final String AI_INDEX_IDX_PATTERN = AI_INDEX_IDX_PREFIX + "*";
     public static final String AI_INDEX_DS_PATTERN = AI_INDEX_DS_PREFIX + "*";
+    public static final String AI_INDEX_IDX_SML_PATTERN = AI_INDEX_IDX_SML_PREFIX + "*";
 
     public static final String AI_INDEX_MAPPINGS_COMPONENT_NAME = "ai-index@mappings";
     public static final String AI_INDEX_DS_SETTINGS_COMPONENT_NAME = "ai-index@ds-settings";
+    public static final String AI_INDEX_SML_MAPPINGS_COMPONENT_NAME = "ai-index-sml@mappings";
 
     public static final String AI_INDEX_IDX_TEMPLATE_NAME = "ai-index-idx";
     public static final String AI_INDEX_DS_TEMPLATE_NAME = "ai-index-ds";
+    public static final String AI_INDEX_IDX_SML_TEMPLATE_NAME = "ai-index-idx-sml-data";
 
     private static final String ROOT_RESOURCE_PATH = "/ai-index/";
     private static final String JSON_EXTENSION = ".json";
@@ -82,6 +88,12 @@ public class AiIndexTemplateRegistry extends IndexTemplateRegistry {
                 ROOT_RESOURCE_PATH + AI_INDEX_DS_SETTINGS_COMPONENT_NAME + JSON_EXTENSION,
                 REGISTRY_VERSION,
                 TEMPLATE_VERSION_VARIABLE
+            ),
+            new IndexTemplateConfig(
+                AI_INDEX_SML_MAPPINGS_COMPONENT_NAME,
+                ROOT_RESOURCE_PATH + AI_INDEX_SML_MAPPINGS_COMPONENT_NAME + JSON_EXTENSION,
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
             ) };
     }
 
@@ -102,6 +114,13 @@ public class AiIndexTemplateRegistry extends IndexTemplateRegistry {
                 REGISTRY_VERSION,
                 TEMPLATE_VERSION_VARIABLE,
                 Map.of("ai-index.ds.index_pattern", AI_INDEX_DS_PATTERN)
+            ),
+            new IndexTemplateConfig(
+                AI_INDEX_IDX_SML_TEMPLATE_NAME,
+                ROOT_RESOURCE_PATH + AI_INDEX_IDX_SML_TEMPLATE_NAME + JSON_EXTENSION,
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE,
+                Map.of("ai-index.idx.sml.index_pattern", AI_INDEX_IDX_SML_PATTERN)
             ) };
     }
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
@@ -38,7 +38,7 @@ public class AiIndexTemplateRegistry extends IndexTemplateRegistry {
     static final int REGISTRY_VERSION = 2;
 
     // The computed checksum of all templates and components that are registered in this registry.
-    static final String COMPUTED_CHECKSUM = "8906a4d";
+    static final String COMPUTED_CHECKSUM = "5801102c";
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.ai-index.template.version";
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
@@ -35,8 +35,11 @@ import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_DS_
 import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_DS_SETTINGS_COMPONENT_NAME;
 import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_DS_TEMPLATE_NAME;
 import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_IDX_PATTERN;
+import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_IDX_SML_PATTERN;
+import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_IDX_SML_TEMPLATE_NAME;
 import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_IDX_TEMPLATE_NAME;
 import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_MAPPINGS_COMPONENT_NAME;
+import static org.elasticsearch.xpack.stack.AiIndexTemplateRegistry.AI_INDEX_SML_MAPPINGS_COMPONENT_NAME;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -81,11 +84,11 @@ public class AiIndexTemplateRegistryTests extends ESTestCase {
         registry = createRegistry(Settings.EMPTY);
         assertThat(
             registry.getComponentTemplateConfigs().keySet(),
-            containsInAnyOrder(AI_INDEX_MAPPINGS_COMPONENT_NAME, AI_INDEX_DS_SETTINGS_COMPONENT_NAME)
+            containsInAnyOrder(AI_INDEX_MAPPINGS_COMPONENT_NAME, AI_INDEX_DS_SETTINGS_COMPONENT_NAME, AI_INDEX_SML_MAPPINGS_COMPONENT_NAME)
         );
         assertThat(
             registry.getComposableTemplateConfigs().keySet(),
-            containsInAnyOrder(AI_INDEX_IDX_TEMPLATE_NAME, AI_INDEX_DS_TEMPLATE_NAME)
+            containsInAnyOrder(AI_INDEX_IDX_TEMPLATE_NAME, AI_INDEX_DS_TEMPLATE_NAME, AI_INDEX_IDX_SML_TEMPLATE_NAME)
         );
     }
 
@@ -144,6 +147,50 @@ public class AiIndexTemplateRegistryTests extends ESTestCase {
         );
         assertThat(template.getIgnoreMissingComponentTemplates(), contains("ai-index@custom"));
         assertThat(template.getDataStreamTemplate(), notNullValue());
+    }
+
+    public void testSmlMappingsComponentDefinesSmlSpecificFields() throws IOException {
+        registry = createRegistry(Settings.EMPTY);
+        ComponentTemplate mappings = registry.getComponentTemplateConfigs().get(AI_INDEX_SML_MAPPINGS_COMPONENT_NAME);
+        assertThat(mappings, notNullValue());
+
+        Map<String, Object> properties = mappingProperties(mappings);
+        assertThat(propertyType(properties, "id"), equalTo("keyword"));
+        assertThat(propertyType(properties, "discovery_labels"), equalTo("nested"));
+        assertThat(propertyType(properties, "extended_attrs"), equalTo("flattened"));
+        assertThat(propertyType(properties, "created_at"), equalTo("date"));
+        assertThat(propertyType(properties, "ingestion_method"), equalTo("keyword"));
+
+        // The tags override carries a lowercase normalizer, unlike the shared ai-index@mappings tags field.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> tags = (Map<String, Object>) properties.get("tags");
+        assertThat(tags.get("normalizer"), equalTo("lowercase"));
+    }
+
+    public void testSmlMappingsComponentIsStrict() throws IOException {
+        registry = createRegistry(Settings.EMPTY);
+        ComponentTemplate mappings = registry.getComponentTemplateConfigs().get(AI_INDEX_SML_MAPPINGS_COMPONENT_NAME);
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(XContentParserConfiguration.EMPTY, mappings.template().mappings().string())
+        ) {
+            assertThat(parser.map().get("dynamic"), equalTo("strict"));
+        }
+    }
+
+    public void testSmlIndexTemplateComposition() {
+        registry = createRegistry(Settings.EMPTY);
+        ComposableIndexTemplate template = registry.getComposableTemplateConfigs().get(AI_INDEX_IDX_SML_TEMPLATE_NAME);
+        assertThat(template, notNullValue());
+        assertThat(template.indexPatterns(), contains(AI_INDEX_IDX_SML_PATTERN));
+        // Composes the shared base mappings with the SML-specific mappings; the SML component wins on overlaps.
+        assertThat(template.composedOf(), contains(AI_INDEX_MAPPINGS_COMPONENT_NAME, AI_INDEX_SML_MAPPINGS_COMPONENT_NAME));
+        // A higher priority than the generic ai-index-idx template so the more specific pattern wins.
+        assertThat(template.priority(), equalTo(600L));
+        // Supplies the write alias that bulk writes (require_alias:true) depend on.
+        assertThat(template.template().aliases().keySet(), contains("ai-index-idx-sml-data"));
+        assertThat(template.template().aliases().get("ai-index-idx-sml-data").writeIndex(), equalTo(true));
+        assertThat(template.getDataStreamTemplate(), nullValue());
     }
 
     public void testRegistryIsUpToDate() throws Exception {

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
@@ -157,7 +157,6 @@ public class AiIndexTemplateRegistryTests extends ESTestCase {
         Map<String, Object> properties = mappingProperties(mappings);
         assertThat(propertyType(properties, "id"), equalTo("keyword"));
         assertThat(propertyType(properties, "discovery_labels"), equalTo("nested"));
-        assertThat(propertyType(properties, "extended_attrs"), equalTo("flattened"));
         assertThat(propertyType(properties, "created_at"), equalTo("date"));
         assertThat(propertyType(properties, "ingestion_method"), equalTo("keyword"));
 

--- a/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/ai-index/10_ai_index_templates.yml
+++ b/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/ai-index/10_ai_index_templates.yml
@@ -66,6 +66,7 @@ setup:
       indices.get_mapping:
         index: ai-index-idx-sml-data-000001
   - match: { ai-index-idx-sml-data-000001.mappings.properties.type.type: keyword }
+  - match: { ai-index-idx-sml-data-000001.mappings.properties.attributes.type: flattened }
   - match: { ai-index-idx-sml-data-000001.mappings.properties.discovery_labels.type: nested }
   - match: { ai-index-idx-sml-data-000001.mappings.properties.ingestion_method.type: keyword }
   - match: { ai-index-idx-sml-data-000001.mappings.properties.tags.normalizer: lowercase }

--- a/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/ai-index/10_ai_index_templates.yml
+++ b/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/ai-index/10_ai_index_templates.yml
@@ -49,3 +49,24 @@ setup:
         name: ai-index-ds-foo
   - match: { data_streams.0.name: ai-index-ds-foo }
   - match: { data_streams.0.template: ai-index-ds }
+
+---
+"Agent Builder SML data index composes the shared base with SML-specific mappings and the write alias":
+  - do:
+      indices.create:
+        index: ai-index-idx-sml-data-000001
+  - match: { acknowledged: true }
+
+  - do:
+      indices.get_alias:
+        index: ai-index-idx-sml-data-000001
+  - match: { ai-index-idx-sml-data-000001.aliases.ai-index-idx-sml-data.is_write_index: true }
+
+  - do:
+      indices.get_mapping:
+        index: ai-index-idx-sml-data-000001
+  - match: { ai-index-idx-sml-data-000001.mappings.properties.type.type: keyword }
+  - match: { ai-index-idx-sml-data-000001.mappings.properties.discovery_labels.type: nested }
+  - match: { ai-index-idx-sml-data-000001.mappings.properties.ingestion_method.type: keyword }
+  - match: { ai-index-idx-sml-data-000001.mappings.properties.tags.normalizer: lowercase }
+  - match: { ai-index-idx-sml-data-000001.mappings.dynamic: strict }


### PR DESCRIPTION
Resolves https://github.com/elastic/search-team/issues/15534 

Followup to https://github.com/elastic/elasticsearch/pull/154594 

Adds a specific Agent Builder SML component template, with a higher priority than some of the other component templates. This allows us to keep using the shared component templates for Agent Builder's SML index. 