### PR TITLE
unmute #155419

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -550,9 +550,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.FederationRemoteDatasetGateRestIT
   method: testDisabledRemoteResolvesDatasetAsMissingIndex
   issue: https://github.com/elastic/elasticsearch/issues/155382
-- class: org.elasticsearch.xpack.encryption.KeyRotationIT
-  method: testConsecutiveRotations
-  issue: https://github.com/elastic/elasticsearch/issues/155419
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=downsample/100_downsample_histograms/Downsample histogram with last value}
   issue: https://github.com/elastic/elasticsearch/issues/155453


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/155503

I thought both mutes were on 9.5, but one was on main and should have been unmuted with the main PR