### PR TITLE
[8.19] ESQL: Remove geo from MV_SORT allowed inputs and added error tests

### DIFF
--- a/docs/changelog/154417.yaml
+++ b/docs/changelog/154417.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 154417
+summary: Fixed the case where MV_SORT incorrectly allowed geospatial types, which are not sortable
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_sample.csv-spec
@@ -162,12 +162,12 @@ true
 
 sample cartesian_point
 required_capability: agg_sample
- 
-FROM airports_web | SORT abbrev | LIMIT 3 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample)
+
+FROM airports_web | SORT abbrev | LIMIT 3 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;
 
-sample:cartesian_point
-[POINT (809321.6344269889 1006514.3393965173), POINT (-1.1868515102256078E7 4170563.5012235222), POINT (-437732.64923689933 585738.5549131387)]
+sample:keyword
+[POINT (-1.1868515102256078E7 4170563.5012235222), POINT (-437732.64923689933 585738.5549131387), POINT (809321.6344269889 1006514.3393965173)]
 ;
 
 
@@ -195,11 +195,11 @@ sample:date_nanos
 
 sample geo_point
 required_capability: agg_sample
- 
-FROM airports | SORT abbrev | LIMIT 2 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample)
+
+FROM airports | SORT abbrev | LIMIT 2 | STATS sample = SAMPLE(location, 999) | EVAL sample = MV_SORT(sample::string)
 ;
 
-sample:geo_point
+sample:keyword
 [POINT (-106.6166851616 35.0491578018276), POINT (-3.93221929167636 5.2543984451492)]
 ;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSort.java
@@ -56,6 +56,8 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isRepresentable;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isSpatial;
 import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
 
 /**
@@ -129,7 +131,13 @@ public class MvSort extends EsqlScalarFunction implements OptionalArgument, Post
             return new TypeResolution("Unresolved children");
         }
 
-        TypeResolution resolution = isType(field, DataType::isRepresentable, sourceText(), FIRST, "representable");
+        TypeResolution resolution = isType(
+            field,
+            t -> isSpatial(t) == false && isRepresentable(t),
+            sourceText(),
+            FIRST,
+            "representableNonSpatial"
+        );
 
         if (resolution.unresolved()) {
             return resolution;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSortErrorTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class MvSortErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+    private static final String FIELD_TYPES = "representableNonSpatial";
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(MvSortTests.parameters());
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new MvSort(source, args.get(0), args.size() > 1 ? args.get(1) : null);
+    }
+
+    /**
+     * Positive tests don't cover every legal shape {@code MV_SORT} accepts (default {@code order},
+     * {@code text} {@code order}, {@code null} {@code order}). Those still type-check, so exclude them
+     * here unless the field type itself is invalid.
+     */
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        return super.testCandidates(cases, valid).filter(types -> {
+            DataType field = types.get(0);
+            if (types.size() == 1) {
+                return isInvalidFieldType(field);
+            }
+            DataType order = types.get(1);
+            if (order == DataType.NULL || DataType.isString(order)) {
+                return isInvalidFieldType(field);
+            }
+            return true;
+        });
+    }
+
+    private static boolean isInvalidFieldType(DataType type) {
+        if (type == DataType.NULL) {
+            return false;
+        }
+        return DataType.isRepresentable(type) == false || DataType.isSpatial(type);
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        // Prefer resolveType order over test-derived validPerPosition: some accepted field types
+        // (e.g. unsigned_long) are missing from MvSortTests, which would mis-attribute the bad arg.
+        String source = sourceForSignature(signature);
+        if (isInvalidFieldType(signature.get(0))) {
+            return equalTo(
+                "first argument of ["
+                    + source
+                    + "] must be ["
+                    + FIELD_TYPES
+                    + "], found value [] type ["
+                    + signature.get(0).typeName()
+                    + "]"
+            );
+        }
+        return equalTo("second argument of [" + source + "] must be [string], found value [] type [" + signature.get(1).typeName() + "]");
+    }
+}


### PR DESCRIPTION
Manual 8.19 backport of https://github.com/elastic/elasticsearch/pull/154417