### PR TITLE
[9.5] ESQL: Unmute H3SphericalGeometryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -20,9 +20,6 @@ tests:
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
-- class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
-  method: testIndexPoints
-  issue: https://github.com/elastic/elasticsearch/issues/142439
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/153507


### PR DESCRIPTION
Removes the `H3SphericalGeometryTests#testIndexPoints` mute on this branch.

The mute points at #142439, which closed on 2026-08-03 when the equivalent unmute merged on `main` as #155529 — so it now references a closed issue.

The test itself is healthy. This exact file is byte-identical to the copy on `8.19` and `9.3`, where it was never muted: over the last 90 days it ran **3,932 times on 8.19 and 3,508 times on 9.3 with zero failures**. Its only recorded failures anywhere were 6 on `main`, inside one three-day window in February, and each was a JVM-wide memory-tracking check charging a leak to whichever test finished next — not a fault in this test, which allocates no tracked memory at all.

Verified locally on this branch with the mute removed: 25 iterations, 0 failures.

<details><summary>Evidence and caveats</summary>

**The misattribution mechanism.** `MockBigArrays` records unreleased arrays in `ACQUIRED_ARRAYS`, a `private static final ConcurrentMap` (`MockBigArrays.java:129` on this branch) shared by every test in the JVM. The check runs in `ESTestCase`'s per-test `@After` (`ESTestCase.java:704-708`), and it *removes* the offending entries (`MockBigArrays.java:140-141`) before throwing — so one leak is reported exactly once, against whichever test method happens to finish next. `TRACK_ALLOCATIONS` is `false` (`:127`), so nothing identifies the real allocator. The message itself is emitted at a single site, `MockBigArrays.java:146`. This class constructs no `MockBigArrays` and contains zero `BigArrays` references; it touches only Lucene geo and H3 code, and `testIndexPoints` is its only test method. For contrast, 63 classes in the same `:x-pack:plugin:esql:test` task do use `BigArrays` and are real candidate leakers sharing that task's JVMs.

**The six failures, from ci-stats.** All 6 are tagged branch `main`: 2026-02-10 20:30 (`wq7bj37idvje6`), 02-12 22:29 (`xlcrsg7tecde4`), 02-13 00:47 (`u76iq2xzxoozm`), 01:12 (`yxhtjcp5xnwps`), 02:07 (`fsvue5nrydzyk`), 15:39 (`k5hvg7jjrheei`). Five report `8 arrays have not been released`, one reports `4 arrays`.

**Why "no failures on this branch" is not the argument.** A muted method emits no CI records at all — not even skipped ones. Over the last 90 days `testIndexPoints` has **0 recorded runs** on this branch, so zero failures here is zero out of zero and proves nothing on its own. The load-bearing evidence is the unmuted sibling branches quoted above (7,440 runs, 0 failures) plus the local runs, not the absence of records here.

**The class's other failures are a different bug.** The same class shows 276 failures over 180 days, but 270 are `classMethod` rather than the test method, and 135 of those are `java.lang.ClassCircularityError: java/security/AllPermissionCollection` — predominantly on 8.19 (95) with 40 on 9.2/9.3, and 89 of the 135 under `openjdk22` tags. That is JDK 22 against 8.19's `SecurityManager` (#155406), unrelated to this mute.

**Provenance.** The mute was created once, by the automation, in commit `b6484048e533` on 2026-02-13. `git log -S"H3SphericalGeometryTests" -- muted-tests.yml` returns exactly that one commit on both `9.5` and `9.4`, and GitHub's compare API reports both branches `behind_by=0` relative to it — so 9.4 and 9.5 were cut from `main` after it landed and inherited the mute, rather than receiving separate backports. `9.3` and `8.19` were cut before it, which is why they run the test unmuted today.

**On `main`, where the mute was removed first.** The same test passed 50 consecutive iterations (build scan `camnjnjkwt24k`), and passed again in a run configured with `-Dtests.jvms=1` alongside 11,248 tests across 233 classes (scan `wvgeu4435644o`). The second shape is the meaningful one, since the detector is JVM-wide and a class run by itself cannot reproduce cross-contamination by construction.

**Caveats.** I could not establish what fixed the original leak, or which test was actually leaking; the absence of failures on `main` after 2026-02-13 is uninformative because the method was muted from that date. Relatedly, #142439's closure is not independent corroboration — it closed one second after #155529 merged, i.e. the unmute closed the issue rather than a fix doing so. If the real leaker were fixed on `main` but not here, this test could be charged again on this branch; the 8.19 and 9.3 run data is what argues against that, since those branches carry the same sibling suites unmuted. Run counts are also bounded by the ci-stats retention I could query and are not authoritative before roughly mid-2025.

</details>

Assisted by Claude
