### PR TITLE
[9.5] uninstall encryption key custom after KeyRotationIT tests (#155503)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -736,9 +736,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
   method: testPitRelocationDuringReshard
   issue: https://github.com/elastic/elasticsearch/issues/155284
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testRotationCompletesWithMultipleHandlers
-  issue: https://github.com/elastic/elasticsearch/issues/153747
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
   method: test {csv-spec:change_point.values int column with all nulls}
   issue: https://github.com/elastic/elasticsearch/issues/155124

--- a/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
+++ b/x-pack/plugin/encryption/src/internalClusterTest/java/org/elasticsearch/xpack/encryption/KeyRotationIT.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -77,6 +78,8 @@ public class KeyRotationIT extends SecurityIntegTestCase {
         for (String nodeName : internalCluster().getNodeNames()) {
             internalCluster().getInstance(KeyRotationCoordinator.class, nodeName).close();
         }
+        var request = new EncryptionResetRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, true);
+        assertAcked(client().execute(TransportEncryptionResetAction.TYPE, request).actionGet());
         waitNoPendingTasksOnAll();
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - uninstall encryption key custom after KeyRotationIT tests (#155503)