### PR TITLE
[9.5] Cache little-endian float layout in DiskBBQ scalar corrections loop (#154373)

### DIFF
--- a/docs/changelog/154373.yaml
+++ b/docs/changelog/154373.yaml
@@ -1,0 +1,5 @@
+pr: 154373
+summary: Cache little-endian float layout in DiskBBQ scalar corrections loop
+area: Vector Search
+type: enhancement
+issues: []

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
@@ -281,6 +281,7 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
 
         static final ValueLayout.OfLong LAYOUT_LE_LONG = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
         static final ValueLayout.OfInt LAYOUT_LE_INT = ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+        static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
 
         protected final IndexInput in;
         protected final int length;
@@ -440,23 +441,14 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
             float maxScore
         ) {
             for (int j = limit; j < bulkSize; j++) {
-                float ax = memorySegment.get(ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN), (long) j * Float.BYTES);
+                float ax = memorySegment.get(LAYOUT_LE_FLOAT, (long) j * Float.BYTES);
 
-                float lx = memorySegment.get(
-                    ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
-                    4L * bulkSize + (long) j * Float.BYTES
-                );
+                float lx = memorySegment.get(LAYOUT_LE_FLOAT, 4L * bulkSize + (long) j * Float.BYTES);
                 lx = (lx - ax) * indexBitScale;
 
-                int targetComponentSum = memorySegment.get(
-                    ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
-                    8L * bulkSize + (long) j * Integer.BYTES
-                );
+                int targetComponentSum = memorySegment.get(LAYOUT_LE_INT, 8L * bulkSize + (long) j * Integer.BYTES);
 
-                float additionalCorrection = memorySegment.get(
-                    ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN),
-                    12L * bulkSize + (long) j * Float.BYTES
-                );
+                float additionalCorrection = memorySegment.get(LAYOUT_LE_FLOAT, 12L * bulkSize + (long) j * Float.BYTES);
 
                 float qcDist = scores[j];
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Cache little-endian float layout in DiskBBQ scalar corrections loop (#154373)