### PR TITLE
ESQL: Unmute StSimplifyPreserveTopologyTests on main

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -74,9 +74,6 @@ tests:
 - class: org.elasticsearch.xpack.prometheus.PrometheusMetadataRestIT
   method: testMultipleEntriesForSameMetricAcrossStreams
   issue: https://github.com/elastic/elasticsearch/issues/147170
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: testEvaluateBlockWithNulls
-  issue: https://github.com/elastic/elasticsearch/issues/147773
 
 # Examples:
 #


### PR DESCRIPTION
Unmutes `StSimplifyPreserveTopologyTests#testEvaluateBlockWithNulls` on main.

The `StackOverflowError` it was muted for is fixed. #151554 capped random test geometries at 100 vertices back in June, but it only credited #150079 -- so this mute got left behind and the test hasn't run on main since April.

Locally with the mute removed: 5720 tests, 0 failures, including 520 runs of this method across 5 seeds (the original failure was seed-dependent).

Closes #147773

<details>
<summary>Evidence and caveats</summary>

**The fix.** #151554 (2026-06-22) added `MAX_TEST_GEOMETRY_POINTS = 100` at `AbstractSpatialGeometryTransformTestCase.java:69`, applied at `:74`/`:76`. Before it, geometries came from nested `GeometryCollection`s of Lucene `nextPolygon()` rings and could reach tens of thousands of vertices, which is what blew the stack in JTS `TaggedLineStringSimplifier.simplifySection`.

**Being precise about causality.** This method's own last failure anywhere was April 2026, and it was already clean through 140,920 pre-fix runs on unmuted 9.4. So the cap isn't demonstrably what fixed *this* method. The cap's effect shows on the class's unmuted siblings on main: 382 failures in May, 143 in June, last on 2026-06-20, then zero from 06-22.

**Strongest safety evidence.** `testEvaluateBlockWithoutNulls` exercises the same evaluator path and has 1,268,442 post-fix runs on main with zero failures, across java-EA, java-matrix, FIPS, Windows and AARCH64 -- covering the JDK spread the original repro used (`-Druntime.java=26`), which 9.4 alone would not.

**Not hiding failures.** The `StackOverflowError` catch #151554 added wraps only the expected-value computation, not the evaluator under test, so a real overflow during evaluation still fails. All suppliers reaching this class are bounded (`testCaseSupplier(...)` capped, `hardcodedSuppliers()` 4-5 vertices).

**Why #145596 stays open.** It's the production-side ticket: a large enough real polygon still hits `StackOverflowError`, because `warnExceptions` at `StSimplifyPreserveTopology.java:220` lists only `IllegalArgumentException`, which can't catch an `Error`. Draft PR #151864 addresses that.

</details>

Assisted by Claude