### PR TITLE
Mute ES|QL stats_sample spatial tests on 9.5

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -784,3 +784,15 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldSourceOnlyRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/155541
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample geo_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample cartesian_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample geo_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample cartesian_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536


### PR DESCRIPTION
The 9.5 backport of #154417 (#155536) has not landed, so 9.5 still allows
spatial types in `MV_SORT` while its BWC counterparts 8.19.20 and 9.4.5
reject them. `bwc-snapshots` Part 3 fails on every 9.5 PR as a result.
Mutes the two affected `stats_sample` csv-spec cases in both the CCQ and
mixed-cluster spec suites. 

These can be unmuted once #155536 merges.