### PR TITLE
Add support for keyword single value code path

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
@@ -40,6 +40,15 @@ final class EscfArrayColumn extends EscfColumn {
         return EscfColumnKind.ARRAY;
     }
 
+    /**
+     * Returns the element (child) column kind, so callers can decide whether the array values are
+     * directly usable as byte-strings (kind == {@link EscfColumnKind#STRING}) without iterating.
+     */
+    @Override
+    public byte leafValueKind() {
+        return child.kind();
+    }
+
     @Override
     byte typeByteForPresent(int row) {
         return SourceValueType.FIXED_ARRAY;

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -53,9 +53,7 @@ public abstract class EscfColumn implements SliceableColumn {
 
     /**
      * The kind of this column's leaf (scalar) values: this column's own {@link #kind()} for scalar
-     * columns, or the element child's kind for an {@link EscfArrayColumn}. A leaf kind of
-     * {@link EscfColumnKind#STRING} means every value is a UTF-8 byte-string that a binary Lucene
-     * column can consume without conversion, enabling zero-copy re-wrapping of the source column.
+     * columns, or the element child's kind for an {@link EscfArrayColumn}.
      */
     public byte leafValueKind() {
         return kind();
@@ -264,6 +262,9 @@ public abstract class EscfColumn implements SliceableColumn {
     static int[] rebasedOffsets(IntsRef ir, int count) {
         int base = ir.offset;
         int rebase = ir.ints[base];
+        if (rebase == 0 && base == 0 && ir.ints.length == count + 1) {
+            return ir.ints;
+        }
         int[] out = new int[count + 1];
         for (int i = 0; i <= count; i++) {
             out[i] = ir.ints[base + i] - rebase;
@@ -276,6 +277,9 @@ public abstract class EscfColumn implements SliceableColumn {
      * rows (i.e. {@code count + 1} offset entries — one fence post per row boundary).
      */
     static IntsRef sliceOffsets(IntsRef offsets, int from, int count) {
+        if (from == 0 && offsets.length == count + 1) {
+            return offsets;
+        }
         return new IntsRef(offsets.ints, offsets.offset + from, count + 1);
     }
 
@@ -285,7 +289,11 @@ public abstract class EscfColumn implements SliceableColumn {
      */
     static BytesReference sliceData(IntsRef offsets, BytesReference data, int count) {
         int byteFrom = intAt(offsets, 0);
-        return data.slice(byteFrom, intAt(offsets, count) - byteFrom);
+        int byteTo = intAt(offsets, count);
+        if (byteFrom == 0 && byteTo == data.length()) {
+            return data;
+        }
+        return data.slice(byteFrom, byteTo - byteFrom);
     }
 
     /** Returns the {@code i}-th logical entry of an {@link IntsRef}, accounting for its {@code offset}. */

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -51,6 +51,26 @@ public abstract class EscfColumn implements SliceableColumn {
     /** The column kind (see {@link EscfColumnKind}). */
     public abstract byte kind();
 
+    /**
+     * The kind of this column's leaf (scalar) values: this column's own {@link #kind()} for scalar
+     * columns, or the element child's kind for an {@link EscfArrayColumn}. A leaf kind of
+     * {@link EscfColumnKind#STRING} means every value is a UTF-8 byte-string that a binary Lucene
+     * column can consume without conversion, enabling zero-copy re-wrapping of the source column.
+     */
+    public byte leafValueKind() {
+        return kind();
+    }
+
+    /**
+     * Returns this column's backing data as an {@link EscfColumnData}, reusing the existing byte
+     * storage (no per-value copy). Symmetric with {@link #from(EscfColumnData)}, this enables
+     * mapper code outside this package to re-wrap a source column under a different Lucene field
+     * type without going through the value-at-a-time {@link EscfColumnBuilder}.
+     */
+    public final EscfColumnData columnData() {
+        return toColumnData();
+    }
+
     /** Builds the typed column view for {@code col}, dispatching on its kind. The fields are already native. */
     public static EscfColumn from(EscfColumnData col) {
         int docCount = col.docCount();

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnTransforms.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnTransforms.java
@@ -27,6 +27,23 @@ public final class EscfColumnTransforms {
     private EscfColumnTransforms() {}
 
     /**
+     * Writes all present values from {@code source} with doc-id &lt; {@code beforeDoc} into
+     * {@code dest} via a fresh cursor. No filtering is applied.
+     *
+     * @throws IllegalArgumentException if {@code beforeDoc} exceeds {@code source.docCount()}
+     */
+    public static void backfillUtf8Before(EscfColumnBuilder dest, EscfColumn source, int beforeDoc) {
+        if (beforeDoc > source.docCount()) {
+            throw new IllegalArgumentException("beforeDoc (" + beforeDoc + ") exceeds source docCount (" + source.docCount() + ")");
+        }
+        // We could always reach down and copy offsets and data directly. We don't need to use cursors.
+        final ObjectTupleCursor<BytesRef> replayCursor = utf8Cursor(source);
+        for (int d = replayCursor.nextDoc(); d < beforeDoc; d = replayCursor.nextDoc()) {
+            dest.setString(d, replayCursor.value());
+        }
+    }
+
+    /**
      * Returns a cursor that stringifies every present value to its UTF-8 keyword form. Nested and
      * flat arrays are flattened to one tuple per leaf element (same doc-id repeated); absent rows
      * and empty arrays emit nothing. JSON null emits a tuple with {@code value()==null}.

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -282,6 +282,10 @@ public abstract class FieldMapper extends Mapper {
      * @param ctx    the batch mapping context; receives output columns via {@code addColumn}
      * @param source the Escf column holding the field's source values for the batch
      */
+    // TODO: See FieldMapper#parse. We need to migrate over multi-value and nullability restricts.
+    // This should be straightforward. We would reject array columns for multi-value and force
+    // dense columns or null replacement for no nullability. We might need to do a check if multi-value
+    // is false and there is an array column scan down the array counts because size 0 or 1 is still valid
     public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
         throw new UnsupportedOperationException(
             "mapColumnBatch not implemented for mapper [" + typeName() + "] on field [" + fullPath() + "]"

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1496,6 +1496,20 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     @Override
+    public boolean supportsBatchIndexing() {
+        // Plain keyword mappers can be driven through parseCreateField by the bulk batch path.
+        // ignore_above is allowed — it's handled by indexValue and only needs addIgnoredField on
+        // the context, which BatchDocumentParserContext records. Dimensions, non-default
+        // normalizers, copy_to, multi-fields, and scripts all pull in behavior that the v1 batch
+        // path does not support.
+        return hasScript() == false
+            && copyTo().copyToFields().isEmpty()
+            && multiFields().iterator().hasNext() == false
+            && normalizerName == null
+            && fieldType().isDimension() == false;
+    }
+
+    @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
         return indexSettings.getMode().isStrictColumnar()
             && supportsColumnarDocValues()

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -57,6 +57,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.escf.EscfColumn;
 import org.elasticsearch.escf.EscfColumnBuilder;
 import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnData;
 import org.elasticsearch.escf.EscfColumnKind;
 import org.elasticsearch.escf.EscfColumnTransforms;
 import org.elasticsearch.escf.LuceneBinaryColumn;
@@ -641,6 +642,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private final IgnoreAbove ignoreAbove;
         private final String nullValue;
+        private final BytesRef nullUtf8Value;
         private final NamedAnalyzer normalizer;
         private final boolean eagerGlobalOrdinals;
         private final FieldValues<String> scriptValues;
@@ -677,6 +679,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 builder.indexSettings.getIndexVersionCreated()
             );
             this.nullValue = builder.nullValue.getValue();
+            this.nullUtf8Value = this.nullValue == null ? null : new BytesRef(this.nullValue);
             this.scriptValues = builder.scriptValues();
             this.isDimension = builder.dimension.getValue();
             this.usesBinaryDocValues = builder.usesBinaryDocValues();
@@ -708,6 +711,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = IGNORE_ABOVE_DEFAULT;
             this.nullValue = null;
+            this.nullUtf8Value = null;
             this.eagerGlobalOrdinals = false;
             this.scriptValues = null;
             this.isDimension = false;
@@ -732,6 +736,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = IGNORE_ABOVE_DEFAULT;
             this.nullValue = null;
+            this.nullUtf8Value = null;
             this.eagerGlobalOrdinals = false;
             this.scriptValues = null;
             this.isDimension = false;
@@ -756,6 +761,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.normalizer = Lucene.KEYWORD_ANALYZER;
             this.ignoreAbove = IGNORE_ABOVE_DEFAULT;
             this.nullValue = null;
+            this.nullUtf8Value = null;
             this.eagerGlobalOrdinals = false;
             this.scriptValues = null;
             this.isDimension = false;
@@ -1533,24 +1539,24 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
-        // Build a scan cursor that converts all ESCF column kinds to BytesRef strings: longs/doubles
-        // via canonical toString, booleans as "true"/"false", strings as-is, arrays element-by-element.
-        // BINARY and KEY_VALUE columns are unsupported and throw when the cursor is iterated.
-        // NOTE: numbers are converted from their parsed values (Long/Double), so non-canonical source
-        // literals (e.g. "1.50", "1e3") will produce the canonical toString form rather than the original
-        // source characters (which the row path preserves via parser.getText()). Tests must use canonical
-        // numeric literals.
-        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source);
         final boolean emitTerms = fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored();
         final boolean emitFallback = storeIgnoredValuesForSyntheticSource();
         final boolean emitDvs = fieldType().hasDocValues();
         if (emitTerms == false && emitDvs == false && emitFallback == false) {
             return;
         }
+
         if (fieldType().usesArrayOrderBinaryDocValues()) {
-            mapColumnBatchArrayOrder(ctx, cursor, emitTerms, emitDvs, emitFallback);
+            // Build a scan cursor that converts all ESCF column kinds to BytesRef strings: longs/doubles
+            // via canonical toString, booleans as "true"/"false", strings as-is, arrays element-by-element.
+            // BINARY and KEY_VALUE columns are unsupported and throw when the cursor is iterated.
+            // NOTE: numbers are converted from their parsed values (Long/Double), so non-canonical source
+            // literals (e.g. "1.50", "1e3") will produce the canonical toString form rather than the original
+            // source characters (which the row path preserves via parser.getText()). Tests must use canonical
+            // numeric literals.
+            mapColumnBatchArrayOrder(ctx, EscfColumnTransforms.utf8Cursor(source), emitTerms, emitDvs, emitFallback);
         } else {
-            mapColumnBatchSingleValue(ctx, cursor, emitTerms, emitDvs, emitFallback);
+            mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
         }
     }
 
@@ -1569,10 +1575,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         final EscfColumnBuilder dvCounts = emitDvs ? mergeLongColumn() : null;
         final EscfColumnBuilder fallback = emitFallback ? mergeStringColumn() : null;
         final EscfColumnBuilder fallbackCounts = emitFallback ? mergeLongColumn() : null;
-
-        // Pre-compute the null_value substitution bytes once for the whole batch.
-        // TODO: Store this as BytesRef on field type eventually
-        final BytesRef nullValueBytes = fieldType().nullValue != null ? new BytesRef(fieldType().nullValue) : null;
+        final BytesRef nullValueBytes = fieldType().nullUtf8Value;
 
         int currentDoc = -1;
         boolean ignoredThisDoc = false;
@@ -1707,19 +1710,35 @@ public final class KeywordFieldMapper extends FieldMapper {
      * plain {@link BinaryDocValuesField} per present doc — no {@code ArrayOrderInlineNull} blob, no
      * {@code .counts} sidecar — mirroring {@code DocValuesFieldFactory.addBinaryField}'s
      * {@code isSingleValued()} branch in the row path.
+     *
+     * <p><b>Fast path (zero-copy wrap).</b> When the source column already holds UTF-8 string values
+     * — either a {@link EscfColumnKind#STRING} scalar column or an
+     * {@link EscfColumnKind#ARRAY}-of-{@link EscfColumnKind#STRING} column — <em>and</em>
+     * {@code ignore_above} cannot drop any value, the source {@link EscfColumnData} is re-wrapped
+     * directly under the target Lucene field type(s) without allocating any
+     * {@link EscfColumnBuilder} or copying bytes. A single validation pass over
+     * {@link EscfColumn#bytesRefCursor()} guards against oversized terms and the
+     * {@code multi_value=false} violation (repeated doc-id for an array with &gt;1 element).
+     *
+     * <p><b>Slow path (unified builder).</b> When the source requires per-value conversion
+     * (numeric/boolean/UNION, or {@code ignore_above} is active), one shared {@link EscfColumnBuilder}
+     * accumulates all accepted values. The finished {@link EscfColumnData} is then wrapped once and
+     * emitted under both field types, halving the allocation of the previous two-builder approach.
      */
     private void mapColumnBatchSingleValue(
         BatchMappingContext ctx,
-        ObjectTupleCursor<BytesRef> cursor,
+        EscfColumn source,
         boolean emitTerms,
         boolean emitDvs,
         boolean emitFallback
     ) {
         final int docCount = ctx.docCount();
-        final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
-        final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
+        boolean valuesProduced = false;
+
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source);
+        EscfColumnBuilder values = source.leafValueKind() != EscfColumnKind.STRING && (emitTerms || emitDvs) ? mergeStringColumn() : null;
         final EscfColumnBuilder fallback = emitFallback ? mergeStringColumn() : null;
-        final BytesRef nullValueBytes = fieldType().nullValue != null ? new BytesRef(fieldType().nullValue) : null;
+        final BytesRef nullValueBytes = fieldType().nullUtf8Value;
 
         int currentDoc = -1;
         boolean valueSeenThisDoc = false;
@@ -1745,6 +1764,13 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (fieldType().ignoreAbove().isIgnored(binaryValue)) {
                 if (ignoredThisDoc == false) {
                     ctx.addIgnoredFieldColumnar(currentDoc, fullPath());
+                    // Deoptimize: we were planning to zero-copy the source column, but now we must
+                    // exclude this doc's value from the output. Lazily create the builder and backfill
+                    // all accepted values from before this doc, then continue building per-value.
+                    if (values == null && (emitTerms || emitDvs)) {
+                        values = mergeStringColumn();
+                        EscfColumnTransforms.backfillUtf8Before(values, source, currentDoc);
+                    }
                     if (fallback != null) {
                         fallback.setString(currentDoc, binaryValue);
                     }
@@ -1763,6 +1789,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (binaryValue.length > MAX_TERM_LENGTH) {
                 throw largeTermException(binaryValue);
             }
+            // TODO: Can move this validation earlier based on array type
             if (valueSeenThisDoc) {
                 // multi_value=false violation: bail so ShardBatchMapper falls back to the row path,
                 // which raises the correct per-doc error (on_failure=FAIL).
@@ -1771,21 +1798,23 @@ public final class KeywordFieldMapper extends FieldMapper {
                 );
             }
             valueSeenThisDoc = true;
-            if (terms != null) {
-                terms.setString(currentDoc, binaryValue);
-            }
-            if (binaryDvs != null) {
-                binaryDvs.setString(currentDoc, binaryValue);
+            valuesProduced = true;
+            if (values != null) {
+                values.setString(currentDoc, binaryValue);
             }
         }
 
         // Emit one term column (frozen fieldType, DocValuesType=NONE for HIGH cardinality) and one
         // plain binary DV column (BinaryDocValuesField.TYPE, omitNorms=false) — no .counts sidecar.
-        if (terms != null && terms.isEmpty() == false) {
-            ctx.addColumn(LuceneBinaryColumn.of(terms.finish(docCount), fieldType().name(), fieldType));
-        }
-        if (binaryDvs != null && binaryDvs.isEmpty() == false) {
-            ctx.addColumn(LuceneBinaryColumn.of(binaryDvs.finish(docCount), fieldType().name(), BinaryDocValuesField.TYPE));
+        // Both columns share the same finished EscfColumnData (one serialization, two field-type wrappers).
+        if (valuesProduced) {
+            final EscfColumnData data = values != null ? values.finish(docCount) : source.columnData();
+            if (emitTerms) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), fieldType));
+            }
+            if (emitDvs) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), BinaryDocValuesField.TYPE));
+            }
         }
         // Synthetic-source fallback for ignore_above values: single BinaryDocValuesField (no counts),
         // mirroring the row-path's addBinaryFieldLegacyEncodingAware isSingleValued() branch.

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1546,14 +1546,17 @@ public final class KeywordFieldMapper extends FieldMapper {
             return;
         }
 
+        // These paths build a scan cursor that converts all ESCF column kinds to BytesRef strings:
+        // longs/doubles via canonical toString, booleans as "true"/"false", strings as-is, arrays
+        // element-by-element. BINARY and KEY_VALUE columns are unsupported and throw when the cursor is
+        // iterated.
+        // NOTE: numbers are converted from their parsed values (Long/Double), so non-canonical source
+        // literals (e.g. "1.50", "1e3") will produce the canonical toString form rather than the original
+        // source characters (which the row path preserves via parser.getText()).
+        // In order to support the original string representations we would need to keep the columns as
+        // strings. This is possible as an eventual user option.
+
         if (fieldType().usesArrayOrderBinaryDocValues()) {
-            // Build a scan cursor that converts all ESCF column kinds to BytesRef strings: longs/doubles
-            // via canonical toString, booleans as "true"/"false", strings as-is, arrays element-by-element.
-            // BINARY and KEY_VALUE columns are unsupported and throw when the cursor is iterated.
-            // NOTE: numbers are converted from their parsed values (Long/Double), so non-canonical source
-            // literals (e.g. "1.50", "1e3") will produce the canonical toString form rather than the original
-            // source characters (which the row path preserves via parser.getText()). Tests must use canonical
-            // numeric literals.
             mapColumnBatchArrayOrder(ctx, EscfColumnTransforms.utf8Cursor(source), emitTerms, emitDvs, emitFallback);
         } else {
             mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
@@ -1705,26 +1708,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
     }
 
-    /**
-     * Columnar batch path for single-valued ({@code multi_value=false}) keyword fields. Emits one
-     * plain {@link BinaryDocValuesField} per present doc — no {@code ArrayOrderInlineNull} blob, no
-     * {@code .counts} sidecar — mirroring {@code DocValuesFieldFactory.addBinaryField}'s
-     * {@code isSingleValued()} branch in the row path.
-     *
-     * <p><b>Fast path (zero-copy wrap).</b> When the source column already holds UTF-8 string values
-     * — either a {@link EscfColumnKind#STRING} scalar column or an
-     * {@link EscfColumnKind#ARRAY}-of-{@link EscfColumnKind#STRING} column — <em>and</em>
-     * {@code ignore_above} cannot drop any value, the source {@link EscfColumnData} is re-wrapped
-     * directly under the target Lucene field type(s) without allocating any
-     * {@link EscfColumnBuilder} or copying bytes. A single validation pass over
-     * {@link EscfColumn#bytesRefCursor()} guards against oversized terms and the
-     * {@code multi_value=false} violation (repeated doc-id for an array with &gt;1 element).
-     *
-     * <p><b>Slow path (unified builder).</b> When the source requires per-value conversion
-     * (numeric/boolean/UNION, or {@code ignore_above} is active), one shared {@link EscfColumnBuilder}
-     * accumulates all accepted values. The finished {@link EscfColumnData} is then wrapped once and
-     * emitted under both field types, halving the allocation of the previous two-builder approach.
-     */
     private void mapColumnBatchSingleValue(
         BatchMappingContext ctx,
         EscfColumn source,
@@ -1742,7 +1725,6 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         int currentDoc = -1;
         boolean valueSeenThisDoc = false;
-        boolean ignoredThisDoc = false;
         while (true) {
             final int nextDoc = cursor.nextDoc();
             if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
@@ -1751,7 +1733,6 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (nextDoc != currentDoc) {
                 currentDoc = nextDoc;
                 valueSeenThisDoc = false;
-                ignoredThisDoc = false;
             }
             BytesRef binaryValue = cursor.value();
             if (binaryValue == null) {
@@ -1761,34 +1742,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     continue;  // null without null_value -> absent (row-path parity)
                 }
             }
-            if (fieldType().ignoreAbove().isIgnored(binaryValue)) {
-                if (ignoredThisDoc == false) {
-                    ctx.addIgnoredFieldColumnar(currentDoc, fullPath());
-                    // Deoptimize: we were planning to zero-copy the source column, but now we must
-                    // exclude this doc's value from the output. Lazily create the builder and backfill
-                    // all accepted values from before this doc, then continue building per-value.
-                    if (values == null && (emitTerms || emitDvs)) {
-                        values = mergeStringColumn();
-                        EscfColumnTransforms.backfillUtf8Before(values, source, currentDoc);
-                    }
-                    if (fallback != null) {
-                        fallback.setString(currentDoc, binaryValue);
-                    }
-                    ignoredThisDoc = true;
-                } else if (fallback != null) {
-                    throw new UnsupportedOperationException(
-                        "mapColumnBatch: more than one ignore_above-exceeded value in single-value field ["
-                            + fullPath()
-                            + "] for doc ["
-                            + currentDoc
-                            + "]"
-                    );
-                }
-                continue;
-            }
-            if (binaryValue.length > MAX_TERM_LENGTH) {
-                throw largeTermException(binaryValue);
-            }
+
             // TODO: Can move this validation earlier based on array type
             if (valueSeenThisDoc) {
                 // multi_value=false violation: bail so ShardBatchMapper falls back to the row path,
@@ -1798,6 +1752,25 @@ public final class KeywordFieldMapper extends FieldMapper {
                 );
             }
             valueSeenThisDoc = true;
+
+            if (fieldType().ignoreAbove().isIgnored(binaryValue)) {
+                ctx.addIgnoredFieldColumnar(currentDoc, fullPath());
+                // Deoptimize: we were planning to zero-copy the source column, but now we must
+                // exclude this doc's value from the output. Lazily create the builder and backfill
+                // all accepted values from before this doc, then continue building per-value.
+                if (values == null && (emitTerms || emitDvs)) {
+                    values = mergeStringColumn();
+                    EscfColumnTransforms.backfillUtf8Before(values, source, currentDoc);
+                }
+                if (fallback != null) {
+                    fallback.setString(currentDoc, binaryValue);
+                }
+                continue;
+            }
+            if (binaryValue.length > MAX_TERM_LENGTH) {
+                throw largeTermException(binaryValue);
+            }
+
             valuesProduced = true;
             if (values != null) {
                 values.setString(currentDoc, binaryValue);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InvertableType;
@@ -1489,31 +1490,32 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    public boolean supportsBatchIndexing() {
-        // Plain keyword mappers can be driven through parseCreateField by the bulk batch path.
-        // ignore_above is allowed — it's handled by indexValue and only needs addIgnoredField on
-        // the context, which BatchDocumentParserContext records. Dimensions, non-default
-        // normalizers, copy_to, multi-fields, and scripts all pull in behavior that the v1 batch
-        // path does not support.
-        return hasScript() == false
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        return indexSettings.getMode().isStrictColumnar()
+            && supportsColumnarDocValues()
+            && hasScript() == false
             && copyTo().copyToFields().isEmpty()
             && multiFields().iterator().hasNext() == false
             && normalizerName == null
             && fieldType().isDimension() == false;
     }
 
-    @Override
-    public boolean supportsColumnarParse(IndexSettings indexSettings) {
-        // Columnar support is limited to strict-columnar index modes (COLUMNAR, LOGSDB_COLUMNAR)
-        // where high-cardinality keywords use the document-order inline-null binary doc-values
-        // encoding (ArrayOrderInlineNull).
-        return indexSettings.getMode().isStrictColumnar()
-            && fieldType().usesArrayOrderBinaryDocValues()
-            && hasScript() == false
-            && copyTo().copyToFields().isEmpty()
-            && multiFields().iterator().hasNext() == false
-            && normalizerName == null
-            && fieldType().isDimension() == false;
+    /**
+     * Returns true when this keyword field's doc-values encoding is supported on the columnar batch
+     * path. Accepts both the array-order (multi_value=true, offsetsFieldName set) and single-valued
+     * binary (multi_value=false) encoding. Other combinations fall back to the row path.
+     */
+    private boolean supportsColumnarDocValues() {
+        if (fieldType().usesBinaryDocValues() == false) {
+            return false;
+        }
+
+        if (fieldType().usesArrayOrderBinaryDocValues()) {
+            return true;
+        }
+
+        // Only support single valued when not ArrayOrderBinaryDocValues
+        return docValuesParameters().multiValue() == false;
     }
 
     // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
@@ -1531,8 +1533,6 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
-        final int docCount = ctx.docCount();
-
         // Build a scan cursor that converts all ESCF column kinds to BytesRef strings: longs/doubles
         // via canonical toString, booleans as "true"/"false", strings as-is, arrays element-by-element.
         // BINARY and KEY_VALUE columns are unsupported and throw when the cursor is iterated.
@@ -1541,15 +1541,28 @@ public final class KeywordFieldMapper extends FieldMapper {
         // source characters (which the row path preserves via parser.getText()). Tests must use canonical
         // numeric literals.
         final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source);
-
         final boolean emitTerms = fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored();
         final boolean emitFallback = storeIgnoredValuesForSyntheticSource();
         final boolean emitDvs = fieldType().hasDocValues();
-
-        // Nothing to emit.
         if (emitTerms == false && emitDvs == false && emitFallback == false) {
             return;
         }
+        if (fieldType().usesArrayOrderBinaryDocValues()) {
+            mapColumnBatchArrayOrder(ctx, cursor, emitTerms, emitDvs, emitFallback);
+        } else {
+            mapColumnBatchSingleValue(ctx, cursor, emitTerms, emitDvs, emitFallback);
+        }
+    }
+
+    private void mapColumnBatchArrayOrder(
+        BatchMappingContext ctx,
+        ObjectTupleCursor<BytesRef> cursor,
+        boolean emitTerms,
+        boolean emitDvs,
+        boolean emitFallback
+    ) {
+        final int docCount = ctx.docCount();
+
         // TODO: make the batch return these column builders to wire up recycling
         final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
         final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
@@ -1685,6 +1698,100 @@ public final class KeywordFieldMapper extends FieldMapper {
                     Defaults.COUNTS_FIELD_TYPE,
                     LongColumn.NumericKind.LONG
                 )
+            );
+        }
+    }
+
+    /**
+     * Columnar batch path for single-valued ({@code multi_value=false}) keyword fields. Emits one
+     * plain {@link BinaryDocValuesField} per present doc — no {@code ArrayOrderInlineNull} blob, no
+     * {@code .counts} sidecar — mirroring {@code DocValuesFieldFactory.addBinaryField}'s
+     * {@code isSingleValued()} branch in the row path.
+     */
+    private void mapColumnBatchSingleValue(
+        BatchMappingContext ctx,
+        ObjectTupleCursor<BytesRef> cursor,
+        boolean emitTerms,
+        boolean emitDvs,
+        boolean emitFallback
+    ) {
+        final int docCount = ctx.docCount();
+        final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
+        final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
+        final EscfColumnBuilder fallback = emitFallback ? mergeStringColumn() : null;
+        final BytesRef nullValueBytes = fieldType().nullValue != null ? new BytesRef(fieldType().nullValue) : null;
+
+        int currentDoc = -1;
+        boolean valueSeenThisDoc = false;
+        boolean ignoredThisDoc = false;
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                break;
+            }
+            if (nextDoc != currentDoc) {
+                currentDoc = nextDoc;
+                valueSeenThisDoc = false;
+                ignoredThisDoc = false;
+            }
+            BytesRef binaryValue = cursor.value();
+            if (binaryValue == null) {
+                if (nullValueBytes != null) {
+                    binaryValue = nullValueBytes;  // substitute, fall through to normal processing
+                } else {
+                    continue;  // null without null_value -> absent (row-path parity)
+                }
+            }
+            if (fieldType().ignoreAbove().isIgnored(binaryValue)) {
+                if (ignoredThisDoc == false) {
+                    ctx.addIgnoredFieldColumnar(currentDoc, fullPath());
+                    if (fallback != null) {
+                        fallback.setString(currentDoc, binaryValue);
+                    }
+                    ignoredThisDoc = true;
+                } else if (fallback != null) {
+                    throw new UnsupportedOperationException(
+                        "mapColumnBatch: more than one ignore_above-exceeded value in single-value field ["
+                            + fullPath()
+                            + "] for doc ["
+                            + currentDoc
+                            + "]"
+                    );
+                }
+                continue;
+            }
+            if (binaryValue.length > MAX_TERM_LENGTH) {
+                throw largeTermException(binaryValue);
+            }
+            if (valueSeenThisDoc) {
+                // multi_value=false violation: bail so ShardBatchMapper falls back to the row path,
+                // which raises the correct per-doc error (on_failure=FAIL).
+                throw new UnsupportedOperationException(
+                    "mapColumnBatch: multi_value=false field [" + fullPath() + "] has more than one value for doc [" + currentDoc + "]"
+                );
+            }
+            valueSeenThisDoc = true;
+            if (terms != null) {
+                terms.setString(currentDoc, binaryValue);
+            }
+            if (binaryDvs != null) {
+                binaryDvs.setString(currentDoc, binaryValue);
+            }
+        }
+
+        // Emit one term column (frozen fieldType, DocValuesType=NONE for HIGH cardinality) and one
+        // plain binary DV column (BinaryDocValuesField.TYPE, omitNorms=false) — no .counts sidecar.
+        if (terms != null && terms.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(terms.finish(docCount), fieldType().name(), fieldType));
+        }
+        if (binaryDvs != null && binaryDvs.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(binaryDvs.finish(docCount), fieldType().name(), BinaryDocValuesField.TYPE));
+        }
+        // Synthetic-source fallback for ignore_above values: single BinaryDocValuesField (no counts),
+        // mirroring the row-path's addBinaryFieldLegacyEncodingAware isSingleValued() branch.
+        if (fallback != null && fallback.isEmpty() == false) {
+            ctx.addColumn(
+                LuceneBinaryColumn.of(fallback.finish(docCount), fieldType().syntheticSourceFallbackFieldName(), BinaryDocValuesField.TYPE)
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -149,7 +149,7 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
     }
 
     public void testTextMapperHappyPath() throws IOException {
-        MapperService ms = mapper(mapping(b -> { b.startObject("t").field("type", "text").endObject(); }));
+        MapperService ms = mapper(mapping(b -> b.startObject("t").field("type", "text").endObject()));
         BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("t"), ms.mappingLookup());
         assertNotNull(resolution);
         assertTrue(resolution.columnMappers()[0] instanceof TextFieldMapper);

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
@@ -208,8 +208,6 @@ public class KeywordFieldMapperColumnarCompatibilityTests extends AbstractColumn
         );
     }
 
-    // --- multi_value=false (single-valued binary doc values) ---
-
     public void testSingleValueMultiValueFalse() throws IOException {
         // One string value, one absent doc, and an empty string.
         assertColumnarMatchesXContent(mapping(b -> {
@@ -319,6 +317,88 @@ public class KeywordFieldMapperColumnarCompatibilityTests extends AbstractColumn
         }),
             columnarSettings(),
             batch("ignore_above multi_value=false", 1L, doc("d1", 1L, "{\"f\":\"toolongvalue\"}"), doc("d2", 2L, "{\"f\":\"short\"}"))
+        );
+    }
+
+    public void testNullValueConfiguredNoNullsMultiValueFalse() throws IOException {
+        // null_value is configured but the batch contains only real string values plus an absent doc.
+        // The fast path must not be disabled by a configured null_value; no substitution should occur
+        // because the source STRING column contains no null slots (explicit JSON nulls promote to UNION).
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("null_value", "NULL");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "null_value configured no nulls multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"alpha\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"beta\"}")
+            )
+        );
+    }
+
+    public void testAllPresentDenseMultiValueFalse() throws IOException {
+        // Every doc has a string value; no absent docs. Exercises the dense (validity==null) wrap in
+        // the fast path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "all present dense multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{\"f\":\"b\"}"),
+                doc("d3", 3L, "{\"f\":\"c\"}")
+            )
+        );
+    }
+
+    public void testManyMixedPresentAbsentMultiValueFalse() throws IOException {
+        // Larger interleaved present/absent batch to stress the SPARSE wrap and the
+        // length-validation scan across many rows.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "many mixed present absent multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"v1\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"v3\"}"),
+                doc("d4", 4L, "{}"),
+                doc("d5", 5L, "{\"f\":\"v5\"}"),
+                doc("d6", 6L, "{\"f\":\"v6\"}"),
+                doc("d7", 7L, "{}")
+            )
+        );
+    }
+
+    public void testSingleElementArrayMultiValueFalse() throws IOException {
+        // A single-element array {"f":["a"]} is a legal value for a multi_value=false field.
+        // The ESCF encoder produces an ARRAY-of-STRING column; the fast path must wrap it
+        // zero-copy, matching the row path which extracts the sole element.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single element array multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"a\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
@@ -207,4 +207,118 @@ public class KeywordFieldMapperColumnarCompatibilityTests extends AbstractColumn
             batch("ignore_above value", 1L, doc("d1", 1L, "{\"f\":\"" + "x".repeat(8192) + "\"}"))
         );
     }
+
+    // --- multi_value=false (single-valued binary doc values) ---
+
+    public void testSingleValueMultiValueFalse() throws IOException {
+        // One string value, one absent doc, and an empty string.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single value multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"\"}")
+            )
+        );
+    }
+
+    public void testAbsentAndNullMultiValueFalse() throws IOException {
+        // Present value, absent doc ({}), and explicit JSON null without null_value -> absent.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "absent and null multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"alpha\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":null}")
+            )
+        );
+    }
+
+    public void testNullValueSubstitutionMultiValueFalse() throws IOException {
+        // Explicit JSON null is substituted with null_value.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("null_value", "NULL");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "null_value substitution multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":null}"),
+                doc("d2", 2L, "{\"f\":\"a\"}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testNoIndexDocValuesOnlyMultiValueFalse() throws IOException {
+        // index:false — only the binary DV column is emitted, no terms column.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("index", false);
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }), columnarSettings(), batch("no-index dv-only multi_value=false", 1L, doc("d1", 1L, "{\"f\":\"only_dv\"}"), doc("d2", 2L, "{}")));
+    }
+
+    public void testIndexedAndDocValuesMultiValueFalse() throws IOException {
+        // Default index:true — both a terms column and a binary DV column are emitted.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "indexed and dv multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"indexed\"}"),
+                doc("d2", 2L, "{\"f\":\"also_indexed\"}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testScalarCoercionsMultiValueFalse() throws IOException {
+        // Numeric and boolean scalars are stringified by utf8Cursor, matching the row path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "scalar coercions multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":3.14}"),
+                doc("d3", 3L, "{\"f\":true}")
+            )
+        );
+    }
+
+    public void testIgnoreAboveMultiValueFalse() throws IOException {
+        // ignore_above: the too-long value is recorded in _ignored and stored as a plain
+        // BinaryDocValuesField synthetic-source fallback (no counts sidecar).
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("ignore_above", 8);
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("ignore_above multi_value=false", 1L, doc("d1", 1L, "{\"f\":\"toolongvalue\"}"), doc("d2", 2L, "{\"f\":\"short\"}"))
+        );
+    }
 }


### PR DESCRIPTION
This commit adds dedicated support the the binary doc values single
value keyword path. We attempt to make the keyword path a no-op if the
underlying column is already valid utf-8 bytes.