### PR TITLE
Use ranges for PromQL histogram CSV tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -529,12 +529,6 @@ tests:
 - class: org.elasticsearch.compute.operator.topn.GroupedTopNOperatorTests
   method: testRandomMultipleColumns
   issue: https://github.com/elastic/elasticsearch/issues/155019
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:promql-native-histogram-support.histogram_sum_increase_exp_histo_all_instances}
-  issue: https://github.com/elastic/elasticsearch/issues/155023
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:promql-native-histogram-support.histogram_avg_increase_exp_histo_all_instances}
-  issue: https://github.com/elastic/elasticsearch/issues/155024
 - class: org.elasticsearch.xpack.inference.integration.SemanticIndexOptionsIT
   method: testValidateIndexOptionsWithBasicLicense
   issue: https://github.com/elastic/elasticsearch/issues/155026

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
@@ -141,9 +141,9 @@ PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025
 | SORT _timeseries;
 
 result:double              | step:datetime            | _timeseries:keyword
-1472.744209..1472.744210   | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
-36.198484..36.198485       | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
-27.706021..27.706022       | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+1472.74..1472.75           | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+36.19..36.20               | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+27.70..27.71               | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
 ;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -164,9 +164,9 @@ PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025
 | SORT _timeseries;
 
 result:double                | step:datetime            | _timeseries:keyword
-0.166581179..0.166581180     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
-0.011137995..0.011137996     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
-0.008197047..0.008197048     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+0.16..0.17                   | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+0.01..0.02                   | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+0.00..0.01                   | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
 ;
 
 histogram_count_aggsum_increase_exp_histo

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/promql-native-histogram-support.csv-spec
@@ -140,10 +140,10 @@ required_capability: promql_increase_on_histogram
 PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_sum(increase(responseTime{instance=~"instance-.*"}[2h])))
 | SORT _timeseries;
 
-result:double      | step:datetime            | _timeseries:keyword
-1472.744209000001  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
-36.19848400000001  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
-27.706021000000007 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+result:double              | step:datetime            | _timeseries:keyword
+1472.744209..1472.744210   | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+36.198484..36.198485       | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+27.706021..27.706022       | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
 ;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -163,10 +163,10 @@ required_capability: promql_increase_on_histogram
 PROMQL index=exp_histo_sample step=2h start="2025-09-25T02:00:00.000Z" end="2025-09-25T02:00:00.000Z" result=(histogram_avg(increase(responseTime{instance=~"instance-.*"}[2h])))
 | SORT _timeseries;
 
-result:double        | step:datetime            | _timeseries:keyword
-0.16658117961769042  | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
-0.011137995076923079 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
-0.008197047633136096 | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
+result:double                | step:datetime            | _timeseries:keyword
+0.166581179..0.166581180     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-0""}"
+0.011137995..0.011137996     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-1""}"
+0.008197047..0.008197048     | 2025-09-25T02:00:00.000Z | "{""instance"":""instance-2""}"
 ;
 
 histogram_count_aggsum_increase_exp_histo


### PR DESCRIPTION
Fixes #155023
Fixes #155024

## Summary
- use narrow range assertions for PromQL histogram sum and average results to tolerate floating-point differences
- unmute the affected CSV tests

## Test plan
- [x] Run `histogram_sum_increase_exp_histo_all_instances` with the reported seed, locale, and timezone
- [x] Run `histogram_avg_increase_exp_histo_all_instances` with the reported seed, locale, and timezone
- [x] Run `git diff --check`