### PR TITLE
Fix NPE in BulkByPaginatedSearchResponseWireSerializingTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
@@ -169,12 +169,12 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
      * details that are not stable for direct equality checks.
      * <p>
      * Equality is defined in terms of wire-relevant state only: top-level fields,
-     * aggregated task status (via
-     * {@link BulkByPaginatedSearchTaskStatusWireSerializingTests.StatusWrapper#statusEquals}),
-     * and the stable attributes of bulk and search failures. Care must be taken for
-     * exceptions, since two messages with the same cause and message would be different
-     * instances after serialization / deserialization, and fail the default equality check.
-     * For this reason, we define custom equality below.
+     * aggregated task status counters (via
+     * {@link BulkByPaginatedSearchTaskStatusTests#assertTaskStatusEquals}), and the stable
+     * attributes of bulk and search failures. Care must be taken for exceptions, since
+     * two messages with the same cause and message would be different instances after
+     * serialization / deserialization, and fail the default equality check. For this
+     * reason, we define custom equality below..
      */
     static class BulkByPaginatedSearchResponseWrapper implements Writeable {
         private final BulkByPaginatedSearchResponse response;
@@ -240,7 +240,11 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
     private static boolean responsesEqual(BulkByPaginatedSearchResponse a, BulkByPaginatedSearchResponse b) {
         if (a.getTook().equals(b.getTook()) == false) return false;
 
-        if (BulkByPaginatedSearchTaskStatusWireSerializingTests.StatusWrapper.statusEquals(a.getStatus(), b.getStatus()) == false) {
+        try {
+            BulkByPaginatedSearchTaskStatusTests.assertTaskStatusEquals(a.getStatus(), b.getStatus());
+            // Equal → skip to next check
+        } catch (AssertionError e) {
+            // Assertion error → not equal
             return false;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
@@ -174,7 +174,7 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
      * attributes of bulk and search failures. Care must be taken for exceptions, since
      * two messages with the same cause and message would be different instances after
      * serialization / deserialization, and fail the default equality check. For this
-     * reason, we define custom equality below..
+     * reason, we define custom equality below.
      */
     static class BulkByPaginatedSearchResponseWrapper implements Writeable {
         private final BulkByPaginatedSearchResponse response;

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchResponseWireSerializingTests.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.index.reindex.BulkByPaginatedSearchTaskStatusWireSerializingTests.mutateStatus;
+
 public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractWireSerializingTestCase<
     BulkByPaginatedSearchResponseWireSerializingTests.BulkByPaginatedSearchResponseWrapper> {
     @Override
@@ -57,7 +59,7 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
             );
             case 1 -> new BulkByPaginatedSearchResponse(
                 r.getTook(),
-                mutateRandomStatus(r.getStatus()),
+                mutateStatus(r.getStatus()),
                 r.getBulkFailures(),
                 r.getSearchFailures(),
                 r.isTimedOut()
@@ -85,19 +87,6 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
             );
             default -> throw new AssertionError();
         });
-    }
-
-    private BulkByPaginatedSearchTask.Status mutateRandomStatus(BulkByPaginatedSearchTask.Status currentStatus) {
-        while (true) {
-            BulkByPaginatedSearchTask.Status candidate = BulkByPaginatedSearchTaskStatusTests.randomStatus();
-            try {
-                BulkByPaginatedSearchTaskStatusTests.assertTaskStatusEquals(currentStatus, candidate);
-                // Equal → try again
-            } catch (AssertionError e) {
-                // Not equal → success
-                return candidate;
-            }
-        }
     }
 
     private List<Failure> mutateBulkFailures(List<Failure> currentFailures) {
@@ -180,12 +169,12 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
      * details that are not stable for direct equality checks.
      * <p>
      * Equality is defined in terms of wire-relevant state only: top-level fields,
-     * aggregated task status counters (via
-     * {@link BulkByPaginatedSearchTaskStatusTests#assertTaskStatusEquals}), and the stable
-     * attributes of bulk and search failures. Care must be taken for exceptions, since
-     * two messages with the same cause and message would be different instances after
-     * serialization / deserialization, and fail the default equality check. For this
-     * reason, we define custom equality below.
+     * aggregated task status (via
+     * {@link BulkByPaginatedSearchTaskStatusWireSerializingTests.StatusWrapper#statusEquals}),
+     * and the stable attributes of bulk and search failures. Care must be taken for
+     * exceptions, since two messages with the same cause and message would be different
+     * instances after serialization / deserialization, and fail the default equality check.
+     * For this reason, we define custom equality below.
      */
     static class BulkByPaginatedSearchResponseWrapper implements Writeable {
         private final BulkByPaginatedSearchResponse response;
@@ -251,11 +240,7 @@ public class BulkByPaginatedSearchResponseWireSerializingTests extends AbstractW
     private static boolean responsesEqual(BulkByPaginatedSearchResponse a, BulkByPaginatedSearchResponse b) {
         if (a.getTook().equals(b.getTook()) == false) return false;
 
-        try {
-            BulkByPaginatedSearchTaskStatusTests.assertTaskStatusEquals(a.getStatus(), b.getStatus());
-            // Equal → skip to next check
-        } catch (AssertionError e) {
-            // Assertion error → not equal
+        if (BulkByPaginatedSearchTaskStatusWireSerializingTests.StatusWrapper.statusEquals(a.getStatus(), b.getStatus()) == false) {
             return false;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchTaskStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchTaskStatusTests.java
@@ -58,6 +58,7 @@ public class BulkByPaginatedSearchTaskStatusTests extends AbstractXContentTestCa
      * Assert that two task statuses are equal after serialization.
      */
     public static void assertTaskStatusEquals(BulkByPaginatedSearchTask.Status expected, BulkByPaginatedSearchTask.Status actual) {
+        assertEquals(expected.getSliceId(), actual.getSliceId());
         assertEquals(expected.getTotal(), actual.getTotal());
         assertEquals(expected.getUpdated(), actual.getUpdated());
         assertEquals(expected.getCreated(), actual.getCreated());

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchTaskStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByPaginatedSearchTaskStatusTests.java
@@ -76,13 +76,17 @@ public class BulkByPaginatedSearchTaskStatusTests extends AbstractXContentTestCa
             BulkByPaginatedSearchTask.StatusOrException sliceStatus = expected.getSliceStatuses().get(i);
             if (sliceStatus == null) {
                 assertNull(actual.getSliceStatuses().get(i));
-            } else if (sliceStatus.getException() == null) {
-                assertNull(actual.getSliceStatuses().get(i).getException());
-                assertTaskStatusEquals(sliceStatus.getStatus(), actual.getSliceStatuses().get(i).getStatus());
             } else {
-                assertNull(actual.getSliceStatuses().get(i).getStatus());
-                // Just check the message because we're not testing exception serialization in general here.
-                assertEquals(sliceStatus.getException().getMessage(), actual.getSliceStatuses().get(i).getException().getMessage());
+                BulkByPaginatedSearchTask.StatusOrException actualSliceStatus = actual.getSliceStatuses().get(i);
+                assertNotNull(actualSliceStatus);
+                if (sliceStatus.getException() == null) {
+                    assertNull(actualSliceStatus.getException());
+                    assertTaskStatusEquals(sliceStatus.getStatus(), actualSliceStatus.getStatus());
+                } else {
+                    assertNull(actualSliceStatus.getStatus());
+                    // Just check the message because we're not testing exception serialization in general here.
+                    assertEquals(sliceStatus.getException().getMessage(), actualSliceStatus.getException().getMessage());
+                }
             }
         }
     }


### PR DESCRIPTION
Fix `BulkByPaginatedSearchResponseWireSerializingTests.testEqualsAndHashcode` NPE when comparing statuses whose slice lists differ (null entry vs status/exception).

Relates: https://github.com/elastic/elasticsearch/issues/155457