### PR TITLE
[8.19] Fix for index.auto_expand_replicas takes priority over ILM "Set Replicas" option [#150407] (#155279)

### DIFF
--- a/docs/changelog/155279.yaml
+++ b/docs/changelog/155279.yaml
@@ -1,0 +1,36 @@
+area: ILM
+breaking:
+  area: ILM
+  details: >-
+    When `number_of_replicas` is specified in the ILM `allocate` action, the
+    `auto_expand_replicas` setting is now explicitly removed from the index.
+    Previously, a pre-existing `auto_expand_replicas` setting would remain and
+    override the configured `number_of_replicas`, causing the action to have no
+    effect on the replica count.
+  impact: >-
+    Indices that have `auto_expand_replicas` set and pass through an ILM
+    `allocate` action with `number_of_replicas` configured will have
+    `auto_expand_replicas` removed. If you rely on `auto_expand_replicas`
+    continuing to take effect after the `allocate` action, remove the
+    `number_of_replicas` setting from that action.
+  notable: false
+  title: ILM allocate action now removes auto_expand_replicas when number_of_replicas is set
+issues:
+  - 150407
+pr: 155279
+summary: >-
+  When `number_of_replicas` is specified in the ILM `allocate` action,
+  `auto_expand_replicas` is now explicitly removed from the index settings.
+
+  Previously, if an index had `auto_expand_replicas` configured, this setting
+  would remain in place even after the `allocate` action ran, overriding the
+  specified `number_of_replicas` and causing the action to have no effect on
+  the actual replica count.
+
+  With this change, specifying `number_of_replicas` in an `allocate` action
+  will always take effect by also clearing `auto_expand_replicas`.
+
+  If you want `auto_expand_replicas` to continue taking effect after the
+  `allocate` action runs, remove the `number_of_replicas` setting from that
+  action.
+type: "breaking"

--- a/docs/changelog/155279.yaml
+++ b/docs/changelog/155279.yaml
@@ -1,6 +1,6 @@
 area: ILM
 breaking:
-  area: ILM
+  area: Index setting
   details: >-
     When `number_of_replicas` is specified in the ILM `allocate` action, the
     `auto_expand_replicas` setting is now explicitly removed from the index.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
@@ -190,6 +190,7 @@ public class AllocateAction implements LifecycleAction {
         Settings.Builder newSettings = Settings.builder();
         if (numberOfReplicas != null) {
             newSettings.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas);
+            newSettings.putNull(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS);
         }
         include.forEach((key, value) -> newSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + key, value));
         exclude.forEach((key, value) -> newSettings.put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + key, value));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocateActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
@@ -175,6 +176,7 @@ public class AllocateActionTests extends AbstractActionTestCase<AllocateAction> 
         Settings.Builder expectedSettings = Settings.builder();
         if (action.getNumberOfReplicas() != null) {
             expectedSettings.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, action.getNumberOfReplicas());
+            expectedSettings.putNull(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS);
         }
         action.getInclude()
             .forEach((key, value) -> expectedSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + key, value));
@@ -215,6 +217,46 @@ public class AllocateActionTests extends AbstractActionTestCase<AllocateAction> 
         // allow an allocate action that only specifies total shards per node (don't expect any exceptions in this case)
         action = new AllocateAction(null, 5, null, null, null);
         assertThat(action.getTotalShardsPerNode(), is(5));
+    }
+
+    public void testAutoExpandReplicasRemovedWhenReplicasSet() {
+        Integer numberOfReplicas = randomIntBetween(0, 4);
+        AllocateAction action = new AllocateAction(numberOfReplicas, null, null, null, null);
+        Settings actualSettings = allocateActionSettings(action);
+        assertThat(actualSettings.get(IndexMetadata.SETTING_NUMBER_OF_REPLICAS), is(String.valueOf(numberOfReplicas)));
+        assertTrue(
+            "auto_expand_replicas must be present as null to remove it",
+            actualSettings.keySet().contains(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)
+        );
+        assertNull(actualSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS));
+    }
+
+    public void testAutoExpandReplicasNotTouchedWhenReplicasNotSet() {
+        AllocateAction action = new AllocateAction(null, 5, null, null, null);
+        Settings actualSettings = allocateActionSettings(action);
+        assertFalse(
+            "auto_expand_replicas must not be included when no replica count is specified",
+            actualSettings.keySet().contains(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)
+        );
+    }
+
+    private Settings allocateActionSettings(AllocateAction action) {
+        String phase = randomAlphaOfLengthBetween(1, 10);
+        StepKey nextStepKey = new StepKey(
+            randomAlphaOfLengthBetween(1, 10),
+            randomAlphaOfLengthBetween(1, 10),
+            randomAlphaOfLengthBetween(1, 10)
+        );
+        List<Step> steps = action.toSteps(null, phase, nextStepKey);
+        UpdateSettingsStep updateSettingsStep = steps.stream()
+            .filter(s -> s instanceof UpdateSettingsStep)
+            .map(s -> (UpdateSettingsStep) s)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no UpdateSettingsStep found in steps returned by AllocateAction#toSteps"));
+        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
+            .settings(indexSettings(IndexVersionUtils.randomCompatibleVersion(), 1, 0))
+            .build();
+        return updateSettingsStep.getSettingsSupplier().apply(indexMetadata);
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocateActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocateActionTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
@@ -253,10 +252,7 @@ public class AllocateActionTests extends AbstractActionTestCase<AllocateAction> 
             .map(s -> (UpdateSettingsStep) s)
             .findFirst()
             .orElseThrow(() -> new AssertionError("no UpdateSettingsStep found in steps returned by AllocateAction#toSteps"));
-        IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
-            .settings(indexSettings(IndexVersionUtils.randomCompatibleVersion(), 1, 0))
-            .build();
-        return updateSettingsStep.getSettingsSupplier().apply(indexMetadata);
+        return updateSettingsStep.getSettings();
     }
 
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -253,6 +253,31 @@ public class TimeSeriesLifecycleActionsIT extends IlmESRestTestCase {
         });
     }
 
+    public void testAllocateActionRemovesAutoExpandReplicas() throws Exception {
+        createIndexWithSettings(
+            client(),
+            index,
+            alias,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+        );
+        AllocateAction allocateAction = new AllocateAction(0, null, null, null, null);
+        String endPhase = randomFrom("warm", "cold");
+        createNewSingletonPolicy(client(), policy, endPhase, allocateAction);
+        updatePolicy(client(), index, policy);
+        assertBusy(() -> {
+            Map<String, Object> settings = getOnlyIndexSettings(client(), index);
+            assertThat(getStepKeyForIndex(client(), index), equalTo(PhaseCompleteStep.finalStep(endPhase).getKey()));
+            assertThat(settings.get(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey()), equalTo("0"));
+            assertNull(
+                "auto_expand_replicas must be removed when an explicit replica count is set by the allocate action",
+                settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)
+            );
+        });
+    }
+
     @SuppressWarnings("unchecked")
     public void testWaitForSnapshot() throws Exception {
         createIndexWithSettings(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix for index.auto_expand_replicas takes priority over ILM "Set Replicas" option [#150407] (#155279)](https://github.com/elastic/elasticsearch/pull/155279)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)