### PR TITLE
[9.3] Limit dot-separated identifiers per version part (#154572)

### DIFF
--- a/docs/changelog/154572.yaml
+++ b/docs/changelog/154572.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 154572
+summary: Limit dot-separated identifiers per version part
+type: bug

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
@@ -50,6 +50,10 @@ class VersionEncoder {
     private static final char BUILD_SEPARATOR = '+';
     private static final String ENCODED_EMPTY_STRING = new String(new byte[] { NO_PRERELEASE_SEPARATOR_BYTE }, Charsets.UTF_8);
 
+    // Max dot-separated identifiers per version part. The patterns below recurse per identifier, so
+    // more than this could overflow the stack.
+    static final int MAX_LEGAL_VERSION_IDENTIFIERS = 32;
+
     // Regex to test relaxed Semver Main Version validity. Allows for more or less than three main version parts
     private static Pattern LEGAL_MAIN_VERSION_SEMVER = Pattern.compile("(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*");
 
@@ -66,8 +70,8 @@ class VersionEncoder {
         VersionParts versionParts = VersionParts.ofVersion(versionString);
 
         // don't treat non-legal versions further, just mark them as illegal and return
-        if (legalVersionString(versionParts) == false) {
-            if (versionString.length() == 0) {
+        if (tooManyIdentifiers(versionParts) || legalVersionString(versionParts) == false) {
+            if (versionString.isEmpty()) {
                 // special case, we want empty string to sort after valid strings, which all start with 0x01, add a higher char that
                 // we are sure to remove when decoding
                 versionString = ENCODED_EMPTY_STRING;
@@ -164,6 +168,22 @@ class VersionEncoder {
             inputPos++;
         }
         return new BytesRef(result, 0, resultPos);
+    }
+
+    // True if any part exceeds MAX_LEGAL_VERSION_IDENTIFIERS. Null parts (no pre-release or build) are within the limit.
+    private static boolean tooManyIdentifiers(VersionParts versionParts) {
+        for (String part : new String[] { versionParts.mainVersion, versionParts.preRelease, versionParts.buildSuffix }) {
+            if (part == null) {
+                continue;
+            }
+            int identifiers = 1;
+            for (int i = 0; i < part.length(); i++) {
+                if (part.charAt(i) == '.' && ++identifiers > MAX_LEGAL_VERSION_IDENTIFIERS) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     static boolean legalVersionString(VersionParts versionParts) {

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionEncoderTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionEncoderTests.java
@@ -91,6 +91,35 @@ public class VersionEncoderTests extends ESTestCase {
         assertEquals("Groups of digits cannot be longer than 127, but found: 128", ex.getMessage());
     }
 
+    public void testTooManyIdentifiersIsMarkedIllegal() {
+        // One more identifier than allowed is rejected before the recursive validation runs, so a
+        // crafted value cannot drive the matcher into a StackOverflowError.
+        String tooMany = "1.".repeat(VersionEncoder.MAX_LEGAL_VERSION_IDENTIFIERS) + "1";
+        EncodedVersion encoded = VersionEncoder.encodeVersion(tooMany);
+        assertFalse(encoded.isLegal);
+        assertEquals(tooMany, decodeVersion(encoded.bytesRef).utf8ToString());
+
+        // The same shape at the limit is still validated normally and is a legal numeric version.
+        String atLimit = "1.".repeat(VersionEncoder.MAX_LEGAL_VERSION_IDENTIFIERS - 1) + "1";
+        assertTrue(VersionEncoder.encodeVersion(atLimit).isLegal);
+    }
+
+    public void testTooManyIdentifiersInPreReleaseAndBuildAreMarkedIllegal() {
+        // The limit applies to the pre-release and build parts too, since their patterns are recursive.
+        int over = VersionEncoder.MAX_LEGAL_VERSION_IDENTIFIERS + 1;
+        assertFalse(VersionEncoder.encodeVersion("1.0.0-" + "a.".repeat(over) + "a").isLegal);
+        assertFalse(VersionEncoder.encodeVersion("1.0.0+" + "a.".repeat(over) + "a").isLegal);
+    }
+
+    public void testIdentifierLimitAppliesPerPartNotInTotal() {
+        // The limit is per part, so a version that stays within it in every part is still legal even
+        // when the parts together hold more than the limit.
+        int atLimit = VersionEncoder.MAX_LEGAL_VERSION_IDENTIFIERS;
+        String main = "1.".repeat(atLimit - 1) + "1";       // atLimit numeric identifiers
+        String preRelease = "a.".repeat(atLimit - 1) + "a"; // atLimit identifiers
+        assertTrue(VersionEncoder.encodeVersion(main + "-" + preRelease).isLegal);
+    }
+
     /**
      * test that encoding and decoding leads back to the same version string
      */


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Limit dot-separated identifiers per version part (#154572)