### PR TITLE
[9.5] Fix ES|QL approximation confidence interval computation for edge case (#155502)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/approximate/ConfidenceInterval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/approximate/ConfidenceInterval.java
@@ -271,11 +271,15 @@ public class ConfidenceInterval extends EsqlScalarFunction {
         // Collect estimates into an array.
         double[] estimates = new double[estimatesCount];
         boolean allNaNs = true;
+        double minEstimate = Double.MAX_VALUE;
+        double maxEstimate = Double.MIN_VALUE;
         int offset = estimatesBlock.getFirstValueIndex(position);
         for (int i = 0; i < estimatesCount; i++) {
             estimates[i] = estimatesBlock.getDouble(offset + i);
             if (Double.isNaN(estimates[i]) == false) {
                 allNaNs = false;
+                minEstimate = Math.min(minEstimate, estimates[i]);
+                maxEstimate = Math.max(maxEstimate, estimates[i]);
             }
         }
 
@@ -337,6 +341,19 @@ public class ConfidenceInterval extends EsqlScalarFunction {
         // Pick the NaN strategy that gives the mean closest to the best estimate.
         boolean ignoreNaNs = Math.abs(meanIgnoreNan - bestEstimate) < Math.abs(meanZeroNan - bestEstimate);
         double mm = ignoreNaNs ? meanIgnoreNan : meanZeroNan;
+
+        if (ignoreNaNs == false) {
+            minEstimate = Math.min(minEstimate, 0.0);
+            maxEstimate = Math.max(maxEstimate, 0.0);
+        }
+        // Estimates are totally inconsistent with bestEstimate. This can happen for metrics that
+        // are monotonic with sample size, such as MIN, MAX, COUNT_DISTINCT.
+        // Allow a little bit of numerical imprecision in the consistency check, which can happen
+        // due to round-off errors when aggregating zero-variance stats (e.g. AVG(x) BY x).
+        if (bestEstimate < minEstimate - 1e-12 * Math.abs(minEstimate) || bestEstimate > maxEstimate + 1e-12 * Math.abs(maxEstimate)) {
+            resultBuilder.appendNull();
+            return;
+        }
 
         // To compute the reliability of each trial's estimate, we use the skewness and kurtosis
         // of the bucket estimates. Under the null hypothesis these should be zero. If these are
@@ -435,7 +452,6 @@ public class ConfidenceInterval extends EsqlScalarFunction {
             resultBuilder.appendDouble((double) reliableCount / trialCount);
             resultBuilder.endPositionEntry();
         } else {
-
             resultBuilder.appendNull();
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/approximate/ConfidenceIntervalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/approximate/ConfidenceIntervalTests.java
@@ -43,6 +43,7 @@ public class ConfidenceIntervalTests extends AbstractScalarFunctionTestCase {
             nanBuckets_ignoreNan(),
             nanBuckets_zeroNan(),
             inconsistentData(),
+            inconsistentDataThatAccidentallyGivesGoodLookingInterval(),
             manyNans()
         );
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, suppliers);
@@ -173,6 +174,62 @@ public class ConfidenceIntervalTests extends AbstractScalarFunctionTestCase {
                     ),
                     new TestCaseSupplier.TypedData(3, DataType.INTEGER, "trialCount"),
                     new TestCaseSupplier.TypedData(5, DataType.INTEGER, "bucketCount"),
+                    new TestCaseSupplier.TypedData(0.8, DataType.DOUBLE, "confidence_level")
+                ),
+                EVALUATOR_STRING,
+                DataType.DOUBLE,
+                nullValue()
+            )
+        );
+    }
+
+    private static TestCaseSupplier inconsistentDataThatAccidentallyGivesGoodLookingInterval() {
+        return new TestCaseSupplier(
+            "inconsistentDataThatAccidentallyGivesGoodLookingInterval",
+            List.of(DataType.DOUBLE, DataType.DOUBLE, DataType.INTEGER, DataType.INTEGER, DataType.DOUBLE),
+            () -> new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(1358.0, DataType.DOUBLE, "bestEstimate"),
+                    new TestCaseSupplier.TypedData(
+                        List.of(
+                            735.0,
+                            724.0,
+                            711.0,
+                            748.0,
+                            733.0,
+                            789.0,
+                            742.0,
+                            757.0,
+                            747.0,
+                            745.0,
+                            736.0,
+                            743.0,
+                            756.0,
+                            754.0,
+                            739.0,
+                            732.0,
+                            722.0,
+                            728.0,
+                            744.0,
+                            754.0,
+                            717.0,
+                            738.0,
+                            750.0,
+                            735.0,
+                            756.0,
+                            764.0,
+                            728.0,
+                            747.0,
+                            740.0,
+                            747.0,
+                            756.0,
+                            725.0
+                        ),
+                        DataType.DOUBLE,
+                        "estimates"
+                    ),
+                    new TestCaseSupplier.TypedData(2, DataType.INTEGER, "trialCount"),
+                    new TestCaseSupplier.TypedData(16, DataType.INTEGER, "bucketCount"),
                     new TestCaseSupplier.TypedData(0.8, DataType.DOUBLE, "confidence_level")
                 ),
                 EVALUATOR_STRING,


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix ES|QL approximation confidence interval computation for edge case (#155502)