### PR TITLE
Bump integration knowledge mappings version

### DIFF
--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -80,7 +80,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final int FLEET_SERVERS_MAPPINGS_VERSION = 1;
     private static final int FLEET_ARTIFACTS_MAPPINGS_VERSION = 1;
     private static final int FLEET_ACTIONS_RESULTS_MAPPINGS_VERSION = 1;
-    private static final int FLEET_INTEGRATION_KNOWLEDGE_MAPPINGS_VERSION = 1;
+    private static final int FLEET_INTEGRATION_KNOWLEDGE_MAPPINGS_VERSION = 2;
 
     @Override
     public Collection<?> createComponents(PluginServices services) {


### PR DESCRIPTION
Our .integration-knowledge-7 mapping is still:
```
{
  ".integration_knowledge-7": {
    "mappings": {
      "dynamic": "false",
      "_meta": {
        "managed_index_mappings_version": 1,
        "description": "Integration package knowledge base content storage",
        "version": "9.3.0"
      },
      "properties": {
        "content": {
          "type": "semantic_text",
          "inference_id": ".elser-2-elasticsearch",
          "model_settings": {
            "service": "elasticsearch",
            "task_type": "sparse_embedding"
          }
        },
        "filename": {
          "type": "keyword"
        },
        "installed_at": {
          "type": "date"
        },
        "package_name": {
          "type": "keyword"
        },
        "version": {
          "type": "version"
        }
      }
    }
  }
}
```
even in 9.4.1 after the inference_id was removed here https://github.com/elastic/elasticsearch/pull/136837
That's because the "version" wasn't bumped, so it thinks it's still up to date.