### PR TITLE
[8.19] ci(updatecli): pin ironbank policy to UBI 9 (#155728)

### DIFF
--- a/.github/updatecli/values.d/ironbank.yml
+++ b/.github/updatecli/values.d/ironbank.yml
@@ -1,3 +1,5 @@
+ubi_version_path: https://repo1.dso.mil/dsop/redhat/ubi/9.x/ubi9
+
 config:
   - path: distribution/docker/src/docker/iron_bank
     dockerfile: ../Dockerfile


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ci(updatecli): pin ironbank policy to UBI 9 (#155728)