### PR TITLE
Deflake stats_first_last TO_LONG warning tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -544,9 +544,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.objectstore.gc.StaleTranslogsGCIT
   method: testIsolatedNodeDoesNotDeleteTranslogs
   issue: https://github.com/elastic/elasticsearch/issues/155130
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsFirstLastIT
-  method: test {csv-spec:stats_first_last.Test aggregating on integers from row}
-  issue: https://github.com/elastic/elasticsearch/issues/153700
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/153434

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_first_last.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_first_last.csv-spec
@@ -49,8 +49,8 @@ ROW row = [
 | STATS first_val = FIRST(number, @timestamp)
 ;
 
-warning:Line 15:10: evaluation of [TO_LONG(number)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number []
+warningRegex:Line 15:10: evaluation of \[TO_LONG\(number\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[\]
 
 first_val:long
 null
@@ -112,8 +112,8 @@ ROW row = [
 | STATS last_val = LAST(number, @timestamp) BY name
 ;
 
-warning:Line 15:10: evaluation of [TO_LONG(number)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number []
+warningRegex:Line 15:10: evaluation of \[TO_LONG\(number\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[\]
 
 last_val:long | name:keyword
 4             | alpha
@@ -427,8 +427,8 @@ ROW row = [
         last_val = LAST(@timestamp, number)
 ;
 
-warning:Line 15:10: evaluation of [TO_LONG(number)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number []
+warningRegex:Line 15:10: evaluation of \[TO_LONG\(number\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 15:10: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[\]
 
 first_val:datetime       | last_val:datetime
 2025-11-25T00:00:01.000Z | 2025-11-25T00:00:05.000Z


### PR DESCRIPTION
Test:                                                                                                     
- stats_first_last.Test aggregating on integers from row                                                  

is flaky and currently muted in #153700                                                 

The test converts empty strings with `TO_LONG(number)`, which fails and emits two warnings per query.                                                                         

The results are always correct, but the warnings can potentially go                                       
missing because ES|QL propagates warnings via ThreadLocals and the header is occasionally lost in transit. 

## What this PR does                                                                                      
The root cause is not in FIRST/LAST and can't be fixed there. Instead it:                                 

1. Relaxes the csv-spec assertions from `warning:` to `warningRegex:` for the affected case.                                                                                 
2. Applies the same change to the two identical sibling blocks in the                                 file ("Test retrieval of first long by timestamp" and "Test                                            
retrieval of last long by timestamp") that have the same query shape, same                                         
warnings, same harness which would flake the same way.              
3. Unmutes the affected case.                                                                             
                                 

Unlike #152679 and #155524, no new deterministic test is needed: the dropped                                    warnings are the generic TO_LONG conversion warnings, not                                                 
FIRST/LAST-specific, and `ToLongTests` already asserts the exact                                          
warning pair on the test thread.                                             
                                       

This is the same approach as #152679 and #155524.                                           

This does not fix the underlying warning-propagation race (#139262 /                                      
#147330); it makes the tests reliable. The alternative is to keep the                                     
case muted until #147330 lands.                                                                           

Closes #153700                        