### PR TITLE
[CI] Fix multiarch testfixture deployment

### DIFF
--- a/.buildkite/scripts/fixture-deploy.sh
+++ b/.buildkite/scripts/fixture-deploy.sh
@@ -5,5 +5,13 @@ set -euo pipefail
 echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USERNAME" --password-stdin docker.elastic.co
 unset DOCKER_REGISTRY_USERNAME DOCKER_REGISTRY_PASSWORD
 
-docker buildx create --use
+# Register QEMU emulation against this agent's live kernel and bootstrap
+# a multi-platform capable buildx builder before building. The VM image
+# only pre-caches the tonistiigi/binfmt image and pre-creates (but does
+# not start) a "multiarch" docker-container buildx builder as the agent
+# user -- binfmt_misc registration does not survive the image bake ->
+# boot cycle, so it must be redone here on every job run. See
+# https://github.com/elastic/ci-agent-images/pull/2907 for details.
+docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+docker buildx inspect --bootstrap
 .ci/scripts/run-gradle.sh deployFixtureDockerImages

--- a/.buildkite/scripts/fixture-deploy.sh
+++ b/.buildkite/scripts/fixture-deploy.sh
@@ -5,13 +5,11 @@ set -euo pipefail
 echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USERNAME" --password-stdin docker.elastic.co
 unset DOCKER_REGISTRY_USERNAME DOCKER_REGISTRY_PASSWORD
 
-# Register QEMU emulation against this agent's live kernel and bootstrap
-# a multi-platform capable buildx builder before building. The VM image
-# only pre-caches the tonistiigi/binfmt image and pre-creates (but does
-# not start) a "multiarch" docker-container buildx builder as the agent
-# user -- binfmt_misc registration does not survive the image bake ->
-# boot cycle, so it must be redone here on every job run. See
+# Register QEMU emulation against this agent's live kernel and create a
+# multi-platform capable buildx builder before building. binfmt_misc
+# registration does not survive the image bake -> boot cycle, so it must
+# be redone here on every job run. See
 # https://github.com/elastic/ci-agent-images/pull/2907 for details.
 docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
-docker buildx inspect --bootstrap
+docker buildx create --driver docker-container --use --bootstrap
 .ci/scripts/run-gradle.sh deployFixtureDockerImages


### PR DESCRIPTION
Problem

deployFixtureDockerImages (via TestFixturesDeployPlugin) builds Docker test fixture images for all Architecture values — i.e. it's a genuine multi-platform build. But .buildkite/scripts/fixture-deploy.sh only runs a bare docker buildx create --use with no QEMU/binfmt registration and no explicit driver, so cross-arch platforms were silently unavailable (or the build fell back to a builder that can't do multi-platform builds at all).

Fix

Move the agent image from family/elasticsearch-ubuntu-2004 to family/elasticsearch-ubuntu-2404 — the image family that received the buildx/qemu fixes in elasticsearch: fix docker multi-platform build support (qemu/buildx) ci-agent-images#2907 (scripts/qemu.sh pre-caches tonistiigi/binfmt, scripts/misc.sh pre-creates a multiarch docker-container buildx builder as the agent user). elasticsearch-ubuntu-2004 is explicitly excluded from qemu.sh's pre-caching logic.
Add the two job-time steps required before any multi-platform docker buildx build, since binfmt_misc registration does not survive the VM image bake-to-boot cycle and must be redone on every job run:
docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
docker buildx inspect --bootstrap
See elastic/ci-agent-images#2907 for the underlying image-side fix and root cause analysis (binfmt_misc is kernel runtime state that doesn't survive the Packer bake-to-AMI-to-boot cycle, and buildx builder definitions are per-user so they must be created by the job's own user, not root).