### PR TITLE
Improve naming for numberOfStartedOrRelocatingShardsForIndex

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -283,12 +283,12 @@ public class RoutingNode implements Iterable<ShardRouting> {
         }
     }
 
-    public int numberOfStartedOrRelocatingShardsForIndex(final Index index) {
+    public int numberOfActiveShardsForIndex(final Index index) {
         final Set<ShardRouting> shardRoutings = shardsByIndex.get(index);
         if (shardRoutings == null) {
             return 0;
         } else {
-            return Math.toIntExact(shardRoutings.stream().filter(shard -> shard.started() || shard.relocating()).count());
+            return Math.toIntExact(shardRoutings.stream().filter(ShardRouting::active).count());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -624,7 +624,7 @@ public class DesiredBalanceComputer {
                 // the total number of shards for that index on that node, in which case the index is new to the node and any index stats
                 // should be added to the node. Count started and relocating shards to be consistent with the logic above.
                 if (indexToCount.getValue() == routingNodes.node(nodeToIndexCountMap.getKey())
-                    .numberOfStartedOrRelocatingShardsForIndex(indexToCount.getKey())) {
+                    .numberOfActiveShardsForIndex(indexToCount.getKey())) {
                     clusterInfoSimulator.simulateAddIndexToNode(nodeToIndexCountMap.getKey(), indexToCount.getKey());
                 }
             }
@@ -635,7 +635,7 @@ public class DesiredBalanceComputer {
             // holds the index, then the index stats should be removed from the node. Count started and relocating shards to be
             // consistent with the logic above.
             for (var index : nodeIdToIndicesWithRemovedShards.getValue()) {
-                if (routingNodes.node(nodeIdToIndicesWithRemovedShards.getKey()).numberOfStartedOrRelocatingShardsForIndex(index) == 0) {
+                if (routingNodes.node(nodeIdToIndicesWithRemovedShards.getKey()).numberOfActiveShardsForIndex(index) == 0) {
                     clusterInfoSimulator.simulateRemoveIndexFromNode(nodeIdToIndicesWithRemovedShards.getKey(), index);
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
@@ -118,7 +118,7 @@ public class RoutingNodeTests extends ESTestCase {
         assertThat(routingNode.numberOfOwningShards(), equalTo(2));
     }
 
-    public void testNumberOfStartedOrRelocatingShards() {
+    public void testNumberOfActiveShardsForIndex() {
         assertThat(routingNode.numberOfActiveShardsForIndex(new Index("test", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(2));
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
@@ -119,7 +119,7 @@ public class RoutingNodeTests extends ESTestCase {
     }
 
     public void testNumberOfStartedOrRelocatingShards() {
-        assertThat(routingNode.numberOfStartedOrRelocatingShardsForIndex(new Index("test", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(2));
+        assertThat(routingNode.numberOfActiveShardsForIndex(new Index("test", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(2));
     }
 
     public void testNumberOfOwningShardsForIndex() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1953,7 +1953,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         {
             DesiredBalanceComputer.maybeSimulateAlreadyStartedShards(clusterInfo, routingNodes, clusterInfoSimulator);
             verify(clusterInfoSimulator).simulateAlreadyStartedShard(startedShard, null);
-            if (routingNodes.node(startedShard.currentNodeId()).numberOfStartedOrRelocatingShardsForIndex(startedShard.index()) == 1) {
+            if (routingNodes.node(startedShard.currentNodeId()).numberOfActiveShardsForIndex(startedShard.index()) == 1) {
                 verify(clusterInfoSimulator).simulateAddIndexToNode(startedShard.currentNodeId(), startedShard.index());
             }
             verifyNoMoreInteractions(clusterInfoSimulator);
@@ -1975,17 +1975,17 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             if (startedShard.currentNodeId() == startedRelocatingShard.currentNodeId()) {
                 // The shards were moved to the same node: if the index is new to that node, then there should be a call to simulate adding
                 // the index stats for the node.
-                if (routingNodes.node(startedShard.currentNodeId()).numberOfStartedOrRelocatingShardsForIndex(startedShard.index()) == 2) {
+                if (routingNodes.node(startedShard.currentNodeId()).numberOfActiveShardsForIndex(startedShard.index()) == 2) {
                     verify(clusterInfoSimulator).simulateAddIndexToNode(startedShard.currentNodeId(), startedShard.index());
                 }
             } else {
                 // Check if the index is new on either node that received a new shard: if either is new, then the index stats should have
                 // been simulated, too.
-                if (routingNodes.node(startedShard.currentNodeId()).numberOfStartedOrRelocatingShardsForIndex(startedShard.index()) == 1) {
+                if (routingNodes.node(startedShard.currentNodeId()).numberOfActiveShardsForIndex(startedShard.index()) == 1) {
                     verify(clusterInfoSimulator).simulateAddIndexToNode(startedShard.currentNodeId(), startedShard.index());
                 }
                 if (routingNodes.node(startedRelocatingShard.currentNodeId())
-                    .numberOfStartedOrRelocatingShardsForIndex(startedRelocatingShard.index()) == 1) {
+                    .numberOfActiveShardsForIndex(startedRelocatingShard.index()) == 1) {
                     verify(clusterInfoSimulator).simulateAddIndexToNode(
                         startedRelocatingShard.currentNodeId(),
                         startedRelocatingShard.index()


### PR DESCRIPTION
There is already a term for "started or relocating" and that's "active". This PR aligns the naming of a method to the existing terminology.

