### PR TITLE
Fix ESCF number mapping parity

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/NumberColumnTransform.java
+++ b/server/src/main/java/org/elasticsearch/escf/NumberColumnTransform.java
@@ -39,11 +39,21 @@ public final class NumberColumnTransform {
         boolean coerce,
         Recycler<BytesRef> recycler
     ) {
+        return toSortableLongColumn(source, type, coerce, recycler, null);
+    }
+
+    public static EscfColumnData toSortableLongColumn(
+        EscfColumn source,
+        NumberFieldMapper.NumberType type,
+        boolean coerce,
+        Recycler<BytesRef> recycler,
+        Long nullReplacement
+    ) {
         return switch (source.kind()) {
             case EscfColumnKind.LONG -> fromLong(source, type, recycler);
             case EscfColumnKind.DOUBLE -> fromDouble(source, type, coerce, recycler);
-            case EscfColumnKind.STRING -> fromString(source, type, coerce, recycler);
-            case EscfColumnKind.ARRAY -> fromArray(source, type, coerce, recycler);
+            case EscfColumnKind.STRING -> fromString(source, type, coerce, recycler, nullReplacement);
+            case EscfColumnKind.ARRAY -> fromArray(source, type, coerce, recycler, nullReplacement);
             default -> throw new UnsupportedOperationException(
                 "toSortableLongColumn: unsupported ESCF column kind ["
                     + EscfColumnKind.name(source.kind())
@@ -56,31 +66,42 @@ public final class NumberColumnTransform {
         EscfColumn source,
         NumberFieldMapper.NumberType type,
         boolean coerce,
-        Recycler<BytesRef> recycler
+        Recycler<BytesRef> recycler,
+        Long nullReplacement
     ) {
         // Materialize the array structure: offsets + child data. The child is always dense (all
         // elements present — absent rows are represented by an empty offset range, not a child gap).
         EscfColumnData sourceData = source.toColumnData();
         EscfColumnData childData = sourceData.child();
         EscfColumn child = EscfColumn.from(childData);
-        EscfColumnData transformedChild = switch (child.kind()) {
-            case EscfColumnKind.LONG -> fromLong(child, type, recycler);
-            case EscfColumnKind.DOUBLE -> fromDouble(child, type, coerce, recycler);
-            case EscfColumnKind.STRING -> fromString(child, type, coerce, recycler);
+        return switch (child.kind()) {
+            case EscfColumnKind.STRING -> fromString(source, type, coerce, recycler, nullReplacement);
+            case EscfColumnKind.LONG -> EscfColumnData.ofArray(
+                sourceData.docCount(),
+                sourceData.validity(),
+                sourceData.offsets(),
+                fromLong(child, type, recycler)
+            );
+            case EscfColumnKind.DOUBLE -> EscfColumnData.ofArray(
+                sourceData.docCount(),
+                sourceData.validity(),
+                sourceData.offsets(),
+                fromDouble(child, type, coerce, recycler)
+            );
             default -> throw new UnsupportedOperationException(
                 "toSortableLongColumn: ARRAY child kind ["
                     + EscfColumnKind.name(child.kind())
                     + "] is not supported — child must be LONG, DOUBLE, or STRING"
             );
         };
-        return EscfColumnData.ofArray(sourceData.docCount(), sourceData.validity(), sourceData.offsets(), transformedChild);
     }
 
     private static EscfColumnData fromString(
         EscfColumn source,
         NumberFieldMapper.NumberType type,
         boolean coerce,
-        Recycler<BytesRef> recycler
+        Recycler<BytesRef> recycler,
+        Long nullReplacement
     ) {
         AbstractXContentParser.checkCoerceString(coerce, classForType(type));
         EscfColumnBuilder builder = newLongBuilder(recycler);
@@ -89,7 +110,14 @@ public final class NumberColumnTransform {
         final long max = integerMaxForType(type);
         final long[] scratch = new long[1];
         for (int doc = cursor.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = cursor.nextDoc()) {
-            builder.setLong(doc, stringToSortableLong(cursor.value(), type, min, max, scratch));
+            BytesRef value = cursor.value();
+            if (coerce && value.length == 0) {
+                if (nullReplacement != null) {
+                    builder.setLong(doc, nullReplacement);
+                }
+                continue;
+            }
+            builder.setLong(doc, stringToSortableLong(value, type, min, max, scratch));
         }
         return builder.finish(source.docCount());
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2807,11 +2807,13 @@ public class NumberFieldMapper extends FieldMapper {
                     + "]"
             );
         }
+        Long nullSortableLong = nullValue != null ? type.toSortableLong(nullValue) : null;
         EscfColumnData outData = NumberColumnTransform.toSortableLongColumn(
             source,
             type,
             coerce(),
-            BytesRefRecycler.NON_RECYCLING_INSTANCE
+            BytesRefRecycler.NON_RECYCLING_INSTANCE,
+            nullSortableLong
         );
         IndexableFieldType columnFieldType = fieldType().indexType().hasDocValuesSkipper()
             ? SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE

--- a/server/src/test/java/org/elasticsearch/escf/NumberColumnTransformTests.java
+++ b/server/src/test/java/org/elasticsearch/escf/NumberColumnTransformTests.java
@@ -761,6 +761,107 @@ public class NumberColumnTransformTests extends ESTestCase {
         assertEquals(1L, readValues(out, 1)[0]);
     }
 
+    /** LONG string: large BigDecimal values truncate toward zero when coerce=true. */
+    public void testStringToLong_bigDecimal_coerceTrue_truncates() {
+        EscfColumnData src = stringColumnData("1234567890123456789.9", "-1234567890123456789.9");
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE
+        );
+        long[] vals = readValues(out, 2);
+        assertEquals(1234567890123456789L, vals[0]);
+        assertEquals(-1234567890123456789L, vals[1]);
+    }
+
+    /** INTEGER string: BigDecimal values truncate when coerce=true, matching parser.intValue. */
+    public void testStringToInteger_bigDecimal_coerceTrue_truncates() {
+        EscfColumnData src = stringColumnData("123.9", "-123.9");
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.INTEGER,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE
+        );
+        long[] vals = readValues(out, 2);
+        assertEquals(123L, vals[0]);
+        assertEquals(-123L, vals[1]);
+    }
+
+    public void testStringToLong_bigIntegerOutOfRange_throws() {
+        EscfColumnData src = stringColumnData("9223372036854775808");
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> NumberColumnTransform.toSortableLongColumn(
+                EscfColumn.from(src),
+                NumberType.LONG,
+                true,
+                BytesRefRecycler.NON_RECYCLING_INSTANCE
+            )
+        );
+        assertTrue("expected out-of-range message but got: " + ex.getMessage(), ex.getMessage().contains("out of range for a long"));
+    }
+
+    public void testStringToInteger_bigIntegerOutOfRange_throws() {
+        EscfColumnData src = stringColumnData("2147483648");
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> NumberColumnTransform.toSortableLongColumn(
+                EscfColumn.from(src),
+                NumberType.INTEGER,
+                true,
+                BytesRefRecycler.NON_RECYCLING_INSTANCE
+            )
+        );
+        assertTrue("expected out-of-range message but got: " + ex.getMessage(), ex.getMessage().contains("out of range for an integer"));
+    }
+
+    /** Empty strings with coerce=true and no null_value become absent values. */
+    public void testStringToLong_emptyString_coerceTrue_becomesAbsent() {
+        EscfColumnData src = stringColumnData("10", "", "30");
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE
+        );
+        long[] vals = readValues(out, 3);
+        assertEquals(10L, vals[0]);
+        assertEquals(Long.MIN_VALUE, vals[1]);
+        assertEquals(30L, vals[2]);
+    }
+
+    /** Empty strings with coerce=true use the mapper null_value when one is configured. */
+    public void testStringToLong_emptyString_coerceTrue_usesNullValue() {
+        EscfColumnData src = stringColumnData("10", "", "30");
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE,
+            99L
+        );
+        long[] vals = readValues(out, 3);
+        assertEquals(10L, vals[0]);
+        assertEquals(99L, vals[1]);
+        assertEquals(30L, vals[2]);
+    }
+
+    public void testStringToLong_emptyString_coerceFalse_throws() {
+        EscfColumnData src = stringColumnData("");
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> NumberColumnTransform.toSortableLongColumn(
+                EscfColumn.from(src),
+                NumberType.LONG,
+                false,
+                BytesRefRecycler.NON_RECYCLING_INSTANCE
+            )
+        );
+        assertTrue("expected coerce message but got: " + ex.getMessage(), ex.getMessage().contains("Long value passed as String"));
+    }
+
     /** LONG string: decimal with coerce=false throws "has a decimal part". */
     public void testStringToLong_decimal_coerceFalse_throws() {
         EscfColumnData src = stringColumnData("1.9");
@@ -954,6 +1055,49 @@ public class NumberColumnTransformTests extends ESTestCase {
         long[][] vals = readArrayValues(out, 2);
         assertArrayEquals(new long[] { NumericUtils.floatToSortableInt(1.5f), NumericUtils.floatToSortableInt(-2.25f) }, vals[0]);
         assertArrayEquals(new long[] { NumericUtils.floatToSortableInt(0.5f) }, vals[1]);
+    }
+
+    /** ARRAY-of-STRING: empty elements are dropped when coerce=true and no null_value is configured. */
+    public void testStringArray_emptyString_coerceTrue_compactsOffsets() {
+        EscfColumnData src = stringArrayColumnData(new String[] { "1", "", "3" }, new String[] { "", "" }, new String[] { "4" });
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE
+        );
+        long[][] vals = readArrayValues(out, 3);
+        assertArrayEquals(new long[] { 1L, 3L }, vals[0]);
+        assertNull(vals[1]);
+        assertArrayEquals(new long[] { 4L }, vals[2]);
+    }
+
+    /** ARRAY-of-STRING: empty elements use null_value when configured. */
+    public void testStringArray_emptyString_coerceTrue_usesNullValue() {
+        EscfColumnData src = stringArrayColumnData(new String[] { "1", "", "3" }, new String[] { "" });
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE,
+            99L
+        );
+        long[][] vals = readArrayValues(out, 2);
+        assertArrayEquals(new long[] { 1L, 99L, 3L }, vals[0]);
+        assertArrayEquals(new long[] { 99L }, vals[1]);
+    }
+
+    /** ARRAY-of-STRING: BigDecimal elements truncate per element when coerce=true. */
+    public void testStringArray_bigDecimal_coerceTrue_truncates() {
+        EscfColumnData src = stringArrayColumnData(new String[] { "1.9", "-2.9" });
+        EscfColumnData out = NumberColumnTransform.toSortableLongColumn(
+            EscfColumn.from(src),
+            NumberType.LONG,
+            true,
+            BytesRefRecycler.NON_RECYCLING_INSTANCE
+        );
+        long[][] vals = readArrayValues(out, 1);
+        assertArrayEquals(new long[] { 1L, -2L }, vals[0]);
     }
 
     private static boolean isLongInRange(long l, NumberType type) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperColumnarCompatibilityTests.java
@@ -186,11 +186,75 @@ public class NumberFieldMapperColumnarCompatibilityTests extends AbstractColumna
         );
     }
 
+    public void testLongField_stringColumn_emptyStringMissing() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "long").endObject()),
+            columnarSettings(),
+            batch("long empty string missing", 1L, doc("d1", 1L, "{\"f\":\"10\"}"), doc("d2", 2L, "{\"f\":\"\"}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testLongField_stringColumn_emptyStringUsesNullValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "long").field("null_value", 7).endObject()),
+            columnarSettings(),
+            batch("long empty string null_value", 1L, doc("d1", 1L, "{\"f\":\"10\"}"), doc("d2", 2L, "{\"f\":\"\"}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testLongField_stringColumn_coerceFalseRejectsNumericString() throws IOException {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> assertColumnarMatchesXContent(
+                mapping(b -> b.startObject(FIELD).field("type", "long").field("coerce", false).endObject()),
+                columnarSettings(),
+                batch("long coerce false string", 1L, doc("d1", 1L, "{\"f\":\"42\"}"))
+            )
+        );
+        assertTrue("expected coerce message but got: " + ex.getMessage(), ex.getMessage().contains("Long value passed as String"));
+    }
+
+    public void testLongField_stringColumn_coerceFalseRejectsEmptyString() throws IOException {
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> assertColumnarMatchesXContent(
+                mapping(b -> b.startObject(FIELD).field("type", "long").field("coerce", false).endObject()),
+                columnarSettings(),
+                batch("long coerce false empty string", 1L, doc("d1", 1L, "{\"f\":\"\"}"))
+            )
+        );
+        assertTrue("expected coerce message but got: " + ex.getMessage(), ex.getMessage().contains("Long value passed as String"));
+    }
+
+    public void testDoubleField_bigIntegerNumberTokenStoredAsStringColumn() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "double").endObject()),
+            columnarSettings(),
+            batch("double big integer token", 1L, doc("d1", 1L, "{\"f\":9223372036854775808}"))
+        );
+    }
+
+    public void testDoubleField_bigDecimalNumberTokenStoredAsStringColumn() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "double").endObject()),
+            columnarSettings(),
+            batch("double big decimal token", 1L, doc("d1", 1L, "{\"f\":1.2345678901234567890123456789}"))
+        );
+    }
+
     public void testIntegerField_stringColumn() throws IOException {
         assertColumnarMatchesXContent(
             mapping(b -> b.startObject(FIELD).field("type", "integer").endObject()),
             columnarSettings(),
             batch("integer string", 1L, doc("d1", 1L, "{\"f\":\"100\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"-50\"}"))
+        );
+    }
+
+    public void testIntegerField_stringColumn_decimalTruncated() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "integer").endObject()),
+            columnarSettings(),
+            batch("integer string decimal coerce", 1L, doc("d1", 1L, "{\"f\":\"123.9\"}"), doc("d2", 2L, "{\"f\":\"-123.9\"}"))
         );
     }
 


### PR DESCRIPTION
Handle empty numeric strings in ESCF column transforms like the
row parser: treat them as missing when coercion is enabled, or
replace them with the mapped null_value when configured.

Also pass null_value through NumberFieldMapper's columnar path,
allow array numeric sources, and add focused transform and mapper
compatibility tests for BigDecimal, BigInteger, empty strings, and
coerce=false behavior.