### PR TITLE
ESQL: Ignore OPTIONS also for MATCH_PHRASE on non-indexed-mapped fields

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -154,9 +154,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/147383
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/148190
 - class: org.elasticsearch.indices.state.OpenCloseIndexIT
   method: testTranslogStats
   issue: https://github.com/elastic/elasticsearch/issues/149852

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -167,9 +167,11 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         // repeat() returns validation error when the Number parameter is a negative foldable
         "Number parameter cannot be negative, found \\[",
 
-        // need to refine the MATCH function generation
+        // need to refine the MATCH function generation: MATCH on a non-index-mapped, non-TEXT field with a string
+        // query value (MATCH_PHRASE only accepts keyword/text, so it has no equivalent query-value type check)
         "query value .* does not match the type .* of non-index-mapped field",
-        "Options are not supported for \\[MATCH\\] function call on non-index-mapped field \\[.*\\]",
+        // need to refine the MATCH / MATCH_PHRASE function generation: options on a non-index-mapped, non-TEXT field
+        "Options are not supported for \\[(?:MATCH|MATCH_PHRASE)\\] function call on non-index-mapped(?:, non-TEXT)? field \\[.*\\]",
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/129561
@@ -726,11 +728,11 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     );
 
     /**
-     * Matches "Options are not supported for [MATCH] function call on non-index-mapped field [X]".
-     * This is the error MATCH raises when called with options on a renamed/computed field.
+     * Matches "Options are not supported for [MATCH|MATCH_PHRASE] function call on non-index-mapped[, non-TEXT] field [X]".
+     * This is the error MATCH/MATCH_PHRASE raises when called with options on a renamed/computed field.
      */
     private static final Pattern MATCH_OPTIONS_NON_INDEX_MAPPED_PATTERN = Pattern.compile(
-        ".*Options are not supported for \\[MATCH\\] function call on non-index-mapped field \\[([^]]+)\\].*",
+        ".*Options are not supported for \\[(?:MATCH|MATCH_PHRASE)\\] function call on non-index-mapped(?:, non-TEXT)? field \\[([^]]+)\\].*",
         Pattern.DOTALL
     );
 

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTestTests.java
@@ -96,4 +96,32 @@ public class GenerativeRestTestTests extends ESTestCase {
         assertFalse(GenerativeRestTest.isFieldFullTextError(error, schema));
     }
 
+    public void testMatchOptionsOnNonIndexMappedNonTextFieldIsAllowed() {
+        String error = "Options are not supported for [MATCH] function call on non-index-mapped, non-TEXT field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), false));
+
+        assertTrue(GenerativeRestTest.isFieldFullTextError(error, schema));
+    }
+
+    public void testMatchPhraseOptionsOnNonIndexMappedFieldIsAllowed() {
+        String error = "Options are not supported for [MATCH_PHRASE] function call on non-index-mapped field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), false));
+
+        assertTrue(GenerativeRestTest.isFieldFullTextError(error, schema));
+    }
+
+    public void testMatchPhraseOptionsOnNonIndexMappedNonTextFieldIsAllowed() {
+        String error = "Options are not supported for [MATCH_PHRASE] function call on non-index-mapped, non-TEXT field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), false));
+
+        assertTrue(GenerativeRestTest.isFieldFullTextError(error, schema));
+    }
+
+    public void testMatchPhraseOptionsOnIndexMappedFieldIsNotAllowed() {
+        String error = "Options are not supported for [MATCH_PHRASE] function call on non-index-mapped field [message]";
+        List<Column> schema = List.of(new Column("message", "keyword", List.of(), true));
+
+        assertFalse(GenerativeRestTest.isFieldFullTextError(error, schema));
+    }
+
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/DedupGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/DedupGenerator.java
@@ -40,10 +40,13 @@ public class DedupGenerator implements CommandGenerator {
             DataType dt = DataType.fromTypeName(c.type());
             if (dt != null
                 && (dt == DataType.AGGREGATE_METRIC_DOUBLE
+                    || dt == DataType.DATE_PERIOD
                     || dt == DataType.DATE_RANGE
+                    || dt == DataType.DOUBLE_RANGE
                     || dt == DataType.EXPONENTIAL_HISTOGRAM
-                    || dt == DataType.TDIGEST
                     || dt == DataType.PARTIAL_AGG
+                    || dt == DataType.TDIGEST
+                    || dt == DataType.TIME_DURATION
                     || dt.isCounter())) {
                 return EMPTY_DESCRIPTION;
             }


### PR DESCRIPTION
Adds MATCH_PHRASE to the list of limitations for using options in generative testing