### PR TITLE
[9.3] Backport bbq_flat yaml refresh fixes (#155078) 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -346,9 +346,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValuesByteRefGroupingAggregatorFunctionTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/155069
-- class: org.elasticsearch.test.rest.yaml.RcsCcsSearchYamlTestSuiteIT
-  method: test {p0=search.vectors/45_knn_search_bit/Vector rescoring has no effect for non-quantized vectors and provides same results as non-rescored knn}
-  issue: https://github.com/elastic/elasticsearch/issues/155328
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/155449

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -328,12 +328,6 @@ tests:
 - class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
   method: testDuel
   issue: https://github.com/elastic/elasticsearch/issues/154243
-- class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
-  method: test {p0=search.vectors/42_knn_search_bbq_flat_bfloat16/Vector rescoring has same scoring as exact search for kNN section}
-  issue: https://github.com/elastic/elasticsearch/issues/154656
-- class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
-  method: test {p0=search.vectors/42_knn_search_bbq_flat/Test knn search}
-  issue: https://github.com/elastic/elasticsearch/issues/154858
 - class: org.elasticsearch.index.mapper.blockloader.LongFieldBlockLoaderTests
   method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=NONE]}
   issue: https://github.com/elastic/elasticsearch/issues/154912

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/180_update_dense_vector_type.yml
@@ -791,6 +791,10 @@ setup:
         max_num_segments: 1
 
   - do:
+      indices.refresh:
+        index: test_index
+
+  - do:
       search:
         index: test_index
         body:
@@ -936,6 +940,10 @@ setup:
       indices.forcemerge:
         index: test_index
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: test_index
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/210_knn_search_profile.yml
@@ -85,6 +85,10 @@ setup:
       indices.forcemerge:
         index: bbq_hnsw
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: bbq_hnsw
 ---
 "Profile rescored knn search":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat.yml
@@ -74,6 +74,9 @@ setup:
       indices.forcemerge:
         index: bbq_flat
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:
@@ -458,6 +461,10 @@ setup:
       indices.forcemerge:
         index: bbq_flat_nested
         max_num_segments: 1
+
+  - do:
+      indices.refresh:
+        index: bbq_flat_nested
 
   - do:
       search:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_bbq_flat_bfloat16.yml
@@ -78,6 +78,9 @@ setup:
       indices.forcemerge:
         index: bbq_flat
         max_num_segments: 1
+
+  - do:
+      indices.refresh: { }
 ---
 "Test knn search":
   - requires:


### PR DESCRIPTION
Backport to 9.3 of https://github.com/elastic/elasticsearch/pull/154996

Backports two test-only visibility fixes:

https://github.com/elastic/elasticsearch/pull/154272 — add index refresh to bbq yaml tests to ensure changes are available
https://github.com/elastic/elasticsearch/pull/154688 — add index refresh after forced merge

Closes #154656 #154858
