### PR TITLE
Expand FFM process annotation task to include test source sets

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPluginFuncTest.groovy
@@ -90,8 +90,17 @@ class ForeignLibraryPluginFuncTest extends AbstractGradleInternalPluginFuncTest 
             public class Lib {}
         """.stripIndent()
 
+        file('src/testFixtures/java/test/FixtureLib.java') << """
+            package test;
+            @fake.Marker
+            public class FixtureLib {}
+        """.stripIndent()
+
         buildFile << """
             apply plugin: 'elasticsearch.foreign-library'
+            // Applied after the plugin, as real consumers do: the testFixtures source set does not exist
+            // when the plugin is applied, so the plugin must register against it lazily.
+            apply plugin: 'java-test-fixtures'
 
             // The plugin pins processForeignAnnotations to JDK 25 because the real processor uses
             // java.lang.classfile (finalized in JDK 24). The dummy processor in this test only uses
@@ -99,7 +108,7 @@ class ForeignLibraryPluginFuncTest extends AbstractGradleInternalPluginFuncTest 
             // runtime, so override the toolchain to the current JVM. The JDK 25 pinning itself is
             // verified by ForeignLibraryPluginSpec — here we just exercise the wiring.
             def currentJavaVersion = JavaVersion.current().majorVersion
-            tasks.named('processForeignAnnotations').configure {
+            tasks.matching { it.name.endsWith('ForeignAnnotations') }.configureEach {
                 javaCompiler = javaToolchains.compilerFor {
                     languageVersion = org.gradle.jvm.toolchain.JavaLanguageVersion.of(currentJavaVersion.toInteger())
                 }
@@ -110,6 +119,7 @@ class ForeignLibraryPluginFuncTest extends AbstractGradleInternalPluginFuncTest 
             dependencies {
                 // compileOnly so the @Marker annotation (SOURCE retention) is visible during compile
                 compileOnly project(':fakeprocessor')
+                testFixturesCompileOnly project(':fakeprocessor')
                 foreignLibraryProcessor project(':fakeprocessor')
             }
         """.stripIndent()
@@ -128,4 +138,14 @@ class ForeignLibraryPluginFuncTest extends AbstractGradleInternalPluginFuncTest 
         file("build/generated-foreign-library-classes/fake-marker.txt").text == "processor ran"
     }
 
+    def "runs the processor against the testFixtures source set too"() {
+        when:
+        def result = gradleRunner('processTestFixturesForeignAnnotations').build()
+
+        then:
+        result.task(":processTestFixturesForeignAnnotations").outcome == TaskOutcome.SUCCESS
+        // Its own output dir, a sibling of main's rather than nested inside it.
+        file("build/generated-foreign-library-classes-testFixtures/fake-marker.txt").text == "processor ran"
+        file("build/generated-foreign-library-classes/fake-marker.txt").exists() == false
+    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
@@ -36,21 +36,17 @@ import javax.inject.Inject;
  * The augment step injects {@code provides org.elasticsearch.foreign.LibraryProvider with ...}
  * directives that reference generated classes the source {@code module-info.java} cannot name.
  *
- * <p>The {@code test} and {@code testFixtures} source sets are processed too, so bindings that only make
- * sense in tests can live next to the tests that use them instead of adding production surface. Those
- * source sets need no {@code module-info.class} augmentation: tests run on the classpath, where
- * {@code ServiceLoader} discovers the generated providers through the {@code META-INF/services} file the
- * annotation processor emits.
+ * <p>All non-main source sets are processed too, so bindings that only make sense in tests
+ * can live next to the tests that use them instead of adding production surface. Those source sets need
+ * no {@code module-info.class} augmentation: tests run on the classpath, where {@code ServiceLoader}
+ * discovers the generated providers through the {@code META-INF/services} file the annotation processor
+ * emits.
  */
 public class ForeignLibraryPlugin implements Plugin<Project> {
 
     private static final JavaLanguageVersion PROCESSOR_TOOLCHAIN = JavaLanguageVersion.of(25);
     private static final String FOREIGN_LIBRARY_PROJECT = ":libs:foreign-library";
     private static final String PROCESSOR_PROJECT = ":libs:foreign-library:processor";
-
-    // Gradle's java-test-fixtures plugin creates the "testFixtures" source set but does not expose its
-    // name as public API, hence the literal.
-    static final List<String> TEST_SOURCE_SET_NAMES = List.of(SourceSet.TEST_SOURCE_SET_NAME, "testFixtures");
 
     static final String PROCESSOR_CONFIGURATION_NAME = "foreignLibraryProcessor";
     static final String PROCESS_ANNOTATIONS_TASK_NAME = "processForeignAnnotations";
@@ -88,9 +84,9 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
 
         swapModuleInfoInJar(project, augmentModuleInfo);
 
-        // Test source sets get the same annotation processing, but no module-info augmentation and no jar
-        // swap: they are non-modular and run on the classpath.
-        sourceSets.matching(sourceSet -> TEST_SOURCE_SET_NAMES.contains(sourceSet.getName())).all(sourceSet -> {
+        // All non-main source sets get the same annotation processing, but no module-info augmentation
+        // and no jar swap: they are non-modular and run on the classpath.
+        sourceSets.matching(sourceSet -> SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName()) == false).all(sourceSet -> {
             TaskProvider<JavaCompile> task = registerProcessAnnotationsTask(project, sourceSet, processorConfiguration);
             sourceSet.getOutput().dir(task.flatMap(JavaCompile::getDestinationDirectory));
         });

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
@@ -12,7 +12,6 @@ package org.elasticsearch.gradle.internal.foreign;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -36,12 +35,22 @@ import javax.inject.Inject;
  * modules that contain {@code @LibrarySpecification} interfaces from {@code libs/foreign-library}.
  * The augment step injects {@code provides org.elasticsearch.foreign.LibraryProvider with ...}
  * directives that reference generated classes the source {@code module-info.java} cannot name.
+ *
+ * <p>The {@code test} and {@code testFixtures} source sets are processed too, so bindings that only make
+ * sense in tests can live next to the tests that use them instead of adding production surface. Those
+ * source sets need no {@code module-info.class} augmentation: tests run on the classpath, where
+ * {@code ServiceLoader} discovers the generated providers through the {@code META-INF/services} file the
+ * annotation processor emits.
  */
 public class ForeignLibraryPlugin implements Plugin<Project> {
 
     private static final JavaLanguageVersion PROCESSOR_TOOLCHAIN = JavaLanguageVersion.of(25);
     private static final String FOREIGN_LIBRARY_PROJECT = ":libs:foreign-library";
     private static final String PROCESSOR_PROJECT = ":libs:foreign-library:processor";
+
+    // Gradle's java-test-fixtures plugin creates the "testFixtures" source set but does not expose its
+    // name as public API, hence the literal.
+    static final List<String> TEST_SOURCE_SET_NAMES = List.of(SourceSet.TEST_SOURCE_SET_NAME, "testFixtures");
 
     static final String PROCESSOR_CONFIGURATION_NAME = "foreignLibraryProcessor";
     static final String PROCESS_ANNOTATIONS_TASK_NAME = "processForeignAnnotations";
@@ -65,15 +74,10 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
 
         Configuration processorConfiguration = addDependencies(project);
 
-        SourceSet mainSourceSet = project.getExtensions().getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-        FileCollection compileClasspath = mainSourceSet.getCompileClasspath();
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
-        TaskProvider<JavaCompile> processAnnotations = registerProcessAnnotationsTask(
-            project,
-            mainSourceSet,
-            compileClasspath,
-            processorConfiguration
-        );
+        TaskProvider<JavaCompile> processAnnotations = registerProcessAnnotationsTask(project, mainSourceSet, processorConfiguration);
         TaskProvider<AugmentForeignModuleInfoTask> augmentModuleInfo = registerAugmentModuleInfoTask(
             project,
             processAnnotations,
@@ -83,6 +87,13 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
         mainSourceSet.getOutput().dir(processAnnotations.flatMap(JavaCompile::getDestinationDirectory));
 
         swapModuleInfoInJar(project, augmentModuleInfo);
+
+        // Test source sets get the same annotation processing, but no module-info augmentation and no jar
+        // swap: they are non-modular and run on the classpath.
+        sourceSets.matching(sourceSet -> TEST_SOURCE_SET_NAMES.contains(sourceSet.getName())).all(sourceSet -> {
+            TaskProvider<JavaCompile> task = registerProcessAnnotationsTask(project, sourceSet, processorConfiguration);
+            sourceSet.getOutput().dir(task.flatMap(JavaCompile::getDestinationDirectory));
+        });
     }
 
     private Configuration addDependencies(Project project) {
@@ -102,18 +113,24 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
 
     private TaskProvider<JavaCompile> registerProcessAnnotationsTask(
         Project project,
-        SourceSet mainSourceSet,
-        FileCollection compileClasspath,
+        SourceSet sourceSet,
         Configuration processorConfiguration
     ) {
         JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         Provider<String> releaseVersion = project.provider(() -> javaExtension.getTargetCompatibility().getMajorVersion());
 
-        TaskProvider<JavaCompile> task = project.getTasks().register(PROCESS_ANNOTATIONS_TASK_NAME, JavaCompile.class, t -> {
-            t.setSource(mainSourceSet.getJava());
-            t.setClasspath(compileClasspath);
+        String taskName = sourceSet.getTaskName("process", "ForeignAnnotations");
+        // Sibling directories rather than one nested under main's: nesting would pull the generated test
+        // classes into main's output.
+        String destinationDir = SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName())
+            ? GENERATED_CLASSES_DIR
+            : GENERATED_CLASSES_DIR + "-" + sourceSet.getName();
+
+        TaskProvider<JavaCompile> task = project.getTasks().register(taskName, JavaCompile.class, t -> {
+            t.setSource(sourceSet.getJava());
+            t.setClasspath(sourceSet.getCompileClasspath());
             t.getOptions().setAnnotationProcessorPath(processorConfiguration);
-            t.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir(GENERATED_CLASSES_DIR));
+            t.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir(destinationDir));
             t.getOptions().getCompilerArgs().add("-proc:only");
             t.getOptions().getCompilerArgumentProviders().add(() -> List.of("-AjavaVersion=" + releaseVersion.get()));
         });

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPluginSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPluginSpec.groovy
@@ -39,6 +39,9 @@ class ForeignLibraryPluginSpec extends Specification {
         processorProject.pluginManager.apply(JavaLibraryPlugin)
 
         consumer.pluginManager.apply(ForeignLibraryPlugin)
+        // Applied after ForeignLibraryPlugin on purpose: java-test-fixtures creates its source set late.
+        // Registering in this order covers ForeignLibraryPlugin referencing a source sets that do not exist yet.
+        consumer.pluginManager.apply("java-test-fixtures")
     }
 
     def "applies java-library plugin"() {
@@ -115,6 +118,51 @@ class ForeignLibraryPluginSpec extends Specification {
 
         then:
         expected in main.output.dirs.files
+    }
+
+    def "registers a process-annotations task for the test and testFixtures source sets"() {
+        when:
+        def task = (JavaCompile) consumer.tasks.getByName(taskName)
+        def processor = consumer.configurations.getByName(ForeignLibraryPlugin.PROCESSOR_CONFIGURATION_NAME)
+
+        then:
+        // Sibling of main's output dir, never nested under it: nesting would pull the generated test
+        // classes into main's output.
+        task.destinationDirectory.get().asFile == new File(consumer.layout.buildDirectory.get().asFile, expectedDir)
+        "-proc:only" in task.options.compilerArgs
+        task.options.annotationProcessorPath == processor
+        // Same JDK 25 pinning as main: the processor uses java.lang.classfile.
+        task.sourceCompatibility == "25"
+        task.options.release.isPresent() == false
+
+        where:
+        taskName                                | expectedDir
+        "processTestForeignAnnotations"         | "generated-foreign-library-classes-test"
+        "processTestFixturesForeignAnnotations" | "generated-foreign-library-classes-testFixtures"
+    }
+
+    def "test source set outputs include their generated classes dir"() {
+        when:
+        def sourceSets = consumer.extensions.getByType(SourceSetContainer)
+        def expected = new File(consumer.layout.buildDirectory.get().asFile, expectedDir)
+
+        then:
+        expected in sourceSets.getByName(sourceSetName).output.dirs.files
+
+        where:
+        sourceSetName  | expectedDir
+        "test"         | "generated-foreign-library-classes-test"
+        "testFixtures" | "generated-foreign-library-classes-testFixtures"
+    }
+
+    def "only the main source set gets module-info augmentation"() {
+        when:
+        def augmentTasks = consumer.tasks.withType(AugmentForeignModuleInfoTask).collect { it.name }
+
+        then:
+        // Test source sets are non-modular and run on the classpath, so ServiceLoader finds the
+        // generated providers through the processor's META-INF/services file instead.
+        augmentTasks == [ForeignLibraryPlugin.AUGMENT_MODULE_INFO_TASK_NAME]
     }
 
     def "jar task depends on augmentForeignModuleInfo"() {


### PR DESCRIPTION
Extracted from my upcoming PR on guard pages for native memory bounds check.

Tested with the bindings needed to create guard pages (mmap/mprotect/etc.). Those will be in testFixtures; the modified plugin works on them and produces the correct generated classes.

Relates to https://github.com/elastic/elasticsearch/issues/153224