### PR TITLE
chore: deps(updatecli): bump ironbank policy to 1.0.1

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -2,7 +2,7 @@
 # https://www.updatecli.io/docs/core/compose/
 policies:
   - name: Handle ironbank bumps
-    policy: ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates:0.5.3@sha256:1d5b2f8ca1c141ebe0368d39ec1cdf8bc32662795a21416907eb02b8bf40d890
+    policy: ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates:1.0.1@sha256:3da3235c59860414679bb358a135f7ea8bec91fc7e045b999b3ec9d950161372
     values:
       - .github/updatecli/values.d/scm.yml
       - .github/updatecli/values.d/ironbank.yml

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -7,7 +7,7 @@ policies:
       - .github/updatecli/values.d/scm.yml
       - .github/updatecli/values.d/ironbank.yml
   - name: Update Updatecli policies
-    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.10.0@sha256:588fb5b274c1e484198885723b5a67688416feeec414d41a33908826e448fd41
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.11.1@sha256:de145eea3f42312f4d1fdedb562adc36adcd54d7568f230ae71f931cc5288321
     values:
       - .github/updatecli/values.d/scm.yml
       - .github/updatecli/values.d/updatecli-compose.yml


### PR DESCRIPTION
Bumps two updatecli policy pins that the automation detected but failed to land as PRs due to a git replication lag on the runner - updatecli committed the changes via the GitHub API, then couldn't pull them back, gave up, and skipped PR creation.

- `ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates`: `0.5.3` → `1.0.1`
- `ghcr.io/updatecli/policies/autodiscovery/updatecli`: `0.10.0` → `0.11.1`

### What changed in ironbank/templates between 0.5.3 and 1.0.1

- **0.6.0**: reads the ubi version from `hardening_manifest.yaml` instead of a Dockerfile
- **1.0.0**: changed the default `ubi_version_path` to UBI 10 (breaking change)
- **1.0.1**: fixed label quoting - labels starting with a YAML indicator such as `>non-issue` previously broke the generated manifest with `yaml: ... did not find expected comment or line break`

The `1.0.0` breaking change (UBI 10 default) is neutralised by the `ubi_version_path` override added in #155728, which pins elasticsearch to UBI 9 explicitly.