### PR TITLE
ES|QL: Shard Cache POC

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldType.java
@@ -178,6 +178,17 @@ public abstract class AbstractScriptFieldType<LeafFactory> extends MappedFieldTy
         );
     }
 
+    /**
+     * Whether two evaluations of this field's script over the same document produce the same value. False for a script
+     * reading randomness, the wall clock or anything outside the document.
+     * <p>
+     * {@link #applyScriptContext} reports the same thing to the context, but only for a caller that <em>queries</em>
+     * the field. A caller that reads its values, as ES|QL does, has to ask here.
+     */
+    public final boolean isResultDeterministic() {
+        return isResultDeterministic;
+    }
+
     protected final void applyScriptContext(SearchExecutionContext context) {
         if (context.allowExpensiveQueries() == false) {
             throw new ElasticsearchException(

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.MappingLookup;
 
@@ -137,27 +138,79 @@ public final class IndicesRequestCache implements Closeable {
         BytesReference value = cache.computeIfAbsent(key, cacheLoader, cancellationRegistrar);
         if (cacheLoader.isLoaded()) {
             key.entity.onMiss();
-            // see if it's the first time we see this reader, and make sure to register a cleanup key
-            CleanupKey cleanupKey = new CleanupKey(cacheEntity, cacheHelper.getKey());
-            if (registeredClosedListeners.containsKey(cleanupKey) == false) {
-                Boolean previous = registeredClosedListeners.putIfAbsent(cleanupKey, Boolean.TRUE);
-                if (previous == null) {
-                    cacheHelper.addClosedListener(cleanupKey);
-                }
-            }
-            /*
-             * Note that we don't use a closed listener for the mapping. Instead
-             * we let cache entries for out of date mappings age out. We do this
-             * because we don't reference count the MappingLookup so we can't tell
-             * when one is no longer used. Mapping updates should be a lot less
-             * frequent than reader closes so this is probably ok. On the other
-             * hand, for read only indices mapping changes are, well, possible,
-             * and readers are never changed. Oh well.
-             */
+            registerCleanupKey(cacheEntity, cacheHelper);
         } else {
             key.entity.onHit();
         }
         return value;
+    }
+
+    /**
+     * Looks a value up without computing one on a miss, recording the hit or the miss. Callers whose computation is not
+     * a synchronous loader - ES|QL computes a whole batch of shards asynchronously and only learns afterwards whether
+     * the result may be stored - probe with this and store later with {@link #put}.
+     * <p>
+     * Counts differ from {@link #getOrCompute} when two callers race for one absent key: there, the second waits for
+     * the first and counts a hit, while here both count a miss. That is what happened, because both go on to compute.
+     *
+     * @return the cached value, or {@code null} when the key is not present
+     */
+    @Nullable
+    BytesReference get(CacheEntity cacheEntity, MappingLookup.CacheKey mappingCacheKey, DirectoryReader reader, BytesReference cacheKey) {
+        final ESCacheHelper cacheHelper = ElasticsearchDirectoryReader.getESReaderCacheHelper(reader);
+        assert cacheHelper != null;
+        BytesReference value = cache.get(new Key(cacheEntity, mappingCacheKey, cacheHelper.getKey(), cacheKey));
+        if (value == null) {
+            cacheEntity.onMiss();
+        } else {
+            cacheEntity.onHit();
+        }
+        return value;
+    }
+
+    /**
+     * Stores a value that was computed outside the cache. An entry that is already present wins, so two concurrent
+     * computations of the same key cannot replace each other's results. Does not record a hit or a miss: the
+     * matching {@link #get} probe already did.
+     */
+    void put(
+        CacheEntity cacheEntity,
+        MappingLookup.CacheKey mappingCacheKey,
+        DirectoryReader reader,
+        BytesReference cacheKey,
+        BytesReference value
+    ) throws Exception {
+        final ESCacheHelper cacheHelper = ElasticsearchDirectoryReader.getESReaderCacheHelper(reader);
+        assert cacheHelper != null;
+        final Key key = new Key(cacheEntity, mappingCacheKey, cacheHelper.getKey(), cacheKey);
+        cache.computeIfAbsent(key, k -> {
+            cacheEntity.onCached(k, value);
+            return value;
+        });
+        registerCleanupKey(cacheEntity, cacheHelper);
+    }
+
+    /**
+     * Registers the reader-close listener that queues this entity's entries for the periodic cleaner, unless a
+     * listener for this (entity, reader) pair is already registered.
+     */
+    private void registerCleanupKey(CacheEntity cacheEntity, ESCacheHelper cacheHelper) {
+        CleanupKey cleanupKey = new CleanupKey(cacheEntity, cacheHelper.getKey());
+        if (registeredClosedListeners.containsKey(cleanupKey) == false) {
+            Boolean previous = registeredClosedListeners.putIfAbsent(cleanupKey, Boolean.TRUE);
+            if (previous == null) {
+                cacheHelper.addClosedListener(cleanupKey);
+            }
+        }
+        /*
+         * Note that we don't use a closed listener for the mapping. Instead
+         * we let cache entries for out of date mappings age out. We do this
+         * because we don't reference count the MappingLookup so we can't tell
+         * when one is no longer used. Mapping updates should be a lot less
+         * frequent than reader closes so this is probably ok. On the other
+         * hand, for read only indices mapping changes are, well, possible,
+         * and readers are never changed. Oh well.
+         */
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1814,6 +1814,54 @@ public class IndicesService extends AbstractLifecycleComponent
         return indicesRequestCache.getOrCompute(cacheEntity, supplier, mappingCacheKey, reader, cacheKey, cancellationRegistrar);
     }
 
+    /**
+     * The plugin hook that folds whatever distinguishes two callers' results for the same query on the same shard, such
+     * as document- and field-level security, into the request cache key. Exposed so that a second caller of the shard
+     * cache reuses the one hook rather than reimplementing it, which is the likely source of a cross-user leak.
+     *
+     * @return the differentiator, or {@code null} when no plugin registered one
+     */
+    @Nullable
+    public CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator() {
+        return requestCacheKeyDifferentiator;
+    }
+
+    /**
+     * Probes the shard request cache for something calculated at the shard level, without computing it on a miss.
+     * The {@link #cacheShardLevelResult} loader contract cannot be used by a caller whose computation is asynchronous
+     * and whose eligibility to be stored is only known once it has finished; such a caller probes here and stores with
+     * {@link #putShardLevelResult}. Records a hit or a miss in the shard's {@code request_cache} statistics either way.
+     *
+     * @param reader a reader for this shard, naming the data version the entry belongs to
+     * @return the cached bytes, or {@code null} when there is no entry for this key
+     */
+    @Nullable
+    public BytesReference getCachedShardLevelResult(
+        IndexShard shard,
+        MappingLookup.CacheKey mappingCacheKey,
+        DirectoryReader reader,
+        BytesReference cacheKey
+    ) {
+        return indicesRequestCache.get(new IndexShardCacheEntity(shard), mappingCacheKey, reader, cacheKey);
+    }
+
+    /**
+     * Stores something calculated at the shard level that was computed outside the cache. The counterpart of
+     * {@link #getCachedShardLevelResult}; an entry already present under this key wins.
+     *
+     * @param reader the reader the value was computed against. Must still be open: the cache keys on its cache key and
+     *               registers a close listener on it to invalidate the entry.
+     */
+    public void putShardLevelResult(
+        IndexShard shard,
+        MappingLookup.CacheKey mappingCacheKey,
+        DirectoryReader reader,
+        BytesReference cacheKey,
+        BytesReference value
+    ) throws Exception {
+        indicesRequestCache.put(new IndexShardCacheEntity(shard), mappingCacheKey, reader, cacheKey, value);
+    }
+
     static final class IndexShardCacheEntity extends AbstractIndexShardCacheEntity {
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexShardCacheEntity.class);
         private final IndexShard indexShard;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ShardResultCacheIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ShardResultCacheIT.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.cache.request.RequestCacheStats;
+import org.elasticsearch.index.mapper.OnScriptError;
+import org.elasticsearch.indices.IndicesRequestCache;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.LongFieldScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.plugin.ShardResultCacheSettings;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * End to end coverage of the ES|QL shard result cache: a second run of an aggregation is served from
+ * {@link IndicesRequestCache} and produces the same rows, a query the verifier refuses never reaches the cache at all,
+ * and anything that changes the rows a shard produces changes the key.
+ */
+@TestLogging(
+    value = "org.elasticsearch.xpack.esql.plugin.ShardResultCache:TRACE",
+    reason = "to explain a hit, a miss or a refusal to cache"
+)
+public class ShardResultCacheIT extends AbstractEsqlIntegTestCase {
+
+    private static final String INDEX = "cacheable";
+
+    /**
+     * Pragmas reach the cache key, and {@link AbstractEsqlIntegTestCase#randomPragmas()} draws a fresh set per query, so
+     * two runs of the same text would otherwise be two different queries as far as the cache is concerned.
+     */
+    private final QueryPragmas pragmas = new QueryPragmas(Settings.EMPTY);
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return pragmas;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(ShardResultCacheSettings.ENABLED.getKey(), true)
+            // The churn gate keeps freshly written shards out, which every shard in a test is.
+            .put(ShardResultCacheSettings.MIN_SHARD_IDLE_TIME.getKey(), TimeValue.ZERO)
+            .build();
+    }
+
+    @Before
+    public void setUpIndex() throws Exception {
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate(INDEX)
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 3))
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                        // ESIntegTestCase randomizes this per index, and the cache honors it.
+                        .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
+                )
+                .setMapping("host", "type=keyword", "cost", "type=long", "@timestamp", "type=date")
+        );
+        List<IndexRequestBuilder> docs = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            docs.add(
+                prepareIndex(INDEX).setSource("host", "host" + (i % 3), "cost", i, "@timestamp", "2024-01-0" + (1 + i % 5) + "T00:00:00Z")
+            );
+        }
+        indexRandom(true, docs);
+        client().admin().indices().prepareRefresh(INDEX).get();
+    }
+
+    public void testAggregationIsServedFromCacheOnSecondRun() {
+        String query = "FROM " + INDEX + " | STATS total = SUM(cost) BY host | SORT host";
+        List<List<Object>> first = runAndCollect(query);
+        RequestCacheStats afterFirst = requestCacheStats();
+        assertThat("the first run must miss on every shard", afterFirst.getMissCount(), greaterThan(0L));
+        assertThat("nothing could have hit yet", afterFirst.getHitCount(), equalTo(0L));
+        assertThat("the first run must have stored something", afterFirst.getMemorySizeInBytes(), greaterThan(0L));
+
+        List<List<Object>> second = runAndCollect(query);
+        assertThat(second, equalTo(first));
+        RequestCacheStats afterSecond = requestCacheStats();
+        assertThat("the second run must hit on every shard that missed", afterSecond.getHitCount(), equalTo(afterFirst.getMissCount()));
+        assertThat("the second run must not miss", afterSecond.getMissCount(), equalTo(afterFirst.getMissCount()));
+    }
+
+    public void testFilterIsPartOfTheKey() {
+        runAndCollect("FROM " + INDEX + " | STATS total = SUM(cost)");
+        long missesAfterFirst = requestCacheStats().getMissCount();
+
+        List<List<Object>> filtered = runAndCollect("FROM " + INDEX + " | WHERE cost > 10 | STATS total = SUM(cost)");
+        assertThat("a different filter is a different key", requestCacheStats().getMissCount(), greaterThan(missesAfterFirst));
+        assertThat(requestCacheStats().getHitCount(), equalTo(0L));
+
+        // ... and the filtered answer is the filtered answer, not the unfiltered entry replayed.
+        assertThat(filtered, equalTo(List.of(List.of(11L + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19))));
+    }
+
+    public void testNewDocumentInvalidatesTheEntry() {
+        String query = "FROM " + INDEX + " | STATS count = COUNT(*)";
+        assertThat(runAndCollect(query), equalTo(List.of(List.of(20L))));
+        RequestCacheStats afterFirst = requestCacheStats();
+        assertThat(afterFirst.getMissCount(), greaterThan(0L));
+
+        prepareIndex(INDEX).setSource("host", "host0", "cost", 100).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        assertThat("a new reader must not be answered from the old reader's entry", runAndCollect(query), equalTo(List.of(List.of(21L))));
+        RequestCacheStats afterRefresh = requestCacheStats();
+        assertThat("the refreshed shard must miss again", afterRefresh.getMissCount(), greaterThan(afterFirst.getMissCount()));
+        // Only the shard that took the new document turned its reader over, so the others still hit.
+        assertThat(afterRefresh.getHitCount(), equalTo(afterFirst.getMissCount() - 1));
+    }
+
+    public void testUnsupportedShapeIsNeverCached() {
+        // A row-returning query: no aggregation at the root, so the verifier refuses it and nothing is probed or stored.
+        runAndCollect("FROM " + INDEX + " | KEEP host, cost | SORT cost | LIMIT 5");
+        RequestCacheStats stats = requestCacheStats();
+        assertThat(stats.getMissCount(), equalTo(0L));
+        assertThat(stats.getHitCount(), equalTo(0L));
+        assertThat(stats.getMemorySizeInBytes(), equalTo(0L));
+    }
+
+    /**
+     * A runtime field whose script returns something new every time makes the shard's rows a function of when they were
+     * read. ES|QL reads such a field's values without ever building a query against it, so the
+     * {@code SearchExecutionContext.isCacheable()} flag that catches this on the DSL path never flips; the mapping has
+     * to be asked directly.
+     */
+    public void testNonDeterministicRuntimeFieldIsNeverCached() throws Exception {
+        String index = "noisy";
+        XContentBuilder mapping = JsonXContent.contentBuilder().startObject();
+        mapping.startObject("runtime").startObject("noise");
+        mapping.field("type", "long").startObject("script").field("source", "").field("lang", NOISE_LANG).endObject();
+        mapping.endObject().endObject();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate(index)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
+                .setMapping(mapping.endObject())
+        );
+        indexRandom(true, List.of(prepareIndex(index).setSource("host", "host0")));
+
+        String query = "FROM " + index + " | STATS total = SUM(noise)";
+        runAndCollect(query);
+        runAndCollect(query);
+        RequestCacheStats stats = requestCacheStats(index);
+        assertThat("a shard reading a non-deterministic field must not even be probed", stats.getMissCount(), equalTo(0L));
+        assertThat(stats.getHitCount(), equalTo(0L));
+        assertThat(stats.getMemorySizeInBytes(), equalTo(0L));
+    }
+
+    /**
+     * The property the whole feature rests on, over every shape the verifier admits rather than over one query: what a
+     * hit replays is what the same query computes with the cache turned off.
+     */
+    public void testAServedResultIsWhatTheQueryWouldHaveComputed() {
+        for (String query : List.of(
+            "FROM " + INDEX + " | STATS total = SUM(cost)",
+            "FROM " + INDEX + " | STATS total = SUM(cost), hosts = COUNT_DISTINCT(host) BY host | SORT host",
+            "FROM " + INDEX + " | WHERE cost > 5 | STATS count = COUNT(*), top = MAX(cost)",
+            "FROM " + INDEX + " | EVAL doubled = cost * 2 | STATS total = SUM(doubled) BY host | SORT host",
+            "FROM " + INDEX + " | WHERE @timestamp >= \"2024-01-03T00:00:00Z\" | STATS count = COUNT(*)"
+        )) {
+            updateClusterSettings(Settings.builder().put(ShardResultCacheSettings.ENABLED.getKey(), false));
+            List<List<Object>> computed = runAndCollect(query);
+
+            updateClusterSettings(Settings.builder().put(ShardResultCacheSettings.ENABLED.getKey(), true));
+            runAndCollect(query);
+            long hitsBefore = requestCacheStats().getHitCount();
+            List<List<Object>> served = runAndCollect(query);
+            assertThat(
+                "the run under test has to be a hit for it to prove anything: " + query,
+                requestCacheStats().getHitCount(),
+                greaterThan(hitsBefore)
+            );
+            assertThat(query, served, equalTo(computed));
+        }
+        updateClusterSettings(Settings.builder().putNull(ShardResultCacheSettings.ENABLED.getKey()));
+    }
+
+    private List<List<Object>> runAndCollect(String query) {
+        try (EsqlQueryResponse response = run(query)) {
+            return getValuesList(response);
+        }
+    }
+
+    private RequestCacheStats requestCacheStats() {
+        return requestCacheStats(INDEX);
+    }
+
+    private RequestCacheStats requestCacheStats(String index) {
+        return client().admin().indices().prepareStats(index).setRequestCache(true).get().getTotal().getRequestCache();
+    }
+
+    private static final String NOISE_LANG = "shard-cache-noise";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(NoisyRuntimeFieldPlugin.class);
+        return plugins;
+    }
+
+    /** A {@code long} runtime field that emits a fresh random value per document and admits to being non-deterministic. */
+    public static class NoisyRuntimeFieldPlugin extends Plugin implements ScriptPlugin {
+        @Override
+        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+            return new ScriptEngine() {
+                @Override
+                public String getType() {
+                    return NOISE_LANG;
+                }
+
+                @Override
+                public <FactoryType> FactoryType compile(
+                    String name,
+                    String code,
+                    ScriptContext<FactoryType> context,
+                    Map<String, String> params
+                ) {
+                    if (context != LongFieldScript.CONTEXT) {
+                        throw new IllegalArgumentException("unsupported context " + context);
+                    }
+                    // Safe: context == LongFieldScript.CONTEXT guarantees FactoryType == LongFieldScript.Factory.
+                    @SuppressWarnings("unchecked")
+                    FactoryType result = (FactoryType) new LongFieldScript.Factory() {
+                        @Override
+                        public boolean isResultDeterministic() {
+                            return false;
+                        }
+
+                        @Override
+                        public LongFieldScript.LeafFactory newFactory(
+                            String fieldName,
+                            Map<String, Object> params,
+                            SearchLookup searchLookup,
+                            OnScriptError onScriptError
+                        ) {
+                            return ctx -> new LongFieldScript(fieldName, params, searchLookup, onScriptError, ctx) {
+                                @Override
+                                public void execute() {
+                                    emit(randomLong());
+                                }
+                            };
+                        }
+                    };
+                    return result;
+                }
+
+                @Override
+                public Set<ScriptContext<?>> getSupportedContexts() {
+                    return Set.of(LongFieldScript.CONTEXT);
+                }
+            };
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NameId.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/NameId.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.core.expression;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -68,6 +69,10 @@ public class NameId implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeLong(id);
+        if (out instanceof PlanStreamOutput planOut) {
+            planOut.writeNameId(id);
+        } else {
+            out.writeLong(id);
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Source.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/tree/Source.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.operator.WarningSourceLocation;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.io.IOException;
@@ -91,7 +92,7 @@ public final class Source implements Writeable, WarningSourceLocation {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (this == EMPTY) {
+        if (this == EMPTY || (out instanceof PlanStreamOutput planOut && planOut.normalizeForIdentity())) {
             out.writeBoolean(false);
             return;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -39,6 +39,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.math.Cast;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
@@ -208,7 +209,10 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
         functionType.writeTo(out);
         out.writeNamedWriteable(left());
         out.writeNamedWriteable(right());
-        out.writeOptionalZoneId(zoneId());
+        // readFrom throws the zone away, so a comparison that has crossed the wire never carries one while one built
+        // here does. A stream that describes what the comparison computes must not see a difference the wire erases.
+        boolean normalized = out instanceof PlanStreamOutput planOut && planOut.normalizeForIdentity();
+        out.writeOptionalZoneId(normalized ? null : zoneId());
     }
 
     public BinaryComparisonOperation getFunctionType() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
@@ -21,6 +21,8 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.Column;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
@@ -73,12 +75,47 @@ public final class PlanStreamOutput extends StreamOutput {
 
     private final int maxSerializedAttributes;
 
+    /**
+     * When non-null, this stream is written for identity rather than for transport, and the parts of a plan that name
+     * the same computation differently from one run to the next are normalized away. The map itself holds the
+     * {@link NameId} rewriting: ids come from a process-global counter and are reallocated again by
+     * {@link PlanStreamInput.NameIdMapper} on deserialize, so raw ids differ between two runs of the same query and
+     * between two nodes; they are replaced by dense ordinals in write order. {@link Source} is elided for the same
+     * reason, through {@link #normalizeForIdentity()}.
+     * <p>
+     * Never used on the transport path: the wire format is unchanged when this is null.
+     */
+    @Nullable
+    private final Map<Long, Long> nameIdOrdinals;
+
     public PlanStreamOutput(StreamOutput delegate, @Nullable Configuration configuration) throws IOException {
         this(delegate, configuration, MAX_SERIALIZED_ATTRIBUTES);
     }
 
     public PlanStreamOutput(StreamOutput delegate, @Nullable Configuration configuration, int maxSerializedAttributes) throws IOException {
+        this(delegate, configuration, maxSerializedAttributes, false);
+    }
+
+    /**
+     * @param normalizeForIdentity see {@link #nameIdOrdinals}
+     */
+    public PlanStreamOutput(StreamOutput delegate, @Nullable Configuration configuration, boolean normalizeForIdentity) throws IOException {
+        this(delegate, configuration, MAX_SERIALIZED_ATTRIBUTES, normalizeForIdentity);
+    }
+
+    /**
+     * @param normalizeForIdentity see {@link #nameIdOrdinals}. Must be {@code false} for anything that is going to be
+     *                             read back as a plan: a normalized stream preserves what the plan computes, not the
+     *                             ids and source positions it computes it under.
+     */
+    public PlanStreamOutput(
+        StreamOutput delegate,
+        @Nullable Configuration configuration,
+        int maxSerializedAttributes,
+        boolean normalizeForIdentity
+    ) throws IOException {
         this.delegate = delegate;
+        this.nameIdOrdinals = normalizeForIdentity ? new HashMap<>() : null;
         if (configuration != null) {
             for (Map.Entry<String, Map<String, Column>> table : configuration.tables().entrySet()) {
                 for (Map.Entry<String, Column> column : table.getValue().entrySet()) {
@@ -126,6 +163,29 @@ public final class PlanStreamOutput extends StreamOutput {
     public void setTransportVersion(TransportVersion version) {
         delegate.setTransportVersion(version);
         super.setTransportVersion(version);
+    }
+
+    /**
+     * Writes a {@link NameId}'s raw id, mapping it to a dense ordinal first when this stream normalizes for identity.
+     * Called by {@link NameId#writeTo}.
+     */
+    public void writeNameId(long id) throws IOException {
+        if (nameIdOrdinals == null) {
+            writeLong(id);
+        } else {
+            writeLong(nameIdOrdinals.computeIfAbsent(id, k -> (long) nameIdOrdinals.size()));
+        }
+    }
+
+    /**
+     * Whether this stream describes what a plan computes rather than how it was written down. A {@link Source} carries
+     * a position in the query text and the text's own length, which differ between a plan parsed from text and the same
+     * plan arriving pre-built, and between two texts that mean the same thing, so it is written as
+     * {@link Source#EMPTY}. Consulted by {@link Source#writeTo} and by
+     * {@code EsqlBinaryComparison#writeTo}, whose zone id the wire drops on read.
+     */
+    public boolean normalizeForIdentity() {
+        return nameIdOrdinals != null;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/ResolvedSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/ResolvedSettings.java
@@ -16,7 +16,10 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -72,7 +75,15 @@ public final class ResolvedSettings implements Writeable {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(values.size());
-        for (Map.Entry<QuerySettingDef<?>, Object> e : values.entrySet()) {
+        /*
+         * By name, because the map's own order is not one: it is an immutable map keyed by identity, and the layout it
+         * probes into depends on the order the entries went in, which differs between a resolved instance and a copy
+         * read back off the wire. Order means nothing to the reader, but these bytes are also digested into the ES|QL
+         * shard result cache key, where the same settings have to produce the same bytes on every node.
+         */
+        List<Map.Entry<QuerySettingDef<?>, Object>> sorted = new ArrayList<>(values.entrySet());
+        sorted.sort(Comparator.comparing(e -> e.getKey().name()));
+        for (Map.Entry<QuerySettingDef<?>, Object> e : sorted) {
             QuerySettingDef def = e.getKey();
             out.writeString(def.name());
             try (BytesStreamOutput valueOut = new BytesStreamOutput()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeSearchContext.java
@@ -17,7 +17,9 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.DefaultShardContext;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Search and shard context used as entries in {@link org.elasticsearch.compute.lucene.IndexedByShardId}. These are shared by both the data
@@ -45,6 +47,13 @@ class ComputeSearchContext implements Releasable {
     @Nullable
     private final SearchContext searchContext;
     private final SetOnce<ShardContext> shardContext = new SetOnce<>();
+    /**
+     * Every {@link EsqlSearchExecutionContext} handed out here. Kept because
+     * {@link org.elasticsearch.index.query.SearchExecutionContext#disableCache()} marks the instance it is called on
+     * and the copy constructor starts a fresh one cacheable, so the search context's own is not told what building this
+     * shard's queries discovered. See {@link #queryConstructionWasCacheable()}.
+     */
+    private final List<EsqlSearchExecutionContext> handedOutContexts = new CopyOnWriteArrayList<>();
 
     ComputeSearchContext(int index, SearchContext searchContext) {
         this.index = index;
@@ -96,12 +105,28 @@ class ComputeSearchContext implements Releasable {
         return createShardContext(() -> {}, QueryWarnings.NOOP);
     }
 
+    /**
+     * Whether everything consulted while building this shard's Lucene queries was a function of the shard's data alone.
+     * False once anything called {@code disableCache()}: a non-deterministic runtime field or script, a terms lookup, or
+     * a read of the query's wall clock. Safe to call after the search context is closed, and after the drivers have
+     * finished, which is when a caller wanting to cache the result has the answer it needs.
+     */
+    boolean queryConstructionWasCacheable() {
+        for (EsqlSearchExecutionContext context : handedOutContexts) {
+            if (context.isCacheable() == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private ShardContext createShardContext(Releasable releasable, QueryWarnings queryWarnings) {
         ensureNotTombstone();
         EsqlSearchExecutionContext searchExecutionContext = new EsqlSearchExecutionContext(
             searchContext.getSearchExecutionContext(),
             queryWarnings
         );
+        handedOutContexts.add(searchExecutionContext);
         // Registered unconditionally; for detached shard contexts this is a no-op since the remote fetch path does not construct
         // Lucene queries and the counter stays at zero.
         searchContext.addReleasable(searchExecutionContext::releaseQueryConstructionMemory);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -260,6 +260,10 @@ public class ComputeService {
         return remoteFetchService;
     }
 
+    BlockFactory blockFactory() {
+        return blockFactory;
+    }
+
     FormatReaderRegistry formatReaderRegistry() {
         return formatReaderRegistry;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -20,6 +20,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.SplitShardCountSummary;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.EmptyIndexedByShardId;
 import org.elasticsearch.compute.lucene.IndexedByShardId;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
@@ -29,9 +31,11 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSink;
 import org.elasticsearch.compute.operator.exchange.ExchangeSinkHandler;
 import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.logging.LogManager;
@@ -90,6 +94,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
     private final ExchangeService exchangeService;
     private final Executor searchExecutor;
     private final ThreadPool threadPool;
+    private final ShardResultCache shardResultCache;
     /**
      * Resolved once: {@link Federation#FEDERATION_ENABLED} is node scoped and takes effect only after a restart, so
      * every external request on this node gets the same answer.
@@ -113,6 +118,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         this.exchangeService = exchangeService;
         this.searchExecutor = searchExecutor;
         this.threadPool = transportService.getThreadPool();
+        this.shardResultCache = new ShardResultCache(
+            searchService.getIndicesService(),
+            clusterService.getClusterSettings(),
+            computeService.blockFactory()
+        );
         this.federationAvailable = Federation.isAvailable(clusterService.getSettings());
         transportService.registerRequestHandler(ComputeService.DATA_ACTION_NAME, searchExecutor, DataNodeRequest::new, this);
     }
@@ -508,6 +518,14 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         private final Map<ShardId, Exception> shardLevelFailures;
         private final AcquiredSearchContexts searchContexts;
         private final PlanTimeProfile planTimeProfile;
+        private final ShardResultCacheSettings cacheSettings;
+        /**
+         * The shared part of the cache key, or {@code null} when this request may not use the cache at all. Non-null
+         * implies {@link #maxConcurrentShards} is 1, which is what lets a batch's captured pages be attributed to one
+         * shard.
+         */
+        @Nullable
+        private final ShardResultCacheKey.QueryPart cacheQueryPart;
 
         DataNodeRequestExecutor(
             EsqlFlags flags,
@@ -518,7 +536,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             boolean failFastOnShardFailure,
             Map<ShardId, Exception> shardLevelFailures,
             ComputeListener computeListener,
-            AcquiredSearchContexts searchContexts
+            AcquiredSearchContexts searchContexts,
+            ShardResultCacheSettings cacheSettings,
+            @Nullable ShardResultCacheKey.QueryPart cacheQueryPart
         ) {
             this.flags = flags;
             this.request = request;
@@ -531,6 +551,13 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             this.blockingSink = exchangeSink.createExchangeSink(() -> {});
             this.searchContexts = searchContexts;
             this.planTimeProfile = new PlanTimeProfile();
+            this.cacheSettings = cacheSettings;
+            this.cacheQueryPart = cacheQueryPart;
+            if (cacheQueryPart != null && maxConcurrentShards != 1) {
+                throw new IllegalStateException(
+                    "a cacheable request must run one shard per batch, but maxConcurrentShards=" + maxConcurrentShards
+                );
+            }
         }
 
         void start() {
@@ -584,6 +611,16 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         batchListener.onResponse(DriverCompletionInfo.EMPTY);
                         return;
                     }
+                    RetainedCacheProbe probe = probeCache(shards, acquiredSearchContexts);
+                    if (probe != null && probe.probe().isHit()) {
+                        if (serveFromCache(probe, pagesProduced, batchListener)) {
+                            return;
+                        }
+                        // The entry could not be replayed, so this shard has to be computed after all, and there is no
+                        // point capturing a value under a key that just failed to round-trip.
+                        probe = null;
+                    }
+                    final ShardResultCapture capture = probe == null ? null : new ShardResultCapture(cacheSettings.maxValueSizeInBytes());
                     var computeContext = new ComputeContext(
                         sessionId,
                         ComputeService.DATA_DESCRIPTION,
@@ -593,7 +630,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         configuration,
                         configuration.newFoldContext(),
                         null,
-                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet),
+                        capture == null
+                            ? () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet)
+                            : () -> capture.wrap(exchangeSink.createExchangeSink(pagesProduced::incrementAndGet)),
                         request.retainSearchContexts()
                     );
                     computeService.runCompute(
@@ -603,10 +642,144 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         computeService.plannerSettings().get(),
                         LocalPhysicalOptimization.ENABLED,
                         planTimeProfile,
-                        batchListener
+                        capture == null ? batchListener : storeThen(probe, capture, batchListener)
                     );
                 }, batchListener::onFailure)
             );
+        }
+
+        /**
+         * A probe plus the searcher that keeps it storable. A shard's {@link SearchContext} is closed as soon as
+         * the last operator holding its shard context releases it, which happens before this batch's completion listener
+         * runs, so holding an {@link Engine.Searcher} is what guarantees the reader stays alive — and therefore
+         * addressable by cache key — when the store finally happens. The compute context is carried for the same reason:
+         * only it can say, once the drivers are done, whether building this shard's queries turned out to be cacheable.
+         */
+        private record RetainedCacheProbe(ShardResultCache.ShardProbe probe, Engine.Searcher searcher, ComputeSearchContext context)
+            implements
+                Releasable {
+            @Override
+            public void close() {
+                searcher.close();
+            }
+        }
+
+        /**
+         * Probes the cache for this batch's single shard.
+         *
+         * @return {@code null} when this shard cannot use the cache, either because the request is not cacheable or
+         *         because its key could not be completed
+         */
+        @Nullable
+        private RetainedCacheProbe probeCache(
+            List<DataNodeRequest.Shard> shards,
+            IndexedByShardId<ComputeSearchContext> acquiredSearchContexts
+        ) {
+            if (cacheQueryPart == null) {
+                return null;
+            }
+            assert shards.size() == 1 : "expected a single shard per batch, got " + shards.size();
+            ComputeSearchContext context = acquiredSearchContexts.iterable().iterator().next();
+            SearchContext searchContext = context.searchContext();
+            /*
+             * The same gate the DSL path applies, here catching whatever preProcess already consulted. It is only half
+             * the gate: ES|QL builds this shard's queries later and against its own context, so the store path asks
+             * that one too, in storeThen.
+             */
+            if (searchContext.getSearchExecutionContext().isCacheable() == false) {
+                return null;
+            }
+            ShardResultCache.ShardProbe probe = shardResultCache.probe(cacheQueryPart, shards.getFirst(), searchContext);
+            if (probe == null) {
+                return null;
+            }
+            if (probe.isHit() == false && shardResultCache.admits(probe.shard(), cacheSettings) == false) {
+                // A miss on a shard the admission policy would refuse: the miss is worth counting, the capture is not
+                // worth paying for.
+                return null;
+            }
+            return new RetainedCacheProbe(probe, probe.shard().acquireSearcher("shard-result-cache"), context);
+        }
+
+        /**
+         * Replays a hit into the exchange in place of running any driver, and completes the batch with no driver
+         * profiles: there were none, and reporting borrowed ones would misattribute another query's work.
+         *
+         * @return false when the entry could not be replayed, in which case nothing was written to the exchange and the
+         *         caller must compute the shard normally
+         */
+        private boolean serveFromCache(
+            RetainedCacheProbe probe,
+            AtomicInteger pagesProduced,
+            ActionListener<DriverCompletionInfo> batchListener
+        ) {
+            final List<Page> pages;
+            try (probe) {
+                // Deserializes everything before writing anything, so a failure here leaves the exchange untouched.
+                pages = shardResultCache.replay(probe.probe().hit());
+            } catch (Exception e) {
+                LOGGER.warn("failed to replay a shard result cache entry; recomputing the shard", e);
+                return false;
+            }
+            ExchangeSink sink = exchangeSink.createExchangeSink(pagesProduced::incrementAndGet);
+            int handedOver = 0;
+            try {
+                for (Page page : pages) {
+                    // The sink owns a page once it has been handed over, and releases it itself if the exchange is
+                    // already finished. Anything not handed over is still ours.
+                    sink.addPage(page);
+                    handedOver++;
+                }
+            } finally {
+                for (int i = handedOver; i < pages.size(); i++) {
+                    pages.get(i).releaseBlocks();
+                }
+                sink.finish();
+                /*
+                 * A computed shard's search context is closed by the last operator to release its shard context. This
+                 * shard has no operators, so closing it here is what keeps a run of hits from holding one context per
+                 * shard open until the whole request ends. It is the same moment a computed batch would have closed
+                 * it, so the node-reduce driver, which sees every context, is no worse off than on a miss.
+                 */
+                probe.context().close();
+            }
+            batchListener.onResponse(DriverCompletionInfo.EMPTY);
+            return true;
+        }
+
+        /**
+         * Wraps the batch listener so a batch that completed normally is stored. Failures skip the store: a partial
+         * capture is indistinguishable from a complete one once it is bytes.
+         */
+        private ActionListener<DriverCompletionInfo> storeThen(
+            RetainedCacheProbe probe,
+            ShardResultCapture capture,
+            ActionListener<DriverCompletionInfo> batchListener
+        ) {
+            return ActionListener.runAfter(batchListener.delegateFailureAndWrap((l, info) -> {
+                /*
+                 * The cacheability question can only be answered here. Building this shard's queries is what discovers
+                 * a non-deterministic runtime field, and that happens on a context ES|QL made for the drivers, after
+                 * the probe.
+                 * Driver failures and cancellations route to onFailure, not here, so reaching this success branch means
+                 * the computation completed normally and the capture is complete.
+                 */
+                if (probe.context().queryConstructionWasCacheable() == false) {
+                    LOGGER.debug("not storing a shard result: building the shard's queries was not cacheable");
+                } else if (shardLevelFailures.containsKey(probe.probe().shard().shardId())) {
+                    /*
+                     * A request that allows partial results turns a shard failure into a recorded failure and a
+                     * successful batch, so a batch can complete having produced fewer rows than the shard holds.
+                     */
+                    LOGGER.debug("not storing a shard result: the shard failed");
+                } else {
+                    BytesReference value = capture.value();
+                    if (value != null) {
+                        shardResultCache.store(probe.probe(), value);
+                    }
+                }
+                l.onResponse(info);
+            }), probe::close);
         }
 
         private void acquireSearchContexts(
@@ -732,7 +905,15 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     exchangeService.finishSinkHandler(request.sessionId(), new TaskCancelledException(task.getReasonCancelled()));
                 });
                 EsqlFlags flags = computeService.createFlags();
-                int maxConcurrentShards = request.pragmas().maxConcurrentShardsPerNode();
+                ShardResultCacheSettings cacheSettings = shardResultCache.settings();
+                ShardResultCacheKey.QueryPart cacheQueryPart = cacheSettings.enabled() ? shardResultCache.queryPart(request, flags) : null;
+                /*
+                 * A batch's captured pages carry no shard attribution, so a cacheable request runs its shards one batch at
+                 * a time to make the attribution unambiguous. This gives up the work stealing that lets one slow shard be
+                 * helped by the drivers of another, which is why it applies only to the shapes the cache admits, where a
+                 * shard's work is a scan and a hash rather than something a peer could usefully take over.
+                 */
+                int maxConcurrentShards = cacheQueryPart == null ? request.pragmas().maxConcurrentShardsPerNode() : 1;
                 DataNodeRequestExecutor dataNodeRequestExecutor = new DataNodeRequestExecutor(
                     flags,
                     request,
@@ -742,7 +923,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     failFastOnShardFailure,
                     shardLevelFailures,
                     computeListener,
-                    searchContexts
+                    searchContexts,
+                    cacheSettings,
+                    cacheQueryPart
                 );
                 dataNodeRequestExecutor.start();
                 // run the node-level reduction

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -636,6 +636,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin
             )
         );
         settings.addAll(PlannerSettings.settings());
+        settings.addAll(ShardResultCacheSettings.settings());
 
         // Inference command settings
         settings.addAll(InferenceSettings.getSettings());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/LiftedTimeRange.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/LiftedTimeRange.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A range predicate over one date field that {@link ShardResultCacheKey} pulled out of the query fingerprint so it can
+ * be resolved per shard instead. {@code from} and {@code to} are epoch millis; either may be absent for a half-open
+ * range.
+ * <p>
+ * Relative-time predicates are the reason this exists. {@code NOW()} folds to a full-precision literal at the
+ * coordinator, so {@code WHERE @timestamp >= NOW() - 24h} ships a different fragment every time it runs and would
+ * produce a fresh key on every dashboard refresh. Resolving the predicate against a shard's own min/max instead
+ * collapses it to a stable marker on every shard whose data the window provably covers or provably excludes, which is
+ * every rolled-over shard the admission policy is interested in.
+ */
+record LiftedTimeRange(String fieldName, @Nullable Long from, boolean includeFrom, @Nullable Long to, boolean includeTo) {
+
+    void writeTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeOptionalLong(from);
+        out.writeBoolean(includeFrom);
+        out.writeOptionalLong(to);
+        out.writeBoolean(includeTo);
+    }
+
+    /**
+     * Resolves this predicate against one shard's reader.
+     *
+     * @param context a throwaway copy of the shard's search execution context. {@code isFieldWithinQuery} records the
+     *                parsed lower bound on the context it is handed; the copy prevents that from mutating or poisoning
+     *                the cacheability flag of the context the query itself is planned against. One copy may be shared
+     *                across multiple calls for different fields on the same shard.
+     * @return the relation, or {@code null} when it cannot be resolved on this shard, in which case the shard must not
+     *         use the cache: the predicate is already out of the fingerprint, so an unresolved relation is not a
+     *         missing optimization but a missing part of the key.
+     */
+    @Nullable
+    static Relation resolve(LiftedTimeRange range, SearchExecutionContext context, SearchContext searchContext) throws IOException {
+        MappedFieldType fieldType = context.getFieldType(range.fieldName());
+        if (fieldType instanceof DateFieldMapper.DateFieldType dateFieldType) {
+            if (dateFieldType.resolution() != DateFieldMapper.Resolution.MILLISECONDS) {
+                // ES|QL datetime literals are epoch millis; a nanosecond-resolution field would reinterpret them.
+                return null;
+            }
+            return dateFieldType.isFieldWithinQuery(
+                searchContext.searcher().getIndexReader(),
+                range.from(),
+                range.to(),
+                range.includeFrom(),
+                range.includeTo(),
+                null,
+                null,
+                context
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Appends the per-shard residue of every lifted predicate to the key: a stable marker where the predicate is
+     * provably always-true ({@link Relation#WITHIN}) or always-false ({@link Relation#DISJOINT}) on this reader, and
+     * the bounds themselves where they genuinely select ({@link Relation#INTERSECTS}).
+     *
+     * @return false when any predicate could not be resolved, meaning this shard must not use the cache
+     */
+    static boolean writeResidue(List<LiftedTimeRange> ranges, SearchContext searchContext, StreamOutput out) throws IOException {
+        if (ranges.isEmpty()) {
+            return true;
+        }
+        /*
+         * A single throwaway copy is enough for all ranges on this shard: each range is for a different field, so
+         * isFieldWithinQuery's per-field state recording does not cross between them.
+         */
+        SearchExecutionContext throwawayContext = new SearchExecutionContext(searchContext.getSearchExecutionContext());
+        for (LiftedTimeRange range : ranges) {
+            Relation relation = resolve(range, throwawayContext, searchContext);
+            if (relation == null) {
+                return false;
+            }
+            out.writeString(range.fieldName());
+            out.writeByte((byte) relation.ordinal());
+            if (relation == Relation.INTERSECTS) {
+                range.writeTo(out);
+            }
+        }
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCache.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.AbstractScriptFieldType;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.logging.LogManager;
@@ -202,6 +203,13 @@ final class ShardResultCache {
      * entries survive. A hot write shard would pay the serialization and evict useful entries to hold something that
      * dies before it is read again.
      * <p>
+     * The check uses two mechanisms. First, if the local checkpoint has not advanced past the committed
+     * {@code max_seq_no} the shard has had no writes since the last flush and is admitted immediately regardless of
+     * {@code Engine.lastWriteNanos}. This matters because {@code lastWriteNanos} is initialized to
+     * {@code System.nanoTime()} at engine construction, so a shard just closed and reopened (for example by a
+     * {@code _cache/clear} operation) looks "just written" for up to {@code minIdleNanos} even with no indexing
+     * activity. Second, when uncommitted writes do exist, {@code lastWriteNanos} gates on the configured idle window.
+     * <p>
      * Advisory, and separately switchable, because it does not hold on a stateless search-tier shard: there
      * {@code index()} throws, so the last write time never advances even while the index tier is busy. That wastes work
      * rather than returning wrong rows.
@@ -211,8 +219,22 @@ final class ShardResultCache {
         if (minIdleNanos == 0) {
             return true;
         }
-        Long lastWriteNanos = shard.tryWithEngineOrNull(engine -> engine == null ? null : engine.getLastWriteNanos());
-        return lastWriteNanos != null && System.nanoTime() - lastWriteNanos >= minIdleNanos;
+        // Read the local checkpoint before entering the engine block; it comes from the replication
+        // tracker which is independent of the engine lifecycle.
+        long localCheckpoint = shard.getLocalCheckpoint();
+        return Boolean.TRUE.equals(shard.tryWithEngineOrNull(engine -> {
+            if (engine == null) {
+                return false;
+            }
+            // If the local checkpoint has not advanced past the committed max_seq_no, no real writes
+            // have occurred since the last flush — admit immediately rather than relying on
+            // lastWriteNanos, which is reset to now at engine construction.
+            String committedMaxSeqNoStr = engine.commitStats().getUserData().get(SequenceNumbers.MAX_SEQ_NO);
+            if (committedMaxSeqNoStr != null && localCheckpoint <= Long.parseLong(committedMaxSeqNoStr)) {
+                return true;
+            }
+            return System.nanoTime() - engine.getLastWriteNanos() >= minIdleNanos;
+        }));
     }
 
     void store(ShardProbe probe, BytesReference value) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCache.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockStreamInput;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.AbstractScriptFieldType;
+import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.xpack.esql.plugin.ShardResultCacheKey.QueryPart;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The ES|QL side of the shard request cache: turns a node request into a per-shard key, probes, replays a hit, and
+ * stores a miss that is eligible.
+ * <p>
+ * The cache itself is {@link org.elasticsearch.indices.IndicesRequestCache}, reused rather than rebuilt. It already
+ * provides reader-close invalidation, shard-clear, periodic cleanup, size accounting and eviction, and the
+ * {@code request_cache} statistics. ES|QL and DSL entries therefore share one memory budget and one set of counters,
+ * which is deliberate: they serve the same purpose, and {@code _cache/clear?request=true} clearing both is the
+ * behavior an operator expects.
+ */
+final class ShardResultCache {
+
+    private static final Logger logger = LogManager.getLogger(ShardResultCache.class);
+
+    private final IndicesService indicesService;
+    private final ClusterSettings clusterSettings;
+    private final BlockFactory blockFactory;
+
+    ShardResultCache(IndicesService indicesService, ClusterSettings clusterSettings, BlockFactory blockFactory) {
+        this.indicesService = indicesService;
+        this.clusterSettings = clusterSettings;
+        this.blockFactory = blockFactory;
+    }
+
+    /**
+     * Everything one shard needs to be served from, or stored into, the cache. The reader and the mapping key are
+     * captured at probe time rather than looked up again at store time: a refresh during execution would otherwise let
+     * a value computed against one reader be stored under a key naming another.
+     */
+    record ShardProbe(
+        BytesReference key,
+        IndexShard shard,
+        MappingLookup.CacheKey mappingCacheKey,
+        DirectoryReader reader,
+        @Nullable BytesReference hit
+    ) {
+        boolean isHit() {
+            return hit != null;
+        }
+    }
+
+    /**
+     * The per-request settings snapshot. Read once per node request so that a dynamic update cannot change the answer
+     * halfway through one query.
+     */
+    ShardResultCacheSettings settings() {
+        return new ShardResultCacheSettings(clusterSettings);
+    }
+
+    /**
+     * The part of the key shared by every shard of this request, or {@code null} when the request is not cacheable at
+     * all. Logs the reason at debug so a disappointing hit rate can be explained.
+     */
+    @Nullable
+    QueryPart queryPart(DataNodeRequest request, EsqlFlags flags) {
+        String reason = ShardResultCacheVerifier.notCacheableReason(request);
+        if (reason != null) {
+            logger.debug("query is not cacheable: {}", reason);
+            return null;
+        }
+        try {
+            return ShardResultCacheKey.queryPart(request, flags);
+        } catch (Exception e) {
+            logger.debug("failed to compute a shard result cache key", e);
+            return null;
+        }
+    }
+
+    /**
+     * Looks one shard up.
+     *
+     * @return the probe, or {@code null} when this shard cannot participate - the key could not be completed, or the
+     *         shard has no usable reader
+     */
+    @Nullable
+    ShardProbe probe(QueryPart queryPart, DataNodeRequest.Shard shard, SearchContext searchContext) {
+        // The same per-index opt-out the DSL path honors in IndicesService.canCache. An operator who turned the request
+        // cache off for an index means it for every reader of that index.
+        if (searchContext.indexShard().indexSettings().isRequestCacheEnabled() == false) {
+            return null;
+        }
+        String nonDeterministicField = nonDeterministicField(queryPart.fieldNames(), searchContext.getSearchExecutionContext());
+        if (nonDeterministicField != null) {
+            logger.debug("query is not cacheable on shard [{}]: non-deterministic field [{}]", shard.shardId(), nonDeterministicField);
+            return null;
+        }
+        try {
+            CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> differentiator = indicesService
+                .requestCacheKeyDifferentiator();
+            BytesReference key = ShardResultCacheKey.forShard(queryPart, shard, searchContext, differentiator);
+            if (key == null) {
+                return null;
+            }
+            IndexShard indexShard = searchContext.indexShard();
+            MappingLookup.CacheKey mappingCacheKey = searchContext.getSearchExecutionContext().mappingCacheKey();
+            DirectoryReader reader = searchContext.searcher().getDirectoryReader();
+            BytesReference hit = indicesService.getCachedShardLevelResult(indexShard, mappingCacheKey, reader, key);
+            logger.trace(
+                () -> Strings.format(
+                    "shard result cache %s on shard [%s] key [%s]",
+                    hit == null ? "miss" : "hit",
+                    indexShard.shardId(),
+                    MessageDigests.toHexString(BytesReference.toBytes(key))
+                )
+            );
+            return new ShardProbe(key, indexShard, mappingCacheKey, reader, hit);
+        } catch (Exception e) {
+            logger.debug("failed to probe the shard result cache", e);
+            return null;
+        }
+    }
+
+    /**
+     * A runtime field whose script does not return the same value twice makes a shard's rows a function of when they
+     * were read. {@link SearchExecutionContext#isCacheable()} reports that too, but only once something has built a
+     * query against the field; ES|QL routinely reads a field's values without ever querying it, so the mapping is
+     * asked directly here.
+     *
+     * @return the name of the first such field, or {@code null} when every field the plan reads is stable on this shard
+     */
+    @Nullable
+    private static String nonDeterministicField(Set<String> fieldNames, SearchExecutionContext context) {
+        for (String fieldName : fieldNames) {
+            if (context.isFieldMapped(fieldName) == false) {
+                continue;
+            }
+            if (context.getFieldType(fieldName) instanceof AbstractScriptFieldType<?> scriptField
+                && scriptField.isResultDeterministic() == false) {
+                return fieldName;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Deserializes a hit. The blocks are accounted against the query's circuit breaker exactly as blocks arriving over
+     * the exchange are, while the cached bytes themselves stay accounted by the cache's own weigher.
+     */
+    List<Page> replay(BytesReference value) throws IOException {
+        List<Page> pages = new ArrayList<>();
+        boolean success = false;
+        try (StreamInput in = value.streamInput()) {
+            in.setTransportVersion(TransportVersion.current());
+            try (BlockStreamInput blockStreamInput = new BlockStreamInput(in, blockFactory)) {
+                int pageCount = blockStreamInput.readVInt();
+                for (int i = 0; i < pageCount; i++) {
+                    pages.add(new Page(blockStreamInput));
+                }
+            }
+            success = true;
+            return pages;
+        } finally {
+            if (success == false) {
+                for (Page page : pages) {
+                    page.releaseBlocks();
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether this shard looks static enough to be worth an entry. Invalidation is reader-close driven and readers only
+     * turn over when there is something new to expose, so a shard that has not been written to recently is one whose
+     * entries survive. A hot write shard would pay the serialization and evict useful entries to hold something that
+     * dies before it is read again.
+     * <p>
+     * Advisory, and separately switchable, because it does not hold on a stateless search-tier shard: there
+     * {@code index()} throws, so the last write time never advances even while the index tier is busy. That wastes work
+     * rather than returning wrong rows.
+     */
+    boolean admits(IndexShard shard, ShardResultCacheSettings settings) {
+        long minIdleNanos = settings.minShardIdleTimeNanos();
+        if (minIdleNanos == 0) {
+            return true;
+        }
+        Long lastWriteNanos = shard.tryWithEngineOrNull(engine -> engine == null ? null : engine.getLastWriteNanos());
+        return lastWriteNanos != null && System.nanoTime() - lastWriteNanos >= minIdleNanos;
+    }
+
+    void store(ShardProbe probe, BytesReference value) {
+        try {
+            indicesService.putShardLevelResult(probe.shard(), probe.mappingCacheKey(), probe.reader(), probe.key(), value);
+            logger.trace(
+                () -> Strings.format(
+                    "stored [%d] bytes for shard [%s] key [%s]",
+                    value.length(),
+                    probe.shard().shardId(),
+                    MessageDigests.toHexString(BytesReference.toBytes(probe.key()))
+                )
+            );
+        } catch (Exception e) {
+            logger.debug("failed to store a shard result cache entry", e);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheKey.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheKey.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.internal.ShardSearchRequest;
+import org.elasticsearch.xpack.esql.Column;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Builds the opaque key ES|QL hands to the shard request cache. Everything that can change the rows a given shard
+ * reader produces has to be in it; the shard copy, its reader version and its mapping version are separate components
+ * of the cache's own key and are not repeated here.
+ * <p>
+ * The key is built in two stages. {@link #queryPart} digests everything that is the same for every shard of one node
+ * request: the canonicalized wire plan, the node flags that drive its local replan, and a default-deny slice of
+ * {@link Configuration}. {@link #forShard} then appends the parts that are per shard: the resharding summary, the
+ * relation of each lifted time predicate against that shard's own data, and the security differentiator.
+ * <p>
+ * Additions to {@link Configuration} default to being <em>in</em> the key. A field that lands in the key without
+ * needing to be there costs hit rate; one left out by accident returns wrong rows.
+ */
+final class ShardResultCacheKey {
+
+    /**
+     * Bumped whenever the layout below changes in a way that would let two different queries produce the same key. It
+     * does not need to be bumped for changes that only affect which entries exist, because entries never outlive the
+     * node process that wrote them.
+     */
+    private static final int FORMAT_VERSION = 1;
+
+    /**
+     * The part of the key that is common to every shard of one node request, plus the time predicates that were pulled
+     * out of the digest and have to be resolved per shard instead, plus the fields the plan reads, whose mapping on a
+     * given shard decides whether that shard may participate at all.
+     */
+    record QueryPart(byte[] digest, List<LiftedTimeRange> liftedRanges, Set<String> fieldNames) {}
+
+    private ShardResultCacheKey() {}
+
+    static QueryPart queryPart(DataNodeRequest request, EsqlFlags flags) throws IOException {
+        List<LiftedTimeRange> liftedRanges = new ArrayList<>();
+        PhysicalPlan canonicalPlan = liftTimeRanges(request.plan(), liftedRanges);
+        Configuration configuration = request.configuration();
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setTransportVersion(TransportVersion.current());
+            out.writeVInt(FORMAT_VERSION);
+            writeFlags(out, flags);
+            /*
+             * Deliberately not keyed: runNodeLevelReduction, reductionLateMaterialization and retainSearchContexts.
+             * They pick how the request is split, and the caller passes the data-node half of that split as
+             * request.plan(), so their effect is already in the plan bytes below. Keying them as well would make the
+             * same shard's result a different entry depending on whether the coordinator happens to be this node.
+             */
+            out.writeString(request.clusterAlias());
+            writeAliasFilters(out, request.aliasFilters());
+            writeConfiguration(out, configuration);
+            for (LiftedTimeRange range : liftedRanges) {
+                // Only the field, so that two windows over the same field can share a key when both resolve to the
+                // same relation. The bounds come back per shard, in forShard.
+                out.writeString(range.fieldName());
+            }
+            out.writeVInt(liftedRanges.size());
+            /*
+             * PlanStreamOutput is the canonical encoding DataNodeRequest itself uses, so hashing it hashes the bytes
+             * that were actually sent rather than a rendering of them. NameIds are normalized because they come from a
+             * global counter and are reallocated again on deserialize, so the raw ids differ run to run.
+             */
+            new PlanStreamOutput(out, configuration, true).writeNamedWriteable(canonicalPlan);
+            return new QueryPart(
+                MessageDigests.digest(out.bytes(), MessageDigests.sha256()),
+                List.copyOf(liftedRanges),
+                fieldNames(request.plan())
+            );
+        }
+    }
+
+    /**
+     * Completes the key for one shard.
+     *
+     * @return the key, or {@code null} when a lifted time predicate could not be resolved against this shard, in which
+     *         case the shard must not use the cache
+     */
+    @Nullable
+    static BytesReference forShard(
+        QueryPart queryPart,
+        DataNodeRequest.Shard shard,
+        SearchContext searchContext,
+        @Nullable CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> differentiator
+    ) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setTransportVersion(TransportVersion.current());
+            out.writeBytes(queryPart.digest());
+            // Resharding changes which documents a copy owns, and the summary travels per shard, so folding it into the
+            // shared digest would let two states of the same physical shard collide.
+            shard.splitShardCountSummary().writeTo(out);
+            if (LiftedTimeRange.writeResidue(queryPart.liftedRanges(), searchContext, out) == false) {
+                return null;
+            }
+            if (differentiator != null) {
+                // The hook the DSL path uses, not a mirror of it: it reads only the index name and the security thread
+                // context, so the minimal per-shard request ES|QL already builds is enough to feed it. Reimplementing
+                // it is the likely source of a cross-user leak.
+                differentiator.accept(searchContext.request(), out);
+            }
+            return new BytesArray(MessageDigests.digest(out.bytes(), MessageDigests.sha256()));
+        }
+    }
+
+    /**
+     * The fields the plan reads. A field name means the same thing on every shard of a request, but what it is mapped
+     * to does not, which is why this is resolved per shard rather than folded into the digest.
+     */
+    private static Set<String> fieldNames(PhysicalPlan plan) {
+        Set<String> names = new HashSet<>();
+        plan.forEachExpressionDown(FieldAttribute.class, field -> names.add(field.fieldName().string()));
+        // A fragment is a field of FragmentExec rather than a child of it, so the walk above does not enter it, and
+        // the fields a data node request reads are nearly all in there.
+        plan.forEachDown(
+            FragmentExec.class,
+            fragmentExec -> fragmentExec.fragment()
+                .forEachExpressionDown(FieldAttribute.class, field -> names.add(field.fieldName().string()))
+        );
+        return Set.copyOf(names);
+    }
+
+    /**
+     * The wire plan is planned again on the data node, with local physical optimization driven by these node-level
+     * flags, so two nodes with different flags can produce different rows from the same plan bytes.
+     * {@code stringLikeOnIndex} changes what {@code _index LIKE} matches, and {@code roundToPushdownThreshold} decides
+     * whether {@code ReplaceRoundToWithQueryAndTags} rewrites a {@code RoundTo} into range queries with tags.
+     * <p>
+     * {@code PlannerSettings} is deliberately not here. Its members pick slice boundaries and buffer sizes, which
+     * change how rows are produced rather than which, or bound shapes the verifier refuses outright: the TopN limit and
+     * the local relation size caps.
+     */
+    private static void writeFlags(StreamOutput out, EsqlFlags flags) throws IOException {
+        out.writeBoolean(flags.stringLikeOnIndex());
+        // Not a vint: the threshold's minimum is -1, which means no pushdown at all.
+        out.writeInt(flags.roundToPushdownThreshold());
+    }
+
+    /**
+     * Digests the fields of {@link Configuration} that can change a shard's rows. Deliberate exclusions:
+     * <ul>
+     *     <li>{@code now} and {@code queryStartTimeNanos} - wall clock. {@code NOW()} still reaches the key, as the
+     *     folded literal it becomes in the plan, so two queries a minute apart cannot collide.</li>
+     *     <li>{@code profile} and {@code explainOnly} - those requests are refused by
+     *     {@link ShardResultCacheVerifier} and so can never reach a key.</li>
+     *     <li>{@code query} - the text. What the shard produces is a function of the plan, which is keyed below; two
+     *     texts that plan to the same fragment may share an entry, and the same text arriving as a prepared statement
+     *     rather than as text must not miss.</li>
+     * </ul>
+     * Everything else is included, including all pragmas. Several pragmas that look like pure parallelism knobs do
+     * change slice boundaries and page framing, and proving harmlessness per pragma buys nothing: pragmas are an expert
+     * debug knob that production queries do not set, so keying them costs no hit rate.
+     */
+    private static void writeConfiguration(StreamOutput out, Configuration configuration) throws IOException {
+        out.writeOptionalString(configuration.clusterName());
+        out.writeOptionalString(configuration.username());
+        out.writeString(configuration.locale().toLanguageTag());
+        configuration.pragmas().writeTo(out);
+        out.writeVInt(configuration.resultTruncationMaxSize(false));
+        out.writeVInt(configuration.resultTruncationDefaultSize(false));
+        out.writeVInt(configuration.resultTruncationMaxSize(true));
+        out.writeVInt(configuration.resultTruncationDefaultSize(true));
+        out.writeBoolean(configuration.allowPartialResults());
+        Map<String, Map<String, Column>> tables = new TreeMap<>(configuration.tables());
+        out.writeMap(tables, (tableOut, columns) -> tableOut.writeMap(new TreeMap<>(columns), StreamOutput::writeWriteable));
+        configuration.resolvedSettings().writeTo(out);
+        out.writeMap(new TreeMap<>(configuration.viewQueries()), StreamOutput::writeString);
+    }
+
+    /** Sorted by index UUID so that two runs of the same query cannot differ only in map iteration order. */
+    private static void writeAliasFilters(StreamOutput out, Map<Index, AliasFilter> aliasFilters) throws IOException {
+        Map<String, AliasFilter> sorted = new TreeMap<>();
+        for (Map.Entry<Index, AliasFilter> entry : aliasFilters.entrySet()) {
+            sorted.put(entry.getKey().getUUID(), entry.getValue());
+        }
+        out.writeMap(sorted, StreamOutput::writeWriteable);
+    }
+
+    /**
+     * Replaces the top-level date range conjuncts of every filter directly above a relation with nothing, collecting
+     * them into {@code liftedRanges} instead. Execution is never affected: only the key is built from the rewritten
+     * plan, which makes this strictly safer than the DSL rewrite it mirrors, where the rewritten query is what runs.
+     * <p>
+     * Default deny. Only conjuncts of a top-level AND, only a single {@code date} field compared against a literal, and
+     * only one lower and one upper bound per field. Anything else stays in the digest verbatim, which costs hit rate
+     * and never correctness.
+     */
+    private static PhysicalPlan liftTimeRanges(PhysicalPlan plan, List<LiftedTimeRange> liftedRanges) {
+        return plan.transformUp(
+            FragmentExec.class,
+            fragmentExec -> fragmentExec.withFragment(liftFromFragment(fragmentExec.fragment(), liftedRanges))
+        );
+    }
+
+    private static LogicalPlan liftFromFragment(LogicalPlan fragment, List<LiftedTimeRange> liftedRanges) {
+        return fragment.transformUp(Filter.class, filter -> {
+            if (filter.child() instanceof EsRelation == false) {
+                return filter;
+            }
+            List<Expression> remaining = new ArrayList<>();
+            // Insertion ordered so that the digest and the per-shard residue agree on the order of the lifted ranges.
+            Map<String, Bounds> byField = new LinkedHashMap<>();
+            for (Expression conjunct : Predicates.splitAnd(filter.condition())) {
+                if (collectBound(conjunct, byField) == false) {
+                    remaining.add(conjunct);
+                }
+            }
+            List<LiftedTimeRange> lifted = new ArrayList<>(byField.size());
+            for (Map.Entry<String, Bounds> entry : byField.entrySet()) {
+                Bounds bounds = entry.getValue();
+                if (bounds.usable()) {
+                    lifted.add(new LiftedTimeRange(entry.getKey(), bounds.from, bounds.includeFrom, bounds.to, bounds.includeTo));
+                } else {
+                    remaining.addAll(bounds.conjuncts);
+                }
+            }
+            if (lifted.isEmpty()) {
+                return filter;
+            }
+            liftedRanges.addAll(lifted);
+            Expression condition = remaining.isEmpty() ? Literal.TRUE : Predicates.combineAnd(remaining);
+            return new Filter(filter.source(), filter.child(), condition);
+        });
+    }
+
+    /**
+     * Records {@code conjunct} as a bound if it is a date range comparison against a literal.
+     *
+     * @return true when the conjunct was consumed, so the caller must not keep it in the residual condition
+     */
+    private static boolean collectBound(Expression conjunct, Map<String, Bounds> byField) {
+        boolean lowerBound = conjunct instanceof GreaterThan || conjunct instanceof GreaterThanOrEqual;
+        boolean upperBound = conjunct instanceof LessThan || conjunct instanceof LessThanOrEqual;
+        if (lowerBound == false && upperBound == false) {
+            return false;
+        }
+        EsqlBinaryComparison comparison = (EsqlBinaryComparison) conjunct;
+        if (comparison.left() instanceof FieldAttribute field
+            && field.dataType() == DataType.DATETIME
+            && comparison.right() instanceof Literal literal
+            && literal.value() instanceof Long value) {
+            boolean inclusive = conjunct instanceof GreaterThanOrEqual || conjunct instanceof LessThanOrEqual;
+            Bounds bounds = byField.computeIfAbsent(field.fieldName().string(), name -> new Bounds());
+            bounds.conjuncts.add(conjunct);
+            if (lowerBound) {
+                bounds.lower(value, inclusive);
+            } else {
+                bounds.upper(value, inclusive);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /** Accumulates at most one lower and one upper bound for a single field. */
+    private static final class Bounds {
+        private final List<Expression> conjuncts = new ArrayList<>();
+        private Long from;
+        private boolean includeFrom;
+        private Long to;
+        private boolean includeTo;
+        private boolean rejected;
+
+        void lower(long value, boolean inclusive) {
+            if (from != null) {
+                rejected = true;
+                return;
+            }
+            from = value;
+            includeFrom = inclusive;
+        }
+
+        void upper(long value, boolean inclusive) {
+            if (to != null) {
+                rejected = true;
+                return;
+            }
+            to = value;
+            includeTo = inclusive;
+        }
+
+        boolean usable() {
+            return rejected == false && (from != null || to != null);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheSettings.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.List;
+
+/**
+ * Node-level knobs for the ES|QL shard result cache. The cache itself is {@link org.elasticsearch.indices.IndicesRequestCache},
+ * so its size, expiry, cleanup interval, per-index enablement and {@code _cache/clear?request=true} handling are the
+ * existing {@code indices.requests.cache.*} / {@code index.requests.cache.enable} settings. Only the ES|QL-specific
+ * kill switch and admission thresholds live here.
+ * <p>
+ * Values are read per request on the data node so that all three are effective as dynamic cluster settings.
+ */
+public final class ShardResultCacheSettings {
+
+    /**
+     * Master switch. On by default; set to {@code false} to disable all probing and storing without restarting.
+     */
+    public static final Setting<Boolean> ENABLED = Setting.boolSetting(
+        "esql.shard_result_cache.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Hard cap on the serialized size of one shard's result. Every ES|QL query is row-bounded, but a bounded row count
+     * is not a bounded byte count, so bytes get their own limit. A shard whose result exceeds this is computed
+     * normally and simply not stored.
+     */
+    public static final Setting<ByteSizeValue> MAX_VALUE_SIZE = Setting.byteSizeSetting(
+        "esql.shard_result_cache.max_value_size",
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.ZERO,
+        ByteSizeValue.of(Integer.MAX_VALUE, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * The churn gate: a shard is only admitted when it has not been written to for at least this long. Invalidation is
+     * reader-close driven and readers only turn over when there is something new to expose, so recent writes predict
+     * entries that die before they are read again. Set to zero to admit every shard, which is what a test wanting a
+     * deterministic hit wants.
+     */
+    public static final Setting<TimeValue> MIN_SHARD_IDLE_TIME = Setting.timeSetting(
+        "esql.shard_result_cache.min_shard_idle_time",
+        TimeValue.timeValueSeconds(30),
+        TimeValue.ZERO,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /** Registered by {@link EsqlPlugin#getSettings()}. */
+    public static List<Setting<?>> settings() {
+        return List.of(ENABLED, MAX_VALUE_SIZE, MIN_SHARD_IDLE_TIME);
+    }
+
+    private final boolean enabled;
+    private final long maxValueSizeInBytes;
+    private final long minShardIdleTimeNanos;
+
+    ShardResultCacheSettings(ClusterSettings clusterSettings) {
+        this(
+            clusterSettings.get(ENABLED),
+            clusterSettings.get(MAX_VALUE_SIZE).getBytes(),
+            clusterSettings.get(MIN_SHARD_IDLE_TIME).nanos()
+        );
+    }
+
+    ShardResultCacheSettings(boolean enabled, long maxValueSizeInBytes, long minShardIdleTimeNanos) {
+        this.enabled = enabled;
+        this.maxValueSizeInBytes = maxValueSizeInBytes;
+        this.minShardIdleTimeNanos = minShardIdleTimeNanos;
+    }
+
+    boolean enabled() {
+        return enabled;
+    }
+
+    long maxValueSizeInBytes() {
+        return maxValueSizeInBytes;
+    }
+
+    long minShardIdleTimeNanos() {
+        return minShardIdleTimeNanos;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheVerifier.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sample;
+import org.elasticsearch.xpack.esql.expression.function.inference.InferenceFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.approximate.Random;
+import org.elasticsearch.xpack.esql.expression.function.scalar.date.Now;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Decides whether a node request's plan may be served from, or stored in, the shard result cache. Default deny: a plan
+ * is cacheable only if every node in it is on the allowlist, so a construct nobody has thought about yet is refused
+ * rather than silently admitted.
+ * <p>
+ * The verdict is a property of the plan and the request, not of any shard, so it is computed once per node request. It
+ * carries a reason for the refusal, which is what makes a low hit rate diagnosable rather than mysterious.
+ */
+final class ShardResultCacheVerifier {
+
+    /**
+     * Exact classes, not {@code instanceof}: {@code TimeSeriesAggregate} and {@code SampledAggregate} extend
+     * {@link Aggregate} and neither is admissible, so a subtype must not inherit its parent's verdict.
+     */
+    private static final Set<Class<? extends LogicalPlan>> ALLOWED_FRAGMENT_NODES = Set.of(
+        Aggregate.class,
+        Filter.class,
+        Eval.class,
+        Project.class,
+        EsRelation.class
+    );
+
+    /**
+     * Expressions whose value is not a function of the shard's data alone.
+     * <ul>
+     *     <li>{@link Random} draws from {@code Randomness.get()} when it is evaluated.</li>
+     *     <li>{@link Sample} defaults its seed to a fresh random long.</li>
+     *     <li>{@link InferenceFunction} calls an external model.</li>
+     *     <li>{@link Now} reads the query's wall clock, which is deliberately not in the key. Coordinator constant
+     *     folding turns it into a literal long before a fragment is shipped, so this entry is a backstop against a
+     *     fragment where folding did not reach it rather than the common case.</li>
+     * </ul>
+     */
+    private static final List<Class<? extends Expression>> NON_DETERMINISTIC_EXPRESSIONS = List.of(
+        Random.class,
+        Sample.class,
+        InferenceFunction.class,
+        Now.class
+    );
+
+    private ShardResultCacheVerifier() {}
+
+    /**
+     * @return {@code null} when the request is cacheable, otherwise the reason it is not
+     */
+    @Nullable
+    static String notCacheableReason(DataNodeRequest request) {
+        // A hit produces no drivers, so a profiled request would show no Lucene operators for the cached shards and
+        // misrepresent its own execution. The DSL path refuses profiled requests for the same reason.
+        if (request.configuration().profile()) {
+            return "profiled request";
+        }
+        if (request.configuration().explainOnly()) {
+            return "explain request";
+        }
+        if (request.externalSplits().isEmpty() == false) {
+            return "external source";
+        }
+        /*
+         * Remote fetch ships doc ids and fetches values later against a context that has to stay retained; a shard
+         * served from cache never opens that context. Reduce-node late materialization needs no such check: it only
+         * rewrites a TopN reduction, and the fragment-root check below admits nothing but an aggregation.
+         */
+        if (request.retainSearchContexts()) {
+            return "remote fetch";
+        }
+        if (request.clusterAlias().isEmpty() == false) {
+            return "cross-cluster execution";
+        }
+        if (request.plan() instanceof ExchangeSinkExec sink) {
+            if (sink.child() instanceof FragmentExec fragmentExec) {
+                return notCacheableFragmentReason(fragmentExec.fragment());
+            }
+            return "unsupported data node plan [" + sink.child().nodeName() + "]";
+        }
+        return "unsupported data node plan";
+    }
+
+    @Nullable
+    private static String notCacheableFragmentReason(LogicalPlan fragment) {
+        /*
+         * Requiring an aggregation at the root keeps the admissible set to shapes whose per-shard output is small,
+         * serializable and order-insensitive. Raw row shapes are excluded because late-materialized doc columns cannot
+         * be serialized at all, and sorted shapes because their reduction is what the follow-up per-operator work is
+         * about.
+         */
+        if (fragment.getClass() != Aggregate.class) {
+            return "fragment root is not an aggregation [" + fragment.nodeName() + "]";
+        }
+        Holder<String> reason = new Holder<>();
+        fragment.forEachDown(node -> {
+            if (reason.get() != null) {
+                return;
+            }
+            if (ALLOWED_FRAGMENT_NODES.contains(node.getClass()) == false) {
+                reason.set("unsupported plan node [" + node.nodeName() + "]");
+                return;
+            }
+            if (node instanceof EsRelation relation && relation.indexMode() != IndexMode.STANDARD) {
+                reason.set("unsupported index mode [" + relation.indexMode() + "]");
+            }
+        });
+        if (reason.get() != null) {
+            return reason.get();
+        }
+        fragment.forEachExpressionDown(Expression.class, expression -> {
+            if (reason.get() != null) {
+                return;
+            }
+            for (Class<? extends Expression> nonDeterministic : NON_DETERMINISTIC_EXPRESSIONS) {
+                if (nonDeterministic.isInstance(expression)) {
+                    reason.set("non-deterministic expression [" + expression.nodeName() + "]");
+                    return;
+                }
+            }
+        });
+        return reason.get();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCapture.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ShardResultCapture.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.compute.operator.exchange.ExchangeSink;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Copies the pages one batch's data drivers emit, so that a batch that turns out to be storable can be stored without
+ * re-running it. Pages are serialized as they pass through the exchange sink, because that is the last point at which
+ * the batch still owns them.
+ * <p>
+ * A shard's output is routinely more than one page - an aggregation emits an intermediate page whenever its partial
+ * emit thresholds are crossed - and exchange transport carries at most one page per response, so there is no existing
+ * container to borrow. The stored value is therefore a page count followed by the pages, so a hit replays exactly the
+ * sequence that was stored rather than truncating to the last page or mis-parsing a bare concatenation.
+ * <p>
+ * Several drivers share one capture (a shard's slices are stolen across {@code taskConcurrency} drivers), so
+ * {@link #record} and {@link #value} are synchronized. Page order is not preserved and does not need to be: the
+ * exchange buffer they feed is already an unordered concurrent queue, so no consumer may depend on the order.
+ */
+final class ShardResultCapture {
+
+    private static final Logger logger = LogManager.getLogger(ShardResultCapture.class);
+
+    private final long maxValueSizeInBytes;
+    private final List<BytesReference> pages = new ArrayList<>();
+    private long totalBytes;
+    private boolean usable = true;
+
+    ShardResultCapture(long maxValueSizeInBytes) {
+        this.maxValueSizeInBytes = maxValueSizeInBytes;
+    }
+
+    /**
+     * The captured value, or {@code null} when this batch produced nothing storable: the size cap was exceeded, or a
+     * page could not be serialized. The latter should not happen for an admitted plan shape - a doc column, for one,
+     * is not serializable at all - but it is caught rather than asserted, because failing to cache is a far better
+     * outcome than failing the query.
+     */
+    @Nullable
+    synchronized BytesReference value() {
+        if (usable == false) {
+            return null;
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setTransportVersion(TransportVersion.current());
+            out.writeVInt(pages.size());
+            BytesReference[] parts = new BytesReference[pages.size() + 1];
+            parts[0] = out.bytes();
+            for (int i = 0; i < pages.size(); i++) {
+                parts[i + 1] = pages.get(i);
+            }
+            return CompositeBytesReference.of(parts);
+        } catch (Exception e) {
+            logger.debug("failed to assemble a shard result cache value", e);
+            return null;
+        }
+    }
+
+    private void record(Page page) {
+        BytesReference bytes;
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setTransportVersion(TransportVersion.current());
+            page.writeTo(out);
+            bytes = out.bytes();
+        } catch (Exception e) {
+            logger.debug("failed to capture a page for the shard result cache", e);
+            synchronized (this) {
+                discard();
+            }
+            return;
+        }
+        synchronized (this) {
+            if (usable == false) {
+                return;
+            }
+            totalBytes += bytes.length();
+            if (totalBytes > maxValueSizeInBytes) {
+                discard();
+                return;
+            }
+            pages.add(bytes);
+        }
+    }
+
+    /** Must be called while holding the monitor on {@code this}. */
+    private void discard() {
+        usable = false;
+        pages.clear();
+    }
+
+    /**
+     * Wraps a sink so that everything written to it is captured on the way through. Serialization happens before the
+     * page is handed on, while this thread is still the only owner.
+     */
+    ExchangeSink wrap(ExchangeSink delegate) {
+        return new ExchangeSink() {
+            @Override
+            public void addPage(Page page) {
+                record(page);
+                delegate.addPage(page);
+            }
+
+            @Override
+            public void finish() {
+                delegate.finish();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return delegate.isFinished();
+            }
+
+            @Override
+            public void addCompletionListener(ActionListener<Void> listener) {
+                delegate.addCompletionListener(listener);
+            }
+
+            @Override
+            public IsBlockedResult waitForWriting() {
+                return delegate.waitForWriting();
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.VerificationException;
@@ -87,6 +88,30 @@ public class QuerySettingsTests extends ESTestCase {
         ResolvedSettings resolved = ResolvedSettings.EMPTY.withOverride(QuerySettings.TIME_ZONE, ZoneId.of("UTC"));
         assertThat(QuerySettings.TIME_ZONE.get(resolved), equalTo(ZoneId.of("UTC").normalized()));
         assertThat(QuerySettings.TIME_ZONE.get(resolved), not(equalTo(ZoneId.of("UTC"))));
+    }
+
+    /**
+     * The same settings have to serialize to the same bytes however they were assembled: the ES|QL shard result cache
+     * digests these bytes into its key, and a request's settings are resolved on the coordinator and read back off the
+     * wire on every other node, which is two different insertion orders into the same immutable map.
+     */
+    public void testWrittenBytesDoNotDependOnHowTheSettingsWereAssembled() throws IOException {
+        ResolvedSettings oneOrder = ResolvedSettings.EMPTY.withOverride(QuerySettings.TIME_ZONE, ZoneId.of("UTC"))
+            .withOverride(QuerySettings.UNMAPPED_FIELDS, UnmappedResolution.DEFAULT)
+            .withOverride(QuerySettings.COLUMN_METADATA, false)
+            .withOverride(QuerySettings.PROJECT_ROUTING, "p*");
+        ResolvedSettings otherOrder = ResolvedSettings.EMPTY.withOverride(QuerySettings.PROJECT_ROUTING, "p*")
+            .withOverride(QuerySettings.COLUMN_METADATA, false)
+            .withOverride(QuerySettings.UNMAPPED_FIELDS, UnmappedResolution.DEFAULT)
+            .withOverride(QuerySettings.TIME_ZONE, ZoneId.of("UTC"));
+        assertThat(bytes(otherOrder), equalTo(bytes(oneOrder)));
+    }
+
+    private static BytesReference bytes(ResolvedSettings settings) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            settings.writeTo(out);
+            return out.bytes();
+        }
     }
 
     public void testAllContainsEveryDeclaredSetting() throws IllegalAccessException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheKeyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheKeyTests.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.routing.SplitShardCountSummary;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.elasticsearch.xpack.esql.session.Versioned;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.configuration;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The shared part of the cache key has to be a function of what a query computes and nothing else. These test that two
+ * independent plannings of the same query agree, and that the things which do change the rows disagree.
+ */
+public class ShardResultCacheKeyTests extends ESTestCase {
+
+    private static final EsqlFlags FLAGS = new EsqlFlags(true, 127);
+
+    private static final String AGGREGATION = """
+        from test
+        | where emp_no > 10
+        | stats x = avg(salary) by languages
+        """;
+
+    public void testTwoPlanningsOfTheSameQueryAgree() throws Exception {
+        // Each planning allocates fresh NameIds from a process-global counter, which is the main thing the key has to
+        // see through.
+        assertThat(digest(request(AGGREGATION)), equalTo(digest(request(AGGREGATION))));
+    }
+
+    public void testSourcePositionsDoNotReachTheKey() throws Exception {
+        // The same query written with different whitespace is the same computation at a different offset. A prepared
+        // statement arriving without its text is the same case, and is what makes this more than cosmetic.
+        String reformatted = "from test | where emp_no > 10       | stats x = avg(salary) by languages";
+        assertThat(digest(request(AGGREGATION)), equalTo(digest(request(reformatted))));
+    }
+
+    public void testADifferentFilterIsADifferentKey() throws Exception {
+        String other = """
+            from test
+            | where emp_no > 11
+            | stats x = avg(salary) by languages
+            """;
+        assertThat(digest(request(AGGREGATION)), not(equalTo(digest(request(other)))));
+    }
+
+    public void testADifferentAggregationIsADifferentKey() throws Exception {
+        String other = """
+            from test
+            | where emp_no > 10
+            | stats x = max(salary) by languages
+            """;
+        assertThat(digest(request(AGGREGATION)), not(equalTo(digest(request(other)))));
+    }
+
+    public void testADifferentGroupingIsADifferentKey() throws Exception {
+        String other = """
+            from test
+            | where emp_no > 10
+            | stats x = avg(salary) by first_name
+            """;
+        assertThat(digest(request(AGGREGATION)), not(equalTo(digest(request(other)))));
+    }
+
+    public void testAliasFilterIsPartOfTheKey() throws Exception {
+        DataNodeRequest plain = request(AGGREGATION);
+        DataNodeRequest filtered = withAliasFilters(
+            plain,
+            Map.of(new Index("test", "test-uuid"), AliasFilter.of(QueryBuilders.termQuery("gender", "F"), "females"))
+        );
+        assertThat(digest(plain), not(equalTo(digest(filtered))));
+    }
+
+    public void testClusterAliasIsPartOfTheKey() throws Exception {
+        DataNodeRequest local = request(AGGREGATION);
+        DataNodeRequest remote = new DataNodeRequest(
+            local.sessionId(),
+            local.configuration(),
+            "remote1",
+            local.shards(),
+            local.aliasFilters(),
+            local.plan(),
+            local.indices(),
+            local.indicesOptions(),
+            local.runNodeLevelReduction(),
+            local.reductionLateMaterialization(),
+            local.retainSearchContexts()
+        );
+        assertThat(digest(local), not(equalTo(digest(remote))));
+    }
+
+    /**
+     * The reduction split picks what the node-reduce driver does, downstream of the entry, and the data-node half of
+     * the split is what the caller hands to the key. Keying the flag too would split one shard's entry in two depending
+     * on whether the coordinator happened to be this node.
+     */
+    public void testTheReductionSplitIsNotPartOfTheKey() throws Exception {
+        DataNodeRequest reducing = request(AGGREGATION);
+        DataNodeRequest notReducing = new DataNodeRequest(
+            reducing.sessionId(),
+            reducing.configuration(),
+            reducing.clusterAlias(),
+            reducing.shards(),
+            reducing.aliasFilters(),
+            reducing.plan(),
+            reducing.indices(),
+            reducing.indicesOptions(),
+            reducing.runNodeLevelReduction() == false,
+            reducing.reductionLateMaterialization(),
+            reducing.retainSearchContexts()
+        );
+        assertThat(digest(reducing), equalTo(digest(notReducing)));
+    }
+
+    /**
+     * A relative-time window ships as a folded literal, so a dashboard refreshing every minute would otherwise produce
+     * a fresh key every minute. The bounds come out of the shared digest and are resolved per shard instead.
+     */
+    public void testTimePredicateBoundsAreLiftedOutOfTheDigest() throws Exception {
+        String early = "from test | where hire_date >= \"2024-01-01T00:00:00Z\" | stats x = avg(salary)";
+        String late = "from test | where hire_date >= \"2024-06-01T00:00:00Z\" | stats x = avg(salary)";
+        ShardResultCacheKey.QueryPart earlyPart = ShardResultCacheKey.queryPart(request(early), FLAGS);
+        ShardResultCacheKey.QueryPart latePart = ShardResultCacheKey.queryPart(request(late), FLAGS);
+        assertThat(earlyPart.liftedRanges().size(), equalTo(1));
+        assertThat(earlyPart.liftedRanges().getFirst().fieldName(), equalTo("hire_date"));
+        assertThat(latePart.liftedRanges().getFirst().from(), not(equalTo(earlyPart.liftedRanges().getFirst().from())));
+        assertThat(earlyPart.digest(), equalTo(latePart.digest()));
+    }
+
+    /**
+     * The wire plan is planned again on the data node under these flags, and both of them can change which rows come
+     * out, so the same plan under different flags has to be a different entry.
+     */
+    public void testNodeFlagsArePartOfTheKey() throws Exception {
+        DataNodeRequest request = request(AGGREGATION);
+        byte[] digest = ShardResultCacheKey.queryPart(request, FLAGS).digest();
+        assertThat(digest, not(equalTo(ShardResultCacheKey.queryPart(request, new EsqlFlags(false, 127)).digest())));
+        assertThat(digest, not(equalTo(ShardResultCacheKey.queryPart(request, new EsqlFlags(true, -1)).digest())));
+    }
+
+    /**
+     * A node request handled on the coordinator's own node arrives as the very plan objects the coordinator built,
+     * while every other node reads a copy off the wire. The two have to key the same, or a shard's entry would be
+     * found only on the runs where its node happened to play the same role as when the entry was written.
+     */
+    public void testAWirePlanKeysTheSameAsTheOneItWasCopiedFrom() throws Exception {
+        List<NamedWriteableRegistry.Entry> writeables = new ArrayList<>(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables());
+        writeables.addAll(new EsqlPlugin().getNamedWriteables());
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(writeables);
+        for (String query : List.of(
+            AGGREGATION,
+            "from test | stats c = count(*)",
+            "from test | stats x = sum(salary) by first_name",
+            "from test | where first_name == \"Bob\" | stats x = max(salary)",
+            "from test | where hire_date >= \"2024-01-01T00:00:00Z\" | stats x = avg(salary)"
+        )) {
+            DataNodeRequest local = request(query);
+            DataNodeRequest remote = copyWriteable(local, registry, DataNodeRequest::new, TransportVersion.current());
+            assertThat(query, digest(remote), equalTo(digest(local)));
+        }
+    }
+
+    /** A predicate over a different field is a different query even once both are lifted. */
+    public void testALiftedPredicateStillNamesItsField() throws Exception {
+        String onHireDate = "from test | where hire_date >= \"2024-01-01T00:00:00Z\" | stats x = avg(salary)";
+        String unfiltered = "from test | stats x = avg(salary)";
+        assertThat(digest(request(onHireDate)), not(equalTo(digest(request(unfiltered)))));
+    }
+
+    /**
+     * The key is default-deny by intent, but nothing enforces that on a field added later: an author who adds a
+     * {@link Configuration} field and forgets this class gets wrong rows, not a lower hit rate. Failing here is the
+     * enforcement. A new field belongs in {@code KEYED} unless it demonstrably cannot change what a shard produces, in
+     * which case it belongs in {@code NOT_KEYED} with the reason recorded in
+     * {@code ShardResultCacheKey#writeConfiguration}.
+     */
+    public void testEveryConfigurationFieldHasAVerdict() {
+        Set<String> keyed = Set.of(
+            "clusterName",
+            "username",
+            "locale",
+            "pragmas",
+            "resultTruncationMaxSizeRegular",
+            "resultTruncationDefaultSizeRegular",
+            "resultTruncationMaxSizeTimeseries",
+            "resultTruncationDefaultSizeTimeseries",
+            "allowPartialResults",
+            "tables",
+            "resolvedSettings",
+            "viewQueries"
+        );
+        Set<String> notKeyed = Set.of("now", "queryStartTimeNanos", "query", "profile", "explainOnly");
+        assertFieldsHaveVerdicts(Configuration.class, keyed, notKeyed);
+    }
+
+    /** The same guard over the node flags, every one of which drives the local replan of the wire plan. */
+    public void testEveryNodeFlagHasAVerdict() {
+        assertFieldsHaveVerdicts(EsqlFlags.class, Set.of("stringLikeOnIndex", "roundToPushdownThreshold"), Set.of());
+    }
+
+    /**
+     * {@link PlannerSettings} members pick slice boundaries, buffer sizes, and TopN caps. They change how rows flow
+     * through the engine rather than which rows a shard produces, and the verifier refuses the shapes (row-returning,
+     * sorted) whose correctness would be affected by them. Any new member therefore belongs here with the same verdict,
+     * unless it demonstrably changes which rows a shard returns — in which case it belongs in {@link EsqlFlags} or in
+     * the node flags written by {@code ShardResultCacheKey#writeFlags}.
+     */
+    public void testEveryPlannerSettingsFieldHasAVerdict() {
+        Set<String> notKeyed = Set.of(
+            "defaultDataPartitioning",
+            "docsThresholdForAutoPartitioning",
+            "valuesLoadingJumboSize",
+            "luceneTopNLimit",
+            "intermediateLocalRelationMaxSize",
+            "partialEmitKeysThreshold",
+            "partialEmitUniquenessThreshold",
+            "timeSeriesTargetChunkRows",
+            "reuseColumnLoadersThreshold",
+            "blockLoaderSizeOrdinals",
+            "blockLoaderSizeScript",
+            "maxKeywordSortFields",
+            "sourceReservationFactor",
+            "bytesRefRamOverestimateThreshold",
+            "bytesRefRamOverestimateFactor",
+            "docSequenceBytesRefFieldThreshold",
+            "parallelTopNPromotionThresholdRows",
+            "parallelTopNMaxWorkers",
+            "inSubqueryHashJoinThreshold"
+        );
+        assertFieldsHaveVerdicts(PlannerSettings.class, Set.of(), notKeyed);
+    }
+
+    /** The same guard over the request, whose fields are the other half of what the shared digest sees. */
+    public void testEveryDataNodeRequestFieldHasAVerdict() {
+        Set<String> keyed = Set.of("configuration", "clusterAlias", "aliasFilters", "plan");
+        /*
+         * sessionId, indices and indicesOptions name the query run and how its target was resolved, not what a shard
+         * computes; shards is per shard and enters through forShard; the three split flags are covered by
+         * testTheReductionSplitIsNotPartOfTheKey; externalSplits is refused outright by the verifier.
+         */
+        Set<String> notKeyed = Set.of(
+            "sessionId",
+            "shards",
+            "indices",
+            "indicesOptions",
+            "runNodeLevelReduction",
+            "reductionLateMaterialization",
+            "retainSearchContexts",
+            "externalSplits"
+        );
+        assertFieldsHaveVerdicts(DataNodeRequest.class, keyed, notKeyed);
+    }
+
+    @SuppressForbidden(reason = "need access to all fields, they are mostly private")
+    private static void assertFieldsHaveVerdicts(Class<?> type, Set<String> keyed, Set<String> notKeyed) {
+        assertThat("a field cannot be both keyed and not", Sets.intersection(keyed, notKeyed), empty());
+        Set<String> declared = Arrays.stream(type.getDeclaredFields())
+            .filter(field -> Modifier.isStatic(field.getModifiers()) == false)
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+        Set<String> verdicts = Sets.union(keyed, notKeyed);
+        assertThat("fields with no recorded verdict", Sets.difference(declared, verdicts), empty());
+        assertThat("verdicts for fields that no longer exist", Sets.difference(verdicts, declared), empty());
+    }
+
+    private static byte[] digest(DataNodeRequest request) throws Exception {
+        return ShardResultCacheKey.queryPart(request, FLAGS).digest();
+    }
+
+    static DataNodeRequest request(String query) {
+        return request(query, Map.of());
+    }
+
+    /**
+     * Plans {@code query} the way the coordinator does and wraps the data-node half of the split in a request.
+     * Everything a test planning must not vary by is pinned: the physical optimizer always runs, and the cluster's
+     * minimum transport version is the current one, because a plan is version-dependent (a {@code SUM} carries a
+     * different overflow mode on an older cluster) and two plannings compared here have to be of one cluster.
+     */
+    static DataNodeRequest request(String query, Map<Index, AliasFilter> aliasFilters) {
+        var analyzer = analyzer().addIndex("test", "mapping-basic.json")
+            .minimumTransportVersion(TransportVersion.current())
+            .buildAnalyzer();
+        TransportVersion minimumVersion = analyzer.context().minimumVersion();
+        LogicalPlan analyzed = new LogicalPlanOptimizer(new LogicalOptimizerContext(TEST_CFG, FoldContext.small(), minimumVersion))
+            .optimize(analyzer.analyze(TEST_PARSER.parseQuery(query)));
+        Versioned<LogicalPlan> logical = new Versioned<>(analyzed, minimumVersion);
+        PhysicalPlan physical = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(TEST_CFG, minimumVersion)).optimize(
+            new Mapper().map(logical)
+        );
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(physical, TEST_CFG);
+        return new DataNodeRequest(
+            "session",
+            configuration(query),
+            "",
+            List.of(new DataNodeRequest.Shard(new ShardId("test", "test-uuid", 0), SplitShardCountSummary.fromInt(0))),
+            aliasFilters,
+            split.v2(),
+            new String[] { "test" },
+            IndicesOptions.STRICT_EXPAND_OPEN,
+            true,
+            false,
+            false
+        );
+    }
+
+    @Override
+    protected List<String> filteredWarnings() {
+        return withDefaultLimitWarning(super.filteredWarnings());
+    }
+
+    private static DataNodeRequest withAliasFilters(DataNodeRequest request, Map<Index, AliasFilter> aliasFilters) {
+        return new DataNodeRequest(
+            request.sessionId(),
+            request.configuration(),
+            request.clusterAlias(),
+            request.shards(),
+            aliasFilters,
+            request.plan(),
+            request.indices(),
+            request.indicesOptions(),
+            request.runNodeLevelReduction(),
+            request.reductionLateMaterialization(),
+            request.retainSearchContexts()
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ShardResultCacheVerifierTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * The verifier is the correctness boundary of the cache: default deny, so what matters is that the admitted set is
+ * exactly the small allowlist and that everything else is refused with a reason.
+ */
+public class ShardResultCacheVerifierTests extends ESTestCase {
+
+    public void testPlainAggregationIsCacheable() {
+        assertCacheable("from test | stats x = avg(salary)");
+        assertCacheable("from test | stats x = avg(salary) by languages");
+        assertCacheable("from test | where emp_no > 10 | stats x = avg(salary) by languages");
+        assertCacheable("from test | eval bonus = salary * 2 | stats x = sum(bonus) by languages");
+        assertCacheable("from test | keep salary, languages | stats x = avg(salary) by languages");
+    }
+
+    public void testRowShapesAreRefused() {
+        // Raw rows are what late materialization loads doc ids for, and a doc column cannot be serialized at all.
+        assertRefused("from test | keep emp_no | limit 10", "fragment root is not an aggregation");
+        assertRefused("from test | sort emp_no | limit 10", "fragment root is not an aggregation");
+    }
+
+    public void testAnUnlistedPlanNodeUnderTheAggregationIsRefused() {
+        assertRefused("from test | mv_expand first_name | stats x = count(*) by first_name", "unsupported plan node");
+        assertRefused("from test | dissect first_name \"%{a}\" | stats x = count(*) by a", "unsupported plan node");
+        assertRefused("from test | sample 0.5 | stats x = count(*)", "unsupported plan node");
+    }
+
+    public void testProfiledRequestsAreRefused() {
+        DataNodeRequest request = request("from test | stats x = avg(salary)");
+        Configuration base = request.configuration();
+        Configuration profiled = new Configuration(
+            base.now(),
+            base.locale(),
+            base.username(),
+            base.clusterName(),
+            base.pragmas(),
+            base.resultTruncationMaxSize(false),
+            base.resultTruncationDefaultSize(false),
+            base.query(),
+            true,
+            base.tables(),
+            base.queryStartTimeNanos(),
+            base.allowPartialResults(),
+            base.resultTruncationMaxSize(true),
+            base.resultTruncationDefaultSize(true),
+            base.resolvedSettings(),
+            base.viewQueries()
+        );
+        assertThat(ShardResultCacheVerifier.notCacheableReason(withConfiguration(request, profiled)), containsString("profiled"));
+    }
+
+    public void testRemoteFetchIsRefused() {
+        DataNodeRequest request = request("from test | stats x = avg(salary)");
+        DataNodeRequest retained = new DataNodeRequest(
+            request.sessionId(),
+            request.configuration(),
+            request.clusterAlias(),
+            request.shards(),
+            request.aliasFilters(),
+            request.plan(),
+            request.indices(),
+            request.indicesOptions(),
+            request.runNodeLevelReduction(),
+            request.reductionLateMaterialization(),
+            true
+        );
+        assertThat(ShardResultCacheVerifier.notCacheableReason(retained), containsString("remote fetch"));
+    }
+
+    public void testCrossClusterIsRefused() {
+        DataNodeRequest request = request("from test | stats x = avg(salary)");
+        DataNodeRequest remote = new DataNodeRequest(
+            request.sessionId(),
+            request.configuration(),
+            "remote1",
+            request.shards(),
+            request.aliasFilters(),
+            request.plan(),
+            request.indices(),
+            request.indicesOptions(),
+            request.runNodeLevelReduction(),
+            request.reductionLateMaterialization(),
+            request.retainSearchContexts()
+        );
+        assertThat(ShardResultCacheVerifier.notCacheableReason(remote), containsString("cross-cluster"));
+    }
+
+    private static void assertCacheable(String query) {
+        assertThat(query, ShardResultCacheVerifier.notCacheableReason(request(query)), nullValue());
+    }
+
+    private static void assertRefused(String query, String reason) {
+        assertThat(query, ShardResultCacheVerifier.notCacheableReason(request(query)), containsString(reason));
+    }
+
+    private static DataNodeRequest request(String query) {
+        return ShardResultCacheKeyTests.request(query);
+    }
+
+    private static DataNodeRequest withConfiguration(DataNodeRequest request, Configuration configuration) {
+        return new DataNodeRequest(
+            request.sessionId(),
+            configuration,
+            request.clusterAlias(),
+            request.shards(),
+            request.aliasFilters(),
+            request.plan(),
+            request.indices(),
+            request.indicesOptions(),
+            request.runNodeLevelReduction(),
+            request.reductionLateMaterialization(),
+            request.retainSearchContexts()
+        );
+    }
+
+    @Override
+    protected List<String> filteredWarnings() {
+        return withDefaultLimitWarning(super.filteredWarnings());
+    }
+}


### PR DESCRIPTION
## Summary

This is a POC, adding a per-shard result cache for ES|QL aggregations. When a data node runs the same aggregation over the same shard data, the partial shard result is served from cache instead of re-executing Lucene and the compute engine. The cache reuses the existing `IndicesRequestCache` that the DSL search path already uses, meaning it shares the same size budget, cleanup interval, and index-level enable/disable setting.

The motivation is the workload Kibana puts on rolled-over log indices: a dashboard refreshing every 30 s re-executes the same `STATS` against the same immutable shards on every cycle. Those shards never change between refreshes. The DSL path caches them today; ES|QL did not.

### End-to-end flow

```mermaid
sequenceDiagram
    participant Client
    participant Coord as Coordinator
    participant DN as Data Node
    participant SC as ShardResultCache
    participant IRC as IndicesRequestCache
    participant L as Lucene / Compute

    Client->>Coord: ES|QL query
    Coord->>Coord: plan · fingerprint (§3.3) · cacheability verdict (§3.4)
    Coord->>DN: DataNodeRequest (plan + fingerprint + cacheable flag)
    Note over DN: maxConcurrentShards = 1 when cacheable (POC §3.7)

    loop for each shard — sequential in POC, concurrent in §3.7 design
        DN->>SC: probe(queryPart, shard, searchContext)
        SC->>IRC: lookup(entity + mapping + reader + key)
        alt cache hit
            IRC-->>SC: cached bytes
            SC-->>DN: ShardProbe(hit = bytes)
            DN->>DN: replay pages into exchange sink
        else cache miss — churn gate + size gate pass
            IRC-->>SC: null
            SC-->>DN: ShardProbe(hit = null)
            DN->>L: runCompute (ShardResultCapture wraps sink)
            L-->>DN: pages flow through capture and into exchange sink
            DN->>SC: store(probe, capturedBytes)
            SC->>IRC: putShardLevelResult(shard, mapping, reader, key, bytes)
        else cache miss — admission rejected
            IRC-->>SC: null
            SC-->>DN: ShardProbe(hit = null)
            DN->>L: runCompute (no capture)
        end
    end

    DN-->>Coord: DriverCompletionInfo (pages already streamed via exchange)
    Coord->>Coord: reduce partial aggregation results
    Coord-->>Client: final result rows
```

### Invalidation: the reader-close mechanism

Invalidation is implicit and correct-by-construction. A refresh opens a new Lucene reader with a new cache key, so any probe on the refreshed reader is a cache miss — stale entries are unreachable even before they are cleaned up. When the old reader closes, a registered listener queues its entries for the periodic `CacheCleaner` (default interval 1 min).

```mermaid
sequenceDiagram
    participant W as Write path
    participant S as IndexShard
    participant L as Lucene
    participant IRC as IndicesRequestCache
    participant CC as CacheCleaner

    Note over IRC: Entry stored under key containing reader R1
    W->>S: index document
    S->>L: refresh triggered
    L->>L: open new reader R2, release reference to R1
    L-->>IRC: R1.onClose() fires → CleanupKey queued
    Note over IRC: Any probe now uses R2 key → miss (R1 entries unreachable)
    CC->>IRC: periodic sweep
    IRC->>IRC: evict queued R1 entries
    Note over IRC: Memory reclaimed, R1 entries were never served stale
```

---

## The cache key

The cache key is a composite of four independently-required components, assembled in two stages.

```mermaid
graph TD
    K["IndicesRequestCache key"]
    K --> E["entity — IndexShard instance"]
    K --> M["mappingCacheKey — MappingLookup.CacheKey"]
    K --> R["readerCacheKey — ElasticsearchDirectoryReader\nchanges on every refresh · drives invalidation"]
    K --> V["value key — BytesReference\nbuilt in two stages"]

    V --> QP["QueryPart — computed at coordinator\nshared across every shard of one request"]
    V --> PS["Per-shard additions — appended at probe time\non the data node"]

    QP --> F["Canonicalized fragment bytes\nNameIds normalised to dense ordinals"]
    QP --> RF["Reduction-split flags\nrunNodeLevelReduction\nreductionLateMaterialization\nretainSearchContexts"]
    QP --> CH["Configuration hash — default deny\nexcludes: now · queryStartTimeNanos\nprofile · explainOnly"]
    QP --> LR["Lifted time-range placeholders\none per hoisted date conjunct (§3.3b)"]

    PS --> SS["SplitShardCountSummary\nper shard on DataNodeRequest.Shard"]
    PS --> SD["Security differentiator\nDLS/FLS via existing DSL hook"]
    PS --> TR["Time-predicate residues\nWITHIN(field) · DISJOINT(field) · folded bounds"]
```

### Why two stages?

The **`QueryPart`** (coordinator side) is computed once and broadcast to all data nodes in the `DataNodeRequest`. It is a SHA-256 of everything that makes a query *semantically distinct*: the canonicalized physical plan fragment, the execution configuration (excluding wall-clock fields like `now`), and the reduction-split flags. `PlanStreamOutput` has a `normalizeForIdentity` mode that replaces fresh `NameId` values with dense ordinals and drops source positions, making the digest stable across independent plannings of the same query.

The **per-shard additions** are appended on the data node at probe time: the `SplitShardCountSummary` (a resharding state that is per-shard, not per-query), the existing security differentiator (which folds DLS/FLS into the key using the same hook the DSL path uses — reuse over reimplementation), and the time-predicate residues.

### Time-predicate lifting

`NOW() - 24h` folds to a full-precision epoch-millis literal at the coordinator. Without normalization, a Kibana dashboard refreshing every 30 s produces 2,880 distinct keys per day — hit rate zero on the workload the feature targets.

The solution mirrors what the DSL path already does with `RangeQueryBuilder.doSearchRewrite`: lift the date range conjuncts out of the fragment hash and resolve them per shard against the shard's own min/max at probe time.

```mermaid
flowchart LR
    subgraph Coord ["Coordinator — fingerprint time"]
        Q["WHERE @timestamp >= NOW()-24h\nAND @timestamp < NOW()"]
        L["Lift date range conjuncts\nreplace each with PLACEHOLDER(field)\nfold remaining fragment normally"]
        Q --> L
    end

    subgraph DN ["Data Node — probe time, per shard"]
        L --> R{"isFieldWithinQuery\nshard min/max vs lifted bounds"}
        R -- "WITHIN\ndata entirely inside range\n→ predicate always true" --> W["Residue: WITHIN(@timestamp)\nKey stable across runs\n→ HIT on repeated queries"]
        R -- "DISJOINT\ndata entirely outside range\n→ predicate always false" --> D["Residue: DISJOINT(@timestamp)\nKey stable (empty contribution)\n→ HIT"]
        R -- "CROSSES\nboundary cuts through shard\n→ rows genuinely change" --> C["Residue: folded epoch-millis bounds\nKey changes every run\n→ MISS (hot write shard)"]
    end
```

Three outcomes: **WITHIN** (shard data entirely inside the time range — predicate is always-true, key is stable, cache hits); **DISJOINT** (shard entirely outside — empty contribution also caches, which matters for index patterns that sweep rolled-over shards outside the window); **CROSSES** (boundary cuts through the shard — bounds matter, key changes run-to-run, the shard misses — and this is the actively-written shard which the churn gate declines to store anyway).

### Probe / store flowchart

```mermaid
flowchart TD
    A([runBatch]) --> B[acquireSearchContexts]
    B --> C{cacheQueryPart\nnon-null?}
    C -- No --> D[runCompute\nall shards unchanged]
    D --> Z([done])
    C -- Yes --> E["probe IndicesRequestCache\nfor this shard"]
    E --> F{hit?}
    F -- Yes --> G["replay cached bytes\nas Pages into exchange sink\nskip runCompute entirely"]
    G --> Z
    F -- No --> H{"admission:\nchurn gate\nsize gate"}
    H -- reject --> I["runCompute\nno ShardResultCapture"]
    I --> Z
    H -- admit --> J["runCompute\nShardResultCapture wraps sink\npages serialised on the way through"]
    J --> K{"complete?\nisCacheable?\nno early termination?\nno failure?"}
    K -- No --> Z
    K -- Yes --> L["store in IndicesRequestCache\nunder retained reader key"]
    L --> Z
```

---

## Admission policy

Two gates prevent wasted cache churn:

**Verifier (plan-shape allowlist, default deny).** `ShardResultCacheVerifier` inspects the physical plan fragment on the coordinator. Only plans rooted at an exact `Aggregate` node with `Filter`, `Eval`, `Project`, or `EsRelation` below are admitted. Explicitly refused: `PROFILE`, `EXPLAIN`, `LIMIT`-containing plans (a shared limiter across shards is batch-dependent), random/sample functions, `InferenceFunction`, `Now`, external splits, `retainSearchContexts` (PIT), and cross-cluster requests.

**Churn gate (write recency).** `ShardResultCache.admits()` checks `Engine.getLastWriteNanos()` against `esql.shard_result_cache.min_shard_idle_time` (default 30 s). A shard written within the window is not stored. Invalidation is reader-close driven — entries die as soon as the reader turns over — but writing to a hot shard every few seconds means every entry has a short lifespan. The gate avoids the cost of storing entries that will be evicted before the next probe.

**Non-deterministic fields.** The DSL path detects non-determinism via `SearchExecutionContext.isCacheable()`, which flips when `nowInMillis()`, non-deterministic scripts, or `disableCache()` is called during query construction. ES|QL builds its pushdown queries on the data node after the hit/miss decision, so the cacheability check can only run at store time. `ShardResultCache` checks `isCacheable()` on the shard's `SearchExecutionContext` before calling `put()`. A second mechanism catches non-deterministic runtime fields that never build a DSL query: `ShardResultCacheKey` walks the mapping and refuses any field whose `AbstractScriptFieldType.isResultDeterministic()` returns false.

---

## POC scope and known limitations

This is a proof-of-concept, not the production design. The main simplification is **`maxConcurrentShards=1`**: cacheable requests run one shard per batch so that pages in the exchange sink can be unambiguously attributed to the shard being computed. Concurrent shard execution (the production design) requires partitioned operator state — each operator would need to emit a per-shard partial result rather than a shared one — which is a separate, larger change.

Other limitations:
- Only `Aggregate → Filter/Eval/Project/EsRelation` shapes are cached. The allowlist grows as per-operator attribution work lands.
- `PlannerSettings` members that affect local plan shape (`luceneTopNLimit`, `maxKeywordSortFields`, `defaultDataPartitioning`) are not yet in the key; shapes that depend on them stay off the allowlist for now.
- The cancellation registrar for `IndicesRequestCache.get()` is not yet wired; cancelled queries waiting on a foreign load block until the load completes.
- The POC accumulates all results before starting output. We need to fix that, pages need to be sent as they are generated, and we should only accumulate up to 1MB per shard for the cache. The extra memory used should be at most 1MB per active driver, restoring backpressure. 

---

## Performance

Measured on a local single-node cluster against a synthetic index that matches the Kibana log-dashboard workload: many shards, data that does not change between runs.

**Setup:**
- Index: `perf_shard_cache`, 20 primary shards, ~5 million documents (`value` float, `category` keyword — 21 distinct values)
- Query: `FROM perf_shard_cache | STATS count = COUNT(*), total = SUM(value), avg_val = AVG(value) BY category`
- Result: 21 rows (one per category)
- `min_shard_idle_time = 0` (churn gate bypassed so cold data is always admitted)
- Baseline: cache disabled, 1 warmup + 3 measured runs

**Results:**

| Phase | Wall time | vs baseline |
|---|---|---|
| Baseline avg (cache OFF, 3 runs) | 0.150 s | — |
| Cold miss (cache ON, all 20 shards miss, entries stored) | 0.163 s | 1.08× slower |
| Cache hit (all 20 shards hit) | 0.014 s | **11× faster** |
| One shard invalidated (19 hits + 1 miss) | 0.016 s | 9.6× faster |
| All shards re-invalidated (full refresh, 20 misses) | 0.166 s | 1.10× slower |

Results were verified to be byte-identical between the cached and non-cached paths in every phase (including the partial-hit phase after inserting a new document).

**Cold miss overhead (1.08×):** The POC forces `maxConcurrentShards=1`, so shards run sequentially instead of the default batch size of up to 10. On a miss the serialization overhead of `ShardResultCapture` is negligible — the slowdown on misses is entirely the sequentialization cost, which disappears in the production design (§3.7).

**Cache memory:** ~85 KiB for all 20 shards' worth of partial aggregation results, stored in `IndicesRequestCache` on the heap.

---

## Settings

All three settings are dynamic cluster settings effective immediately without restart.

| Setting | Default | Description |
|---|---|---|
| `esql.shard_result_cache.enabled` | `true` | Master kill switch. Set `false` to disable probing and storing without restart. |
| `esql.shard_result_cache.max_value_size` | `1mb` | Hard cap on one shard's serialized result. Larger results are computed normally and not stored. |
| `esql.shard_result_cache.min_shard_idle_time` | `30s` | Churn gate. A shard written within this window is not stored. Set to `0` to bypass (useful in tests). |

---

## Files changed

**New files:**
- `ShardResultCache.java` — ES|QL-side cache facade: `probe()`, `replay()`, `store()`, `admits()`
- `ShardResultCacheKey.java` — Two-stage key builder: `queryPart()` (coordinator) + `forShard()` (data node); `liftTimeRanges()` for date conjunct extraction
- `ShardResultCacheSettings.java` — The three cluster settings above
- `ShardResultCacheVerifier.java` — Plan-shape admission allowlist
- `ShardResultCapture.java` — `ExchangeSink` wrapper that serializes pages on the way through, outside the lock
- `LiftedTimeRange.java` — Time-predicate lifting and per-shard `WITHIN`/`DISJOINT`/`CROSSES` resolution

**Modified files:**
- `DataNodeComputeHandler.java` — Integrates probe/replay/store into `runBatch`; forces `maxConcurrentShards=1` for cacheable requests
- `ComputeService.java` — Computes `cacheQueryPart` at the coordinator and attaches it to the node request
- `EsqlPlugin.java` — Registers `ShardResultCache` as a component and its settings
- `PlanStreamOutput.java` — Adds `normalizeForIdentity` mode for byte-stable plan serialization
- `IndicesRequestCache.java` — Adds `get()` (probe) and `put()` (store) alongside the existing `getOrCompute()`
- `IndicesService.java` — Exposes `getCachedShardLevelResult()` and `putShardLevelResult()` for the ES|QL caller

**Tests:**
- `ShardResultCacheIT.java` — Integration test: hit on second run, filter changes the key, new document invalidates, unsupported shape never reaches cache, non-deterministic runtime field never cached, served result equals computed result across all admitted shapes
- `ShardResultCacheKeyTests.java` — Unit test: two independent plannings agree, source positions don't reach the key, every `Configuration`/`EsqlFlags`/`PlannerSettings`/`DataNodeRequest` field has an explicit verdict (keyed or excluded-with-reason)
- `ShardResultCacheVerifierTests.java` — Unit test: admitted shapes, refused shapes, each refusal reason

---

