### PR TITLE
Support concurrent uploads in GCS

### DIFF
--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.nio.file.NoSuchFileException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
 
@@ -99,6 +100,23 @@ class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
         CheckedConsumer<OutputStream, IOException> writer
     ) throws IOException {
         blobStore.writeBlob(purpose, buildKey(blobName), failIfAlreadyExists, writer);
+    }
+
+    @Override
+    public boolean supportsConcurrentMultipartUploads() {
+        return blobStore.supportsParallelCompositeUpload();
+    }
+
+    @Override
+    public void writeBlobAtomic(
+        OperationPurpose purpose,
+        String blobName,
+        long blobSize,
+        BlobMultiPartInputStreamProvider provider,
+        boolean failIfAlreadyExists,
+        Executor executor
+    ) throws IOException {
+        blobStore.writeParallelCompositeBlob(purpose, buildKey(blobName), blobSize, provider, failIfAlreadyExists);
     }
 
     @Override

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.common.BackoffPolicy;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobContainer.BlobMultiPartInputStreamProvider;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.BlobStoreActionStats;
@@ -424,9 +425,53 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         }
     }
 
+    /**
+     * Uploads a blob using GCS parallel composite upload
+     *
+     * @param purpose             the operation purpose
+     * @param blobName            the full key of the target blob (including path prefix)
+     * @param blobSize            the exact number of bytes in the blob
+     * @param provider            supplies an {@link java.io.InputStream} for the full blob content
+     * @param failIfAlreadyExists whether to throw a {@link java.nio.file.FileAlreadyExistsException}
+     *                            if the target blob already exists
+     */
+    void writeParallelCompositeBlob(
+        OperationPurpose purpose,
+        String blobName,
+        long blobSize,
+        BlobMultiPartInputStreamProvider provider,
+        boolean failIfAlreadyExists
+    ) throws IOException {
+        // TODO: this currently uses the write thread pool
+        assert purpose != OperationPurpose.SNAPSHOT_DATA && purpose != OperationPurpose.SNAPSHOT_METADATA;
+        if (blobSize <= getLargeBlobThresholdInBytes()) {
+            try (var inputStream = provider.apply(0L, blobSize)) {
+                writeBlob(purpose, blobName, inputStream, blobSize, failIfAlreadyExists);
+            }
+            return;
+        }
+        final BlobInfo blobInfo = applyStorageClass(BlobInfo.newBuilder(bucketName, blobName), purpose).build();
+        final Storage.BlobWriteOption[] writeOptions = failIfAlreadyExists ? NO_OVERWRITE_NO_MD5 : OVERWRITE_NO_MD5;
+        try (var inputStream = provider.apply(0L, blobSize)) {
+            client().meteredParallelCompositeUpload(purpose, blobInfo, inputStream, bufferSize, writeOptions);
+        } catch (IOException e) {
+            if (failIfAlreadyExists) {
+                final StorageException se = (StorageException) ExceptionsHelper.unwrap(e, StorageException.class);
+                if (se != null && se.getCode() == HTTP_PRECON_FAILED) {
+                    throw new FileAlreadyExistsException(blobName, null, se.getMessage());
+                }
+            }
+            throw e;
+        }
+    }
+
     // non-static, package private for testing
     long getLargeBlobThresholdInBytes() {
         return LARGE_BLOB_THRESHOLD_BYTE_SIZE;
+    }
+
+    boolean supportsParallelCompositeUpload() {
+        return storageService.supportsParallelCompositeUpload();
     }
 
     // possible options for #writeBlobResumable uploads

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,6 +56,8 @@ import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -67,11 +70,19 @@ public class GoogleCloudStorageService {
     private final GoogleCloudStorageClientsManager clientsManager;
 
     private final boolean isServerless;
+    @Nullable
+    private final Executor parallelCompositeUploadExecutor;
 
     public GoogleCloudStorageService(ClusterService clusterService, ProjectResolver projectResolver) {
         final Settings nodeSettings = clusterService.getSettings();
         this.isServerless = DiscoveryNode.isStateless(nodeSettings);
         this.clientsManager = new GoogleCloudStorageClientsManager(nodeSettings, projectResolver.supportsMultipleProjects());
+        // For parallel composite uploads, the calling thread blocks on tasks submitted to this executor, causing a deadlock if the thread
+        // pool only has 1 thread or is a DeterministicTaskQueue
+        Executor writeExecutor = clusterService.threadPool().executor(ThreadPool.Names.WRITE);
+        this.parallelCompositeUploadExecutor = writeExecutor instanceof ThreadPoolExecutor pool && pool.getCorePoolSize() > 1
+            ? writeExecutor
+            : null;
         if (projectResolver.supportsMultipleProjects()) {
             clusterService.addHighPriorityApplier(this.clientsManager);
         }
@@ -114,6 +125,10 @@ public class GoogleCloudStorageService {
         final GcsRepositoryStatsCollector statsCollector
     ) throws IOException {
         return clientsManager.client(projectId, clientName, repositoryName, statsCollector);
+    }
+
+    boolean supportsParallelCompositeUpload() {
+        return parallelCompositeUploadExecutor != null;
     }
 
     GoogleCloudStorageClientSettings clientSettings(@Nullable ProjectId projectId, final String clientName) {
@@ -188,7 +203,7 @@ public class GoogleCloudStorageService {
         };
 
         final StorageOptions storageOptions = createStorageOptions(gcsClientSettings, httpTransportOptions);
-        return new MeteredStorage(storageOptions.getService(), statsCollector);
+        return new MeteredStorage(storageOptions.getService(), statsCollector, parallelCompositeUploadExecutor);
     }
 
     StorageOptions createStorageOptions(

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
@@ -18,20 +18,29 @@ import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BlobWriteSession;
+import com.google.cloud.storage.BlobWriteSessionConfigs;
 import com.google.cloud.storage.CopyWriter;
+import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.spi.v1.HttpStorageRpc;
 
 import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Streams;
 import org.elasticsearch.core.SuppressForbidden;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.util.Iterator;
 import java.util.OptionalInt;
+import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.repositories.gcs.StorageOperation.COPY;
@@ -49,17 +58,49 @@ public class MeteredStorage {
     private final Storage storage;
     private final com.google.api.services.storage.Storage storageRpc;
     private final GcsRepositoryStatsCollector statsCollector;
+    @Nullable
+    private final Storage parallelCompositeUploadStorage;
+    private final ThreadLocal<OperationPurpose> callPurpose = new ThreadLocal<>();
 
-    public MeteredStorage(Storage storage, GcsRepositoryStatsCollector statsCollector) {
+    public MeteredStorage(Storage storage, GcsRepositoryStatsCollector statsCollector, @Nullable Executor parallelCompositeUploadExecutor) {
         this.storage = storage;
         this.storageRpc = getStorageRpc(storage);
         this.statsCollector = statsCollector;
+        if (parallelCompositeUploadExecutor != null) {
+            final Executor meteringExecutor = task -> {
+                // callPurpose set on the calling thread before tasks are submitted
+                final OperationPurpose purpose = callPurpose.get();
+                assert purpose != null;
+                parallelCompositeUploadExecutor.execute(() -> {
+                    callPurpose.set(purpose);
+                    try {
+                        statsCollector.collectRunnable(purpose, INSERT, task);
+                    } finally {
+                        callPurpose.remove();
+                    }
+                });
+            };
+            this.parallelCompositeUploadStorage = storage.getOptions()
+                .toBuilder()
+                .setBlobWriteSessionConfig(
+                    BlobWriteSessionConfigs.parallelCompositeUpload()
+                        .withExecutorSupplier(ParallelCompositeUploadBlobWriteSessionConfig.ExecutorSupplier.useExecutor(meteringExecutor))
+                        .withPartNamingStrategy(ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy.useObjectNameAsPrefix())
+                        .withPartCleanupStrategy(ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy.always())
+                )
+                .build()
+                .getService();
+        } else {
+            this.parallelCompositeUploadStorage = null;
+        }
     }
 
+    // for testing
     MeteredStorage(Storage storage, com.google.api.services.storage.Storage storageRpc, GcsRepositoryStatsCollector statsCollector) {
         this.storage = storage;
         this.storageRpc = storageRpc;
         this.statsCollector = statsCollector;
+        this.parallelCompositeUploadStorage = null;
     }
 
     @SuppressForbidden(reason = "need access to storage client")
@@ -339,6 +380,34 @@ public class MeteredStorage {
             public Iterator<Blob> iterator() {
                 return new MeteredIterator(iterable.iterator());
             }
+        }
+    }
+
+    /**
+     * Uploads a blob using GCS parallel composite upload
+     *
+     * @param purpose      the operation purpose
+     * @param blobInfo     metadata for the target blob
+     * @param inputStream  full content of the blob to upload
+     * @param bufferSize   copy-buffer size in bytes used when streaming data into the channel
+     * @param writeOptions write options such as {@code doesNotExist()} for conditional writes
+     */
+    public void meteredParallelCompositeUpload(
+        OperationPurpose purpose,
+        BlobInfo blobInfo,
+        InputStream inputStream,
+        int bufferSize,
+        Storage.BlobWriteOption... writeOptions
+    ) throws IOException {
+        assert parallelCompositeUploadStorage != null;
+        callPurpose.set(purpose);
+        try {
+            final BlobWriteSession session = parallelCompositeUploadStorage.blobWriteSession(blobInfo, writeOptions);
+            try (WritableByteChannel channel = session.open()) {
+                Streams.copy(inputStream, Channels.newOutputStream(channel), new byte[bufferSize]);
+            }
+        } finally {
+            callPurpose.remove();
         }
     }
 

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -24,10 +24,12 @@ import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -128,6 +130,9 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
             ClusterServiceUtils.createClusterService(new DeterministicTaskQueue().getThreadPool())
         );
         when(pluginServices.projectResolver()).thenReturn(TestProjectResolvers.DEFAULT_PROJECT_ONLY);
+        final var threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(ThreadPool.Names.WRITE)).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        when(pluginServices.threadPool()).thenReturn(threadPool);
         try (GoogleCloudStoragePlugin plugin = new GoogleCloudStoragePlugin(settings1)) {
             plugin.createComponents(pluginServices);
             final GoogleCloudStorageService storageService = plugin.storageService.get();
@@ -172,6 +177,9 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
             ClusterServiceUtils.createClusterService(new DeterministicTaskQueue().getThreadPool())
         );
         when(pluginServices.projectResolver()).thenReturn(TestProjectResolvers.DEFAULT_PROJECT_ONLY);
+        final var threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(ThreadPool.Names.WRITE)).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        when(pluginServices.threadPool()).thenReturn(threadPool);
         try (GoogleCloudStoragePlugin plugin = new GoogleCloudStoragePlugin(settings)) {
             plugin.createComponents(pluginServices);
             final GoogleCloudStorageService storageService = plugin.storageService.get();

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -35,13 +35,17 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.zip.CRC32C;
 import java.util.zip.GZIPInputStream;
 
 import static fixture.gcs.MockGcsBlobStore.failAndThrow;
@@ -225,7 +229,8 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                         multipartUpload.name(),
                         ifGenerationMatch,
                         multipartUpload.content(),
-                        emptyToNull(multipartUpload.storageClass())
+                        emptyToNull(multipartUpload.storageClass()),
+                        multipartUpload.userMetadata()
                     );
                     writeBlobVersionAsJson(exchange, newBlobVersion);
                 } catch (IllegalArgumentException e) {
@@ -284,6 +289,23 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                 // don't fail deletes here, fixture will inject failures before reaching this point
                 final var deleteStatus = deleteObject(object);
                 exchange.sendResponseHeaders(deleteStatus.getStatus(), -1);
+            } else if (Regex.simpleMatch("POST /storage/v1/b/" + bucket + "/o/*compose*", request)) {
+                // Compose Object https://cloud.google.com/storage/docs/json_api/v1/objects/compose
+                final String rawPath = exchange.getRequestURI().getPath();
+                final String prefix = "/storage/v1/b/" + bucket + "/o/";
+                final String destObject = URLDecoder.decode(
+                    rawPath.substring(prefix.length(), rawPath.length() - "/compose".length()),
+                    UTF_8
+                );
+                final Long ifGenerationMatch = parseOptionalLongParameter(exchange, IF_GENERATION_MATCH);
+                final List<String> sourceNames = parseComposeSourceNames(requestBody);
+                final MockGcsBlobStore.BlobVersion composed = mockGcsBlobStore.compose(
+                    sourceNames,
+                    destObject,
+                    ifGenerationMatch,
+                    parseStorageClass(requestBody)
+                );
+                writeBlobVersionAsJson(exchange, composed);
             } else if (Regex.simpleMatch("POST /storage/v1/b/" + bucket + "/o*/rewriteTo/b/" + bucket + "/o/*", request)) {
                 final var matcher = REWRITE_PATTERN.matcher(request);
                 if (matcher.find() == false) {
@@ -556,6 +578,19 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         }
     }
 
+    private static String computeCrc32c(BytesReference content) {
+        final CRC32C crc32c = new CRC32C();
+        final byte[] bytes = BytesReference.toBytes(content);
+        crc32c.update(bytes);
+        final long value = crc32c.getValue();
+        final byte[] encoded = new byte[4];
+        encoded[0] = (byte) ((value >> 24) & 0xff);
+        encoded[1] = (byte) ((value >> 16) & 0xff);
+        encoded[2] = (byte) ((value >> 8) & 0xff);
+        encoded[3] = (byte) (value & 0xff);
+        return Base64.getEncoder().encodeToString(encoded);
+    }
+
     private static void writeBlobAsXContent(
         MockGcsBlobStore.BlobVersion blobVersion,
         XContentBuilder builder,
@@ -574,8 +609,12 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         builder.field("size", String.valueOf(blobVersion.contents().length()));
         builder.field("generation", String.valueOf(blobVersion.generation()));
         builder.field("updated", ISO_MILLIS_UTC.format(blobVersion.lastModified()));
+        builder.field("crc32c", computeCrc32c(blobVersion.contents()));
         if (blobVersion.storageClass() != null) {
             builder.field("storageClass", blobVersion.storageClass());
+        }
+        if (blobVersion.userMetadata() != null) {
+            builder.field("metadata", blobVersion.userMetadata());
         }
         builder.endObject();
     }
@@ -605,7 +644,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
      * without going through the HTTP API.
      */
     public void putBlob(String path, BytesReference contents) {
-        mockGcsBlobStore.updateBlob(path, null, contents, null);
+        mockGcsBlobStore.updateBlob(path, null, contents, null, null);
     }
 
     /**
@@ -617,6 +656,30 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
     }
 
     private static final Pattern STORAGE_CLASS_PATTERN = Pattern.compile("\"storageClass\"\\s*:\\s*\"([^\"]*)\"");
+    private static final Pattern COMPOSE_SOURCE_NAME_PATTERN = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]*)\"");
+    private static final Pattern COMPOSE_SOURCE_OBJECTS_PATTERN = Pattern.compile("\"sourceObjects\"\\s*:\\s*\\[(.*?)]", Pattern.DOTALL);
+
+    private static List<String> parseComposeSourceNames(BytesReference body) throws IOException {
+        final String content;
+        if (isGzip(body)) {
+            try (var in = new GZIPInputStream(body.streamInput())) {
+                content = new String(in.readAllBytes(), UTF_8);
+            }
+        } else {
+            content = body.utf8ToString();
+        }
+        final var sourceObjectsMatcher = COMPOSE_SOURCE_OBJECTS_PATTERN.matcher(content);
+        if (sourceObjectsMatcher.find() == false) {
+            return List.of();
+        }
+        final String sourceObjectsContent = sourceObjectsMatcher.group(1);
+        final List<String> names = new ArrayList<>();
+        final var nameMatcher = COMPOSE_SOURCE_NAME_PATTERN.matcher(sourceObjectsContent);
+        while (nameMatcher.find()) {
+            names.add(nameMatcher.group(1));
+        }
+        return names;
+    }
 
     /**
      * Extracts the {@code storageClass} field from a request body containing GCS object metadata JSON. The body may be gzip-compressed

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MockGcsBlobStore.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MockGcsBlobStore.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +43,14 @@ public class MockGcsBlobStore {
     private final ConcurrentMap<String, ResumableUpload> resumableUploads = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Rewrite> ongoingRewrites = new ConcurrentHashMap<>();
 
-    record BlobVersion(String path, long generation, BytesReference contents, Instant lastModified, @Nullable String storageClass) {}
+    record BlobVersion(
+        String path,
+        long generation,
+        BytesReference contents,
+        Instant lastModified,
+        @Nullable String storageClass,
+        @Nullable Map<String, String> userMetadata
+    ) {}
 
     record ResumableUpload(
         String uploadId,
@@ -122,7 +130,13 @@ public class MockGcsBlobStore {
         return blob;
     }
 
-    BlobVersion updateBlob(String path, Long ifGenerationMatch, BytesReference contents, @Nullable String storageClass) {
+    BlobVersion updateBlob(
+        String path,
+        Long ifGenerationMatch,
+        BytesReference contents,
+        @Nullable String storageClass,
+        @Nullable Map<String, String> userMetadata
+    ) {
         return blobs.compute(path, (name, existing) -> {
             if (existing != null) {
                 if (ifGenerationMatch != null) {
@@ -138,7 +152,7 @@ public class MockGcsBlobStore {
                         );
                     }
                 }
-                return new BlobVersion(path, existing.generation + 1, contents, Instant.now(), storageClass);
+                return new BlobVersion(path, existing.generation + 1, contents, Instant.now(), storageClass, userMetadata);
             } else {
                 if (ifGenerationMatch != null && ifGenerationMatch != 0) {
                     throw new GcsRestException(
@@ -146,7 +160,7 @@ public class MockGcsBlobStore {
                         "Blob does not exist, expected generation " + ifGenerationMatch
                     );
                 }
-                return new BlobVersion(path, 1, contents, Instant.now(), storageClass);
+                return new BlobVersion(path, 1, contents, Instant.now(), storageClass, userMetadata);
             }
         });
     }
@@ -208,7 +222,13 @@ public class MockGcsBlobStore {
             if (valueToReturn.completed) {
                 updateResponse.set(new UpdateResponse(RestStatus.OK.getStatus(), valueToReturn.getRange(), valueToReturn.length()));
             } else if (contentRange.hasSize() && contentRange.size() == valueToReturn.contents.length()) {
-                updateBlob(valueToReturn.path(), valueToReturn.ifGenerationMatch(), valueToReturn.contents, valueToReturn.storageClass());
+                updateBlob(
+                    valueToReturn.path(),
+                    valueToReturn.ifGenerationMatch(),
+                    valueToReturn.contents,
+                    valueToReturn.storageClass(),
+                    null
+                );
                 valueToReturn = valueToReturn.complete();
                 updateResponse.set(new UpdateResponse(RestStatus.OK.getStatus(), valueToReturn.getRange(), valueToReturn.length()));
             } else {
@@ -224,6 +244,20 @@ public class MockGcsBlobStore {
 
     boolean deleteBlob(String path) {
         return blobs.remove(path) != null;
+    }
+
+    BlobVersion compose(List<String> sourceNames, String destinationPath, Long ifGenerationMatch, @Nullable String storageClass) {
+        final List<BytesReference> parts = new ArrayList<>(sourceNames.size());
+        for (String name : sourceNames) {
+            parts.add(getBlob(name, null, null).contents());
+        }
+        return updateBlob(
+            destinationPath,
+            ifGenerationMatch,
+            CompositeBytesReference.of(parts.toArray(BytesReference[]::new)),
+            storageClass,
+            null
+        );
     }
 
     record Rewrite(
@@ -277,7 +311,7 @@ public class MockGcsBlobStore {
                     totalBytesRewritten,
                     objectSize,
                     done ? null : newRewriteToken,
-                    done ? updateBlob(dstPath, null, rewrite.srcContents, rewrite.dstStorageClass()) : null
+                    done ? updateBlob(dstPath, null, rewrite.srcContents, rewrite.dstStorageClass(), null) : null
                 )
             );
             // Save entry if not done or previously was saved with rewrite token

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MultipartUpload.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MultipartUpload.java
@@ -16,7 +16,11 @@ import org.elasticsearch.common.bytes.CompositeBytesReference;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public record MultipartUpload(
@@ -26,20 +30,32 @@ public record MultipartUpload(
     String crc32,
     String md5,
     String storageClass,
+    Map<String, String> userMetadata,
     BytesReference content
 ) {
 
     static final Pattern METADATA_PATTERN = Pattern.compile("\"(bucket|name|generation|crc32c|md5Hash|storageClass)\":\"([^\"]*)\"");
+    private static final Pattern USER_METADATA_BLOCK_PATTERN = Pattern.compile("\"metadata\":\\{([^}]*)}");
+    private static final Pattern USER_METADATA_ENTRY_PATTERN = Pattern.compile("\"([^\"]+)\":\"([^\"]*)\"");
 
     /**
      * Reads HTTP content of MultipartUpload. First part is always json metadata, followed by binary parts.
      */
-    public static MultipartUpload parseBody(HttpExchange exchange, InputStream gzipInput) throws IOException {
-        final var reader = MultipartContent.Reader.readGzipStream(exchange, gzipInput);
+    public static MultipartUpload parseBody(HttpExchange exchange, InputStream input) throws IOException {
+        final PushbackInputStream peeking = new PushbackInputStream(input, 2);
+        final int b1 = peeking.read();
+        final int b2 = peeking.read();
+        peeking.unread(b2);
+        peeking.unread(b1);
+        final boolean isGzip = (b1 & 0xff) == 0x1f && (b2 & 0xff) == 0x8b;
+        final var reader = isGzip
+            ? MultipartContent.Reader.readGzipStream(exchange, peeking)
+            : MultipartContent.Reader.readStream(MultipartContent.Reader.getBoundary(exchange), peeking);
 
         // read first body-part - blob metadata json
         final var firstPart = reader.next();
-        final var match = METADATA_PATTERN.matcher(firstPart.content().utf8ToString());
+        final String metadataJson = firstPart.content().utf8ToString();
+        final var match = METADATA_PATTERN.matcher(metadataJson);
         String bucket = "", name = "", gen = "", crc = "", md5 = "", storageClass = "";
         while (match.find()) {
             switch (match.group(1)) {
@@ -52,6 +68,8 @@ public record MultipartUpload(
             }
         }
 
+        final Map<String, String> userMetadata = parseUserMetadata(metadataJson);
+
         // read and combine remaining parts
         final var blobParts = new ArrayList<BytesReference>();
         while (reader.hasNext()) {
@@ -59,7 +77,20 @@ public record MultipartUpload(
         }
         final var compositeBuf = CompositeBytesReference.of(blobParts.toArray(new BytesReference[0]));
 
-        return new MultipartUpload(bucket, name, gen, crc, md5, storageClass, compositeBuf);
+        return new MultipartUpload(bucket, name, gen, crc, md5, storageClass, userMetadata, compositeBuf);
+    }
+
+    private static Map<String, String> parseUserMetadata(String json) {
+        final Matcher blockMatcher = USER_METADATA_BLOCK_PATTERN.matcher(json);
+        if (blockMatcher.find() == false) {
+            return null;
+        }
+        final Matcher entryMatcher = USER_METADATA_ENTRY_PATTERN.matcher(blockMatcher.group(1));
+        final Map<String, String> result = new LinkedHashMap<>();
+        while (entryMatcher.find()) {
+            result.put(entryMatcher.group(1), entryMatcher.group(2));
+        }
+        return result.isEmpty() ? null : result;
     }
 
 }

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -103,14 +103,14 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertJsonResponseBody(
             new TestHttpResponse(RestStatus.OK, Strings.format("""
                 {"kind":"storage#objects","items":[{"kind":"storage#object","bucket":"%s","name":"%s","id":"%s","size":"50",\
-                "generation":"1","updated":"2024-01-01T00:00:00.000Z"}],"prefixes":[]}""", bucket, blobName, blobName)),
+                "generation":"1","updated":"2024-01-01T00:00:00.000Z","crc32c":"*"}],"prefixes":[]}""", bucket, blobName, blobName)),
             listBlobs(handler, bucket, null, null)
         );
 
         assertJsonResponseBody(
             new TestHttpResponse(RestStatus.OK, Strings.format("""
                 {"kind":"storage#objects","items":[{"kind":"storage#object","bucket":"%s","name":"%s","id":"%s","size":"50",\
-                "generation":"1","updated":"2024-01-01T00:00:00.000Z"}],"prefixes":[]}""", bucket, blobName, blobName)),
+                "generation":"1","updated":"2024-01-01T00:00:00.000Z","crc32c":"*"}],"prefixes":[]}""", bucket, blobName, blobName)),
             listBlobs(handler, bucket, "path/", null)
         );
 
@@ -387,7 +387,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertJsonResponseBody(
             new TestHttpResponse(RestStatus.OK, Strings.format("""
                 {"kind":"storage#objects","items":[{"kind":"storage#object","bucket":"%s","name":"%s","id":"%s","size":"130",\
-                "generation":"1","updated":"2024-01-01T00:00:00.000Z"}],"prefixes":[]}""", bucket, blobName, blobName)),
+                "generation":"1","updated":"2024-01-01T00:00:00.000Z","crc32c":"*"}],"prefixes":[]}""", bucket, blobName, blobName)),
             handleRequest(handler, "GET", "/storage/v1/b/" + bucket + "/o")
         );
 
@@ -395,7 +395,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertJsonResponseBody(
             new TestHttpResponse(RestStatus.OK, Strings.format("""
                 {"kind":"storage#object","bucket":"%s","name":"%s","id":"%s","size":"130","generation":"1",\
-                "updated":"2024-01-01T00:00:00.000Z"}""", bucket, blobName, blobName)),
+                "updated":"2024-01-01T00:00:00.000Z","crc32c":"*"}""", bucket, blobName, blobName)),
             handleRequest(handler, "GET", "/storage/v1/b/" + bucket + "/o/" + blobName)
         );
     }
@@ -802,7 +802,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     }
 
     private static String normalizeUpdated(String json) {
-        return json.replaceAll("\"updated\":\"[^\"]+\"", "\"updated\":\"*\"");
+        return json.replaceAll("\"updated\":\"[^\"]+\"", "\"updated\":\"*\"").replaceAll("\"crc32c\":\"[^\"]+\"", "\"crc32c\":\"*\"");
     }
 
     private record TestHttpResponse(int status, BytesReference body, Headers headers) {

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/GoogleObjectStoreTests.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/GoogleObjectStoreTests.java
@@ -22,7 +22,9 @@ import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoryStats;
@@ -34,6 +36,7 @@ import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collection;
@@ -46,6 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 
@@ -188,6 +192,43 @@ public class GoogleObjectStoreTests extends AbstractMockObjectStoreIntegTestCase
             ) {
                 assertArrayEquals(BytesReference.toBytes(blobData), is.readAllBytes());
             }
+        } finally {
+            internalCluster().stopNode(node);
+        }
+    }
+
+    public void testWriteBlobAtomicViaParallelCompositeUpload() throws Exception {
+        final String node = startMasterAndIndexNode();
+        try {
+            final var objectStoreService = getCurrentMasterObjectStoreService();
+
+            final String indexName = randomIdentifier();
+            createIndex(indexName, indexSettings(1, 0).build());
+            final var shardId = new ShardId(resolveIndex(indexName), 0);
+            final long primaryTerm = 1L;
+
+            final var blobContainer = objectStoreService.getProjectBlobContainer(shardId, primaryTerm);
+            assumeTrue("PCU requires a multi-threaded WRITE pool", blobContainer.supportsConcurrentMultipartUploads());
+            Set<String> blobs = new HashSet<>(blobContainer.listBlobs(OperationPurpose.INDICES).keySet());
+
+            // LARGE_BLOB_THRESHOLD_BYTE_SIZE is 5MB
+            final byte[] blobContent = randomByteArrayOfLength((int) ByteSizeValue.ofMb(randomIntBetween(6, 30)).getBytes());
+            final String blobName = "test_parallel_composite_upload_blob";
+            blobContainer.writeBlobAtomic(
+                OperationPurpose.INDICES,
+                blobName,
+                blobContent.length,
+                (offset, length) -> new ByteArrayInputStream(blobContent, Math.toIntExact(offset), Math.toIntExact(length)),
+                false,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE
+            );
+
+            try (var readBack = blobContainer.readBlob(OperationPurpose.INDICES, blobName)) {
+                assertArrayEquals(blobContent, readBack.readAllBytes());
+            }
+            blobs.add(blobName);
+            // check that temp blobs were deleted
+            assertThat(blobContainer.listBlobs(OperationPurpose.INDICES).keySet(), equalTo(blobs));
         } finally {
             internalCluster().stopNode(node);
         }


### PR DESCRIPTION
GCS does concurrent uploads via [parallel composite uploads](https://docs.cloud.google.com/storage/docs/parallel-composite-uploads). The SDK uploads the blob in chunks and uses the [compose API](https://cloud.google.com/storage/docs/json_api/v1/objects/compose) to concatenate these chunks into a new blob.

Parallel composite uploads are configured via `BlobWriteSessionConfigs` for the client `Storage` class and allows supplying an executor. We save these `Storage` instances in `MeteredStorage`, which we cache, making it difficult to use the executor supplied by the `BlobContainer` concurrent upload method `writeBlobAtomic`. I added another `Storage` instance to each `MeteredStorage` client that always uses the write thread pool. This will need to change if we use concurrent uploads for snapshots in the future.

In the SDK parallel composite upload implementation, the calling thread blocks on the tasks submitted to the executor, resulting in a deadlock if the thread pool only has 1 thread or is a `DeterministicTaskQueue` as used in tests. I added a check to disable parallel composite uploads in these cases.

For the multithreaded parallel composite upload, I wrapped the write thread pool executor it uses to collect stats. Since the stats collector needs an `OperationPurpose`, I added a `ThreadLocal<OperationPurpose>` to `MeteredStorage` for the calling thread to pass onto the threads running the concurrent uploads.