### PR TITLE
[9.5] Increase suite timeout for LookupJoinTypesIT to 40 minutes (#155775)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
@@ -8,9 +8,11 @@
 package org.elasticsearch.xpack.esql.action;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.lucene.queryparser.ext.Extensions.Pair;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -106,6 +108,7 @@ import static org.hamcrest.Matchers.is;
 // TODO: This suite creates a lot of indices. It should be sufficient to just create 1 main index with 1 field per relevant type and 1
 // lookup index with 1 field per relevant type; only union types require additional main indices so we can have the same field mapped to
 // different types.
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 @ClusterScope(scope = SUITE, numClientNodes = 1, numDataNodes = 1)
 @LuceneTestCase.SuppressFileSystems(value = "HandleLimitFS")
 public class LookupJoinTypesIT extends ESIntegTestCase {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Increase suite timeout for LookupJoinTypesIT to 40 minutes (#155775)