### PR TITLE
[9.4] Use readArraySize in readImmutableMap and readImmutableOpenMap (#154525)

### DIFF
--- a/docs/changelog/154525.yaml
+++ b/docs/changelog/154525.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 154525
+summary: Use `readArraySize` in `readImmutableMap` and `readImmutableOpenMap`
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -120,7 +120,6 @@ public final class SearchContextId {
             }
             return new SearchContextId(shards, aliasFilters);
         } catch (IOException e) {
-            assert false : e;
             throw new IllegalArgumentException(e);
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -869,14 +869,14 @@ public abstract class StreamInput extends InputStream {
      * @return The immutable map
      */
     public <K, V> Map<K, V> readImmutableMap(Writeable.Reader<K> keyReader, Writeable.Reader<V> valueReader) throws IOException {
-        final int size = readVInt();
+        final int size = readArraySize();
         if (size == 0) {
             return Map.of();
         } else if (size == 1) {
             return Map.of(keyReader.read(this), valueReader.read(this));
         }
         @SuppressWarnings({ "rawtypes", "unchecked" })
-        Map.Entry<K, V> entries[] = new Map.Entry[size];
+        Map.Entry<K, V>[] entries = new Map.Entry[size];
         for (int i = 0; i < size; ++i) {
             entries[i] = Map.entry(keyReader.read(this), valueReader.read(this));
         }
@@ -891,7 +891,7 @@ public abstract class StreamInput extends InputStream {
      */
     public <K, V> ImmutableOpenMap<K, V> readImmutableOpenMap(Writeable.Reader<K> keyReader, Writeable.Reader<V> valueReader)
         throws IOException {
-        final int size = readVInt();
+        final int size = readArraySize();
         if (size == 0) {
             return ImmutableOpenMap.of();
         }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
@@ -154,5 +155,22 @@ public class SearchContextIdTests extends ESTestCase {
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SearchContextId.decode(registry, id));
         assertThat(e.getMessage(), equalTo("unknown transport version [" + unknownTransportVersion.id() + "] reading search context id"));
+    }
+
+    public void testDecodingWithForgedOversizedAliasFilterMapThrows() {
+        byte[] payload = new byte[] {
+            (byte) 0xa7,
+            (byte) 0xc7,
+            (byte) 0xba,
+            0x04,        // transport version
+            0x00,        // empty shards map
+            (byte) 0x80,
+            (byte) 0xa8,
+            (byte) 0xd6,
+            (byte) 0xb9,
+            0x07         // alias-filter map size ~1e9
+        };
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
+        expectThrows(IllegalArgumentException.class, () -> SearchContextId.decode(registry, new BytesArray(payload)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/StreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/StreamInputTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.io.stream;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -131,5 +132,18 @@ public class StreamInputTests extends ESTestCase {
         System.arraycopy("💩".getBytes(UTF_8), 0, bytes, 0, 4);
         assertThrows(IOException.class, () -> in.tryReadStringFromBytes(bytes, 0, bytes.length, 2));
         verify(in, never()).skip(anyLong());
+    }
+
+    public void testReadImmutableMapsRejectOversizedDeclaration() throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeVInt(1_000_000_000);
+            var payload = out.bytes();
+            try (var in = payload.streamInput()) {
+                expectThrows(EOFException.class, () -> in.readImmutableMap(StreamInput::readString, StreamInput::readString));
+            }
+            try (var in = payload.streamInput()) {
+                expectThrows(EOFException.class, () -> in.readImmutableOpenMap(StreamInput::readString, StreamInput::readString));
+            }
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Use readArraySize in readImmutableMap and readImmutableOpenMap (#154525)