### PR TITLE
Expand max batched operations

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/ShardBatchIndexer.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/ShardBatchIndexer.java
@@ -58,7 +58,7 @@ public final class ShardBatchIndexer {
     }, Setting.Property.NodeScope);
 
     // Maximum number of operations to parse and index in a single pass to bound memory usage.
-    static final int BATCH_CHUNK_SIZE = 32;
+    static final int BATCH_CHUNK_SIZE = 5000;
 
     private ShardBatchIndexer() {}
 


### PR DESCRIPTION
We previously limited the number of max batched operations to a very low
number to provent OOMs in CI due to high LuceneDocument memory usage. We
not use columnar indexing which does not have nearly the overhead.
Increase the max batch size to a number more closely matching what we
run benchmarks on. We will continue to iterate on this.