### PR TITLE
ES|QL: Support MV_FIRST/LAST/COUNT and VALUES for double_range

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregatorFunction.java
@@ -1,0 +1,175 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunction} implementation for {@link ValuesDoubleRangeAggregator}.
+ * This class is generated. Edit {@code AggregatorImplementer} instead.
+ */
+public final class ValuesDoubleRangeAggregatorFunction implements AggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("values", ElementType.DOUBLE_RANGE)  );
+
+  private final DriverContext driverContext;
+
+  private final ValuesDoubleRangeAggregator.SingleState state;
+
+  private final List<Integer> channels;
+
+  ValuesDoubleRangeAggregatorFunction(DriverContext driverContext, List<Integer> channels) {
+    this.driverContext = driverContext;
+    this.channels = channels;
+    this.state = ValuesDoubleRangeAggregator.initSingle(driverContext);
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.allFalse()) {
+      // Entire page masked away
+    } else if (mask.allTrue()) {
+      addRawInputNotMasked(page);
+    } else {
+      addRawInputMasked(page, mask);
+    }
+  }
+
+  private void addRawInputMasked(Page page, BooleanVector mask) {
+    DoubleRangeBlock valueBlock = page.getBlock(channels.get(0));
+    if (valueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    addRawBlock(valueBlock, mask);
+  }
+
+  private void addRawInputNotMasked(Page page) {
+    DoubleRangeBlock valueBlock = page.getBlock(channels.get(0));
+    if (valueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    addRawBlock(valueBlock);
+  }
+
+  private void addRawBlock(DoubleRangeBlock valueBlock) {
+    DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int p = 0; p < valueBlock.getPositionCount(); p++) {
+      int valueValueCount = valueBlock.getValueCount(p);
+      if (valueValueCount == 0) {
+        continue;
+      }
+      int valueStart = valueBlock.getFirstValueIndex(p);
+      int valueEnd = valueStart + valueValueCount;
+      for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+        DoubleRangeBlockBuilder.DoubleRange valueValue = valueBlock.getDoubleRange(valueOffset, valueScratch);
+        ValuesDoubleRangeAggregator.combine(state, valueValue);
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleRangeBlock valueBlock, BooleanVector mask) {
+    DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int p = 0; p < valueBlock.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
+      int valueValueCount = valueBlock.getValueCount(p);
+      if (valueValueCount == 0) {
+        continue;
+      }
+      int valueStart = valueBlock.getFirstValueIndex(p);
+      int valueEnd = valueStart + valueValueCount;
+      for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+        DoubleRangeBlockBuilder.DoubleRange valueValue = valueBlock.getDoubleRange(valueOffset, valueScratch);
+        ValuesDoubleRangeAggregator.combine(state, valueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(Page page) {
+    assert channels.size() == intermediateBlockCount();
+    assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
+    Block valuesUncast = page.getBlock(channels.get(0));
+    if (valuesUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleRangeBlock values = (DoubleRangeBlock) valuesUncast;
+    assert values.getPositionCount() == 1;
+    DoubleRangeBlockBuilder.DoubleRange valuesScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    ValuesDoubleRangeAggregator.combineIntermediate(state, values);
+  }
+
+  @Override
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+    state.toIntermediate(blocks, offset, driverContext);
+  }
+
+  @Override
+  public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+    blocks[offset] = ValuesDoubleRangeAggregator.evaluateFinal(state, driverContext);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregatorFunctionSupplier.java
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link AggregatorFunctionSupplier} implementation for {@link ValuesDoubleRangeAggregator}.
+ * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
+ */
+public final class ValuesDoubleRangeAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  public ValuesDoubleRangeAggregatorFunctionSupplier() {
+  }
+
+  @Override
+  public List<IntermediateStateDesc> nonGroupingIntermediateStateDesc() {
+    return ValuesDoubleRangeAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public List<IntermediateStateDesc> groupingIntermediateStateDesc() {
+    return ValuesDoubleRangeGroupingAggregatorFunction.intermediateStateDesc();
+  }
+
+  @Override
+  public ValuesDoubleRangeAggregatorFunction aggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ValuesDoubleRangeAggregatorFunction(driverContext, channels);
+  }
+
+  @Override
+  public ValuesDoubleRangeGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
+      List<Integer> channels) {
+    return new ValuesDoubleRangeGroupingAggregatorFunction(channels, driverContext);
+  }
+
+  @Override
+  public String describe() {
+    return "values_double of ranges";
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleRangeGroupingAggregatorFunction.java
@@ -1,0 +1,286 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.compute.aggregation;
+
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.List;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link GroupingAggregatorFunction} implementation for {@link ValuesDoubleRangeAggregator}.
+ * This class is generated. Edit {@code GroupingAggregatorImplementer} instead.
+ */
+public final class ValuesDoubleRangeGroupingAggregatorFunction implements GroupingAggregatorFunction {
+  private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+      new IntermediateStateDesc("values", ElementType.DOUBLE_RANGE)  );
+
+  private final ValuesDoubleRangeAggregator.GroupingState state;
+
+  private final List<Integer> channels;
+
+  private final DriverContext driverContext;
+
+  ValuesDoubleRangeGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext) {
+    this.channels = channels;
+    this.state = ValuesDoubleRangeAggregator.initGrouping(driverContext);
+    this.driverContext = driverContext;
+  }
+
+  public static List<IntermediateStateDesc> intermediateStateDesc() {
+    return INTERMEDIATE_STATE_DESC;
+  }
+
+  @Override
+  public int intermediateBlockCount() {
+    return INTERMEDIATE_STATE_DESC.size();
+  }
+
+  @Override
+  public GroupingAggregatorFunction.AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds,
+      Page page) {
+    DoubleRangeBlock valueBlock = page.getBlock(channels.get(0));
+    if (valueBlock.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block. But we
+       * still need to track that some groups may not have been seen
+       * so that they are initialized to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+      return null;
+    }
+    maybeEnableGroupIdTracking(seenGroupIds, valueBlock);
+    return new GroupingAggregatorFunction.AddInput() {
+      @Override
+      public void add(int positionOffset, IntArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valueBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntBigArrayBlock groupIds) {
+        addRawInput(positionOffset, groupIds, valueBlock);
+      }
+
+      @Override
+      public void add(int positionOffset, IntVector groupIds) {
+        addRawInput(positionOffset, groupIds, valueBlock);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, DoubleRangeBlock valueBlock) {
+    DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (valueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          DoubleRangeBlockBuilder.DoubleRange valueValue = valueBlock.getDoubleRange(valueOffset, valueScratch);
+          ValuesDoubleRangeAggregator.combine(state, groupId, valueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block valuesUncast = page.getBlock(channels.get(0));
+    if (valuesUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleRangeBlock values = (DoubleRangeBlock) valuesUncast;
+    DoubleRangeBlockBuilder.DoubleRange valuesScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        ValuesDoubleRangeAggregator.combineIntermediate(state, groupId, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups,
+      DoubleRangeBlock valueBlock) {
+    DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      if (valueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          DoubleRangeBlockBuilder.DoubleRange valueValue = valueBlock.getDoubleRange(valueOffset, valueScratch);
+          ValuesDoubleRangeAggregator.combine(state, groupId, valueValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block valuesUncast = page.getBlock(channels.get(0));
+    if (valuesUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleRangeBlock values = (DoubleRangeBlock) valuesUncast;
+    DoubleRangeBlockBuilder.DoubleRange valuesScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valuesPosition = groupPosition + positionOffset;
+        ValuesDoubleRangeAggregator.combineIntermediate(state, groupId, values, valuesPosition);
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, DoubleRangeBlock valueBlock) {
+    DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      if (valueBlock.isNull(valuesPosition)) {
+        continue;
+      }
+      int groupId = groups.getInt(groupPosition);
+      int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+      int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+      for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+        DoubleRangeBlockBuilder.DoubleRange valueValue = valueBlock.getDoubleRange(valueOffset, valueScratch);
+        ValuesDoubleRangeAggregator.combine(state, groupId, valueValue);
+      }
+    }
+  }
+
+  @Override
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+    state.enableGroupIdTracking(new SeenGroupIds.Empty());
+    assert channels.size() == intermediateBlockCount();
+    Block valuesUncast = page.getBlock(channels.get(0));
+    if (valuesUncast.areAllValuesNull()) {
+      /*
+       * All values are null so we can skip processing this block.
+       * NOTE: Microbenchmarks point to long sequences of ConstantNullBlocks
+       *       being fast without this. Likely the branch predictor is kicking
+       *       in there. But we do this anyway, just so we don't have to trust
+       *       it. It's magic. Glorious magic. But it's deep magic. And we won't
+       *       always have long sequences of ConstantNullBlock. And this code
+       *       shows readers we've thought about this.
+       */
+      return;
+    }
+    DoubleRangeBlock values = (DoubleRangeBlock) valuesUncast;
+    DoubleRangeBlockBuilder.DoubleRange valuesScratch = new DoubleRangeBlockBuilder.DoubleRange();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int groupId = groups.getInt(groupPosition);
+      int valuesPosition = groupPosition + positionOffset;
+      ValuesDoubleRangeAggregator.combineIntermediate(state, groupId, values, valuesPosition);
+    }
+  }
+
+  private void maybeEnableGroupIdTracking(SeenGroupIds seenGroupIds, DoubleRangeBlock valueBlock) {
+    if (valueBlock.mayHaveNulls()) {
+      /*
+       * Some values in the block are null so some group ids may not
+       * be seen. We need to track which ones so we can initialize
+       * them to null when we read their values.
+       */
+      state.enableGroupIdTracking(seenGroupIds);
+    }
+  }
+
+  @Override
+  public void selectedMayContainUnseenGroups(SeenGroupIds seenGroupIds) {
+    state.enableGroupIdTracking(seenGroupIds);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+      IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+    return ValuesDoubleRangeAggregator.prepareEvaluateIntermediate(state, selected, ctx);
+  }
+
+  @Override
+  public GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(IntVector selected,
+      GroupingAggregatorEvaluationContext ctx) {
+    return ValuesDoubleRangeAggregator.prepareEvaluateFinal(state, selected, ctx);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName()).append("[");
+    sb.append("channels=").append(channels);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() {
+    state.close();
+  }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesDoubleRangeAggregator.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongLongHashTable;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;
+import org.elasticsearch.compute.ann.Aggregator;
+import org.elasticsearch.compute.ann.GroupingAggregator;
+import org.elasticsearch.compute.ann.IntermediateState;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Aggregates distinct {@code double_range} values.
+ */
+@Aggregator({ @IntermediateState(name = "values", type = "DOUBLE_RANGE_BLOCK") })
+@GroupingAggregator
+class ValuesDoubleRangeAggregator {
+
+    public static SingleState initSingle(DriverContext driverContext) {
+        return new SingleState(driverContext.blockFactory());
+    }
+
+    public static void combine(SingleState state, DoubleRangeBlockBuilder.DoubleRange value) {
+        state.values.add(Double.doubleToLongBits(value.from()), Double.doubleToLongBits(value.to()));
+    }
+
+    public static void combineIntermediate(SingleState state, DoubleRangeBlock values) {
+        DoubleRangeBlockBuilder.DoubleRange scratch = new DoubleRangeBlockBuilder.DoubleRange();
+        int start = values.getFirstValueIndex(0);
+        int end = start + values.getValueCount(0);
+        for (int i = start; i < end; i++) {
+            DoubleRangeBlockBuilder.DoubleRange value = values.getDoubleRange(i, scratch);
+            state.values.add(Double.doubleToLongBits(value.from()), Double.doubleToLongBits(value.to()));
+        }
+    }
+
+    public static Block evaluateFinal(SingleState state, DriverContext driverContext) {
+        return state.toBlock(driverContext.blockFactory());
+    }
+
+    public static GroupingState initGrouping(DriverContext driverContext) {
+        return new GroupingState(driverContext);
+    }
+
+    public static void combine(GroupingState state, int groupId, DoubleRangeBlockBuilder.DoubleRange value) {
+        state.addValue(groupId, value.from(), value.to());
+    }
+
+    public static void combineIntermediate(GroupingState state, int groupId, DoubleRangeBlock values, int valuesPosition) {
+        DoubleRangeBlockBuilder.DoubleRange scratch = new DoubleRangeBlockBuilder.DoubleRange();
+        int start = values.getFirstValueIndex(valuesPosition);
+        int end = start + values.getValueCount(valuesPosition);
+        for (int i = start; i < end; i++) {
+            DoubleRangeBlockBuilder.DoubleRange value = values.getDoubleRange(i, scratch);
+            state.addValue(groupId, value.from(), value.to());
+        }
+    }
+
+    public static GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateIntermediate(
+        GroupingState state,
+        IntVector selected,
+        GroupingAggregatorEvaluationContext context
+    ) {
+        return state.prepareForEmitting(context.blockFactory(), selected);
+    }
+
+    public static GroupingAggregatorFunction.PreparedForEvaluation prepareEvaluateFinal(
+        GroupingState state,
+        IntVector selected,
+        GroupingAggregatorEvaluationContext context
+    ) {
+        return state.prepareForEmitting(context.blockFactory(), selected);
+    }
+
+    public static class SingleState implements AggregatorState {
+        private final LongLongHashTable values;
+
+        private SingleState(BlockFactory blockFactory) {
+            values = HashImplFactory.newLongLongHash(blockFactory);
+        }
+
+        @Override
+        public void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+            blocks[offset] = toBlock(driverContext.blockFactory());
+        }
+
+        Block toBlock(BlockFactory blockFactory) {
+            if (values.size() == 0) {
+                return blockFactory.newConstantNullBlock(1);
+            }
+            try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder((int) values.size())) {
+                if (values.size() > 1) {
+                    builder.beginPositionEntry();
+                }
+                for (long id = 0; id < values.size(); id++) {
+                    builder.appendDoubleRange(Double.longBitsToDouble(values.getKey1(id)), Double.longBitsToDouble(values.getKey2(id)));
+                }
+                if (values.size() > 1) {
+                    builder.endPositionEntry();
+                }
+                return builder.build();
+            }
+        }
+
+        @Override
+        public void close() {
+            values.close();
+        }
+    }
+
+    /**
+     * State for grouped {@code VALUES} over {@code double_range} values.
+     */
+    public static class GroupingState implements GroupingAggregatorState {
+        private final BlockFactory blockFactory;
+        private final BytesRefHash bytes;
+        private IntArray firstValues;
+        private final ValuesNextLong nextValues;
+        private final byte[] encodeBuffer = new byte[16];
+        private final BytesRef encodeScratch = new BytesRef(encodeBuffer, 0, 16);
+
+        private GroupingState(DriverContext driverContext) {
+            blockFactory = driverContext.blockFactory();
+            BytesRefHash newBytes = null;
+            IntArray newFirstValues = null;
+            ValuesNextLong newNextValues = null;
+            boolean success = false;
+            try {
+                newBytes = new BytesRefHash(1, driverContext.bigArrays());
+                newFirstValues = driverContext.bigArrays().newIntArray(1, true);
+                newNextValues = new ValuesNextLong(driverContext.blockFactory());
+                success = true;
+            } finally {
+                if (success == false) {
+                    Releasables.closeExpectNoException(newBytes, newFirstValues, newNextValues);
+                }
+            }
+            bytes = newBytes;
+            firstValues = newFirstValues;
+            nextValues = newNextValues;
+        }
+
+        void addValue(int groupId, double from, double to) {
+            int valueOrdinal = Math.toIntExact(
+                BlockHash.hashOrdToGroup(bytes.add(encode(Double.doubleToLongBits(from), Double.doubleToLongBits(to))))
+            );
+            if (groupId < firstValues.size()) {
+                int current = firstValues.get(groupId) - 1;
+                if (current < 0) {
+                    firstValues.set(groupId, valueOrdinal + 1);
+                } else if (current != valueOrdinal) {
+                    nextValues.add(groupId, valueOrdinal);
+                }
+            } else {
+                firstValues = blockFactory.bigArrays().grow(firstValues, groupId + 1);
+                firstValues.set(groupId, valueOrdinal + 1);
+            }
+        }
+
+        private BytesRef encode(long from, long to) {
+            for (int i = 7; i >= 0; i--) {
+                encodeBuffer[i] = (byte) (from & 0xff);
+                from >>= 8;
+                encodeBuffer[8 + i] = (byte) (to & 0xff);
+                to >>= 8;
+            }
+            return encodeScratch;
+        }
+
+        @Override
+        public void enableGroupIdTracking(SeenGroupIds seenGroupIds) {}
+
+        GroupingAggregatorFunction.PreparedForEvaluation prepareForEmitting(BlockFactory blockFactory, IntVector selected) {
+            return new PreparedForEmitting(selected, blockFactory);
+        }
+
+        private class PreparedForEmitting implements GroupingAggregatorFunction.PreparedForEvaluation {
+            private final BlockFactory blockFactory;
+            private final ValuesNextPreparedForEmitting next;
+
+            private PreparedForEmitting(IntVector selected, BlockFactory blockFactory) {
+                this.blockFactory = blockFactory;
+                next = nextValues.prepareForEmitting(blockFactory, selected);
+            }
+
+            @Override
+            public void evaluate(Block[] blocks, int offset, IntVector selectedInPage) {
+                blocks[offset] = buildOutputBlock(blockFactory, selectedInPage, next);
+            }
+
+            @Override
+            public void close() {
+                next.close();
+            }
+        }
+
+        Block buildOutputBlock(BlockFactory blockFactory, IntVector selected, ValuesNextPreparedForEmitting next) {
+            BytesRef scratch = new BytesRef(16);
+            try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(selected.getPositionCount())) {
+                DoubleRangeBlockBuilder.DoubleRange range = new DoubleRangeBlockBuilder.DoubleRange();
+                for (int s = 0; s < selected.getPositionCount(); s++) {
+                    int group = selected.getInt(s);
+                    int firstValue = group >= firstValues.size() ? -1 : firstValues.get(group) - 1;
+                    if (firstValue < 0) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    int nextValuesStart = next.nextValuesStart(group);
+                    int nextValuesEnd = next.nextValuesEnd(group);
+                    if (nextValuesEnd == nextValuesStart) {
+                        builder.appendDoubleRange(decode(bytes.get(firstValue, scratch), range));
+                    } else {
+                        builder.beginPositionEntry();
+                        builder.appendDoubleRange(decode(bytes.get(firstValue, scratch), range));
+                        for (int i = nextValuesStart; i < nextValuesEnd; i++) {
+                            builder.appendDoubleRange(decode(bytes.get(nextValues.getInt(next, i), scratch), range));
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+                return builder.build();
+            }
+        }
+
+        private static DoubleRangeBlockBuilder.DoubleRange decode(BytesRef encoded, DoubleRangeBlockBuilder.DoubleRange range) {
+            long from = 0;
+            long to = 0;
+            for (int i = 0; i < 8; i++) {
+                from = (from << 8) | (encoded.bytes[encoded.offset + i] & 0xff);
+                to = (to << 8) | (encoded.bytes[encoded.offset + 8 + i] & 0xff);
+            }
+            return range.reset(Double.longBitsToDouble(from), Double.longBitsToDouble(to));
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(bytes, firstValues, nextValues);
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
@@ -853,6 +853,7 @@ public abstract class AbstractAggregationTestCase extends AbstractFunctionTestCa
             case DATETIME, DATE_NANOS, LONG, COUNTER_LONG, UNSIGNED_LONG, GEOHASH, GEOTILE, GEOHEX -> "Long";
             case AGGREGATE_METRIC_DOUBLE -> "AggregateMetricDouble";
             case DATE_RANGE -> "LongRange";
+            case DOUBLE_RANGE -> "DoubleRange";
             case EXPONENTIAL_HISTOGRAM -> "ExponentialHistogram";
             case NULL -> "Null";
             case TDIGEST -> "TDigest";

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
@@ -360,6 +361,20 @@ public final class MultiRowTestCaseSupplier {
         addSuppliers(cases, minRows, maxRows, "random date range", DataType.DATE_RANGE, () -> {
             LongRangeBlockBuilder.LongRange r = TestCaseSupplier.randomDateRange();
             return r;
+        });
+
+        return cases;
+    }
+
+    public static List<TypedDataSupplier> doubleRangeCases(int minRows, int maxRows) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
+        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally() == false) {
+            return cases;
+        }
+
+        addSuppliers(cases, minRows, maxRows, "random double range", DataType.DOUBLE_RANGE, () -> {
+            DoubleRangeBlockBuilder.DoubleRange range = TestCaseSupplier.randomDoubleRange();
+            return range;
         });
 
         return cases;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
@@ -1,5 +1,5 @@
 doubleRangeBlockLoader
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -16,7 +16,7 @@ height_range:double_range | description:keyword
 ;
 
 toRange
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 ROW from = 1.5, to = 2.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -28,7 +28,7 @@ height_range:double_range
 ;
 
 toRangeNullLeft
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 ROW to = 1.5
 | EVAL height_range = TO_RANGE(null, to)
@@ -40,7 +40,7 @@ null
 ;
 
 toRangeNullRight
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 ROW from = 1.5
 | EVAL height_range = TO_RANGE(from, null)
@@ -52,7 +52,7 @@ null
 ;
 
 toRangeInvalidBounds
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 ROW from = 2.5, to = 1.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -66,7 +66,7 @@ null
 ;
 
 toString
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -84,7 +84,7 @@ height_range_string:keyword | description:keyword
 ;
 
 rangeMinMax
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -102,7 +102,7 @@ height_range:double_range | min_bound:double | max_bound:double | description:ke
 ;
 
 rangeMinMaxRoundTrip
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 
 FROM heights
 | WHERE description == "Short"
@@ -115,7 +115,7 @@ height_range:double_range | new_range:double_range
 ;
 
 doubleRangeEquality
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 required_capability: equality_double_range
 
 FROM heights
@@ -128,7 +128,7 @@ Short
 ;
 
 doubleRangeNotEquals
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 required_capability: equality_double_range
 
 FROM heights
@@ -145,7 +145,7 @@ Very Tall
 ;
 
 doubleRangeSelfEquality
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 required_capability: equality_double_range
 
 FROM heights
@@ -164,7 +164,7 @@ Very Tall
 ;
 
 doubleRangeIn
-required_capability: double_range_field_type_development_v5
+required_capability: double_range_field_type_development_v6
 required_capability: equality_double_range
 
 FROM heights
@@ -176,4 +176,85 @@ FROM heights
 description:keyword
 Short
 Tall
+;
+
+mvFirstLastDoubleRange
+required_capability: double_range_field_type_development_v6
+
+FROM heights
+| WHERE description == "Short"
+| EVAL first_range = MV_FIRST(height_range),
+       last_range = MV_LAST(height_range)
+| KEEP first_range, last_range
+;
+
+first_range:double_range | last_range:double_range
+1.5..1.6                 | 1.5..1.6
+;
+
+mvCountDoubleRange
+required_capability: double_range_field_type_development_v6
+
+FROM heights
+| WHERE height_range IS NOT NULL
+| STATS ranges = VALUES(height_range)
+| EVAL count = MV_COUNT(ranges)
+| KEEP count
+;
+
+count:integer
+5
+;
+
+valuesDoubleRange
+required_capability: double_range_field_type_development_v6
+
+FROM heights
+| WHERE height_range IS NOT NULL
+| STATS ranges = VALUES(height_range)
+| EVAL strings = MV_SORT(TO_STRING(ranges))
+| KEEP strings
+;
+
+strings:keyword
+[0.0..1.5, 1.5..1.6, 1.6..1.8, 1.8..2.0, 2.0..5.0]
+;
+
+valuesDoubleRangeGrouped
+required_capability: double_range_field_type_development_v6
+
+FROM heights
+| WHERE height_range IS NOT NULL
+| EVAL short = description LIKE "*Short*"
+| STATS ranges = VALUES(height_range) BY short
+| EVAL strings = MV_SORT(TO_STRING(ranges))
+| SORT short
+| KEEP strings, short
+;
+
+strings:keyword                  | short:boolean
+[1.6..1.8, 1.8..2.0, 2.0..5.0] | false
+[0.0..1.5, 1.5..1.6]           | true
+;
+
+mvExpandValuesDoubleRangeGrouped
+required_capability: double_range_field_type_development_v6
+
+FROM heights
+| WHERE height_range IS NOT NULL
+| EVAL short = description LIKE "*Short*"
+| STATS ranges = VALUES(height_range) BY short
+| EVAL count = MV_COUNT(ranges)
+| MV_EXPAND ranges
+| EVAL range_string = TO_STRING(ranges)
+| SORT short, range_string
+| KEEP ranges, short, count
+;
+
+ranges:double_range | short:boolean | count:integer
+1.6..1.8            | false         | 3
+1.8..2.0            | false         | 3
+2.0..5.0            | false         | 3
+0.0..1.5            | true          | 2
+1.5..1.6            | true          | 2
 ;

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstDoubleRangeEvaluator.java
@@ -1,0 +1,98 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
+
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link MvFirst}.
+ * This class is generated. Edit {@code MvEvaluatorImplementer} instead.
+ */
+public final class MvFirstDoubleRangeEvaluator extends AbstractMultivalueFunction.AbstractEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(MvFirstDoubleRangeEvaluator.class);
+
+  public MvFirstDoubleRangeEvaluator(ExpressionEvaluator field, DriverContext driverContext) {
+    super(driverContext, field);
+  }
+
+  @Override
+  public String name() {
+    return "MvFirst";
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
+  @Override
+  public Block evalNullable(Block fieldVal) {
+    DoubleRangeBlock v = (DoubleRangeBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = v.getValueCount(p);
+        if (valueCount == 0) {
+          builder.appendNull();
+          continue;
+        }
+        int first = v.getFirstValueIndex(p);
+        int end = first + valueCount;
+        DoubleRangeBlockBuilder.DoubleRange result = MvFirst.process(v, first, end, valueScratch);
+        builder.appendDoubleRange(result);
+      }
+      return builder.build();
+    }
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
+  @Override
+  public Block evalNotNullable(Block fieldVal) {
+    DoubleRangeBlock v = (DoubleRangeBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = v.getValueCount(p);
+        int first = v.getFirstValueIndex(p);
+        int end = first + valueCount;
+        DoubleRangeBlockBuilder.DoubleRange result = MvFirst.process(v, first, end, valueScratch);
+        builder.appendDoubleRange(result);
+      }
+      return builder.build();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    return BASE_RAM_BYTES_USED + field.baseRamBytesUsed();
+  }
+
+  public static class Factory implements ExpressionEvaluator.Factory {
+    private final ExpressionEvaluator.Factory field;
+
+    public Factory(ExpressionEvaluator.Factory field) {
+      this.field = field;
+    }
+
+    @Override
+    public MvFirstDoubleRangeEvaluator get(DriverContext context) {
+      return new MvFirstDoubleRangeEvaluator(field.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "MvFirst[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastDoubleRangeEvaluator.java
@@ -1,0 +1,98 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
+
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link MvLast}.
+ * This class is generated. Edit {@code MvEvaluatorImplementer} instead.
+ */
+public final class MvLastDoubleRangeEvaluator extends AbstractMultivalueFunction.AbstractEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(MvLastDoubleRangeEvaluator.class);
+
+  public MvLastDoubleRangeEvaluator(ExpressionEvaluator field, DriverContext driverContext) {
+    super(driverContext, field);
+  }
+
+  @Override
+  public String name() {
+    return "MvLast";
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
+  @Override
+  public Block evalNullable(Block fieldVal) {
+    DoubleRangeBlock v = (DoubleRangeBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = v.getValueCount(p);
+        if (valueCount == 0) {
+          builder.appendNull();
+          continue;
+        }
+        int first = v.getFirstValueIndex(p);
+        int end = first + valueCount;
+        DoubleRangeBlockBuilder.DoubleRange result = MvLast.process(v, first, end, valueScratch);
+        builder.appendDoubleRange(result);
+      }
+      return builder.build();
+    }
+  }
+
+  /**
+   * Evaluate blocks containing at least one multivalued field.
+   */
+  @Override
+  public Block evalNotNullable(Block fieldVal) {
+    DoubleRangeBlock v = (DoubleRangeBlock) fieldVal;
+    int positionCount = v.getPositionCount();
+    try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = v.getValueCount(p);
+        int first = v.getFirstValueIndex(p);
+        int end = first + valueCount;
+        DoubleRangeBlockBuilder.DoubleRange result = MvLast.process(v, first, end, valueScratch);
+        builder.appendDoubleRange(result);
+      }
+      return builder.build();
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    return BASE_RAM_BYTES_USED + field.baseRamBytesUsed();
+  }
+
+  public static class Factory implements ExpressionEvaluator.Factory {
+    private final ExpressionEvaluator.Factory field;
+
+    public Factory(ExpressionEvaluator.Factory field) {
+      this.field = field;
+    }
+
+    @Override
+    public MvLastDoubleRangeEvaluator get(DriverContext context) {
+      return new MvLastDoubleRangeEvaluator(field.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "MvLast[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2142,7 +2142,7 @@ public class EsqlCapabilities {
         /**
          * Support for the DOUBLE_RANGE field type.
          */
-        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5(Build.current().isSnapshot()),
+        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6(Build.current().isSnapshot()),
 
         /**
          * Network direction function.
@@ -3385,7 +3385,7 @@ public class EsqlCapabilities {
         /**
          * Support for equality ({@code ==}, {@code !=}) and {@code IN} with the {@code double_range} type.
          */
-        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5.isEnabled()),
+        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled()),
 
         /**
          * Fix TopN encoding/decoding of {@code long_range} values.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Values.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Values.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesBooleanAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesBytesRefAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesDoubleAggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.ValuesDoubleRangeAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesLongAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.ValuesLongRangeAggregatorFunctionSupplier;
@@ -68,7 +69,8 @@ public class Values extends AggregateFunction implements ToAggregator {
         Map.entry(DataType.GEOTILE, ValuesLongAggregatorFunctionSupplier::new),
         Map.entry(DataType.GEOHEX, ValuesLongAggregatorFunctionSupplier::new),
         Map.entry(DataType.BOOLEAN, ValuesBooleanAggregatorFunctionSupplier::new),
-        Map.entry(DataType.DATE_RANGE, ValuesLongRangeAggregatorFunctionSupplier::new)
+        Map.entry(DataType.DATE_RANGE, ValuesLongRangeAggregatorFunctionSupplier::new),
+        Map.entry(DataType.DOUBLE_RANGE, ValuesDoubleRangeAggregatorFunctionSupplier::new)
     );
 
     @FunctionInfo(
@@ -80,6 +82,7 @@ public class Values extends AggregateFunction implements ToAggregator {
             "date_nanos",
             "date_range",
             "double",
+            "double_range",
             "flattened",
             "geo_point",
             "geo_shape",
@@ -127,6 +130,7 @@ public class Values extends AggregateFunction implements ToAggregator {
                 "date_nanos",
                 "date_range",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCount.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCount.java
@@ -61,6 +61,7 @@ public class MvCount extends AbstractMultivalueFunction implements AnyNullIsNull
                 "date_nanos",
                 "date_range",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirst.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirst.java
@@ -14,6 +14,8 @@ import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongRangeBlock;
@@ -61,6 +63,7 @@ public class MvFirst extends AbstractMultivalueFunction implements AnyNullIsNull
             "date_nanos",
             "date_range",
             "double",
+            "double_range",
             "flattened",
             "geo_point",
             "geo_shape",
@@ -98,6 +101,7 @@ public class MvFirst extends AbstractMultivalueFunction implements AnyNullIsNull
                 "date_nanos",
                 "date_range",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",
@@ -148,6 +152,7 @@ public class MvFirst extends AbstractMultivalueFunction implements AnyNullIsNull
             case BOOLEAN -> new MvFirstBooleanEvaluator.Factory(fieldEval);
             case BYTES_REF -> new MvFirstBytesRefEvaluator.Factory(fieldEval);
             case DOUBLE -> new MvFirstDoubleEvaluator.Factory(fieldEval);
+            case DOUBLE_RANGE -> new MvFirstDoubleRangeEvaluator.Factory(fieldEval);
             case INT -> new MvFirstIntEvaluator.Factory(fieldEval);
             case LONG -> new MvFirstLongEvaluator.Factory(fieldEval);
             case LONG_RANGE -> new MvFirstLongRangeEvaluator.Factory(fieldEval);
@@ -194,5 +199,15 @@ public class MvFirst extends AbstractMultivalueFunction implements AnyNullIsNull
     @MvEvaluator(extraName = "LongRange")
     static LongRangeBlockBuilder.LongRange process(LongRangeBlock block, int start, int end, LongRangeBlockBuilder.LongRange scratch) {
         return block.getLongRange(start, scratch);
+    }
+
+    @MvEvaluator(extraName = "DoubleRange")
+    static DoubleRangeBlockBuilder.DoubleRange process(
+        DoubleRangeBlock block,
+        int start,
+        int end,
+        DoubleRangeBlockBuilder.DoubleRange scratch
+    ) {
+        return block.getDoubleRange(start, scratch);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLast.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLast.java
@@ -14,6 +14,8 @@ import org.elasticsearch.compute.ann.MvEvaluator;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongRangeBlock;
@@ -61,6 +63,7 @@ public class MvLast extends AbstractMultivalueFunction implements AnyNullIsNull 
             "date_nanos",
             "date_range",
             "double",
+            "double_range",
             "flattened",
             "geo_point",
             "geo_shape",
@@ -98,6 +101,7 @@ public class MvLast extends AbstractMultivalueFunction implements AnyNullIsNull 
                 "date_nanos",
                 "date_range",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",
@@ -148,6 +152,7 @@ public class MvLast extends AbstractMultivalueFunction implements AnyNullIsNull 
             case BOOLEAN -> new MvLastBooleanEvaluator.Factory(fieldEval);
             case BYTES_REF -> new MvLastBytesRefEvaluator.Factory(fieldEval);
             case DOUBLE -> new MvLastDoubleEvaluator.Factory(fieldEval);
+            case DOUBLE_RANGE -> new MvLastDoubleRangeEvaluator.Factory(fieldEval);
             case INT -> new MvLastIntEvaluator.Factory(fieldEval);
             case LONG -> new MvLastLongEvaluator.Factory(fieldEval);
             case LONG_RANGE -> new MvLastLongRangeEvaluator.Factory(fieldEval);
@@ -194,5 +199,15 @@ public class MvLast extends AbstractMultivalueFunction implements AnyNullIsNull 
     @MvEvaluator(extraName = "LongRange")
     static LongRangeBlockBuilder.LongRange process(LongRangeBlock block, int start, int end, LongRangeBlockBuilder.LongRange scratch) {
         return block.getLongRange(end - 1, scratch);
+    }
+
+    @MvEvaluator(extraName = "DoubleRange")
+    static DoubleRangeBlockBuilder.DoubleRange process(
+        DoubleRangeBlock block,
+        int start,
+        int end,
+        DoubleRangeBlockBuilder.DoubleRange scratch
+    ) {
+        return block.getDoubleRange(end - 1, scratch);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -115,10 +115,10 @@ public final class AggregateMapper {
             case EXPONENTIAL_HISTOGRAM -> DataType.EXPONENTIAL_HISTOGRAM;
             case TDIGEST -> DataType.TDIGEST;
             case LONG_RANGE -> DataType.DATE_RANGE;
+            case DOUBLE_RANGE -> DataType.DOUBLE_RANGE;
             // Dense vectors are internally represented as float blocks
             case FLOAT -> DataType.DENSE_VECTOR;
-            // TODO: DOUBLE_RANGE support
-            case NULL, COMPOSITE, AGGREGATE_METRIC_DOUBLE, DOUBLE_RANGE, UNKNOWN -> throw new EsqlIllegalArgumentException(
+            case NULL, COMPOSITE, AGGREGATE_METRIC_DOUBLE, UNKNOWN -> throw new EsqlIllegalArgumentException(
                 "unsupported agg type: " + elementType
             );
         };

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1628,7 +1628,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testDoubleRangeUnsupportedOperations() {
-        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V5.isEnabled());
+        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled());
         analyzer().addIndex("heights", "mapping-heights.json")
             .stripErrorPrefix(true)
             .error("FROM heights | SORT height_range", containsString("cannot sort on double_range"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -45,6 +46,10 @@ public class ValuesTests extends AbstractAggregationTestCase {
     public static Iterable<Object[]> parameters() {
         var suppliers = new ArrayList<TestCaseSupplier>();
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
+        FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled()
+            ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(doubleRangeAppliesTo)).toList()
+            : List.of();
 
         Stream.of(
             MultiRowTestCaseSupplier.intCases(1, 1000, Integer.MIN_VALUE, Integer.MAX_VALUE, true),
@@ -54,6 +59,7 @@ public class ValuesTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
+            doubleRangeCases,
             MultiRowTestCaseSupplier.booleanCases(1, 1000),
             MultiRowTestCaseSupplier.ipCases(1, 1000),
             MultiRowTestCaseSupplier.versionCases(1, 1000),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
@@ -10,7 +10,9 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -44,6 +46,9 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
         dateTimes(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateNanos(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateRanges(cases);
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled()) {
+            doubleRanges(cases);
+        }
         geoPoints(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         cartesianPoints(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         geoShape(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
@@ -82,6 +87,28 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
                 "MvCount[field=Attribute[channel=0]]",
                 DataType.INTEGER,
                 equalTo(mvData.size())
+            );
+        }));
+    }
+
+    private static void doubleRanges(List<TestCaseSupplier> cases) {
+        FunctionAppliesTo appliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+        cases.add(new TestCaseSupplier("mv_count(double_range)", List.of(DataType.DOUBLE_RANGE), () -> {
+            DoubleRangeBlockBuilder.DoubleRange value = TestCaseSupplier.randomDoubleRange();
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(List.of(value), DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvCount[field=Attribute[channel=0]]",
+                DataType.INTEGER,
+                equalTo(1)
+            );
+        }));
+        cases.add(new TestCaseSupplier("mv_count(<double_ranges>)", List.of(DataType.DOUBLE_RANGE), () -> {
+            List<DoubleRangeBlockBuilder.DoubleRange> values = randomList(1, 10, TestCaseSupplier::randomDoubleRange);
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(values, DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvCount[field=Attribute[channel=0]]",
+                DataType.INTEGER,
+                equalTo(values.size())
             );
         }));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -54,6 +55,9 @@ public class MvFirstTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled()) {
+            doubleRanges(cases);
+        }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);
     }
 
@@ -74,6 +78,28 @@ public class MvFirstTests extends AbstractMultivalueFunctionTestCase {
                 List.of(new TestCaseSupplier.TypedData(values, DataType.DATE_RANGE, "field").withAppliesTo(dateRangeAppliesTo)),
                 "MvFirst[field=Attribute[channel=0]]",
                 DataType.DATE_RANGE,
+                equalTo(values.get(0))
+            );
+        }));
+    }
+
+    private static void doubleRanges(List<TestCaseSupplier> cases) {
+        FunctionAppliesTo appliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+        cases.add(new TestCaseSupplier("mv_first(double_range)", List.of(DataType.DOUBLE_RANGE), () -> {
+            DoubleRangeBlockBuilder.DoubleRange value = TestCaseSupplier.randomDoubleRange();
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(List.of(value), DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvFirst[field=Attribute[channel=0]]",
+                DataType.DOUBLE_RANGE,
+                equalTo(value)
+            );
+        }));
+        cases.add(new TestCaseSupplier("mv_first(double_ranges)", List.of(DataType.DOUBLE_RANGE), () -> {
+            List<DoubleRangeBlockBuilder.DoubleRange> values = randomList(1, 10, TestCaseSupplier::randomDoubleRange);
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(values, DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvFirst[field=Attribute[channel=0]]",
+                DataType.DOUBLE_RANGE,
                 equalTo(values.get(0))
             );
         }));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -54,6 +55,9 @@ public class MvLastTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V6.isEnabled()) {
+            doubleRanges(cases);
+        }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);
     }
 
@@ -74,6 +78,28 @@ public class MvLastTests extends AbstractMultivalueFunctionTestCase {
                 List.of(new TestCaseSupplier.TypedData(values, DataType.DATE_RANGE, "field").withAppliesTo(dateRangeAppliesTo)),
                 "MvLast[field=Attribute[channel=0]]",
                 DataType.DATE_RANGE,
+                equalTo(values.get(values.size() - 1))
+            );
+        }));
+    }
+
+    private static void doubleRanges(List<TestCaseSupplier> cases) {
+        FunctionAppliesTo appliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+        cases.add(new TestCaseSupplier("mv_last(double_range)", List.of(DataType.DOUBLE_RANGE), () -> {
+            DoubleRangeBlockBuilder.DoubleRange value = TestCaseSupplier.randomDoubleRange();
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(List.of(value), DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvLast[field=Attribute[channel=0]]",
+                DataType.DOUBLE_RANGE,
+                equalTo(value)
+            );
+        }));
+        cases.add(new TestCaseSupplier("mv_last(double_ranges)", List.of(DataType.DOUBLE_RANGE), () -> {
+            List<DoubleRangeBlockBuilder.DoubleRange> values = randomList(1, 10, TestCaseSupplier::randomDoubleRange);
+            return new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(values, DataType.DOUBLE_RANGE, "field").withAppliesTo(appliesTo)),
+                "MvLast[field=Attribute[channel=0]]",
+                DataType.DOUBLE_RANGE,
                 equalTo(values.get(values.size() - 1))
             );
         }));


### PR DESCRIPTION
Part of #154463.

Adds support for `double_range` in the required `MV_` functions according to our AI-skill for ranges: `MV_FIRST`, `MV_LAST` and `MV_COUNT` and the `VALUES` aggregation.

The `MV_` functions are trivial, `VALUES` comes with a hand (or rather AI) written, custom aggregator.
This aggregation is very much a copy of the variant for `LongRange`, but uses doubles by converting them to `Double.toRawLongBits` first.