### PR TITLE
Produce byte centroids in flat-threshold path for byte fields

### DIFF
--- a/docs/changelog/155795.yaml
+++ b/docs/changelog/155795.yaml
@@ -1,0 +1,7 @@
+area: Vector Search
+issues:
+ - 155783
+ - 155784
+pr: 155795
+summary: Produce byte centroids in flat-threshold path for byte fields
+type: bug

--- a/docs/changelog/155795.yaml
+++ b/docs/changelog/155795.yaml
@@ -1,7 +1,0 @@
-area: Vector Search
-issues:
- - 155783
- - 155784
-pr: 155795
-summary: Produce byte centroids in flat-threshold path for byte fields
-type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsWriter.java
@@ -532,17 +532,26 @@ public abstract class IVFVectorsWriter<CI> extends KnnVectorsWriter {
      * @return a {@link CentroidAssignments} instance with one centroid and
      *         all vectors assigned to it
      */
-    protected final CentroidInformation<float[]> buildFlatCentroidAssignments(FieldInfo fieldInfo, ClusteringVectorValues<?> vectorValues)
+    protected final CentroidInformation<?> buildFlatCentroidAssignments(FieldInfo fieldInfo, ClusteringVectorValues<?> vectorValues)
         throws IOException {
         int dimension = fieldInfo.getVectorDimension();
         int count = vectorValues.size();
-        float[] centroid = new float[dimension];
-        accumulateVectors(fieldInfo.getVectorEncoding(), vectorValues, centroid);
+        float[] floatCentroid = new float[dimension];
+        accumulateVectors(fieldInfo.getVectorEncoding(), vectorValues, floatCentroid);
         for (int d = 0; d < dimension; d++) {
-            centroid[d] /= count;
+            floatCentroid[d] /= count;
+        }
+        // For byte fields with native byte support, produce byte centroids so that the
+        // on-disk format stores them as bytes and merge can reuse them without type mismatch.
+        if (supportsByteNative() && fieldInfo.getVectorEncoding() == VectorEncoding.BYTE) {
+            byte[] byteCentroid = new byte[dimension];
+            for (int d = 0; d < dimension; d++) {
+                byteCentroid[d] = (byte) Math.clamp(Math.round(floatCentroid[d]), -128, 127);
+            }
+            return CentroidInformation.ofBytes(dimension, new byte[][] { byteCentroid }, new int[count], OverspillAssignments.NONE);
         }
         // For flat centroid assignments there is a single global centroid and no secondary centroid assignments
-        return CentroidInformation.ofFloat(dimension, new float[][] { centroid }, new int[count], OverspillAssignments.NONE);
+        return CentroidInformation.ofFloat(dimension, new float[][] { floatCentroid }, new int[count], OverspillAssignments.NONE);
     }
 
     /**


### PR DESCRIPTION
## Summary

- `buildFlatCentroidAssignments` unconditionally produced `CentroidInformation<float[]>` even for byte fields with `supportsByteNative()`, writing `byteCentroids=false` in the segment metadata.
- During merge, the byte merge path read this centroid data as `KMeansFloatVectorValues` and passed it to `CentroidOps.BYTE.concatenate()`, which cast to `ClusteringByteVectorValues` — causing a `ClassCastException` on the merge thread.
- Fix: widen the return type to `CentroidInformation<?>` and, when the field is byte-encoded and `supportsByteNative()` is true, round the float mean centroid to bytes and return `CentroidInformation<byte[]>`. This follows the same encoding-aware dispatch pattern already used elsewhere in the flush path.

## References

Closes #155783
Closes #155784