### PR TITLE
[9.3] test(tsdb): fix skipIndexIntervalSize range in ES819DocValuesDuelTests (#154635)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -325,9 +325,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:fuse.FuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/153911
-- class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
-  method: testDuel
-  issue: https://github.com/elastic/elasticsearch/issues/154243
 - class: org.elasticsearch.index.mapper.blockloader.LongFieldBlockLoaderTests
   method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=NONE]}
   issue: https://github.com/elastic/elasticsearch/issues/154912

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
@@ -60,7 +60,7 @@ public class DocValuesCodecDuelTests extends ESTestCase {
 
                 final DocValuesFormat docValuesFormat = randomBoolean()
                     ? new ES819TSDBDocValuesFormat(
-                        ESTestCase.randomIntBetween(1, 4096),
+                        ESTestCase.randomIntBetween(2, 4096),
                         ESTestCase.randomIntBetween(1, 512),
                         random().nextBoolean(),
                         ES819TSDBDocValuesFormatTests.randomBinaryCompressionMode(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [test(tsdb): fix skipIndexIntervalSize range in ES819DocValuesDuelTests (#154635)](https://github.com/elastic/elasticsearch/pull/154635)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)