### PR TITLE
ES|QL: Add score support for search at runtime

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.ScoreOperator;
 import java.io.IOException;
 
 /**
- * {@link ScoreOperator.ExpressionScorer} to run a Lucene {@link Query} during
+ * {@link ExpressionEvaluator} to run a Lucene {@link Query} during
  * the compute engine's normal execution, yielding the corresponding scores into
  * a {@link DoubleVector}.
  * Elements that don't match will have a score of {@link #NO_MATCH_SCORE}.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.ScoreOperator;
 
 import java.io.IOException;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneQueryScoreEvaluator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.ScoreOperator;
@@ -27,7 +28,7 @@ import java.io.IOException;
  * Elements that don't match will have a score of {@link #NO_MATCH_SCORE}.
  * @see LuceneQueryScoreEvaluator
  */
-public class LuceneQueryScoreEvaluator extends LuceneQueryEvaluator<DoubleBlock.Builder> implements ScoreOperator.ExpressionScorer {
+public class LuceneQueryScoreEvaluator extends LuceneQueryEvaluator<DoubleBlock.Builder> implements ExpressionEvaluator {
 
     public static final double NO_MATCH_SCORE = 0.0;
 
@@ -36,8 +37,13 @@ public class LuceneQueryScoreEvaluator extends LuceneQueryEvaluator<DoubleBlock.
     }
 
     @Override
-    public DoubleBlock score(Page page) {
+    public DoubleBlock eval(Page page) {
         return (DoubleBlock) executeQuery(page);
+    }
+
+    @Override
+    public long baseRamBytesUsed() {
+        return 0;
     }
 
     @Override
@@ -65,9 +71,9 @@ public class LuceneQueryScoreEvaluator extends LuceneQueryEvaluator<DoubleBlock.
         builder.appendDouble(scorer.score());
     }
 
-    public record Factory(IndexedByShardId<ShardConfig> shardConfigs) implements ScoreOperator.ExpressionScorer.Factory {
+    public record Factory(IndexedByShardId<ShardConfig> shardConfigs) implements ExpressionEvaluator.Factory {
         @Override
-        public ScoreOperator.ExpressionScorer get(DriverContext context) {
+        public ExpressionEvaluator get(DriverContext context) {
             return new LuceneQueryScoreEvaluator(context.blockFactory(), shardConfigs);
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
@@ -83,20 +83,4 @@ public class ScoreOperator extends AbstractPageMappingOperator {
     public void close() {
         Releasables.closeExpectNoException(scorer, super::close);
     }
-
-    /**
-     * Evaluates the score of an expression one {@link Page} at a time.
-     */
-    public interface ExpressionScorer extends Releasable {
-        /** A Factory for creating ExpressionScorers. */
-        interface Factory {
-            ExpressionScorer get(DriverContext context);
-        }
-
-        /**
-         * Scores the expression.
-         * @return the returned Block has its own reference and the caller is responsible for releasing it.
-         */
-        DoubleBlock score(Page page);
-    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
@@ -20,7 +21,7 @@ import org.elasticsearch.core.Releasables;
  */
 public class ScoreOperator extends AbstractPageMappingOperator {
 
-    public record ScoreOperatorFactory(ExpressionScorer.Factory scorerFactory, int scoreBlockPosition) implements OperatorFactory {
+    public record ScoreOperatorFactory(ExpressionEvaluator.Factory scorerFactory, int scoreBlockPosition) implements OperatorFactory {
 
         @Override
         public Operator get(DriverContext driverContext) {
@@ -34,10 +35,10 @@ public class ScoreOperator extends AbstractPageMappingOperator {
     }
 
     private final BlockFactory blockFactory;
-    private final ExpressionScorer scorer;
+    private final ExpressionEvaluator scorer;
     private final int scoreBlockPosition;
 
-    public ScoreOperator(BlockFactory blockFactory, ExpressionScorer scorer, int scoreBlockPosition) {
+    public ScoreOperator(BlockFactory blockFactory, ExpressionEvaluator scorer, int scoreBlockPosition) {
         this.blockFactory = blockFactory;
         this.scorer = scorer;
         this.scoreBlockPosition = scoreBlockPosition;
@@ -62,7 +63,7 @@ public class ScoreOperator extends AbstractPageMappingOperator {
     }
 
     private Block calculateScoresBlock(Page page) {
-        try (DoubleBlock evalScores = scorer.score(page); DoubleBlock existingScores = page.getBlock(scoreBlockPosition)) {
+        try (DoubleBlock evalScores = (DoubleBlock) scorer.eval(page); DoubleBlock existingScores = page.getBlock(scoreBlockPosition)) {
             // TODO Optimize for constant scores?
             int rowCount = page.getPositionCount();
             DoubleVector.Builder builder = blockFactory.newDoubleVectorFixedBuilder(rowCount);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ScoreOperator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
 /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/MatchFunctionIT.java
@@ -273,7 +273,38 @@ public class MatchFunctionIT extends AbstractEsqlIntegTestCase {
         try (var resp = run(query)) {
             assertColumnNames(resp.columns(), List.of("id", "_score"));
             assertColumnTypes(resp.columns(), List.of("integer", "double"));
-            assertValues(resp.values(), List.of(List.of(1, 0.0), List.of(6, 0.0)));
+            assertValues(resp.values(), List.of(List.of(1, 1.0), List.of(6, 1.0)));
+        }
+    }
+
+    public void testWhereRuntimeMatchWithOptionsAndScore() {
+        var query = """
+            FROM test METADATA _score
+            | WHERE match(to_text(concat(content, " extra")), "fox dog", { "operator": "AND", "boost": 1.5 })
+            | KEEP id, _score
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "_score"));
+            assertColumnTypes(resp.columns(), List.of("integer", "double"));
+            assertValues(resp.values(), List.of(List.of(6, 3.0)));
+        }
+    }
+
+    public void testWhereRuntimeMatchTermWithScore() {
+        var query = """
+            FROM test METADATA _score
+            | EVAL new_id = id + 1
+            | WHERE new_id:"3.0" OR new_id:"2.0"
+            | KEEP id, new_id, _score
+            | SORT id
+            """;
+
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("id", "new_id", "_score"));
+            assertColumnTypes(resp.columns(), List.of("integer", "integer", "double"));
+            assertValues(resp.values(), List.of(List.of(1, 2, 1.0), List.of(2, 3, 1.0)));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchScoreTokenStreamEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchScoreTokenStreamEvaluator.java
@@ -1,0 +1,127 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link Match}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class MatchScoreTokenStreamEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(MatchScoreTokenStreamEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator fieldBlock;
+
+  private final Analyzer analyzer;
+
+  private final Map<BytesRef, Integer> queryTerms;
+
+  private final BytesRef scratch;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public MatchScoreTokenStreamEvaluator(Source source, ExpressionEvaluator fieldBlock,
+      Analyzer analyzer, Map<BytesRef, Integer> queryTerms, BytesRef scratch,
+      DriverContext driverContext) {
+    this.source = source;
+    this.fieldBlock = fieldBlock;
+    this.analyzer = analyzer;
+    this.queryTerms = queryTerms;
+    this.scratch = scratch;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (BytesRefBlock fieldBlockBlock = (BytesRefBlock) fieldBlock.eval(page)) {
+      return eval(page.getPositionCount(), fieldBlockBlock);
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += fieldBlock.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, BytesRefBlock fieldBlockBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        result.appendDouble(Match.scoreTokenStream(p, fieldBlockBlock, this.analyzer, this.queryTerms, this.scratch));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "MatchScoreTokenStreamEvaluator[" + "fieldBlock=" + fieldBlock + ", analyzer=" + analyzer + ", queryTerms=" + queryTerms + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(fieldBlock);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory fieldBlock;
+
+    private final Analyzer analyzer;
+
+    private final Map<BytesRef, Integer> queryTerms;
+
+    private final Function<DriverContext, BytesRef> scratch;
+
+    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock, Analyzer analyzer,
+        Map<BytesRef, Integer> queryTerms, Function<DriverContext, BytesRef> scratch) {
+      this.source = source;
+      this.fieldBlock = fieldBlock;
+      this.analyzer = analyzer;
+      this.queryTerms = queryTerms;
+      this.scratch = scratch;
+    }
+
+    @Override
+    public MatchScoreTokenStreamEvaluator get(DriverContext context) {
+      return new MatchScoreTokenStreamEvaluator(source, fieldBlock.get(context), analyzer, queryTerms, scratch.apply(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "MatchScoreTokenStreamEvaluator[" + "fieldBlock=" + fieldBlock + ", analyzer=" + analyzer + ", queryTerms=" + queryTerms + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchScoreLuceneQueryEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchScoreLuceneQueryEvaluator.java
@@ -1,0 +1,125 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import java.lang.Override;
+import java.lang.String;
+import java.util.function.Function;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RuntimeSearch}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RuntimeSearchScoreLuceneQueryEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RuntimeSearchScoreLuceneQueryEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator fieldBlock;
+
+  private final Analyzer analyzer;
+
+  private final Query query;
+
+  private final BytesRef scratch;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RuntimeSearchScoreLuceneQueryEvaluator(Source source, ExpressionEvaluator fieldBlock,
+      Analyzer analyzer, Query query, BytesRef scratch, DriverContext driverContext) {
+    this.source = source;
+    this.fieldBlock = fieldBlock;
+    this.analyzer = analyzer;
+    this.query = query;
+    this.scratch = scratch;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (BytesRefBlock fieldBlockBlock = (BytesRefBlock) fieldBlock.eval(page)) {
+      return eval(page.getPositionCount(), fieldBlockBlock);
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += fieldBlock.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, BytesRefBlock fieldBlockBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        result.appendDouble(RuntimeSearch.scoreLuceneQuery(p, fieldBlockBlock, this.analyzer, this.query, this.scratch));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RuntimeSearchScoreLuceneQueryEvaluator[" + "fieldBlock=" + fieldBlock + ", analyzer=" + analyzer + ", query=" + query + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(fieldBlock);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory fieldBlock;
+
+    private final Analyzer analyzer;
+
+    private final Query query;
+
+    private final Function<DriverContext, BytesRef> scratch;
+
+    public Factory(Source source, ExpressionEvaluator.Factory fieldBlock, Analyzer analyzer,
+        Query query, Function<DriverContext, BytesRef> scratch) {
+      this.source = source;
+      this.fieldBlock = fieldBlock;
+      this.analyzer = analyzer;
+      this.query = query;
+      this.scratch = scratch;
+    }
+
+    @Override
+    public RuntimeSearchScoreLuceneQueryEvaluator get(DriverContext context) {
+      return new RuntimeSearchScoreLuceneQueryEvaluator(source, fieldBlock.get(context), analyzer, query, scratch.apply(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "RuntimeSearchScoreLuceneQueryEvaluator[" + "fieldBlock=" + fieldBlock + ", analyzer=" + analyzer + ", query=" + query + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchScoreTermEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearchScoreTermEvaluator.java
@@ -1,0 +1,102 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RuntimeSearch}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RuntimeSearchScoreTermEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RuntimeSearchScoreTermEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator matches;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RuntimeSearchScoreTermEvaluator(Source source, ExpressionEvaluator matches,
+      DriverContext driverContext) {
+    this.source = source;
+    this.matches = matches;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (BooleanBlock matchesBlock = (BooleanBlock) matches.eval(page)) {
+      return eval(page.getPositionCount(), matchesBlock);
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += matches.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, BooleanBlock matchesBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        result.appendDouble(RuntimeSearch.scoreTerm(p, matchesBlock));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RuntimeSearchScoreTermEvaluator[" + "matches=" + matches + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(matches);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory matches;
+
+    public Factory(Source source, ExpressionEvaluator.Factory matches) {
+      this.source = source;
+      this.matches = matches;
+    }
+
+    @Override
+    public RuntimeSearchScoreTermEvaluator get(DriverContext context) {
+      return new RuntimeSearchScoreTermEvaluator(source, matches.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "RuntimeSearchScoreTermEvaluator[" + "matches=" + matches + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.compute.lucene.query.LuceneQueryEvaluator;
 import org.elasticsearch.compute.lucene.query.LuceneQueryEvaluator.ShardConfig;
 import org.elasticsearch.compute.lucene.query.LuceneQueryExpressionEvaluator;
 import org.elasticsearch.compute.lucene.query.LuceneQueryScoreEvaluator;
-import org.elasticsearch.compute.operator.ScoreOperator;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.esql.capabilities.PostAnalysisPlanVerificationAware;
@@ -620,7 +619,7 @@ public abstract class FullTextFunction extends Function
     }
 
     @Override
-    public ScoreOperator.ExpressionScorer.Factory toScorer(ToScorer toScorer) {
+    public ExpressionEvaluator.Factory toScorer(ToScorer toScorer) {
         return new LuceneQueryScoreEvaluator.Factory(toShardConfigs(toScorer.shardContexts()));
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -7,15 +7,20 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
 import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -57,11 +62,13 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static java.util.Map.entry;
+import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.elasticsearch.index.query.MatchQueryBuilder.ANALYZER_FIELD;
 import static org.elasticsearch.index.query.MatchQueryBuilder.FUZZY_REWRITE_FIELD;
@@ -673,5 +680,97 @@ public class Match extends SingleFieldFullTextFunction implements OptionalArgume
             return false;
         }
         return fieldBlock.hasValue(position, query);
+    }
+
+    @Evaluator(extraName = "ScoreTokenStream", allNullsIsNull = false)
+    static double scoreTokenStream(
+        @Position int position,
+        BytesRefBlock fieldBlock,
+        @Fixed Analyzer analyzer,
+        @Fixed Map<BytesRef, Integer> queryTerms,
+        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRef scratch
+    ) {
+        if (fieldBlock == null) {
+            return 0;
+        }
+
+        int maxScore = queryTerms.values().stream().reduce(0, Integer::sum);
+        if (maxScore == 0) {
+            return 0;
+        }
+
+        final var valueCount = fieldBlock.getValueCount(position);
+        final var startIndex = fieldBlock.getFirstValueIndex(position);
+
+        int currentScore = 0;
+        for (int valueIndex = startIndex; valueIndex < startIndex + valueCount; valueIndex++) {
+            scratch = fieldBlock.getBytesRef(valueIndex, scratch);
+            int score = 0;
+            try (TokenStream stream = analyzer.tokenStream(RuntimeSearch.CONTENT_FIELD, scratch.utf8ToString())) {
+                stream.reset();
+
+                Set<BytesRef> foundTerms = new HashSet<>();
+
+                TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+                while (stream.incrementToken()) {
+                    if (foundTerms.contains(term.getBytesRef()) == false && queryTerms.containsKey(term.getBytesRef())) {
+                        foundTerms.add(term.getBytesRef());
+                        score += queryTerms.get(term.getBytesRef());
+                        if (score >= maxScore) {
+                            break;
+                        }
+                    }
+                }
+
+                stream.end();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (score >= maxScore) {
+                return maxScore;
+            }
+            if (score > currentScore) {
+                currentScore = score;
+            }
+        }
+
+        return currentScore;
+    }
+
+    @Override
+    public boolean contributesToScore() {
+        return true;
+    }
+
+    @Override
+    public ExpressionEvaluator.Factory toScorer(ToScorer toScorer) {
+        if (isRuntimeSearch() == false) {
+            return super.toScorer(toScorer);
+        }
+
+        if (field.dataType() == TEXT && options() == null) {
+
+            Map<BytesRef, Integer> queryTerms;
+            try {
+                queryTerms = RuntimeSearch.analyzeTermsWithCounts(Lucene.STANDARD_ANALYZER, (String) queryAsObject());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            return new MatchScoreTokenStreamEvaluator.Factory(
+                this.source(),
+                toScorer.toEvaluator(field()),
+                Lucene.STANDARD_ANALYZER,
+                queryTerms,
+                (driverContext -> new BytesRef())
+            );
+        }
+
+        if (field.dataType() == TEXT && options() != null) {
+            var matchQuery = new MatchQuery(source(), RuntimeSearch.CONTENT_FIELD, queryAsObject(), matchQueryOptions());
+            return RuntimeSearch.textScoreEvaluatorForQuery(source(), toScorer.toEvaluator(field()), matchQuery);
+        }
+        return new RuntimeSearchScoreTermEvaluator.Factory(this.source(), toScorer.toEvaluator(this));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/RuntimeSearch.java
@@ -17,11 +17,13 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.similarities.BooleanSimilarity;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.ann.Position;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
@@ -32,7 +34,9 @@ import org.elasticsearch.xpack.esql.planner.RuntimeSearchExecutionContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
@@ -133,6 +137,20 @@ public final class RuntimeSearch {
         return terms;
     }
 
+    static Map<BytesRef, Integer> analyzeTermsWithCounts(Analyzer analyzer, String query) throws IOException {
+        Map<BytesRef, Integer> terms = new HashMap<>();
+
+        try (TokenStream stream = analyzer.tokenStream(CONTENT_FIELD, query)) {
+            stream.reset();
+            TermToBytesRefAttribute term = stream.addAttribute(TermToBytesRefAttribute.class);
+            while (stream.incrementToken()) {
+                terms.compute(BytesRef.deepCopyOf(term.getBytesRef()), (k, v) -> v == null ? 1 : v + 1);
+            }
+            stream.end();
+        }
+        return terms;
+    }
+
     /**
      * Exact (unanalyzed) value equality, shared by the runtime full-text functions for types that a pushed-down
      * query matches as a single term: {@code keyword} for {@code match} and {@code match_phrase} (and {@code ip},
@@ -218,6 +236,32 @@ public final class RuntimeSearch {
         );
     }
 
+    public static ExpressionEvaluator.Factory textScoreEvaluatorForQuery(
+        Source source,
+        ExpressionEvaluator.Factory fieldEvaluator,
+        org.elasticsearch.xpack.esql.core.querydsl.query.Query query
+    ) {
+        Query luceneQuery;
+        try {
+            luceneQuery = query.toQueryBuilder().toQuery(RuntimeSearchExecutionContext.create(List.of(CONTENT_FIELD)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        if (luceneQuery instanceof MatchAllDocsQuery) {
+            return ConstantEvaluators.CONSTANT_TRUE_FACTORY;
+        }
+        if (luceneQuery instanceof MatchNoDocsQuery) {
+            return ConstantEvaluators.CONSTANT_FALSE_FACTORY;
+        }
+        return new RuntimeSearchScoreLuceneQueryEvaluator.Factory(
+            source,
+            fieldEvaluator,
+            Lucene.STANDARD_ANALYZER,
+            luceneQuery,
+            context -> new BytesRef()
+        );
+    }
+
     @Evaluator(extraName = "TextWithLuceneQuery", warnExceptions = { IOException.class }, allNullsIsNull = false)
     static boolean processText(
         @Position int position,
@@ -244,5 +288,51 @@ public final class RuntimeSearch {
             }
         }
         return false;
+    }
+
+    @Evaluator(extraName = "ScoreLuceneQuery", allNullsIsNull = false)
+    static double scoreLuceneQuery(
+        @Position int position,
+        BytesRefBlock fieldBlock,
+        @Fixed Analyzer analyzer,
+        @Fixed Query query,
+        @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRef scratch
+    ) {
+        if (fieldBlock == null) {
+            return 0;
+        }
+
+        final var valueCount = fieldBlock.getValueCount(position);
+        final var startIndex = fieldBlock.getFirstValueIndex(position);
+
+        MemoryIndex index = new MemoryIndex();
+        for (int valueIndex = startIndex; valueIndex < startIndex + valueCount; valueIndex++) {
+
+            scratch = fieldBlock.getBytesRef(valueIndex, scratch);
+            index.addField(RuntimeSearch.CONTENT_FIELD, scratch.utf8ToString(), analyzer);
+        }
+
+        IndexSearcher searcher = index.createSearcher();
+        // TODO: Do we need to create BooleanSimilarity every time?
+        searcher.setSimilarity(new BooleanSimilarity());
+        TopDocs topDocs;
+        try {
+            topDocs = searcher.search(query, 1);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // TODO: check if scoreDocs[0].score is max score
+        if (topDocs.scoreDocs.length > 0) {
+            return topDocs.scoreDocs[0].score;
+        }
+        return 0;
+    }
+
+    @Evaluator(extraName = "ScoreTerm", allNullsIsNull = false)
+    static double scoreTerm(@Position int position, BooleanBlock matches) {
+        if (matches == null) {
+            return 0;
+        }
+        return matches.getBoolean(position) ? 1 : 0;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Score.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Score.java
@@ -15,7 +15,6 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.ScoreOperator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -92,7 +91,11 @@ public class Score extends Function implements EvaluatorMapper {
 
     @Override
     public ExpressionEvaluator.Factory toEvaluator(EvaluatorMapper.ToEvaluator toEvaluator) {
-        ScoreOperator.ExpressionScorer.Factory scorerFactory = ScoreMapper.toScorer(children().getFirst(), toEvaluator.shardContexts());
+        ExpressionEvaluator.Factory scorerFactory = ScoreMapper.toScorer(
+            children().getFirst(),
+            toEvaluator.shardContexts(),
+            toEvaluator::apply
+        );
         return driverContext -> new ScorerEvaluatorFactory(scorerFactory).get(driverContext);
     }
 
@@ -122,7 +125,7 @@ public class Score extends Function implements EvaluatorMapper {
         return new Score(source, query);
     }
 
-    private record ScorerEvaluatorFactory(ScoreOperator.ExpressionScorer.Factory scoreFactory) implements ExpressionEvaluator.Factory {
+    private record ScorerEvaluatorFactory(ExpressionEvaluator.Factory scoreFactory) implements ExpressionEvaluator.Factory {
 
         @Override
         public ExpressionEvaluator get(DriverContext context) {
@@ -130,12 +133,12 @@ public class Score extends Function implements EvaluatorMapper {
         }
     }
 
-    private record ScorerEvaluator(ScoreOperator.ExpressionScorer scorer) implements ExpressionEvaluator {
+    private record ScorerEvaluator(ExpressionEvaluator scorer) implements ExpressionEvaluator {
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ScorerEvaluator.class);
 
         @Override
         public Block eval(Page page) {
-            return scorer.score(page);
+            return scorer.eval(page);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/logical/BinaryLogic.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.ScoreOperator;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -125,7 +124,7 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
     }
 
     @Override
-    public ScoreOperator.ExpressionScorer.Factory toScorer(ToScorer toScorer) {
+    public ExpressionEvaluator.Factory toScorer(ToScorer toScorer) {
         return context -> new BinaryLogicScorer(context, toScorer.toScorer(left()).get(context), toScorer.toScorer(right()).get(context));
     }
 
@@ -137,18 +136,26 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
     /**
      * Binary logic adds together scores coming from the left and right expressions, both for conjunctions and disjunctions
      */
-    private record BinaryLogicScorer(DriverContext driverContext, ScoreOperator.ExpressionScorer left, ScoreOperator.ExpressionScorer right)
+    private record BinaryLogicScorer(DriverContext driverContext, ExpressionEvaluator left, ExpressionEvaluator right)
         implements
-            ScoreOperator.ExpressionScorer {
+            ExpressionEvaluator {
         @Override
-        public DoubleBlock score(Page page) {
+        public DoubleBlock eval(Page page) {
             DoubleVector.Builder builder = driverContext.blockFactory().newDoubleVectorFixedBuilder(page.getPositionCount());
-            try (DoubleVector leftVector = left.score(page).asVector(); DoubleVector rightVector = right.score(page).asVector()) {
+            try (
+                DoubleVector leftVector = (DoubleVector) left.eval(page).asVector();
+                DoubleVector rightVector = (DoubleVector) right.eval(page).asVector()
+            ) {
                 for (int i = 0; i < page.getPositionCount(); i++) {
                     builder.appendDouble(leftVector.getDouble(i) + rightVector.getDouble(i));
                 }
             }
             return builder.build().asBlock();
+        }
+
+        @Override
+        public long baseRamBytesUsed() {
+            return 0;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -2080,7 +2080,20 @@ public class LocalExecutionPlanner {
 
             int scoreBlock = filterOperation.layout.get(scoreAttribute.id()).channel();
             filterOperation = filterOperation.with(
-                new ScoreOperator.ScoreOperatorFactory(ScoreMapper.toScorer(filter.condition(), context.shardContexts), scoreBlock),
+                new ScoreOperator.ScoreOperatorFactory(
+                    ScoreMapper.toScorer(
+                        filter.condition(),
+                        context.shardContexts,
+                        (exp) -> EvalMapper.toEvaluator(
+                            context.foldCtx(),
+                            exp,
+                            source.layout,
+                            context.shardContexts,
+                            context.analysisRegistry
+                        )
+                    ),
+                    scoreBlock
+                ),
                 filterOperation.layout
             );
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ExpressionScoreMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ExpressionScoreMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.score;
 
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.operator.ScoreOperator.ExpressionScorer;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -17,14 +18,16 @@ import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
  */
 public interface ExpressionScoreMapper {
     interface ToScorer {
-        ExpressionScorer.Factory toScorer(Expression expression);
+        ExpressionEvaluator.Factory toScorer(Expression expression);
+
+        ExpressionEvaluator.Factory toEvaluator(Expression expression);
 
         default IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts() {
             throw new UnsupportedOperationException("Shard contexts should only be needed for scoring operations");
         }
     }
 
-    ExpressionScorer.Factory toScorer(ToScorer toScorer);
+    ExpressionEvaluator.Factory toScorer(ToScorer toScorer);
 
     default boolean contributesToScore() {
         return true;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ExpressionScoreMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ExpressionScoreMapper.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.esql.score;
 
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
-import org.elasticsearch.compute.operator.ScoreOperator.ExpressionScorer;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
 
 /**
- * Maps expressions that have a mapping to an {@link ExpressionScorer}. Allows for transforming expressions into their corresponding scores.
+ * Allows for transforming expressions into their corresponding scores.
+ * Maps expressions that contribute to the score to an {@link ExpressionEvaluator} that evaluates the scores.
  */
 public interface ExpressionScoreMapper {
     interface ToScorer {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ScoreMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/score/ScoreMapper.java
@@ -9,31 +9,40 @@ package org.elasticsearch.xpack.esql.score;
 
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.ScoreOperator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
+
+import java.util.function.Function;
 
 /**
  * Maps an expression tree into ExpressionScorer.Factory, so scores can be evaluated for an expression tree.
  */
 public class ScoreMapper {
 
-    public static ScoreOperator.ExpressionScorer.Factory toScorer(
+    public static ExpressionEvaluator.Factory toScorer(
         Expression expression,
-        IndexedByShardId<? extends ShardContext> shardContexts
+        IndexedByShardId<? extends ShardContext> shardContexts,
+        Function<Expression, ExpressionEvaluator.Factory> toEvaluator
     ) {
         if (expression instanceof ExpressionScoreMapper mapper && mapper.contributesToScore()) {
             return mapper.toScorer(new ExpressionScoreMapper.ToScorer() {
+
                 @Override
-                public ScoreOperator.ExpressionScorer.Factory toScorer(Expression expression) {
-                    return ScoreMapper.toScorer(expression, shardContexts);
+                public ExpressionEvaluator.Factory toScorer(Expression expression) {
+                    return ScoreMapper.toScorer(expression, shardContexts, toEvaluator);
                 }
 
                 @Override
                 public IndexedByShardId<? extends ShardContext> shardContexts() {
                     return shardContexts;
+                }
+
+                @Override
+                public ExpressionEvaluator.Factory toEvaluator(Expression expression) {
+                    return toEvaluator.apply(expression);
                 }
             });
         }
@@ -41,13 +50,18 @@ public class ScoreMapper {
         return page -> new DefaultScoreMapper().get(page);
     }
 
-    public static class DefaultScoreMapper implements ScoreOperator.ExpressionScorer.Factory {
+    public static class DefaultScoreMapper implements ExpressionEvaluator.Factory {
         @Override
-        public ScoreOperator.ExpressionScorer get(DriverContext driverContext) {
-            return new ScoreOperator.ExpressionScorer() {
+        public ExpressionEvaluator get(DriverContext driverContext) {
+            return new ExpressionEvaluator() {
                 @Override
-                public DoubleBlock score(Page page) {
+                public DoubleBlock eval(Page page) {
                     return driverContext.blockFactory().newConstantDoubleBlockWith(0.0, page.getPositionCount());
+                }
+
+                @Override
+                public long baseRamBytesUsed() {
+                    return 0;
                 }
 
                 @Override


### PR DESCRIPTION
still a draft

I removed `ScoreOperator.ExpressionScorer` and instead used basic `ExpressionEvaluator`s to compute the score.
Technically - an expression scorer is just a different way to evaluate an

I found it easier to work with `ExpressionEvaluator` rather than `ScoreOperator.ExpressionScorer`, which was my intial approach.
We also get the advantage of having a very easy way to generate these expression evaluators - using the `@Evaluator` annotation, which then generates the right `ExpressionEvaluator`.

