### PR TITLE
test: bound TaskExecutorTests latch waits

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/service/TaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TaskExecutorTests.java
@@ -184,8 +184,8 @@ public class TaskExecutorTests extends ESTestCase {
         submitTask("unblock-task", unblockTask);
 
         block.countDown();
-        block2.await();
-        blockCompleted.await();
+        assertTrue(block2.await(10, TimeUnit.SECONDS));
+        assertTrue(blockCompleted.await(10, TimeUnit.SECONDS));
     }
 
     public void testTimeoutTask() throws Exception {
@@ -228,7 +228,7 @@ public class TaskExecutorTests extends ESTestCase {
         };
         submitTask("block-task", test2);
 
-        timedOut.await();
+        assertTrue(timedOut.await(10, TimeUnit.SECONDS));
         block.countDown();
         final CountDownLatch allProcessed = new CountDownLatch(1);
         TestTask test3 = new TestTask() {
@@ -244,7 +244,7 @@ public class TaskExecutorTests extends ESTestCase {
             }
         };
         submitTask("block-task", test3);
-        allProcessed.await(); // executed another task to double check that execute on the timed out update task is not called...
+        assertTrue(allProcessed.await(10, TimeUnit.SECONDS)); // executed another task to double check that execute on the timed out update task is not called...
         assertThat(executeCalled.get(), equalTo(false));
     }
 
@@ -275,7 +275,7 @@ public class TaskExecutorTests extends ESTestCase {
         }
 
         block.close();
-        latch.await();
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
 
         Priority prevPriority = null;
         for (PrioritizedTask task : tasks) {


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/33561612.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Replaced unbounded test-thread latch waits with asserted ten-second waits so failures terminate clearly.
