### PR TITLE
[REST] Restrict text content charsets to UTF-8

### DIFF
--- a/docs/changelog/155701.yaml
+++ b/docs/changelog/155701.yaml
@@ -1,0 +1,6 @@
+area: Infra/REST API
+issues:
+ - 22769
+pr: 155701
+summary: Reject non-UTF-8 charset parameters for textual REST request bodies
+type: bug

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
@@ -44,7 +44,12 @@ public enum XContentType implements MediaType {
 
         @Override
         public Set<HeaderValue> headerValues() {
-            return Set.of(new HeaderValue("application/json"), new HeaderValue("application/x-ndjson"), new HeaderValue("application/*"));
+            Map<String, String> parameters = Map.of("charset", "utf-8");
+            return Set.of(
+                new HeaderValue("application/json", parameters),
+                new HeaderValue("application/x-ndjson", parameters),
+                new HeaderValue("application/*", parameters)
+            );
         }
     },
     /**
@@ -82,7 +87,7 @@ public enum XContentType implements MediaType {
 
         @Override
         public Set<HeaderValue> headerValues() {
-            return Set.of(new HeaderValue("application/yaml"));
+            return Set.of(new HeaderValue("application/yaml", Map.of("charset", "utf-8")));
         }
     },
     /**
@@ -121,8 +126,14 @@ public enum XContentType implements MediaType {
         @Override
         public Set<HeaderValue> headerValues() {
             return Set.of(
-                new HeaderValue(VENDOR_APPLICATION_PREFIX + "json", Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN)),
-                new HeaderValue(VENDOR_APPLICATION_PREFIX + "x-ndjson", Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN))
+                new HeaderValue(
+                    VENDOR_APPLICATION_PREFIX + "json",
+                    Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN, "charset", "utf-8")
+                ),
+                new HeaderValue(
+                    VENDOR_APPLICATION_PREFIX + "x-ndjson",
+                    Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN, "charset", "utf-8")
+                )
             );
         }
 
@@ -171,7 +182,12 @@ public enum XContentType implements MediaType {
 
         @Override
         public Set<HeaderValue> headerValues() {
-            return Set.of(new HeaderValue(VENDOR_APPLICATION_PREFIX + "yaml", Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN)));
+            return Set.of(
+                new HeaderValue(
+                    VENDOR_APPLICATION_PREFIX + "yaml",
+                    Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN, "charset", "utf-8")
+                )
+            );
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/XContentTypeTests.java
@@ -40,6 +40,17 @@ public class XContentTypeTests extends ESTestCase {
         assertThat(XContentType.fromMediaType(mediaType + "; charset=UTF-8"), equalTo(expectedXContentType));
     }
 
+    public void testRejectsUnsupportedCharset() {
+        assertThat(XContentType.fromMediaType("application/json; charset=iso-8859-1"), nullValue());
+        assertThat(XContentType.fromMediaType("application/x-ndjson; charset=iso-8859-1"), nullValue());
+        assertThat(XContentType.fromMediaType("application/yaml; charset=iso-8859-1"), nullValue());
+        assertThat(XContentType.fromMediaType("application/vnd.elasticsearch+json; compatible-with=8; charset=iso-8859-1"), nullValue());
+        assertThat(
+            XContentType.fromMediaType("application/vnd.elasticsearch+yaml; compatible-with=8; charset=utf-8"),
+            equalTo(XContentType.VND_YAML)
+        );
+    }
+
     public void testFromJsonUppercase() throws Exception {
         String mediaType = "application/json".toUpperCase(Locale.ROOT);
         XContentType expectedXContentType = XContentType.JSON;

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -236,6 +236,16 @@ public class RestRequestTests extends ESTestCase {
         }
     }
 
+    public void testRejectsNonUtf8ContentType() {
+        RestRequest restRequest = contentRestRequest(
+            "{}",
+            Collections.emptyMap(),
+            Collections.singletonMap("Content-Type", Collections.singletonList("application/json; charset=iso-8859-1"))
+        );
+
+        assertNull(restRequest.getXContentType());
+    }
+
     public void testPlainTextSupport() {
         RestRequest restRequest = contentRestRequest(
             randomAlphaOfLengthBetween(1, 30),


### PR DESCRIPTION
Relates #22769

## Overview
The media-type registry currently accepts arbitrary `charset` parameters for textual XContent types, even though Elasticsearch parses those request bodies as UTF-8. This change makes the accepted media-type contract match the parser behavior.

## Details
- allow `charset=utf-8` for JSON, NDJSON, YAML, and their versioned vendor media types
- reject non-UTF-8 charsets before a request is treated as XContent
- leave binary Smile and CBOR media types unchanged
- add registry and REST request regression coverage

This intentionally does not add decoding for non-UTF-8 request bodies.

## Verification
- `:server:test --tests org.elasticsearch.common.xcontent.XContentTypeTests --tests org.elasticsearch.rest.RestRequestTests`
- `:libs:x-content:test`
- `:libs:x-content:spotlessJavaCheck`
- `:server:spotlessJavaCheck`