### PR TITLE
ES|QL: Support double_range equality and IN

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -455,7 +455,7 @@ def prop(Name, Type, type, TYPE, BYTES, Array) {
     "boolean"    : type == "boolean" ? "true" : "",
     "nanosMillis": Name == "NanosMillis" ? "true" : "",
     "millisNanos": Name == "MillisNanos" ? "true" : "",
-    "LongRange"  : Name == "LongRange" ? "true" : "",
+    "Range"      : Name.endsWith("Range") ? "true" : "",
   ]
 }
 
@@ -471,6 +471,7 @@ tasks.named('stringTemplates').configure {
   var expHistoProperties = prop("ExponentialHistogram", "ExponentialHistogram", "ExponentialHistogram", "EXPONENTIAL_HISTOGRAM", "", "")
   var tdigestProperties = prop("TDigest", "TDigest", "tdigest", "TDIGEST", "", "")
   var longRangeProperties = prop("LongRange", "LongRange", "LongRange", "LONG_RANGE", "", "")
+  var doubleRangeProperties = prop("DoubleRange", "DoubleRange", "DoubleRange", "DOUBLE_RANGE", "", "")
 
   File inInputFile = file("src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st")
   template {
@@ -512,6 +513,11 @@ tasks.named('stringTemplates').configure {
     it.properties = longRangeProperties
     it.inputFile = inInputFile
     it.outputFile = "org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InLongRangeEvaluator.java"
+  }
+  template {
+    it.properties = doubleRangeProperties
+    it.inputFile = inInputFile
+    it.outputFile = "org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleRangeEvaluator.java"
   }
 
   File coalesceInputFile = file("src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/X-CoalesceEvaluator.java.st")

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.core.Nullable;
@@ -1737,10 +1738,23 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         return List.of(new TypedDataSupplier("<random date range>", TestCaseSupplier::randomDateRange, DataType.DATE_RANGE));
     }
 
+    public static List<TypedDataSupplier> doubleRangeCases() {
+        return List.of(new TypedDataSupplier("<random double range>", TestCaseSupplier::randomDoubleRange, DataType.DOUBLE_RANGE));
+    }
+
     public static LongRangeBlockBuilder.LongRange randomDateRange() {
         var from = randomMillisUpToYear9999();
         var to = randomLongBetween(from + 1, MAX_MILLIS_BEFORE_9999);
         return new LongRangeBlockBuilder.LongRange(from, to);
+    }
+
+    public static DoubleRangeBlockBuilder.DoubleRange randomDoubleRange() {
+        double first = randomDouble();
+        double second;
+        do {
+            second = randomDouble();
+        } while (first == second);
+        return new DoubleRangeBlockBuilder.DoubleRange(Math.min(first, second), Math.max(first, second));
     }
 
     /**

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
@@ -1,5 +1,5 @@
 doubleRangeBlockLoader
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -16,7 +16,7 @@ height_range:double_range | description:keyword
 ;
 
 toRange
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 ROW from = 1.5, to = 2.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -28,7 +28,7 @@ height_range:double_range
 ;
 
 toRangeNullLeft
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 ROW to = 1.5
 | EVAL height_range = TO_RANGE(null, to)
@@ -40,7 +40,7 @@ null
 ;
 
 toRangeNullRight
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 ROW from = 1.5
 | EVAL height_range = TO_RANGE(from, null)
@@ -52,7 +52,7 @@ null
 ;
 
 toRangeInvalidBounds
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 ROW from = 2.5, to = 1.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -66,7 +66,7 @@ null
 ;
 
 toString
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -84,7 +84,7 @@ height_range_string:keyword | description:keyword
 ;
 
 rangeMinMax
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -102,7 +102,7 @@ height_range:double_range | min_bound:double | max_bound:double | description:ke
 ;
 
 rangeMinMaxRoundTrip
-required_capability: double_range_field_type_development_v4
+required_capability: double_range_field_type_development_v5
 
 FROM heights
 | WHERE description == "Short"
@@ -112,4 +112,68 @@ FROM heights
 
 height_range:double_range | new_range:double_range
 1.5..1.6                  | 1.5..1.6
+;
+
+doubleRangeEquality
+required_capability: double_range_field_type_development_v5
+required_capability: equality_double_range
+
+FROM heights
+| WHERE height_range == TO_RANGE(1.5, 1.6)
+| KEEP description
+;
+
+description:keyword
+Short
+;
+
+doubleRangeNotEquals
+required_capability: double_range_field_type_development_v5
+required_capability: equality_double_range
+
+FROM heights
+| WHERE height_range != TO_RANGE(1.5, 1.6)
+| KEEP description
+| SORT description
+;
+
+description:keyword
+Medium Height
+Tall
+Very Short
+Very Tall
+;
+
+doubleRangeSelfEquality
+required_capability: double_range_field_type_development_v5
+required_capability: equality_double_range
+
+FROM heights
+| EVAL equal = height_range == height_range
+| WHERE equal
+| KEEP description
+| SORT description
+;
+
+description:keyword
+Medium Height
+Short
+Tall
+Very Short
+Very Tall
+;
+
+doubleRangeIn
+required_capability: double_range_field_type_development_v5
+required_capability: equality_double_range
+
+FROM heights
+| WHERE height_range IN (TO_RANGE(1.5, 1.6), TO_RANGE(1.8, 2.0))
+| KEEP description
+| SORT description
+;
+
+description:keyword
+Short
+Tall
 ;

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleRangeEvaluator.java
@@ -11,8 +11,8 @@ package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.LongRangeBlock;
-import org.elasticsearch.compute.data.LongRangeBlockBuilder;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -29,8 +29,8 @@ import java.util.BitSet;
  * {@link ExpressionEvaluator} implementation for {@link In}.
  * This class is generated. Edit {@code X-InEvaluator.java.st} instead.
  */
-public class InLongRangeEvaluator implements ExpressionEvaluator {
-    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(InLongRangeEvaluator.class);
+public class InDoubleRangeEvaluator implements ExpressionEvaluator {
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(InDoubleRangeEvaluator.class);
 
     private final Source source;
 
@@ -42,7 +42,7 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings;
 
-    public InLongRangeEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator[] rhs, DriverContext driverContext) {
+    public InDoubleRangeEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator[] rhs, DriverContext driverContext) {
         this.source = source;
         this.lhs = lhs;
         this.rhs = rhs;
@@ -51,23 +51,23 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
 
     @Override
     public Block eval(Page page) {
-        try (LongRangeBlock lhsBlock = (LongRangeBlock) lhs.eval(page)) {
-            LongRangeBlock[] rhsBlocks = new LongRangeBlock[rhs.length];
+        try (DoubleRangeBlock lhsBlock = (DoubleRangeBlock) lhs.eval(page)) {
+            DoubleRangeBlock[] rhsBlocks = new DoubleRangeBlock[rhs.length];
             try (Releasable rhsRelease = Releasables.wrap(rhsBlocks)) {
                 for (int i = 0; i < rhsBlocks.length; i++) {
-                    rhsBlocks[i] = (LongRangeBlock) rhs[i].eval(page);
+                    rhsBlocks[i] = (DoubleRangeBlock) rhs[i].eval(page);
                 }
                 return eval(page.getPositionCount(), lhsBlock, rhsBlocks);
             }
         }
     }
 
-    private BooleanBlock eval(int positionCount, LongRangeBlock lhsBlock, LongRangeBlock[] rhsBlocks) {
+    private BooleanBlock eval(int positionCount, DoubleRangeBlock lhsBlock, DoubleRangeBlock[] rhsBlocks) {
         try (BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
-            LongRangeBlockBuilder.LongRange lhsScratch = new LongRangeBlockBuilder.LongRange();
-            LongRangeBlockBuilder.LongRange[] rhsScratch = new LongRangeBlockBuilder.LongRange[rhs.length];
+            DoubleRangeBlockBuilder.DoubleRange lhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
+            DoubleRangeBlockBuilder.DoubleRange[] rhsScratch = new DoubleRangeBlockBuilder.DoubleRange[rhs.length];
             for (int i = 0; i < rhs.length; i++) {
-                rhsScratch[i] = new LongRangeBlockBuilder.LongRange();
+                rhsScratch[i] = new DoubleRangeBlockBuilder.DoubleRange();
             }
             BitSet nulls = new BitSet(rhs.length);
             BitSet mvs = new BitSet(rhs.length);
@@ -98,17 +98,17 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
                         continue;
                     }
                     int o = rhsBlocks[i].getFirstValueIndex(p);
-                    rhsScratch[i] = rhsBlocks[i].getLongRange(o, rhsScratch[i]);
+                    rhsScratch[i] = rhsBlocks[i].getDoubleRange(o, rhsScratch[i]);
                 }
                 if (nulls.cardinality() == rhsBlocks.length || mvs.cardinality() == rhsBlocks.length) {
                     result.appendNull();
                     continue;
                 }
-                foundMatch = In.processLongRange(
+                foundMatch = In.processDoubleRange(
                     //
                     nulls,
                     mvs,
-                    lhsBlock.getLongRange(lhsBlock.getFirstValueIndex(p), lhsScratch),
+                    lhsBlock.getDoubleRange(lhsBlock.getFirstValueIndex(p), lhsScratch),
                     rhsScratch
                 );
                 if (foundMatch) {
@@ -127,7 +127,7 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
 
     @Override
     public String toString() {
-        return "InLongRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + Arrays.toString(rhs) + "]";
+        return "InDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + Arrays.toString(rhs) + "]";
     }
 
     @Override
@@ -164,14 +164,14 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
         }
 
         @Override
-        public InLongRangeEvaluator get(DriverContext context) {
+        public InDoubleRangeEvaluator get(DriverContext context) {
             ExpressionEvaluator[] rhs = Arrays.stream(this.rhs).map(a -> a.get(context)).toArray(ExpressionEvaluator[]::new);
-            return new InLongRangeEvaluator(source, lhs.get(context), rhs, context);
+            return new InDoubleRangeEvaluator(source, lhs.get(context), rhs, context);
         }
 
         @Override
         public String toString() {
-            return "InLongRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + Arrays.toString(rhs) + "]";
+            return "InDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + Arrays.toString(rhs) + "]";
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsDoubleRangeEvaluator.java
@@ -1,0 +1,141 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link Equals}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class EqualsDoubleRangeEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(EqualsDoubleRangeEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator lhs;
+
+  private final ExpressionEvaluator rhs;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public EqualsDoubleRangeEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
+      DriverContext driverContext) {
+    this.source = source;
+    this.lhs = lhs;
+    this.rhs = rhs;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleRangeBlock lhsBlock = (DoubleRangeBlock) lhs.eval(page)) {
+      try (DoubleRangeBlock rhsBlock = (DoubleRangeBlock) rhs.eval(page)) {
+        return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += lhs.baseRamBytesUsed();
+    baseRamBytesUsed += rhs.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BooleanBlock eval(int positionCount, DoubleRangeBlock lhsBlock,
+      DoubleRangeBlock rhsBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange lhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      DoubleRangeBlockBuilder.DoubleRange rhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (lhsBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (rhsBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        DoubleRangeBlockBuilder.DoubleRange lhs = lhsBlock.getDoubleRange(lhsBlock.getFirstValueIndex(p), lhsScratch);
+        DoubleRangeBlockBuilder.DoubleRange rhs = rhsBlock.getDoubleRange(rhsBlock.getFirstValueIndex(p), rhsScratch);
+        result.appendBoolean(Equals.processDoubleRange(lhs, rhs));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "EqualsDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lhs, rhs);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory lhs;
+
+    private final ExpressionEvaluator.Factory rhs;
+
+    public Factory(Source source, ExpressionEvaluator.Factory lhs,
+        ExpressionEvaluator.Factory rhs) {
+      this.source = source;
+      this.lhs = lhs;
+      this.rhs = rhs;
+    }
+
+    @Override
+    public EqualsDoubleRangeEvaluator get(DriverContext context) {
+      return new EqualsDoubleRangeEvaluator(source, lhs.get(context), rhs.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "EqualsDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsDoubleRangeEvaluator.java
@@ -1,0 +1,141 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link NotEquals}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class NotEqualsDoubleRangeEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(NotEqualsDoubleRangeEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator lhs;
+
+  private final ExpressionEvaluator rhs;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public NotEqualsDoubleRangeEvaluator(Source source, ExpressionEvaluator lhs,
+      ExpressionEvaluator rhs, DriverContext driverContext) {
+    this.source = source;
+    this.lhs = lhs;
+    this.rhs = rhs;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleRangeBlock lhsBlock = (DoubleRangeBlock) lhs.eval(page)) {
+      try (DoubleRangeBlock rhsBlock = (DoubleRangeBlock) rhs.eval(page)) {
+        return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += lhs.baseRamBytesUsed();
+    baseRamBytesUsed += rhs.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BooleanBlock eval(int positionCount, DoubleRangeBlock lhsBlock,
+      DoubleRangeBlock rhsBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange lhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      DoubleRangeBlockBuilder.DoubleRange rhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (lhsBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (rhsBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        DoubleRangeBlockBuilder.DoubleRange lhs = lhsBlock.getDoubleRange(lhsBlock.getFirstValueIndex(p), lhsScratch);
+        DoubleRangeBlockBuilder.DoubleRange rhs = rhsBlock.getDoubleRange(rhsBlock.getFirstValueIndex(p), rhsScratch);
+        result.appendBoolean(NotEquals.processDoubleRange(lhs, rhs));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "NotEqualsDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lhs, rhs);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory lhs;
+
+    private final ExpressionEvaluator.Factory rhs;
+
+    public Factory(Source source, ExpressionEvaluator.Factory lhs,
+        ExpressionEvaluator.Factory rhs) {
+      this.source = source;
+      this.lhs = lhs;
+      this.rhs = rhs;
+    }
+
+    @Override
+    public NotEqualsDoubleRangeEvaluator get(DriverContext context) {
+      return new NotEqualsDoubleRangeEvaluator(source, lhs.get(context), rhs.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "NotEqualsDoubleRangeEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2128,7 +2128,7 @@ public class EsqlCapabilities {
         /**
          * Support for the DOUBLE_RANGE field type.
          */
-        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V4(Build.current().isSnapshot()),
+        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5(Build.current().isSnapshot()),
 
         /**
          * Network direction function.
@@ -3367,6 +3367,11 @@ public class EsqlCapabilities {
          * Support for equality (==, !=) and IN with date_range type.
          */
         EQUALITY_DATE_RANGE(DATE_RANGE_FIELD_TYPE_V6.isEnabled()),
+
+        /**
+         * Support for equality ({@code ==}, {@code !=}) and {@code IN} with the {@code double_range} type.
+         */
+        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5.isEnabled()),
 
         /**
          * Fix TopN encoding/decoding of {@code long_range} values.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -10,6 +10,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
@@ -55,6 +56,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
         Map.entry(DataType.DATETIME, EqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, EqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_RANGE, EqualsLongRangeEvaluator.Factory::new),
+        Map.entry(DataType.DOUBLE_RANGE, EqualsDoubleRangeEvaluator.Factory::new),
         Map.entry(DataType.GEO_POINT, EqualsGeometriesEvaluator.Factory::new),
         Map.entry(DataType.CARTESIAN_POINT, EqualsGeometriesEvaluator.Factory::new),
         Map.entry(DataType.GEO_SHAPE, EqualsGeometriesEvaluator.Factory::new),
@@ -94,6 +96,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "exponential_histogram",
                 "flattened",
                 "geo_point",
@@ -123,6 +126,7 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "exponential_histogram",
                 "flattened",
                 "geo_point",
@@ -282,6 +286,11 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
 
     @Evaluator(extraName = "LongRange")
     static boolean processLongRange(LongRangeBlockBuilder.LongRange lhs, LongRangeBlockBuilder.LongRange rhs) {
+        return lhs.equals(rhs);
+    }
+
+    @Evaluator(extraName = "DoubleRange")
+    static boolean processDoubleRange(DoubleRangeBlockBuilder.DoubleRange lhs, DoubleRangeBlockBuilder.DoubleRange rhs) {
         return lhs.equals(rhs);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -371,8 +371,8 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
             if (lit.value() instanceof Collection<?>) {
                 return Translatable.NO;
             }
-            // date_range fields don't support scalar term/range queries; equality must be evaluated in the compute engine
-            if (left().dataType() == DataType.DATE_RANGE) {
+            // Range fields don't support scalar term/range queries; equality must be evaluated in the compute engine.
+            if (left().dataType() == DataType.DATE_RANGE || left().dataType() == DataType.DOUBLE_RANGE) {
                 return Translatable.NO;
             }
             if (pushdownPredicates.isPushableFieldAttribute(left())) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/In.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
@@ -61,6 +62,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE_RANGE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
@@ -143,6 +145,7 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
                 "cartesian_shape",
                 "date_range",
                 "double",
+                "double_range",
                 "geo_point",
                 "geo_shape",
                 "geohash",
@@ -164,6 +167,7 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
                 "cartesian_shape",
                 "date_range",
                 "double",
+                "double_range",
                 "geo_point",
                 "geo_shape",
                 "geohash",
@@ -377,6 +381,9 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
         if (commonType == DATE_RANGE) {
             return new InLongRangeEvaluator.Factory(source(), lhs, factories);
         }
+        if (commonType == DOUBLE_RANGE) {
+            return new InDoubleRangeEvaluator.Factory(source(), lhs, factories);
+        }
         if (commonType == NULL) {
             return ConstantEvaluators.CONSTANT_NULL_FACTORY;
         }
@@ -499,13 +506,30 @@ public class In extends EsqlScalarFunction implements TranslationAware.SingleVal
         return false;
     }
 
+    static boolean processDoubleRange(
+        BitSet nulls,
+        BitSet mvs,
+        DoubleRangeBlockBuilder.DoubleRange lhs,
+        DoubleRangeBlockBuilder.DoubleRange[] rhs
+    ) {
+        for (int i = 0; i < rhs.length; i++) {
+            if ((nulls != null && nulls.get(i)) || (mvs != null && mvs.get(i))) {
+                continue;
+            }
+            if (lhs.equals(rhs[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         if (Expressions.foldable(list()) == false) {
             return Translatable.NO;
         }
-        // date_range fields don't support scalar term/range queries; IN must be evaluated in the compute engine
-        if (value.dataType() == DATE_RANGE) {
+        // Range fields don't support scalar term/range queries; IN must be evaluated in the compute engine.
+        if (value.dataType() == DATE_RANGE || value.dataType() == DOUBLE_RANGE) {
             return Translatable.NO;
         }
         if (pushdownPredicates.isPushableAttribute(value)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
@@ -10,6 +10,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
@@ -53,6 +54,7 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
         Map.entry(DataType.DATETIME, NotEqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, NotEqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_RANGE, NotEqualsLongRangeEvaluator.Factory::new),
+        Map.entry(DataType.DOUBLE_RANGE, NotEqualsDoubleRangeEvaluator.Factory::new),
         Map.entry(DataType.GEO_POINT, NotEqualsGeometriesEvaluator.Factory::new),
         Map.entry(DataType.CARTESIAN_POINT, NotEqualsGeometriesEvaluator.Factory::new),
         Map.entry(DataType.GEO_SHAPE, NotEqualsGeometriesEvaluator.Factory::new),
@@ -92,6 +94,7 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "exponential_histogram",
                 "flattened",
                 "geo_point",
@@ -121,6 +124,7 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "exponential_histogram",
                 "flattened",
                 "geo_point",
@@ -211,6 +215,11 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
 
     @Evaluator(extraName = "LongRange")
     static boolean processLongRange(LongRangeBlockBuilder.LongRange lhs, LongRangeBlockBuilder.LongRange rhs) {
+        return false == lhs.equals(rhs);
+    }
+
+    @Evaluator(extraName = "DoubleRange")
+    static boolean processDoubleRange(DoubleRangeBlockBuilder.DoubleRange lhs, DoubleRangeBlockBuilder.DoubleRange rhs) {
         return false == lhs.equals(rhs);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st
@@ -15,12 +15,12 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.$Type$Block;
-$if(!LongRange)$
+$if(!Range)$
 import org.elasticsearch.compute.data.$Type$Vector;
 import org.elasticsearch.compute.data.BooleanVector;
 $endif$
-$if(LongRange)$
-import org.elasticsearch.compute.data.LongRangeBlockBuilder;
+$if(Range)$
+import org.elasticsearch.compute.data.$Type$BlockBuilder;
 $endif$
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
@@ -66,7 +66,7 @@ public class In$Name$Evaluator implements ExpressionEvaluator {
                 for (int i = 0; i < rhsBlocks.length; i++) {
                     rhsBlocks[i] = ($Type$Block) rhs[i].eval(page);
                 }
-$if(!LongRange)$
+$if(!Range)$
                 $Type$Vector lhsVector = lhsBlock.asVector();
                 if (lhsVector == null) {
                     return eval(page.getPositionCount(), lhsBlock, rhsBlocks);
@@ -104,11 +104,11 @@ $elseif(BytesRef)$
             for (int i = 0; i < rhs.length; i++) {
                 rhsScratch[i] = new BytesRef();
             }
-$elseif(LongRange)$
-            LongRangeBlockBuilder.LongRange lhsScratch = new LongRangeBlockBuilder.LongRange();
-            LongRangeBlockBuilder.LongRange[] rhsScratch = new LongRangeBlockBuilder.LongRange[rhs.length];
+$elseif(Range)$
+            $Type$BlockBuilder.$Type$ lhsScratch = new $Type$BlockBuilder.$Type$();
+            $Type$BlockBuilder.$Type$[] rhsScratch = new $Type$BlockBuilder.$Type$[rhs.length];
             for (int i = 0; i < rhs.length; i++) {
-                rhsScratch[i] = new LongRangeBlockBuilder.LongRange();
+                rhsScratch[i] = new $Type$BlockBuilder.$Type$();
             }
 $endif$
             BitSet nulls = new BitSet(rhs.length);
@@ -157,8 +157,8 @@ $elseif(boolean)$
                     } else {
                         hasFalse = true;
                     }
-$elseif(LongRange)$
-                    rhsScratch[i] = rhsBlocks[i].getLongRange(o, rhsScratch[i]);
+$elseif(Range)$
+                    rhsScratch[i] = rhsBlocks[i].get$Type$(o, rhsScratch[i]);
 $else$
                     rhsValues[i] = rhsBlocks[i].get$Type$(o);
 $endif$
@@ -174,8 +174,14 @@ $elseif(BytesRef)$
 $elseif(NanosMillis)$
                 // Even though these are longs, they're in different units and need special handling
                 foundMatch = In.processNanosMilils(nulls, mvs, lhsBlock.get$Type$(lhsBlock.getFirstValueIndex(p)), rhsValues);
-$elseif(LongRange)$
-                foundMatch = In.processLongRange(nulls, mvs, lhsBlock.getLongRange(lhsBlock.getFirstValueIndex(p), lhsScratch), rhsScratch);
+$elseif(Range)$
+                foundMatch = In.process$Type$(
+                    //
+                    nulls,
+                    mvs,
+                    lhsBlock.get$Type$(lhsBlock.getFirstValueIndex(p), lhsScratch),
+                    rhsScratch
+                );
 $else$
                 foundMatch = In.process(nulls, mvs, lhsBlock.get$Type$(lhsBlock.getFirstValueIndex(p)), rhsValues);
 $endif$
@@ -193,7 +199,7 @@ $endif$
         }
     }
 
-$if(!LongRange)$
+$if(!Range)$
     private BooleanBlock eval(int positionCount, $Type$Vector lhsVector, $Type$Vector[] rhsVectors) {
         try (BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
 $if(int)$

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2673,8 +2673,8 @@ public class VerifierTests extends ESTestCase {
             equalTo(
                 "1:26: first argument of [\"3 days\"::date_period == to_dateperiod(\"3 days\")] must be "
                     + "[boolean, cartesian_point, cartesian_shape, date_nanos, date_range, datetime, dense_vector, double, "
-                    + "exponential_histogram, flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, integer, "
-                    + "ip, keyword, long, tdigest, text, unsigned_long or version], "
+                    + "double_range, exponential_histogram, flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, "
+                    + "integer, ip, keyword, long, tdigest, text, unsigned_long or version], "
                     + "found value [\"3 days\"::date_period] type [date_period]"
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1628,7 +1628,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testDoubleRangeUnsupportedOperations() {
-        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V4.isEnabled());
+        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5.isEnabled());
         analyzer().addIndex("heights", "mapping-heights.json")
             .stripErrorPrefix(true)
             .error("FROM heights | SORT height_range", containsString("cannot sort on double_range"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsErrorTests.java
@@ -36,7 +36,7 @@ public class EqualsErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     }
 
     private static final String TYPE_ERROR =
-        "boolean, cartesian_point, cartesian_shape, date_nanos, date_range, datetime, dense_vector, double, exponential_histogram, "
-            + "flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, integer, ip, keyword, long, tdigest, text, "
-            + "unsigned_long or version";
+        "boolean, cartesian_point, cartesian_shape, date_nanos, date_range, datetime, dense_vector, double, double_range, "
+            + "exponential_histogram, flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, integer, ip, keyword, "
+            + "long, tdigest, text, unsigned_long or version";
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
@@ -294,6 +294,23 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
             );
         }
 
+        // Double range cases
+        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            suppliers.addAll(
+                TestCaseSupplier.forBinaryNotCasting(
+                    "EqualsDoubleRangeEvaluator",
+                    "lhs",
+                    "rhs",
+                    Object::equals,
+                    DataType.BOOLEAN,
+                    TestCaseSupplier.doubleRangeCases(),
+                    TestCaseSupplier.doubleRangeCases(),
+                    List.of(),
+                    false
+                )
+            );
+        }
+
         // Dense vector cases
         suppliers.add(new TestCaseSupplier("<dense_vector>, <dense_vector>", List.of(DataType.DENSE_VECTOR, DataType.DENSE_VECTOR), () -> {
             int dimensions = between(64, 128);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
@@ -296,6 +296,11 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
 
         // Double range cases
         if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+            List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = TestCaseSupplier.doubleRangeCases()
+                .stream()
+                .map(c -> c.withAppliesTo(doubleRangeAppliesTo))
+                .toList();
             suppliers.addAll(
                 TestCaseSupplier.forBinaryNotCasting(
                     "EqualsDoubleRangeEvaluator",
@@ -303,8 +308,8 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
                     "rhs",
                     Object::equals,
                     DataType.BOOLEAN,
-                    TestCaseSupplier.doubleRangeCases(),
-                    TestCaseSupplier.doubleRangeCases(),
+                    doubleRangeCases,
+                    doubleRangeCases,
                     List.of(),
                     false
                 )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -10,6 +10,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
@@ -52,6 +53,9 @@ public class InTests extends AbstractFunctionTestCase {
             bytesRefs(suppliers, i);
             if (DataType.DATE_RANGE.supportedVersion().supportedLocally()) {
                 dateRanges(suppliers, i);
+            }
+            if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+                doubleRanges(suppliers, i);
             }
         }
         return parameterSuppliersFromTypedData(suppliers);
@@ -268,6 +272,29 @@ public class InTests extends AbstractFunctionTestCase {
             return new TestCaseSupplier.TestCase(
                 args,
                 matchesPattern("InLongRangeEvaluator.*"),
+                DataType.BOOLEAN,
+                equalTo(inlist.contains(field))
+            );
+        }));
+    }
+
+    private static void doubleRanges(List<TestCaseSupplier> suppliers, int items) {
+        suppliers.add(new TestCaseSupplier("double_range", typesList(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE, items), () -> {
+            var drSupplier = TestCaseSupplier.doubleRangeCases().get(0).supplier();
+            List<DoubleRangeBlockBuilder.DoubleRange> inlist = randomList(
+                items,
+                items,
+                () -> (DoubleRangeBlockBuilder.DoubleRange) drSupplier.get()
+            );
+            DoubleRangeBlockBuilder.DoubleRange field = inlist.get(0);
+            List<TestCaseSupplier.TypedData> args = new ArrayList<>(inlist.size() + 1);
+            for (DoubleRangeBlockBuilder.DoubleRange i : inlist) {
+                args.add(new TestCaseSupplier.TypedData(i, DataType.DOUBLE_RANGE, "inlist"));
+            }
+            args.add(new TestCaseSupplier.TypedData(field, DataType.DOUBLE_RANGE, "field"));
+            return new TestCaseSupplier.TestCase(
+                args,
+                matchesPattern("InDoubleRangeEvaluator.*"),
                 DataType.BOOLEAN,
                 equalTo(inlist.contains(field))
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.DocsV3Support;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.junit.AfterClass;
 
@@ -36,6 +37,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
 import static org.elasticsearch.xpack.esql.expression.function.DocsV3Support.renderNegatedOperator;
+import static org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier.appliesTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
 
@@ -280,6 +282,7 @@ public class InTests extends AbstractFunctionTestCase {
 
     private static void doubleRanges(List<TestCaseSupplier> suppliers, int items) {
         suppliers.add(new TestCaseSupplier("double_range", typesList(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE, items), () -> {
+            var doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
             var drSupplier = TestCaseSupplier.doubleRangeCases().get(0).supplier();
             List<DoubleRangeBlockBuilder.DoubleRange> inlist = randomList(
                 items,
@@ -289,9 +292,9 @@ public class InTests extends AbstractFunctionTestCase {
             DoubleRangeBlockBuilder.DoubleRange field = inlist.get(0);
             List<TestCaseSupplier.TypedData> args = new ArrayList<>(inlist.size() + 1);
             for (DoubleRangeBlockBuilder.DoubleRange i : inlist) {
-                args.add(new TestCaseSupplier.TypedData(i, DataType.DOUBLE_RANGE, "inlist"));
+                args.add(new TestCaseSupplier.TypedData(i, DataType.DOUBLE_RANGE, "inlist").withAppliesTo(doubleRangeAppliesTo));
             }
-            args.add(new TestCaseSupplier.TypedData(field, DataType.DOUBLE_RANGE, "field"));
+            args.add(new TestCaseSupplier.TypedData(field, DataType.DOUBLE_RANGE, "field").withAppliesTo(doubleRangeAppliesTo));
             return new TestCaseSupplier.TestCase(
                 args,
                 matchesPattern("InDoubleRangeEvaluator.*"),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsErrorTests.java
@@ -36,7 +36,7 @@ public class NotEqualsErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     }
 
     private static final String TYPE_ERROR =
-        "boolean, cartesian_point, cartesian_shape, date_nanos, date_range, datetime, dense_vector, double, exponential_histogram, "
-            + "flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, integer, ip, keyword, long, tdigest, text, "
-            + "unsigned_long or version";
+        "boolean, cartesian_point, cartesian_shape, date_nanos, date_range, datetime, dense_vector, double, double_range, "
+            + "exponential_histogram, flattened, geo_point, geo_shape, geohash, geohex, geotile, histogram, integer, ip, keyword, "
+            + "long, tdigest, text, unsigned_long or version";
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
@@ -293,6 +293,11 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
 
         // Double range cases
         if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+            List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = TestCaseSupplier.doubleRangeCases()
+                .stream()
+                .map(c -> c.withAppliesTo(doubleRangeAppliesTo))
+                .toList();
             suppliers.addAll(
                 TestCaseSupplier.forBinaryNotCasting(
                     "NotEqualsDoubleRangeEvaluator",
@@ -300,8 +305,8 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
                     "rhs",
                     (l, r) -> false == l.equals(r),
                     DataType.BOOLEAN,
-                    TestCaseSupplier.doubleRangeCases(),
-                    TestCaseSupplier.doubleRangeCases(),
+                    doubleRangeCases,
+                    doubleRangeCases,
                     List.of(),
                     false
                 )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
@@ -291,6 +291,23 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
             );
         }
 
+        // Double range cases
+        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            suppliers.addAll(
+                TestCaseSupplier.forBinaryNotCasting(
+                    "NotEqualsDoubleRangeEvaluator",
+                    "lhs",
+                    "rhs",
+                    (l, r) -> false == l.equals(r),
+                    DataType.BOOLEAN,
+                    TestCaseSupplier.doubleRangeCases(),
+                    TestCaseSupplier.doubleRangeCases(),
+                    List.of(),
+                    false
+                )
+            );
+        }
+
         // Dense vector cases
         suppliers.add(new TestCaseSupplier("<dense_vector>, <dense_vector>", List.of(DataType.DENSE_VECTOR, DataType.DENSE_VECTOR), () -> {
             int dimensions = between(64, 128);


### PR DESCRIPTION
Part of #154463

## Summary
- add equality, inequality, and `IN` evaluators for `double_range`
- keep range comparisons in the compute engine instead of unsupported Lucene pushdown
- add generated evaluators plus unit and CSV-spec coverage

## Testing
- targeted comparison unit tests in snapshot and non-snapshot modes
- `double_range` CSV-spec tests in snapshot and non-snapshot modes
- StringTemplate generation and Spotless checks