### PR TITLE
Mark coordinator lookup join as tech preview feature

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -21,7 +21,7 @@ FROM <source_index>
 `<lookup_index>`
 :   The name of the lookup index. This must be a specific index name or alias. Wildcards and remote cluster prefixes are not supported. If the query source includes remote indices, the lookup index must exist on all involved clusters. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
 
-    In cross-cluster or cross-project queries, you can prefix the index name with `_coordinator:` to run the lookup on the coordinating node of the local cluster or origin project instead of on each remote cluster or linked project. This allows `LOOKUP JOIN` to be used after pipeline-breaking commands such as `STATS`, `LIMIT`, `SORT`. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: preview`
+    In cross-cluster or cross-project queries, you can prefix the index name with `_coordinator:` to run the lookup on the coordinating node of the local cluster or origin project instead of on each remote cluster or linked project. This allows `LOOKUP JOIN` to be used after pipeline-breaking commands such as `STATS`, `LIMIT`, `SORT`. {applies_to}`stack: preview 9.6+` {applies_to}`serverless: preview`
    
      
 `<join_condition>`

--- a/docs/reference/query-languages/esql/esql-cross-clusters.md
+++ b/docs/reference/query-languages/esql/esql-cross-clusters.md
@@ -417,7 +417,7 @@ FROM my-index-000001,cluster_one:my-index-000001,cluster_two:my-index-000001
 
 {{esql}} [`LOOKUP JOIN`](/reference/query-languages/esql/esql-lookup-join.md#cross-cluster-support) is supported in cross-cluster queries. By default, {{esql}} resolves the lookup index on every cluster in the query and each cluster joins against its own local index with that name. In this case, the lookup index must exist on every cluster being queried. This follows the same pattern as [remote mode Enrich](#esql-enrich-remote).
 
-{applies_to}`stack: ga 9.6+` If the lookup index is missing from one or more remote clusters, use [coordinator mode](/reference/query-languages/esql/esql-lookup-join.md#coordinator-mode) to join against a local cluster lookup index copy.
+{applies_to}`stack: preview 9.6+` If the lookup index is missing from one or more remote clusters, use [coordinator mode](/reference/query-languages/esql/esql-lookup-join.md#coordinator-mode) to join against a local cluster lookup index copy.
 
 
 ## Excluding clusters or indices from {{esql}} query [ccq-exclude]

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -91,7 +91,8 @@ If the lookup index is missing from one or more linked projects, use [coordinato
 ### Run `LOOKUP JOIN` on coordinating node [coordinator-mode]
 
 ```{applies_to}
-stack: ga 9.6+
+stack: preview 9.6+
+serverless: preview
 ```
 
 In cross-cluster or cross-project queries, you can prefix the index name with `_coordinator:` to run the lookup on the local cluster or origin project instead of on each remote cluster or linked project.


### PR DESCRIPTION
This change marks `_coordinator:` LOOKUP JOIN feature as a tech preview in docs.