### PR TITLE
[8.19] Trip request breaker on phrase and term suggesters (#154837)

### DIFF
--- a/docs/changelog/154837.yaml
+++ b/docs/changelog/154837.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 154837
+summary: Trip request breaker on term and phrase suggesters based on backing array estimates
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/SuggesterCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/SuggesterCircuitBreakerIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.suggest;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.suggest.phrase.DirectCandidateGeneratorBuilder;
+import org.elasticsearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.search.suggest.SuggestBuilders.phraseSuggestion;
+import static org.elasticsearch.search.suggest.SuggestBuilders.termSuggestion;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+/** Verifies that oversized term and phrase suggester queues are rejected before they can exhaust the shard heap. */
+public class SuggesterCircuitBreakerIT extends ESIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put("indices.breaker.request.type", "memory")
+            .put("indices.breaker.request.limit", "100mb")
+            .build();
+    }
+
+    /**
+     * DirectSpellChecker derives its candidate inspection bound from {@code shard_size}. A value close to
+     * {@link Integer#MAX_VALUE} can drive its growable candidate queue toward billions of entries, so the request
+     * breaker must reject the configuration before candidate collection begins.
+     */
+    public void testTermSuggestShardSizeTripsCircuitBreaker() throws IOException {
+        createTestIndex();
+        assertCircuitBreaks(
+            "term",
+            termSuggestion("body").text("the quik brown").suggestMode(SuggestMode.ALWAYS).shardSize(Integer.MAX_VALUE - 17)
+        );
+    }
+
+    /**
+     * CandidateScorer eagerly allocates a Lucene priority queue sized to {@code shard_size}. The request breaker must
+     * trip before an oversized backing array is allocated.
+     */
+    public void testPhraseSuggestShardSizeTripsCircuitBreaker() throws IOException {
+        createTestIndex();
+        assertCircuitBreaks(
+            "phrase",
+            phraseSuggestion("body").text("the quik brown")
+                .addCandidateGenerator(new DirectCandidateGeneratorBuilder("body").suggestMode("always"))
+                .shardSize(Integer.MAX_VALUE - 17)
+        );
+    }
+
+    /**
+     * A huge direct-generator size can drive DirectSpellChecker's growable candidate queue toward billions of entries.
+     * The request breaker must reject it before candidate collection begins.
+     */
+    public void testPhraseSuggestDirectGeneratorSizeTripsCircuitBreaker() throws IOException {
+        createTestIndex();
+        assertCircuitBreaks(
+            "phrase",
+            phraseSuggestion("body").text("the quik brown")
+                .addCandidateGenerator(new DirectCandidateGeneratorBuilder("body").suggestMode("always").size(Integer.MAX_VALUE - 17))
+        );
+    }
+
+    private void createTestIndex() throws IOException {
+        assertAcked(prepareCreate("test").setMapping("body", "type=text"));
+        ensureGreen();
+        indexDoc("test", "1", "body", "the quick brown fox jumps over the lazy dog");
+        refresh();
+    }
+
+    private void assertCircuitBreaks(String name, SuggestionBuilder<?> suggestion) {
+        Exception exception = expectThrows(
+            Exception.class,
+            () -> prepareSearch("test").setAllowPartialSearchResults(false)
+                .setSize(0)
+                .suggest(new SuggestBuilder().addSuggestion(name, suggestion))
+                .get()
+        );
+        CircuitBreakingException circuitBreakingException = (CircuitBreakingException) ExceptionsHelper.unwrap(
+            exception,
+            CircuitBreakingException.class
+        );
+        assertThat(circuitBreakingException, notNullValue());
+        assertThat(circuitBreakingException.getMessage(), containsString(name + "-suggest-collector"));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggester.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import java.io.IOException;
 
@@ -41,6 +42,12 @@ public abstract class Suggester<T extends SuggestionSearchContext.SuggestionCont
             return emptySuggestion(name, suggestion, spare);
         }
         return innerExecute(name, suggestion, searcher, spare);
+    }
+
+    protected static long priorityQueueRamBytesUsed(int size) {
+        return RamUsageEstimator.alignObjectSize(
+            (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (size + 1L) * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggester.java
@@ -18,7 +18,6 @@ import org.apache.lucene.search.suggest.document.CompletionQuery;
 import org.apache.lucene.search.suggest.document.TopSuggestDocs;
 import org.apache.lucene.search.suggest.document.TopSuggestDocsCollector;
 import org.apache.lucene.util.CharsRefBuilder;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.suggest.Suggest;
@@ -34,6 +33,8 @@ import java.util.Set;
 public class CompletionSuggester extends Suggester<CompletionSuggestionContext> {
 
     public static final CompletionSuggester INSTANCE = new CompletionSuggester();
+
+    private static final String COLLECTOR_MEMORY_LABEL = "completion-suggest-collector";
 
     private CompletionSuggester() {}
 
@@ -52,10 +53,8 @@ public class CompletionSuggester extends Suggester<CompletionSuggestionContext> 
             // TopSuggestGroupDocsCollector uses a Lucene's SuggestScoreDocPriorityQueue
             // which extends PriorityQueue and allocates a heap array of length shardSize + 1. This is the
             // dominant cost so we make sure here we have enough heap to allocate it
-            long collectorBytes = RamUsageEstimator.alignObjectSize(
-                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (shardSize + 1L) * RamUsageEstimator.NUM_BYTES_OBJECT_REF
-            );
-            searchExecutionContext.addCircuitBreakerMemory(collectorBytes, "completion-suggest-collector");
+            long collectorBytes = priorityQueueRamBytesUsed(shardSize);
+            searchExecutionContext.addCircuitBreakerMemory(collectorBytes, COLLECTOR_MEMORY_LABEL);
             try {
                 TopSuggestGroupDocsCollector collector = new TopSuggestGroupDocsCollector(shardSize, suggestionContext.isSkipDuplicates());
                 suggest(searcher, suggestionContext.toQuery(), collector);

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 
 public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
+
+    private static final String COLLECTOR_MEMORY_LABEL = "phrase-suggest-collector";
     private final BytesRef SEPARATOR = new BytesRef(" ");
     private static final String SUGGESTION_TEMPLATE_VAR_NAME = "suggestion";
 
@@ -68,12 +70,19 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
         final IndexReader indexReader = searcher.getIndexReader();
         List<PhraseSuggestionContext.DirectCandidateGenerator> generators = suggestion.generators();
         final int numGenerators = generators.size();
+        SearchExecutionContext searchExecutionContext = suggestion.getSearchExecutionContext();
+
         final List<CandidateGenerator> gens = new ArrayList<>(generators.size());
+        long maxGeneratorQueueBytes = 0L;
         for (int i = 0; i < numGenerators; i++) {
             PhraseSuggestionContext.DirectCandidateGenerator generator = generators.get(i);
             DirectSpellChecker directSpellChecker = generator.createDirectSpellChecker();
             Terms terms = MultiTerms.getTerms(indexReader, generator.field());
             if (terms != null) {
+                maxGeneratorQueueBytes = Math.max(
+                    maxGeneratorQueueBytes,
+                    directSpellCheckerQueueRamBytesUsed(generator.size(), generator.maxInspections())
+                );
                 gens.add(
                     new DirectCandidateGenerator(
                         directSpellChecker,
@@ -100,6 +109,14 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             final BytesRef separator = suggestion.separator();
             WordScorer wordScorer = suggestion.model()
                 .newScorer(indexReader, suggestTerms, suggestField, realWordErrorLikelihood, separator);
+            // CandidateScorer eagerly allocates a Lucene PriorityQueue sized to shard_size. DirectSpellChecker uses a
+            // growable candidate queue bounded by generator size * max_inspections. These queues are built sequentially,
+            // so reserve the largest backing-array estimate as a coarse guard against oversized configuration values.
+            final long collectorBytes = Math.max(priorityQueueRamBytesUsed(suggestion.getShardSize()), maxGeneratorQueueBytes);
+            var circuitBreaker = suggestion.getSearchExecutionContext().getCircuitBreaker();
+            if (circuitBreaker != null) {
+                circuitBreaker.addEstimateBytesAndMaybeBreak(collectorBytes, COLLECTOR_MEMORY_LABEL);
+            }
             Result checkerResult;
             try (TokenStream stream = tokenStream(suggestion.getAnalyzer(), suggestion.getText(), spare, suggestion.getField())) {
                 checkerResult = checker.getCorrections(
@@ -111,6 +128,12 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                     suggestion.confidence(),
                     suggestion.gramSize()
                 );
+            } finally {
+                // These queues are local to getCorrections: CandidateScorer drains its queue into the result and
+                // DirectSpellChecker does not retain its candidate queues.
+                if (circuitBreaker != null) {
+                    circuitBreaker.addWithoutBreaking(-collectorBytes, COLLECTOR_MEMORY_LABEL);
+                }
             }
 
             PhraseSuggestion.Entry resultEntry = buildResultEntry(suggestion, spare, checkerResult.cutoffScore);
@@ -128,7 +151,6 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                     // from the index for a correction, collateMatch is updated
                     final Map<String, Object> vars = suggestion.getCollateScriptParams();
                     vars.put(SUGGESTION_TEMPLATE_VAR_NAME, spare.toString());
-                    SearchExecutionContext searchExecutionContext = suggestion.getSearchExecutionContext();
                     final String querySource = scriptFactory.newInstance(vars).execute();
                     try (
                         XContentParser parser = XContentFactory.xContent(querySource)
@@ -162,6 +184,13 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             response.addTerm(buildResultEntry(suggestion, spare, Double.MIN_VALUE));
         }
         return response;
+    }
+
+    private static long directSpellCheckerQueueRamBytesUsed(int size, int maxInspections) {
+        // Lucene multiplies these values using int arithmetic. Compute in long and saturate so an overflowing
+        // configuration still receives the largest possible preflight estimate.
+        long maxCandidates = Math.max(size, (long) size * maxInspections);
+        return priorityQueueRamBytesUsed((int) Math.min(maxCandidates, Integer.MAX_VALUE));
     }
 
     private static TokenStream tokenStream(Analyzer analyzer, BytesRef query, CharsRefBuilder spare, String field) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -132,7 +132,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                 // These queues are local to getCorrections: CandidateScorer drains its queue into the result and
                 // DirectSpellChecker does not retain its candidate queues.
                 if (circuitBreaker != null) {
-                    circuitBreaker.addWithoutBreaking(-collectorBytes, COLLECTOR_MEMORY_LABEL);
+                    circuitBreaker.addWithoutBreaking(-collectorBytes);
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 public final class TermSuggester extends Suggester<TermSuggestionContext> {
 
+    private static final String COLLECTOR_MEMORY_LABEL = "term-suggest-collector";
+
     public static final TermSuggester INSTANCE = new TermSuggester();
 
     private TermSuggester() {}
@@ -39,25 +41,53 @@ public final class TermSuggester extends Suggester<TermSuggestionContext> {
         final IndexReader indexReader = searcher.getIndexReader();
         TermSuggestion response = new TermSuggestion(name, suggestion.getSize(), suggestion.getDirectSpellCheckerSettings().sort());
         List<Token> tokens = queryTerms(suggestion, spare);
-        for (Token token : tokens) {
-            // TODO: Extend DirectSpellChecker in 4.1, to get the raw suggested words as BytesRef
-            SuggestWord[] suggestedWords = directSpellChecker.suggestSimilar(
-                token.term,
-                suggestion.getShardSize(),
-                indexReader,
-                suggestion.getDirectSpellCheckerSettings().suggestMode()
-            );
-            var termBytes = token.term.bytes();
-            var termEncoded = new XContentString.UTF8Bytes(termBytes.bytes, termBytes.offset, termBytes.length);
-            Text key = new Text(termEncoded);
-            TermSuggestion.Entry resultEntry = new TermSuggestion.Entry(key, token.startOffset, token.endOffset - token.startOffset);
-            for (SuggestWord suggestWord : suggestedWords) {
-                Text word = new Text(suggestWord.string);
-                resultEntry.addOption(new TermSuggestion.Entry.Option(word, suggestWord.freq, suggestWord.score));
-            }
-            response.addTerm(resultEntry);
+        if (tokens.isEmpty()) {
+            return response;
         }
-        return response;
+
+        // DirectSpellChecker uses a growable candidate queue bounded by shard_size * max_inspections. Reserve its
+        // backing-array estimate as a coarse guard against an oversized shard_size before processing any token.
+        final long collectorBytes = directSpellCheckerQueueRamBytesUsed(
+            suggestion.getShardSize(),
+            suggestion.getDirectSpellCheckerSettings().maxInspections()
+        );
+        var circuitBreaker = suggestion.getSearchExecutionContext().getCircuitBreaker();
+        if (circuitBreaker != null) {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(collectorBytes, COLLECTOR_MEMORY_LABEL);
+        }
+        try {
+            for (Token token : tokens) {
+                // TODO: Extend DirectSpellChecker in 4.1, to get the raw suggested words as BytesRef
+                SuggestWord[] suggestedWords = directSpellChecker.suggestSimilar(
+                    token.term,
+                    suggestion.getShardSize(),
+                    indexReader,
+                    suggestion.getDirectSpellCheckerSettings().suggestMode()
+                );
+                var termBytes = token.term.bytes();
+                var termEncoded = new XContentString.UTF8Bytes(termBytes.bytes, termBytes.offset, termBytes.length);
+                Text key = new Text(termEncoded);
+                TermSuggestion.Entry resultEntry = new TermSuggestion.Entry(key, token.startOffset, token.endOffset - token.startOffset);
+                for (SuggestWord suggestWord : suggestedWords) {
+                    Text word = new Text(suggestWord.string);
+                    resultEntry.addOption(new TermSuggestion.Entry.Option(word, suggestWord.freq, suggestWord.score));
+                }
+                response.addTerm(resultEntry);
+            }
+            return response;
+        } finally {
+            if (circuitBreaker != null) {
+                circuitBreaker.addWithoutBreaking(-collectorBytes, COLLECTOR_MEMORY_LABEL);
+            }
+        }
+    }
+
+    private static long directSpellCheckerQueueRamBytesUsed(int size, int maxInspections) {
+        // Lucene multiplies these values using int arithmetic. Compute in long and saturate so an overflowing
+        // configuration still receives the largest possible preflight estimate.
+        long maxCandidates = Math.max(size, (long) size * maxInspections);
+        int queueSize = (int) Math.min(maxCandidates, Integer.MAX_VALUE);
+        return priorityQueueRamBytesUsed(queueSize);
     }
 
     private static List<Token> queryTerms(SuggestionContext suggestion, CharsRefBuilder spare) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggester.java
@@ -77,7 +77,7 @@ public final class TermSuggester extends Suggester<TermSuggestionContext> {
             return response;
         } finally {
             if (circuitBreaker != null) {
-                circuitBreaker.addWithoutBreaking(-collectorBytes, COLLECTOR_MEMORY_LABEL);
+                circuitBreaker.addWithoutBreaking(-collectorBytes);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggesterCircuitBreakerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggesterCircuitBreakerTests.java
@@ -189,7 +189,7 @@ public class PhraseSuggesterCircuitBreakerTests extends ESTestCase {
         }
     }
 
-    public void testNoCBUsageWithoutCollateScript() throws IOException {
+    public void testCollectorCBReleasedWithoutCollateScript() throws IOException {
         Directory dir = new ByteBuffersDirectory();
         try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(new WhitespaceAnalyzer()))) {
             Document doc = new Document();
@@ -241,8 +241,96 @@ public class PhraseSuggesterCircuitBreakerTests extends ESTestCase {
             suggestion.setConfidence(0.0f);
             suggestion.setText(new BytesRef("hello"));
 
+            PhraseSuggestionContext.DirectCandidateGenerator generator = new PhraseSuggestionContext.DirectCandidateGenerator();
+            generator.setField("body");
+            generator.suggestMode(SuggestMode.SUGGEST_MORE_POPULAR);
+            generator.size(10);
+            suggestion.addGenerator(generator);
+
             PhraseSuggester.INSTANCE.innerExecute("test", suggestion, searcher, new CharsRefBuilder());
-            assertThat("No CB bytes should be used when there is no collate script", cb.getUsed(), equalTo(0L));
+            assertThat("temporary collector memory must be released after the suggestion", cb.getUsed(), equalTo(0L));
+            assertThat(
+                "temporary collector memory must not enter query-construction accounting",
+                ctx.getQueryConstructionMemoryUsed(),
+                equalTo(0L)
+            );
+        }
+    }
+
+    /**
+     * A missing suggest field cannot build any correction queues. A one-byte breaker proves that this branch does not
+     * attempt a collector reservation: any such reservation would trip the test breaker.
+     */
+    public void testNoCBReservationWhenSuggestFieldHasNoTerms() throws IOException {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(new WhitespaceAnalyzer()))) {
+                Document doc = new Document();
+                doc.add(new Field("other", "hello world", TextField.TYPE_NOT_STORED));
+                writer.addDocument(doc);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                CircuitBreaker cb = newLimitedBreaker(ByteSizeValue.ofBytes(1));
+
+                IndexVersion indexVersion = IndexVersion.current();
+                Settings indexSettingsSettings = indexSettings(indexVersion, 1, 1).build();
+                IndexSettings indexSettings = new IndexSettings(
+                    IndexMetadata.builder("test").settings(indexSettingsSettings).build(),
+                    Settings.EMPTY
+                );
+                SearchExecutionContext baseCtx = new SearchExecutionContext(
+                    0,
+                    0,
+                    indexSettings,
+                    null,
+                    null,
+                    null,
+                    MappingLookup.EMPTY,
+                    null,
+                    null,
+                    parserConfig(),
+                    writableRegistry(),
+                    null,
+                    searcher,
+                    System::currentTimeMillis,
+                    null,
+                    null,
+                    () -> true,
+                    null,
+                    Collections.emptyMap(),
+                    null,
+                    MapperMetrics.NOOP,
+                    SHARD_SEARCH_STATS
+                );
+                SearchExecutionContext ctx = new SearchExecutionContext(baseCtx, cb);
+
+                PhraseSuggestionContext suggestion = new PhraseSuggestionContext(ctx);
+                suggestion.setField("body");
+                suggestion.setAnalyzer(new WhitespaceAnalyzer());
+                suggestion.setSize(5);
+                suggestion.setShardSize(5);
+                suggestion.setGramSize(1);
+                suggestion.setConfidence(0.0f);
+                suggestion.setText(new BytesRef("hello"));
+
+                PhraseSuggestionContext.DirectCandidateGenerator generator = new PhraseSuggestionContext.DirectCandidateGenerator();
+                generator.setField("body");
+                generator.suggestMode(SuggestMode.SUGGEST_MORE_POPULAR);
+                generator.size(10);
+                suggestion.addGenerator(generator);
+
+                assertEquals("CB must be zero before innerExecute", 0L, cb.getUsed());
+
+                PhraseSuggester.INSTANCE.innerExecute("test", suggestion, searcher, new CharsRefBuilder());
+
+                assertThat(
+                    "no query-construction memory should be tracked when the suggest field has no terms",
+                    ctx.getQueryConstructionMemoryUsed(),
+                    equalTo(0L)
+                );
+                assertThat("no raw CB usage should remain when the suggest field has no terms", cb.getUsed(), equalTo(0L));
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggesterCircuitBreakerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggesterCircuitBreakerTests.java
@@ -300,8 +300,7 @@ public class PhraseSuggesterCircuitBreakerTests extends ESTestCase {
                     null,
                     Collections.emptyMap(),
                     null,
-                    MapperMetrics.NOOP,
-                    SHARD_SEARCH_STATS
+                    MapperMetrics.NOOP
                 );
                 SearchExecutionContext ctx = new SearchExecutionContext(baseCtx, cb);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Trip request breaker on phrase and term suggesters (#154837)](https://github.com/elastic/elasticsearch/pull/154837)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)