### PR TITLE
ESQL: Unmute H3SphericalGeometryTests on main

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -17,9 +17,6 @@ tests:
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
-- class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
-  method: testIndexPoints
-  issue: https://github.com/elastic/elasticsearch/issues/142439
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/155496


### PR DESCRIPTION
Unmutes `H3SphericalGeometryTests#testIndexPoints` on main.

The leak it was muted for was never in this test. `MockBigArrays` tracks unreleased arrays JVM-wide and blames whichever suite runs teardown next -- and in all 6 of these failures, `CsvTests` had blown its suite timeout on `mmr.*` tests in the same JVM seconds earlier. #142463 fixed that and unmuted the identical collateral victim (#142442, `RemoteClusterUtilsTests`), but left this one muted by oversight. The MMR trigger has been gone since March.

Locally with the mute removed: 10 iterations, 0 failures.

Closes #142439

<details>
<summary>Evidence and caveats</summary>

**The misattribution mechanism.** `ACQUIRED_ARRAYS` is a `private static final ConcurrentMap` (`MockBigArrays.java:129`), so it's shared by every test in the JVM. The check runs in `ESTestCase`'s `@After` (`ESTestCase.java:704-708`) and *removes* the offending entries (`:140-141`) before throwing (`:161`) -- so one leak is reported exactly once, against an arbitrary suite. `TRACK_ALLOCATIONS` is `false` (`:127`), so no allocation stack points at the real allocator. This class touches only Lucene geo and H3 code and constructs no `MockBigArrays`.

**Co-occurrence, all 6 builds.** `CsvTests` suite timeout vs H3 report, within 0-1s each time: `wq7bj37idvje6` 20:30:22/20:30:22, `xlcrsg7tecde4` 22:29:02/22:29:03, `u76iq2xzxoozm` 00:47:22/00:47:22, `yxhtjcp5xnwps` 01:11:59/01:12:00, `fsvue5nrydzyk` 02:07:31/02:07:31, `k5hvg7jjrheei` 15:39:25/15:39:26. The same message also hit `AnalyzerUnmappedTests` (3) and `RemoteClusterUtilsTests` (2) in that window.

**Trigger gone.** `mmr.*` csv-spec failures: 165 in the week of 2026-02-09, then 7, 1, 1, 9, and zero since the week of 2026-03-30. #142437 (`MMROperatorTests`, page release) closed completed 2026-03-03 and is unmuted on main.

**The signature is not extinct.** `N arrays have not been released` has appeared since February -- 02-23 (`QueriesTests`, "2 arrays"), 03-05 and 03-27 (`esql:compute`), 05-19 and 06-15/16 (`StatelessTranslogIT`). Different tasks, so different JVMs, and different counts, so not the MMR trigger -- but by the mechanism above, any of them could equally blame an innocent suite.

**Coverage honesty.** `testIndexPoints` is the only test method here, but the ES|QL `H3SphericalGeometry` has no caller in the esql module: `H3SphericalUtil.getLatLonGeometry` is its only constructor and nothing in esql invokes it, while ES|QL's live H3 path is `computeGeoBounds` via `GeoHexBoundedPredicate`. So this is about removing a stale mute and matching #142442's disposition, not recovering valuable coverage.

**Scope.** main only; 9.4 keeps its own mute, which will point at a closed issue after this merges. Also note the assertion is JVM-wide, so running this class alone cannot reproduce cross-contamination by construction.

</details>

Assisted by Claude