### PR TITLE
[9.5] Parse scroll id from a bounded byte array (#154542)

### DIFF
--- a/docs/changelog/154542.yaml
+++ b/docs/changelog/154542.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 154542
+summary: Parse scroll id from a bounded byte array
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchHelper.java
@@ -11,7 +11,7 @@ package org.elasticsearch.action.search;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.VersionCheckingStreamOutput;
@@ -25,7 +25,6 @@ import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.transport.RemoteClusterAware;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -74,30 +73,30 @@ public final class TransportSearchHelper {
     }
 
     static ParsedScrollId parseScrollId(String scrollId) {
-        try (
-            var decodedInputStream = Base64.getUrlDecoder().wrap(new ByteArrayInputStream(scrollId.getBytes(StandardCharsets.ISO_8859_1)));
-            var in = new InputStreamStreamInput(decodedInputStream)
-        ) {
-            final boolean includeContextUUID;
-            final String type;
-            final String firstChunk = in.readString();
-            if (INCLUDE_CONTEXT_UUID.equals(firstChunk)) {
-                includeContextUUID = true;
-                type = in.readString();
-            } else {
-                includeContextUUID = false;
-                type = firstChunk;
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(scrollId.getBytes(StandardCharsets.ISO_8859_1));
+            try (var in = new BytesArray(decoded).streamInput()) {
+                final boolean includeContextUUID;
+                final String type;
+                final String firstChunk = in.readString();
+                if (INCLUDE_CONTEXT_UUID.equals(firstChunk)) {
+                    includeContextUUID = true;
+                    type = in.readString();
+                } else {
+                    includeContextUUID = false;
+                    type = firstChunk;
+                }
+                final SearchContextIdForNode[] context = in.readArray(
+                    includeContextUUID
+                        ? TransportSearchHelper::readSearchContextIdForNodeIncludingContextUUID
+                        : TransportSearchHelper::readSearchContextIdForNodeExcludingContextUUID,
+                    SearchContextIdForNode[]::new
+                );
+                if (in.available() > 0) {
+                    throw new IllegalArgumentException("Not all bytes were read");
+                }
+                return new ParsedScrollId(type, context);
             }
-            final SearchContextIdForNode[] context = in.readArray(
-                includeContextUUID
-                    ? TransportSearchHelper::readSearchContextIdForNodeIncludingContextUUID
-                    : TransportSearchHelper::readSearchContextIdForNodeExcludingContextUUID,
-                SearchContextIdForNode[]::new
-            );
-            if (in.available() > 0) {
-                throw new IllegalArgumentException("Not all bytes were read");
-            }
-            return new ParsedScrollId(type, context);
         } catch (Exception e) {
             throw new IllegalArgumentException("Cannot parse scroll id", e);
         }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchHelperTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.MockBytesRefRecycler;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.shard.ShardId;
@@ -17,6 +19,9 @@ import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Base64;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -93,5 +98,18 @@ public class TransportSearchHelperTests extends ESTestCase {
         ParsedScrollId parsed = TransportSearchHelper.parseScrollId(scrollId);
         assertEquals(ParsedScrollId.QUERY_THEN_FETCH_TYPE, parsed.getType());
         assertEquals(1, parsed.getContext().length);
+    }
+
+    public void testParseScrollIdRejectsOversizedContextArray() throws IOException {
+        // Forged scroll_id declaring a large context array with no element data.
+        // The size must be rejected before it is used to allocate SearchContextIdForNode[].
+        final byte[] payload;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeString(ParsedScrollId.QUERY_AND_FETCH_TYPE);
+            out.writeVInt(1_000_000_000);
+            payload = BytesReference.toBytes(out.bytes());
+        }
+        String forgedId = Base64.getUrlEncoder().encodeToString(payload);
+        expectThrows(IllegalArgumentException.class, () -> TransportSearchHelper.parseScrollId(forgedId));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Parse scroll id from a bounded byte array (#154542)