### PR TITLE
Add security stats to monitoring mapping

### DIFF
--- a/docs/changelog/155552.yaml
+++ b/docs/changelog/155552.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 155552
+summary: Add security stats to monitoring mapping
+type: enhancement

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -2771,6 +2771,71 @@
                   }
                 }
               }
+            },
+            "security": {
+              "properties": {
+                "stats": {
+                  "properties": {
+                    "dls": {
+                      "properties": {
+                        "cache": {
+                          "properties": {
+                            "entries": {
+                              "properties": {
+                                "count": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "memory": {
+                              "properties": {
+                                "bytes": {
+                                  "type": "long"
+                                }
+                              }
+                            },
+                            "hits": {
+                              "properties": {
+                                "count": {
+                                  "type": "long"
+                                },
+                                "time": {
+                                  "properties": {
+                                    "ms": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "misses": {
+                              "properties": {
+                                "count": {
+                                  "type": "long"
+                                },
+                                "time": {
+                                  "properties": {
+                                    "ms": {
+                                      "type": "long"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "evictions": {
+                              "properties": {
+                                "count": {
+                                  "type": "long"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 25;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 26;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Metricbeat's elasticsearch module gained a `security_stats` metricset in elastic/beats#50674, which scrapes `GET /_security/stats` (available in Elasticsearch 9.2) and publishes the per-node Document Level Security cache counters under `elasticsearch.security.stats.dls.cache`.

The `.monitoring-es-mb` template maps fields with dynamic set to false, so any path it does not declare is stored in `_source` but never indexed. Without these mappings the counters reach the monitoring cluster and then silently disappear from aggregations and dashboards.

Map the seven DLS cache leaves as long, matching how every other count, bytes, and ms leaf in the template is typed.

Bump `STACK_MONITORING_REGISTRY_VERSION` so existing deployments reinstall the template rather than keeping the old mapping.
