### PR TITLE
Updates 9.3.8 and 9.4.4 release notes with security update link

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -120,7 +120,7 @@ Transform:
 ## 9.3.8 [elasticsearch-9.3.8-release-notes]
 
 ::::{important} 
-The 9.3.8 release contains fixes for potential security vulnerabilities. For details, go to https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+The 9.3.8 release contains fixes for potential security vulnerabilities. For details, go to [security announcements](https://discuss.elastic.co/c/announcements/security-announcements/31).
 ::::
 
 ### Features and enhancements [elasticsearch-9.3.8-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -23,7 +23,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ## 9.4.4 [elasticsearch-9.4.4-release-notes]
 
 ::::{important} 
-The 9.4.4 release contains fixes for potential security vulnerabilities. For details, go to https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+The 9.4.4 release contains fixes for potential security vulnerabilities. For details, go to [security announcements](https://discuss.elastic.co/c/announcements/security-announcements/31).
 ::::
 
 ### Features and enhancements [elasticsearch-9.4.4-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -22,6 +22,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.4.4 [elasticsearch-9.4.4-release-notes]
 
+::::{important} 
+The 9.4.4 release contains fixes for potential security vulnerabilities. For details, go to https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+::::
+
 ### Features and enhancements [elasticsearch-9.4.4-features-enhancements]
 
 Authentication:
@@ -114,6 +118,10 @@ Transform:
 
 
 ## 9.3.8 [elasticsearch-9.3.8-release-notes]
+
+::::{important} 
+The 9.3.8 release contains fixes for potential security vulnerabilities. For details, go to https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+::::
 
 ### Features and enhancements [elasticsearch-9.3.8-features-enhancements]
 


### PR DESCRIPTION
Added security vulnerability notices to 9.3.8 and 9.4.4 release notes.

Related to https://github.com/elastic/docs-content-internal/issues/1544.