### PR TITLE
[9.5] ESQL: Unmute StSimplifyPreserveTopologyTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -86,9 +86,6 @@ tests:
 - class: org.elasticsearch.xpack.prometheus.PrometheusMetadataRestIT
   method: testMultipleEntriesForSameMetricAcrossStreams
   issue: https://github.com/elastic/elasticsearch/issues/147170
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StSimplifyPreserveTopologyTests
-  method: testEvaluateBlockWithNulls
-  issue: https://github.com/elastic/elasticsearch/issues/147773
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/150782


### PR DESCRIPTION
Unmutes `StSimplifyPreserveTopologyTests#testEvaluateBlockWithNulls` on this branch. Mirror of #155528, which did the same on `main`.

The `StackOverflowError` it was muted for is fixed here. #151554 capped random test geometries at 100 vertices in June and reached 9.5, but the mute was left behind because that PR credited only #150079. #147773, which this mute points at, closed on 2026-07-31 — this was the last reference to it in any mute file on any branch.

Verified locally on this branch with the mute removed: 5200 tests, 0 failures, including 520 runs of the unmuted method across 5 seeds, since the original failure was seed-dependent.

<details><summary>Evidence and caveats</summary>

**The fix is present on this branch.** `MAX_TEST_GEOMETRY_POINTS = 100` at `AbstractSpatialGeometryTransformTestCase.java:69`, applied at `:74` and `:76`, so JTS's recursive simplifier no longer exhausts the stack on pathological random geometries. It arrived via #151554 (merged 2026-06-22).

**The failure is gone everywhere it can be observed.** Zero failures of this class on any branch since 2026-06-20 — two days before the fix merged. Over 180 days: `main` 1,058 failures with the last on 2026-06-20, `9.4` 136 with the last on 2026-05-28, and this branch 0 out of roughly 1.58M executions. Separating the noise, the class's class-level (`classMethod`) failures split into two unrelated causes: 60 `java.lang.StackOverflowError` (the real defect, 2026-04-01 → 2026-06-20) and 64 `java.lang.ClassCircularityError: java/security/AllPermissionCollection` confined to 2026-04-22 → 04-30, which is unrelated infrastructure and should not be read as this bug.

**The mute is what suppressed it here, and nothing else.** Since #155528 merged, `main` has run this method 32,864 times and `9.4` 13,000 times with zero failures, while this branch has no records for it at all — consistent with the mute rather than with the test being absent. Meanwhile the unmuted siblings in the same class, including `testEvaluateInManyThreads` and `testEvaluateBlockWithoutNulls`, have run over 465,000 times on this branch in the last 14 days with zero failures, exercising the same evaluator path.

**Scope.** `main` and `9.4` are already clean (#155528 and #155408). `9.3`, `9.2` and `8.19` do not contain this test class at all, so nothing is left after this. No `Closes` line: #147773 was already closed by #155528, so this references it rather than closing it.

**Caveats.** A muted method emits no CI records at all, not even skipped ones, so "zero failures on this branch" is zero out of zero for the muted method specifically — the positive evidence is the local run above plus the unmuted siblings and the other two branches. The production-side gap remains open and is not addressed here: `warnExceptions` at `StSimplifyPreserveTopology.java:220` lists only `IllegalArgumentException`, which cannot catch an `Error`, so a large enough real user polygon can still surface a raw `StackOverflowError`. That is tracked by #145596 and its draft PR #151864, owned by @craigtaverner.

</details>

Assisted by Claude
