### PR TITLE
[9.4] ESQL: Fix FROM_BASE64 generating wrong non-UTF strings

### DIFF
--- a/docs/changelog/154955.yaml
+++ b/docs/changelog/154955.yaml
@@ -1,0 +1,8 @@
+area: ES|QL
+issues: []
+pr: 154955
+summary: >-
+  Fix FROM_BASE64 generating wrong non-UTF strings. Previously it could create
+  binary values that ES|QL does not yet support in other operations; only valid
+  UTF-8 is supported, and invalid cases now return null with a warning.
+type: bug

--- a/docs/reference/query-languages/esql/_snippets/functions/description/from_base64.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/from_base64.md
@@ -4,3 +4,6 @@
 
 Decode a base64 string.
 
+{applies_to}`stack: ga 9.4.5+`
+Returns `null` and adds a warning header to the response if the decoded bytes are not
+well-formed UTF-8.

--- a/docs/reference/query-languages/esql/_snippets/functions/description/from_base64.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/from_base64.md
@@ -7,3 +7,4 @@ Decode a base64 string.
 {applies_to}`stack: ga 9.4.5+`
 Returns `null` and adds a warning header to the response if the decoded bytes are not
 well-formed UTF-8.
+

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Utf8Sanitizer.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.ByteUtils;
+
+import java.util.Arrays;
+
+/**
+ * Validates and, if necessary, repairs UTF-8 byte sequences that enter ES|QL as {@code KEYWORD}
+ * values from external sources (Parquet, ORC, Arrow).
+ * <p>
+ * ES|QL assumes every {@code KEYWORD}/{@code TEXT} {@link BytesRef} holds well-formed UTF-8: for
+ * example {@code Utf8AscTopNEncoder}/{@code Utf8DescTopNEncoder} index a 248-entry code-length table
+ * by the raw lead byte, so a byte in {@code 0xF8..0xFF} throws {@link ArrayIndexOutOfBoundsException}
+ * on the sort path. External writers (notably Spark) can emit malformed UTF-8 in string-annotated
+ * columns, so the byte hygiene ES|QL relies on cannot be assumed at the source boundary.
+ * <p>
+ * {@link #sanitize(BytesRef)} returns the input unchanged when it is already well-formed (the common,
+ * fast path with no allocation) and otherwise returns a copy in which each maximal ill-formed
+ * subsequence is replaced by a single Unicode replacement character {@code U+FFFD} ({@code EF BF BD}).
+ * The "substitution of maximal subparts" behaviour matches the Unicode recommendation and the output
+ * of ICU / Spark, so downstream {@code KEYWORD} operations become total without silently dropping or
+ * merging distinct malformed inputs.
+ */
+public final class Utf8Sanitizer {
+
+    private Utf8Sanitizer() {}
+
+    /** {@code U+FFFD} REPLACEMENT CHARACTER encoded as UTF-8. */
+    private static final byte[] REPLACEMENT = { (byte) 0xEF, (byte) 0xBF, (byte) 0xBD };
+
+    /** Mask selecting the high bit of every byte in a {@code long}; a zero result means all-ASCII. */
+    private static final long ASCII_MASK = 0x8080808080808080L;
+
+    /**
+     * Advances {@code i} past a maximal run of all-ASCII 8-byte words, stopping at the first word
+     * containing a non-ASCII byte or at {@code wordEnd} (the exclusive bound past which an 8-byte read
+     * would cross {@code end}). Returns {@code i} unchanged when no full ASCII word starts at {@code i}.
+     */
+    private static int skipAsciiWords(byte[] bytes, int i, int wordEnd) {
+        while (i < wordEnd && (((long) ByteUtils.LITTLE_ENDIAN_LONG.get(bytes, i)) & ASCII_MASK) == 0) {
+            i += Long.BYTES;
+        }
+        return i;
+    }
+
+    /**
+     * Allocation-free scan reporting whether {@code [off, off+len)} is well-formed UTF-8.
+     */
+    public static boolean isWellFormed(byte[] bytes, int off, int len) {
+        int i = off;
+        int end = off + len;
+        // ASCII-dominant columns (the common case) are skipped a word at a time instead of byte at a time;
+        // any non-ASCII byte in the word falls through to the scalar path below.
+        int wordEnd = end - Long.BYTES + 1;
+        while (i < end) {
+            i = skipAsciiWords(bytes, i, wordEnd);
+            if (i >= end) {
+                break;
+            }
+            int b0 = bytes[i] & 0xFF;
+            if (b0 < 0x80) {
+                // ASCII
+                i++;
+                continue;
+            }
+            int consumed = sequenceLength(bytes, i, end);
+            if (consumed < 0) {
+                return false;
+            }
+            i += consumed;
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code in} unchanged when it is well-formed UTF-8, otherwise a new {@link BytesRef}
+     * (offset 0) with every maximal ill-formed subsequence replaced by {@code U+FFFD}.
+     */
+    public static BytesRef sanitize(BytesRef in) {
+        if (in == null) {
+            return null;
+        }
+        if (isWellFormed(in.bytes, in.offset, in.length)) {
+            return in;
+        }
+        return new BytesRef(repair(in.bytes, in.offset, in.length));
+    }
+
+    /**
+     * Length of the well-formed UTF-8 sequence starting at {@code i}, or the negated length of the
+     * maximal ill-formed subpart (always {@code <= -1}) when the sequence is malformed. The negated
+     * length lets {@link #repair} advance by exactly the maximal subpart, emitting one {@code U+FFFD}
+     * per Unicode's substitution recommendation.
+     */
+    private static int sequenceLength(byte[] bytes, int i, int end) {
+        int b0 = bytes[i] & 0xFF;
+        if (b0 < 0x80) {
+            return 1;
+        }
+        // Continuation byte or C0/C1 (always overlong) as a lead: ill-formed, maximal subpart is one byte.
+        if (b0 < 0xC2) {
+            return -1;
+        }
+        if (b0 < 0xE0) {
+            // 2-byte sequence C2..DF 80..BF
+            if (i + 1 >= end || isCont(bytes[i + 1]) == false) {
+                return -1;
+            }
+            return 2;
+        }
+        if (b0 < 0xF0) {
+            // 3-byte sequence; the second byte range excludes overlong (E0) and surrogates (ED).
+            int lo = (b0 == 0xE0) ? 0xA0 : 0x80;
+            int hi = (b0 == 0xED) ? 0x9F : 0xBF;
+            if (i + 1 >= end || inRange(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isCont(bytes[i + 2]) == false) {
+                // Maximal subpart is the two valid leading bytes.
+                return -2;
+            }
+            return 3;
+        }
+        if (b0 < 0xF5) {
+            // 4-byte sequence; the second byte range excludes overlong (F0) and > U+10FFFF (F4).
+            int lo = (b0 == 0xF0) ? 0x90 : 0x80;
+            int hi = (b0 == 0xF4) ? 0x8F : 0xBF;
+            if (i + 1 >= end || inRange(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isCont(bytes[i + 2]) == false) {
+                return -2;
+            }
+            if (i + 3 >= end || isCont(bytes[i + 3]) == false) {
+                return -3;
+            }
+            return 4;
+        }
+        // 0xF5..0xFF: never a valid lead byte.
+        return -1;
+    }
+
+    private static byte[] repair(byte[] bytes, int off, int len) {
+        // Worst case each input byte becomes a 3-byte replacement; grow-on-demand keeps the common
+        // "few bad bytes" case compact without a second pass.
+        byte[] out = new byte[len + 8];
+        int outLen = 0;
+        int i = off;
+        int end = off + len;
+        int wordEnd = end - Long.BYTES + 1;
+        while (i < end) {
+            // Bulk-copy runs of ASCII words instead of re-deriving a 1-byte sequence length per byte.
+            int runEnd = skipAsciiWords(bytes, i, wordEnd);
+            if (runEnd > i) {
+                int runLen = runEnd - i;
+                out = ensureCapacity(out, outLen + runLen);
+                System.arraycopy(bytes, i, out, outLen, runLen);
+                outLen += runLen;
+                if (runEnd >= end) {
+                    break;
+                }
+                i = runEnd;
+            }
+            int consumed = sequenceLength(bytes, i, end);
+            if (consumed > 0) {
+                out = ensureCapacity(out, outLen + consumed);
+                System.arraycopy(bytes, i, out, outLen, consumed);
+                outLen += consumed;
+                i += consumed;
+            } else {
+                out = ensureCapacity(out, outLen + REPLACEMENT.length);
+                System.arraycopy(REPLACEMENT, 0, out, outLen, REPLACEMENT.length);
+                outLen += REPLACEMENT.length;
+                i += -consumed;
+            }
+        }
+        return outLen == out.length ? out : Arrays.copyOf(out, outLen);
+    }
+
+    private static byte[] ensureCapacity(byte[] out, int needed) {
+        if (needed <= out.length) {
+            return out;
+        }
+        return Arrays.copyOf(out, Math.max(needed, out.length + (out.length >> 1)));
+    }
+
+    private static boolean isCont(byte b) {
+        return (b & 0xC0) == 0x80;
+    }
+
+    private static boolean inRange(byte b, int lo, int hi) {
+        int v = b & 0xFF;
+        return v >= lo && v <= hi;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/Utf8SanitizerTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class Utf8SanitizerTests extends ESTestCase {
+
+    private static final byte[] FFFD = { (byte) 0xEF, (byte) 0xBF, (byte) 0xBD };
+
+    public void testWellFormedInputsAreReturnedUnchanged() {
+        for (String s : new String[] { "", "ascii", "caf\u00e9", "\u20ac euro", "\ud83d\ude00 emoji", "mixed \u4e2d\u6587 text" }) {
+            BytesRef in = new BytesRef(s);
+            assertTrue(s, Utf8Sanitizer.isWellFormed(in.bytes, in.offset, in.length));
+            BytesRef out = Utf8Sanitizer.sanitize(in);
+            assertSame("well-formed input must not be copied", in, out);
+        }
+    }
+
+    public void testNullIsPassedThrough() {
+        assertNull(Utf8Sanitizer.sanitize(null));
+    }
+
+    public void testLoneContinuationByte() {
+        assertSanitized(new byte[] { (byte) 0x80 }, FFFD);
+        assertSanitized(new byte[] { 'a', (byte) 0xBF, 'b' }, concat(bytes('a'), FFFD, bytes('b')));
+    }
+
+    public void testHighLeadBytesF0xF8ToFF() {
+        // These are the bytes that crash Utf8AscTopNEncoder's 248-entry table.
+        for (int b = 0xF8; b <= 0xFF; b++) {
+            assertSanitized(new byte[] { (byte) b }, FFFD);
+        }
+    }
+
+    public void testTruncatedSequences() {
+        // 2-byte lead with no continuation.
+        assertSanitized(new byte[] { (byte) 0xC3 }, FFFD);
+        // 3-byte lead with only one valid continuation: maximal subpart is 2 bytes -> single U+FFFD.
+        assertSanitized(new byte[] { (byte) 0xE2, (byte) 0x82 }, FFFD);
+        // 4-byte lead truncated after two continuations -> single U+FFFD.
+        assertSanitized(new byte[] { (byte) 0xF0, (byte) 0x9F, (byte) 0x98 }, FFFD);
+    }
+
+    public void testOverlongEncodingsRejected() {
+        // Overlong '/' (0x2F) as C0 AF and as E0 80 AF.
+        assertSanitized(new byte[] { (byte) 0xC0, (byte) 0xAF }, concat(FFFD, FFFD));
+        assertSanitized(new byte[] { (byte) 0xE0, (byte) 0x80, (byte) 0xAF }, concat(FFFD, FFFD, FFFD));
+    }
+
+    public void testSurrogateRangeRejected() {
+        // U+D800 encoded as ED A0 80 is ill-formed in UTF-8.
+        assertSanitized(new byte[] { (byte) 0xED, (byte) 0xA0, (byte) 0x80 }, concat(FFFD, FFFD, FFFD));
+    }
+
+    public void testValidMultibyteAdjacentToInvalid() {
+        byte[] euro = "\u20ac".getBytes(StandardCharsets.UTF_8);
+        byte[] input = concat(bytes('x'), euro, new byte[] { (byte) 0xFF }, euro, bytes('y'));
+        byte[] expected = concat(bytes('x'), euro, FFFD, euro, bytes('y'));
+        assertSanitized(input, expected);
+    }
+
+    public void testSanitizedOutputIsWellFormed() {
+        for (int iter = 0; iter < 200; iter++) {
+            byte[] random = new byte[randomIntBetween(0, 64)];
+            random(random);
+            BytesRef out = Utf8Sanitizer.sanitize(new BytesRef(random, 0, random.length));
+            assertTrue("sanitized output must be valid UTF-8", Utf8Sanitizer.isWellFormed(out.bytes, out.offset, out.length));
+        }
+    }
+
+    public void testLongAsciiRunIsWellFormed() {
+        // Exercises the word-wide fast path over several full 8-byte words plus a partial tail.
+        for (int len : new int[] { 7, 8, 9, 15, 16, 17, 63, 64, 65 }) {
+            byte[] ascii = new byte[len];
+            Arrays.fill(ascii, (byte) 'a');
+            BytesRef in = new BytesRef(ascii);
+            assertTrue("len=" + len, Utf8Sanitizer.isWellFormed(in.bytes, in.offset, in.length));
+            assertSame(in, Utf8Sanitizer.sanitize(in));
+        }
+    }
+
+    public void testMalformedByteAtEveryWordPosition() {
+        // A single ill-formed lead byte is detected (and repaired) no matter where it falls
+        // relative to an 8-byte fast-path word, including exactly on a word boundary.
+        int len = 20;
+        for (int pos = 0; pos < len; pos++) {
+            byte[] bytes = new byte[len];
+            Arrays.fill(bytes, (byte) 'a');
+            bytes[pos] = (byte) 0xFF;
+            byte[] expected = concat(repeat((byte) 'a', pos), FFFD, repeat((byte) 'a', len - pos - 1));
+            assertSanitized(bytes, expected);
+        }
+    }
+
+    private static byte[] repeat(byte b, int count) {
+        byte[] out = new byte[count];
+        Arrays.fill(out, b);
+        return out;
+    }
+
+    public void testRespectsOffsetAndLength() {
+        byte[] backing = concat(new byte[] { (byte) 0xFF, (byte) 0xFF }, "ok".getBytes(StandardCharsets.UTF_8), new byte[] { (byte) 0xFF });
+        BytesRef slice = new BytesRef(backing, 2, 2);
+        BytesRef out = Utf8Sanitizer.sanitize(slice);
+        assertSame(slice, out);
+        assertEquals("ok", out.utf8ToString());
+    }
+
+    private void random(byte[] bytes) {
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) randomInt(255);
+        }
+    }
+
+    private void assertSanitized(byte[] input, byte[] expected) {
+        assertFalse("test input must be malformed", Utf8Sanitizer.isWellFormed(input, 0, input.length));
+        BytesRef out = Utf8Sanitizer.sanitize(new BytesRef(input, 0, input.length));
+        assertEquals(new BytesRef(expected), out);
+        assertTrue(Utf8Sanitizer.isWellFormed(out.bytes, out.offset, out.length));
+    }
+
+    private static byte[] bytes(char c) {
+        return new byte[] { (byte) c };
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int len = 0;
+        for (byte[] p : parts) {
+            len += p.length;
+        }
+        byte[] out = new byte[len];
+        int pos = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, pos, p.length);
+            pos += p.length;
+        }
+        return out;
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2492,6 +2492,116 @@ ZWxhc3RpYw== | elastic
 // end::from_base64-result[]
 ;
 
+base64DecodeInvalidUtf8
+required_capability: fn_from_base64_validate_utf8
+// Truncated UTF-8 lead byte 0xF0 ('a' + 0xF0).
+ROW a = FROM_BASE64("YfA=")
+| KEEP a
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+a:keyword
+null
+;
+
+base64DecodeInvalidUtf8Contains
+required_capability: fn_from_base64_validate_utf8
+required_capability: fn_contains
+// Invalid UTF-8 from FROM_BASE64 must not crash CONTAINS.
+ROW c = CONTAINS(FROM_BASE64("YfA="), "a")
+;
+
+warning:Line 1:18: evaluation of [FROM_BASE64(\"YfA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:18: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+c:boolean
+null
+;
+
+base64DecodeMixedMvExpandSort
+required_capability: fn_from_base64_validate_utf8
+ROW enc = ["YfA=", "ZWxhc3RpYw=="]
+| MV_EXPAND enc
+| EVAL d = FROM_BASE64(enc)
+| SORT d
+| KEEP d
+;
+
+warning:Line 3:12: evaluation of [FROM_BASE64(enc)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:12: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+
+d:keyword
+elastic
+null
+;
+
+base64DecodeMixedMvExpand
+required_capability: fn_from_base64_validate_utf8
+ROW enc = ["ZWxhc3RpYw==", "YfA=", "not!!base64"]
+| MV_EXPAND enc
+| EVAL d = FROM_BASE64(enc)
+| KEEP enc, d
+;
+
+warning:Line 3:12: evaluation of [FROM_BASE64(enc)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:12: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet
+warning:Line 3:12: java.lang.IllegalArgumentException: Illegal base64 character 21
+
+enc:keyword    | d:keyword
+ZWxhc3RpYw==   | elastic
+YfA=           | null
+not!!base64    | null
+;
+
+base64DecodeInvalidBase64
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("not!!base64")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"not!!base64\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Illegal base64 character 21
+
+a:keyword
+null
+;
+
+base64DecodeInvalidBase64WrongEndingUnit
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("YfAAAAAAAAAAAAAAAAAAAAAA=")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfAAAAAAAAAAAAAAAAAAAAAA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Input byte array has wrong 4-byte ending unit
+
+a:keyword
+null
+;
+
+base64DecodeInvalidBase64InsufficientBits
+required_capability: fn_from_base64_validate_utf8
+ROW a = FROM_BASE64("YfAAAAAAAAAAAAAAAAAAAAAAA=")
+;
+
+warning:Line 1:9: evaluation of [FROM_BASE64(\"YfAAAAAAAAAAAAAAAAAAAAAAA=\")] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.IllegalArgumentException: Last unit does not have enough valid bits
+
+a:keyword
+null
+;
+
+base64EncodeDecodeUnicode
+required_capability: base64_decode_encode
+ROW a = "cafè ☕ 日本語"
+| EVAL e = TO_BASE64(a), d = FROM_BASE64(e)
+| KEEP a, d
+;
+
+a:keyword       | d:keyword
+cafè ☕ 日本語   | cafè ☕ 日本語
+;
+
 base64EncodeDecodeEmp#[skip:-8.13.99,reason:new base64 function added in 8.14]
 required_capability: base64_decode_encode
 

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Evaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Evaluator.java
@@ -53,7 +53,7 @@ public final class FromBase64Evaluator implements ExpressionEvaluator {
       if (fieldVector == null) {
         return eval(page.getPositionCount(), fieldBlock);
       }
-      return eval(page.getPositionCount(), fieldVector).asBlock();
+      return eval(page.getPositionCount(), fieldVector);
     }
   }
 
@@ -80,18 +80,28 @@ public final class FromBase64Evaluator implements ExpressionEvaluator {
               continue position;
         }
         BytesRef field = fieldBlock.getBytesRef(fieldBlock.getFirstValueIndex(p), fieldScratch);
-        result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        try {
+          result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        } catch (IllegalArgumentException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }
   }
 
-  public BytesRefVector eval(int positionCount, BytesRefVector fieldVector) {
-    try(BytesRefVector.Builder result = driverContext.blockFactory().newBytesRefVectorBuilder(positionCount)) {
+  public BytesRefBlock eval(int positionCount, BytesRefVector fieldVector) {
+    try(BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
       BytesRef fieldScratch = new BytesRef();
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef field = fieldVector.getBytesRef(p, fieldScratch);
-        result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        try {
+          result.appendBytesRef(FromBase64.process(field, this.oScratch));
+        } catch (IllegalArgumentException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.data.Utf8Sanitizer;
 import org.elasticsearch.compute.expression.ConstantEvaluators;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
@@ -104,83 +105,10 @@ public class FromBase64 extends UnaryScalarFunction {
         oScratch.grow(field.length);
         oScratch.clear();
         int decodedSize = Base64.getDecoder().decode(bytes, oScratch.bytes());
-        if (isWellFormedUtf8(oScratch.bytes(), 0, decodedSize) == false) {
+        if (Utf8Sanitizer.isWellFormed(oScratch.bytes(), 0, decodedSize) == false) {
             throw new IllegalArgumentException("decoded value is not valid UTF-8, which is not supported yet");
         }
         return new BytesRef(oScratch.bytes(), 0, decodedSize);
-    }
-
-    /**
-     * Allocation-free scan reporting whether {@code [off, off+len)} is well-formed UTF-8.
-     * Inlined from the Utf8Sanitizer helper that does not exist on this release branch.
-     */
-    static boolean isWellFormedUtf8(byte[] bytes, int off, int len) {
-        int i = off;
-        int end = off + len;
-        while (i < end) {
-            int b0 = bytes[i] & 0xFF;
-            if (b0 < 0x80) {
-                i++;
-                continue;
-            }
-            int consumed = utf8SequenceLength(bytes, i, end);
-            if (consumed < 0) {
-                return false;
-            }
-            i += consumed;
-        }
-        return true;
-    }
-
-    private static int utf8SequenceLength(byte[] bytes, int i, int end) {
-        int b0 = bytes[i] & 0xFF;
-        if (b0 < 0x80) {
-            return 1;
-        }
-        if (b0 < 0xC2) {
-            return -1;
-        }
-        if (b0 < 0xE0) {
-            if (i + 1 >= end || isUtf8Cont(bytes[i + 1]) == false) {
-                return -1;
-            }
-            return 2;
-        }
-        if (b0 < 0xF0) {
-            int lo = (b0 == 0xE0) ? 0xA0 : 0x80;
-            int hi = (b0 == 0xED) ? 0x9F : 0xBF;
-            if (i + 1 >= end || inUtf8Range(bytes[i + 1], lo, hi) == false) {
-                return -1;
-            }
-            if (i + 2 >= end || isUtf8Cont(bytes[i + 2]) == false) {
-                return -2;
-            }
-            return 3;
-        }
-        if (b0 < 0xF5) {
-            int lo = (b0 == 0xF0) ? 0x90 : 0x80;
-            int hi = (b0 == 0xF4) ? 0x8F : 0xBF;
-            if (i + 1 >= end || inUtf8Range(bytes[i + 1], lo, hi) == false) {
-                return -1;
-            }
-            if (i + 2 >= end || isUtf8Cont(bytes[i + 2]) == false) {
-                return -2;
-            }
-            if (i + 3 >= end || isUtf8Cont(bytes[i + 3]) == false) {
-                return -3;
-            }
-            return 4;
-        }
-        return -1;
-    }
-
-    private static boolean isUtf8Cont(byte b) {
-        return (b & 0xC0) == 0x80;
-    }
-
-    private static boolean inUtf8Range(byte b, int lo, int hi) {
-        int v = b & 0xFF;
-        return v >= lo && v <= hi;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
@@ -42,11 +42,20 @@ public class FromBase64 extends UnaryScalarFunction {
         "FromBase64",
         FromBase64::new
     );
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(FromBase64.class).unary(FromBase64::new).name("from_base64");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(FromBase64.class)
+        .unary(FromBase64::new)
+        // Reject decoded bytes that are not well-formed UTF-8 (null + warning instead of a broken keyword).
+        .capabilities("validate_utf8")
+        .name("from_base64");
 
     @FunctionInfo(
         returnType = "keyword",
         description = "Decode a base64 string.",
+        detailedDescription = """
+            {applies_to}`stack: ga 9.4.5+`
+            Returns `null` and adds a warning header to the response if the decoded bytes are not
+            well-formed UTF-8.
+            """,
         examples = @Example(file = "string", tag = "from_base64")
     )
     public FromBase64(
@@ -88,14 +97,90 @@ public class FromBase64 extends UnaryScalarFunction {
         return NodeInfo.create(this, FromBase64::new, field());
     }
 
-    @Evaluator()
+    @Evaluator(warnExceptions = { IllegalArgumentException.class })
     static BytesRef process(BytesRef field, @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRefBuilder oScratch) {
         byte[] bytes = new byte[field.length];
         System.arraycopy(field.bytes, field.offset, bytes, 0, field.length);
         oScratch.grow(field.length);
         oScratch.clear();
         int decodedSize = Base64.getDecoder().decode(bytes, oScratch.bytes());
+        if (isWellFormedUtf8(oScratch.bytes(), 0, decodedSize) == false) {
+            throw new IllegalArgumentException("decoded value is not valid UTF-8, which is not supported yet");
+        }
         return new BytesRef(oScratch.bytes(), 0, decodedSize);
+    }
+
+    /**
+     * Allocation-free scan reporting whether {@code [off, off+len)} is well-formed UTF-8.
+     * Inlined from the Utf8Sanitizer helper that does not exist on this release branch.
+     */
+    static boolean isWellFormedUtf8(byte[] bytes, int off, int len) {
+        int i = off;
+        int end = off + len;
+        while (i < end) {
+            int b0 = bytes[i] & 0xFF;
+            if (b0 < 0x80) {
+                i++;
+                continue;
+            }
+            int consumed = utf8SequenceLength(bytes, i, end);
+            if (consumed < 0) {
+                return false;
+            }
+            i += consumed;
+        }
+        return true;
+    }
+
+    private static int utf8SequenceLength(byte[] bytes, int i, int end) {
+        int b0 = bytes[i] & 0xFF;
+        if (b0 < 0x80) {
+            return 1;
+        }
+        if (b0 < 0xC2) {
+            return -1;
+        }
+        if (b0 < 0xE0) {
+            if (i + 1 >= end || isUtf8Cont(bytes[i + 1]) == false) {
+                return -1;
+            }
+            return 2;
+        }
+        if (b0 < 0xF0) {
+            int lo = (b0 == 0xE0) ? 0xA0 : 0x80;
+            int hi = (b0 == 0xED) ? 0x9F : 0xBF;
+            if (i + 1 >= end || inUtf8Range(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isUtf8Cont(bytes[i + 2]) == false) {
+                return -2;
+            }
+            return 3;
+        }
+        if (b0 < 0xF5) {
+            int lo = (b0 == 0xF0) ? 0x90 : 0x80;
+            int hi = (b0 == 0xF4) ? 0x8F : 0xBF;
+            if (i + 1 >= end || inUtf8Range(bytes[i + 1], lo, hi) == false) {
+                return -1;
+            }
+            if (i + 2 >= end || isUtf8Cont(bytes[i + 2]) == false) {
+                return -2;
+            }
+            if (i + 3 >= end || isUtf8Cont(bytes[i + 3]) == false) {
+                return -3;
+            }
+            return 4;
+        }
+        return -1;
+    }
+
+    private static boolean isUtf8Cont(byte b) {
+        return (b & 0xC0) == 0x80;
+    }
+
+    private static boolean inUtf8Range(byte b, int lo, int hi) {
+        int v = b & 0xFF;
+        return v >= lo && v <= hi;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java
@@ -49,16 +49,11 @@ public class FromBase64 extends UnaryScalarFunction {
         .capabilities("validate_utf8")
         .name("from_base64");
 
-    @FunctionInfo(
-        returnType = "keyword",
-        description = "Decode a base64 string.",
-        detailedDescription = """
-            {applies_to}`stack: ga 9.4.5+`
-            Returns `null` and adds a warning header to the response if the decoded bytes are not
-            well-formed UTF-8.
-            """,
-        examples = @Example(file = "string", tag = "from_base64")
-    )
+    @FunctionInfo(returnType = "keyword", description = "Decode a base64 string.", detailedDescription = """
+        {applies_to}`stack: ga 9.4.5+`
+        Returns `null` and adds a warning header to the response if the decoded bytes are not
+        well-formed UTF-8.
+        """, examples = @Example(file = "string", tag = "from_base64"))
     public FromBase64(
         Source source,
         @Param(name = "string", type = { "keyword", "text" }, description = "A base64 string.") Expression string

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Tests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64Tests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.expression.function.UnaryTestCaseHelper;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -35,13 +36,63 @@ public class FromBase64Tests extends AbstractScalarFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
-        unary().expectedOutputType(DataType.KEYWORD)
-            .expectedFromString(s -> new BytesRef(Base64.getDecoder().decode(s.getBytes(StandardCharsets.UTF_8))))
-            .evaluatorToString("FromBase64Evaluator[field=%0]")
+
+        // Valid base64 → well-formed UTF-8 keyword
+        helper().expectedFromString(encoded -> new BytesRef(decode(encoded)))
             .strings("empty", () -> "")
-            .strings("54 ascii characters", () -> randomAlphaOfLength(54))
+            .strings("ascii", () -> encode(randomAlphaOfLengthBetween(1, 54)))
+            .strings("unicode", () -> encode(randomRealisticUnicodeOfCodepointLengthBetween(1, 20)))
             .build(suppliers);
+
+        // Valid base64, but decoded bytes are not well-formed UTF-8 → null + warning
+        helper().expectNullAndWarningsFromString(
+            encoded -> List.of("Line 1:1: java.lang.IllegalArgumentException: decoded value is not valid UTF-8, which is not supported yet")
+        )
+            .strings("truncated lead byte", () -> encode(new byte[] { 'a', (byte) 0xF0 }))
+            .strings("lone lead byte", () -> encode(new byte[] { (byte) 0xF0 }))
+            .build(suppliers);
+
+        // Not valid base64 at all → null + warning (decode throws before UTF-8 check)
+        helper().expectNullAndWarningsFromString(
+            encoded -> List.of("Line 1:1: java.lang.IllegalArgumentException: " + decodeErrorMessage(encoded))
+        )
+            .strings("invalid alphabet", () -> "not!!base64")
+            // Padding / unit errors previously surfaced as uncaught 400s at runtime.
+            .strings("wrong 4-byte ending unit", () -> "YfAAAAAAAAAAAAAAAAAAAAAA=")
+            .strings("insufficient bits in last unit", () -> "YfAAAAAAAAAAAAAAAAAAAAAAA=")
+            .build(suppliers);
+
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
+    }
+
+    private static UnaryTestCaseHelper helper() {
+        return unary().expectedOutputType(DataType.KEYWORD).evaluatorToString("FromBase64Evaluator[field=%0]");
+    }
+
+    private static String encode(String plain) {
+        return encode(plain.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encode(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private static byte[] decode(String encoded) {
+        return Base64.getDecoder().decode(encoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Message from {@link Base64.Decoder} for an input that must not decode successfully.
+     * Uses the same {@code decode(byte[], byte[])} overload as {@link FromBase64#process}.
+     */
+    private static String decodeErrorMessage(String invalidBase64) {
+        byte[] src = invalidBase64.getBytes(StandardCharsets.UTF_8);
+        try {
+            Base64.getDecoder().decode(src, new byte[src.length]);
+            throw new AssertionError("expected invalid base64: " + invalidBase64);
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        }
     }
 
     @Override


### PR DESCRIPTION
Manual 9.4 backport of https://github.com/elastic/elasticsearch/pull/154955