### PR TITLE
Add index_terms parameter to long field type

### DIFF
--- a/docs/changelog/155545.yaml
+++ b/docs/changelog/155545.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 155545
+summary: Add `index_terms` parameter to long field type
+type: feature

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -137,9 +137,19 @@ public class NumberFieldMapper extends FieldMapper {
      * Encodes an integer into the term used by the {@code index_terms} inverted index, such that
      * unsigned byte-wise (lexicographic) term order matches numeric order.
      */
-    static BytesRef encodeIndexTerm(int value) {
+    static BytesRef encodeIntIndexTerm(int value) {
         byte[] bytes = new byte[Integer.BYTES];
         NumericUtils.intToSortableBytes(value, bytes, 0);
+        return new BytesRef(bytes);
+    }
+
+    /**
+     * Encodes a long into the term used by the {@code index_terms} inverted index, such that
+     * unsigned byte-wise (lexicographic) term order matches numeric order.
+     */
+    static BytesRef encodeLongIndexTerm(long value) {
+        byte[] bytes = new byte[Long.BYTES];
+        NumericUtils.longToSortableBytes(value, bytes, 0);
         return new BytesRef(bytes);
     }
 
@@ -177,6 +187,24 @@ public class NumberFieldMapper extends FieldMapper {
         private final int numericVal;
 
         IndexTermsIntegerField(String name, int value, BytesRef term) {
+            super(name, term, INDEX_TERMS_FIELD_TYPE);
+            this.numericVal = value;
+        }
+
+        @Override
+        public Number numericValue() {
+            return numericVal;
+        }
+    }
+
+    /**
+     * A Lucene field that stores a sortable-bytes term in the inverted index and the original
+     * long value in sorted numeric doc values, using a single consistent field type.
+     */
+    private static class IndexTermsLongField extends Field {
+        private final long numericVal;
+
+        IndexTermsLongField(String name, long value, BytesRef term) {
             super(name, term, INDEX_TERMS_FIELD_TYPE);
             this.numericVal = value;
         }
@@ -296,8 +324,8 @@ public class NumberFieldMapper extends FieldMapper {
 
             this.indexTerms = Parameter.boolParam("index_terms", false, m -> toType(m).indexTerms, false).addValidator(v -> {
                 if (v) {
-                    if (type != NumberType.INTEGER) {
-                        throw new IllegalArgumentException("[index_terms] is only supported on [integer] fields");
+                    if (type != NumberType.INTEGER && type != NumberType.LONG) {
+                        throw new IllegalArgumentException("[index_terms] is only supported on [integer] and [long] fields");
                     }
                     if (indexed.getValue() == false) {
                         throw new IllegalArgumentException("[index_terms] requires that [index] is true");
@@ -1470,6 +1498,32 @@ public class NumberFieldMapper extends FieldMapper {
                 return IntPoint.newSetQuery(field, v);
             }
 
+            /**
+             * Byte, Short, Integer and Long values are handled directly, since none of them can
+             * carry a decimal part; other types (Double, Float, BigDecimal, String, BytesRef, ...)
+             * are routed through a double, which is exact across the whole integer range.
+             */
+            @Override
+            BytesRef encodeIndexTermOrNull(Object value) {
+                if (value instanceof Integer i) {
+                    return encodeIntIndexTerm(i);
+                }
+                if (value instanceof Byte b) {
+                    return encodeIntIndexTerm(b);
+                }
+                if (value instanceof Short s) {
+                    return encodeIntIndexTerm(s);
+                }
+                if (value instanceof Long l) {
+                    return (l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE) ? encodeIntIndexTerm(l.intValue()) : null;
+                }
+                double doubleValue = NumberType.objectToDouble(value);
+                if (doubleValue % 1 != 0 || doubleValue < Integer.MIN_VALUE || doubleValue > Integer.MAX_VALUE) {
+                    return null;
+                }
+                return encodeIntIndexTerm((int) doubleValue);
+            }
+
             @Override
             public Query rangeQuery(
                 String field,
@@ -1514,7 +1568,7 @@ public class NumberFieldMapper extends FieldMapper {
                     // index_terms has no BKD points, so range queries go through the terms
                     // dictionary directly instead of falling back to doc values -- this also
                     // means range queries work even when doc_values is disabled.
-                    query = new TermRangeQuery(field, encodeIndexTerm(l), encodeIndexTerm(u), true, true);
+                    query = new TermRangeQuery(field, encodeIntIndexTerm(l), encodeIntIndexTerm(u), true, true);
                     if (hasDocValues) {
                         Query dvQuery = SortedNumericDocValuesRangeQuery.newRangeQuery(field, l, u);
                         query = new IndexOrDocValuesQuery(query, dvQuery);
@@ -1691,6 +1745,33 @@ public class NumberFieldMapper extends FieldMapper {
                 return LongPoint.newSetQuery(field, v);
             }
 
+            /**
+             * Byte, Short, Integer and Long values are handled directly, since none of them can
+             * carry a decimal part. Every other type goes through {@link #parse(Object, boolean)}
+             * rather than a double: a double cannot represent every long exactly above 2^53, so
+             * routing large values through one would round them onto a term that either matches
+             * the wrong documents or none at all.
+             */
+            @Override
+            BytesRef encodeIndexTermOrNull(Object value) {
+                if (value instanceof Long l) {
+                    return encodeLongIndexTerm(l);
+                }
+                if (value instanceof Integer i) {
+                    return encodeLongIndexTerm(i);
+                }
+                if (value instanceof Short s) {
+                    return encodeLongIndexTerm(s);
+                }
+                if (value instanceof Byte b) {
+                    return encodeLongIndexTerm(b);
+                }
+                if (hasDecimalPart(value) || isOutOfRange(value)) {
+                    return null;
+                }
+                return encodeLongIndexTerm(parse(value, true));
+            }
+
             @Override
             public Query rangeQuery(
                 String field,
@@ -1705,7 +1786,16 @@ public class NumberFieldMapper extends FieldMapper {
             ) {
                 return longRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, (l, u) -> {
                     Query query;
-                    if (hasPoints) {
+                    if (hasTerms) {
+                        // index_terms has no BKD points, so range queries go through the terms
+                        // dictionary directly instead of falling back to doc values -- this also
+                        // means range queries work even when doc_values is disabled.
+                        query = new TermRangeQuery(field, encodeLongIndexTerm(l), encodeLongIndexTerm(u), true, true);
+                        if (hasDocValues) {
+                            Query dvQuery = SortedNumericDocValuesRangeQuery.newRangeQuery(field, l, u);
+                            query = new IndexOrDocValuesQuery(query, dvQuery);
+                        }
+                    } else if (hasPoints) {
                         query = LongPoint.newRangeQuery(field, l, u);
                         if (hasDocValues) {
                             Query dvQuery = SortedNumericDocValuesRangeQuery.newRangeQuery(field, l, u);
@@ -1872,6 +1962,19 @@ public class NumberFieldMapper extends FieldMapper {
         public abstract Query termQuery(String field, Object value, IndexType indexType);
 
         public abstract Query termsQuery(String field, Collection<?> values);
+
+        /**
+         * Maps a query value to the sortable-bytes term used by an {@code index_terms} field of
+         * this type, or returns {@code null} if the value cannot match any document. A value with
+         * a fractional part, or one outside this type's range, can never match and so is excluded
+         * rather than raising an error.
+         * <p>
+         * Only the types that accept {@code index_terms} implement this; the term width has to
+         * match the width the values were indexed at, so there is no meaningful default.
+         */
+        BytesRef encodeIndexTermOrNull(Object value) {
+            throw new UnsupportedOperationException("[index_terms] is not supported on [" + name + "] fields");
+        }
 
         public abstract Query rangeQuery(
             String field,
@@ -2393,9 +2496,11 @@ public class NumberFieldMapper extends FieldMapper {
             failIfNotIndexedNorDocValuesFallback(context);
             if (indexTerms) {
                 assert indexType.hasTerms() : "[index_terms] requires a terms index";
-                BytesRef term = indexTermOrNull(value);
+                BytesRef term = type.encodeIndexTermOrNull(value);
                 if (term == null) {
-                    return Queries.newMatchNoDocsQuery("Value [" + value + "] cannot match an [index_terms] integer field");
+                    return Queries.newMatchNoDocsQuery(
+                        "Value [" + value + "] cannot match an [index_terms] [" + type.typeName() + "] field"
+                    );
                 }
                 return new TermQuery(new Term(name(), term));
             }
@@ -2409,13 +2514,13 @@ public class NumberFieldMapper extends FieldMapper {
                 assert indexType.hasTerms() : "[index_terms] requires a terms index";
                 List<BytesRef> terms = new ArrayList<>(values.size());
                 for (Object value : values) {
-                    BytesRef term = indexTermOrNull(value);
+                    BytesRef term = type.encodeIndexTermOrNull(value);
                     if (term != null) {
                         terms.add(term);
                     }
                 }
                 if (terms.isEmpty()) {
-                    return Queries.newMatchNoDocsQuery("No values can match an [index_terms] integer field");
+                    return Queries.newMatchNoDocsQuery("No values can match an [index_terms] [" + type.typeName() + "] field");
                 }
                 return new TermInSetQuery(name(), terms);
             }
@@ -2439,34 +2544,6 @@ public class NumberFieldMapper extends FieldMapper {
         /** Returns {@code true} if this field uses an inverted index for terms ({@code index_terms: true}). */
         public boolean isIndexedWithTerms() {
             return indexType.hasTerms();
-        }
-
-        /**
-         * Maps a query value to the sortable-bytes term used by an {@code index_terms} integer
-         * field, or returns {@code null} if the value cannot match any document. Byte, Short,
-         * Integer and Long values are handled directly, since none of them can carry a decimal
-         * part; other types (Double, Float, BigDecimal, String, BytesRef, ...) are checked for a
-         * decimal part and range, since a value with a fractional part or outside the integer
-         * range can never match a document and is excluded rather than raising an error.
-         */
-        private BytesRef indexTermOrNull(Object value) {
-            if (value instanceof Integer i) {
-                return encodeIndexTerm(i);
-            }
-            if (value instanceof Byte b) {
-                return encodeIndexTerm(b);
-            }
-            if (value instanceof Short s) {
-                return encodeIndexTerm(s);
-            }
-            if (value instanceof Long l) {
-                return (l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE) ? encodeIndexTerm(l.intValue()) : null;
-            }
-            double doubleValue = NumberType.objectToDouble(value);
-            if (doubleValue % 1 != 0 || doubleValue < Integer.MIN_VALUE || doubleValue > Integer.MAX_VALUE) {
-                return null;
-            }
-            return encodeIndexTerm((int) doubleValue);
         }
 
         @Override
@@ -2938,9 +3015,9 @@ public class NumberFieldMapper extends FieldMapper {
         final var indexType = fieldType.indexType();
         if (indexTerms) {
             if (indexType.hasDocValues()) {
-                document.add(new IndexTermsIntegerField(name, i, encodeIndexTerm(i)));
+                document.add(new IndexTermsIntegerField(name, i, encodeIntIndexTerm(i)));
             } else {
-                document.add(new Field(name, encodeIndexTerm(i), INDEX_TERMS_FIELD_TYPE_INDEX_ONLY));
+                document.add(new Field(name, encodeIntIndexTerm(i), INDEX_TERMS_FIELD_TYPE_INDEX_ONLY));
             }
         } else {
             if (indexType.hasPoints() && indexType.hasDocValues()) {
@@ -2958,12 +3035,20 @@ public class NumberFieldMapper extends FieldMapper {
 
     private void addLongFields(LuceneDocument document, String name, long l) {
         final var indexType = fieldType.indexType();
-        if (indexType.hasPoints() && indexType.hasDocValues()) {
-            document.add(new LongField(name, l, Field.Store.NO));
-        } else if (indexType.hasDocValues()) {
-            dvFactory.addNumericField(document, name, l);
-        } else if (indexType.hasPoints()) {
-            document.add(new LongPoint(name, l));
+        if (indexTerms) {
+            if (indexType.hasDocValues()) {
+                document.add(new IndexTermsLongField(name, l, encodeLongIndexTerm(l)));
+            } else {
+                document.add(new Field(name, encodeLongIndexTerm(l), INDEX_TERMS_FIELD_TYPE_INDEX_ONLY));
+            }
+        } else {
+            if (indexType.hasPoints() && indexType.hasDocValues()) {
+                document.add(new LongField(name, l, Field.Store.NO));
+            } else if (indexType.hasDocValues()) {
+                dvFactory.addNumericField(document, name, l);
+            } else if (indexType.hasPoints()) {
+                document.add(new LongPoint(name, l));
+            }
         }
         if (stored) {
             document.add(new StoredField(name, l));

--- a/server/src/test/java/org/elasticsearch/index/mapper/IntegerFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IntegerFieldMapperTests.java
@@ -135,14 +135,6 @@ public class IntegerFieldMapperTests extends WholeNumberFieldMapperTests {
         assertEquals(value, dvField.numericValue().intValue());
     }
 
-    public void testIndexTermsOnlyAllowedOnInteger() {
-        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
-            b.field("type", "long");
-            b.field("index_terms", true);
-        })));
-        assertThat(e.getMessage(), containsString("[index_terms] is only supported on [integer] fields"));
-    }
-
     public void testIndexTermsRequiresIndex() {
         Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
             b.field("type", "integer");

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -9,11 +9,22 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
@@ -22,7 +33,10 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -46,6 +60,12 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
             NumberTypeOutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, new BigInteger("9223372036854775808"), "out of range of long"),
             NumberTypeOutOfRangeSpec.of(NumberFieldMapper.NumberType.LONG, new BigInteger("-9223372036854775809"), "out of range of long")
         );
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker checker) throws IOException {
+        super.registerParameters(checker);
+        checker.registerConflictCheck("index_terms", b -> b.field("index_terms", true));
     }
 
     @Override
@@ -175,6 +195,158 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
 
     protected boolean supportsBulkLongBlockReading() {
         return true;
+    }
+
+    /**
+     * The sortable-bytes encoding covers the whole long range, so any value from Long.MIN_VALUE to
+     * Long.MAX_VALUE is indexed and searchable -- negatives included. Both extremes are exercised
+     * alongside a random value.
+     */
+    public void testIndexTermsIndexesSortableBytesTerms() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("index_terms", true);
+        }));
+
+        long value = randomFrom(Long.MIN_VALUE, Long.MAX_VALUE, randomLong());
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", value)));
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+
+        // Should have a terms field (inverted index) with the sortable-bytes encoded value
+        long termsCount = fields.stream().filter(f -> f.fieldType().indexOptions().compareTo(IndexOptions.NONE) > 0).count();
+        assertEquals(1, termsCount);
+        IndexableField termsField = fields.stream()
+            .filter(f -> f.fieldType().indexOptions().compareTo(IndexOptions.NONE) > 0)
+            .findFirst()
+            .get();
+        byte[] expected = new byte[Long.BYTES];
+        NumericUtils.longToSortableBytes(value, expected, 0);
+        assertEquals(new BytesRef(expected), termsField.binaryValue());
+        // Terms are the full 8 bytes: the integer-width encoding would still index and still look
+        // sorted, but would never match a query term.
+        assertEquals(Long.BYTES, termsField.binaryValue().length);
+
+        // Should have doc values
+        long dvCount = fields.stream().filter(f -> f.fieldType().docValuesType() != DocValuesType.NONE).count();
+        assertEquals(1, dvCount);
+        IndexableField dvField = fields.stream().filter(f -> f.fieldType().docValuesType() != DocValuesType.NONE).findFirst().get();
+        assertEquals(value, dvField.numericValue().longValue());
+    }
+
+    public void testIndexTermsRequiresIndex() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("index_terms", true);
+            b.field("index", false);
+        })));
+        assertThat(e.getMessage(), containsString("[index_terms] requires that [index] is true"));
+    }
+
+    public void testIndexTermsRejectedOnLegacyIndex() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(IndexVersion.fromId(5000099), fieldMapping(b -> {
+            b.field("type", "long");
+            b.field("index_terms", true);
+        })));
+        assertThat(e.getMessage(), containsString("[index_terms] is not supported on legacy indices"));
+    }
+
+    private static Set<Integer> matchingDocIds(IndexSearcher searcher, Query query) throws IOException {
+        TopDocs topDocs = searcher.search(query, searcher.getIndexReader().maxDoc());
+        Set<Integer> docIds = new TreeSet<>();
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            docIds.add(scoreDoc.doc);
+        }
+        return docIds;
+    }
+
+    /**
+     * Indexes the same random long values into a points-based field and two index_terms fields (one
+     * with doc values, one without), across a random number of segments, and asserts that term,
+     * terms and range queries match the exact same set of documents.
+     */
+    public void testIndexTermsMatchesPointsRandomized() throws IOException {
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field1").field("type", "long").endObject();
+            b.startObject("field2").field("type", "long").field("index_terms", true).endObject();
+            b.startObject("field3").field("type", "long").field("index_terms", true).field("doc_values", false).endObject();
+        }));
+
+        int numDocs = randomIntBetween(500, 1000);
+        long[] values = new long[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            // Mix full-range longs with values near the int boundary, where a wrong-width or
+            // double-routed encoding would be most likely to go unnoticed.
+            values[i] = switch (randomIntBetween(0, 2)) {
+                case 0 -> randomLong();
+                case 1 -> randomLongBetween(Integer.MAX_VALUE - 10L, Integer.MAX_VALUE + 10L);
+                default -> randomLongBetween(-100, 100);
+            };
+        }
+
+        withLuceneIndex(mapperService, iw -> {
+            for (long value : values) {
+                ParsedDocument doc = mapperService.documentMapper()
+                    .parse(source(b -> b.field("field1", value).field("field2", value).field("field3", value)));
+                iw.addDocument(doc.rootDoc());
+                // Occasionally commit so the index ends up with several segments rather than one.
+                if (rarely()) {
+                    iw.commit();
+                }
+            }
+        }, ir -> {
+            IndexSearcher searcher = newSearcher(ir);
+            NumberFieldMapper.NumberFieldType ft1 = (NumberFieldMapper.NumberFieldType) mapperService.fieldType("field1");
+            NumberFieldMapper.NumberFieldType ft2 = (NumberFieldMapper.NumberFieldType) mapperService.fieldType("field2");
+            NumberFieldMapper.NumberFieldType ft3 = (NumberFieldMapper.NumberFieldType) mapperService.fieldType("field3");
+            SearchExecutionContext context = createSearchExecutionContext(mapperService);
+
+            int iters = 5;
+            for (int iter = 0; iter < iters; iter++) {
+                long termValue = randomBoolean() ? values[randomIntBetween(0, numDocs - 1)] : randomLong();
+                Set<Integer> expectedTermDocs = matchingDocIds(searcher, ft1.termQuery(termValue, context));
+                assertEquals(
+                    "term query [" + termValue + "]",
+                    expectedTermDocs,
+                    matchingDocIds(searcher, ft2.termQuery(termValue, context))
+                );
+                assertEquals(
+                    "term query [" + termValue + "]",
+                    expectedTermDocs,
+                    matchingDocIds(searcher, ft3.termQuery(termValue, context))
+                );
+
+                int numTerms = randomIntBetween(1, 10);
+                List<Object> termsList = new ArrayList<>(numTerms);
+                for (int t = 0; t < numTerms; t++) {
+                    termsList.add(randomBoolean() ? values[randomIntBetween(0, numDocs - 1)] : randomLong());
+                }
+                Set<Integer> expectedTermsDocs = matchingDocIds(searcher, ft1.termsQuery(termsList, context));
+                assertEquals("terms query " + termsList, expectedTermsDocs, matchingDocIds(searcher, ft2.termsQuery(termsList, context)));
+                assertEquals("terms query " + termsList, expectedTermsDocs, matchingDocIds(searcher, ft3.termsQuery(termsList, context)));
+
+                long boundA = randomLong();
+                long boundB = randomLong();
+                long lower = Math.min(boundA, boundB);
+                long upper = Math.max(boundA, boundB);
+                boolean includeLower = randomBoolean();
+                boolean includeUpper = randomBoolean();
+                String rangeDesc = (includeLower ? "[" : "(") + lower + "," + upper + (includeUpper ? "]" : ")");
+                Set<Integer> expectedRangeDocs = matchingDocIds(
+                    searcher,
+                    ft1.rangeQuery(lower, upper, includeLower, includeUpper, context)
+                );
+                assertEquals(
+                    "range query " + rangeDesc + " with doc values",
+                    expectedRangeDocs,
+                    matchingDocIds(searcher, ft2.rangeQuery(lower, upper, includeLower, includeUpper, context))
+                );
+                assertEquals(
+                    "range query " + rangeDesc + " without doc values",
+                    expectedRangeDocs,
+                    matchingDocIds(searcher, ft3.rangeQuery(lower, upper, includeLower, includeUpper, context))
+                );
+            }
+        });
     }
 
     public void testColumnarArrayOrderRoundTrip() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -226,6 +226,75 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertTrue(ft.termsQuery(Arrays.asList(2.1, 2147483648L), MOCK_CONTEXT) instanceof MatchNoDocsQuery);
     }
 
+    private static NumberFieldType indexTermsLongFieldType() {
+        return new NumberFieldType(
+            "field",
+            NumberType.LONG,
+            IndexType.terms(true, true),
+            false,
+            true,
+            null,
+            Collections.emptyMap(),
+            null,
+            false,
+            null,
+            null,
+            false,
+            false,
+            true
+        );
+    }
+
+    private static BytesRef sortableBytesTermLong(long value) {
+        byte[] bytes = new byte[Long.BYTES];
+        NumericUtils.longToSortableBytes(value, bytes, 0);
+        return new BytesRef(bytes);
+    }
+
+    /**
+     * A query value reaches the term through a different branch depending on its java type, so each
+     * is checked here. Values above 2^53 are not exactly representable as a double, so the string
+     * branch in particular must parse as a long rather than route through one: Long.MAX_VALUE and
+     * its neighbour share a double, and would otherwise collapse onto the same term.
+     */
+    public void testIndexTermsLongTermQuery() {
+        NumberFieldType ft = indexTermsLongFieldType();
+        for (long value : new long[] { 42, -1, Long.MAX_VALUE, Long.MAX_VALUE - 1, Long.MIN_VALUE, (1L << 53) + 1 }) {
+            TermQuery expected = new TermQuery(new Term("field", sortableBytesTermLong(value)));
+            assertEquals("long value [" + value + "]", expected, ft.termQuery(value, MOCK_CONTEXT));
+            assertEquals("string value [" + value + "]", expected, ft.termQuery(Long.toString(value), MOCK_CONTEXT));
+        }
+        // An int-typed value widens to the same term a long-typed one produces.
+        assertEquals(new TermQuery(new Term("field", sortableBytesTermLong(42))), ft.termQuery(42, MOCK_CONTEXT));
+    }
+
+    public void testIndexTermsLongTermQueryNonMatchingValues() {
+        NumberFieldType ft = indexTermsLongFieldType();
+        // Decimal and out-of-long-range values cannot match any document.
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+        assertTrue(ft.termQuery("9223372036854775808", MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+        assertTrue(ft.termQuery("-9223372036854775809", MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+    }
+
+    public void testIndexTermsLongTermsQuery() {
+        NumberFieldType ft = indexTermsLongFieldType();
+        assertEquals(
+            new TermInSetQuery("field", Arrays.asList(sortableBytesTermLong(1), sortableBytesTermLong(-2))),
+            ft.termsQuery(Arrays.asList(1, -2), MOCK_CONTEXT)
+        );
+        // Values that fit a long but not an integer are matchable here, unlike on an integer field.
+        assertEquals(
+            new TermInSetQuery("field", Collections.singletonList(sortableBytesTermLong(2147483648L))),
+            ft.termsQuery(Collections.singletonList(2147483648L), MOCK_CONTEXT)
+        );
+        // Non-matching values (decimal, out-of-range) are dropped; matching ones remain.
+        assertEquals(
+            new TermInSetQuery("field", Collections.singletonList(sortableBytesTermLong(3))),
+            ft.termsQuery(Arrays.asList(3, 2.1, "9223372036854775808"), MOCK_CONTEXT)
+        );
+        assertTrue(ft.termsQuery(Arrays.asList(2.1, "9223372036854775808"), MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+    }
+
     private static MappedFieldType unsearchable() {
         return new NumberFieldType(
             "field",


### PR DESCRIPTION
Terms queries with large value lists on long fields are matched via a BKD point-in-set query, whose cost degrades as the list grows and approaches a near-full-index scan once it covers roughly 1% of the field's value range. #153163 added an opt-in `index_terms` parameter to integer fields to match through the terms dictionary instead, measuring 5-20x faster search across list sizes from 1 to 100,000 terms. This extends the parameter to `long`:

```js
  PUT /events
  {
    "mappings": {
      "properties": {
        "event_id": {
          "type": "long",
          "index_terms": true
        }
      }
    }
  }
```

- `index_terms` indexes values into the terms dictionary **instead of** the BKD tree, not in addition to it: the field's `IndexType` reports `hasPoints() == false`, so no point index is written at all. Sorted numeric doc values are still stored for aggregations.
- Terms use the same sortable-bytes encoding the BKD index would have used, so unsigned byte-wise term order matches numeric order and negative values are supported.
- `term`/`terms` queries are redirected to that terms dictionary.
- Range queries are redirected to a `TermRangeQuery` over the same sortable-bytes terms, which also means range queries keep working when `doc_values` is disabled.
- `index_terms` requires `[index]` to be `true`.



### Index size

`index_terms` swaps the BKD index for a terms dictionary plus postings, so its size effect depends on how many distinct values there are. Measured over 2M docs on Lucene 10.5, force-merged, comparing just that swapped structure (doc values are identical either way):

| value distribution | BKD points | index_terms | Δ |
|---|---|---|---|
| 10k distinct / 2M docs | 5.2 MB | 4.3 MB | **−17%** |
| random 63-bit | 16.7 MB | 19.2 MB | +15% |
| 2M values over a 20M range | 7.4 MB | 11.2 MB | +51% |
| sequential unique | 2.0 MB | 4.9 MB | +145% |

Cheapest where values repeat — one term plus one packed postings list beats storing every value/doc pair — and most expensive for dense unique IDs. `long` is not penalised more than `integer` here: on random values `long` pays +15% where `integer` pays +29%, since the terms FST prefix-compresses the sortable bytes while BKD pays for all 8.

Part of #155533.
