### PR TITLE
[9.5] Fix circuit breaker undercounting memory for wildcard and regexp queries (#155368)

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -731,6 +731,7 @@ public class PercolateQueryBuilder extends LeafQueryBuilder<PercolateQueryBuilde
                 if (bytes > 0) {
                     source.releaseQueryConstructionMemory(bytes);
                 }
+                clearPreChargedQueries();
             }
         };
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
@@ -210,6 +211,35 @@ public class QueryBuilderStoreTests extends ESTestCase {
                     searchExecutionContext.releaseQueryConstructionMemory();
                 }
             }
+        }
+    }
+
+    public void testPercolateContextReleaseClearsPreChargedQueries() throws IOException {
+        String fieldName = "keyword_field";
+        QueryBuilder[] queryBuilders = new QueryBuilder[] { new TermQueryBuilder(fieldName, "value") };
+
+        try (Directory directory = newDirectory()) {
+            PercolatorTestSetup setup = setupPercolatorTest(directory, fieldName, queryBuilders);
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(100));
+            SearchExecutionContext baseContext = new SearchExecutionContext(setup.baseContext(), breaker);
+            SearchExecutionContext percolateContext = PercolateQueryBuilder.newPercolateSearchContext(baseContext, false);
+
+            long baselineUsed = breaker.getUsed();
+
+            new WildcardQueryBuilder(fieldName, "test*pattern*with*wildcards").toQuery(percolateContext);
+            new RegexpQueryBuilder(fieldName, ".*test.*regexp.*pattern.*").toQuery(percolateContext);
+
+            Query marker = new TermQuery(new Term(fieldName, "marker"));
+            percolateContext.markQueryMemoryPreCharged(marker);
+            assertTrue("query should be reported as pre-charged before release", percolateContext.isQueryMemoryPreCharged(marker));
+
+            percolateContext.releaseQueryConstructionMemory();
+
+            assertFalse(
+                "percolate context release must clear the pre-charged set so it does not retain query references",
+                percolateContext.isQueryMemoryPreCharged(marker)
+            );
+            assertThat("percolate context release must return the request breaker to baseline", breaker.getUsed(), equalTo(baselineUsed));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -233,7 +233,8 @@ public abstract class StringFieldType extends TermBasedFieldType {
                     ? new AutomatonQueryWithDescription(term, dfa, term.text())
                     : new AutomatonQuery(term, dfa, false, method);
             }
-            context.addCircuitBreakerMemory(0L, reservation, "wildcard-compiled:" + name());
+            context.addCircuitBreakerMemory(query.ramBytesUsed(), reservation, "wildcard-compiled:" + name());
+            context.markQueryMemoryPreCharged(query);
         } else {
             if (caseInsensitive) {
                 query = method == null ? new CaseInsensitiveWildcardQuery(term) : new CaseInsensitiveWildcardQuery(term, false, method);
@@ -274,10 +275,8 @@ public abstract class StringFieldType extends TermBasedFieldType {
             query = method == null
                 ? new AutomatonQueryWithDescription(term, dfa, "/" + term.text() + "/")
                 : new AutomatonQuery(term, dfa, false, method);
-            // Construction succeeded; refund the pre-flight reservation. The retained
-            // ramBytesUsed() of the produced query is charged once per phase by the
-            // visitor walk in AbstractQueryBuilder#toQuery.
-            context.addCircuitBreakerMemory(0L, reservation, "regexp-compiled:" + name());
+            context.addCircuitBreakerMemory(query.ramBytesUsed(), reservation, "regexp-compiled:" + name());
+            context.markQueryMemoryPreCharged(query);
         } else {
             query = method == null
                 ? new RegexpQuery(new Term(name(), indexedValueForSearch(value)), syntaxFlags, matchFlags, maxDeterminizedStates)

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -797,6 +797,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
 
             TermRangeQuery query = new TermRangeQuery(name(), lower, upper, lowerInclusive, upperInclusive);
             context.addCircuitBreakerMemory(query.ramBytesUsed(), "range:" + name());
+            context.markQueryMemoryPreCharged(query);
             return query;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -119,7 +119,11 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
 
     @Override
     public final Query toQuery(SearchExecutionContext context) throws IOException {
-        MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount(), context.getCircuitBreaker());
+        MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(
+            IndexSearcher.getMaxClauseCount(),
+            context.getCircuitBreaker(),
+            context::isQueryMemoryPreCharged
+        );
         Query query = toQuery(context, visitor);
         if (query != null) {
             context.addCircuitBreakerMemory(visitor.getEstimatedBytes(), "query");

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -356,7 +356,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         }
         MaxClauseCountQueryVisitor clauseVisitor = new MaxClauseCountQueryVisitor(
             IndexSearcher.getMaxClauseCount(),
-            context.getCircuitBreaker()
+            context.getCircuitBreaker(),
+            context::isQueryMemoryPreCharged
         );
         Set<Query> deduplicate = new HashSet<>();
         for (QueryBuilder query : clauses) {

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -304,10 +304,8 @@ public class RegexpQueryBuilder extends LeafQueryBuilder<RegexpQueryBuilder> imp
             reservation = new AutomatonQueryCostEstimator(dfa.ramBytesUsed()).estimate();
             context.addCircuitBreakerMemory(reservation, "regexp-compiled:" + fieldName);
             query = method == null ? new AutomatonQuery(term, dfa) : new AutomatonQuery(term, dfa, false, method);
-            // Construction succeeded; refund the pre-flight reservation. The retained
-            // ramBytesUsed() of the produced query is charged once per phase by the
-            // visitor walk in AbstractQueryBuilder#toQuery.
-            context.addCircuitBreakerMemory(0L, reservation, "regexp-compiled:" + fieldName);
+            context.addCircuitBreakerMemory(query.ramBytesUsed(), reservation, "regexp-compiled:" + fieldName);
+            context.markQueryMemoryPreCharged(query);
         } else {
             query = method == null
                 ? new RegexpQuery(term, sanitisedSyntaxFlag, matchFlagsValue, maxDeterminizedStates)

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -139,6 +140,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
     @Nullable
     private final CircuitBreaker circuitBreaker;
     private final AtomicLong queryConstructionMemoryUsed = new AtomicLong(0);
+    private final Set<Query> preChargedQueries = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
     public SearchExecutionContext(
         int shardId,
@@ -855,10 +857,34 @@ public class SearchExecutionContext extends QueryRewriteContext {
     }
 
     /**
+     * Marks that {@code query}'s memory was already charged to the breaker at construction time, so the visitor walk skips it.
+     */
+    public void markQueryMemoryPreCharged(Query query) {
+        if (query != null) {
+            preChargedQueries.add(query);
+        }
+    }
+
+    /**
+     * @return {@code true} if {@code query} was already charged at construction time (see {@link #markQueryMemoryPreCharged}).
+     */
+    public boolean isQueryMemoryPreCharged(Query query) {
+        return preChargedQueries.contains(query);
+    }
+
+    /**
+     * Drops all pre-charge markers.
+     */
+    protected final void clearPreChargedQueries() {
+        preChargedQueries.clear();
+    }
+
+    /**
      * Release all accumulated query construction memory back to the circuit breaker. Safe to
      * call multiple times; subsequent calls after the pool is drained are no-ops.
      */
     public void releaseQueryConstructionMemory() {
+        clearPreChargedQueries();
         long memoryToRelease = queryConstructionMemoryUsed.getAndSet(0);
         if (memoryToRelease > 0 && circuitBreaker != null) {
             circuitBreaker.addWithoutBreaking(-memoryToRelease);

--- a/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
@@ -26,6 +26,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.lucene.search.cost.PointRangeQueryCostEstimator;
 
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -37,7 +38,7 @@ import java.util.function.Supplier;
  * can charge the request circuit breaker once per top-level call instead of once per leaf builder.
  * <p>
  * When a non-null {@link CircuitBreaker} is supplied, the visitor trips it mid-walk as soon as the
- * projected total (breaker baseline plus running estimate) exceeds the limit, so pathological
+ * projected total (live {@code breaker.getUsed()} plus running estimate) exceeds the limit, so pathological
  * queries fail before their full Lucene tree is materialised.
  * <p>
  * {@link IndexOrDocValuesQuery} is counted as one clause and its inner queries are ignored;
@@ -56,16 +57,22 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
 
     @Nullable
     private final CircuitBreaker breaker;
-    private long breakerBaseline;
+
+    @Nullable
+    private final Predicate<Query> preCharged;
 
     public MaxClauseCountQueryVisitor(int maxClauseCount) {
         this(maxClauseCount, null);
     }
 
     public MaxClauseCountQueryVisitor(int maxClauseCount, @Nullable CircuitBreaker breaker) {
+        this(maxClauseCount, breaker, null);
+    }
+
+    public MaxClauseCountQueryVisitor(int maxClauseCount, @Nullable CircuitBreaker breaker, @Nullable Predicate<Query> preCharged) {
         this.maxClauseCount = maxClauseCount;
         this.breaker = breaker;
-        this.breakerBaseline = breaker == null ? 0L : breaker.getUsed();
+        this.preCharged = preCharged;
     }
 
     public int getMaxClauseCount() {
@@ -89,15 +96,12 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
     }
 
     /**
-     * Clears the accumulated clause count and byte estimate, and recaptures the breaker baseline
-     * from {@code breaker.getUsed()} when a breaker is configured.
+     * Clears the accumulated clause count and byte estimate. The breaker projection reads
+     * {@code breaker.getUsed()} live, so there is no cached baseline to recapture.
      */
     public void reset() {
         numClauses = 0;
         estimatedBytes = 0L;
-        if (breaker != null) {
-            breakerBaseline = breaker.getUsed();
-        }
     }
 
     public void merge(MaxClauseCountQueryVisitor other) {
@@ -118,6 +122,13 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
      */
     private void chargeBytesFor(Query query, int termMultiplier) {
         assert termMultiplier > 0 : "termMultiplier must be positive, got " + termMultiplier;
+
+        if (preCharged != null && preCharged.test(query)) {
+            // Retained bytes were already charged to the breaker at construction time (e.g. wildcard / regexp automata under
+            // their dedicated category); skip so the same leaf is not counted twice.
+            return;
+        }
+
         long bytes;
         if (query instanceof FuzzyQuery fq) {
             bytes = FuzzyQueries.estimateBytes(fq);
@@ -141,7 +152,7 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
             return;
         }
 
-        long projected = breakerBaseline + estimatedBytes;
+        long projected = breaker.getUsed() + estimatedBytes;
         if (projected > limit) {
             // Throw-only: circuitBreak bumps trippedCount and throws, but does NOT touch the breaker's
             // used counter. The accumulated estimate is committed in a single addCircuitBreakerMemory

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -47,6 +47,7 @@ import java.util.Set;
 
 import static org.apache.lucene.search.MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
@@ -362,6 +363,19 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             false
         );
         assertEquals(inclusiveLower, ft.rangeQuery("lower", null, true, false, MOCK_CONTEXT));
+    }
+
+    public void testSingleSidedRangeQueryChargesBreakerOnceAndMarksPreCharged() {
+        KeyedFlattenedFieldType ft = createFieldType();
+        SearchExecutionContext context = mock(SearchExecutionContext.class);
+        when(context.allowExpensiveQueries()).thenReturn(true);
+
+        Query query = ft.rangeQuery("lower", null, true, false, context);
+
+        assertTrue("single-sided keyed range must build a TermRangeQuery", query instanceof TermRangeQuery);
+        long ramBytesUsed = ((TermRangeQuery) query).ramBytesUsed();
+        verify(context).addCircuitBreakerMemory(ramBytesUsed, "range:" + ft.name());
+        verify(context).markQueryMemoryPreCharged(query);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -45,6 +46,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 
 public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilder> {
@@ -526,6 +529,71 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
                 "duplicate filter clauses must be deduplicated by the bool query and charge the breaker exactly once",
                 singleClauseDelta,
                 duplicateDelta
+            );
+        } finally {
+            context.releaseQueryConstructionMemory();
+        }
+    }
+
+    public void testBoolFilterWildcardClausesChargedOncePerAutomaton() throws IOException {
+        assertDedupWildcardClausesChargedOnce(true);
+    }
+
+    public void testBoolMustNotWildcardClausesChargedOncePerAutomaton() throws IOException {
+        assertDedupWildcardClausesChargedOnce(false);
+    }
+
+    private void assertDedupWildcardClausesChargedOnce(boolean filter) throws IOException {
+        String patternOne = "test*pattern*one*here*";
+        String patternTwo = "another*completely*different*pattern*two*";
+
+        long automatonOne;
+        long automatonTwo;
+        CircuitBreaker measureBreaker = createCircuitBreakerService();
+        SearchExecutionContext measureContext = new SearchExecutionContext(createSearchExecutionContext(), measureBreaker);
+        try {
+            Query first = new WildcardQueryBuilder(TEXT_FIELD_NAME, patternOne).toQuery(measureContext);
+            Query second = new WildcardQueryBuilder(TEXT_FIELD_NAME, patternTwo).toQuery(measureContext);
+            assertThat("wildcard automaton query must be Accountable", first, instanceOf(Accountable.class));
+            assertThat("wildcard automaton query must be Accountable", second, instanceOf(Accountable.class));
+            automatonOne = ((Accountable) first).ramBytesUsed();
+            automatonTwo = ((Accountable) second).ramBytesUsed();
+        } finally {
+            measureContext.releaseQueryConstructionMemory();
+        }
+        long expected = automatonOne + automatonTwo;
+        long smallerAutomaton = Math.min(automatonOne, automatonTwo);
+        assertTrue("precondition: distinct wildcard automata must retain bytes", smallerAutomaton > 0);
+
+        CircuitBreaker cb = createCircuitBreakerService();
+        SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext(), cb);
+        try {
+            BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+            if (filter) {
+                boolQuery.filter(new WildcardQueryBuilder(TEXT_FIELD_NAME, patternOne))
+                    .filter(new WildcardQueryBuilder(TEXT_FIELD_NAME, patternTwo));
+            } else {
+                boolQuery.mustNot(new WildcardQueryBuilder(TEXT_FIELD_NAME, patternOne))
+                    .mustNot(new WildcardQueryBuilder(TEXT_FIELD_NAME, patternTwo));
+            }
+
+            long before = cb.getUsed();
+            boolQuery.toQuery(context);
+            long delta = cb.getUsed() - before;
+
+            String clause = filter ? "filter" : "must_not";
+            assertThat(
+                "bool " + clause + " wildcard clauses must charge both automata at least once",
+                delta,
+                greaterThanOrEqualTo(expected)
+            );
+            assertThat(
+                "bool "
+                    + clause
+                    + " wildcard clauses must charge each automaton exactly once; the dedup clause visitor must honor the "
+                    + "pre-charged predicate so construction-time bytes are not counted again under CATEGORY_QUERY",
+                delta,
+                lessThan(expected + smallerAutomaton)
             );
         } finally {
             context.releaseQueryConstructionMemory();

--- a/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -153,6 +153,18 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
         assertCircuitBreakerAccountsForQuery(new RegexpQueryBuilder(TEXT_FIELD_NAME, ".*test.*pattern.*"));
     }
 
+    public void testRegexpQueryContinuouslyAccountedDuringConstruction() {
+        assertCircuitBreakerContinuouslyAccountsDuringConstruction(
+            context -> context.getFieldType(TEXT_FIELD_NAME).regexpQuery(".*test.*pattern.*more.*", 0, 0, 10000, null, context)
+        );
+    }
+
+    public void testRegexpQueryNoBreakerDipUnderConcurrency() throws Exception {
+        assertNoBreakerDipUnderConcurrentConstruction(
+            context -> context.getFieldType(TEXT_FIELD_NAME).regexpQuery(".*test.*pattern.*more.*", 0, 0, 10000, null, context)
+        );
+    }
+
     public void testRegexpCircuitBreakerTripsWithLowLimit() {
         assertCircuitBreakerTripsOnQueryConstruction("500kb", () -> {
             BoolQueryBuilder boolQuery = new BoolQueryBuilder();

--- a/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -207,6 +207,18 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
         assertCircuitBreakerAccountsForQuery(new WildcardQueryBuilder(TEXT_FIELD_NAME, "test*pattern*with*wildcards*"));
     }
 
+    public void testWildcardQueryContinuouslyAccountedDuringConstruction() {
+        assertCircuitBreakerContinuouslyAccountsDuringConstruction(
+            context -> context.getFieldType(TEXT_FIELD_NAME).wildcardQuery("test*pattern*with*many*wildcards*", null, false, context)
+        );
+    }
+
+    public void testWildcardQueryNoBreakerDipUnderConcurrency() throws Exception {
+        assertNoBreakerDipUnderConcurrentConstruction(
+            context -> context.getFieldType(TEXT_FIELD_NAME).wildcardQuery("test*pattern*with*many*wildcards*", null, false, context)
+        );
+    }
+
     public void testCircuitBreakerTripsWithLowLimit() {
         assertCircuitBreakerTripsOnQueryConstruction("1mb", () -> {
             BoolQueryBuilder boolQuery = new BoolQueryBuilder();

--- a/server/src/test/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitorTests.java
@@ -259,7 +259,7 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
         assertEquals(0L, visitor.getEstimatedBytes());
     }
 
-    public void testResetRecapturesBreakerBaseline() {
+    public void testPostResetTripsReflectLiveBreakerUsage() {
         long limit = 1_000L;
         FakeCircuitBreaker breaker = new FakeCircuitBreaker(limit, 0L);
         MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount(), breaker);
@@ -272,7 +272,7 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
         visitor.reset();
 
         expectThrows(CircuitBreakingException.class, () -> new AccountableTestQuery(200L).visit(visitor));
-        assertTrue("reset() must recapture the breaker baseline so post-reset trips reflect new used", breaker.tripped);
+        assertTrue("post-reset trips must reflect the live breaker usage read at check time", breaker.tripped);
     }
 
     public void testResetWithoutBreakerIsANoOpForBaseline() {
@@ -337,7 +337,7 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
         assertTrue("second leaf should have tripped the breaker", breaker.tripped);
     }
 
-    public void testBreakerBaselineIsCapturedAtConstructionTime() {
+    public void testPreExistingBreakerUsageIsIncludedInProjection() {
         long limit = 1_000L;
         long preExisting = 900L;
         FakeCircuitBreaker breaker = new FakeCircuitBreaker(limit, preExisting);
@@ -345,6 +345,26 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
 
         expectThrows(CircuitBreakingException.class, () -> new AccountableTestQuery(200L).visit(visitor));
         assertTrue(breaker.tripped);
+    }
+
+    public void testPreChargedBytesCountTowardMidWalkTripViaLiveUsed() {
+        long limit = 1000L;
+        FakeCircuitBreaker breaker = new FakeCircuitBreaker(limit, 0L);
+        Query preChargedAutomaton = new AccountableTestQuery(10000L);
+        MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(
+            IndexSearcher.getMaxClauseCount(),
+            breaker,
+            q -> q == preChargedAutomaton
+        );
+
+        breaker.setUsed(800L);
+        preChargedAutomaton.visit(visitor);
+        assertEquals("pre-charged bytes must never enter the committed estimate", 0L, visitor.getEstimatedBytes());
+        assertEquals("the pre-charged leaf must still be counted as a clause", 1, visitor.getNumClauses());
+        assertFalse("visiting the pre-charged leaf must not trip on its own", breaker.tripped);
+
+        expectThrows(CircuitBreakingException.class, () -> new AccountableTestQuery(300L).visit(visitor));
+        assertTrue("mid-walk projection must include pre-charged bytes via live breaker.getUsed()", breaker.tripped);
     }
 
     public void testMergeRoutesThroughEarlyTripPeek() {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -114,7 +114,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -125,6 +129,8 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public abstract class AbstractBuilderTestCase extends ESTestCase {
 
@@ -483,9 +489,11 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             long beforeContextTally = context.getQueryConstructionMemoryUsed();
             CircuitBreakingException exception = expectThrows(CircuitBreakingException.class, () -> query.toQuery(context));
             assertThat(exception.getMessage(), containsString("Data too large"));
-            assertEquals("breaker must not retain bytes after a mid-walk query-construction trip", beforeUsed, breaker.getUsed());
+
+            context.releaseQueryConstructionMemory();
+            assertEquals("breaker must not retain bytes after releasing query-construction memory", beforeUsed, breaker.getUsed());
             assertEquals(
-                "query-construction tally must not retain bytes after a mid-walk trip",
+                "query-construction tally must not retain bytes after release",
                 beforeContextTally,
                 context.getQueryConstructionMemoryUsed()
             );
@@ -516,6 +524,96 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         } finally {
             context.releaseQueryConstructionMemory();
         }
+    }
+
+    protected static void assertCircuitBreakerContinuouslyAccountsDuringConstruction(Function<SearchExecutionContext, Query> queryBuilder) {
+        CircuitBreaker breaker = createCircuitBreakerService();
+        SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext(), breaker);
+        try {
+            long before = breaker.getUsed();
+            Query query = queryBuilder.apply(context);
+            assertThat("test query must be Accountable", query, instanceOf(Accountable.class));
+            long retained = ((Accountable) query).ramBytesUsed();
+            assertThat(
+                "automaton retained memory must stay charged after construction (no release-before-commit window)",
+                breaker.getUsed() - before,
+                greaterThanOrEqualTo(retained)
+            );
+        } finally {
+            context.releaseQueryConstructionMemory();
+        }
+    }
+
+    protected static void assertNoBreakerDipUnderConcurrentConstruction(Function<SearchExecutionContext, Query> queryBuilder)
+        throws Exception {
+        CircuitBreaker breaker = createCircuitBreakerService();
+        SearchExecutionContext contextA = new SearchExecutionContext(createSearchExecutionContext(), breaker);
+        SearchExecutionContext contextB = new SearchExecutionContext(createSearchExecutionContext(), breaker);
+
+        CountDownLatch built = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicLong retainedA = new AtomicLong();
+        AtomicLong retainedB = new AtomicLong();
+        AtomicReference<Exception> workerFailure = new AtomicReference<>();
+
+        class Worker extends Thread {
+            private final SearchExecutionContext context;
+            private final AtomicLong retained;
+
+            Worker(SearchExecutionContext context, AtomicLong retained) {
+                this.context = context;
+                this.retained = retained;
+            }
+
+            @Override
+            public void run() {
+                boolean signaledBuilt = false;
+                try {
+                    Query query = queryBuilder.apply(context);
+                    retained.set(((Accountable) query).ramBytesUsed());
+
+                    built.countDown();
+                    signaledBuilt = true;
+                    if (release.await(30, TimeUnit.SECONDS) == false) {
+                        workerFailure.compareAndSet(null, new IllegalStateException("worker timed out awaiting release signal"));
+                    }
+                } catch (Exception e) {
+                    workerFailure.compareAndSet(null, e);
+                } finally {
+                    if (signaledBuilt == false) {
+                        built.countDown();
+                    }
+                    context.releaseQueryConstructionMemory();
+                }
+            }
+        }
+
+        Worker a = new Worker(contextA, retainedA);
+        Worker b = new Worker(contextB, retainedB);
+        a.start();
+        b.start();
+        try {
+            assertTrue("workers did not finish building within timeout", built.await(30, TimeUnit.SECONDS));
+            if (workerFailure.get() == null) {
+                assertThat(
+                    "breaker used must cover both live automata (no release-before-commit dip)",
+                    breaker.getUsed(),
+                    greaterThanOrEqualTo(retainedA.get() + retainedB.get())
+                );
+            }
+        } catch (Exception e) {
+            workerFailure.compareAndSet(null, e);
+        } finally {
+            release.countDown();
+        }
+        a.join(TimeUnit.SECONDS.toMillis(30));
+        b.join(TimeUnit.SECONDS.toMillis(30));
+        assertFalse("worker A did not terminate within timeout", a.isAlive());
+        assertFalse("worker B did not terminate within timeout", b.isAlive());
+        if (workerFailure.get() != null) {
+            throw workerFailure.get();
+        }
+        assertEquals("breaker must be fully released after both requests end", 0L, breaker.getUsed());
     }
 
     private static class ServiceHolder implements Closeable {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix circuit breaker undercounting memory for wildcard and regexp queries (#155368)](https://github.com/elastic/elasticsearch/pull/155368)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)