### PR TITLE
[9.5] Add columnar as valid changelog area (#155657)

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -33,6 +33,7 @@
             "Client",
             "Cluster Coordination",
             "Codec",
+            "Columnar",
             "Data streams",
             "DLM",
             "Discovery-Plugins",


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Add columnar as valid changelog area (#155657)