### PR TITLE
[9.4] Allow GC of closed search contexts in ES|QL (#155418)

### DIFF
--- a/docs/changelog/155418.yaml
+++ b/docs/changelog/155418.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155418
+summary: Allow GC of closed search contexts in ES|QL
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/AcquiredSearchContexts.java
@@ -53,8 +53,17 @@ class AcquiredSearchContexts implements Releasable {
         checkNotClosed();
         var startingIndex = nextAddIndex;
         for (var cse : searchContexts) {
-            allContexts[nextAddIndex] = new ComputeSearchContext(nextAddIndex, cse);
-            nextAddIndex++;
+            final int idx = nextAddIndex++;
+            cse.addReleasable(() -> {
+                synchronized (AcquiredSearchContexts.this) {
+                    ComputeSearchContext ctx = allContexts[idx];
+                    if (ctx != null) {
+                        // Allow GC of closed search contexts as soon as they are released.
+                        allContexts[idx] = ctx.tombstone();
+                    }
+                }
+            });
+            allContexts[idx] = new ComputeSearchContext(idx, cse);
         }
         return new SubRanged<>(allContexts, startingIndex, nextAddIndex);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -16,6 +18,8 @@ import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.DefaultShardContext;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
+
+import java.util.Objects;
 
 /**
  * Search and shard context used as entries in {@link org.elasticsearch.compute.lucene.IndexedByShardId}. These are shared by both the data
@@ -28,12 +32,30 @@ import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardCo
  */
 class ComputeSearchContext implements Releasable {
     private final int index;
+    @Nullable
     private final SearchContext searchContext;
     private final SetOnce<ShardContext> shardContext = new SetOnce<>();
 
     ComputeSearchContext(int index, SearchContext searchContext) {
         this.index = index;
-        this.searchContext = searchContext;
+        this.searchContext = Objects.requireNonNull(searchContext);
+    }
+
+    private ComputeSearchContext(int index) {
+        this.index = index;
+        this.searchContext = null;
+    }
+
+    /** Tombstone with no {@link SearchContext}, so the closed search context can be GC'd. */
+    ComputeSearchContext tombstone() {
+        return new ComputeSearchContext(index);
+    }
+
+    private void ensureNotTombstone() {
+        if (searchContext == null) {
+            assert false : "ComputeSearchContext for index [" + index + "] was already closed";
+            throw new AlreadyClosedException("ComputeSearchContext for index [" + index + "] was already closed");
+        }
     }
 
     public int index() {
@@ -48,10 +70,12 @@ class ComputeSearchContext implements Releasable {
     }
 
     public SearchContext searchContext() {
+        ensureNotTombstone();
         return searchContext;
     }
 
     private ShardContext createShardContext() {
+        ensureNotTombstone();
         SearchExecutionContext searchExecutionContext = new SearchExecutionContext(searchContext.getSearchExecutionContext()) {
             @Override
             public SourceProvider createSourceProvider(SourceFilter sourceFilter) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -1086,9 +1086,6 @@ public class ComputeService {
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);
-
-            List<SearchExecutionContext> localContexts = new ArrayList<>();
-            context.searchExecutionContexts().iterable().forEach(localContexts::add);
             boolean hasExternalSource = plan.anyMatch(
                 p -> p instanceof ExternalSourceExec
                     || (p instanceof FragmentExec f && f.fragment().anyMatch(ExternalRelation.class::isInstance))
@@ -1096,6 +1093,8 @@ public class ComputeService {
             PhysicalPlan localPlan;
             final String logicalPlanString;
             if (localPhysicalOptimization == LocalPhysicalOptimization.ENABLED) {
+                List<SearchExecutionContext> localContexts = new ArrayList<>();
+                context.searchExecutionContexts().iterable().forEach(localContexts::add);
                 if (hasExternalSource) {
                     localPlan = PlannerUtils.localPlan(
                         plannerSettings,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Allow GC of closed search contexts in ES|QL (#155418)](https://github.com/elastic/elasticsearch/pull/155418)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)