### PR TITLE
[9.3] Fix smart retry pruning of parameterized tests (#155253)

### DIFF
--- a/.buildkite/scripts/smart-retry/README.md
+++ b/.buildkite/scripts/smart-retry/README.md
@@ -36,6 +36,32 @@ Here's the overall process that makes this work, ignoring spot preemptions for n
 - Upload this file as a Buildkite artifact (which the next attempt, if there is one, will download)
 - Automatically retry this step if there were any failures for tests that haven't executed twice
 
+### Pruning granularity
+
+`InternalTestRerunPlugin` prunes previously successful work at three levels, from coarsest to finest:
+
+- **Task**: a task listed in `successfulTasks` is disabled outright with `onlyIf(false)`.
+- **Suite**: a class listed in `successfulSuites` is excluded with a `Class.*` filter pattern.
+- **Individual test**: a `Class#method` reference listed in `successfulTests` is excluded with a filter pattern for that method.
+
+Individual test pruning needs care for suites run by the randomized runner with a `@ParametersFactory`, because those report one test per parameter, for example `test {yaml=analysis-common/30_tokenizers/letter}`.
+`RandomizedRunner#applyFilters` keeps a test candidate as soon as *either* its parameterized description *or* its bare method description is allowed to run, so excluding only the parameterized name has no effect at all.
+The plugin therefore emits the bare `Class.method` pattern in addition to the parameterized one.
+That does not take the method's other parameters down with it: those still carry a parameterized name that no pattern matches, which is enough to keep them running.
+`MutedTestsBuildService` does the same thing for `muted-tests.yml`, and the two mechanisms contribute patterns to the same filter.
+
+### Ordered suites
+
+Individual test pruning assumes tests are independent. Upgrade suites are not: they are parameterized over upgrade phases and an early phase sets up the cluster state a later phase asserts on, so skipping a phase that already passed makes the later phase fail.
+
+Projects hosting such suites opt out in their `build.gradle`:
+
+```groovy
+smartRetry.pruneIndividualTests.set(false)
+```
+
+Task and suite pruning stay active for those projects, since both either skip a suite in its entirety or not at all.
+
 ### Spot Preemptions
 
 Here's how the above process additionally handles spot preemptions:

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginFuncTest.groovy
@@ -125,6 +125,110 @@ class InternalTestRerunPluginFuncTest extends AbstractGradleFuncTest {
         testExecuted(result.output, "SubProject2TestClazz1 > someTest2")
     }
 
+    def "excludes a single parameter of a parameterized test while its siblings still run"() {
+        given:
+        parameterizedTestSetup()
+        writeHistory(
+            [],
+            [":subproject1:test": ["org.acme.ParameterizedTestClazz#someTest1 {phase=0}"]]
+        )
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SUCCESS
+        testNotExecuted(result.output, "someTest1 > someTest1 {phase=0}")
+        testExecuted(result.output, "someTest1 > someTest1 {phase=1}")
+        testExecuted(result.output, "someTest1 > someTest1 {phase=2}")
+        // The bare method pattern the randomized runner needs must not take the other method down with it
+        testExecuted(result.output, "someTest2 > someTest2 {phase=0}")
+    }
+
+    def "excludes a plain method of a randomized runner suite that has no parameters"() {
+        given:
+        parameterizedTestSetup()
+        writeHistory(
+            [],
+            [":subproject1:test": ["org.acme.RandomizedTestClazz#someTest1"]]
+        )
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SUCCESS
+        // Without parameters both descriptions the runner checks are identical, so the single bare pattern excludes it
+        testNotExecuted(result.output, "RandomizedTestClazz > someTest1")
+        testExecuted(result.output, "RandomizedTestClazz > someTest2")
+    }
+
+    def "excludes an entire parameterized suite via suite level pruning"() {
+        given:
+        parameterizedTestSetup()
+        writeHistory(
+            [],
+            [:],
+            [":subproject1:test": ["org.acme.ParameterizedTestClazz"]]
+        )
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SUCCESS
+        result.output.contains("excluding 1 successful suites and 0 successful tests")
+        testNotExecuted(result.output, "someTest1 > someTest1 {phase=0}")
+        testNotExecuted(result.output, "someTest1 > someTest1 {phase=1}")
+        testNotExecuted(result.output, "someTest1 > someTest1 {phase=2}")
+        testNotExecuted(result.output, "someTest2 > someTest2 {phase=0}")
+        // The plain suite in the same task is untouched
+        testExecuted(result.output, "SubProject1TestClazz1 > someTest1")
+    }
+
+    def "runs all parameters when the project opted out of individual test pruning"() {
+        given:
+        parameterizedTestSetup(true)
+        writeHistory(
+            [],
+            [":subproject1:test": ["org.acme.ParameterizedTestClazz#someTest1 {phase=0}"]]
+        )
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SUCCESS
+        result.output.contains("project opted out of individual test pruning")
+        testExecuted(result.output, "someTest1 > someTest1 {phase=0}")
+        testExecuted(result.output, "someTest1 > someTest1 {phase=1}")
+    }
+
+    def "suite level pruning still applies when the project opted out of individual test pruning"() {
+        given:
+        parameterizedTestSetup(true)
+        writeHistory(
+            [],
+            [":subproject1:test": ["org.acme.ParameterizedTestClazz#someTest1 {phase=0}"]],
+            [":subproject1:test": ["org.acme.SubProject1TestClazz1"]]
+        )
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SUCCESS
+        // A single message covers both halves of the outcome, instead of one line per concern
+        result.output.contains(
+            "excluding 1 successful suites from :subproject1:test and rerunning 1 successful tests " +
+                "(project opted out of individual test pruning)"
+        )
+        result.output.contains("rerunning 1 successful tests in :subproject1:test") == false
+        testNotExecuted(result.output, "SubProject1TestClazz1 > someTest1")
+        testExecuted(result.output, "someTest1 > someTest1 {phase=0}")
+    }
+
+    def "task level pruning still applies when the project opted out of individual test pruning"() {
+        given:
+        parameterizedTestSetup(true)
+        writeHistory([":subproject1:test"], [:])
+        when:
+        def result = gradleRunner("test", "--warning-mode", "all").build()
+        then:
+        result.task(":subproject1:test").outcome == TaskOutcome.SKIPPED
+        result.output.contains("succeeded in previous run")
+    }
+
     def "handles malformed failed-test-history gracefully"() {
         given:
         simpleTestSetup()
@@ -211,15 +315,24 @@ class InternalTestRerunPluginFuncTest extends AbstractGradleFuncTest {
         output.contains(testReference) == false
     }
 
-    private File writeHistory(List<String> successfulTasks, Map<String, List<String>> successfulTests) {
+    private File writeHistory(
+        List<String> successfulTasks,
+        Map<String, List<String>> successfulTests,
+        Map<String, List<String>> successfulSuites = [:]
+    ) {
         def tasksJson = successfulTasks.collect { "\"$it\"" }.join(", ")
         def testsEntries = successfulTests.collect { taskPath, tests ->
             def testsJson = tests.collect { "\"$it\"" }.join(", ")
             "\"$taskPath\": [$testsJson]"
         }.join(", ")
+        def suitesEntries = successfulSuites.collect { taskPath, suites ->
+            def suitesJson = suites.collect { "\"$it\"" }.join(", ")
+            "\"$taskPath\": [$suitesJson]"
+        }.join(", ")
         file(".failed-test-history.json") << """
 {
   "successfulTasks": [$tasksJson],
+  "successfulSuites": {$suitesEntries},
   "successfulTests": {$testsEntries}
 }
 """
@@ -253,6 +366,95 @@ class InternalTestRerunPluginFuncTest extends AbstractGradleFuncTest {
         subProject(":subproject2") {
             createTest("SubProject2TestClazz1")
             createTest("SubProject2TestClazz2")
+        }
+    }
+
+    /**
+     * Sets up a single subproject holding a suite parameterized by the randomized runner alongside a plain JUnit4 suite.
+     * The randomized runner reports such tests as {@code someTest1 {phase=0}} and only excludes one when both that name
+     * and the bare method name are filtered out, which is what the parameterized pruning has to get right.
+     */
+    void parameterizedTestSetup(boolean optOutOfIndividualTestPruning = false) {
+        buildFile << """
+        allprojects {
+                apply plugin: 'java'
+                apply plugin: 'elasticsearch.internal-test-rerun'
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    testImplementation 'junit:junit:4.13.1'
+                    testImplementation 'com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.8.2'
+                }
+
+                tasks.named("test").configure {
+                    testLogging {
+                        events("started", "skipped")
+                    }
+                }
+            }
+            """
+        subProject(":subproject1") {
+            if (optOutOfIndividualTestPruning) {
+                buildFile << """
+                smartRetry.pruneIndividualTests.set(false)
+                """
+            }
+            createTest("SubProject1TestClazz1")
+            file("src/test/java/org/acme/RandomizedTestClazz.java") << """
+            package org.acme;
+
+            import com.carrotsearch.randomizedtesting.RandomizedRunner;
+            import org.junit.Test;
+            import org.junit.runner.RunWith;
+
+            @RunWith(RandomizedRunner.class)
+            public class RandomizedTestClazz {
+
+                @Test
+                public void someTest1() {
+                }
+
+                @Test
+                public void someTest2() {
+                }
+            }
+            """
+            file("src/test/java/org/acme/ParameterizedTestClazz.java") << """
+            package org.acme;
+
+            import com.carrotsearch.randomizedtesting.RandomizedRunner;
+            import com.carrotsearch.randomizedtesting.annotations.Name;
+            import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+            import java.util.List;
+            import org.junit.Test;
+            import org.junit.runner.RunWith;
+
+            @RunWith(RandomizedRunner.class)
+            public class ParameterizedTestClazz {
+
+                private final int phase;
+
+                public ParameterizedTestClazz(@Name("phase") int phase) {
+                    this.phase = phase;
+                }
+
+                @ParametersFactory(shuffle = false)
+                public static Iterable<Object[]> parameters() {
+                    return List.of(new Object[] { 0 }, new Object[] { 1 }, new Object[] { 2 });
+                }
+
+                @Test
+                public void someTest1() {
+                }
+
+                @Test
+                public void someTest2() {
+                }
+            }
+            """
         }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPlugin.java
@@ -16,6 +16,7 @@ import org.elasticsearch.gradle.internal.test.rerun.model.FailedTestsReport;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -25,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,7 +41,8 @@ import java.util.Set;
  * <ul>
  *   <li>Skips entire test tasks listed in {@code successfulTasks}</li>
  *   <li>Excludes individual passing tests listed in {@code successfulTests}
- *       from partially-failed tasks</li>
+ *       from partially-failed tasks, unless the project disabled that via
+ *       {@link SmartRetryExtension#getPruneIndividualTests()}</li>
  *   <li>Runs everything else normally</li>
  * </ul>
  * If no history file exists, all tests run normally.
@@ -54,15 +57,22 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
     public void apply(Project project) {
         File settingsRoot = project.getLayout().getSettingsDirectory().getAsFile();
 
+        SmartRetryExtension extension = project.getExtensions().create("smartRetry", SmartRetryExtension.class);
+        extension.getPruneIndividualTests().convention(true);
+
         Provider<RetryTestsBuildService> retryTestsProvider = project.getGradle()
             .getSharedServices()
             .registerIfAbsent("retryTests", RetryTestsBuildService.class, spec -> {
                 spec.getParameters().getInfoPath().set(settingsRoot);
             });
-        project.getTasks().withType(Test.class).configureEach(task -> configureTestTask(task, retryTestsProvider));
+        project.getTasks().withType(Test.class).configureEach(task -> configureTestTask(task, retryTestsProvider, extension));
     }
 
-    private static void configureTestTask(Test test, Provider<RetryTestsBuildService> testsBuildServiceProvider) {
+    private static void configureTestTask(
+        Test test,
+        Provider<RetryTestsBuildService> testsBuildServiceProvider,
+        SmartRetryExtension extension
+    ) {
         FailedTestsReport report = testsBuildServiceProvider.get().getReport();
         if (report == null) {
             test.getLogger().info("No failed test history found, running all tests");
@@ -82,7 +92,32 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
 
         List<String> suitesToExclude = testsBuildServiceProvider.get().getSuccessfulSuitesForTask(test.getPath());
         List<String> testsToExclude = testsBuildServiceProvider.get().getSuccessfulTestsForTask(test.getPath());
-        if (suitesToExclude.isEmpty() == false || testsToExclude.isEmpty() == false) {
+        if (suitesToExclude.isEmpty() && testsToExclude.isEmpty()) {
+            test.getLogger().lifecycle("Smart retry: running all tests for {} (not confirmed successful in previous run)", test.getPath());
+            return;
+        }
+
+        if (extension.getPruneIndividualTests().get() == false && testsToExclude.isEmpty() == false) {
+            int rerunTestCount = testsToExclude.size();
+            testsToExclude = List.of();
+            if (suitesToExclude.isEmpty()) {
+                test.getLogger()
+                    .lifecycle(
+                        "Smart retry: rerunning {} successful tests in {} (project opted out of individual test pruning)",
+                        rerunTestCount,
+                        test.getPath()
+                    );
+                return;
+            }
+            test.getLogger()
+                .lifecycle(
+                    "Smart retry: excluding {} successful suites from {} and rerunning {} successful tests "
+                        + "(project opted out of individual test pruning)",
+                    suitesToExclude.size(),
+                    test.getPath(),
+                    rerunTestCount
+                );
+        } else {
             test.getLogger()
                 .lifecycle(
                     "Smart retry: excluding {} successful suites and {} successful tests from {} (rerunning failures)",
@@ -90,24 +125,48 @@ public abstract class InternalTestRerunPlugin implements Plugin<Project> {
                     testsToExclude.size(),
                     test.getPath()
                 );
-            test.filter(filter -> {
-                for (String className : suitesToExclude) {
-                    filter.excludeTestsMatching(className + ".*");
-                }
-                for (String testRef : testsToExclude) {
-                    int hashIdx = testRef.indexOf('#');
-                    if (hashIdx < 0) {
-                        test.getLogger().warn("Skipping malformed test reference in smart retry: {}", testRef);
-                        continue;
-                    }
-                    String className = testRef.substring(0, hashIdx);
-                    String methodName = testRef.substring(hashIdx + 1);
-                    filter.excludeTestsMatching(className + "." + methodName);
-                }
-            });
-        } else {
-            test.getLogger().lifecycle("Smart retry: running all tests for {} (not confirmed successful in previous run)", test.getPath());
         }
+
+        Set<String> methodExcludePatterns = buildMethodExcludePatterns(testsToExclude, test.getLogger());
+        test.filter(filter -> {
+            for (String className : suitesToExclude) {
+                filter.excludeTestsMatching(className + ".*");
+            }
+            for (String pattern : methodExcludePatterns) {
+                filter.excludeTestsMatching(pattern);
+            }
+        });
+    }
+
+    /**
+     * Translates {@code Class#method} references into Gradle test filter patterns.
+     * <p>
+     * Tests run by the randomized runner with a {@code @ParametersFactory} are reported with their parameters appended, for
+     * example {@code test {yaml=analysis-common/30_tokenizers/letter}}. Such a test is only excluded when both its
+     * parameterized name and its bare method name match an exclude pattern, because
+     * {@code RandomizedRunner#applyFilters} keeps a candidate as soon as either description is allowed to run. So for a
+     * parameterized reference we emit the bare method name in addition to the parameterized one. That does not
+     * over-exclude the method's other parameters: those keep a parameterized name no pattern matches, which is enough to
+     * keep them running.
+     */
+    static Set<String> buildMethodExcludePatterns(List<String> testRefs, Logger logger) {
+        Set<String> patterns = new LinkedHashSet<>();
+        for (String testRef : testRefs) {
+            int hashIdx = testRef.indexOf('#');
+            if (hashIdx < 0) {
+                logger.warn("Skipping malformed test reference in smart retry: {}", testRef);
+                continue;
+            }
+            String className = testRef.substring(0, hashIdx);
+            String methodName = testRef.substring(hashIdx + 1);
+            patterns.add(className + "." + methodName);
+
+            int paramsIdx = methodName.indexOf(" {");
+            if (paramsIdx >= 0) {
+                patterns.add(className + "." + methodName.substring(0, paramsIdx));
+            }
+        }
+        return patterns;
     }
 
     public abstract static class RetryTestsBuildService implements BuildService<RetryTestsBuildService.Params> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/SmartRetryExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rerun/SmartRetryExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test.rerun;
+
+import org.gradle.api.provider.Property;
+
+/**
+ * Per-project configuration for the smart retry mechanism implemented by {@link InternalTestRerunPlugin}.
+ * <p>
+ * Registered on every project as {@code smartRetry}.
+ */
+public abstract class SmartRetryExtension {
+
+    /**
+     * Whether individual test methods that passed in a previous build attempt may be excluded when the task is retried.
+     * Defaults to {@code true}.
+     * <p>
+     * Projects whose suites depend on execution order must set this to {@code false}. The canonical example is an upgrade
+     * suite parameterized over upgrade phases: an earlier phase both asserts behaviour and establishes the cluster state a
+     * later phase relies on, so a phase that passed must still run when a later phase is retried. Disabling this leaves
+     * task-level and suite-level pruning in place, since those either skip a suite in its entirety or not at all.
+     */
+    public abstract Property<Boolean> getPruneIndividualTests();
+}

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/rerun/InternalTestRerunPluginTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test.rerun;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+public class InternalTestRerunPluginTests {
+
+    private final Logger logger = Logging.getLogger(InternalTestRerunPluginTests.class);
+
+    @Test
+    public void testPlainMethodYieldsSinglePattern() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(List.of("org.es.FooTest#testBar"), logger);
+
+        assertThat(patterns, contains("org.es.FooTest.testBar"));
+    }
+
+    @Test
+    public void testParameterizedMethodAlsoYieldsBarePattern() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(
+            List.of("org.es.FooTest#testBar {upgradedNodes=0}"),
+            logger
+        );
+
+        assertThat(patterns, contains("org.es.FooTest.testBar {upgradedNodes=0}", "org.es.FooTest.testBar"));
+    }
+
+    @Test
+    public void testYamlSuiteParametersYieldBothPatterns() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(
+            List.of("org.es.ClientYamlTestSuiteIT#test {yaml=analysis-common/30_tokenizers/letter}"),
+            logger
+        );
+
+        assertThat(
+            patterns,
+            contains("org.es.ClientYamlTestSuiteIT.test {yaml=analysis-common/30_tokenizers/letter}", "org.es.ClientYamlTestSuiteIT.test")
+        );
+    }
+
+    @Test
+    public void testBarePatternIsSharedAcrossParametersOfTheSameMethod() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(
+            List.of("org.es.FooTest#testBar {upgradedNodes=0}", "org.es.FooTest#testBar {upgradedNodes=1}"),
+            logger
+        );
+
+        assertThat(
+            patterns,
+            contains("org.es.FooTest.testBar {upgradedNodes=0}", "org.es.FooTest.testBar", "org.es.FooTest.testBar {upgradedNodes=1}")
+        );
+    }
+
+    @Test
+    public void testDuplicateReferencesCollapse() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(
+            List.of("org.es.FooTest#testBar", "org.es.FooTest#testBar"),
+            logger
+        );
+
+        assertThat(patterns, contains("org.es.FooTest.testBar"));
+    }
+
+    @Test
+    public void testMalformedReferencesAreSkipped() {
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(
+            List.of("org.es.FooTest", "org.es.FooTest#testBar"),
+            logger
+        );
+
+        assertThat(patterns, contains("org.es.FooTest.testBar"));
+    }
+
+    @Test
+    public void testEmptyInputYieldsNoPatterns() {
+        assertThat(InternalTestRerunPlugin.buildMethodExcludePatterns(List.of(), logger), empty());
+    }
+
+    @Test
+    public void testBraceWithoutLeadingSpaceIsTreatedAsPlainMethodName() {
+        // Only the randomized runner's " {" separator marks parameters. A brace anywhere else is part of the method name.
+        Set<String> patterns = InternalTestRerunPlugin.buildMethodExcludePatterns(List.of("org.es.FooTest#testBar{x}"), logger);
+
+        assertThat(patterns.size(), equalTo(1));
+        assertThat(patterns, contains("org.es.FooTest.testBar{x}"));
+    }
+}

--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -13,6 +13,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   javaRestTestImplementation project(':test:fixtures:geoip-fixture')
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))

--- a/modules/ingest-geoip/qa/geoip-reindexed/build.gradle
+++ b/modules/ingest-geoip/qa/geoip-reindexed/build.gradle
@@ -12,6 +12,9 @@ import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
 
 dependencies {
   javaRestTestImplementation project(':test:fixtures:geoip-fixture')

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 buildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedFullClusterRestartTestCase.java
@@ -35,6 +35,16 @@ import static org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus.UPGRADE
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+/**
+ * Base class for full cluster restart suites. Each suite is run twice, once against the old cluster and once after it has
+ * been restarted on the current version. The two runs build on each other: the old-cluster run creates the indices and
+ * other state that the upgraded run asserts survived the restart.
+ * <p>
+ * Because of that, a project hosting such a suite must opt out of smart retry's individual test pruning in its
+ * {@code build.gradle}, otherwise a run that passed in an earlier build attempt is skipped on retry and the run it was
+ * setting up fails:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
+ */
 @TestCaseOrdering(FullClusterRestartTestOrdering.class)
 public abstract class ParameterizedFullClusterRestartTestCase extends ESRestTestCase {
 

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -13,6 +13,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
+// MultiVersionRepositoryAccessIT is parameterized over sequential steps that build on each other's repository state,
+// so a step that passed must still run when a later step is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 buildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   // The single task per BWC version drives the whole old/new/old/new repository access scenario from one JVM. The two clusters
   // (old and current version) and the four sequential steps are wired up inside MultiVersionRepositoryAccessIT itself.

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -16,6 +16,10 @@ apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.fwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
+// so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 testArtifacts {
   registerTestArtifactFromSourceSet(sourceSets.javaRestTest)
 }

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ParameterizedRollingUpgradeTestCase.java
@@ -34,6 +34,16 @@ import java.util.stream.IntStream;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+/**
+ * Base class for rolling upgrade suites. Each suite is run once per upgrade phase, from a fully old cluster through to a
+ * fully upgraded one, driving the shared cluster one node further with every phase. Phases therefore build on each other:
+ * an early phase typically indexes the documents or creates the resources a later phase asserts on.
+ * <p>
+ * Because of that, a project hosting such a suite must opt out of smart retry's individual test pruning in its
+ * {@code build.gradle}, otherwise a phase that passed in an earlier build attempt is skipped on retry and the later phase
+ * it was setting up fails:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
+ */
 public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase {
     protected static final int NODE_NUM = 3;
     private static final String OLD_CLUSTER_VERSION = System.getProperty("tests.old_cluster_version");

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
@@ -11,6 +11,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(testArtifact(project(":qa:full-cluster-restart"), "javaRestTest"))

--- a/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
@@ -12,6 +12,10 @@ apply plugin: 'elasticsearch.internal-test-artifact-base'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the inference endpoints a later phase
+// asserts on, so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(path: xpackModule('inference'))

--- a/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/build.gradle
+++ b/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/build.gradle
@@ -12,6 +12,10 @@ apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.fwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
+// so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   javaRestTestImplementation project(xpackModule('logsdb'))
   javaRestTestImplementation project(':test:test-clusters')

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/build.gradle
@@ -11,6 +11,10 @@ apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 apply plugin: 'elasticsearch.internal-test-artifact' // needed to run logsdb rest tests in serverless
 
+// Test methods share the class-scoped cluster and upgrade it in place, so a method that passed must still run when a later
+// method is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)

--- a/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/shutdown/qa/full-cluster-restart/build.gradle
@@ -11,6 +11,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   // TODO: Remove core dependency and change tests to not use builders that are part of xpack-core.
   // Currently needed for MlConfigIndexMappingsFullClusterRestartIT and SLM classes used in

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -14,6 +14,10 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
+// so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   testImplementation project(':x-pack:qa')
 }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -11,6 +11,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.bc-upgrade-test'
 
+// Each suite is parameterized over the old and upgraded cluster and the old-cluster run sets up the state the upgraded run
+// asserts on, so a parameter that passed must still run when the other one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   // TODO: Remove core dependency and change tests to not use builders that are part of xpack-core.
   // Currently needed for MlConfigIndexMappingsFullClusterRestartIT and SLM classes used in

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -10,6 +10,10 @@ import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
+// Each suite is parameterized over the upgrade states and an earlier state sets up the cluster state a later one asserts on,
+// so a state that passed must still run when a later state is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   javaRestTestImplementation project(':x-pack:qa')
 }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -13,6 +13,10 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 apply plugin: 'elasticsearch.rest-resources'
 
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
+// so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   testImplementation testArtifact(project(':server'))
   testImplementation testArtifact(project(xpackModule('core')))


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix smart retry pruning of parameterized tests (#155253)