### PR TITLE
ESQL: Migrate remaining Warnings creation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
@@ -66,7 +66,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             DriverContext driverContext,
             List<Integer> channels
         ) {
-            var warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            var warnings = driverContext.createWarnings(source);
             return new IncreaseExponentialHistogramGroupingAggregatorFunction(channels, driverContext, warnings);
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -62,7 +62,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
 
         @Override
         public RateIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext, List<Integer> channels) {
-            var warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            var warnings = driverContext.createWarnings(source);
             return new RateIntGroupingAggregatorFunction(channels, driverContext, isRateOverTime, isDateNanos, warnings);
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -62,7 +62,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
 
         @Override
         public RateLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext, List<Integer> channels) {
-            var warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            var warnings = driverContext.createWarnings(source);
             return new RateLongGroupingAggregatorFunction(channels, driverContext, isRateOverTime, isDateNanos, warnings);
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperator.java
@@ -240,7 +240,7 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingToIteratorOpe
      * Builds a {@link LoaderAndConverter} for a given shard.
      */
     public interface BuildLoader {
-        LoaderAndConverter build(DriverContext.WarningsMode warningsMode, int shard);
+        LoaderAndConverter build(DriverContext driverContext, int shard);
     }
 
     /**
@@ -565,7 +565,7 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingToIteratorOpe
         }
 
         void newShard(int shard) {
-            LoaderAndConverter l = info.buildLoader.build(driverContext.warningsMode(), shard);
+            LoaderAndConverter l = info.buildLoader.build(driverContext, shard);
             loader = l.loader;
             converter = l.converter == null ? null : converterEvaluators.get(shard, fieldIdx, info.name, l.converter);
             log.debug("moved to shard {} {} {}", shard, loader, converter);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverThreadContextWarningLossTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverThreadContextWarningLossTests.java
@@ -236,7 +236,7 @@ public class DriverThreadContextWarningLossTests extends ESTestCase {
         @Override
         protected Page process(Page page) {
             if (warned.compareAndSet(false, true)) {
-                Warnings warnings = Warnings.createOnlyWarnings(driverContext.warningsMode(), TEST_SOURCE_LOCATION);
+                Warnings warnings = driverContext.createOnlyWarnings(TEST_SOURCE_LOCATION);
                 warnings.registerWarning(warningMessage);
             }
             return page;
@@ -297,7 +297,7 @@ public class DriverThreadContextWarningLossTests extends ESTestCase {
         protected Page process(Page page) {
             Warning warning = warningsByPageIndex.get(pageIndex.getAndIncrement());
             if (warning != null && warning.warned().compareAndSet(false, true)) {
-                Warnings warnings = Warnings.createOnlyWarnings(driverContext.warningsMode(), WarnOnFirstPageOperator.TEST_SOURCE_LOCATION);
+                Warnings warnings = driverContext.createOnlyWarnings(WarnOnFirstPageOperator.TEST_SOURCE_LOCATION);
                 warnings.registerWarning(warning.message());
             }
             return page;

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InBooleanEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InBooleanEvaluator.java
@@ -183,7 +183,7 @@ public class InBooleanEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InBytesRefEvaluator.java
@@ -174,7 +174,7 @@ public class InBytesRefEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleEvaluator.java
@@ -163,7 +163,7 @@ public class InDoubleEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InDoubleRangeEvaluator.java
@@ -147,7 +147,7 @@ public class InDoubleRangeEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InIntEvaluator.java
@@ -163,7 +163,7 @@ public class InIntEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InLongEvaluator.java
@@ -163,7 +163,7 @@ public class InLongEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InLongRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InLongRangeEvaluator.java
@@ -147,7 +147,7 @@ public class InLongRangeEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InMillisNanosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InMillisNanosEvaluator.java
@@ -163,7 +163,7 @@ public class InMillisNanosEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InNanosMillisEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated-src/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InNanosMillisEvaluator.java
@@ -163,7 +163,7 @@ public class InNanosMillisEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -412,7 +412,7 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
                 finishPages = dropDocBlockOperator(request.extractFields);
             }
             releasables.add(finishPages);
-            var warnings = Warnings.createWarnings(DriverContext.WarningsMode.COLLECT, request.source);
+            var warnings = driverContext.createWarnings(request.source);
             LookupEnrichQueryGenerator queryList = queryList(request, shardContext.executionContext, aliasFilter, warnings);
 
             // Stage 1

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
@@ -535,7 +535,7 @@ public class LookupExecutionPlanner {
             SearchExecutionContext searchExecutionContext = lookupDriverContext.searchExecutionContext();
             IndexedByShardId<? extends ShardContext> shardContexts = new IndexedByShardIdFromSingleton<>(shardContext, shardId);
 
-            Warnings warnings = Warnings.createWarnings(DriverContext.WarningsMode.COLLECT, planSource);
+            Warnings warnings = lookupDriverContext.createWarnings(planSource);
             QueryBuilder rewrittenQuery = rewriteQuery(query, searchExecutionContext);
 
             LookupEnrichQueryGenerator queryList = getBulkKeywordQueryGenerator(warnings);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionPlanner.java
@@ -345,7 +345,7 @@ public class LookupExecutionPlanner {
         OperatorFactory mvBulkLookupMvFilterOperatorFactory = new OperatorFactory() {
             @Override
             public Operator get(DriverContext driverContext) {
-                Warnings warnings = Warnings.createWarnings(driverContext.warningsMode(), lookupSource);
+                Warnings warnings = driverContext.createWarnings(lookupSource);
                 return new FilterOperator(new BulkLookupSingleValued(driverContext, channelOffset, warnings));
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/command/CompoundOutputEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/command/CompoundOutputEvaluator.java
@@ -74,9 +74,7 @@ public final class CompoundOutputEvaluator implements ColumnExtractOperator.Eval
     ) implements ColumnExtractOperator.Evaluator.Factory {
 
         public CompoundOutputEvaluator create(DriverContext driverContext) {
-            Warnings warnings = (driverContext == null || source == null)
-                ? Warnings.NOOP_WARNINGS
-                : Warnings.createWarnings(driverContext.warningsMode(), source);
+            Warnings warnings = (driverContext == null || source == null) ? Warnings.NOOP_WARNINGS : driverContext.createWarnings(source);
             OutputFieldsCollector outputFieldsCollector = outputFieldsCollectorProvider.createOutputFieldsCollector();
             return new CompoundOutputEvaluator(inputType, multiValueStrategy, warnings, outputFieldsCollector);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/BlockLoaderWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/BlockLoaderWarnings.java
@@ -18,19 +18,19 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
  * cheap to create.
  */
 public class BlockLoaderWarnings implements org.elasticsearch.index.mapper.blockloader.Warnings {
-    private final DriverContext.WarningsMode warningsMode;
+    private final DriverContext driverContext;
     private final Source source;
     private Warnings delegate;
 
-    public BlockLoaderWarnings(DriverContext.WarningsMode warningsMode, Source source) {
-        this.warningsMode = warningsMode;
+    public BlockLoaderWarnings(DriverContext driverContext, Source source) {
+        this.driverContext = driverContext;
         this.source = source;
     }
 
     @Override
     public void registerException(Class<? extends Exception> exceptionClass, String message) {
         if (delegate == null) {
-            delegate = Warnings.createOnlyWarnings(warningsMode, source);
+            delegate = driverContext.createOnlyWarnings(source);
         }
         delegate.registerException(exceptionClass, message);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -419,7 +419,7 @@ public final class Case extends EsqlScalarFunction {
                  * Rather than go into depth about this in the warning message,
                  * we just say "false".
                  */
-                Warnings.createWarningsTreatedAsFalse(driverContext.warningsMode(), conditionSource),
+                driverContext.createWarningsTreatedAsFalse(conditionSource),
                 condition.get(driverContext),
                 value.get(driverContext)
             );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -135,7 +135,7 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction implem
 
         protected AbstractEvaluator(DriverContext driverContext, Source source) {
             this.driverContext = driverContext;
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
 
         protected abstract ExpressionEvaluator next();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java
@@ -169,7 +169,7 @@ public class FromAggregateMetricDouble extends EsqlScalarFunction implements Con
                     eval,
                     subFieldIndex,
                     // We use this factory method to be compatible with the AvgBlockLoader
-                    Warnings.createOnlyWarnings(context.warningsMode(), source())
+                    context.createOnlyWarnings(source())
                 );
             }
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSingleValueOrNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSingleValueOrNull.java
@@ -174,7 +174,7 @@ public class MvSingleValueOrNull extends AbstractMultivalueFunction implements A
             if (warningsList == null) {
                 warningsList = new ArrayList<>(warningSources.size());
                 for (Source s : warningSources) {
-                    warningsList.add(Warnings.createWarnings(driverContext.warningsMode(), s));
+                    warningsList.add(driverContext.createWarnings(s));
                 }
             }
             return warningsList;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
@@ -190,7 +190,7 @@ final class ReplaceConstantOrdinalEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DenseVectorScalarEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DenseVectorScalarEvaluator.java
@@ -109,7 +109,7 @@ class DenseVectorScalarEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DenseVectorsEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DenseVectorsEvaluator.java
@@ -116,7 +116,7 @@ class DenseVectorsEvaluator implements ExpressionEvaluator {
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st
@@ -282,7 +282,7 @@ $endif$
 
     private Warnings warnings() {
         if (warnings == null) {
-            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+            this.warnings = driverContext.createWarnings(source);
         }
         return warnings;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -299,7 +299,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
     }
 
     private ValuesSourceReaderOperator.LoaderAndConverter blockLoaderAndConverter(
-        DriverContext.WarningsMode warningsMode,
+        DriverContext driverContext,
         int shardId,
         Attribute attr,
         MappedFieldType.FieldExtractPreference fieldExtractPreference
@@ -312,7 +312,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // Apply any block loader function if present
 
         BlockLoaderFunctionConfig functionConfig = null;
-        BlockLoaderWarnings warnings = new BlockLoaderWarnings(warningsMode, attr.source());
+        BlockLoaderWarnings warnings = new BlockLoaderWarnings(driverContext, attr.source());
         String fieldName = getFieldName(attr);
         if (attr instanceof TimeSeriesMetadataAttribute timeSeriesMetadataAttribute) {
             functionConfig = new BlockLoaderFunctionConfig.TimeSeriesMetadata(false, timeSeriesMetadataAttribute.excludedFields());
@@ -650,8 +650,8 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             DataType dataType = attr.dataType();
             var preference = fieldExtractPreference.apply(attr);
             ElementType elementType = PlannerUtils.toElementType(dataType, preference);
-            ValuesSourceReaderOperator.BuildLoader buildLoader = (warningsMode, s) -> blockLoaderAndConverter(
-                warningsMode,
+            ValuesSourceReaderOperator.BuildLoader buildLoader = (driverContext, s) -> blockLoaderAndConverter(
+                driverContext,
                 s,
                 attr,
                 preference

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -867,6 +867,9 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                 )
             );
             if (loader == null) {
+                // Compute-time warning: queued for the later warnings-sink fix. Not routed through the in-scope
+                // blockloader `warnings` object because its only method, registerException(Class, String), would
+                // reframe this plain message as a located exception-style warning, changing the emitted content.
                 HeaderWarning.addWarning("Field [{}] cannot be retrieved, it is unsupported or not indexed; returning null", name);
                 return ConstantNull.INSTANCE;
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
@@ -10,11 +10,13 @@ package org.elasticsearch.xpack.esql.planner;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.lucene.IndexedByShardIdFromSingleton;
 import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.querydsl.query.QueryWarnings;
 import org.elasticsearch.compute.test.NoOpReleasable;
+import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -317,7 +319,8 @@ public class EsPhysicalOperationProvidersTests extends MapperServiceTestCase {
             MappedFieldType.FieldExtractPreference.NONE
         );
         var fieldInfo = provider.extractFields(fieldExtractExec).getFirst();
-        return fieldInfo.buildLoader().build(DriverContext.WarningsMode.COLLECT, 0);
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        return fieldInfo.buildLoader().build(driverContext, 0);
     }
 
     private static Settings tsdbSettings(String temporalityFieldName) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -784,7 +784,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         );
         var p = plan.driverFactories.get(0).driverSupplier().physicalOperation();
         var fieldInfo = ((ValuesSourceReaderOperator.Factory) p.intermediateOperatorFactories.get(0)).fields().get(0);
-        return fieldInfo.buildLoader().build(DriverContext.WarningsMode.COLLECT, 0);
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        return fieldInfo.buildLoader().build(driverContext, 0);
     }
 
     private int randomEstimatedRowSize(boolean huge) {


### PR DESCRIPTION
Migrates most remaining `Warnings.create` calls to `DriverContext.createWarnings`.

Here are the remaining Warnings constructions:
- All remaining test helpers (WarningsTests, SingleValueQuery*Tests, *FunctionBridgeTests,
  PromqlHistogramQuantileStatesTests, BulkLookupSingleValuedTests, LookupQueryOperatorTests,
  EnrichQuerySourceOperatorTests)

We'll migrate them when we change how Warnings are collected.

While we're here, we triaged a few HeaderWarnings.addWarnings calls. These rules are safe enough, though worth fixing later:
- parser/LogicalPlanBuilder.java
- optimizer/rules/logical/RemoveStatsOverride.java
- optimizer/rules/logical/WarnLostSortOrder.java
- optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
- analysis/Analyzer.java
- approximation/ApproximationVerifier.java
- dsltranslate/RequestFilterRewriter.java (planning-time filter rewrite)

These are sneaky, and should move, but in the follow-up:
- datasources/StreamingParallelParsingCoordinator.java
- datasources/AsyncExternalSourceOperator.java
- datasources/AsyncExternalSourceOperatorFactory.java
- datasources/SchemaReconciliation.java
- datasources/spi/SkipWarnings.java
- datasources/ExternalSourceResolver.java

