### PR TITLE
Unmute encryption-at-rest suite timeout tests on main

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -538,9 +538,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.SemanticIndexOptionsIT
   method: testValidateIndexOptionsWithBasicLicense
   issue: https://github.com/elastic/elasticsearch/issues/155026
-- class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=downsample/100_downsample_histograms/Downsample tdigest with last value}
-  issue: https://github.com/elastic/elasticsearch/issues/155028
 - class: org.elasticsearch.compute.aggregation.BulkArrowAggregationTests
   method: testSumIntOverArrowBufferMasked
   issue: https://github.com/elastic/elasticsearch/issues/153586
@@ -559,9 +556,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
   method: test {csv-spec:stats.sumWithOverflowGroupingRow}
   issue: https://github.com/elastic/elasticsearch/issues/155155
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=tsdb/05_dimension_and_metric_in_non_tsdb_index/add time series mappings}
-  issue: https://github.com/elastic/elasticsearch/issues/155331
 - class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
   method: testContinuousEvents
   issue: https://github.com/elastic/elasticsearch/issues/153782


### PR DESCRIPTION
Tests failed due to a transient timeout, unmuting to see if failures reoccur

Fixes #155028
Fixes #155331