### PR TITLE
[9.4] ESQL: Remove geo from MV_SORT allowed inputs and added error tests

### DIFF
--- a/docs/changelog/154417.yaml
+++ b/docs/changelog/154417.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154417
+summary: Fixed the case where MV_SORT incorrectly allowed geospatial types, which are not sortable
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
@@ -173,12 +173,12 @@ true
 
 sample cartesian_point
 required_capability: agg_sample
- 
-FROM airports_web | SORT abbrev | LIMIT 3 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample)
+
+FROM airports_web | SORT abbrev | LIMIT 3 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;
 
-sample:cartesian_point
-[POINT (809321.6344269889 1006514.3393965173), POINT (-1.1868515102256078E7 4170563.5012235222), POINT (-437732.64923689933 585738.5549131387)]
+sample:keyword
+[POINT (-1.1868515102256078E7 4170563.5012235222), POINT (-437732.64923689933 585738.5549131387), POINT (809321.6344269889 1006514.3393965173)]
 ;
 
 
@@ -206,11 +206,11 @@ sample:date_nanos
 
 sample geo_point
 required_capability: agg_sample
- 
-FROM airports | SORT abbrev | LIMIT 2 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample)
+
+FROM airports | SORT abbrev | LIMIT 2 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;
 
-sample:geo_point
+sample:keyword
 [POINT (-106.6166851616 35.0491578018276), POINT (-3.93221929167636 5.2543984451492)]
 ;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
@@ -54,7 +54,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
-import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isRepresentableExceptCountersDenseVectorAggregateMetricDoubleAndHistogram;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isRepresentableExceptCountersSpatialDenseVectorAggregateMetricDoubleAndHistogram;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
 
@@ -130,7 +130,11 @@ public class MvSort extends EsqlScalarFunction implements OptionalArgument, Post
             return new TypeResolution("Unresolved children");
         }
 
-        TypeResolution resolution = isRepresentableExceptCountersDenseVectorAggregateMetricDoubleAndHistogram(field, sourceText(), FIRST);
+        TypeResolution resolution = isRepresentableExceptCountersSpatialDenseVectorAggregateMetricDoubleAndHistogram(
+            field,
+            sourceText(),
+            FIRST
+        );
 
         if (resolution.unresolved()) {
             return resolution;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -318,7 +318,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDenseVectorErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToVersionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvIntersectionErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSortErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvUnionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.nulls.CoalesceErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayErrorTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortErrorTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DENSE_VECTOR;
+import static org.elasticsearch.xpack.esql.core.type.DataType.EXPONENTIAL_HISTOGRAM;
+import static org.elasticsearch.xpack.esql.core.type.DataType.HISTOGRAM;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TDIGEST;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MvSortErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+    private static final String FIELD_TYPES = "any type except counter, spatial types, dense_vector, "
+        + "aggregate_metric_double, tdigest, histogram, exponential_histogram, or date_range";
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(MvSortTests.parameters());
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new MvSort(source, args.get(0), args.size() > 1 ? args.get(1) : null);
+    }
+
+    /**
+     * Positive tests don't cover every legal shape {@code MV_SORT} accepts (default {@code order},
+     * {@code text} {@code order}, {@code null} {@code order}). Those still type-check, so exclude them
+     * here unless the field type itself is invalid.
+     */
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        return super.testCandidates(cases, valid).filter(types -> {
+            DataType field = types.get(0);
+            if (types.size() == 1) {
+                return isInvalidFieldType(field);
+            }
+            DataType order = types.get(1);
+            if (order == DataType.NULL || DataType.isString(order)) {
+                return isInvalidFieldType(field);
+            }
+            return true;
+        });
+    }
+
+    private static boolean isInvalidFieldType(DataType type) {
+        if (type == DataType.NULL) {
+            return false;
+        }
+        return DataType.isRepresentable(type) == false
+            || DataType.isSpatialOrGrid(type)
+            || type == DENSE_VECTOR
+            || type == AGGREGATE_METRIC_DOUBLE
+            || type == EXPONENTIAL_HISTOGRAM
+            || type == HISTOGRAM
+            || type == TDIGEST
+            || type == DATE_RANGE;
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        // Prefer resolveType order over test-derived validPerPosition: some accepted field types
+        // (e.g. unsigned_long) are missing from MvSortTests, which would mis-attribute the bad arg.
+        String source = sourceForSignature(signature);
+        if (isInvalidFieldType(signature.get(0))) {
+            return equalTo(
+                "first argument of ["
+                    + source
+                    + "] must be ["
+                    + FIELD_TYPES
+                    + "], found value [] type ["
+                    + signature.get(0).typeName()
+                    + "]"
+            );
+        }
+        return equalTo("second argument of [" + source + "] must be [string], found value [] type [" + signature.get(1).typeName() + "]");
+    }
+}


### PR DESCRIPTION
Manual 9.4 backport of https://github.com/elastic/elasticsearch/pull/154417