### PR TITLE
[Transform] Add support for string_stats aggregation

### DIFF
--- a/docs/changelog/155698.yaml
+++ b/docs/changelog/155698.yaml
@@ -1,0 +1,6 @@
+area: Transform
+issues:
+ - 51925
+pr: 155698
+summary: Add support for string_stats aggregations in pivot transforms
+type: enhancement

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -22,41 +23,43 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-public class InternalStringStats extends InternalAggregation {
+public class InternalStringStats extends InternalNumericMetricsAggregation.MultiValue {
 
     enum Metrics {
         count {
-            Object getFieldValue(InternalStringStats stats) {
+            double getFieldValue(InternalStringStats stats) {
                 return stats.getCount();
             }
         },
         min_length {
-            Object getFieldValue(InternalStringStats stats) {
+            double getFieldValue(InternalStringStats stats) {
                 return stats.getMinLength();
             }
         },
         max_length {
-            Object getFieldValue(InternalStringStats stats) {
+            double getFieldValue(InternalStringStats stats) {
                 return stats.getMaxLength();
             }
         },
         avg_length {
-            Object getFieldValue(InternalStringStats stats) {
+            double getFieldValue(InternalStringStats stats) {
                 return stats.getAvgLength();
             }
         },
         entropy {
-            Object getFieldValue(InternalStringStats stats) {
+            double getFieldValue(InternalStringStats stats) {
                 return stats.getEntropy();
             }
         };
 
-        abstract Object getFieldValue(InternalStringStats stats);
+        abstract double getFieldValue(InternalStringStats stats);
     }
 
-    private final DocValueFormat format;
+    static final Set<String> METRIC_NAMES = Set.of("count", "min_length", "max_length", "avg_length", "entropy");
+
     private final boolean showDistribution;
     private final long count;
     private final long totalLength;
@@ -75,8 +78,7 @@ public class InternalStringStats extends InternalAggregation {
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) {
-        super(name, metadata);
-        this.format = formatter;
+        super(name, formatter, metadata);
         this.showDistribution = showDistribution;
         this.count = count;
         this.totalLength = totalLength;
@@ -88,7 +90,6 @@ public class InternalStringStats extends InternalAggregation {
     /** Read from a stream. */
     public InternalStringStats(StreamInput in) throws IOException {
         super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
         showDistribution = in.readBoolean();
         count = in.readVLong();
         totalLength = in.readVLong();
@@ -192,12 +193,18 @@ public class InternalStringStats extends InternalAggregation {
         return format.format(getEntropy()).toString();
     }
 
-    public Object value(String name) {
+    @Override
+    public double value(String name) {
         try {
             return Metrics.valueOf(name).getFieldValue(this);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Unknown value [" + name + "] in string stats aggregation");
         }
+    }
+
+    @Override
+    public Iterable<String> valueNames() {
+        return METRIC_NAMES;
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregationBuilder.java
@@ -25,8 +25,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
-public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilder<StringStatsAggregationBuilder> {
+public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilder.MetricsAggregationBuilder<StringStatsAggregationBuilder> {
 
     public static final String NAME = "string_stats";
     public static final ValuesSourceRegistry.RegistryKey<StringStatsAggregatorSupplier> REGISTRY_KEY =
@@ -79,11 +81,6 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
     }
 
     @Override
-    public BucketCardinality bucketCardinality() {
-        return BucketCardinality.NONE;
-    }
-
-    @Override
     protected StringStatsAggregatorFactory innerBuild(
         AggregationContext context,
         ValuesSourceConfig config,
@@ -113,6 +110,16 @@ public class StringStatsAggregationBuilder extends ValuesSourceAggregationBuilde
     @Override
     public String getType() {
         return NAME;
+    }
+
+    @Override
+    public Set<String> metricNames() {
+        return InternalStringStats.METRIC_NAMES;
+    }
+
+    @Override
+    public Optional<Set<String>> getOutputFieldNames() {
+        return Optional.of(InternalStringStats.METRIC_NAMES);
     }
 
     /**

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -2327,6 +2328,62 @@ public class TransformPivotRestIT extends TransformRestTestCase {
                 hasEntry("lower_sampling", 0.8057492524072662)
             )
         );
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    public void testPivotWithStringStats() throws Exception {
+        var transformId = "string_stats_transform";
+        var transformIndex = "string_stats_pivot_reviews";
+        setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
+
+        var createTransformRequest = createRequestWithAuth(
+            "PUT",
+            getTransformEndpoint() + transformId,
+            BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS
+        );
+
+        var config = Strings.format("""
+            {
+              "source": {
+                "index": "%s"
+              },
+              "dest": {
+                "index": "%s"
+              },
+              "pivot": {
+                "group_by": {
+                  "reviewer": {
+                    "terms": {
+                      "field": "user_id"
+                    }
+                  }
+                },
+                "aggregations": {
+                  "business_stats": {
+                    "string_stats": {
+                      "field": "business_id"
+                    }
+                  }
+                }
+              }
+            }""", REVIEWS_INDEX_NAME, transformIndex);
+
+        createTransformRequest.setJsonEntity(config);
+        var createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));
+        assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+
+        startAndWaitForTransform(transformId, transformIndex, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
+        assertTrue(indexExists(transformIndex));
+
+        var searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_4");
+        assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
+        var stringStatsMap = (Map<String, Object>) ((List<?>) XContentMapValues.extractValue(
+            "hits.hits._source.business_stats",
+            searchResult
+        )).get(0);
+        assertThat(stringStatsMap, allOf(hasEntry("count", 41.0), hasEntry("min_length", 10.0), hasEntry("max_length", 11.0)));
+        assertThat(stringStatsMap.get("avg_length"), equalTo(10.487804878048781));
+        assertThat((Double) stringStatsMap.get("entropy"), lessThan(4.0));
     }
 
     public void testPivotWithBoxplot() throws Exception {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -76,7 +76,6 @@ public final class TransformAggregations {
         "sampler",
         "significant_terms", // https://github.com/elastic/elasticsearch/issues/51073
         "significant_text",
-        "string_stats", // https://github.com/elastic/elasticsearch/issues/51925
         "top_hits",
         "t_test", // https://github.com/elastic/elasticsearch/issues/54503,
         "variable_width_histogram", // https://github.com/elastic/elasticsearch/issues/58140
@@ -120,7 +119,8 @@ public final class TransformAggregations {
         TOP_METRICS("top_metrics", SOURCE),
         STATS("stats", DOUBLE),
         BOXPLOT("boxplot", DOUBLE),
-        EXTENDED_STATS("extended_stats", DOUBLE);
+        EXTENDED_STATS("extended_stats", DOUBLE),
+        STRING_STATS("string_stats", DOUBLE);
 
         private final String aggregationType;
         private final String targetMapping;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.analytics.stringstats.InternalStringStats;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
@@ -730,6 +731,38 @@ public class AggregationResultUtilsTests extends ESTestCase {
             AggregationResultUtils.getExtractor(agg)
                 .value(agg, Map.of("filter.mv_metric.approx_answer", "double", "filter.mv_metric.exact_answer", "long"), "filter"),
             hasEqualEntriesInOrder(asOrderedMap("approx_answer", 42.2, "exact_answer", Long.valueOf(42)))
+        );
+    }
+
+    public void testStringStatsAggExtractor() {
+        Aggregation agg = new InternalStringStats(
+            "string_stats",
+            2,
+            6,
+            2,
+            4,
+            Map.of("a", 3L, "b", 3L),
+            false,
+            DocValueFormat.RAW,
+            Map.of()
+        );
+
+        Map<String, String> fieldTypeMap = Map.of(
+            "string_stats.count",
+            "double",
+            "string_stats.min_length",
+            "double",
+            "string_stats.max_length",
+            "double",
+            "string_stats.avg_length",
+            "double",
+            "string_stats.entropy",
+            "double"
+        );
+
+        assertThat(
+            AggregationResultUtils.getExtractor(agg).value(agg, fieldTypeMap, ""),
+            equalTo(Map.of("count", 2.0, "min_length", 2.0, "max_length", 4.0, "avg_length", 3.0, "entropy", 1.0))
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.aggregations.metrics.StatsAggregationBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.boxplot.BoxplotAggregationBuilder;
+import org.elasticsearch.xpack.analytics.stringstats.StringStatsAggregationBuilder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -143,6 +144,9 @@ public class TransformAggregationsTests extends ESTestCase {
         // extended stats
         assertEquals("double", TransformAggregations.resolveTargetMapping("extended_stats", "double"));
 
+        // string stats
+        assertEquals("double", TransformAggregations.resolveTargetMapping("string_stats", "keyword"));
+
         // boxplot
         assertEquals("double", TransformAggregations.resolveTargetMapping("boxplot", "double"));
 
@@ -255,6 +259,24 @@ public class TransformAggregationsTests extends ESTestCase {
                 hasEntry("extended_stats.std_deviation_bounds.lower_population", "extended_stats"),
                 hasEntry("extended_stats.std_deviation_bounds.upper_sampling", "extended_stats"),
                 hasEntry("extended_stats.std_deviation_bounds.lower_sampling", "extended_stats")
+            )
+        );
+    }
+
+    public void testGetAggregationOutputTypesStringStats() {
+        var stringStatsAggregationBuilder = new StringStatsAggregationBuilder("string_stats");
+
+        var inputAndOutputTypes = TransformAggregations.getAggregationInputAndOutputTypes(stringStatsAggregationBuilder);
+        var outputTypes = inputAndOutputTypes.v2();
+        assertEquals(5, outputTypes.size());
+        assertThat(
+            outputTypes,
+            allOf(
+                hasEntry("string_stats.count", "string_stats"),
+                hasEntry("string_stats.min_length", "string_stats"),
+                hasEntry("string_stats.max_length", "string_stats"),
+                hasEntry("string_stats.avg_length", "string_stats"),
+                hasEntry("string_stats.entropy", "string_stats")
             )
         );
     }


### PR DESCRIPTION
Closes #51925

## Overview
Add pivot transform support for the remaining `string_stats` aggregation.

## Details
- expose the five scalar string statistics as numeric multi-value metrics
- provide output field names for transform mapping inference
- reuse the existing numeric multi-value extraction path
- add unit coverage and a single-node REST integration test

`show_distribution` is intentionally not exposed as a transform field because it is an object-valued optional response, while pivot output fields currently require scalar metric values.

## Verification
- `:x-pack:plugin:transform:test` focused pivot tests
- Analytics string-stats regression tests
- Transform and Analytics Spotless checks
- `TransformPivotRestIT#testPivotWithStringStats`