### PR TITLE
Fix AzureBlobContainerStatsTests.testRetriesAndOperationsAreTrackedSeparately

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/http/ResponseInjectingHttpHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/http/ResponseInjectingHttpHandler.java
@@ -14,6 +14,7 @@ import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
 import org.elasticsearch.rest.RestStatus;
@@ -97,12 +98,15 @@ public class ResponseInjectingHttpHandler implements ESMockAPIBasedRepositoryInt
 
         @Override
         public void writeResponse(HttpExchange exchange, HttpHandler delegateHandler) throws IOException {
-            if (responseBody != null) {
-                byte[] responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
-                exchange.sendResponseHeaders(status.getStatus(), responseBytes.length == 0 ? -1 : responseBytes.length);
-                exchange.getResponseBody().write(responseBytes);
-            } else {
-                exchange.sendResponseHeaders(status.getStatus(), -1);
+            try (exchange) {
+                Streams.readFully(exchange.getRequestBody());
+                if (responseBody != null) {
+                    byte[] responseBytes = responseBody.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(status.getStatus(), responseBytes.length == 0 ? -1 : responseBytes.length);
+                    exchange.getResponseBody().write(responseBytes);
+                } else {
+                    exchange.sendResponseHeaders(status.getStatus(), -1);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes flaky `AzureBlobContainerStatsTests.testRetriesAndOperationsAreTrackedSeparately` by draining the request body and closing the exchange in `ResponseInjectingHttpHandler.FixedRequestHandler` before returning an injected status (e.g. `429`). This mimics what `AzureBlobContainerRetriesTests` and `AzureSasTokenTests` already do in their own tests.

Without draining, JDK `HttpServer` can leave the keep-alive connection unusable. From the HttpExchange javadoc:
```
 * Closing an exchange without consuming all of the request body is not
 * an error but may make the underlying TCP connection unusable for following
 * exchanges. The effect of failing to terminate an exchange is undefined, but
 * will typically result in resources failing to be freed/reused.
```
which I think might be causing the retry to then intermittently hit `PrematureCloseException: Connection prematurely closed BEFORE response` after an injected `429` on `PUT` Blob, as seen in the logs: https://github.com/elastic/elasticsearch/issues/146899#issuecomment-5165059527

When this happens, the actual request counts ends up being off by one (because the retry causes `requests+=3` instead of `requests+=2`) compared to the expected one.

Relates to: https://github.com/elastic/elasticsearch/issues/146899