### PR TITLE
Allow configuring Fleet agent index shards

### DIFF
--- a/docs/changelog/155658.yaml
+++ b/docs/changelog/155658.yaml
@@ -1,0 +1,5 @@
+area: Infra/Plugins
+issues: []
+pr: 155658
+summary: Allow configuring Fleet agent index shards
+type: enhancement

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -18,10 +18,12 @@ import org.elasticsearch.action.datastreams.DeleteDataStreamAction.Request;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
@@ -67,6 +69,13 @@ import static org.elasticsearch.xpack.core.ClientHelper.FLEET_ORIGIN;
 public class Fleet extends Plugin implements SystemIndexPlugin {
 
     public static final String FLEET_SECRETS_INDEX_NAME = ".fleet-secrets";
+    static final Setting<Integer> FLEET_AGENTS_INDEX_NUMBER_OF_SHARDS_SETTING = Setting.intSetting(
+        "xpack.fleet.agents.index.number_of_shards",
+        1,
+        1,
+        1024,
+        Setting.Property.NodeScope
+    );
 
     private static final int CURRENT_INDEX_VERSION = 7;
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
@@ -100,7 +109,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         return List.of(
             fleetActionsSystemIndexDescriptor(),
-            fleetAgentsSystemIndexDescriptor(),
+            fleetAgentsSystemIndexDescriptor(settings),
             fleetEnrollmentApiKeysSystemIndexDescriptor(),
             fleetSecretsSystemIndexDescriptor(),
             fleetPoliciesSystemIndexDescriptor(),
@@ -109,6 +118,11 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             fleetArtifactsSystemIndexDescriptors(),
             fleetIntegrationKnowledgeSystemIndexDescriptor()
         );
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(FLEET_AGENTS_INDEX_NUMBER_OF_SHARDS_SETTING);
     }
 
     @Override
@@ -137,8 +151,13 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             .build();
     }
 
-    private static SystemIndexDescriptor fleetAgentsSystemIndexDescriptor() {
-        return systemIndexDescriptorBuilderFrom("/fleet-agents.json", FLEET_AGENTS_MAPPINGS_VERSION).setType(Type.EXTERNAL_MANAGED)
+    private static SystemIndexDescriptor fleetAgentsSystemIndexDescriptor(Settings settings) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), FLEET_AGENTS_INDEX_NUMBER_OF_SHARDS_SETTING.get(settings))
+            .build();
+        return systemIndexDescriptorBuilderFrom("/fleet-agents.json", FLEET_AGENTS_MAPPINGS_VERSION, indexSettings).setType(
+            Type.EXTERNAL_MANAGED
+        )
             .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
             .setOrigin(FLEET_ORIGIN)
             .setPrimaryIndex(".fleet-agents-" + CURRENT_INDEX_VERSION)
@@ -320,6 +339,14 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     }
 
     private static SystemIndexDescriptor.Builder systemIndexDescriptorBuilderFrom(String resource, int mappingsVersion) {
+        return systemIndexDescriptorBuilderFrom(resource, mappingsVersion, Settings.EMPTY);
+    }
+
+    private static SystemIndexDescriptor.Builder systemIndexDescriptorBuilderFrom(
+        String resource,
+        int mappingsVersion,
+        Settings additionalSettings
+    ) {
         try {
             Template template = TemplateUtils.loadTemplate(
                 resource,
@@ -329,7 +356,8 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
                 false,
                 Template::parse
             );
-            return SystemIndexDescriptor.builder().setMappings(template.mappings().string()).setSettings(template.settings());
+            Settings settings = Settings.builder().put(template.settings()).put(additionalSettings).build();
+            return SystemIndexDescriptor.builder().setMappings(template.mappings().string()).setSettings(settings);
         } catch (IOException e) {
             throw new ElasticsearchParseException("invalid template [{}]", resource);
         }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.fleet;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 
 public class FleetTests extends ESTestCase {
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors() {
@@ -63,6 +65,27 @@ public class FleetTests extends ESTestCase {
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-secrets")));
 
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".integration_knowledge")));
+    }
+
+    public void testFleetAgentsIndexDefaultsToOnePrimaryShard() {
+        SystemIndexDescriptor descriptor = fleetAgentsDescriptor(Settings.EMPTY);
+
+        assertThat(descriptor.getSettings().getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null), equalTo(1));
+    }
+
+    public void testFleetAgentsIndexPrimaryShardCountIsConfigurable() {
+        Settings settings = Settings.builder().put(Fleet.FLEET_AGENTS_INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 4).build();
+        SystemIndexDescriptor descriptor = fleetAgentsDescriptor(settings);
+
+        assertThat(descriptor.getSettings().getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null), equalTo(4));
+    }
+
+    private static SystemIndexDescriptor fleetAgentsDescriptor(Settings settings) {
+        return new Fleet().getSystemIndexDescriptors(settings)
+            .stream()
+            .filter(descriptor -> descriptor.matchesIndexPattern(".fleet-agents"))
+            .findFirst()
+            .orElseThrow();
     }
 
     public void testFleetFeature() {


### PR DESCRIPTION
## Summary

Adds the node setting `xpack.fleet.agents.index.number_of_shards` and applies it when Elasticsearch creates the `.fleet-agents` system index. The setting defaults to one, preserving current behavior unless an environment opts in. Existing `.fleet-agents` indices are unchanged because their primary shard count is static.

Adds unit coverage for both the default and an explicitly configured four-primary layout.

## Experiment and rollout

The Serverless QA and Staging overrides are in https://github.com/elastic/serverless-gitops/pull/155710. If the controlled Staging experiment is successful toward achieving 100k-agent scale, we will promote the setting override to Production. If it is unsuccessful, we will revert both this Elasticsearch change and the serverless-gitops overrides.

## 100k scale-test evidence

Tracking issue: https://github.com/elastic/ingest-dev/issues/8895

Test run: https://buildkite.com/elastic/observability-perf/builds/6690

During the large failure wave in this run, the sole `.fleet-agents-7[0]` primary became an Elasticsearch indexing hotspot. Its indexing thread-pool utilization reached 100.1% with 8,829 ms queue latency. Elasticsearch logged 18,358 slow bulk transport operations (p50 7.25 s, p95 13.36 s, max 13.81 s) and 527 `.fleet-agents` search-shard notification failures.

The same interval produced 22,148 Fleet Server context-deadline errors, 77,889 rejected bulk dispatches, and waves of 25,645 HTTP 429, 16,627 HTTP 500, and 2,224 HTTP 503 responses. Allowing multiple `.fleet-agents` primaries lets configured environments distribute this indexing load across more shard paths.
