### PR TITLE
ES|QL: load _unmapped sink keys via SET unmapped_fields="load"

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RuntimeField;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -176,6 +177,13 @@ class FieldCapabilitiesFetcher {
         for (Map.Entry<String, MappedFieldType> entry : context.getAllFields()) {
             final String field = entry.getKey();
             MappedFieldType ft = entry.getValue();
+            // The implicit _unmapped sink is derived state (re-injected every parse, never serialized into the mapping source).
+            // Excluding it from field caps is the third leg of that "derived state is invisible" contract, consistent with
+            // ObjectMapper.serializeMappers already skipping it. Without this, FROM <columnar-index> leaks an _unmapped:flattened
+            // column whose value is a JSON blob of every absorbed key.
+            if (context.getIndexSettings().isFlattenedUnmappedFieldsEnabled() && FlattenedFieldMapper.UNMAPPED_SINK_NAME.equals(field)) {
+                continue;
+            }
             if (fieldNameFilter.test(field) == false && ((includeDimensions && ft.isDimension()) == false)) {
                 continue;
             }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedUnmappedFieldsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedUnmappedFieldsTests.java
@@ -17,7 +17,9 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DynamicFieldType;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -232,5 +234,57 @@ public class FlattenedUnmappedFieldsTests extends MapperServiceTestCase {
             b.endObject();
         })));
         assertThat(e.getMessage(), containsString("does not support [flattened]"));
+    }
+
+    /**
+     * Verifies the read primitive that the ES|QL {@code unmapped_fields="load"} path uses: the sink's field type implements
+     * {@link DynamicFieldType}, and {@code getChildFieldType(fullDottedKey)} returns a {@link FlattenedFieldMapper.KeyedFlattenedFieldType}
+     * whose name is {@code _unmapped._keyed} (the physical doc-values field) and whose {@code key()} is the verbatim stored key.
+     * This is the inverse of {@code FlattenedFieldParser.indexValueAtPath}'s empty-ContentPath write path, so the read/write formats
+     * cannot diverge as long as this test passes.
+     */
+    public void testGetChildFieldTypeResolvesAbsorbedKey() throws IOException {
+        MapperService mapperService = columnarService(b -> {});
+        FlattenedFieldMapper sink = (FlattenedFieldMapper) mapperService.mappingLookup().getMapper(FlattenedFieldMapper.UNMAPPED_SINK_NAME);
+        assertTrue(sink.isUnmappedSink());
+        MappedFieldType childFt = ((DynamicFieldType) sink.fieldType()).getChildFieldType("outer.inner.leaf");
+        assertNotNull(childFt);
+        assertTrue(childFt instanceof FlattenedFieldMapper.KeyedFlattenedFieldType);
+        assertEquals(FlattenedFieldMapper.UNMAPPED_SINK_NAME + FlattenedFieldMapper.KEYED_FIELD_SUFFIX, childFt.name());
+        assertTrue("keyed flattened DV field must have doc values for the block loader path", childFt.hasDocValues());
+        assertEquals("outer.inner.leaf", ((FlattenedFieldMapper.KeyedFlattenedFieldType) childFt).key());
+    }
+
+    /**
+     * Guards the choice to keep sink-key resolution ES|QL-local rather than adding it to {@code FieldTypeLookup.getDynamicField}.
+     * {@code MappingLookup.getFieldType} must return {@code null} for absorbed keys, because {@code DocumentParser.getLeafMapper}
+     * treats any non-null field type as proof of a runtime field and returns a no-op mapper — which would silently drop the value on the
+     * second document. Failing this test means a server-side fallback was inadvertently added.
+     */
+    public void testMappingLookupDoesNotResolveAbsorbedKey() throws IOException {
+        MapperService mapperService = columnarService(b -> {});
+        assertNull(
+            "FieldTypeLookup must not resolve absorbed keys; resolution is ES|QL-local only",
+            mapperService.mappingLookup().getFieldType("outer.inner.leaf")
+        );
+    }
+
+    /**
+     * Guards against a regression where adding a server-side sink-key resolution would cause {@code DocumentParser.getLeafMapper}
+     * to treat the second document's absorbed key as a runtime field and return a no-op mapper, silently dropping the value.
+     * Both documents must absorb the value, emit no dynamic mapping update, and leave no trace in {@code _ignored_source}.
+     */
+    public void testSecondDocumentWithAbsorbedKeyIsAlsoAbsorbed() throws IOException {
+        DocumentMapper mapper = columnarService(b -> {}).documentMapper();
+        String value = randomAlphanumericOfLength(6);
+
+        ParsedDocument doc1 = mapper.parse(source(b -> b.field("repeat.field", value)));
+        assertNull("first document must produce no mapping update", doc1.dynamicMappingsUpdate());
+        assertTrue(hasKeyedSlot(doc1, "repeat.field\0" + value));
+
+        ParsedDocument doc2 = mapper.parse(source(b -> b.field("repeat.field", value)));
+        assertNull("second document with the same absorbed key must also produce no mapping update", doc2.dynamicMappingsUpdate());
+        assertTrue("second document value must be absorbed, not dropped by a no-op mapper", hasKeyedSlot(doc2, "repeat.field\0" + value));
+        assertTrue(doc2.rootDoc().getFields(IgnoredSourceFieldMapper.NAME).isEmpty());
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -330,6 +330,8 @@ public class CsvTestsDataLoader {
         new TestDataset("path_lookup").withSetting("lookup-settings.json"),
         new TestDataset("flattened_typed").withRequiredCapabilities(EsqlCapabilities.Cap.FLATTENED_DATATYPE),
         new TestDataset("ts_flattened", "mapping-ts_flattened.json", "ts_flattened.csv", "ts_flattened-settings.json"),
+        new TestDataset("unmapped_sink", "mapping-unmapped_sink.json", "unmapped_sink.csv", "unmapped-sink-settings.json")
+            .withRequiredCapabilities(EsqlCapabilities.Cap.FLATTENED_UNMAPPED_SINK_LOAD),
         new TestDataset("host_threat_list").withSetting("lookup-settings.json"),
         new TestDataset("host_info_lookup").withSetting("lookup-settings.json"),
         new TestDataset(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/unmapped_sink.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/unmapped_sink.csv
@@ -1,0 +1,4 @@
+@timestamp:date,level:keyword,response_code:integer,request.path:keyword,cluster:keyword
+2025-01-01T00:00:00Z,info,200,/api/v1,prod
+2025-01-01T00:01:00Z,warn,404,/api/v2,prod
+2025-01-01T00:02:00Z,info,200,/api/v1,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened-unmapped-sink-load.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened-unmapped-sink-load.csv-spec
@@ -1,0 +1,112 @@
+sink not in column list
+required_capability: flattened_unmapped_sink_load
+
+FROM unmapped_sink
+| SORT @timestamp ASC
+| LIMIT 3
+;
+
+@timestamp:date
+2025-01-01T00:00:00.000Z
+2025-01-01T00:01:00.000Z
+2025-01-01T00:02:00.000Z
+;
+
+// -------------------------------------------------------
+load top-level absorbed key
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| KEEP @timestamp, level
+| SORT @timestamp ASC
+;
+
+@timestamp:date          | level:keyword
+2025-01-01T00:00:00.000Z | info
+2025-01-01T00:01:00.000Z | warn
+2025-01-01T00:02:00.000Z | info
+;
+
+// -------------------------------------------------------
+load nested absorbed key with nulls
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| KEEP @timestamp, request.path
+| SORT @timestamp ASC
+;
+
+@timestamp:date          | request.path:keyword
+2025-01-01T00:00:00.000Z | /api/v1
+2025-01-01T00:01:00.000Z | /api/v2
+2025-01-01T00:02:00.000Z | /api/v1
+;
+
+// -------------------------------------------------------
+load key absent in some docs returns null
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| KEEP @timestamp, cluster
+| SORT @timestamp ASC
+;
+
+@timestamp:date          | cluster:keyword
+2025-01-01T00:00:00.000Z | prod
+2025-01-01T00:01:00.000Z | prod
+2025-01-01T00:02:00.000Z | null
+;
+
+// -------------------------------------------------------
+filter by absorbed key is evaluated post-extraction not pushed to Lucene
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| WHERE level == "warn"
+| KEEP @timestamp, level
+;
+
+@timestamp:date          | level:keyword
+2025-01-01T00:01:00.000Z | warn
+;
+
+// -------------------------------------------------------
+stats by absorbed key
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| STATS count = COUNT(*) BY level
+| SORT count DESC, level ASC
+;
+
+count:long | level:keyword
+2          | info
+1          | warn
+;
+
+// -------------------------------------------------------
+numeric value absorbed as keyword string
+required_capability: flattened_unmapped_sink_load
+required_capability: optional_fields_v5
+
+SET unmapped_fields="load"\;
+FROM unmapped_sink
+| KEEP @timestamp, response_code
+| SORT @timestamp ASC
+;
+
+@timestamp:date          | response_code:keyword
+2025-01-01T00:00:00.000Z | 200
+2025-01-01T00:01:00.000Z | 404
+2025-01-01T00:02:00.000Z | 200
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-unmapped_sink.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-unmapped_sink.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "@timestamp": { "type": "date" }
+  }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/unmapped-sink-settings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/settings/unmapped-sink-settings.json
@@ -1,0 +1,10 @@
+{
+  "index": {
+    "mode": "columnar",
+    "mapping": {
+      "flattened_unmapped_fields": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.lucene.query.LuceneQueryEvaluator;
 import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.SliceIndexing;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.rest.action.admin.cluster.RestNodesCapabilitiesAction;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
@@ -509,6 +510,15 @@ public class EsqlCapabilities {
          * is only supported by full integration tests. So this capability is used to disable some tests in CsvTests.
          */
         LOAD_FLATTENED_FIELD,
+
+        /**
+         * Keys absorbed into the implicit {@code _unmapped} flattened sink on strict-columnar indices (enabled by
+         * {@code index.mapping.flattened_unmapped_fields.enabled}) are loadable via {@code SET unmapped_fields="load"}.
+         * Snapshot-only; tied to the server-side {@link FlattenedFieldMapper#UNMAPPED_FIELDS_FEATURE_FLAG}.
+         * Known limitations: keys are always keyword-typed; multi-values are sorted and deduplicated by the doc-values reader;
+         * wildcard enumeration ({@code foo.*}) is not supported; only explicitly-named keys load.
+         */
+        FLATTENED_UNMAPPED_SINK_LOAD(FlattenedFieldMapper.UNMAPPED_FIELDS_FEATURE_FLAG),
 
         /**
          * Support for the {@code flattened} data type in ES|QL, which loads flattened fields as JSON objects.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -517,6 +517,10 @@ public class Verifier {
      * Reject loading sub-fields of flattened fields when {@code unmapped_fields="load"}, by checking if any
      * {@link PotentiallyUnmappedKeywordEsField} is a sub-field of a parent field whose original type is flattened. The reason is that
      * flattened subfields resolution may eventually differ from what happens when {@code unmapped_fields="load"}.
+     * <p>
+     * The implicit {@code _unmapped} sink is deliberately out of scope for this check: it is hidden from field caps and therefore
+     * never present in {@code esRelation.output()}, so its absorbed keys (e.g. {@code foo.bar}) have no user-visible flattened parent
+     * and are correctly handled by the {@code DefaultShardContextForUnmappedField} resolution path.
      */
     private static void checkFlattenedSubFieldLoad(LogicalPlan plan, Failures failures) {
         plan.forEachDown(EsRelation.class, esRelation -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -57,6 +57,7 @@ import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
@@ -473,7 +474,33 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         @Override
         public @Nullable MappedFieldType fieldType(String name) {
             var superResult = super.fieldType(name);
-            return superResult == null && name.equals(fullFieldName) ? createUnmappedFieldType(name, this) : superResult;
+            if (superResult != null || name.equals(fullFieldName) == false) {
+                return superResult;
+            }
+            // Try the implicit _unmapped sink before falling back to the _source-based keyword type.
+            // FlattenedFieldParser.indexValueAtPath uses an empty ContentPath, so "foo.bar" is stored verbatim as the key —
+            // getChildFieldType("foo.bar") is the exact inverse. The returned KeyedFlattenedFieldType.name() is "_unmapped._keyed",
+            // not "foo.bar", but nothing on this path uses fieldType.name() for layout; the operator uses the attribute name.
+            var sinkMft = sinkFieldType();
+            if (sinkMft != null) {
+                return sinkMft;
+            }
+            return createUnmappedFieldType(name, this);
+        }
+
+        /**
+         * Returns a {@link FlattenedFieldMapper.KeyedFlattenedFieldType} for {@code fullFieldName} backed by the implicit
+         * {@code _unmapped} sink, or {@code null} if the sink is absent or the setting is not enabled on this index.
+         * Self-gating: {@link FlattenedFieldMapper#isUnmappedSink()} is false unless both the feature flag and strict-columnar mode
+         * are active, so on any other index this always returns {@code null} and the caller falls through to the existing path.
+         */
+        private @Nullable MappedFieldType sinkFieldType() {
+            if (mappingLookup().getMapper(FlattenedFieldMapper.UNMAPPED_SINK_NAME) instanceof FlattenedFieldMapper sink
+                && sink.isUnmappedSink()
+                && sink.fieldType() instanceof DynamicFieldType dft) {
+                return dft.getChildFieldType(fullFieldName);
+            }
+            return null;
         }
 
         static MappedFieldType createUnmappedFieldType(String name, DefaultShardContext context) {


### PR DESCRIPTION
## Summary

- Keys absorbed by the implicit `_unmapped` `FlattenedFieldMapper` on strict-columnar indices (`index.mapping.flattened_unmapped_fields.enabled=true`) are now loadable in ES|QL when `SET unmapped_fields="load"` is in effect.
- `FieldCapabilitiesFetcher` now skips `_unmapped` so it does not appear as a spurious `flattened` column in `FROM <columnar-index>` output.
- New `FLATTENED_UNMAPPED_SINK_LOAD` capability (tied to the server-side feature flag) gates the dataset loader and csv-spec tests.

## How it works

The core change is in `DefaultShardContextForUnmappedField.fieldType()` in `EsPhysicalOperationProviders.java`. Before falling back to the `_source`-based keyword type it checks whether the index has an `_unmapped` sink and, if so, delegates to `RootFlattenedFieldType.getChildFieldType(fullFieldName)` — the exact inverse of `FlattenedFieldParser.indexValueAtPath`, which stores keys verbatim (empty `ContentPath`). The returned `KeyedFlattenedFieldType` produces a `BYTES_REF` block via `KeyedFlattenedDocValuesBlockLoader`, matching `PotentiallyUnmappedKeywordEsField`'s `KEYWORD` element type. The fallback is self-gating via `FlattenedFieldMapper.isUnmappedSink()`, so no change in behaviour on non-sink indices.

The fix is ES|QL-local only. A server-side fallback in `FieldTypeLookup` would break the write path: `DocumentParser.getLeafMapper` asserts `fieldType.hasDocValues() == false` for any non-null hit, so the second document containing an absorbed key would trip the assert (dev) or silently drop the value (prod).

## Known limitations

- Sink keys are always `keyword`-typed; the write path stringifies via `parser().text()`.
- Multi-values are sorted and deduplicated by the doc-values reader.
- Wildcard enumeration (`foo.*`) is not supported; only explicitly-named keys load.
- Predicates on sink keys are not pushed to Lucene (`PotentiallyUnmappedKeywordEsField` is not pushable).

## Test plan

- [ ] New unit tests in `FlattenedUnmappedFieldsTests`: child field type resolution, `MappingLookup` negative (server path not taken), second-doc absorption not dropped.
- [ ] 7 new csv-spec cases in `flattened-unmapped-sink-load.csv-spec`: no sink column in output, top-level key load, nested key with nulls, absent key → null, post-extraction filter, STATS BY, numeric-as-keyword.
- [ ] Run: `./gradlew :x-pack:plugin:esql:internalClusterTest --tests 'org.elasticsearch.xpack.esql.CsvIT.*flattened-unmapped-sink-load*'`

Relates to the `_unmapped` sink write-path work (PR #155007 / commit `82c8f7ac`).