### PR TITLE
[9.4] Fix NPE in BulkByScrollResponseWireSerializingTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseWireSerializingTests.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.index.reindex.BulkByScrollTaskStatusWireSerializingTests.mutateStatus;
+
 public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerializingTestCase<
     BulkByScrollResponseWireSerializingTests.BulkByScrollResponseWrapper> {
     @Override
@@ -57,7 +59,7 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
             );
             case 1 -> new BulkByScrollResponse(
                 r.getTook(),
-                mutateRandomStatus(r.getStatus()),
+                mutateStatus(r.getStatus()),
                 r.getBulkFailures(),
                 r.getSearchFailures(),
                 r.isTimedOut()
@@ -85,19 +87,6 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
             );
             default -> throw new AssertionError();
         });
-    }
-
-    private BulkByScrollTask.Status mutateRandomStatus(BulkByScrollTask.Status currentStatus) {
-        while (true) {
-            BulkByScrollTask.Status candidate = BulkByScrollTaskStatusTests.randomStatus();
-            try {
-                BulkByScrollTaskStatusTests.assertTaskStatusEquals(currentStatus, candidate);
-                // Equal → try again
-            } catch (AssertionError e) {
-                // Not equal → success
-                return candidate;
-            }
-        }
     }
 
     private List<Failure> mutateBulkFailures(List<Failure> currentFailures) {
@@ -180,12 +169,12 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
      * details that are not stable for direct equality checks.
      * <p>
      * Equality is defined in terms of wire-relevant state only: top-level fields,
-     * aggregated task status counters (via
-     * {@link BulkByScrollTaskStatusTests#assertTaskStatusEquals}), and the stable
-     * attributes of bulk and search failures. Care must be taken for exceptions, since
-     * two messages with the same cause and message would be different instances after
-     * serialization / deserialization, and fail the default equality check. For this
-     * reason, we define custom equality below.
+     * aggregated task status (via
+     * {@link BulkByScrollTaskStatusWireSerializingTests.StatusWrapper#statusEquals}),
+     * and the stable attributes of bulk and search failures. Care must be taken for
+     * exceptions, since two messages with the same cause and message would be different
+     * instances after serialization / deserialization, and fail the default equality check.
+     * For this reason, we define custom equality below.
      */
     static class BulkByScrollResponseWrapper implements Writeable {
         private final BulkByScrollResponse response;
@@ -251,11 +240,7 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
     private static boolean responsesEqual(BulkByScrollResponse a, BulkByScrollResponse b) {
         if (a.getTook().equals(b.getTook()) == false) return false;
 
-        try {
-            BulkByScrollTaskStatusTests.assertTaskStatusEquals(a.getStatus(), b.getStatus());
-            // Equal → skip to next check
-        } catch (AssertionError e) {
-            // Assertion error → not equal
+        if (BulkByScrollTaskStatusWireSerializingTests.StatusWrapper.statusEquals(a.getStatus(), b.getStatus()) == false) {
             return false;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseWireSerializingTests.java
@@ -169,12 +169,12 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
      * details that are not stable for direct equality checks.
      * <p>
      * Equality is defined in terms of wire-relevant state only: top-level fields,
-     * aggregated task status (via
-     * {@link BulkByScrollTaskStatusWireSerializingTests.StatusWrapper#statusEquals}),
-     * and the stable attributes of bulk and search failures. Care must be taken for
-     * exceptions, since two messages with the same cause and message would be different
-     * instances after serialization / deserialization, and fail the default equality check.
-     * For this reason, we define custom equality below.
+     * aggregated task status counters (via
+     * {@link BulkByScrollTaskStatusTests#assertTaskStatusEquals}), and the stable
+     * attributes of bulk and search failures. Care must be taken for exceptions, since
+     * two messages with the same cause and message would be different instances after
+     * serialization / deserialization, and fail the default equality check. For this
+     * reason, we define custom equality below.
      */
     static class BulkByScrollResponseWrapper implements Writeable {
         private final BulkByScrollResponse response;
@@ -240,7 +240,11 @@ public class BulkByScrollResponseWireSerializingTests extends AbstractWireSerial
     private static boolean responsesEqual(BulkByScrollResponse a, BulkByScrollResponse b) {
         if (a.getTook().equals(b.getTook()) == false) return false;
 
-        if (BulkByScrollTaskStatusWireSerializingTests.StatusWrapper.statusEquals(a.getStatus(), b.getStatus()) == false) {
+        try {
+            BulkByScrollTaskStatusTests.assertTaskStatusEquals(a.getStatus(), b.getStatus());
+            // Equal → skip to next check
+        } catch (AssertionError e) {
+            // Assertion error → not equal
             return false;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
@@ -58,6 +58,7 @@ public class BulkByScrollTaskStatusTests extends AbstractXContentTestCase<BulkBy
      * Assert that two task statuses are equal after serialization.
      */
     public static void assertTaskStatusEquals(BulkByScrollTask.Status expected, BulkByScrollTask.Status actual) {
+        assertEquals(expected.getSliceId(), actual.getSliceId());
         assertEquals(expected.getTotal(), actual.getTotal());
         assertEquals(expected.getUpdated(), actual.getUpdated());
         assertEquals(expected.getCreated(), actual.getCreated());

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
@@ -76,13 +76,17 @@ public class BulkByScrollTaskStatusTests extends AbstractXContentTestCase<BulkBy
             BulkByScrollTask.StatusOrException sliceStatus = expected.getSliceStatuses().get(i);
             if (sliceStatus == null) {
                 assertNull(actual.getSliceStatuses().get(i));
-            } else if (sliceStatus.getException() == null) {
-                assertNull(actual.getSliceStatuses().get(i).getException());
-                assertTaskStatusEquals(sliceStatus.getStatus(), actual.getSliceStatuses().get(i).getStatus());
             } else {
-                assertNull(actual.getSliceStatuses().get(i).getStatus());
-                // Just check the message because we're not testing exception serialization in general here.
-                assertEquals(sliceStatus.getException().getMessage(), actual.getSliceStatuses().get(i).getException().getMessage());
+                BulkByScrollTask.StatusOrException actualSliceStatus = actual.getSliceStatuses().get(i);
+                assertNotNull(actualSliceStatus);
+                if (sliceStatus.getException() == null) {
+                    assertNull(actualSliceStatus.getException());
+                    assertTaskStatusEquals(sliceStatus.getStatus(), actualSliceStatus.getStatus());
+                } else {
+                    assertNull(actualSliceStatus.getStatus());
+                    // Just check the message because we're not testing exception serialization in general here.
+                    assertEquals(sliceStatus.getException().getMessage(), actualSliceStatus.getException().getMessage());
+                }
             }
         }
     }


### PR DESCRIPTION
Fix `BulkByPaginatedSearchResponseWireSerializingTests.testEqualsAndHashcode` NPE when comparing statuses whose slice lists differ (null entry vs status/exception).

Backport of https://github.com/elastic/elasticsearch/pull/155499

Relates: https://github.com/elastic/elasticsearch/issues/155457