### PR TITLE
[9.5] ESQL: Fix FROM_BASE64 generating wrong non-UTF strings

### DIFF
--- a/docs/changelog/154955.yaml
+++ b/docs/changelog/154955.yaml
@@ -1,0 +1,8 @@
+area: ES|QL
+issues: []
+pr: 154955
+summary: >-
+  Fix FROM_BASE64 generating wrong non-UTF strings. Previously it could create
+  binary values that ES|QL does not yet support in other operations; only valid
+  UTF-8 is supported, and invalid cases now return null with a warning.
+type: bug

--- a/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/from_base64.md
+++ b/docs/reference/query-languages/esql/_snippets/generated/x-pack-esql/functions/description/from_base64.md
@@ -4,3 +4,7 @@
 
 Decode a base64 string.
 
+{applies_to}`stack: ga 9.4.5+`
+Returns `null` and adds a warning header to the response if the decoded bytes are not
+well-formed UTF-8.
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2644,6 +2644,116 @@ ZWxhc3RpYw== | elastic
 // end::from_base64-result[]
 ;
 
+base64DecodeInvalidUtf8
+required_capability: fn_from_base64_validate_utf8
+// Truncated UTF-8 lead byte 0xF0 ('a' + 0xF0).
+ROW a = FROM_BASE64("YfA=")
+| KEEP a
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+a:keyword
+null
+;
+
+base64DecodeInvalidUtf8Contains
+required_capability: fn_from_base64_validate_utf8
+required_capability: fn_contains
+// Invalid UTF-8 from FROM_BASE64 must not crash CONTAINS.
+ROW c = CONTAINS(FROM_BASE64("YfA="), "a")
+;
+
+warning:Line 1:18: evaluation of [FROM_BASE64(\"YfA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:18: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+c:boolean
+null
+;
+
+base64DecodeMixedMvExpandSort
+required_capability: fn_from_base64_validate_utf8
+ROW enc = ["YfA=", "ZWxhc3RpYw=="]
+| MV_EXPAND enc
+| EVAL d = FROM_BASE64(enc)
+| SORT d
+| KEEP d
+;
+
+warning:Line 3:12: evaluation of [FROM_BASE64(enc)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:12: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+d:keyword
+elastic
+null
+;
+
+base64DecodeMixedMvExpand
+required_capability: fn_from_base64_validate_utf8
+ROW enc = ["ZWxhc3RpYw==", "YfA=", "not!!base64"]
+| MV_EXPAND enc
+| EVAL d = FROM_BASE64(enc)
+| KEEP enc, d
+;
+
+warning:Line 3:12: evaluation of [FROM_BASE64(enc)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:12: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+warning:Line 3:12: java.lang.IllegalArgumentException: Illegal base64 character 21
+
+enc:keyword    | d:keyword
+ZWxhc3RpYw==   | elastic
+YfA=           | null
+not!!base64    | null
+;
+
+base64DecodeInvalidBase64
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("not!!base64")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"not!!base64\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Illegal base64 character 21
+
+a:keyword
+null
+;
+
+base64DecodeInvalidBase64WrongEndingUnit
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("YfAAAAAAAAAAAAAAAAAAAAAA=")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfAAAAAAAAAAAAAAAAAAAAAA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Input byte array has wrong 4-byte ending unit
+
+a:keyword
+null
+;
+
+base64DecodeInvalidBase64InsufficientBits
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("YfAAAAAAAAAAAAAAAAAAAAAAA=")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfAAAAAAAAAAAAAAAAAAAAAAA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Last unit does not have enough valid bits
+
+a:keyword
+null
+;
+
+base64EncodeDecodeUnicode
+required_capability: base64_decode_encode
+ROW a = "cafè ☕ 日本語"
+| EVAL e = TO_BASE64(a), d = FROM_BASE64(e)
+| KEEP a, d
+;
+
+a:keyword       | d:keyword
+cafè ☕ 日本語   | cafè ☕ 日本語
+;
+
 base64EncodeDecodeEmp
 required_capability: base64_decode_encode
 

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Evaluator.java
@@ -53,7 +53,7 @@ public final class FromBase64Evaluator implements ExpressionEvaluator {
       if (fieldVector == null) {
         return eval(page.getPositionCount(), fieldBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), fieldVector);
     }
   }
 
@@ -80,18 +80,28 @@ public final class FromBase64Evaluator implements ExpressionEvaluator {
               continue position;
         }
         BytesRef field = fieldBlock.getBytesRef(fieldBlock.getFirstValueIndex(p), fieldScratch);
-        result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        try {
+          result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        } catch (IllegalArgumentException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }
   }
 
-  public BytesRefVector eval(int positionCount, BytesRefVector fieldVector) {
-    try(BytesRefVector.Builder result = driverContext.blockFactory().newBytesRefVectorBuilder(positionCount)) {
+  public BytesRefBlock eval(int positionCount, BytesRefVector fieldVector) {
+    try(BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
       BytesRef fieldScratch = new BytesRef();
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef field = fieldVector.getBytesRef(p, fieldScratch);
-        result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        try {
+          result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        } catch (IllegalArgumentException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -42,12 +43,21 @@ public class FromBase64 extends UnaryScalarFunction {
         "FromBase64",
         FromBase64::new
     );
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(FromBase64.class).unary(FromBase64::new).name("from_base64");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(FromBase64.class)
+        .unary(FromBase64::new)
+        // Reject decoded bytes that are not well-formed UTF-8 (null + warning instead of a broken keyword).
+        .capabilities("validate_utf8")
+        .name("from_base64");
 
     @FunctionInfo(
         returnType = "keyword",
         briefSummary = "Decodes a base64 string.",
         description = "Decode a base64 string.",
+        detailedDescription = """
+            {applies_to}`stack: ga 9.4.5+`
+            Returns `null` and adds a warning header to the response if the decoded bytes are not
+            well-formed UTF-8.
+            """,
         examples = @Example(file = "string", tag = "from_base64")
     )
     public FromBase64(
@@ -89,13 +99,16 @@ public class FromBase64 extends UnaryScalarFunction {
         return NodeInfo.create(this, FromBase64::new, field());
     }
 
-    @Evaluator()
+    @Evaluator(warnExceptions = { IllegalArgumentException.class })
     static BytesRef process(BytesRef field, @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRefBuilder oScratch) {
         byte[] bytes = new byte[field.length];
         System.arraycopy(field.bytes, field.offset, bytes, 0, field.length);
         oScratch.grow(field.length);
         oScratch.clear();
         int decodedSize = Base64.getDecoder().decode(bytes, oScratch.bytes());
+        if (Utf8Sanitizer.isWellFormed(oScratch.bytes(), 0, decodedSize) == false) {
+            throw new IllegalArgumentException("decoded value is not valid UTF-8, which is not supported yet");
+        }
         return new BytesRef(oScratch.bytes(), 0, decodedSize);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Tests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Tests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.expression.function.UnaryTestCaseHelper;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -35,13 +36,63 @@ public class FromBase64Tests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
-        unary().expectedOutputType(DataType.KEYWORD)
-            .expectedFromString(s -> new BytesRef(Base64.getDecoder().decode(s.getBytes(StandardCharsets.UTF_8))))
-            .evaluatorToString("FromBase64Evaluator[field=%0]")
+
+        // Valid base64 → well-formed UTF-8 keyword
+        helper().expectedFromString(encoded -> new BytesRef(decode(encoded)))
             .strings("empty", () -> "")
-            .strings("54 ascii characters", () -> randomAlphaOfLength(54))
+            .strings("ascii", () -> encode(randomAlphaOfLengthBetween(1, 54)))
+            .strings("unicode", () -> encode(randomRealisticUnicodeOfCodepointLengthBetween(1, 20)))
             .build(suppliers);
+
+        // Valid base64, but decoded bytes are not well-formed UTF-8 → null + warning
+        helper().expectNullAndWarningsFromString(
+            encoded -> List.of("Line 1:1: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet")
+        )
+            .strings("truncated lead byte", () -> encode(new byte[] { 'a', (byte) 0xF0 }))
+            .strings("lone lead byte", () -> encode(new byte[] { (byte) 0xF0 }))
+            .build(suppliers);
+
+        // Not valid base64 at all → null + warning (decode throws before UTF-8 check)
+        helper().expectNullAndWarningsFromString(
+            encoded -> List.of("Line 1:1: java.lang.IllegalArgumentException: " + decodeErrorMessage(encoded))
+        )
+            .strings("invalid alphabet", () -> "not!!base64")
+            // Padding / unit errors previously surfaced as uncaught 400s at runtime.
+            .strings("wrong 4-byte ending unit", () -> "YfAAAAAAAAAAAAAAAAAAAAAA=")
+            .strings("insufficient bits in last unit", () -> "YfAAAAAAAAAAAAAAAAAAAAAAA=")
+            .build(suppliers);
+
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
+    }
+
+    private static UnaryTestCaseHelper helper() {
+        return unary().expectedOutputType(DataType.KEYWORD).evaluatorToString("FromBase64Evaluator[field=%0]");
+    }
+
+    private static String encode(String plain) {
+        return encode(plain.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encode(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private static byte[] decode(String encoded) {
+        return Base64.getDecoder().decode(encoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Message from {@link Base64.Decoder} for an input that must not decode successfully.
+     * Uses the same {@code decode(byte[], byte[])} overload as {@link FromBase64#process}.
+     */
+    private static String decodeErrorMessage(String invalidBase64) {
+        byte[] src = invalidBase64.getBytes(StandardCharsets.UTF_8);
+        try {
+            Base64.getDecoder().decode(src, new byte[src.length]);
+            throw new AssertionError("expected invalid base64: " + invalidBase64);
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        }
     }
 
     @Override


### PR DESCRIPTION
Manual 9.5 backport of https://github.com/elastic/elasticsearch/pull/154955