### PR TITLE
Use ordinals in PackDims aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PackDimsGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PackDimsGroupingAggregatorFunction.java
@@ -6,16 +6,27 @@
  */
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DimsPacker;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
+import java.util.Arrays;
 import java.util.List;
 
 public final class PackDimsGroupingAggregatorFunction implements GroupingAggregatorFunction {
@@ -25,10 +36,13 @@ public final class PackDimsGroupingAggregatorFunction implements GroupingAggrega
     private final DriverContext driverContext;
     private final DimensionValuesByteRefGroupingAggregatorFunction delegate;
 
+    private OrdinalState ordinalState;
+
     public PackDimsGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext) {
         this.channels = channels.stream().mapToInt(n -> n).toArray();
         this.driverContext = driverContext;
         this.delegate = new DimensionValuesByteRefGroupingAggregatorFunction(channels, driverContext);
+        this.ordinalState = new OrdinalState(driverContext);
     }
 
     @Override
@@ -39,35 +53,40 @@ public final class PackDimsGroupingAggregatorFunction implements GroupingAggrega
     // This should not run on the production, but add these for completeness
     @Override
     public AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds, Page page) {
+        flushOrdinalStateToDelegate();
         final Block[] inputBlocks = new Block[channels.length];
         for (int i = 0; i < channels.length; i++) {
             inputBlocks[i] = page.getBlock(channels[i]);
         }
         final var valuesBlock = DimsPacker.packMultiColumns(driverContext, inputBlocks).asBlock();
+        return addToFallback(valuesBlock);
+    }
+
+    private AddInput addToFallback(BytesRefBlock packedBlock) {
         return new AddInput() {
             @Override
             public void add(int positionOffset, IntArrayBlock groupIds) {
-                delegate.addInputValuesBlock(positionOffset, groupIds, valuesBlock);
+                delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
             }
 
             @Override
             public void add(int positionOffset, IntBigArrayBlock groupIds) {
-                delegate.addInputValuesBlock(positionOffset, groupIds, valuesBlock);
+                delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
             }
 
             @Override
             public void add(int positionOffset, IntVector groupIds) {
-                var valuesVector = valuesBlock.asVector();
+                var valuesVector = packedBlock.asVector();
                 if (valuesVector != null) {
                     delegate.addInputValuesVector(positionOffset, groupIds, valuesVector);
                 } else {
-                    delegate.addInputValuesBlock(positionOffset, groupIds, valuesBlock);
+                    delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
                 }
             }
 
             @Override
             public void close() {
-                valuesBlock.close();
+                packedBlock.close();
             }
         };
     }
@@ -79,32 +98,234 @@ public final class PackDimsGroupingAggregatorFunction implements GroupingAggrega
 
     @Override
     public void addIntermediateInput(int positionOffset, IntArrayBlock groups, Page page) {
+        flushOrdinalStateToDelegate();
         delegate.addIntermediateInput(positionOffset, groups, page);
     }
 
     @Override
     public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
+        flushOrdinalStateToDelegate();
         delegate.addIntermediateInput(positionOffset, groups, page);
     }
 
     @Override
     public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+        flushOrdinalStateToDelegate();
         delegate.addIntermediateInput(positionOffset, groups, page);
     }
 
     @Override
+    public AddInput prepareProcessIntermediateInputPage(SeenGroupIds seenGroupIds, Page page) {
+        BytesRefBlock packedBlock = page.getBlock(channels[0]);
+        BytesRefVector packedVector = packedBlock.asVector();
+        if (packedVector == null || ordinalState == null) {
+            flushOrdinalStateToDelegate();
+            packedBlock.incRef();
+            return addToFallback(packedBlock);
+        }
+        return new AddInput() {
+            @Override
+            public void add(int positionOffset, IntArrayBlock groupIds) {
+                flushOrdinalStateToDelegate();
+                delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
+            }
+
+            @Override
+            public void add(int positionOffset, IntBigArrayBlock groupIds) {
+                flushOrdinalStateToDelegate();
+                delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
+            }
+
+            @Override
+            public void add(int positionOffset, IntVector groupIds) {
+                if (ordinalState != null) {
+                    var packedOrdinals = packedVector.asOrdinals();
+                    if (packedOrdinals != null) {
+                        ordinalState.addOrdinalVector(positionOffset, groupIds, packedOrdinals);
+                    } else {
+                        ordinalState.addVector(positionOffset, groupIds, packedVector);
+                    }
+                } else {
+                    delegate.addInputValuesBlock(positionOffset, groupIds, packedBlock);
+                }
+            }
+
+            @Override
+            public void close() {
+
+            }
+        };
+    }
+
+    private void flushOrdinalStateToDelegate() {
+        if (ordinalState != null) {
+            var state = ordinalState;
+            ordinalState = null;
+            try (state) {
+                state.fallbackToDelegate();
+            }
+        }
+    }
+
+    @Override
     public PreparedForEvaluation prepareEvaluateIntermediate(IntVector selected, GroupingAggregatorEvaluationContext ctx) {
-        return delegate.prepareEvaluateIntermediate(selected, ctx);
+        if (ordinalState != null) {
+            return ordinalState.preparedForEvaluation(selected, ctx);
+        } else {
+            return delegate.prepareEvaluateIntermediate(selected, ctx);
+        }
     }
 
     @Override
     public PreparedForEvaluation prepareEvaluateFinal(IntVector selected, GroupingAggregatorEvaluationContext ctx) {
-        return delegate.prepareEvaluateFinal(selected, ctx);
+        return prepareEvaluateIntermediate(selected, ctx);
+    }
+
+    private class OrdinalState implements Releasable {
+        private BytesRefArray values;
+        private int[] ords;
+        private int maxGroupId = -1;
+        private int[] mappedOrds = new int[0];
+
+        OrdinalState(DriverContext driverContext) {
+            this.values = new BytesRefArray(PageCacheRecycler.PAGE_SIZE_IN_BYTES, driverContext.bigArrays());
+            this.ords = new int[1024];
+            Arrays.fill(this.ords, -1);
+        }
+
+        private void ensureOrds(int groupId) {
+            if (groupId >= ords.length) {
+                int oldLen = ords.length;
+                ords = ArrayUtil.grow(ords, groupId + 1);
+                Arrays.fill(ords, oldLen, ords.length, -1);
+            }
+        }
+
+        void addVector(int positionOffset, IntVector groupIds, BytesRefVector vector) {
+            BytesRef scratch = new BytesRef();
+            for (int p = 0; p < groupIds.getPositionCount(); p++) {
+                int groupId = groupIds.getInt(p);
+                ensureOrds(groupId);
+                if (ords[groupId] == -1) {
+                    ords[groupId] = Math.toIntExact(values.size());
+                    values.append(vector.getBytesRef(positionOffset + p, scratch));
+                    maxGroupId = Math.max(maxGroupId, groupId);
+                }
+            }
+        }
+
+        void addOrdinalVector(int positionOffset, IntVector groupIds, OrdinalBytesRefVector ordinalVector) {
+            BytesRef scratch = new BytesRef();
+            int nextOrd = Math.toIntExact(values.size());
+            BytesRefVector dict = ordinalVector.getDictionaryVector();
+            // for new pages
+            if (positionOffset == 0) {
+                if (mappedOrds.length < dict.getPositionCount()) {
+                    mappedOrds = new int[dict.getPositionCount()];
+                }
+                Arrays.fill(mappedOrds, -1);
+            }
+            IntVector ordinals = ordinalVector.getOrdinalsVector();
+            for (int p = 0; p < groupIds.getPositionCount(); p++) {
+                int groupId = groupIds.getInt(p);
+                ensureOrds(groupId);
+                if (ords[groupId] == -1) {
+                    int ord = ordinals.getInt(positionOffset + p);
+                    int mappedOrd = mappedOrds[ord];
+                    if (mappedOrd == -1) {
+                        values.append(dict.getBytesRef(ord, scratch));
+                        mappedOrds[ord] = mappedOrd = nextOrd++;
+                    }
+                    ords[groupId] = mappedOrd;
+                    maxGroupId = Math.max(maxGroupId, groupId);
+                }
+            }
+        }
+
+        void fallbackToDelegate() {
+            if (maxGroupId == -1) {
+                return;
+            }
+            BytesRefVector dict = driverContext.blockFactory().newBytesRefArrayVector(values, Math.toIntExact(values.size()));
+            values = null;
+            try {
+                final IntBlock ordinals;
+                try (var builder = driverContext.blockFactory().newIntBlockBuilder(maxGroupId + 1)) {
+                    for (int g = 0; g <= maxGroupId; g++) {
+                        int ord = ords[g];
+                        if (ord == -1) {
+                            builder.appendNull();
+                        } else {
+                            builder.appendInt(ord);
+                        }
+                    }
+                    ordinals = builder.build();
+                }
+                try (
+                    IntVector groupIds = driverContext.blockFactory().newIntRangeVector(0, maxGroupId + 1);
+                    OrdinalBytesRefBlock valuesBlock = new OrdinalBytesRefBlock(ordinals, dict)
+                ) {
+                    dict = null;
+                    delegate.addInputValuesBlock(0, groupIds, valuesBlock);
+                }
+            } finally {
+                ords = null;
+                Releasables.close(dict);
+            }
+        }
+
+        PreparedForEvaluation preparedForEvaluation(IntVector selected, GroupingAggregatorEvaluationContext ctx) {
+            int valuesSize = Math.toIntExact(values.size());
+            mappedOrds = new int[0];
+            return (blocks, offset, selectedInPage) -> {
+                int[] mappedOrds = new int[valuesSize];
+                Arrays.fill(mappedOrds, -1);
+                int nextOrd = 0;
+                BytesRef scratch = new BytesRef();
+                final int positionCount = selectedInPage.getPositionCount();
+                try (
+                    var ordBuilder = ctx.blockFactory().newIntBlockBuilder(positionCount);
+                    var dictBuilder = ctx.blockFactory().newBytesRefVectorBuilder(positionCount)
+                ) {
+                    for (int p = 0; p < positionCount; p++) {
+                        int groupId = selectedInPage.getInt(p);
+                        int ord = groupId < ords.length ? ords[groupId] : -1;
+                        if (ord < 0) {
+                            ordBuilder.appendNull();
+                            continue;
+                        }
+                        int mappedOrd = mappedOrds[ord];
+                        if (mappedOrd == -1) {
+                            dictBuilder.appendBytesRef(values.get(ord, scratch));
+                            mappedOrd = mappedOrds[ord] = nextOrd++;
+                        }
+                        ordBuilder.appendInt(mappedOrd);
+                    }
+                    IntBlock ordsBlock = null;
+                    BytesRefVector dictVector = null;
+                    try {
+                        ordsBlock = ordBuilder.build();
+                        dictVector = dictBuilder.build();
+                        blocks[offset] = new OrdinalBytesRefBlock(ordsBlock, dictVector);
+                        ordsBlock = null;
+                        dictVector = null;
+                    } finally {
+                        Releasables.close(ordsBlock, dictVector);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(values);
+            values = null;
+        }
     }
 
     @Override
     public void close() {
-        Releasables.close(delegate);
+        Releasables.close(delegate, ordinalState);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PackDimsGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PackDimsGroupingAggregatorFunctionTests.java
@@ -12,8 +12,11 @@ import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DimsPacker;
 import org.elasticsearch.compute.operator.Driver;
@@ -28,6 +31,7 @@ import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.core.Releasables;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,5 +124,135 @@ public class PackDimsGroupingAggregatorFunctionTests extends ComputeTestCase {
         }
         assertThat(actualDim0, equalTo(expectedDim0));
         assertThat(actualDim1, equalTo(expectedDim1));
+    }
+
+    private BytesRefVector randomInputVector(BytesRef[] dictValues, int size) {
+        if (randomBoolean()) {
+            try (var builder = blockFactory().newBytesRefVectorBuilder(size)) {
+                for (int i = 0; i < size; i++) {
+                    builder.appendBytesRef(randomFrom(dictValues));
+                }
+                return builder.build();
+            }
+        }
+        int[] mappedOrds = new int[dictValues.length];
+        Arrays.fill(mappedOrds, -1);
+        int nextOrd = 0;
+        try (var dictBuilder = blockFactory().newBytesRefVectorBuilder(size); var ordsBuilder = blockFactory().newIntVectorBuilder(size);) {
+            int ord = randomIntBetween(0, dictValues.length - 1);
+            for (int p = 0; p < size; p++) {
+                int mappedOrd = mappedOrds[ord];
+                if (mappedOrd == -1) {
+                    mappedOrd = nextOrd++;
+                    dictBuilder.appendBytesRef(dictValues[ord]);
+                }
+                ordsBuilder.appendInt(mappedOrd);
+            }
+            return new OrdinalBytesRefVector(ordsBuilder.build(), dictBuilder.build());
+        }
+    }
+
+    private BytesRefBlock randomInputBlock(BytesRef[] dictValues, int size) {
+        try (var builder = blockFactory().newBytesRefBlockBuilder(size)) {
+            int valueCount = between(0, 2);
+            if (valueCount == 1) {
+                builder.appendBytesRef(randomFrom(dictValues));
+            } else if (valueCount == 0) {
+                builder.appendNull();
+            } else {
+                builder.beginPositionEntry();
+                for (int i = 0; i < valueCount; i++) {
+                    builder.appendBytesRef(randomFrom(dictValues));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    public void testIntermediateInput() {
+        BlockFactory blockFactory = blockFactory();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        int dictSize = between(1, 20);
+        BytesRef[] dictValues = new BytesRef[dictSize];
+        for (int i = 0; i < dictSize; i++) {
+            dictValues[i] = new BytesRef("v" + i);
+        }
+        int numPages = between(1, 5);
+        var packedAggs = new PackDimsGroupingAggregatorFunction(List.of(0), driverContext);
+        var dimAggs = new DimensionValuesByteRefGroupingAggregatorFunction(List.of(0), driverContext);
+        int maxGroupId = -1;
+        boolean fallback = false;
+        for (int i = 0; i < numPages; i++) {
+            final Page page;
+            if (frequently()) {
+                page = new Page(randomInputVector(dictValues, between(1, 100)).asBlock());
+            } else {
+                BytesRefBlock bytesBlock = randomInputBlock(dictValues, between(1, 100));
+                fallback |= bytesBlock.asVector() == null;
+                page = new Page(bytesBlock);
+            }
+            try (
+                var addInput1 = dimAggs.prepareProcessIntermediateInputPage(null, page);
+                var addInput2 = packedAggs.prepareProcessIntermediateInputPage(null, page)
+            ) {
+                int positionOffset = 0;
+                while (positionOffset < page.getPositionCount()) {
+                    int positionCount = between(1, page.getPositionCount() - positionOffset);
+                    try (var groupsBuilder = blockFactory.newIntVectorBuilder(positionCount)) {
+                        for (int p = 0; p < positionCount; p++) {
+                            if (maxGroupId > 0 && randomBoolean()) {
+                                groupsBuilder.appendInt(between(0, maxGroupId));
+                            } else {
+                                maxGroupId++;
+                                groupsBuilder.appendInt(maxGroupId);
+                            }
+                        }
+                        try (var groupIds = groupsBuilder.build()) {
+                            addInput1.add(positionOffset, groupIds);
+                            addInput2.add(positionOffset, groupIds);
+                        }
+                    }
+                    positionOffset += positionCount;
+                }
+            }
+            page.close();
+        }
+
+        try (var evalCtx = new GroupingAggregatorEvaluationContext(driverContext)) {
+            IntVector allSelected;
+            try (var sb = blockFactory.newIntVectorFixedBuilder(maxGroupId + 1)) {
+                for (int g = 0; g <= maxGroupId; g++) {
+                    sb.appendInt(g);
+                }
+                allSelected = sb.build();
+            }
+            try (
+                allSelected;
+                var eval1 = packedAggs.prepareEvaluateIntermediate(allSelected, evalCtx);
+                var eval2 = dimAggs.prepareEvaluateIntermediate(allSelected, evalCtx);
+            ) {
+                int offset = 0;
+                while (offset <= maxGroupId) {
+                    int end = between(offset + 1, maxGroupId + 1);
+                    Block[] out1 = new Block[1];
+                    Block[] out2 = new Block[1];
+                    try (var selected = blockFactory.newIntRangeVector(offset, end)) {
+                        eval1.evaluate(out1, 0, selected);
+                        eval2.evaluate(out2, 0, selected);
+                        assertThat(out1[0], equalTo(out2[0]));
+                        if (fallback == false) {
+                            assertNotNull(((BytesRefBlock) out1[0]).asOrdinals());
+                        }
+                    } finally {
+                        Releasables.close(out1);
+                        Releasables.close(out2);
+                    }
+                    offset = end;
+                }
+            }
+        } finally {
+            Releasables.close(packedAggs, dimAggs);
+        }
     }
 }


### PR DESCRIPTION
This change uses ordinals to reduce memory usage in PackDimsAgg. Instead of storing one value per group like DimensionValues, or hashing every value into a dictionary like ValuesAggregation, this aggregation builds its dictionary directly from the input block's existing ordinals when available. It might not be as compact as ValuesAggregation's hash-based dictionary, but since time-series data arrives ordered by tsid, the resulting dictionary should still be compact in practice.