### PR TITLE
[9.5] Adding ensureGreen check in RankEvalRequestIT to ensure all indices are available (#154681)

### DIFF
--- a/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
@@ -58,6 +58,9 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         prepareIndex(TEST_INDEX).setId("6").setSource("id", 6, "text", "amsterdam", "population", 851573).get();
 
         // add another index for testing closed indices etc...
+        createIndex("test2");
+        ensureGreen();
+
         prepareIndex("test2").setId("7").setSource("id", 7, "text", "amsterdam", "population", 851573).get();
         refresh();
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -778,9 +778,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:mv_union.testMvUnionNullReturnedWhenFirstArgIsNull}
   issue: https://github.com/elastic/elasticsearch/issues/155707
-- class: org.elasticsearch.index.rankeval.RankEvalRequestIT
-  method: testIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/155708
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldSourceOnlyRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/155541


### PR DESCRIPTION
backport of https://github.com/elastic/elasticsearch/pull/154681

closes https://github.com/elastic/elasticsearch/issues/155708