### PR TITLE
Add columnar as valid changelog area

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -33,6 +33,7 @@
             "Client",
             "Cluster Coordination",
             "Codec",
+            "Columnar",
             "Data streams",
             "DLM",
             "Discovery-Plugins",


### PR DESCRIPTION
This PR adds `Columnar` to the list of valid entries for the changelog `area`.

The impetus is bug fix #155430, where the CI automatically generated the changelog entry with area: columnar, but columnar isn't in the list of valid areas. 
