### PR TITLE
Fix columnar prefix dynamic_properties mapping race

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -319,9 +319,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectIT
   method: testUpdateTransformWithProjectRouting
   issue: https://github.com/elastic/elasticsearch/issues/147534
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/columnar: no prefix_properties when dynamic is only set at root level}"
-  issue: https://github.com/elastic/elasticsearch/issues/153390
 - class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
   method: testDataStreamValidationDoesNotBreakUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/153413
@@ -397,9 +394,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
   method: testSeqNoPartiallyRetainedByCcrLease
   issue: https://github.com/elastic/elasticsearch/issues/152498
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
-  issue: https://github.com/elastic/elasticsearch/issues/154062
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/154157
@@ -415,12 +409,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
   method: testMaxExpressionDepth_nestedAbs_maxAllowed {default}
   issue: https://github.com/elastic/elasticsearch/issues/154380
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: multiple sub-objects with all three supported dynamic values}"
-  issue: https://github.com/elastic/elasticsearch/issues/154464
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: "test {yaml=mapping/70_columnar_prefix_dynamic_properties/logsdb_columnar: no prefix_properties when dynamic is only set at root level}"
-  issue: https://github.com/elastic/elasticsearch/issues/154537
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityCcrMigrationIT
   method: testRcs1SetupAgain
   issue: https://github.com/elastic/elasticsearch/issues/154539
@@ -547,9 +535,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=downsample/100_downsample_histograms/Downsample histogram with last value}
   issue: https://github.com/elastic/elasticsearch/issues/155453
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: "test {p0=mapping/70_columnar_prefix_dynamic_properties/columnar: multiple sub-objects with all three supported dynamic values}"
-  issue: https://github.com/elastic/elasticsearch/issues/155501
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecKnnFunctionIT
   method: test {csv-spec:knn-function.knnAfterChainedRename}
   issue: https://github.com/elastic/elasticsearch/issues/155518

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/70_columnar_prefix_dynamic_properties.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/70_columnar_prefix_dynamic_properties.yml
@@ -38,6 +38,10 @@ setup:
           version: "9.5.0"
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_columnar_root_only_dynamic
   - is_true: test_columnar_root_only_dynamic.mappings.properties.version
@@ -148,6 +152,10 @@ setup:
             term:
               resource.service: "my-service"
   - match: { hits.total.value: 1 }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:
@@ -369,6 +377,10 @@ setup:
           version: "9.5.0"
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_logsdb_columnar_root_only_dynamic
   - is_true: test_logsdb_columnar_root_only_dynamic.mappings.properties.@timestamp
@@ -416,6 +428,10 @@ setup:
             term:
               attributes.host: "es-node-1"
   - match: { hits.total.value: 1 }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:
@@ -482,6 +498,10 @@ setup:
             term:
               resource.service: "my-service"
   - match: { hits.total.value: 1 }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:
@@ -748,6 +768,10 @@ setup:
             term:
               attributes.host: "es-node-1"
   - match: { hits.total.value: 0 }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
These tests rarely failed because a `get_mapping` assertion on a dynamically-mapped field could observe a stale mapping in a mixed/multi-node cluster, when the request hit a node that had not yet applied the cluster state update triggered by the preceding `index` request.

Same fix as #148161: wait for pending cluster state events with `wait_for_events: languid` before those `get_mapping` calls, then unmute.

Fixes #153390
Fixes #154062
Fixes #154464
Fixes #154537
Fixes #155501