### PR TITLE
Revert "deps: Bump ironbank version to 10.2"

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/ironbank/Dockerfile
@@ -20,7 +20,7 @@
 
 ARG BASE_REGISTRY=registry1.dso.mil
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=10.2
+ARG BASE_TAG=9.8
 
 ################################################################################
 # Build stage 1 `builder`:

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -11,7 +11,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "10.2"
+  BASE_TAG: "9.8"
 # Docker image labels
 labels:
   org.opencontainers.image.title: "elasticsearch"


### PR DESCRIPTION
Reverts elastic/elasticsearch#155674

The ironbank/templates policy v1.0.0 changed its default ubi_version_path from 9.x/ubi9 to 10.x/ubi10 as a breaking change. Elasticsearch is not ready to move to UBI 10 yet.
Configuration change will be handled here: https://github.com/elastic/elasticsearch/pull/155728