### PR TITLE
Fix exponential histogram merging with zero bucket overlap

### DIFF
--- a/docs/changelog/155459.yaml
+++ b/docs/changelog/155459.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 153665
+pr: 155459
+summary: Fix exponential histogram merging with zero bucket overlap
+type: bug

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
@@ -212,23 +212,17 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
         CopyableBucketIterator negBucketsB = b.negativeBuckets().iterator();
 
         ZeroBucket zeroBucket = a.zeroBucket().merge(b.zeroBucket());
-        zeroBucket = zeroBucket.collapseOverlappingBucketsForAll(posBucketsA, negBucketsA, posBucketsB, negBucketsB);
 
         FixedCapacityExponentialHistogram buffer = factory.acquireBuffer();
         try {
 
-            buffer.setZeroBucket(zeroBucket);
             buffer.setSum(a.sum() + b.sum());
             buffer.setMin(nanAwareAggregate(a.min(), b.min(), Math::min));
             buffer.setMax(nanAwareAggregate(a.max(), b.max(), Math::max));
 
             int targetScale = Math.min(factory.maxScale, Math.min(a.scale(), b.scale()));
 
-            // We might exceed our limit for the total number of buckets for the targetScale.
-            // We try the merge optimistically, assuming that everything fits.
-            // If we fail, we reduce the target scale to make everything fit.
-
-            mergeBucketsInto(negBucketsA, posBucketsA, negBucketsB, posBucketsB, targetScale, Long::sum, buffer);
+            mergeBucketsInto(zeroBucket, negBucketsA, posBucketsA, negBucketsB, posBucketsB, targetScale, Long::sum, buffer);
             FixedCapacityExponentialHistogram temp = result;
             result = buffer;
             buffer = temp;
@@ -238,6 +232,7 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
     }
 
     private void mergeBucketsInto(
+        ZeroBucket zeroBucket,
         CopyableBucketIterator negBucketsA,
         CopyableBucketIterator posBucketsA,
         CopyableBucketIterator negBucketsB,
@@ -260,6 +255,8 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
             countCombineFunction
         );
 
+        output.setZeroBucket(zeroBucket.collapseOverlappingBucketsForAll(positiveMerged, negativeMerged));
+
         // We might exceed our limit for the total number of buckets for the targetScale.
         // We try the merge optimistically, assuming that everything fits.
         // If we fail, we reduce the target scale to make everything fit and redo the merge
@@ -276,6 +273,9 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
             output.resetBuckets(targetScale);
             positiveMerged = new MergingBucketIterator(posBucketsA, posBucketsB, targetScale, countCombineFunction);
             negativeMerged = new MergingBucketIterator(negBucketsA, negBucketsB, targetScale, countCombineFunction);
+
+            output.setZeroBucket(zeroBucket.collapseOverlappingBucketsForAll(positiveMerged, negativeMerged));
+
             overflowCount = putBuckets(output, negativeMerged, false, null);
             overflowCount += putBuckets(output, positiveMerged, true, null);
 
@@ -432,6 +432,7 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
         FixedCapacityExponentialHistogram buffer = factory.acquireBuffer();
         try {
             mergeBucketsInto(
+                subtractedZeroBucket,
                 a.negativeBuckets().iterator(),
                 a.positiveBuckets().iterator(),
                 negBucketsB,
@@ -440,7 +441,6 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
                 bucketDifferenceOperator,
                 buffer
             );
-            buffer.setZeroBucket(subtractedZeroBucket);
 
             // we might have clamped negative buckets away, so we need to scale down the remaining buckets to compensate for that
             long desiredTargetCount = aValueCount - bValueCount;

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMergerTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMergerTests.java
@@ -44,6 +44,32 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class ExponentialHistogramMergerTests extends ExponentialHistogramTestCase {
 
+    public void testZeroBucketDoesNotOverlapBucketsAfterMerge() {
+        try (
+            ReleasableExponentialHistogram input = ExponentialHistogramTestUtils.randomHistogram(ExponentialHistogramCircuitBreaker.noop());
+            ExponentialHistogramMerger merger = ExponentialHistogramMerger.create(randomIntBetween(4, 100), breaker())
+        ) {
+            merger.add(input);
+            ExponentialHistogram result = merger.get();
+
+            for (ExponentialHistogram.Buckets buckets : List.of(result.negativeBuckets(), result.positiveBuckets())) {
+                BucketIterator closestToZero = buckets.iterator();
+                if (closestToZero.hasNext()) {
+                    assertThat(
+                        "zero bucket overlaps with the closest populated bucket",
+                        ExponentialScaleUtils.compareExponentiallyScaledValues(
+                            result.zeroBucket().index(),
+                            result.zeroBucket().scale(),
+                            closestToZero.peekIndex(),
+                            closestToZero.scale()
+                        ),
+                        lessThanOrEqualTo(0)
+                    );
+                }
+            }
+        }
+    }
+
     public void testZeroThresholdCollapsesOverlappingBuckets() {
         ExponentialHistogram first = createAutoReleasedHistogram(b -> b.zeroBucket(ZeroBucket.create(2.0001, 10)));
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -382,9 +382,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceBufferTests
   method: testRecordInformationalWarningAppliesOneGlobalCapAcrossManyCallers
   issue: https://github.com/elastic/elasticsearch/issues/153652
-- class: org.elasticsearch.exponentialhistogram.ExponentialHistogramMergerTests
-  method: testDifferenceForCumulativeHistos
-  issue: https://github.com/elastic/elasticsearch/issues/153665
 - class: org.elasticsearch.xpack.esql.parser.ParamsParserTests
   method: testMixedSingleDoubleParams
   issue: https://github.com/elastic/elasticsearch/issues/153746


### PR DESCRIPTION
Fixes #153665.

This PR fixes a small bug which which was uncovered by the linked test: When merging exponential histograms, we also have to take care of the special zero bucket: The zero buckets of the histograms to be merged are combined, which means that the zero threshold needs to be increased to the bigger one of the incoming histograms.

In addition, we do not allow the zero bucket to overlap with regular buckets of the histogram. The latter invariant was not fully respected by the histogram merging algorithm: If we need to reduce the scale, histogram buckets will become bigger. This means even if they previously didn't overlap the zero bucket, they can after reducing the scale. This was not handled correctly by the merging algorithm.

We now fixed this by collapsing overlapping buckets after the scale reduction instead of doing it before. I also added a dedicated reproducer for this problem. 