### PR TITLE
[8.19] Isolate old-repo test repo dirs per test class (#155550)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -218,9 +218,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
   issue: https://github.com/elastic/elasticsearch/issues/116777
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldSourceOnlyRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120080
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/118214
@@ -275,9 +272,6 @@ tests:
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120148
 - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
   issue: https://github.com/elastic/elasticsearch/issues/120575
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT

--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.oldrepos;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
@@ -20,7 +19,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.oldelasticsearch.OldElasticsearchContainer;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
@@ -48,8 +46,8 @@ import java.io.IOException;
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
 public class DocValueOnlyFieldsIT extends ESClientYamlSuiteTestCase {
 
-    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer();
-    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster();
+    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer(DocValueOnlyFieldsIT.class);
+    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster(DocValueOnlyFieldsIT.class);
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(oldEs).around(cluster);
@@ -98,9 +96,7 @@ public class DocValueOnlyFieldsIT extends ESClientYamlSuiteTestCase {
 
         setupDone = true;
 
-        String repoLocation = PathUtils.get(System.getProperty("tests.repo.location"))
-            .resolve(RandomizedTest.getContext().getTargetClass().getName())
-            .toString();
+        String repoLocation = OldEsTestCluster.repoLocation(DocValueOnlyFieldsIT.class);
 
         String indexName = "test";
         String repoName = "doc_values_repo";

--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldEsTestCluster.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldEsTestCluster.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.oldrepos;
 
+import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.fixtures.oldelasticsearch.OldElasticsearchContainer;
@@ -21,21 +22,40 @@ final class OldEsTestCluster {
     private OldEsTestCluster() {}
 
     /**
-     * Creates a new {@link OldElasticsearchContainer} for the version and repo location supplied
-     * via {@code tests.es.version} / {@code tests.repo.location} system properties.
+     * Computes a per-test-class snapshot repository directory nested under the shared
+     * {@code tests.repo.location} base directory.
+     * <p>
+     * Each test class must get its own isolated subdirectory because
+     * {@link OldElasticsearchContainer}'s entrypoint wipes its bind-mounted repo directory on
+     * every container start. All three old-repo test classes share the same Gradle task and run
+     * in separate, potentially concurrent, forked JVMs; if they shared one directory, one
+     * class's container startup could wipe out snapshot data another class was still using,
+     * causing spurious recovery failures after a cluster restart.
      */
-    static OldElasticsearchContainer newContainer() {
-        return new OldElasticsearchContainer(System.getProperty("tests.es.version"), System.getProperty("tests.repo.location"));
+    static String repoLocation(Class<?> testClass) {
+        return PathUtils.get(System.getProperty("tests.repo.location")).resolve(testClass.getName()).toString();
     }
 
     /**
-     * Creates the shared two-node cluster configuration used by all old-repo snapshot tests.
+     * Creates a new {@link OldElasticsearchContainer} for the version supplied via the
+     * {@code tests.es.version} system property, bind-mounting the per-{@code testClass} repo
+     * directory computed by {@link #repoLocation(Class)}.
      */
-    static ElasticsearchCluster newCluster() {
+    static OldElasticsearchContainer newContainer(Class<?> testClass) {
+        return new OldElasticsearchContainer(System.getProperty("tests.es.version"), repoLocation(testClass));
+    }
+
+    /**
+     * Creates the shared two-node cluster configuration used by all old-repo snapshot tests,
+     * with {@code path.repo} set to the per-{@code testClass} repo directory computed by
+     * {@link #repoLocation(Class)}.
+     */
+    static ElasticsearchCluster newCluster(Class<?> testClass) {
+        String repoLocation = repoLocation(testClass);
         return ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
             .nodes(2)
-            .setting("path.repo", () -> System.getProperty("tests.repo.location"))
+            .setting("path.repo", () -> repoLocation)
             .setting("xpack.license.self_generated.type", "trial")
             .setting("xpack.security.enabled", "true")
             .user("admin", "admin-password", "superuser", false)

--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldMappingsIT.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldMappingsIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.oldrepos;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.TestMethodAndParams;
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
@@ -25,7 +24,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.oldelasticsearch.OldElasticsearchContainer;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
@@ -77,8 +75,8 @@ public class OldMappingsIT extends ESRestTestCase {
         }
     }
 
-    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer();
-    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster();
+    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer(OldMappingsIT.class);
+    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster(OldMappingsIT.class);
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(oldEs).around(cluster);
@@ -113,9 +111,7 @@ public class OldMappingsIT extends ESRestTestCase {
 
         setupDone = true;
 
-        String repoLocation = PathUtils.get(System.getProperty("tests.repo.location"))
-            .resolve(RandomizedTest.getContext().getTargetClass().getName())
-            .toString();
+        String repoLocation = OldEsTestCluster.repoLocation(OldMappingsIT.class);
 
         String repoName = "old_mappings_repo";
         String snapshotName = "snap";

--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
@@ -70,8 +70,8 @@ import static org.hamcrest.Matchers.startsWith;
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
 public class OldRepositoryAccessIT extends ESRestTestCase {
 
-    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer();
-    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster();
+    private static final OldElasticsearchContainer oldEs = OldEsTestCluster.newContainer(OldRepositoryAccessIT.class);
+    private static final ElasticsearchCluster cluster = OldEsTestCluster.newCluster(OldRepositoryAccessIT.class);
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(oldEs).around(cluster);
@@ -110,8 +110,9 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
     }
 
     public void runTest(boolean sourceOnlyRepository) throws IOException {
-        String repoLocation = System.getProperty("tests.repo.location");
-        repoLocation = PathUtils.get(repoLocation).resolve("source_only_" + sourceOnlyRepository).toString();
+        String repoLocation = PathUtils.get(OldEsTestCluster.repoLocation(OldRepositoryAccessIT.class))
+            .resolve("source_only_" + sourceOnlyRepository)
+            .toString();
         assumeTrue(
             "source only repositories only supported since ES 6.5.0",
             sourceOnlyRepository == false || oldVersion.onOrAfter(Version.fromString("6.5.0"))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Isolate old-repo test repo dirs per test class (#155550)](https://github.com/elastic/elasticsearch/pull/155550)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)