### PR TITLE
[CI] SnapshotLifecycleRestIT testSnapshotRetentionWithMissingRepo failing [#154353]

### DIFF
--- a/x-pack/plugin/slm/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/slm/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleStats;
 import org.elasticsearch.xpack.core.slm.SnapshotRetentionConfiguration;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -103,6 +104,17 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
+    }
+
+    /**
+     * Several tests here create a snapshot with a retention period of 1ms and then assert that the snapshot exists before triggering
+     * retention themselves. SLM retention otherwise runs on a default schedule of 01:30 node-local time, which would delete such a
+     * snapshot the moment it fires, so any test straddling that instant would fail. Pin the schedule to a cron that never fires;
+     * tests that need retention to run on a schedule override this setting themselves.
+     */
+    @Before
+    public void disableScheduledSLMRetention() throws IOException {
+        updatePersistentSetting(LifecycleSettings.SLM_RETENTION_SCHEDULE, NEVER_EXECUTE_CRON_SCHEDULE);
     }
 
     public void testMissingRepo() throws Exception {
@@ -465,15 +477,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         }, 60, TimeUnit.SECONDS);
 
         // Run retention every second
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
-        req.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_RETENTION_SCHEDULE, "*/1 * * * * ?"));
-        try (XContentBuilder builder = jsonBuilder()) {
-            req.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            Request r = new Request("PUT", "/_cluster/settings");
-            r.setJsonEntity(Strings.toString(builder));
-            Response updateSettingsResp = client().performRequest(r);
-            assertAcked(updateSettingsResp);
-        }
+        updatePersistentSetting(LifecycleSettings.SLM_RETENTION_SCHEDULE, "*/1 * * * * ?");
 
         logSLMPolicies();
 
@@ -506,15 +510,8 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
             }, 60, TimeUnit.SECONDS);
 
         } finally {
-            // Unset retention
-            ClusterUpdateSettingsRequest unsetRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
-            unsetRequest.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_RETENTION_SCHEDULE, (String) null));
-            try (XContentBuilder builder = jsonBuilder()) {
-                unsetRequest.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                Request r = new Request("PUT", "/_cluster/settings");
-                r.setJsonEntity(Strings.toString(builder));
-                client().performRequest(r);
-            }
+            // Stop running retention on a schedule again
+            updatePersistentSetting(LifecycleSettings.SLM_RETENTION_SCHEDULE, NEVER_EXECUTE_CRON_SCHEDULE);
         }
     }
 
@@ -928,14 +925,17 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
     }
 
     private void disableSLMMinimumIntervalValidation() throws IOException {
+        updatePersistentSetting(LifecycleSettings.SLM_MINIMUM_INTERVAL, "0s");
+    }
+
+    private void updatePersistentSetting(String setting, String value) throws IOException {
         ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
-        req.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_MINIMUM_INTERVAL, "0s"));
+        req.persistentSettings(Settings.builder().put(setting, value));
         try (XContentBuilder builder = jsonBuilder()) {
             req.toXContent(builder, ToXContent.EMPTY_PARAMS);
             Request r = new Request("PUT", "/_cluster/settings");
             r.setJsonEntity(Strings.toString(builder));
-            Response updateSettingsResp = client().performRequest(r);
-            assertAcked(updateSettingsResp);
+            assertAcked(client().performRequest(r));
         }
     }
 


### PR DESCRIPTION
`testSnapshotRetentionWithMissingRepo` and `testBasicTimeBasedRetention` create an SLM policy with `expire_after: 1ms` and no `min_count`, execute it, then assert the snapshot exists before triggering retention themselves. With `min_count` unset nothing protects the last remaining snapshot, so it is deletable a millisecond after it is taken — and retention doesn't only run when the test asks. `slm.retention_schedule` defaults to 01:30 in the *node's* local timezone, which the node inherits from the randomized `-Dtests.timezone`. When that scheduled run lands between the policy execution and the assertion it deletes the snapshot; the policy's own cron never fires, so nothing recreates it and `assertBusy` spins for its full 60 seconds before reporting `snapshot_missing_exception`. All seven historical failures with this signature occurred at 01:29:5x, across seven unrelated timezones.

A `@Before` hook now pins `slm.retention_schedule` to the never-firing cron already defined in this file, so retention only runs when a test triggers it explicitly. It is applied as a persistent cluster setting rather than on the cluster spec because the framework writes `elasticsearch.yml` values unquoted and a cron starting with `*` is a YAML alias that breaks node startup; and per-test because `wipeCluster` clears persistent settings between tests. `testBasicTimeBasedRetention` still sets its own one-second schedule, now restoring the never-fire value instead of unsetting it, which previously fell back to the flaky default. 

ℹ️ Will need an unmute on the 9.5 branch

Fixes #154353