### PR TITLE
ESQL: add InnerJoin operator

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/InnerJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/InnerJoin.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.join;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn.ExecuteLocation;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.SortPreserving;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.function.Predicate.not;
+import static java.util.stream.Stream.concat;
+import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
+
+/**
+ * Like {@link LookupJoin} but unmatched results are dropped.
+ */
+public class InnerJoin extends Join implements SortPreserving {
+
+    private final List<Attribute> addedFields;
+    private final boolean unique;
+    private List<Attribute> lazyOutput;
+
+    public InnerJoin(
+        Source source,
+        LogicalPlan left,
+        LogicalPlan right,
+        List<Attribute> leftFields,
+        List<Attribute> rightFields,
+        List<Attribute> addedFields,
+        boolean unique
+    ) {
+        super(source, left, right, JoinTypes.INNER, leftFields, rightFields, null, ExecuteLocation.COORDINATOR);
+        this.addedFields = addedFields;
+        this.unique = unique;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    public List<Attribute> leftFields() {
+        return config().leftFields();
+    }
+
+    public List<Attribute> rightFields() {
+        return config().rightFields();
+    }
+
+    public List<Attribute> addedFields() {
+        return addedFields;
+    }
+
+    public boolean unique() {
+        return unique;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            lazyOutput = mergeOutputAttributes(
+                concat(right().output().stream().filter(not(rightFields()::contains)), leftFields().stream()).toList(),
+                left().output().stream().filter(not(leftFields()::contains)).toList()
+            );
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public List<NamedExpression> computeOutputExpressions(List<? extends NamedExpression> left, List<? extends NamedExpression> right) {
+        return new ArrayList<>(output());
+    }
+
+    @Override
+    public boolean expressionsResolved() {
+        return true;
+    }
+
+    /**
+     * Finds the first (bottom-up) {@link InnerJoin} whose right subquery has not yet been replaced with results.
+     */
+    public static LogicalPlanTuple firstSubPlan(LogicalPlan optimizedPlan, Set<LocalRelation> subPlansResults) {
+        var subPlanHolder = new Holder<LogicalPlan>();
+        optimizedPlan.forEachUp(InnerJoin.class, join -> {
+            if (subPlanHolder.get() == null) {
+                if ((join.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) == false) {
+                    subPlanHolder.set(join.right());
+                }
+            }
+        });
+
+        var subPlan = subPlanHolder.get();
+        if (subPlan == null) {
+            return null;
+        }
+        subPlan.setOptimized();
+        // same instance held on the join's right side, so it doubles as the identity key used to substitute the
+        // materialized result back into the main plan hence both tuple slots are the same.
+        return new LogicalPlanTuple(subPlan, subPlan);
+    }
+
+    /**
+     * Rebuilds the main plan after the right-side subquery has been materialized, replacing the matching InnerJoin's right child with
+     * the materialized local relation.
+     */
+    public static LogicalPlan newMainPlan(LogicalPlan optimizedPlan, LogicalPlanTuple subPlans, LocalRelation resultWrapper) {
+        LogicalPlan newPlan = optimizedPlan.transformUp(
+            InnerJoin.class,
+            join -> join.right() == subPlans.originalSubPlan() ? join.replaceRight(resultWrapper) : join
+        );
+        newPlan.setOptimized();
+        return newPlan;
+    }
+
+    @Override
+    public InnerJoin replaceChildren(LogicalPlan left, LogicalPlan right) {
+        return new InnerJoin(source(), left, right, leftFields(), rightFields(), addedFields, unique);
+    }
+
+    @Override
+    protected NodeInfo<Join> info() {
+        return NodeInfo.create(this, InnerJoin::new, left(), right(), leftFields(), rightFields(), addedFields, unique);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        InnerJoin innerJoin = (InnerJoin) o;
+        return unique == innerJoin.unique && addedFields.equals(innerJoin.addedFields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), addedFields, unique);
+    }
+
+    /**
+     * Tuple holding the subplan to execute and the original plan node used as the identity key when substituting the result back.
+     */
+    public record LogicalPlanTuple(LogicalPlan subPlan, LogicalPlan originalSubPlan) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/DistinctByExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/DistinctByExec.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Physical plan for {@link org.elasticsearch.compute.operator.DistinctByOperator}.
+ */
+public class DistinctByExec extends UnaryExec {
+
+    private final Attribute key;
+    private final boolean failOnDuplicate;
+
+    public DistinctByExec(Source source, PhysicalPlan child, Attribute key, boolean failOnDuplicate) {
+        super(source, child);
+        this.key = key;
+        this.failOnDuplicate = failOnDuplicate;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    public Attribute key() {
+        return key;
+    }
+
+    public boolean failOnDuplicate() {
+        return failOnDuplicate;
+    }
+
+    @Override
+    public DistinctByExec replaceChild(PhysicalPlan newChild) {
+        return new DistinctByExec(source(), newChild, key, failOnDuplicate);
+    }
+
+    @Override
+    protected NodeInfo<? extends PhysicalPlan> info() {
+        return NodeInfo.create(this, DistinctByExec::new, child(), key, failOnDuplicate);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        DistinctByExec that = (DistinctByExec) o;
+        return failOnDuplicate == that.failOnDuplicate && key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), key, failOnDuplicate);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
@@ -113,6 +113,12 @@ public class HashJoinExec extends BinaryExec implements EstimatesRowSize {
             rightWithAppendedKeys.removeAll(rightFields);
             rightWithAppendedKeys.addAll(leftFields);
 
+            for (Attribute f : addedFields) {
+                if (right().outputSet().contains(f) == false) {
+                    rightWithAppendedKeys.add(f);
+                }
+            }
+
             lazyOutput = mergeOutputAttributes(rightWithAppendedKeys, leftOutputWithoutKeys);
         }
         return lazyOutput;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1498,7 +1498,7 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planDistinctBy(DistinctByExec distinctBy, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(distinctBy.child(), context);
         var key = source.layout.get(distinctBy.key().id());
-        if (key == null || PlannerUtils.toElementType(key.type()) == ElementType.INT) {
+        if (key == null || PlannerUtils.toElementType(key.type()) != ElementType.INT) {
             throw new IllegalStateException("distinct-by requires non-null integer key, got [" + distinctBy.key() + "]");
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -161,6 +161,7 @@ import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
 import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
+import org.elasticsearch.xpack.esql.plan.physical.DistinctByExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
@@ -207,6 +208,7 @@ import org.elasticsearch.xpack.esql.plan.physical.UserAgentExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.CompletionExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.RerankExec;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.score.ScoreMapper;
@@ -457,6 +459,8 @@ public class LocalExecutionPlanner {
             return planEnrich(enrich, context);
         } else if (node instanceof HashJoinExec join) {
             return planHashJoin(join, context);
+        } else if (node instanceof DistinctByExec distinctBy) {
+            return planDistinctBy(distinctBy, context);
         } else if (node instanceof LookupJoinExec join) {
             return planLookupJoin(join, context);
         }
@@ -1409,17 +1413,29 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planHashJoin(HashJoinExec join, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(join.left(), context);
         int positionsChannel = source.layout.numberOfChannels();
+        LocalSourceExec localSourceExec = (LocalSourceExec) join.joinData();
+        Page localData = localSourceExec.supplier().get();
+
+        // see {@link Mapper#JOIN_MARKER_PREFIX}
+        Attribute marker = null;
+        for (Attribute f : join.addedFields()) {
+            if (Mapper.isJoinMarker(f) && localSourceExec.outputSet().contains(f) == false) {
+                marker = f;
+                break;
+            }
+        }
 
         Layout.Builder layoutBuilder = source.layout.builder();
+        if (marker != null) {
+            layoutBuilder.append(marker);
+        }
         for (Attribute f : join.output()) {
-            if (join.left().outputSet().contains(f)) {
+            if (join.left().outputSet().contains(f) || f.equals(marker)) {
                 continue;
             }
             layoutBuilder.append(f);
         }
         Layout layout = layoutBuilder.build();
-        LocalSourceExec localSourceExec = (LocalSourceExec) join.joinData();
-        Page localData = localSourceExec.supplier().get();
 
         RowInTableLookupOperator.Key[] keys = new RowInTableLookupOperator.Key[join.leftFields().size()];
         int[] blockMapping = new int[join.leftFields().size()];
@@ -1446,8 +1462,12 @@ public class LocalExecutionPlanner {
         source = source.with(new RowInTableLookupOperator.Factory(keys, blockMapping), layout);
 
         // Load the "values" from each match
+        int loadedFields = 0;
         var joinDataOutput = join.joinData().output();
         for (Attribute f : join.addedFields()) {
+            if (f.equals(marker)) {
+                continue;
+            }
             Block localField = null;
             for (int l = 0; l < joinDataOutput.size(); l++) {
                 if (joinDataOutput.get(l).name().equals(f.name())) {
@@ -1461,13 +1481,28 @@ public class LocalExecutionPlanner {
                 new ColumnLoadOperator.Factory(new ColumnLoadOperator.Values(f.name(), localField), positionsChannel),
                 layout
             );
+            loadedFields++;
         }
 
+        if (marker != null) {
+            // The "positions" channel is requested as an added field; nothing to drop.
+            return source;
+        }
         // Drop the "positions" of the match
         List<Integer> projection = new ArrayList<>();
         IntStream.range(0, positionsChannel).boxed().forEach(projection::add);
-        IntStream.range(positionsChannel + 1, positionsChannel + 1 + join.addedFields().size()).boxed().forEach(projection::add);
+        IntStream.range(positionsChannel + 1, positionsChannel + 1 + loadedFields).boxed().forEach(projection::add);
         return source.with(new ProjectOperatorFactory(projection), layout);
+    }
+
+    private PhysicalOperation planDistinctBy(DistinctByExec distinctBy, LocalExecutionPlannerContext context) {
+        PhysicalOperation source = plan(distinctBy.child(), context);
+        var key = source.layout.get(distinctBy.key().id());
+        if (key == null || PlannerUtils.toElementType(key.type()) == ElementType.INT) {
+            throw new IllegalStateException("distinct-by requires non-null integer key, got [" + distinctBy.key() + "]");
+        }
+
+        return source.with(new DistinctByOperator.OrdinalIntKeyFactory(key.channel(), distinctBy.failOnDuplicate()), source.layout);
     }
 
     private PhysicalOperation planLookupJoin(LookupJoinExec join, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
@@ -11,7 +11,13 @@ import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.grouping.GroupingFunction;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.TemporaryNameGenerator;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.BinaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -30,10 +36,13 @@ import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.InnerJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.plan.physical.DistinctByExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
 import org.elasticsearch.xpack.esql.plan.physical.HashJoinExec;
 import org.elasticsearch.xpack.esql.plan.physical.LimitByExec;
@@ -43,6 +52,7 @@ import org.elasticsearch.xpack.esql.plan.physical.LookupJoinExec;
 import org.elasticsearch.xpack.esql.plan.physical.MergeExec;
 import org.elasticsearch.xpack.esql.plan.physical.MetricsInfoExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNByExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.plan.physical.TsInfoExec;
@@ -60,6 +70,26 @@ import java.util.List;
  * instances, which represent data being sent back from the data nodes to the coordinating node.</p>
  */
 public class Mapper {
+
+    /* Used to add inner join semantics atop of left join operator. */
+    public static final String JOIN_MARKER_PREFIX = Attribute.rawTemporaryName("_join_marker");
+
+    /** Fresh synthetic INTEGER lookup-ordinal attribute, see {@link #JOIN_MARKER_PREFIX}. */
+    public static ReferenceAttribute newJoinMarker(Source source) {
+        return new ReferenceAttribute(
+            source,
+            null,
+            TemporaryNameGenerator.locallyUniqueTemporaryName(JOIN_MARKER_PREFIX),
+            DataType.INTEGER,
+            Nullability.TRUE,
+            null,
+            true
+        );
+    }
+
+    public static boolean isJoinMarker(Attribute attr) {
+        return attr.name() != null && attr.name().startsWith(JOIN_MARKER_PREFIX);
+    }
 
     public PhysicalPlan map(Versioned<LogicalPlan> versionedPlan) {
         // We ignore the version for now, but it's fine to use later for plans that work
@@ -202,6 +232,33 @@ public class Mapper {
     }
 
     private PhysicalPlan mapBinary(BinaryPlan bp) {
+        if (bp instanceof InnerJoin innerJoin) {
+            PhysicalPlan left = mapInner(bp.left());
+            PhysicalPlan right = mapInner(bp.right());
+            if (right instanceof LocalSourceExec localData) {
+                var marker = newJoinMarker(innerJoin.source());
+                List<Attribute> addedFields = new ArrayList<>(innerJoin.addedFields());
+                addedFields.add(marker);
+                PhysicalPlan join = new HashJoinExec(
+                    innerJoin.source(),
+                    left,
+                    localData,
+                    innerJoin.leftFields(),
+                    innerJoin.rightFields(),
+                    addedFields
+                );
+                // inner join := left join where marker != null
+                join = new FilterExec(innerJoin.source(), join, new IsNotNull(innerJoin.source(), marker));
+                if (innerJoin.unique()) {
+                    // Guard: unique=true requires every build row to be matched at most once. The marker
+                    // is unique per build row, so a distinct-by on it alone detects duplicates independent
+                    // of the join key types and count.
+                    join = new DistinctByExec(innerJoin.source(), join, marker, true);
+                }
+                return new ProjectExec(innerJoin.source(), join, innerJoin.output());
+            }
+            return MapperUtils.unsupported(bp);
+        }
         if (bp instanceof Join join) {
             JoinConfig config = join.config();
             if (config.type() != JoinTypes.LEFT) {
@@ -309,4 +366,5 @@ public class Mapper {
         }
         return child;
     }
+
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -115,6 +115,7 @@ import org.elasticsearch.xpack.esql.plan.logical.UnresolvedIpLocation;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.InnerJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
@@ -946,7 +947,7 @@ public class EsqlSession {
     ) {
         SubPlanAndCallback subPlanAndCallback = null;
 
-        // Find the first (bottom-up) SemiJoin or InlineJoin that needs subplan execution.
+        // Find the first (bottom-up) SemiJoin/InnerJoin/InlineJoin that needs subplan execution.
         // Processing bottom-up ensures inner subplans (e.g. INLINE STATS inside IN subquery)
         // are resolved before outer ones that depend on them.
         LogicalPlan firstJoin = findFirstSubPlanJoin(mainPlan, subPlansResults);
@@ -970,6 +971,17 @@ public class EsqlSession {
                         blockFactory,
                         localRelationPage
                     );
+                }, () -> releaseLocalRelationBlocks(localRelationPage), true);
+            }
+        } else if (firstJoin instanceof InnerJoin) {
+            InnerJoin.LogicalPlanTuple subPlans = InnerJoin.firstSubPlan(mainPlan, subPlansResults);
+            if (subPlans != null) {
+                AtomicReference<Page> localRelationPage = new AtomicReference<>();
+                subPlanAndCallback = new SubPlanAndCallback(subPlans.subPlan(), result -> {
+                    LocalRelation resultWrapper = resultToPlan(subPlans.subPlan().source(), result);
+                    localRelationPage.set(resultWrapper.supplier().get());
+                    subPlansResults.add(resultWrapper);
+                    return InnerJoin.newMainPlan(mainPlan, subPlans, resultWrapper);
                 }, () -> releaseLocalRelationBlocks(localRelationPage), true);
             }
         } else if (firstJoin instanceof InlineJoin) {
@@ -1005,23 +1017,30 @@ public class EsqlSession {
     }
 
     /**
-     * Finds the first (bottom-up) SemiJoin or InlineJoin in the plan that has an unresolved subplan.
+     * Finds the first (bottom-up) SemiJoin, InnerJoin or InlineJoin in the plan that has an unresolved subplan.
      * Returns the join node itself, or null if none found.
      */
     private static LogicalPlan findFirstSubPlanJoin(LogicalPlan plan, Set<LocalRelation> subPlansResults) {
         Holder<LogicalPlan> result = new Holder<>();
-        // Evaluate the right hand side of a SemiJoin or InlineJoin, unless it is a LocalRelation and registered in subPlansResults already
+        // Evaluate the right hand side of a SemiJoin/InnerJoin/InlineJoin, unless it is a LocalRelation and registered in subPlansResults
+        // already
         plan.forEachUp(p -> {
             if (result.get() != null) {
                 return;
             }
-            // Whether checking the subquery join or InlineJoin first does not matter, the plan is processed bottom up, looking for
+            // Whether checking the subquery join, InnerJoin or InlineJoin first does not matter, the plan is processed bottom up, looking
+            // for
             // joins whose right child haven't been evaluated yet
             if (p instanceof AbstractSubqueryJoin sj) {
                 if (sj.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
                     return; // already processed
                 }
                 result.set(sj);
+            } else if (p instanceof InnerJoin ej) {
+                if (ej.right() instanceof LocalRelation lr && subPlansResults.contains(lr)) {
+                    return; // already processed
+                }
+                result.set(ej);
             } else if (p instanceof InlineJoin ij) {
                 if (ij.right().anyMatch(r -> r instanceof StubRelation)) {
                     result.set(ij);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationSupportTests.java
@@ -90,6 +90,7 @@ import org.elasticsearch.xpack.esql.plan.logical.fuse.FuseScoreEval;
 import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.AntiJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.InnerJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.MarkJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.SemiJoin;
@@ -196,6 +197,7 @@ public class ApproximationSupportTests extends ESTestCase {
         AntiJoin.class,
         Dedup.class,
         Drop.class,
+        InnerJoin.class,
         InlineStats.class,
         Keep.class,
         MarkJoin.class,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/join/InnerJoinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/join/InnerJoinTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.join;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getFieldAttribute;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Unit tests for {@link InnerJoin}: it is an INNER {@link Join} subtype, and it participates in the coordinator phase loop via its own
+ * {@link InnerJoin#firstSubPlan} / {@link InnerJoin#newMainPlan} hooks. Unlike the SEMI family ({@link AbstractSubqueryJoin}), its
+ * {@link InnerJoin#newMainPlan} path simply replaces the right child with the materialized {@link LocalRelation} so the mapper can
+ * lower the node to LEFT {@code HashJoinExec} + lookup-ordinal filter - it does not rewrite into an {@code IN} list or hash join.
+ */
+public class InnerJoinTests extends ESTestCase {
+
+    public void testIsInnerJoinWithInnerJoinShape() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute value = getFieldAttribute("v", DataType.LONG);
+        InnerJoin innerJoin = innerJoin(leftKey, rightKey, value, true);
+
+        assertThat(innerJoin, instanceOf(Join.class));
+        assertThat(innerJoin.config().type(), sameInstance(JoinTypes.INNER));
+        assertThat(innerJoin.leftFields(), equalTo(List.of(leftKey)));
+        assertThat(innerJoin.rightFields(), equalTo(List.of(rightKey)));
+        assertThat(innerJoin.addedFields(), equalTo(List.of(value)));
+        assertThat(innerJoin.unique(), is(true));
+        // INNER equi-join output: the copied build column(s) plus the (probe) join key, as the physical HashJoinExec produces.
+        assertThat(innerJoin.output(), equalTo(List.of(value, leftKey)));
+    }
+
+    public void testNotSerialized() {
+        InnerJoin innerJoin = innerJoin(getFieldAttribute("k", DataType.LONG), getFieldAttribute("k", DataType.LONG), null, false);
+        expectThrows(UnsupportedOperationException.class, () -> innerJoin.writeTo((StreamOutput) null));
+        expectThrows(UnsupportedOperationException.class, innerJoin::getWriteableName);
+    }
+
+    public void testFirstSubPlanFindsInnerJoinRight() {
+        InnerJoin innerJoin = innerJoin(getFieldAttribute("k", DataType.LONG), getFieldAttribute("k", DataType.LONG), null, true);
+
+        InnerJoin.LogicalPlanTuple tuple = InnerJoin.firstSubPlan(innerJoin, new HashSet<>());
+        assertThat(tuple, notNullValue());
+        // The right subquery is the very instance held on the join, doubling as the identity key for newMainPlan.
+        assertThat(tuple.subPlan(), sameInstance(innerJoin.right()));
+        assertThat(tuple.originalSubPlan(), sameInstance(innerJoin.right()));
+    }
+
+    public void testFirstSubPlanSkipsAlreadyMaterializedRight() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        LocalRelation materializedRight = localRelation(List.of(rightKey));
+        InnerJoin innerJoin = new InnerJoin(
+            Source.EMPTY,
+            localRelation(List.of(leftKey)),
+            materializedRight,
+            List.of(leftKey),
+            List.of(rightKey),
+            List.of(),
+            false
+        );
+
+        Set<LocalRelation> processed = new HashSet<>();
+        processed.add(materializedRight);
+        assertThat(InnerJoin.firstSubPlan(innerJoin, processed), nullValue());
+    }
+
+    public void testNewMainPlanReplacesRightWithLocalRelation() {
+        FieldAttribute leftKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute rightKey = getFieldAttribute("k", DataType.LONG);
+        FieldAttribute value = getFieldAttribute("v", DataType.LONG);
+        InnerJoin innerJoin = innerJoin(leftKey, rightKey, value, true);
+
+        InnerJoin.LogicalPlanTuple tuple = InnerJoin.firstSubPlan(innerJoin, new HashSet<>());
+        assertThat(tuple, notNullValue());
+
+        LocalRelation materialized = localRelation(List.of(rightKey, value));
+        LogicalPlan newMain = InnerJoin.newMainPlan(innerJoin, tuple, materialized);
+
+        // Still an InnerJoin (not rewritten into a Filter/HashJoin like the SEMI family), now with the materialized build side on its
+        // right.
+        InnerJoin rebuilt = as(newMain, InnerJoin.class);
+        assertThat(rebuilt.right(), sameInstance(materialized));
+        assertThat(rebuilt.left(), sameInstance(innerJoin.left()));
+        assertThat(rebuilt.leftFields(), equalTo(innerJoin.leftFields()));
+        assertThat(rebuilt.rightFields(), equalTo(innerJoin.rightFields()));
+        assertThat(rebuilt.addedFields(), equalTo(innerJoin.addedFields()));
+        assertThat(rebuilt.unique(), is(innerJoin.unique()));
+    }
+
+    private static InnerJoin innerJoin(FieldAttribute leftKey, FieldAttribute rightKey, FieldAttribute addedValue, boolean unique) {
+        List<Attribute> rightOutput = addedValue == null ? List.of(rightKey) : List.of(rightKey, addedValue);
+        List<Attribute> added = addedValue == null ? List.of() : List.of(addedValue);
+        return new InnerJoin(
+            Source.EMPTY,
+            localRelation(List.of(leftKey)),
+            localRelation(rightOutput),
+            List.of(leftKey),
+            List.of(rightKey),
+            added,
+            unique
+        );
+    }
+
+    private static LocalRelation localRelation(List<Attribute> output) {
+        return new LocalRelation(Source.EMPTY, output, LocalSupplier.of(new Page(0)));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.EmptyIndexedByShardId;
 import org.elasticsearch.compute.lucene.IndexedByShardIdFromList;
@@ -30,12 +32,19 @@ import org.elasticsearch.compute.lucene.query.DataPartitioning;
 import org.elasticsearch.compute.lucene.query.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.query.LuceneTopNSourceOperator;
 import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.ColumnLoadOperator;
+import org.elasticsearch.compute.operator.DistinctByOperator;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.FilterOperator;
 import org.elasticsearch.compute.operator.LocalSourceOperator;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.ProjectOperator;
+import org.elasticsearch.compute.operator.RowInTableLookupOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.compute.test.NoOpReleasable;
 import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -79,16 +88,25 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvide
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.index.EsIndexGenerator;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns;
 import org.elasticsearch.xpack.esql.plan.QuerySettings;
 import org.elasticsearch.xpack.esql.plan.ResolvedSettings;
 import org.elasticsearch.xpack.esql.plan.logical.MetricsInfo;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.DistinctByExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.HashJoinExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.MetricsInfoExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
@@ -106,6 +124,8 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -836,6 +856,294 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
                 }
             };
         };
+    }
+
+    public void testPlanInnerJoinManyToOne() throws IOException {
+        // LEFT hash-join emits the lookup ordinal and loads values; FilterExec drops misses (null ordinal);
+        // the final Project drops the ordinal.
+        assertThat(
+            planInnerJoinFactories(false),
+            contains(
+                RowInTableLookupOperator.Factory.class,
+                ColumnLoadOperator.Factory.class,
+                FilterOperator.FilterOperatorFactory.class,
+                ProjectOperator.ProjectOperatorFactory.class
+            )
+        );
+    }
+
+    public void testPlanInnerJoinOneToOneHasDistinctByGuard() throws IOException {
+        // unique=true adds an OrdinalIntKeyFactory guard after the filter, keyed on the lookup ordinal
+        // (unique per build row), independent of the join key types and count.
+        assertThat(
+            planInnerJoinFactories(true),
+            contains(
+                RowInTableLookupOperator.Factory.class,
+                ColumnLoadOperator.Factory.class,
+                FilterOperator.FilterOperatorFactory.class,
+                DistinctByOperator.OrdinalIntKeyFactory.class,
+                ProjectOperator.ProjectOperatorFactory.class
+            )
+        );
+    }
+
+    public void testInnerJoinUniqueDuplicateBuildKeyThrows() {
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> runInnerJoin(innerJoinExec(true, new long[] { 10 }, new long[] { 10, 10, 20 }, new long[] { 100, 100, 200 }))
+        );
+        assertThat(e.getMessage(), containsString("found a duplicate row"));
+    }
+
+    public void testInnerJoinManyToOneGathersAndDropsMisses() throws IOException {
+        // group_left: many probe rows per build row; the miss (99) is dropped by the inner-join filter.
+        // Final page order matches InnerJoin.output(): added build columns, then left join keys.
+        List<Page> results = runInnerJoin(
+            innerJoinExec(false, new long[] { 10, 20, 10, 99, 30 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 })
+        );
+        assertInnerJoinOutput(results, List.of(100L, 200L, 100L, 300L), List.of(10L, 20L, 10L, 30L));
+    }
+
+    public void testInnerJoinOneToOneUniqueProbe() throws IOException {
+        List<Page> results = runInnerJoin(
+            innerJoinExec(true, new long[] { 10, 20, 30 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 })
+        );
+        assertInnerJoinOutput(results, List.of(100L, 200L, 300L), List.of(10L, 20L, 30L));
+    }
+
+    public void testInnerJoinOneToOneProbeDuplicatesThrows() {
+        // unique=true requires probe-side uniqueness; duplicate probe keys matching the same build row throw.
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> runInnerJoin(innerJoinExec(true, new long[] { 10, 20, 10 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 }))
+        );
+        assertThat(e.getMessage(), equalTo("input must not have duplicates when [failOnDuplicate] set to [true]"));
+    }
+
+    public void testInnerJoinDuplicateBuildKeyThrows() {
+        // A duplicate key on the build ("one") side is rejected when the lookup table is built.
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> runInnerJoin(innerJoinExec(false, new long[] { 10 }, new long[] { 10, 10, 20 }, new long[] { 100, 100, 200 }))
+        );
+        assertThat(e.getMessage(), containsString("found a duplicate row"));
+    }
+
+    public void testInnerJoinManyToOneFanOutAllowsProbeDuplicates() throws IOException {
+        // group_left: several probe rows share one build key. Unlike 1:1 there is no guard, so probe
+        // duplicates are allowed and each row fans out carrying the same build value.
+        List<Page> results = runInnerJoin(
+            innerJoinExec(false, new long[] { 10, 10, 10, 20 }, new long[] { 10, 20 }, new long[] { 100, 200 })
+        );
+        assertInnerJoinOutput(results, List.of(100L, 100L, 100L, 200L), List.of(10L, 10L, 10L, 20L));
+    }
+
+    public void testInnerJoinMultiColumnKey() throws IOException {
+        // The real join key spans (labels..., step): a match requires equality on BOTH key columns.
+        // Probe (10, 2) matches only the first column of build (10, 1) -> miss, dropped.
+        // Output after Project: [v0, k0, k1] per InnerJoin.output().
+        PhysicalPlan innerJoin = innerJoinExec(
+            false,
+            List.of(new long[] { 10, 20, 10 }, new long[] { 1, 1, 2 }), // probe (k0, k1)
+            List.of(new long[] { 10, 20, 30 }, new long[] { 1, 1, 1 }), // build (k0, k1)
+            List.of(new long[] { 100, 200, 300 })                       // build v0
+        );
+        assertInnerJoinRows(runInnerJoin(innerJoin), List.of(List.of(100L, 10L, 1L), List.of(200L, 20L, 1L)));
+    }
+
+    public void testInnerJoinCopiesMultipleBuildColumns() throws IOException {
+        // group_left(l1, l2): more than one build column is gathered onto each surviving probe row.
+        // Output after Project: [v0, v1, k0] per InnerJoin.output().
+        PhysicalPlan innerJoin = innerJoinExec(
+            false,
+            List.of(new long[] { 10, 20, 10 }),                        // probe (k0)
+            List.of(new long[] { 10, 20 }),                            // build (k0)
+            List.of(new long[] { 100, 200 }, new long[] { 111, 222 })  // build (v0, v1)
+        );
+        assertInnerJoinRows(runInnerJoin(innerJoin), List.of(List.of(100L, 111L, 10L), List.of(200L, 222L, 20L), List.of(100L, 111L, 10L)));
+    }
+
+    public void testInnerJoinEmptyBuildProducesNoRows() throws IOException {
+        // Empty "one" side -> every probe row misses -> the inner join drops everything.
+        List<Page> results = runInnerJoin(innerJoinExec(false, new long[] { 10, 20 }, new long[] {}, new long[] {}));
+        assertInnerJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testInnerJoinEmptyProbeProducesNoRows() throws IOException {
+        List<Page> results = runInnerJoin(innerJoinExec(false, new long[] {}, new long[] { 10, 20 }, new long[] { 100, 200 }));
+        assertInnerJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testInnerJoinAllProbeRowsMissProduceNoRows() throws IOException {
+        // Non-empty build, but no probe key exists on the build side -> empty inner-join result.
+        List<Page> results = runInnerJoin(innerJoinExec(false, new long[] { 1, 2, 3 }, new long[] { 10, 20 }, new long[] { 100, 200 }));
+        assertInnerJoinOutput(results, List.of(), List.of());
+    }
+
+    public void testInnerJoinMultivaluedBuildKeyThrows() {
+        // The lookup table only supports single-valued keys; a multivalued build key is rejected.
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+        ReferenceAttribute buildKey = new ReferenceAttribute(Source.EMPTY, "k0", DataType.LONG);
+        ReferenceAttribute buildValue = new ReferenceAttribute(Source.EMPTY, "v0", DataType.LONG);
+        LongBlock.Builder keyBuilder = blockFactory.newLongBlockBuilder(2);
+        keyBuilder.beginPositionEntry().appendLong(10).appendLong(20).endPositionEntry(); // multivalued key
+        keyBuilder.appendLong(30);
+        LocalSourceExec build = new LocalSourceExec(
+            Source.EMPTY,
+            List.of(buildKey, buildValue),
+            LocalSupplier.of(new Page(keyBuilder.build(), blockFactory.newLongArrayVector(new long[] { 100, 200 }, 2).asBlock()))
+        );
+        ReferenceAttribute probeKey = new ReferenceAttribute(Source.EMPTY, "k0", DataType.LONG);
+        LocalSourceExec probe = new LocalSourceExec(
+            Source.EMPTY,
+            List.of(probeKey),
+            LocalSupplier.of(new Page(blockFactory.newLongArrayVector(new long[] { 10 }, 1).asBlock()))
+        );
+        PhysicalPlan innerJoin = innerJoinPhysical(false, probe, build, List.of(probeKey), List.of(buildKey), List.of(buildValue));
+        var e = expectThrows(IllegalArgumentException.class, () -> runInnerJoin(innerJoin));
+        assertThat(e.getMessage(), containsString("only single valued keys are supported"));
+    }
+
+    /**
+     * Builds the physical plan shape Mapper produces for InnerJoin:
+     * LEFT HashJoin(lookup ordinal as added field) -> Filter(ordinal IS NOT NULL) -> [DistinctBy(ordinal) when unique] -> Project.
+     */
+    private PhysicalPlan innerJoinExec(boolean unique, long[] probeKeys, long[] buildKeys, long[] buildValues) {
+        return innerJoinExec(unique, List.of(probeKeys), List.of(buildKeys), List.of(buildValues));
+    }
+
+    private PhysicalPlan innerJoinExec(boolean unique, List<long[]> probeKeyCols, List<long[]> buildKeyCols, List<long[]> buildValueCols) {
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+
+        List<Attribute> buildKeyAttrs = new ArrayList<>();
+        for (int c = 0; c < buildKeyCols.size(); c++) {
+            buildKeyAttrs.add(new ReferenceAttribute(Source.EMPTY, "k" + c, DataType.LONG));
+        }
+        List<Attribute> buildValueAttrs = new ArrayList<>();
+        for (int c = 0; c < buildValueCols.size(); c++) {
+            buildValueAttrs.add(new ReferenceAttribute(Source.EMPTY, "v" + c, DataType.LONG));
+        }
+        List<Block> buildBlocks = new ArrayList<>();
+        for (long[] col : buildKeyCols) {
+            buildBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        for (long[] col : buildValueCols) {
+            buildBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        List<Attribute> buildOutput = new ArrayList<>(buildKeyAttrs);
+        buildOutput.addAll(buildValueAttrs);
+        LocalSourceExec build = new LocalSourceExec(
+            Source.EMPTY,
+            buildOutput,
+            LocalSupplier.of(new Page(buildBlocks.toArray(new Block[0])))
+        );
+
+        List<Attribute> probeKeyAttrs = new ArrayList<>();
+        for (int c = 0; c < probeKeyCols.size(); c++) {
+            probeKeyAttrs.add(new ReferenceAttribute(Source.EMPTY, "k" + c, DataType.LONG));
+        }
+        List<Block> probeBlocks = new ArrayList<>();
+        for (long[] col : probeKeyCols) {
+            probeBlocks.add(blockFactory.newLongArrayVector(col, col.length).asBlock());
+        }
+        LocalSourceExec probe = new LocalSourceExec(
+            Source.EMPTY,
+            probeKeyAttrs,
+            LocalSupplier.of(new Page(probeBlocks.toArray(new Block[0])))
+        );
+
+        return innerJoinPhysical(unique, probe, build, probeKeyAttrs, buildKeyAttrs, buildValueAttrs);
+    }
+
+    private static PhysicalPlan innerJoinPhysical(
+        boolean unique,
+        LocalSourceExec probe,
+        LocalSourceExec build,
+        List<Attribute> probeKeyAttrs,
+        List<Attribute> buildKeyAttrs,
+        List<Attribute> buildValueAttrs
+    ) {
+        ReferenceAttribute ordinal = Mapper.newJoinMarker(Source.EMPTY);
+        List<Attribute> addedFields = new ArrayList<>(buildValueAttrs);
+        addedFields.add(ordinal);
+        PhysicalPlan join = new HashJoinExec(Source.EMPTY, probe, build, probeKeyAttrs, buildKeyAttrs, addedFields);
+        join = new FilterExec(Source.EMPTY, join, new IsNotNull(Source.EMPTY, ordinal));
+        if (unique) {
+            join = new DistinctByExec(Source.EMPTY, join, ordinal, true);
+        }
+        List<Attribute> leftOutputWithoutKeys = probe.output().stream().filter(attr -> probeKeyAttrs.contains(attr) == false).toList();
+        List<Attribute> rightWithAppendedKeys = new ArrayList<>(build.output());
+        rightWithAppendedKeys.removeAll(buildKeyAttrs);
+        rightWithAppendedKeys.addAll(probeKeyAttrs);
+        List<Attribute> output = new ArrayList<>(
+            org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes(rightWithAppendedKeys, leftOutputWithoutKeys)
+        );
+        return new ProjectExec(Source.EMPTY, join, output);
+    }
+
+    private LocalExecutionPlanner.LocalExecutionPlan planInnerJoin(PhysicalPlan innerJoin) throws IOException {
+        return planner().plan("test", FoldContext.small(), PlannerSettings.DEFAULTS, innerJoin, EmptyIndexedByShardId.instance());
+    }
+
+    /**
+     * Classes of the intermediate operator factories for the Mapper-shaped InnerJoin physical plan.
+     */
+    private List<Class<?>> planInnerJoinFactories(boolean unique) throws IOException {
+        PhysicalPlan innerJoin = innerJoinExec(unique, new long[] { 10, 20, 10 }, new long[] { 10, 20, 30 }, new long[] { 100, 200, 300 });
+        List<Class<?>> factories = new ArrayList<>();
+        for (var factory : planInnerJoin(innerJoin).driverFactories.get(0)
+            .driverSupplier()
+            .physicalOperation().intermediateOperatorFactories) {
+            factories.add(factory.getClass());
+        }
+        return factories;
+    }
+
+    /**
+     * Plans then runs a Mapper-shaped InnerJoin physical plan end to end.
+     */
+    private List<Page> runInnerJoin(PhysicalPlan innerJoin) throws IOException {
+        var op = planInnerJoin(innerJoin).driverFactories.get(0).driverSupplier().physicalOperation();
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        var runner = new TestDriverRunner().builder(driverContext);
+        runner.input(op.sourceOperatorFactory.get(driverContext));
+        return runner.run(op.intermediateOperatorFactories.toArray(new Operator.OperatorFactory[0]));
+    }
+
+    /** Asserts single-key InnerJoin pages in InnerJoin.output() order: build value, then left key. */
+    private void assertInnerJoinOutput(List<Page> results, List<Long> expectedValues, List<Long> expectedKeys) {
+        List<Long> values = new ArrayList<>();
+        List<Long> keys = new ArrayList<>();
+        for (Page page : results) {
+            LongBlock valueBlock = page.getBlock(0);
+            LongBlock keyBlock = page.getBlock(1);
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                values.add(valueBlock.getLong(valueBlock.getFirstValueIndex(p)));
+                keys.add(keyBlock.getLong(keyBlock.getFirstValueIndex(p)));
+            }
+        }
+        assertThat(values, equalTo(expectedValues));
+        assertThat(keys, equalTo(expectedKeys));
+    }
+
+    /**
+     * Asserts the full output rows of a Mapper-shaped InnerJoin plan whose output is entirely {@code LONG}
+     * columns, in InnerJoin.output() order (added build columns, then left join keys).
+     */
+    private void assertInnerJoinRows(List<Page> results, List<List<Long>> expectedRows) {
+        List<List<Long>> rows = new ArrayList<>();
+        for (Page page : results) {
+            for (int p = 0; p < page.getPositionCount(); p++) {
+                List<Long> row = new ArrayList<>();
+                for (int b = 0; b < page.getBlockCount(); b++) {
+                    LongBlock block = page.getBlock(b);
+                    row.add(block.getLong(block.getFirstValueIndex(p)));
+                }
+                rows.add(row);
+            }
+        }
+        assertThat(rows, equalTo(expectedRows));
     }
 
     private LocalExecutionPlanner planner() throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/mapper/InnerJoinMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/mapper/InnerJoinMapperTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.planner.mapper;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.plan.logical.join.InnerJoin;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.physical.DistinctByExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.HashJoinExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.session.Versioned;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.planner.mapper.Mapper.JOIN_MARKER_PREFIX;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.startsWith;
+
+public class InnerJoinMapperTests extends ESTestCase {
+
+    public void testMapsInnerJoinToLeftHashJoinFilterOnLookupOrdinal() {
+        InnerJoin innerJoin = innerJoin(false);
+        PhysicalPlan physical = new Mapper().map(new Versioned<>(innerJoin, TransportVersion.current()));
+
+        ProjectExec project = as(physical, ProjectExec.class);
+        assertThat(project.projections(), equalTo(innerJoin.output()));
+
+        FilterExec filter = as(project.child(), FilterExec.class);
+        IsNotNull isNotNull = as(filter.condition(), IsNotNull.class);
+        Attribute ordinal = as(isNotNull.field(), Attribute.class);
+        assertThat(ordinal.name(), startsWith(JOIN_MARKER_PREFIX));
+
+        HashJoinExec join = as(filter.child(), HashJoinExec.class);
+        assertThat(join.addedFields(), hasItem(sameInstance(ordinal)));
+        // The ordinal is emitted by the join itself for the downstream filter...
+        assertThat(join.output(), hasItem(sameInstance(ordinal)));
+        // ...but is not a build column: the planner binds it to the RowInTableLookup positions channel.
+        LocalSourceExec build = as(join.joinData(), LocalSourceExec.class);
+        assertThat(build.outputSet().contains(ordinal), equalTo(false));
+    }
+
+    public void testMapsUniqueInnerJoinGuardsOutputWithDistinctBy() {
+        InnerJoin innerJoin = innerJoin(true, new long[] { 10, 10 }, new long[] { 100, 200 });
+        PhysicalPlan physical = new Mapper().map(new Versioned<>(innerJoin, TransportVersion.current()));
+
+        ProjectExec project = as(physical, ProjectExec.class);
+        DistinctByExec distinctBy = as(project.child(), DistinctByExec.class);
+        FilterExec filter = as(distinctBy.child(), FilterExec.class);
+        Attribute ordinal = as(as(filter.condition(), IsNotNull.class).field(), Attribute.class);
+        assertThat(ordinal.name(), startsWith(JOIN_MARKER_PREFIX));
+
+        // Guard keys on the lookup ordinal alone (unique per build row), not on the join key columns.
+        assertThat(distinctBy.key(), sameInstance(ordinal));
+        assertThat(distinctBy.failOnDuplicate(), equalTo(true));
+
+        HashJoinExec join = as(filter.child(), HashJoinExec.class);
+        assertThat(join.addedFields(), hasItem(sameInstance(ordinal)));
+    }
+
+    private static InnerJoin innerJoin(boolean unique) {
+        return innerJoin(unique, new long[] { 10, 20 }, new long[] { 100, 200 });
+    }
+
+    private static InnerJoin innerJoin(boolean unique, long[] buildKeys, long[] buildValues) {
+        var blockFactory = TestBlockFactory.getNonBreakingInstance();
+        ReferenceAttribute probeKey = new ReferenceAttribute(Source.EMPTY, "k", DataType.LONG);
+        LocalRelation probe = new LocalRelation(
+            Source.EMPTY,
+            List.of(probeKey),
+            LocalSupplier.of(new Page(blockFactory.newLongArrayVector(new long[] { 10, 20 }, 2).asBlock()))
+        );
+        ReferenceAttribute buildKey = new ReferenceAttribute(Source.EMPTY, "k", DataType.LONG);
+        ReferenceAttribute buildValue = new ReferenceAttribute(Source.EMPTY, "bval", DataType.LONG);
+        LocalRelation build = new LocalRelation(
+            Source.EMPTY,
+            List.of(buildKey, buildValue),
+            LocalSupplier.of(
+                new Page(
+                    blockFactory.newLongArrayVector(buildKeys, buildKeys.length).asBlock(),
+                    blockFactory.newLongArrayVector(buildValues, buildValues.length).asBlock()
+                )
+            )
+        );
+        return new InnerJoin(Source.EMPTY, probe, build, List.of(probeKey), List.of(buildKey), List.of(buildValue), unique);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.AntiJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.InnerJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinType;
@@ -408,6 +409,8 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             return JoinTypes.ANTI;
         } else if (toBuildClass == MarkJoin.class) {
             return JoinTypes.MARK;
+        } else if (toBuildClass == InnerJoin.class) {
+            return JoinTypes.INNER;
         } else if (toBuildClass == Join.class || toBuildClass == LookupJoin.class || toBuildClass == InlineJoin.class) {
             return JoinTypes.LEFT;
         }


### PR DESCRIPTION
## What

ESQL only executes LEFT joins today. PromQL vector matching (`a / on(x) b`, `group_left`, etc) needs an INNER EQUI JOIN. 

This PR adds INNER executable join type to ESQL (PromQL is the first consumer).

## How

Add `EqJoin`, an INNER `Join` subtype (coordinator-ephemeral). Its right (build) side runs as an independent subquery that the coordinator phase loop materializes to a `LocalRelation` before the join. 

`Mapper` lowers the 

`EqJoin` 

to

`RowInTableLookup`

-> `DistinctBy` # for one-to-one semantics

->  `Filter(ordinal not null)` # for inner semantics

->  `ColumnLoad`

-> `Project`
