### PR TITLE
ES|QL|DS Fix spurious WARN for incomplete batches + rename log prefixes

### DIFF
--- a/docs/changelog/155510.yaml
+++ b/docs/changelog/155510.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155510
+summary: "Fix spurious WARN for incomplete batches in BidirectionalBatchExchangeClient on failure/cancellation path"
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeClient.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeClient.java
@@ -164,7 +164,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         this.serverNodeSupplier = serverNodeSupplier;
         this.responseHeadersCollector = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
         logger.debug(
-            "[BidirectionalBatchExchangeClient] Created BidirectionalBatchExchangeClient: sharedExchangeId={}, maxBufferSize={}, maxWorkers={}",
+            "Created BidirectionalBatchExchangeClient: sharedExchangeId={}, maxBufferSize={}, maxWorkers={}",
             sharedExchangeId,
             maxBufferSize,
             maxWorkers
@@ -178,7 +178,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      * Per-server client-to-server exchanges are created lazily in getOrCreateServerConnection().
      */
     private void initialize() {
-        logger.debug("[BidirectionalBatchExchangeClient] Initializing BidirectionalBatchExchangeClient (shared state only)");
+        logger.debug("Initializing BidirectionalBatchExchangeClient (shared state only)");
 
         // Create source handler for server-to-client direction (shared for all servers)
         serverToClientSourceHandler = new ExchangeSourceHandler(maxBufferSize, executor);
@@ -188,7 +188,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         // All servers send results to the same source handler, sorted by batchId
         ExchangeSource exchangeSource = serverToClientSourceHandler.createExchangeSource();
         sortedSource = new BatchSortedExchangeSource(exchangeSource);
-        logger.debug("[BidirectionalBatchExchangeClient] Created shared server-to-client sorted source: exchangeId={}", sharedExchangeId);
+        logger.debug("Created shared server-to-client sorted source: exchangeId={}", sharedExchangeId);
 
         // Tracks completion of all worker channels. The initial ref is released by finish().
         // On completion: if no failure was recorded, notify success; otherwise it was already handled.
@@ -263,12 +263,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         });
         worker.statusRef = responseRefs.acquireListener();
         initializeWorker(worker);
-        logger.debug(
-            "[BidirectionalBatchExchangeClient] Created new worker: workerId={}, serverNode={}, totalWorkers={}",
-            workerId,
-            serverNode.getId(),
-            workers.size()
-        );
+        logger.debug("Created new worker: workerId={}, serverNode={}, totalWorkers={}", workerId, serverNode.getId(), workers.size());
         return worker;
     }
 
@@ -277,7 +272,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void initializeWorker(Worker worker) {
         logger.debug(
-            "[BidirectionalBatchExchangeClient] Initializing worker: workerId={}, node={}, clientToServerId={}",
+            "Initializing worker: workerId={}, node={}, clientToServerId={}",
             worker.workerId,
             worker.serverNode.getId(),
             worker.clientToServerId
@@ -297,7 +292,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 exchangeService.finishSinkHandler(worker.clientToServerId, e);
             })
         );
-        logger.debug("[BidirectionalBatchExchangeClient] Created client-to-server sink handler: exchangeId={}", worker.clientToServerId);
+        logger.debug("Created client-to-server sink handler: exchangeId={}", worker.clientToServerId);
 
         // Send setup request to server via callback
         serverSetupCallback.sendSetupRequest(
@@ -306,7 +301,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             worker.serverToClientId,
             ActionListener.wrap(planString -> {
                 try {
-                    logger.debug("[BidirectionalBatchExchangeClient] Server setup complete for worker={}", worker.workerId);
+                    logger.debug("Server setup complete for worker={}", worker.workerId);
                     // Pass lookup plan to consumer if provided (with workerKey for tracking)
                     if (lookupPlanConsumer != null && planString != null) {
                         String workerKey = worker.serverNode.getId() + ":worker" + worker.workerId;
@@ -320,7 +315,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                         logger,
                         Level.ERROR,
                         e,
-                        "[BidirectionalBatchExchangeClient] Server setup callback failed for worker={}: {}",
+                        "Server setup callback failed for worker={}: {}",
                         worker.workerId,
                         e.getMessage()
                     );
@@ -331,14 +326,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                     worker.setupReadyListener.onFailure(e);
                 }
             }, e -> {
-                logExchangeFailure(
-                    logger,
-                    Level.ERROR,
-                    e,
-                    "[BidirectionalBatchExchangeClient] Server setup failed for worker={}: {}",
-                    worker.workerId,
-                    e.getMessage()
-                );
+                logExchangeFailure(logger, Level.ERROR, e, "Server setup failed for worker={}: {}", worker.workerId, e.getMessage());
                 onWorkerConnectionComplete(worker, "Setup failed");
                 worker.sinkRef.onFailure(e);
                 worker.statusRef.onFailure(e);
@@ -353,7 +341,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void connectToServerSink(Worker worker) {
         logger.debug(
-            "[BidirectionalBatchExchangeClient] Connecting to server sink for worker={}, node={}, serverToClientId={}",
+            "Connecting to server sink for worker={}, node={}, serverToClientId={}",
             worker.workerId,
             worker.serverNode.getId(),
             worker.serverToClientId
@@ -379,7 +367,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         try {
             Transport.Connection connection = transportService.getConnection(worker.serverNode);
             logger.debug(
-                "[BidirectionalBatchExchangeClient] Sending batch exchange status request for worker={}, node={}, exchangeId={}",
+                "Sending batch exchange status request for worker={}, node={}, exchangeId={}",
                 worker.workerId,
                 worker.serverNode.getId(),
                 worker.serverToClientId
@@ -392,7 +380,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 ActionListener.<BatchExchangeStatusResponse>wrap(response -> {
                     responseHeadersCollector.collect();
                     logger.debug(
-                        "[BidirectionalBatchExchangeClient] Received batch exchange status response for worker={}, success={}",
+                        "Received batch exchange status response for worker={}, success={}",
                         worker.workerId,
                         response.isSuccess()
                     );
@@ -405,7 +393,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                             logger,
                             Level.WARN,
                             failure,
-                            "[BidirectionalBatchExchangeClient] Batch exchange status response indicates failure for worker={}: {}",
+                            "Batch exchange status response indicates failure for worker={}: {}",
                             worker.workerId,
                             failure != null ? failure.getMessage() : "unknown"
                         );
@@ -418,7 +406,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                         logger,
                         Level.ERROR,
                         failure,
-                        "[BidirectionalBatchExchangeClient] Failed to receive batch exchange status response for worker={}: {}",
+                        "Failed to receive batch exchange status response for worker={}: {}",
                         worker.workerId,
                         failure.getMessage()
                     );
@@ -426,7 +414,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                     worker.statusRef.onFailure(failure);
                 })
             );
-            logger.debug("[BidirectionalBatchExchangeClient] Batch exchange status request sent for worker={}", worker.workerId);
+            logger.debug("Batch exchange status request sent for worker={}", worker.workerId);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to send batch exchange status request for worker [" + worker.workerId + "]", e);
         }
@@ -442,13 +430,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
     private void notifyFailure(Exception failure) {
         setPrimaryFailure(failure);
         if (failureTriggered.compareAndSet(false, true)) {
-            logExchangeFailure(
-                logger,
-                Level.ERROR,
-                failure,
-                "[BidirectionalBatchExchangeClient] Notifying failure: {}",
-                failure.getMessage()
-            );
+            logExchangeFailure(logger, Level.ERROR, failure, "Notifying failure: {}", failure.getMessage());
             // Notify the operator's failure listener FIRST, before unblocking the driver.
             // This ensures that when the driver thread unblocks, the operator's failure field
             // is already set, so getOutput() will throw the real error immediately.
@@ -464,7 +446,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 logger,
                 Level.WARN,
                 failure,
-                "[BidirectionalBatchExchangeClient] Additional failure (primary={}): {}",
+                "Additional failure (primary={}): {}",
                 primaryFailure.get() == failure,
                 failure.getMessage()
             );
@@ -719,12 +701,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         startedBatchCount++;
         page.allowPassingToDifferentDriver();
         worker.clientToServerSink.addPage(page);
-        logger.trace(
-            "[BidirectionalBatchExchangeClient] Sent batch {} to worker {}, pending={}",
-            metadata.batchId(),
-            worker.workerId,
-            worker.pendingBatches
-        );
+        logger.trace("Sent batch {} to worker {}, pending={}", metadata.batchId(), worker.workerId, worker.pendingBatches);
     }
 
     /**
@@ -753,18 +730,14 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         if (worker != null) {
             int pending = --worker.pendingBatches;
             logger.trace(
-                "[BidirectionalBatchExchangeClient] Batch {} completed on worker {}, pending={}, total completed={}",
+                "Batch {} completed on worker {}, pending={}, total completed={}",
                 batchId,
                 worker.workerId,
                 pending,
                 completedBatchCount
             );
         } else {
-            logger.trace(
-                "[BidirectionalBatchExchangeClient] Batch {} completed (worker not found), total completed={}",
-                batchId,
-                completedBatchCount
-            );
+            logger.trace("Batch {} completed (worker not found), total completed={}", batchId, completedBatchCount);
         }
     }
 
@@ -788,10 +761,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             if (pendingWorkerConnections.get() > 0) {
                 // Don't finish yet - wait for all pending connections to be established
                 // The last connection to establish will call doFinish()
-                logger.debug(
-                    "[BidirectionalBatchExchangeClient] Deferring finish, pending worker connections={}",
-                    pendingWorkerConnections.get()
-                );
+                logger.debug("Deferring finish, pending worker connections={}", pendingWorkerConnections.get());
                 return;
             }
             doFinish();
@@ -807,7 +777,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void onWorkerConnectionComplete(Worker worker, String reason) {
         int remaining = pendingWorkerConnections.decrementAndGet();
-        logger.debug("[BidirectionalBatchExchangeClient] {} for worker {}, remaining pending={}", reason, worker.workerId, remaining);
+        logger.debug("{} for worker {}, remaining pending={}", reason, worker.workerId, remaining);
         if (remaining == 0 && finishRequested) {
             synchronized (sendFinishLock) {
                 doFinish();
@@ -826,10 +796,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         assert Thread.holdsLock(sendFinishLock) : "doFinish must be called while holding sendFinishLock";
         for (Worker worker : workers) {
             if (worker.clientToServerSink != null && worker.clientToServerSink.isFinished() == false && worker.finished == false) {
-                logger.debug(
-                    "[BidirectionalBatchExchangeClient] Finishing client-to-server exchange for worker={} (no more batches will be sent)",
-                    worker.workerId
-                );
+                logger.debug("Finishing client-to-server exchange for worker={} (no more batches will be sent)", worker.workerId);
                 worker.clientToServerSink.finish();
                 worker.finished = true;
             }
@@ -860,7 +827,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         try {
             finish();
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[BidirectionalBatchExchangeClient] Error calling finish()", e);
+            logExchangeFailure(logger, Level.ERROR, e, "Error calling finish()", e);
         }
 
         // Drain all sink handler buffers to release any pages, then explicitly remove the sink handler
@@ -872,25 +839,19 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             try {
                 if (worker.clientToServerSinkHandler != null) {
                     logger.debug(
-                        "[BidirectionalBatchExchangeClient] Draining sink handler buffer for worker={}, isFinished={}",
+                        "Draining sink handler buffer for worker={}, isFinished={}",
                         worker.workerId,
                         worker.clientToServerSinkHandler.isFinished()
                     );
                     worker.clientToServerSinkHandler.onFailure(new TaskCancelledException("client stopped"));
                 }
             } catch (Exception e) {
-                logExchangeFailure(
-                    logger,
-                    Level.ERROR,
-                    e,
-                    "[BidirectionalBatchExchangeClient] Error draining sink handler for worker=" + worker.workerId,
-                    e
-                );
+                logExchangeFailure(logger, Level.ERROR, e, "Error draining sink handler for worker=" + worker.workerId, e);
             }
             try {
                 exchangeService.finishSinkHandler(worker.clientToServerId, new TaskCancelledException("client stopped"));
             } catch (Exception e) {
-                logger.debug("[BidirectionalBatchExchangeClient] finishSinkHandler already done for worker={}", worker.workerId);
+                logger.debug("finishSinkHandler already done for worker={}", worker.workerId);
             }
         }
     }
@@ -915,7 +876,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             return;
         }
         closed = true;
-        logger.debug("[BidirectionalBatchExchangeClient] Closing BidirectionalBatchExchangeClient");
+        logger.debug("Closing BidirectionalBatchExchangeClient");
 
         stop();
 
@@ -926,52 +887,40 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         int started = startedBatchCount;
         int completed = completedBatchCount;
         if (started > 0 && completed < started && primaryFailure.get() == null) {
-            logger.warn("[BidirectionalBatchExchangeClient] Closing with incomplete batches: started={}, completed={}", started, completed);
+            logger.warn("Closing with incomplete batches: started={}, completed={}", started, completed);
         }
 
         // Finish the shared server-to-client source handler to signal completion
         try {
             if (serverToClientSourceHandler != null) {
-                logger.debug("[BidirectionalBatchExchangeClient] Finishing server-to-client source handler");
+                logger.debug("Finishing server-to-client source handler");
                 serverToClientSourceHandler.finishEarly(true, ActionListener.noop());
             }
         } catch (Exception e) {
-            logExchangeFailure(
-                logger,
-                Level.ERROR,
-                e,
-                "[BidirectionalBatchExchangeClient] Error finishing server-to-client source handler",
-                e
-            );
+            logExchangeFailure(logger, Level.ERROR, e, "Error finishing server-to-client source handler", e);
         }
 
         // Close the sorted source to release any buffered pages
         try {
             if (sortedSource != null) {
-                logger.debug("[BidirectionalBatchExchangeClient] Closing sorted source");
+                logger.debug("Closing sorted source");
                 sortedSource.close();
             }
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[BidirectionalBatchExchangeClient] Error closing sorted source", e);
+            logExchangeFailure(logger, Level.ERROR, e, "Error closing sorted source", e);
         }
 
         // Remove the source handler from the exchange service
         try {
             if (serverToClientSourceHandler != null) {
-                logger.debug("[BidirectionalBatchExchangeClient] Removing server-to-client source handler");
+                logger.debug("Removing server-to-client source handler");
                 exchangeService.removeExchangeSourceHandler(sharedExchangeId);
             }
         } catch (Exception e) {
-            logExchangeFailure(
-                logger,
-                Level.ERROR,
-                e,
-                "[BidirectionalBatchExchangeClient] Error removing server-to-client source handler",
-                e
-            );
+            logExchangeFailure(logger, Level.ERROR, e, "Error removing server-to-client source handler", e);
         }
 
-        logger.debug("[BidirectionalBatchExchangeClient] BidirectionalBatchExchangeClient closed");
+        logger.debug("BidirectionalBatchExchangeClient closed");
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeClient.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeClient.java
@@ -164,7 +164,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         this.serverNodeSupplier = serverNodeSupplier;
         this.responseHeadersCollector = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
         logger.debug(
-            "[LookupJoinClient] Created BidirectionalBatchExchangeClient: sharedExchangeId={}, maxBufferSize={}, maxWorkers={}",
+            "[BidirectionalBatchExchangeClient] Created BidirectionalBatchExchangeClient: sharedExchangeId={}, maxBufferSize={}, maxWorkers={}",
             sharedExchangeId,
             maxBufferSize,
             maxWorkers
@@ -178,7 +178,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      * Per-server client-to-server exchanges are created lazily in getOrCreateServerConnection().
      */
     private void initialize() {
-        logger.debug("[LookupJoinClient] Initializing BidirectionalBatchExchangeClient (shared state only)");
+        logger.debug("[BidirectionalBatchExchangeClient] Initializing BidirectionalBatchExchangeClient (shared state only)");
 
         // Create source handler for server-to-client direction (shared for all servers)
         serverToClientSourceHandler = new ExchangeSourceHandler(maxBufferSize, executor);
@@ -188,7 +188,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         // All servers send results to the same source handler, sorted by batchId
         ExchangeSource exchangeSource = serverToClientSourceHandler.createExchangeSource();
         sortedSource = new BatchSortedExchangeSource(exchangeSource);
-        logger.debug("[LookupJoinClient] Created shared server-to-client sorted source: exchangeId={}", sharedExchangeId);
+        logger.debug("[BidirectionalBatchExchangeClient] Created shared server-to-client sorted source: exchangeId={}", sharedExchangeId);
 
         // Tracks completion of all worker channels. The initial ref is released by finish().
         // On completion: if no failure was recorded, notify success; otherwise it was already handled.
@@ -264,7 +264,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         worker.statusRef = responseRefs.acquireListener();
         initializeWorker(worker);
         logger.debug(
-            "[LookupJoinClient] Created new worker: workerId={}, serverNode={}, totalWorkers={}",
+            "[BidirectionalBatchExchangeClient] Created new worker: workerId={}, serverNode={}, totalWorkers={}",
             workerId,
             serverNode.getId(),
             workers.size()
@@ -277,7 +277,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void initializeWorker(Worker worker) {
         logger.debug(
-            "[LookupJoinClient] Initializing worker: workerId={}, node={}, clientToServerId={}",
+            "[BidirectionalBatchExchangeClient] Initializing worker: workerId={}, node={}, clientToServerId={}",
             worker.workerId,
             worker.serverNode.getId(),
             worker.clientToServerId
@@ -297,7 +297,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 exchangeService.finishSinkHandler(worker.clientToServerId, e);
             })
         );
-        logger.debug("[LookupJoinClient] Created client-to-server sink handler: exchangeId={}", worker.clientToServerId);
+        logger.debug("[BidirectionalBatchExchangeClient] Created client-to-server sink handler: exchangeId={}", worker.clientToServerId);
 
         // Send setup request to server via callback
         serverSetupCallback.sendSetupRequest(
@@ -306,7 +306,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             worker.serverToClientId,
             ActionListener.wrap(planString -> {
                 try {
-                    logger.debug("[LookupJoinClient] Server setup complete for worker={}", worker.workerId);
+                    logger.debug("[BidirectionalBatchExchangeClient] Server setup complete for worker={}", worker.workerId);
                     // Pass lookup plan to consumer if provided (with workerKey for tracking)
                     if (lookupPlanConsumer != null && planString != null) {
                         String workerKey = worker.serverNode.getId() + ":worker" + worker.workerId;
@@ -320,7 +320,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                         logger,
                         Level.ERROR,
                         e,
-                        "[LookupJoinClient] Server setup callback failed for worker={}: {}",
+                        "[BidirectionalBatchExchangeClient] Server setup callback failed for worker={}: {}",
                         worker.workerId,
                         e.getMessage()
                     );
@@ -335,7 +335,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                     logger,
                     Level.ERROR,
                     e,
-                    "[LookupJoinClient] Server setup failed for worker={}: {}",
+                    "[BidirectionalBatchExchangeClient] Server setup failed for worker={}: {}",
                     worker.workerId,
                     e.getMessage()
                 );
@@ -353,7 +353,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void connectToServerSink(Worker worker) {
         logger.debug(
-            "[LookupJoinClient] Connecting to server sink for worker={}, node={}, serverToClientId={}",
+            "[BidirectionalBatchExchangeClient] Connecting to server sink for worker={}, node={}, serverToClientId={}",
             worker.workerId,
             worker.serverNode.getId(),
             worker.serverToClientId
@@ -379,7 +379,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         try {
             Transport.Connection connection = transportService.getConnection(worker.serverNode);
             logger.debug(
-                "[LookupJoinClient] Sending batch exchange status request for worker={}, node={}, exchangeId={}",
+                "[BidirectionalBatchExchangeClient] Sending batch exchange status request for worker={}, node={}, exchangeId={}",
                 worker.workerId,
                 worker.serverNode.getId(),
                 worker.serverToClientId
@@ -392,7 +392,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 ActionListener.<BatchExchangeStatusResponse>wrap(response -> {
                     responseHeadersCollector.collect();
                     logger.debug(
-                        "[LookupJoinClient] Received batch exchange status response for worker={}, success={}",
+                        "[BidirectionalBatchExchangeClient] Received batch exchange status response for worker={}, success={}",
                         worker.workerId,
                         response.isSuccess()
                     );
@@ -405,7 +405,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                             logger,
                             Level.WARN,
                             failure,
-                            "[LookupJoinClient] Batch exchange status response indicates failure for worker={}: {}",
+                            "[BidirectionalBatchExchangeClient] Batch exchange status response indicates failure for worker={}: {}",
                             worker.workerId,
                             failure != null ? failure.getMessage() : "unknown"
                         );
@@ -418,7 +418,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                         logger,
                         Level.ERROR,
                         failure,
-                        "[LookupJoinClient] Failed to receive batch exchange status response for worker={}: {}",
+                        "[BidirectionalBatchExchangeClient] Failed to receive batch exchange status response for worker={}: {}",
                         worker.workerId,
                         failure.getMessage()
                     );
@@ -426,7 +426,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                     worker.statusRef.onFailure(failure);
                 })
             );
-            logger.debug("[LookupJoinClient] Batch exchange status request sent for worker={}", worker.workerId);
+            logger.debug("[BidirectionalBatchExchangeClient] Batch exchange status request sent for worker={}", worker.workerId);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to send batch exchange status request for worker [" + worker.workerId + "]", e);
         }
@@ -442,7 +442,13 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
     private void notifyFailure(Exception failure) {
         setPrimaryFailure(failure);
         if (failureTriggered.compareAndSet(false, true)) {
-            logExchangeFailure(logger, Level.ERROR, failure, "[LookupJoinClient] Notifying failure: {}", failure.getMessage());
+            logExchangeFailure(
+                logger,
+                Level.ERROR,
+                failure,
+                "[BidirectionalBatchExchangeClient] Notifying failure: {}",
+                failure.getMessage()
+            );
             // Notify the operator's failure listener FIRST, before unblocking the driver.
             // This ensures that when the driver thread unblocks, the operator's failure field
             // is already set, so getOutput() will throw the real error immediately.
@@ -458,7 +464,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                 logger,
                 Level.WARN,
                 failure,
-                "[LookupJoinClient] Additional failure (primary={}): {}",
+                "[BidirectionalBatchExchangeClient] Additional failure (primary={}): {}",
                 primaryFailure.get() == failure,
                 failure.getMessage()
             );
@@ -714,7 +720,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         page.allowPassingToDifferentDriver();
         worker.clientToServerSink.addPage(page);
         logger.trace(
-            "[LookupJoinClient] Sent batch {} to worker {}, pending={}",
+            "[BidirectionalBatchExchangeClient] Sent batch {} to worker {}, pending={}",
             metadata.batchId(),
             worker.workerId,
             worker.pendingBatches
@@ -747,14 +753,18 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         if (worker != null) {
             int pending = --worker.pendingBatches;
             logger.trace(
-                "[LookupJoinClient] Batch {} completed on worker {}, pending={}, total completed={}",
+                "[BidirectionalBatchExchangeClient] Batch {} completed on worker {}, pending={}, total completed={}",
                 batchId,
                 worker.workerId,
                 pending,
                 completedBatchCount
             );
         } else {
-            logger.trace("[LookupJoinClient] Batch {} completed (worker not found), total completed={}", batchId, completedBatchCount);
+            logger.trace(
+                "[BidirectionalBatchExchangeClient] Batch {} completed (worker not found), total completed={}",
+                batchId,
+                completedBatchCount
+            );
         }
     }
 
@@ -778,7 +788,10 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             if (pendingWorkerConnections.get() > 0) {
                 // Don't finish yet - wait for all pending connections to be established
                 // The last connection to establish will call doFinish()
-                logger.debug("[LookupJoinClient] Deferring finish, pending worker connections={}", pendingWorkerConnections.get());
+                logger.debug(
+                    "[BidirectionalBatchExchangeClient] Deferring finish, pending worker connections={}",
+                    pendingWorkerConnections.get()
+                );
                 return;
             }
             doFinish();
@@ -794,7 +807,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
      */
     private void onWorkerConnectionComplete(Worker worker, String reason) {
         int remaining = pendingWorkerConnections.decrementAndGet();
-        logger.debug("[LookupJoinClient] {} for worker {}, remaining pending={}", reason, worker.workerId, remaining);
+        logger.debug("[BidirectionalBatchExchangeClient] {} for worker {}, remaining pending={}", reason, worker.workerId, remaining);
         if (remaining == 0 && finishRequested) {
             synchronized (sendFinishLock) {
                 doFinish();
@@ -814,7 +827,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         for (Worker worker : workers) {
             if (worker.clientToServerSink != null && worker.clientToServerSink.isFinished() == false && worker.finished == false) {
                 logger.debug(
-                    "[LookupJoinClient] Finishing client-to-server exchange for worker={} (no more batches will be sent)",
+                    "[BidirectionalBatchExchangeClient] Finishing client-to-server exchange for worker={} (no more batches will be sent)",
                     worker.workerId
                 );
                 worker.clientToServerSink.finish();
@@ -847,7 +860,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
         try {
             finish();
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinClient] Error calling finish()", e);
+            logExchangeFailure(logger, Level.ERROR, e, "[BidirectionalBatchExchangeClient] Error calling finish()", e);
         }
 
         // Drain all sink handler buffers to release any pages, then explicitly remove the sink handler
@@ -859,7 +872,7 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             try {
                 if (worker.clientToServerSinkHandler != null) {
                     logger.debug(
-                        "[LookupJoinClient] Draining sink handler buffer for worker={}, isFinished={}",
+                        "[BidirectionalBatchExchangeClient] Draining sink handler buffer for worker={}, isFinished={}",
                         worker.workerId,
                         worker.clientToServerSinkHandler.isFinished()
                     );
@@ -870,14 +883,14 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
                     logger,
                     Level.ERROR,
                     e,
-                    "[LookupJoinClient] Error draining sink handler for worker=" + worker.workerId,
+                    "[BidirectionalBatchExchangeClient] Error draining sink handler for worker=" + worker.workerId,
                     e
                 );
             }
             try {
                 exchangeService.finishSinkHandler(worker.clientToServerId, new TaskCancelledException("client stopped"));
             } catch (Exception e) {
-                logger.debug("[LookupJoinClient] finishSinkHandler already done for worker={}", worker.workerId);
+                logger.debug("[BidirectionalBatchExchangeClient] finishSinkHandler already done for worker={}", worker.workerId);
             }
         }
     }
@@ -902,48 +915,63 @@ public final class BidirectionalBatchExchangeClient extends BidirectionalBatchEx
             return;
         }
         closed = true;
-        logger.debug("[LookupJoinClient] Closing BidirectionalBatchExchangeClient");
+        logger.debug("[BidirectionalBatchExchangeClient] Closing BidirectionalBatchExchangeClient");
 
         stop();
 
-        // Log incomplete batches for debugging
+        // Only warn about incomplete batches when there is no recorded failure.
+        // On the failure/cancellation path this is expected: cleanupBatchResources() discards
+        // active batches without calling markBatchCompleted, and the real error has already
+        // propagated via batchExchangeStatusListener.onFailure().
         int started = startedBatchCount;
         int completed = completedBatchCount;
-        if (started > 0 && completed < started) {
-            logger.warn("[LookupJoinClient] Closing with incomplete batches: started={}, completed={}", started, completed);
+        if (started > 0 && completed < started && primaryFailure.get() == null) {
+            logger.warn("[BidirectionalBatchExchangeClient] Closing with incomplete batches: started={}, completed={}", started, completed);
         }
 
         // Finish the shared server-to-client source handler to signal completion
         try {
             if (serverToClientSourceHandler != null) {
-                logger.debug("[LookupJoinClient] Finishing server-to-client source handler");
+                logger.debug("[BidirectionalBatchExchangeClient] Finishing server-to-client source handler");
                 serverToClientSourceHandler.finishEarly(true, ActionListener.noop());
             }
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinClient] Error finishing server-to-client source handler", e);
+            logExchangeFailure(
+                logger,
+                Level.ERROR,
+                e,
+                "[BidirectionalBatchExchangeClient] Error finishing server-to-client source handler",
+                e
+            );
         }
 
         // Close the sorted source to release any buffered pages
         try {
             if (sortedSource != null) {
-                logger.debug("[LookupJoinClient] Closing sorted source");
+                logger.debug("[BidirectionalBatchExchangeClient] Closing sorted source");
                 sortedSource.close();
             }
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinClient] Error closing sorted source", e);
+            logExchangeFailure(logger, Level.ERROR, e, "[BidirectionalBatchExchangeClient] Error closing sorted source", e);
         }
 
         // Remove the source handler from the exchange service
         try {
             if (serverToClientSourceHandler != null) {
-                logger.debug("[LookupJoinClient] Removing server-to-client source handler");
+                logger.debug("[BidirectionalBatchExchangeClient] Removing server-to-client source handler");
                 exchangeService.removeExchangeSourceHandler(sharedExchangeId);
             }
         } catch (Exception e) {
-            logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinClient] Error removing server-to-client source handler", e);
+            logExchangeFailure(
+                logger,
+                Level.ERROR,
+                e,
+                "[BidirectionalBatchExchangeClient] Error removing server-to-client source handler",
+                e
+            );
         }
 
-        logger.debug("[LookupJoinClient] BidirectionalBatchExchangeClient closed");
+        logger.debug("[BidirectionalBatchExchangeClient] BidirectionalBatchExchangeClient closed");
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeServer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeServer.java
@@ -109,7 +109,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         this.serverToClientId = serverToClientId;
         this.clientNode = clientNode;
         logger.debug(
-            "[BidirectionalBatchExchangeServer] Created BidirectionalBatchExchangeServer: clientToServerId={}, serverToClientId={}, maxBufferSize={}",
+            "Created BidirectionalBatchExchangeServer: clientToServerId={}, serverToClientId={}, maxBufferSize={}",
             clientToServerId,
             serverToClientId,
             maxBufferSize
@@ -151,24 +151,24 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
      * Called automatically from the constructor.
      */
     private void initialize() {
-        logger.debug("[BidirectionalBatchExchangeServer] Initializing BidirectionalBatchExchangeServer");
+        logger.debug("Initializing BidirectionalBatchExchangeServer");
         // Create source handler for client-to-server direction
         clientToServerSourceHandler = new ExchangeSourceHandler(maxBufferSize, executor);
         exchangeService.addExchangeSourceHandler(clientToServerId, clientToServerSourceHandler);
         clientToServerSource = new ExchangeSourceOperator(clientToServerSourceHandler.createExchangeSource());
-        logger.debug("[BidirectionalBatchExchangeServer] Created client-to-server source handler: exchangeId={}", clientToServerId);
+        logger.debug("Created client-to-server source handler: exchangeId={}", clientToServerId);
 
         // Create or get sink handler for server-to-client direction
         // Uses getOrCreateSinkHandler to allow pre-registration of the handler (e.g., for test setup coordination)
         serverToClientSinkHandler = exchangeService.getOrCreateSinkHandler(serverToClientId, maxBufferSize);
         serverToClientSink = serverToClientSinkHandler.createExchangeSink(() -> {});
-        logger.debug("[BidirectionalBatchExchangeServer] Created server-to-client sink handler: exchangeId={}", serverToClientId);
+        logger.debug("Created server-to-client sink handler: exchangeId={}", serverToClientId);
 
         // Register this server with ExchangeService so it can receive BatchExchangeStatusRequest messages
         // The handler is registered once in ExchangeService.registerTransportHandler() and routes to servers
         exchangeService.registerBatchExchangeServer(serverToClientId, this);
-        logger.debug("[BidirectionalBatchExchangeServer] Registered with ExchangeService for exchangeId={}", serverToClientId);
-        logger.debug("[BidirectionalBatchExchangeServer] BidirectionalBatchExchangeServer initialized successfully");
+        logger.debug("Registered with ExchangeService for exchangeId={}", serverToClientId);
+        logger.debug("BidirectionalBatchExchangeServer initialized successfully");
     }
 
     /**
@@ -184,14 +184,11 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
 
         // Check if server is already closing - if so, reply with failure immediately
         if (closing) {
-            logger.error(
-                "[BidirectionalBatchExchangeServer] Received BatchExchangeStatusRequest but server is already closing for exchangeId={}",
-                serverToClientId
-            );
+            logger.error("Received BatchExchangeStatusRequest but server is already closing for exchangeId={}", serverToClientId);
             try {
                 channel.sendResponse(new BatchExchangeStatusResponse(new IllegalStateException("Server is closing")));
             } catch (Exception e) {
-                logger.debug("[BidirectionalBatchExchangeServer] Failed to send failure response (server closing)", e);
+                logger.debug("Failed to send failure response (server closing)", e);
             }
             return;
         }
@@ -200,7 +197,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // This MUST be done before starting processing to ensure we can always reply on error
         batchExchangeStatusListener = new ChannelActionListener<>(channel);
         logger.debug(
-            "[BidirectionalBatchExchangeServer] BatchExchangeStatusRequest received for exchangeId={}, stored listener (processing will start now)",
+            "BatchExchangeStatusRequest received for exchangeId={}, stored listener (processing will start now)",
             serverToClientId
         );
 
@@ -214,7 +211,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                 logger,
                 Level.ERROR,
                 e,
-                "[BidirectionalBatchExchangeServer] Failed to start driver after BatchExchangeStatusRequest for exchangeId={}: {}",
+                "Failed to start driver after BatchExchangeStatusRequest for exchangeId={}: {}",
                 serverToClientId,
                 e.getMessage()
             );
@@ -232,17 +229,14 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
     private void onClientReady() {
         if (driverPrepared == false) {
             String errorMsg = "Driver not prepared when BatchExchangeStatusRequest received";
-            logger.error(
-                "[BidirectionalBatchExchangeServer] onClientReady called but driver not prepared yet for exchangeId={}",
-                serverToClientId
-            );
+            logger.error("onClientReady called but driver not prepared yet for exchangeId={}", serverToClientId);
             // Reply with failure since we can't start processing
             sendBatchExchangeStatusResponse(new IllegalStateException(errorMsg));
             return;
         }
         if (closing) {
             String errorMsg = "Server is closing when BatchExchangeStatusRequest received";
-            logger.error("[BidirectionalBatchExchangeServer] Server is closing, cannot start driver for exchangeId={}", serverToClientId);
+            logger.error("Server is closing, cannot start driver for exchangeId={}", serverToClientId);
             // Reply with failure since we can't start processing
             sendBatchExchangeStatusResponse(new IllegalStateException(errorMsg));
             return;
@@ -257,11 +251,11 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // Mark driver as started before actually starting it
         driverStarted = true;
 
-        logger.debug("[BidirectionalBatchExchangeServer] Client is ready, starting driver for exchangeId={}", serverToClientId);
+        logger.debug("Client is ready, starting driver for exchangeId={}", serverToClientId);
         // driverFuture was already created in startBatchProcessing(), reuse it
         // The driver completion listener will handle both success and failure cases and reply
         Driver.start(threadContext, executor, batchDriver, Driver.DEFAULT_MAX_ITERATIONS, createDriverCompletionListener());
-        logger.debug("[BidirectionalBatchExchangeServer] Server driver started");
+        logger.debug("Server driver started");
     }
 
     /**
@@ -278,26 +272,17 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
      */
     private ActionListener<Void> createDriverCompletionListener() {
         return ActionListener.wrap(ignored -> {
-            logger.debug(
-                "[BidirectionalBatchExchangeServer] Driver completion listener onResponse called (success) for exchangeId={}",
-                serverToClientId
-            );
+            logger.debug("Driver completion listener onResponse called (success) for exchangeId={}", serverToClientId);
             responseHeadersCollector.collect();
             driverFuture.onResponse(null);
-            logger.debug("[BidirectionalBatchExchangeServer] Batch processing completed successfully for exchangeId={}", serverToClientId);
+            logger.debug("Batch processing completed successfully for exchangeId={}", serverToClientId);
             // Close server resources BEFORE releasing the driver ref
             // This ensures DirectoryReader etc. are closed before client proceeds with cleanup
             Exception closeException = null;
             try {
                 close();
             } catch (Exception e) {
-                logExchangeFailure(
-                    logger,
-                    Level.ERROR,
-                    e,
-                    "[BidirectionalBatchExchangeServer] Exception during close after successful driver completion",
-                    e
-                );
+                logExchangeFailure(logger, Level.ERROR, e, "Exception during close after successful driver completion", e);
                 closeException = e;
             }
             // Release driver ref - success if close() succeeded, failure if close() threw
@@ -308,7 +293,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             }
         }, failure -> {
             logger.debug(
-                "[BidirectionalBatchExchangeServer] Driver completion listener onFailure called for exchangeId={}, failure={}",
+                "Driver completion listener onFailure called for exchangeId={}, failure={}",
                 serverToClientId,
                 failure != null ? failure.getMessage() : "unknown"
             );
@@ -319,13 +304,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             try {
                 close();
             } catch (Exception e) {
-                logExchangeFailure(
-                    logger,
-                    Level.ERROR,
-                    e,
-                    "[BidirectionalBatchExchangeServer] Exception during close after driver failure",
-                    e
-                );
+                logExchangeFailure(logger, Level.ERROR, e, "Exception during close after driver failure", e);
             }
             // Release driver ref with failure - the response coordinator's FailureCollector
             // will pick the best error across driver and sink channels
@@ -344,7 +323,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         ActionListener<BatchExchangeStatusResponse> listener = batchExchangeStatusListener;
         if (listener != null) {
             logger.debug(
-                "[BidirectionalBatchExchangeServer] Sending batch exchange status {} response for exchangeId={}",
+                "Sending batch exchange status {} response for exchangeId={}",
                 failure == null ? "success" : "failure",
                 serverToClientId
             );
@@ -368,16 +347,13 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                     logger,
                     Level.ERROR,
                     e,
-                    "[BidirectionalBatchExchangeServer] Failed to send batch exchange status response for exchangeId={}: {}",
+                    "Failed to send batch exchange status response for exchangeId={}: {}",
                     serverToClientId,
                     e.getMessage()
                 );
             }
         } else {
-            logger.error(
-                "[BidirectionalBatchExchangeServer] Cannot send batch exchange status response: listener is null for exchangeId={}",
-                serverToClientId
-            );
+            logger.error("Cannot send batch exchange status response: listener is null for exchangeId={}", serverToClientId);
         }
     }
 
@@ -395,11 +371,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         TimeValue statusInterval,
         Releasable releasable
     ) {
-        logger.debug(
-            "[BidirectionalBatchExchangeServer] Starting batch processing: sessionId={}, operators={}",
-            sessionId,
-            intermediateOperators.size()
-        );
+        logger.debug("Starting batch processing: sessionId={}, operators={}", sessionId, intermediateOperators.size());
 
         long startTime = System.currentTimeMillis();
         long startNanos = System.nanoTime();
@@ -421,23 +393,11 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         try (EsqlRefCountingListener responseCoordinator = new EsqlRefCountingListener(ActionListener.wrap(v -> {
             sendBatchExchangeStatusResponse(null);
         }, e -> {
-            logExchangeFailure(
-                logger,
-                Level.ERROR,
-                e,
-                "[BidirectionalBatchExchangeServer] Server failed, propagating failure to exchange sink handler",
-                e
-            );
+            logExchangeFailure(logger, Level.ERROR, e, "Server failed, propagating failure to exchange sink handler", e);
             try {
                 serverToClientSinkHandler.onFailure(e);
             } catch (Exception ex) {
-                logExchangeFailure(
-                    logger,
-                    Level.ERROR,
-                    ex,
-                    "[BidirectionalBatchExchangeServer] Exception propagating failure to sink handler",
-                    ex
-                );
+                logExchangeFailure(logger, Level.ERROR, ex, "Exception propagating failure to sink handler", ex);
             }
             sendBatchExchangeStatusResponse(e);
         }))) {
@@ -453,10 +413,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
 
             // Connect to the client's sink handler for client-to-server exchange
             // This should be called after the client has created its sink handler
-            logger.debug(
-                "[BidirectionalBatchExchangeServer] Connecting to client sink handler via transport for client-to-server exchange, exchangeId={}",
-                clientToServerId
-            );
+            logger.debug("Connecting to client sink handler via transport for client-to-server exchange, exchangeId={}", clientToServerId);
             connectRemoteSink(clientNode, clientToServerId, clientToServerSourceHandler, sinkRef, "client sink handler");
         }
         // Signal that the remote sink has been added to the source handler.
@@ -464,7 +421,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // until the actual fetch completes. This prevents the race where the driver starts
         // before the fetch is registered.
         remoteSinkReady.onResponse(null);
-        logger.debug("[BidirectionalBatchExchangeServer] Remote sink added, signaling ready");
+        logger.debug("Remote sink added, signaling ready");
         // Create sink operator that writes to server-to-client exchange
         serverToClientSinkOperator = new ExchangeSinkOperator(serverToClientSink);
         ExchangeSinkOperator baseSinkOperator = serverToClientSinkOperator;
@@ -477,7 +434,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // Driver does NOT close the releasable - everything is handled in server.close()
         this.releasableRef.set(releasable);
         logger.debug(
-            "[BidirectionalBatchExchangeServer] Stored releasable in releasableRef for cleanup: releasable={}",
+            "Stored releasable in releasableRef for cleanup: releasable={}",
             releasable != null ? releasable.getClass().getSimpleName() : "null"
         );
 
@@ -499,20 +456,17 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             statusInterval,
             () -> {
                 // No-op - server.close() will handle all cleanup
-                logger.debug("[BidirectionalBatchExchangeServer] Driver finished, releasable will be closed by server.close()");
+                logger.debug("Driver finished, releasable will be closed by server.close()");
             }
         );
-        logger.debug("[BidirectionalBatchExchangeServer] BatchDriver created");
+        logger.debug("BatchDriver created");
 
         // Store thread context for later driver startup
         this.threadContext = threadContext;
         this.responseHeadersCollector = new ResponseHeadersCollector(threadContext);
 
         // Handler was already registered in initialize(), no need to register again
-        logger.debug(
-            "[BidirectionalBatchExchangeServer] Driver prepared, will start when BatchExchangeStatusRequest is received for exchangeId={}",
-            serverToClientId
-        );
+        logger.debug("Driver prepared, will start when BatchExchangeStatusRequest is received for exchangeId={}", serverToClientId);
 
         // Mark driver as prepared (but not started yet)
         driverPrepared = true;
@@ -525,8 +479,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         clientReadyTimeoutFuture = transportService.getThreadPool().scheduler().schedule(() -> {
             if (driverStarted == false && closing == false) {
                 logger.warn(
-                    "[BidirectionalBatchExchangeServer] Timeout waiting for BatchExchangeStatusRequest from client after {}s, "
-                        + "closing server for exchangeId={}",
+                    "Timeout waiting for BatchExchangeStatusRequest from client after {}s, " + "closing server for exchangeId={}",
                     CLIENT_READY_TIMEOUT_SECONDS,
                     serverToClientId
                 );
@@ -542,34 +495,23 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                 try {
                     close();
                 } catch (Exception e) {
-                    logExchangeFailure(
-                        logger,
-                        Level.ERROR,
-                        e,
-                        "[BidirectionalBatchExchangeServer] Exception during timeout cleanup for exchangeId={}",
-                        serverToClientId,
-                        e
-                    );
+                    logExchangeFailure(logger, Level.ERROR, e, "Exception during timeout cleanup for exchangeId={}", serverToClientId, e);
                 }
             }
         }, CLIENT_READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        logger.debug(
-            "[BidirectionalBatchExchangeServer] Scheduled client ready timeout: {}s for exchangeId={}",
-            CLIENT_READY_TIMEOUT_SECONDS,
-            serverToClientId
-        );
+        logger.debug("Scheduled client ready timeout: {}s for exchangeId={}", CLIENT_READY_TIMEOUT_SECONDS, serverToClientId);
     }
 
     @Override
     public void close() {
         // Prevent recursive close if server is part of a releasable that includes itself
         if (closing) {
-            logger.debug("[BidirectionalBatchExchangeServer] Already closing, skipping recursive close");
+            logger.debug("Already closing, skipping recursive close");
             return;
         }
         closing = true;
 
-        logger.debug("[BidirectionalBatchExchangeServer] Closing BidirectionalBatchExchangeServer");
+        logger.debug("Closing BidirectionalBatchExchangeServer");
 
         // Cancel the client ready timeout if it's still pending
         if (clientReadyTimeoutFuture != null) {
@@ -594,31 +536,31 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         Releasable releasable = releasableRef.getAndSet(null);
         if (releasable != null) {
             try {
-                logger.debug("[BidirectionalBatchExchangeServer] Closing releasable resources (shardContext, localBreaker, etc.)");
+                logger.debug("Closing releasable resources (shardContext, localBreaker, etc.)");
                 releasable.close();
-                logger.debug("[BidirectionalBatchExchangeServer] Releasable resources closed successfully");
+                logger.debug("Releasable resources closed successfully");
             } catch (Exception e) {
-                logExchangeFailure(logger, Level.WARN, e, "[BidirectionalBatchExchangeServer] Exception closing releasable", e);
+                logExchangeFailure(logger, Level.WARN, e, "Exception closing releasable", e);
             }
         } else {
-            logger.warn("[BidirectionalBatchExchangeServer] No releasable to close (releasableRef was null)");
+            logger.warn("No releasable to close (releasableRef was null)");
         }
 
         // Don't need to close batchDriver - when driver finishes, it already closes its operators
         // and the releasable passed to it. The driver itself doesn't need explicit closing.
         if (serverToClientSink != null && serverToClientSink.isFinished() == false) {
-            logger.debug("[BidirectionalBatchExchangeServer] Finishing server-to-client sink");
+            logger.debug("Finishing server-to-client sink");
             serverToClientSink.finish();
         }
         if (clientToServerSource != null) {
-            logger.debug("[BidirectionalBatchExchangeServer] Closing client-to-server source");
+            logger.debug("Closing client-to-server source");
             clientToServerSource.close();
         }
         if (clientToServerSourceHandler != null) {
             // Drain any pages remaining in the source handler's buffer before removing.
             // When server fails, pages that were transferred from client but not yet consumed
             // would leak if we don't drain them here.
-            logger.debug("[BidirectionalBatchExchangeServer] Draining client-to-server source handler buffer and removing handler");
+            logger.debug("Draining client-to-server source handler buffer and removing handler");
             clientToServerSourceHandler.finishEarly(true, ActionListener.noop());
             exchangeService.removeExchangeSourceHandler(clientToServerId);
         }
@@ -626,15 +568,15 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             // Don't call finishSinkHandler() immediately - the client may still be reading pages.
             // Wait for the sink handler to be actually finished (all pages consumed) before cleaning up.
             serverToClientSinkHandler.addCompletionListener(ActionListener.wrap(v -> {
-                logger.debug("[BidirectionalBatchExchangeServer] Sink handler completed, finishing it");
+                logger.debug("Sink handler completed, finishing it");
                 exchangeService.finishSinkHandler(serverToClientId, null);
             }, e -> {
-                logger.debug("[BidirectionalBatchExchangeServer] Sink handler completed with error, finishing it: {}", e.getMessage());
+                logger.debug("Sink handler completed with error, finishing it: {}", e.getMessage());
                 exchangeService.finishSinkHandler(serverToClientId, e);
             }));
         }
         // Unregister this server from ExchangeService
         exchangeService.unregisterBatchExchangeServer(serverToClientId);
-        logger.debug("[BidirectionalBatchExchangeServer] BidirectionalBatchExchangeServer closed");
+        logger.debug("BidirectionalBatchExchangeServer closed");
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeServer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeServer.java
@@ -109,7 +109,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         this.serverToClientId = serverToClientId;
         this.clientNode = clientNode;
         logger.debug(
-            "[LookupJoinServer] Created BidirectionalBatchExchangeServer: clientToServerId={}, serverToClientId={}, maxBufferSize={}",
+            "[BidirectionalBatchExchangeServer] Created BidirectionalBatchExchangeServer: clientToServerId={}, serverToClientId={}, maxBufferSize={}",
             clientToServerId,
             serverToClientId,
             maxBufferSize
@@ -151,24 +151,24 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
      * Called automatically from the constructor.
      */
     private void initialize() {
-        logger.debug("[LookupJoinServer] Initializing BidirectionalBatchExchangeServer");
+        logger.debug("[BidirectionalBatchExchangeServer] Initializing BidirectionalBatchExchangeServer");
         // Create source handler for client-to-server direction
         clientToServerSourceHandler = new ExchangeSourceHandler(maxBufferSize, executor);
         exchangeService.addExchangeSourceHandler(clientToServerId, clientToServerSourceHandler);
         clientToServerSource = new ExchangeSourceOperator(clientToServerSourceHandler.createExchangeSource());
-        logger.debug("[LookupJoinServer] Created client-to-server source handler: exchangeId={}", clientToServerId);
+        logger.debug("[BidirectionalBatchExchangeServer] Created client-to-server source handler: exchangeId={}", clientToServerId);
 
         // Create or get sink handler for server-to-client direction
         // Uses getOrCreateSinkHandler to allow pre-registration of the handler (e.g., for test setup coordination)
         serverToClientSinkHandler = exchangeService.getOrCreateSinkHandler(serverToClientId, maxBufferSize);
         serverToClientSink = serverToClientSinkHandler.createExchangeSink(() -> {});
-        logger.debug("[LookupJoinServer] Created server-to-client sink handler: exchangeId={}", serverToClientId);
+        logger.debug("[BidirectionalBatchExchangeServer] Created server-to-client sink handler: exchangeId={}", serverToClientId);
 
         // Register this server with ExchangeService so it can receive BatchExchangeStatusRequest messages
         // The handler is registered once in ExchangeService.registerTransportHandler() and routes to servers
         exchangeService.registerBatchExchangeServer(serverToClientId, this);
-        logger.debug("[LookupJoinServer] Registered with ExchangeService for exchangeId={}", serverToClientId);
-        logger.debug("[LookupJoinServer] BidirectionalBatchExchangeServer initialized successfully");
+        logger.debug("[BidirectionalBatchExchangeServer] Registered with ExchangeService for exchangeId={}", serverToClientId);
+        logger.debug("[BidirectionalBatchExchangeServer] BidirectionalBatchExchangeServer initialized successfully");
     }
 
     /**
@@ -185,13 +185,13 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // Check if server is already closing - if so, reply with failure immediately
         if (closing) {
             logger.error(
-                "[LookupJoinServer] Received BatchExchangeStatusRequest but server is already closing for exchangeId={}",
+                "[BidirectionalBatchExchangeServer] Received BatchExchangeStatusRequest but server is already closing for exchangeId={}",
                 serverToClientId
             );
             try {
                 channel.sendResponse(new BatchExchangeStatusResponse(new IllegalStateException("Server is closing")));
             } catch (Exception e) {
-                logger.debug("[LookupJoinServer] Failed to send failure response (server closing)", e);
+                logger.debug("[BidirectionalBatchExchangeServer] Failed to send failure response (server closing)", e);
             }
             return;
         }
@@ -200,7 +200,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // This MUST be done before starting processing to ensure we can always reply on error
         batchExchangeStatusListener = new ChannelActionListener<>(channel);
         logger.debug(
-            "[LookupJoinServer] BatchExchangeStatusRequest received for exchangeId={}, stored listener (processing will start now)",
+            "[BidirectionalBatchExchangeServer] BatchExchangeStatusRequest received for exchangeId={}, stored listener (processing will start now)",
             serverToClientId
         );
 
@@ -214,7 +214,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                 logger,
                 Level.ERROR,
                 e,
-                "[LookupJoinServer] Failed to start driver after BatchExchangeStatusRequest for exchangeId={}: {}",
+                "[BidirectionalBatchExchangeServer] Failed to start driver after BatchExchangeStatusRequest for exchangeId={}: {}",
                 serverToClientId,
                 e.getMessage()
             );
@@ -232,14 +232,17 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
     private void onClientReady() {
         if (driverPrepared == false) {
             String errorMsg = "Driver not prepared when BatchExchangeStatusRequest received";
-            logger.error("[LookupJoinServer] onClientReady called but driver not prepared yet for exchangeId={}", serverToClientId);
+            logger.error(
+                "[BidirectionalBatchExchangeServer] onClientReady called but driver not prepared yet for exchangeId={}",
+                serverToClientId
+            );
             // Reply with failure since we can't start processing
             sendBatchExchangeStatusResponse(new IllegalStateException(errorMsg));
             return;
         }
         if (closing) {
             String errorMsg = "Server is closing when BatchExchangeStatusRequest received";
-            logger.error("[LookupJoinServer] Server is closing, cannot start driver for exchangeId={}", serverToClientId);
+            logger.error("[BidirectionalBatchExchangeServer] Server is closing, cannot start driver for exchangeId={}", serverToClientId);
             // Reply with failure since we can't start processing
             sendBatchExchangeStatusResponse(new IllegalStateException(errorMsg));
             return;
@@ -254,11 +257,11 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // Mark driver as started before actually starting it
         driverStarted = true;
 
-        logger.debug("[LookupJoinServer] Client is ready, starting driver for exchangeId={}", serverToClientId);
+        logger.debug("[BidirectionalBatchExchangeServer] Client is ready, starting driver for exchangeId={}", serverToClientId);
         // driverFuture was already created in startBatchProcessing(), reuse it
         // The driver completion listener will handle both success and failure cases and reply
         Driver.start(threadContext, executor, batchDriver, Driver.DEFAULT_MAX_ITERATIONS, createDriverCompletionListener());
-        logger.debug("[LookupJoinServer] Server driver started");
+        logger.debug("[BidirectionalBatchExchangeServer] Server driver started");
     }
 
     /**
@@ -275,10 +278,13 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
      */
     private ActionListener<Void> createDriverCompletionListener() {
         return ActionListener.wrap(ignored -> {
-            logger.debug("[LookupJoinServer] Driver completion listener onResponse called (success) for exchangeId={}", serverToClientId);
+            logger.debug(
+                "[BidirectionalBatchExchangeServer] Driver completion listener onResponse called (success) for exchangeId={}",
+                serverToClientId
+            );
             responseHeadersCollector.collect();
             driverFuture.onResponse(null);
-            logger.debug("[LookupJoinServer] Batch processing completed successfully for exchangeId={}", serverToClientId);
+            logger.debug("[BidirectionalBatchExchangeServer] Batch processing completed successfully for exchangeId={}", serverToClientId);
             // Close server resources BEFORE releasing the driver ref
             // This ensures DirectoryReader etc. are closed before client proceeds with cleanup
             Exception closeException = null;
@@ -289,7 +295,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                     logger,
                     Level.ERROR,
                     e,
-                    "[LookupJoinServer] Exception during close after successful driver completion",
+                    "[BidirectionalBatchExchangeServer] Exception during close after successful driver completion",
                     e
                 );
                 closeException = e;
@@ -302,7 +308,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             }
         }, failure -> {
             logger.debug(
-                "[LookupJoinServer] Driver completion listener onFailure called for exchangeId={}, failure={}",
+                "[BidirectionalBatchExchangeServer] Driver completion listener onFailure called for exchangeId={}, failure={}",
                 serverToClientId,
                 failure != null ? failure.getMessage() : "unknown"
             );
@@ -313,7 +319,13 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             try {
                 close();
             } catch (Exception e) {
-                logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinServer] Exception during close after driver failure", e);
+                logExchangeFailure(
+                    logger,
+                    Level.ERROR,
+                    e,
+                    "[BidirectionalBatchExchangeServer] Exception during close after driver failure",
+                    e
+                );
             }
             // Release driver ref with failure - the response coordinator's FailureCollector
             // will pick the best error across driver and sink channels
@@ -332,7 +344,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         ActionListener<BatchExchangeStatusResponse> listener = batchExchangeStatusListener;
         if (listener != null) {
             logger.debug(
-                "[LookupJoinServer] Sending batch exchange status {} response for exchangeId={}",
+                "[BidirectionalBatchExchangeServer] Sending batch exchange status {} response for exchangeId={}",
                 failure == null ? "success" : "failure",
                 serverToClientId
             );
@@ -356,14 +368,14 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                     logger,
                     Level.ERROR,
                     e,
-                    "[LookupJoinServer] Failed to send batch exchange status response for exchangeId={}: {}",
+                    "[BidirectionalBatchExchangeServer] Failed to send batch exchange status response for exchangeId={}: {}",
                     serverToClientId,
                     e.getMessage()
                 );
             }
         } else {
             logger.error(
-                "[LookupJoinServer] Cannot send batch exchange status response: listener is null for exchangeId={}",
+                "[BidirectionalBatchExchangeServer] Cannot send batch exchange status response: listener is null for exchangeId={}",
                 serverToClientId
             );
         }
@@ -383,7 +395,11 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         TimeValue statusInterval,
         Releasable releasable
     ) {
-        logger.debug("[LookupJoinServer] Starting batch processing: sessionId={}, operators={}", sessionId, intermediateOperators.size());
+        logger.debug(
+            "[BidirectionalBatchExchangeServer] Starting batch processing: sessionId={}, operators={}",
+            sessionId,
+            intermediateOperators.size()
+        );
 
         long startTime = System.currentTimeMillis();
         long startNanos = System.nanoTime();
@@ -405,11 +421,23 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         try (EsqlRefCountingListener responseCoordinator = new EsqlRefCountingListener(ActionListener.wrap(v -> {
             sendBatchExchangeStatusResponse(null);
         }, e -> {
-            logExchangeFailure(logger, Level.ERROR, e, "[LookupJoinServer] Server failed, propagating failure to exchange sink handler", e);
+            logExchangeFailure(
+                logger,
+                Level.ERROR,
+                e,
+                "[BidirectionalBatchExchangeServer] Server failed, propagating failure to exchange sink handler",
+                e
+            );
             try {
                 serverToClientSinkHandler.onFailure(e);
             } catch (Exception ex) {
-                logExchangeFailure(logger, Level.ERROR, ex, "[LookupJoinServer] Exception propagating failure to sink handler", ex);
+                logExchangeFailure(
+                    logger,
+                    Level.ERROR,
+                    ex,
+                    "[BidirectionalBatchExchangeServer] Exception propagating failure to sink handler",
+                    ex
+                );
             }
             sendBatchExchangeStatusResponse(e);
         }))) {
@@ -426,7 +454,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             // Connect to the client's sink handler for client-to-server exchange
             // This should be called after the client has created its sink handler
             logger.debug(
-                "[LookupJoinServer] Connecting to client sink handler via transport for client-to-server exchange, exchangeId={}",
+                "[BidirectionalBatchExchangeServer] Connecting to client sink handler via transport for client-to-server exchange, exchangeId={}",
                 clientToServerId
             );
             connectRemoteSink(clientNode, clientToServerId, clientToServerSourceHandler, sinkRef, "client sink handler");
@@ -436,7 +464,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // until the actual fetch completes. This prevents the race where the driver starts
         // before the fetch is registered.
         remoteSinkReady.onResponse(null);
-        logger.debug("[LookupJoinServer] Remote sink added, signaling ready");
+        logger.debug("[BidirectionalBatchExchangeServer] Remote sink added, signaling ready");
         // Create sink operator that writes to server-to-client exchange
         serverToClientSinkOperator = new ExchangeSinkOperator(serverToClientSink);
         ExchangeSinkOperator baseSinkOperator = serverToClientSinkOperator;
@@ -449,7 +477,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         // Driver does NOT close the releasable - everything is handled in server.close()
         this.releasableRef.set(releasable);
         logger.debug(
-            "[LookupJoinServer] Stored releasable in releasableRef for cleanup: releasable={}",
+            "[BidirectionalBatchExchangeServer] Stored releasable in releasableRef for cleanup: releasable={}",
             releasable != null ? releasable.getClass().getSimpleName() : "null"
         );
 
@@ -471,10 +499,10 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             statusInterval,
             () -> {
                 // No-op - server.close() will handle all cleanup
-                logger.debug("[LookupJoinServer] Driver finished, releasable will be closed by server.close()");
+                logger.debug("[BidirectionalBatchExchangeServer] Driver finished, releasable will be closed by server.close()");
             }
         );
-        logger.debug("[LookupJoinServer] BatchDriver created");
+        logger.debug("[BidirectionalBatchExchangeServer] BatchDriver created");
 
         // Store thread context for later driver startup
         this.threadContext = threadContext;
@@ -482,7 +510,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
 
         // Handler was already registered in initialize(), no need to register again
         logger.debug(
-            "[LookupJoinServer] Driver prepared, will start when BatchExchangeStatusRequest is received for exchangeId={}",
+            "[BidirectionalBatchExchangeServer] Driver prepared, will start when BatchExchangeStatusRequest is received for exchangeId={}",
             serverToClientId
         );
 
@@ -497,7 +525,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         clientReadyTimeoutFuture = transportService.getThreadPool().scheduler().schedule(() -> {
             if (driverStarted == false && closing == false) {
                 logger.warn(
-                    "[LookupJoinServer] Timeout waiting for BatchExchangeStatusRequest from client after {}s, "
+                    "[BidirectionalBatchExchangeServer] Timeout waiting for BatchExchangeStatusRequest from client after {}s, "
                         + "closing server for exchangeId={}",
                     CLIENT_READY_TIMEOUT_SECONDS,
                     serverToClientId
@@ -518,7 +546,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
                         logger,
                         Level.ERROR,
                         e,
-                        "[LookupJoinServer] Exception during timeout cleanup for exchangeId={}",
+                        "[BidirectionalBatchExchangeServer] Exception during timeout cleanup for exchangeId={}",
                         serverToClientId,
                         e
                     );
@@ -526,7 +554,7 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             }
         }, CLIENT_READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         logger.debug(
-            "[LookupJoinServer] Scheduled client ready timeout: {}s for exchangeId={}",
+            "[BidirectionalBatchExchangeServer] Scheduled client ready timeout: {}s for exchangeId={}",
             CLIENT_READY_TIMEOUT_SECONDS,
             serverToClientId
         );
@@ -536,12 +564,12 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
     public void close() {
         // Prevent recursive close if server is part of a releasable that includes itself
         if (closing) {
-            logger.debug("[LookupJoinServer] Already closing, skipping recursive close");
+            logger.debug("[BidirectionalBatchExchangeServer] Already closing, skipping recursive close");
             return;
         }
         closing = true;
 
-        logger.debug("[LookupJoinServer] Closing BidirectionalBatchExchangeServer");
+        logger.debug("[BidirectionalBatchExchangeServer] Closing BidirectionalBatchExchangeServer");
 
         // Cancel the client ready timeout if it's still pending
         if (clientReadyTimeoutFuture != null) {
@@ -566,31 +594,31 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
         Releasable releasable = releasableRef.getAndSet(null);
         if (releasable != null) {
             try {
-                logger.debug("[LookupJoinServer] Closing releasable resources (shardContext, localBreaker, etc.)");
+                logger.debug("[BidirectionalBatchExchangeServer] Closing releasable resources (shardContext, localBreaker, etc.)");
                 releasable.close();
-                logger.debug("[LookupJoinServer] Releasable resources closed successfully");
+                logger.debug("[BidirectionalBatchExchangeServer] Releasable resources closed successfully");
             } catch (Exception e) {
-                logExchangeFailure(logger, Level.WARN, e, "[LookupJoinServer] Exception closing releasable", e);
+                logExchangeFailure(logger, Level.WARN, e, "[BidirectionalBatchExchangeServer] Exception closing releasable", e);
             }
         } else {
-            logger.warn("[LookupJoinServer] No releasable to close (releasableRef was null)");
+            logger.warn("[BidirectionalBatchExchangeServer] No releasable to close (releasableRef was null)");
         }
 
         // Don't need to close batchDriver - when driver finishes, it already closes its operators
         // and the releasable passed to it. The driver itself doesn't need explicit closing.
         if (serverToClientSink != null && serverToClientSink.isFinished() == false) {
-            logger.debug("[LookupJoinServer] Finishing server-to-client sink");
+            logger.debug("[BidirectionalBatchExchangeServer] Finishing server-to-client sink");
             serverToClientSink.finish();
         }
         if (clientToServerSource != null) {
-            logger.debug("[LookupJoinServer] Closing client-to-server source");
+            logger.debug("[BidirectionalBatchExchangeServer] Closing client-to-server source");
             clientToServerSource.close();
         }
         if (clientToServerSourceHandler != null) {
             // Drain any pages remaining in the source handler's buffer before removing.
             // When server fails, pages that were transferred from client but not yet consumed
             // would leak if we don't drain them here.
-            logger.debug("[LookupJoinServer] Draining client-to-server source handler buffer and removing handler");
+            logger.debug("[BidirectionalBatchExchangeServer] Draining client-to-server source handler buffer and removing handler");
             clientToServerSourceHandler.finishEarly(true, ActionListener.noop());
             exchangeService.removeExchangeSourceHandler(clientToServerId);
         }
@@ -598,15 +626,15 @@ public final class BidirectionalBatchExchangeServer extends BidirectionalBatchEx
             // Don't call finishSinkHandler() immediately - the client may still be reading pages.
             // Wait for the sink handler to be actually finished (all pages consumed) before cleaning up.
             serverToClientSinkHandler.addCompletionListener(ActionListener.wrap(v -> {
-                logger.debug("[LookupJoinServer] Sink handler completed, finishing it");
+                logger.debug("[BidirectionalBatchExchangeServer] Sink handler completed, finishing it");
                 exchangeService.finishSinkHandler(serverToClientId, null);
             }, e -> {
-                logger.debug("[LookupJoinServer] Sink handler completed with error, finishing it: {}", e.getMessage());
+                logger.debug("[BidirectionalBatchExchangeServer] Sink handler completed with error, finishing it: {}", e.getMessage());
                 exchangeService.finishSinkHandler(serverToClientId, e);
             }));
         }
         // Unregister this server from ExchangeService
         exchangeService.unregisterBatchExchangeServer(serverToClientId);
-        logger.debug("[LookupJoinServer] BidirectionalBatchExchangeServer closed");
+        logger.debug("[BidirectionalBatchExchangeServer] BidirectionalBatchExchangeServer closed");
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeTests.java
@@ -399,6 +399,80 @@ public class BidirectionalBatchExchangeTests extends ESTestCase {
     }
 
     /**
+     * Regression test for the spurious "Closing with incomplete batches" WARN that fired on every
+     * cancellation or error. Root cause: {@code StreamingLookupFromIndexOperator.cleanupBatchResources}
+     * discards in-flight batches without calling {@link BidirectionalBatchExchangeClient#markBatchCompleted},
+     * so the counters always read {@code started=N, completed=N-1} on the failure path.
+     *
+     * <p>The fix guards the WARN with {@code primaryFailure.get() == null}: when a failure is recorded,
+     * the counter discrepancy is expected and the real error has already propagated via
+     * {@link ActionListener#onFailure} — there is nothing actionable about the WARN.
+     *
+     * <p>This test reproduces the counter state seen in production by using a setup callback that
+     * fails synchronously: {@link BidirectionalBatchExchangeClient#sendPage} first passes
+     * {@code checkFailure()} (primaryFailure is null), then creates a worker whose setup fails
+     * immediately (setting primaryFailure), then {@code startedBatchCount++} executes. On close:
+     * {@code started=1, completed=0, primaryFailure != null}.
+     */
+    public void testNoSpuriousIncompletesBatchWarnOnFailure() throws Exception {
+        ThreadPool threadPool = threadPool();
+        BlockFactory blockFactory = blockFactory();
+        TestInfrastructure infra = setupTestInfrastructure(threadPool, blockFactory);
+        try {
+            String sessionId = "test-session-no-warn-" + UUID.randomUUID().toString().substring(0, 8);
+            PlainActionFuture<Void> batchExchangeStatusFuture = new PlainActionFuture<>();
+
+            // Fails synchronously — reproduces the production failure path where a task is
+            // cancelled while a batch is in-flight.
+            BidirectionalBatchExchangeClient.ServerSetupCallback failingCallback = (
+                node,
+                clientToServerId,
+                serverToClientId,
+                listener) -> listener.onFailure(new TaskCancelledException("task cancelled"));
+
+            BidirectionalBatchExchangeClient client = new BidirectionalBatchExchangeClient(
+                sessionId,
+                infra.clientExchangeService(),
+                threadPool.executor(ThreadPool.Names.SEARCH),
+                10,
+                infra.clientTransportService(),
+                mock(Task.class),
+                batchExchangeStatusFuture,
+                CLIENT_SETTINGS,
+                failingCallback,
+                null,
+                1,
+                () -> infra.serverTransportServices().get(0).getLocalNode()
+            );
+
+            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(1);
+            builder.appendInt(42);
+            IntBlock block = builder.build();
+            Page page = new Page(block);
+            client.sendPage(page.withBatchMetadata(new BatchMetadata(0, 0, true)));
+            page.releaseBlocks();
+
+            assertTrue("client should have recorded the setup failure", client.hasFailed());
+
+            // Before the fix, close() emitted WARN because started(1) > completed(0) regardless
+            // of primaryFailure. After the fix the guard suppresses it.
+            String loggerName = BidirectionalBatchExchangeClient.class.getCanonicalName();
+            MockLog.assertThatLogger(
+                client::close,
+                BidirectionalBatchExchangeClient.class,
+                new MockLog.UnseenEventExpectation(
+                    "no spurious WARN for incomplete batches on failure path",
+                    loggerName,
+                    Level.WARN,
+                    "*incomplete batches*"
+                )
+            );
+        } finally {
+            cleanupServices(infra, threadPool);
+        }
+    }
+
+    /**
      * Asserts that {@link BidirectionalBatchExchangeBase#logExchangeFailure}, called with
      * {@code nonCancellationLevel}, logs the given failure at {@code nonCancellationLevel} for a genuine failure,
      * or at DEBUG for a cancellation (which is downgraded), and not at the other of those two levels.


### PR DESCRIPTION
# Fix spurious WARN for incomplete batches + rename log prefixes

## Observed behaviour

`BidirectionalBatchExchangeClient` emitted a WARN on every cancelled or
failed query:

```
[LookupJoinClient] Closing with incomplete batches: started=5, completed=4
```

The counter difference was always exactly 1, regardless of total batch
count — a systematic, not random, signal.

## Root cause

`StreamingLookupFromIndexOperator.cleanupBatchResources()` discards
in-flight batches on the failure path by clearing the active-batch map
without calling `markBatchCompleted`. This leaves
`startedBatchCount = N` and `completedBatchCount = N-1` on every
teardown. The real error was already propagated via
`batchExchangeStatusListener.onFailure()` before `close()` ran, so the
WARN carried no actionable information.

## Fix

Guard the WARN with `primaryFailure.get() == null`. When a failure is
recorded the discrepancy is expected and the WARN is suppressed. The
WARN still fires for a genuine programming error where `primaryFailure`
is null and batches were lost without explanation.

A regression test (`testNoSpuriousIncompletesBatchWarnOnFailure`) drives
the client through a synchronous setup failure, reproducing the exact
counter state seen in production (`started=1, completed=0,
primaryFailure!=null`), and asserts the WARN is absent.

## Remove message prefixes

Log prefixes `[LookupJoinClient]` and `[LookupJoinServer]` have been
removed.  `[BidirectionalBatchExchangeClient]` and
`[BidirectionalBatchExchangeServer]` are already logged in the logger name. 
The classes are designed for reusebeyond lookup join, 
so the old prefixes were misleading for any other consumer.
