### PR TITLE
[8.19] Migrate snapshot-based-recoveries qa/fs to JUnit rule cluster (#154487)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -59,7 +59,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:rolling-upgrade");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-based-recoveries:qa:fs");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-based-recoveries:qa:license-enforcing");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-repo-test-kit:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:sql:qa:jdbc:multi-node");

--- a/x-pack/plugin/snapshot-based-recoveries/qa/fs/build.gradle
+++ b/x-pack/plugin/snapshot-based-recoveries/qa/fs/build.gradle
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
-
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('snapshot-based-recoveries'))))
 }
-
-final File repoDir = file("$buildDir/testclusters/snapshot-recoveries-repo")
 
 restResources {
   restApi {
@@ -22,18 +18,6 @@ restResources {
   }
 }
 
-tasks.withType(Test).configureEach {
-  doFirst {
-    delete(repoDir)
-  }
-  nonInputProperties.systemProperty 'tests.path.repo', repoDir
-}
-
-testClusters.matching { it.name == "javaRestTest" }.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 3
-
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'path.repo', repoDir.absolutePath, IGNORE_VALUE
-  setting 'xpack.security.enabled', 'false'
+tasks.named("javaRestTest").configure {
+  usesDefaultDistribution("requires DEFAULT distribution for trial license and snapshot-based recovery")
 }

--- a/x-pack/plugin/snapshot-based-recoveries/qa/fs/src/javaRestTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/FsSnapshotBasedRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/qa/fs/src/javaRestTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/FsSnapshotBasedRecoveryIT.java
@@ -8,8 +8,32 @@
 package org.elasticsearch.xpack.snapshotbasedrecoveries.recovery;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 public class FsSnapshotBasedRecoveryIT extends AbstractSnapshotBasedRecoveryRestTestCase {
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .nodes(3)
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+        .setting("xpack.security.enabled", "false")
+        .build();
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @Override
     protected String repositoryType() {
@@ -18,6 +42,6 @@ public class FsSnapshotBasedRecoveryIT extends AbstractSnapshotBasedRecoveryRest
 
     @Override
     protected Settings repositorySettings() {
-        return Settings.builder().put("location", System.getProperty("tests.path.repo")).build();
+        return Settings.builder().put("location", repoDirectory.getRoot().getPath()).build();
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate snapshot-based-recoveries qa/fs to JUnit rule cluster (#154487)](https://github.com/elastic/elasticsearch/pull/154487)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)