### PR TITLE
[docs] Document connector known issues for recent fixes

### DIFF
--- a/docs/reference/search-connectors/es-connectors-known-issues.md
+++ b/docs/reference/search-connectors/es-connectors-known-issues.md
@@ -177,6 +177,15 @@ The connector service has the following known issues:
     **Fix**: [elastic/connectors#4078](https://github.com/elastic/connectors/pull/4078), shipped in 8.19.17, 9.3.6, 9.4.3, and 9.5.0.
 
 
+* **Outlook connector aborts the sync for mailbox-less accounts or when SSL is enabled without a certificate**
+
+    On on-prem Exchange, AD users with an SMTP address but no mailbox caused `ErrorNonExistentMailbox` and aborted the whole sync. Separately, `ssl_enabled` with an empty certificate wrote an empty CA file and raised `NO_CERTIFICATE_OR_CRL_FOUND`.
+
+    **Affected versions**: 8.11.0–8.19.17, 9.0.0–9.3.6, and 9.4.0–9.4.2. On-prem Exchange only.
+
+    **Fix**: [elastic/connectors#4085](https://github.com/elastic/connectors/pull/4085), shipped in 8.19.18, 9.3.7, 9.4.3, and 9.5.0. Mailbox-less accounts are skipped with a warning; SSL with no certificate falls back to an unverified connection and logs a warning.
+
+
 * **Outlook connector syncs intermittently fail with `NO_CERTIFICATE_OR_CRL_FOUND` when SSL is enabled**
 
     With SSL enabled, the connector wrote the configured CA to a fixed file on disk (`outlook_cert.cer`) shared across the process. Concurrent or overlapping syncs raced on it, causing an intermittent `SSLError: [X509] no certificate or crl found (NO_CERTIFICATE_OR_CRL_FOUND)` that aborted syncs with no configuration change between runs.
@@ -184,6 +193,98 @@ The connector service has the following known issues:
     **Affected versions**: 8.11.0–8.19.17, 9.0.0–9.3.6, and 9.4.0–9.4.2. On-prem Exchange with SSL enabled only.
 
     **Fix**: [elastic/connectors#4094](https://github.com/elastic/connectors/pull/4094), shipped in 8.19.18, 9.3.7, 9.4.3, and 9.5.0.
+
+
+* **Confluence Data Center / Server syncs can fail with HTTP 500 and require site-admin credentials**
+
+    Content search expanded unused `space.permissions` on Data Center / Server. That expansion can return HTTP 500 for non-administrator accounts (CONFSERVER-99908), which forced customers to over-grant site admin to the functional user. Confluence Cloud is not affected.
+
+    **Affected versions**: 8.13.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. Confluence Data Center / Server only.
+
+    **Fix**: [elastic/connectors#4118](https://github.com/elastic/connectors/pull/4118), shipped in 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
+
+
+* **GitHub connector syncs can succeed while indexing little or no data**
+
+    Page-level fetch failures were caught by a broad `except Exception`, logged as a warning, and swallowed. A sync could therefore complete successfully after failing to fetch issues, pull requests, or files — and the framework could delete previously indexed documents as a result.
+
+    **Affected versions**: 8.10.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3.
+
+    **Fix**: [elastic/connectors#4119](https://github.com/elastic/connectors/pull/4119), shipped in 8.19.19, 9.3.8, 9.4.4, and 9.5.0. Page-level fetch errors now fail the sync; only per-document enrichment errors are skipped.
+
+
+* **Outlook connector aborts the sync when Exchange items have null field values**
+
+    A single mail, calendar, contact, or attachment item with a missing nullable field (for example `mail.sender` → `'NoneType' object has no attribute 'email_address'`) aborted the entire sync. Optional folders that were absent also failed the account.
+
+    **Affected versions**: 8.11.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. On-prem Exchange only.
+
+    **Fix**: [elastic/connectors#4123](https://github.com/elastic/connectors/pull/4123), shipped in 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
+
+
+* **Outlook connector aborts the sync when the Contacts folder contains a distribution list**
+
+    The Contacts folder returns both `Contact` and `DistributionList` items, but the formatter assumed every item was a `Contact`, raising `'DistributionList' object has no attribute 'email_addresses'` and aborting the sync. Shared and resource mailboxes that lack Calendar or Tasks folders hit the same abort path.
+
+    **Affected versions**: 8.11.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. On-prem Exchange only.
+
+    **Fix**: [elastic/connectors#4147](https://github.com/elastic/connectors/pull/4147), shipped in 8.19.19, 9.3.8, 9.4.4, 9.5.0, and 9.6.0.
+
+
+* **MongoDB connector syncs fail on out-of-range BSON datetimes**
+
+    Documents with dates outside the Python `datetime` range (years 1–9999) cause pymongo to raise `InvalidBSON` (for example `year 643385 is out of range`) and abort the sync. The default `datetime_conversion` value remains `DATETIME` (raise).
+
+    **Affected versions**: All versions that use the default `DATETIME` conversion, including after the mitigation below.
+
+    **Workaround**: In advanced configuration, set `datetime_conversion` to `DATETIME_CLAMP` so out-of-range values are clamped to valid dates and the sync can continue. See the [MongoDB connector reference](/reference/search-connectors/es-connectors-mongodb.md).
+
+    **Fix**: Mitigation added in [elastic/connectors#4148](https://github.com/elastic/connectors/pull/4148), shipped in 8.19.19, 9.3.8, 9.4.4, 9.5.0, and 9.6.0.
+
+
+* **Outlook connector aborts the sync on unexpected Exchange item types or folder errors**
+
+    Folders could contain stray item types (for example a `CalendarItem` in a mail folder → `'CalendarItem' object has no attribute 'sender'`), or raise `ErrorManagedFolderNotFound` / `ErrorAccessDenied`. Any of these aborted the sync instead of skipping the bad item, folder, or account.
+
+    **Affected versions**: 8.11.0–8.19.19, 9.0.0–9.3.8, and 9.4.0–9.4.4. On-prem Exchange only.
+
+    **Fix**: [elastic/connectors#4158](https://github.com/elastic/connectors/pull/4158), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.0, and 9.6.0.
+
+
+* **Outlook connector aborts calendar sync on unrecognised EWS elements**
+
+    Some Exchange servers return elements such as `EndTimeZone` as siblings of calendar items. exchangelib raises `ValueError: Item type …EndTimeZone was unexpected in a BaseFolder folder` while loading the folder, which aborted the sync before per-item handling ran.
+
+    **Affected versions**: 8.11.0–8.19.19, 9.0.0–9.3.8, and 9.4.0–9.4.4. On-prem Exchange only.
+
+    **Fix**: [elastic/connectors#4287](https://github.com/elastic/connectors/pull/4287), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.0, and 9.6.0.
+
+
+* **Outlook connector DLS hides mailbox content from its owner**
+
+    With document-level security enabled, access control documents grant prefixed identities (`email:user@example.com`) while content documents stored the raw SMTP address. The DLS `terms` query intersection is empty, so mailbox owners see none of their own documents.
+
+    **Affected versions**: All versions with Outlook DLS enabled, through 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
+
+    **Fix**: [elastic/connectors#4291](https://github.com/elastic/connectors/pull/4291), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0. After upgrading, run a **full content sync** so `_allow_access_control` is rewritten on existing documents; an access control sync alone is not enough.
+
+
+* **Confluence connector DLS over-grants access on pages with inherited restrictions**
+
+    When a page inherits view restrictions from ancestors (or must satisfy both its own and parent restrictions), the connector ignored or incompletely applied the ancestor chain and fell back to broad space permissions. Users could see pages in Elasticsearch that they cannot view in Confluence.
+
+    **Affected versions**: All versions with Confluence DLS enabled, through 8.19.19, 9.3.8, 9.4.4, and 9.5.0. Cloud, Server, and Data Center.
+
+    **Fix**: [elastic/connectors#4297](https://github.com/elastic/connectors/pull/4297), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0. After upgrading, run a **full content sync** to rewrite `_allow_access_control`.
+
+
+* **SharePoint Online syncs abort on the system list `SharePointHomeCacheList`**
+
+    Microsoft Graph can return the system list `SharePointHomeCacheList`. Fetching its attachments via SharePoint REST returns Unauthorized and aborts the whole sync. Sync-rule exclusions cannot prevent this because they apply after the list is fetched.
+
+    **Affected versions**: 8.9.0–8.19.19, 9.0.0–9.3.8, and 9.4.0–9.4.4.
+
+    **Fix**: [elastic/connectors#4306](https://github.com/elastic/connectors/pull/4306), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0.
 
 
 ## Individual connector known issues [es-connectors-known-issues-specific]

--- a/docs/reference/search-connectors/es-connectors-known-issues.md
+++ b/docs/reference/search-connectors/es-connectors-known-issues.md
@@ -190,16 +190,16 @@ The connector service has the following known issues:
 
     With SSL enabled, the connector wrote the configured CA to a fixed file on disk (`outlook_cert.cer`) shared across the process. Concurrent or overlapping syncs raced on it, causing an intermittent `SSLError: [X509] no certificate or crl found (NO_CERTIFICATE_OR_CRL_FOUND)` that aborted syncs with no configuration change between runs.
 
-    **Affected versions**: 8.11.0–8.19.17, 9.0.0–9.3.6, and 9.4.0–9.4.2. On-prem Exchange with SSL enabled only.
+    **Affected versions**: 8.11.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. On-prem Exchange with SSL enabled only.
 
-    **Fix**: [elastic/connectors#4094](https://github.com/elastic/connectors/pull/4094), shipped in 8.19.18, 9.3.7, 9.4.3, and 9.5.0.
+    **Fix**: [elastic/connectors#4094](https://github.com/elastic/connectors/pull/4094), shipped in 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
 
 
 * **Confluence Data Center / Server syncs can fail with HTTP 500 and require site-admin credentials**
 
     Content search expanded unused `space.permissions` on Data Center / Server. That expansion can return HTTP 500 for non-administrator accounts (CONFSERVER-99908), which forced customers to over-grant site admin to the functional user. Confluence Cloud is not affected.
 
-    **Affected versions**: 8.13.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. Confluence Data Center / Server only.
+    **Affected versions**: 8.7.0–8.19.18, 9.0.0–9.3.7, and 9.4.0–9.4.3. Confluence Data Center / Server only.
 
     **Fix**: [elastic/connectors#4118](https://github.com/elastic/connectors/pull/4118), shipped in 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
 
@@ -264,18 +264,18 @@ The connector service has the following known issues:
 
     With document-level security enabled, access control documents grant prefixed identities (`email:user@example.com`) while content documents stored the raw SMTP address. The DLS `terms` query intersection is empty, so mailbox owners see none of their own documents.
 
-    **Affected versions**: All versions with Outlook DLS enabled, through 8.19.19, 9.3.8, 9.4.4, and 9.5.0.
+    **Affected versions**: All versions with Outlook DLS enabled, through 8.19.19, 9.3.8, and 9.4.4.
 
-    **Fix**: [elastic/connectors#4291](https://github.com/elastic/connectors/pull/4291), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0. After upgrading, run a **full content sync** so `_allow_access_control` is rewritten on existing documents; an access control sync alone is not enough.
+    **Fix**: [elastic/connectors#4291](https://github.com/elastic/connectors/pull/4291), shipped in 9.3.9, 9.4.5, 9.5.0, and 9.6.0. After upgrading, run a **full content sync** so `_allow_access_control` is rewritten on existing documents; an access control sync alone is not enough.
 
 
 * **Confluence connector DLS over-grants access on pages with inherited restrictions**
 
     When a page inherits view restrictions from ancestors (or must satisfy both its own and parent restrictions), the connector ignored or incompletely applied the ancestor chain and fell back to broad space permissions. Users could see pages in Elasticsearch that they cannot view in Confluence.
 
-    **Affected versions**: All versions with Confluence DLS enabled, through 8.19.19, 9.3.8, 9.4.4, and 9.5.0. Cloud, Server, and Data Center.
+    **Affected versions**: All versions with Confluence DLS enabled, through 8.19.19, 9.3.8, and 9.4.4. Cloud, Server, and Data Center.
 
-    **Fix**: [elastic/connectors#4297](https://github.com/elastic/connectors/pull/4297), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0. After upgrading, run a **full content sync** to rewrite `_allow_access_control`.
+    **Fix**: [elastic/connectors#4297](https://github.com/elastic/connectors/pull/4297), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.0, and 9.6.0. After upgrading, run a **full content sync** to rewrite `_allow_access_control`.
 
 
 * **SharePoint Online syncs abort on the system list `SharePointHomeCacheList`**
@@ -284,7 +284,7 @@ The connector service has the following known issues:
 
     **Affected versions**: 8.9.0–8.19.19, 9.0.0–9.3.8, and 9.4.0–9.4.4.
 
-    **Fix**: [elastic/connectors#4306](https://github.com/elastic/connectors/pull/4306), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.1, and 9.6.0.
+    **Fix**: [elastic/connectors#4306](https://github.com/elastic/connectors/pull/4306), shipped in 8.19.20, 9.3.9, 9.4.5, 9.5.0, and 9.6.0.
 
 
 ## Individual connector known issues [es-connectors-known-issues-specific]


### PR DESCRIPTION
## Summary

Adds Connector known-issues entries for product-facing fixes on [elastic/connectors](https://github.com/elastic/connectors) `main` since the last documented Outlook SSL cert-file race ([elastic/connectors#4094](https://github.com/elastic/connectors/pull/4094) / #152570).

Each entry follows the existing known-issues format (symptom, **Affected versions**, **Fix** / **Workaround** where needed). Outlook SDH hardenings are separate bullets.

| PR | Connector | Topic |
| --- | --- | --- |
| [#4085](https://github.com/elastic/connectors/pull/4085) | Outlook | Mailbox-less accounts / empty SSL cert abort sync |
| [#4118](https://github.com/elastic/connectors/pull/4118) | Confluence DC/Server | `space.permissions` HTTP 500 / site-admin requirement |
| [#4119](https://github.com/elastic/connectors/pull/4119) | GitHub | Swallowed fetch errors → empty “successful” syncs |
| [#4123](https://github.com/elastic/connectors/pull/4123) | Outlook | Null Exchange fields abort sync |
| [#4147](https://github.com/elastic/connectors/pull/4147) | Outlook | DistributionList in Contacts aborts sync |
| [#4148](https://github.com/elastic/connectors/pull/4148) | MongoDB | Out-of-range BSON datetimes (opt-in `DATETIME_CLAMP`) |
| [#4158](https://github.com/elastic/connectors/pull/4158) | Outlook | Unexpected item types / folder errors abort sync |
| [#4287](https://github.com/elastic/connectors/pull/4287) | Outlook | Unrecognised EWS elements abort calendar sync |
| [#4291](https://github.com/elastic/connectors/pull/4291) | Outlook | DLS identity prefix mismatch hides mailbox content |
| [#4297](https://github.com/elastic/connectors/pull/4297) | Confluence | Inherited page restrictions over-granted under DLS |
| [#4306](https://github.com/elastic/connectors/pull/4306) | SharePoint Online | `SharePointHomeCacheList` Unauthorized aborts sync |

Shipped versions are based on the first release tag that contains each backport where available; otherwise the connectors branch `VERSION` / PR backport labels (for example 8.19.20, 9.3.9, 9.4.5).

## Test plan

- [x] Docs-only change; entries match the style of existing Outlook / Jira known-issues bullets
- [ ] Spot-check rendered page for `es-connectors-known-issues` after merge (or via docs preview)
- [ ] Confirm backport/`shipped in` patch numbers against the next connectors releases if any label drifts


Made with [Cursor](https://cursor.com)