### PR TITLE
Unmute encryption-at-rest suite timeout test on 9.5

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -745,9 +745,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
   method: testFeatureImportanceValues
   issue: https://github.com/elastic/elasticsearch/issues/155327
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search/90_search_after/date_nanos}
-  issue: https://github.com/elastic/elasticsearch/issues/155451
 - class: org.elasticsearch.index.reindex.BulkByPaginatedSearchResponseWireSerializingTests
   method: testEqualsAndHashcode
   issue: https://github.com/elastic/elasticsearch/issues/155457


### PR DESCRIPTION
Tests failed due to a transient timeout, unmuting to see if failures reoccur

Fixes #155451