### PR TITLE
Rename scroll to paginated search

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
@@ -282,7 +282,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         assertThat(ALLOWED_OPERATIONS.drainPermits(), equalTo(0));
 
         ReindexRequestBuilder builder = new ReindexRequestBuilder(client).source(INDEX_NAME).destination("target_index");
-        // Scroll by 1 so that cancellation is easier to control
+        // Batch by 1 so that cancellation is easier to control
         builder.source().setSize(1);
 
         int numModifiedDocs = randomIntBetween(builder.request().getSlices() * 2, numDocs);

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByPaginatedSearchAction.java
@@ -555,8 +555,8 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             @Override
             protected void doRun() throws Exception {
                 /*
-                 * It is important that the batch start time be calculated from here, scroll response to scroll response. That way the time
-                 * waiting on the scroll doesn't count against this batch in the throttle.
+                 * It is important that the batch start time be calculated from here, paginated search response to paginated search
+                 * response. That way the time waiting on the search doesn't count against this batch in the throttle.
                  */
                 prepareBulkRequest(System.nanoTime(), asyncResponse);
             }
@@ -742,7 +742,7 @@ public abstract class AbstractAsyncBulkByPaginatedSearchAction<
             }
 
             if (paginatedHitSource.hasMoreBatches() == false) {
-                // Index contains fewer matching docs than max_docs (found < max_docs <= scroll size)
+                // Index contains fewer matching docs than max_docs (found < max_docs <= batch size)
                 refreshAndFinish(emptyList(), emptyList(), false);
                 return;
             }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 /**
- * Implementation of delete-by-query using scrolling and bulk.
+ * Implementation of delete-by-query using paginated search and bulk requests.
  */
 public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByPaginatedSearchAction<DeleteByQueryRequest, TransportDeleteByQueryAction> {
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/PaginatedHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/PaginatedHitSource.java
@@ -169,8 +169,8 @@ public abstract class PaginatedHitSource {
     );
 
     /**
-     * Called to release pagination resources (e.g. clear scroll context).
-     * For PIT-based pagination this is a no-op as the PIT is closed elsewhere.
+     * Called to release pagination resources held by this hit source. For scroll-based pagination this clears the
+     * scroll context. For PIT-based pagination this is a no-op as the PIT is closed elsewhere.
      *
      * @param onCompletion implementers must call this after completing the release whether they are
      *        successful or not

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -959,7 +959,7 @@ public class Reindexer {
     }
 
     /**
-     * Simple implementation of reindex using scrolling and bulk. There are tons
+     * Simple implementation of reindex using paginated search and bulk. There are tons
      * of optimizations that can be done on certain types of reindex requests
      * but this makes no attempt to do any of them so it can be as simple
      * possible.

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
@@ -135,7 +135,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
     }
 
     /**
-     * Simple implementation of update-by-query using scrolling and bulk.
+     * Simple implementation of update-by-query using paginated search and bulk.
      */
     static class AsyncIndexBySearchAction extends AbstractAsyncBulkByPaginatedSearchAction<
         UpdateByQueryRequest,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/package-info.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/package-info.java
@@ -8,8 +8,8 @@
  */
 
 /**
- * Actions that modify documents based on the results of a scrolling query like {@link org.elasticsearch.index.reindex.ReindexAction},
- * {@link org.elasticsearch.index.reindex.UpdateByQueryAction}, and
+ * Actions that modify documents based on the results of a paginated search like
+ * {@link org.elasticsearch.index.reindex.ReindexAction}, {@link org.elasticsearch.index.reindex.UpdateByQueryAction}, and
  * {@link org.elasticsearch.index.reindex.DeleteByQueryAction}.
  */
 package org.elasticsearch.reindex;

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByPaginatedSearchActionTests.java
@@ -2601,7 +2601,7 @@ public class AsyncBulkByPaginatedSearchActionTests extends ESTestCase {
     /**
      * Blocks in {@code consumeHits} after {@code super} returns (first batch taken) until the test finishes {@code finishHim},
      * so {@link AbstractAsyncBulkByPaginatedSearchAction#currentPaginatedSearchResponse} stays {@code null} across {@code finishHim}'s
-     * {@code getAndSet} when {@code maxDocs} leaves a partial scroll batch.
+     * {@code getAndSet} when {@code maxDocs} leaves a partial batch.
      */
     private static final class PaginatedSearchConsumableHitsResponseGate extends
         AbstractAsyncBulkByPaginatedSearchAction.PaginatedSearchConsumableHitsResponse {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/CancelTests.java
@@ -84,7 +84,7 @@ public class CancelTests extends ReindexTestCase {
         Matcher<String> taskDescriptionMatcher
     ) throws Exception {
         createIndex(INDEX);
-        // Scroll by 1 so that cancellation is easier to control
+        // Batch by 1 so that cancellation is easier to control
         builder.source().setSize(1);
         AbstractBulkByPaginatedSearchRequest<?> request = builder.request();
         // Total number of documents created for this test (~10 per primary shard per slice)

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexBasicTests.java
@@ -169,8 +169,8 @@ public class ReindexBasicTests extends ReindexTestCase {
     }
 
     /**
-     * Tests that high throttling (that would exceed the scroll keep-alive) does not terminate a reindexing operation early.
-     * This is achieved by setting the scroll keep-alive to 500ms second, and the throttling is (5 docs at 4 req/s ≈ 1.25s)
+     * Tests that high throttling (that would exceed the search context keep-alive) does not terminate a reindexing operation early.
+     * This is achieved by setting the scroll keep-alive to 500ms, and the throttling is (5 docs at 4 req/s ≈ 1.25s).
      */
     public void testSmallScrollTimeoutWithHeavyThrottleCompletes() {
         String prefix = randomAlphaOfLength(8).toLowerCase(Locale.ROOT);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
@@ -190,7 +190,7 @@ public class RetryTests extends ESIntegTestCase {
         indicesAdmin().prepareRefresh("source").get();
 
         AbstractBulkByPaginatedSearchRequestBuilder<?, ?> builder = request.apply(internalCluster().masterClient());
-        // Make sure we use more than one batch so we have to scroll
+        // Make sure we use more than one batch
         builder.source().setSize(DOC_COUNT / randomIntBetween(2, 10));
 
         logger.info("Blocking bulk so we start to get bulk rejections");

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
@@ -1,5 +1,5 @@
 "Throttle the request":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -76,7 +76,7 @@
 "Rethrottle to -1 which turns off throttling":
   - skip:
       features: warnings
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -134,7 +134,7 @@
 
 ---
 "Rethrottle but not unlimited":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_basic.yml
@@ -25,7 +25,7 @@
   - is_false: task
   - is_false: deleted
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -64,7 +64,7 @@
   - is_false: task
   - is_false: deleted
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -120,7 +120,7 @@
   - is_false: response.task
   - is_false: response.deleted
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -165,7 +165,7 @@
   - match: {failures.0.cause.index:  dest}
   - gte: { took: 0 }
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -204,7 +204,7 @@
   - match: {throttled_millis: 0}
   - gte: { took: 0 }
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -236,7 +236,7 @@
         id:      "1"
   - match: { _source: {} }
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -280,7 +280,7 @@
   - match: { _source.text: "test" }
   - is_false: _source.filtered
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
@@ -1,6 +1,6 @@
 ---
 "Throttle the request":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -92,7 +92,7 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -144,7 +144,7 @@
 
 ---
 "Rethrottle but not unlimited":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -46,7 +46,7 @@
               text: test
   - match: {hits.total: 1}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -101,7 +101,7 @@
             match_all: {}
   - match: {hits.total: 1}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -150,7 +150,7 @@
               text: test
   - match: {hits.total: 1}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -210,7 +210,7 @@
               text: test
   - match: {hits.total: 1}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -276,7 +276,7 @@
               text: test
   - match: {hits.total: 1}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -385,7 +385,7 @@
 
 ---
 "Reindex from remote with rethrottle":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -458,7 +458,7 @@
               text: test
   - match: {hits.total: 3}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
@@ -78,7 +78,7 @@ setup:
   - match: {hits.total: 1}
   - match: {hits.hits.0._id: "3"}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source
@@ -136,7 +136,7 @@ setup:
   - match: {hits.total: 1}
   - match: {hits.hits.0._id: "3"}
 
-  # Make sure reindex closed all the scroll contexts
+  # Make sure reindex closed all the search contexts
   - do:
       indices.stats:
         index: source

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/60_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/60_throttle.yml
@@ -1,5 +1,5 @@
 "Throttle the request":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -66,7 +66,7 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:
@@ -110,7 +110,7 @@
 
 ---
 "Rethrottle but not unlimited":
-  # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
+  # Throttling happens between each paginated search batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
       indices.create:


### PR DESCRIPTION
Reindexing now uses point-in-time search, falling back to scroll only on remote nodes that don't support PIT. This is the final PR renaming scroll specific references to use paginated search instead
