### PR TITLE
[9.4] add docs and test for using expand_wildcards (#155660)

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/explain-lifecycle.md
+++ b/docs/reference/elasticsearch/rest-apis/explain-lifecycle.md
@@ -57,6 +57,8 @@ GET /_cluster/health?wait_for_status=green&timeout=10s
 GET my-index-000001/_ilm/explain?human
 ```
 
+To include hidden indices when using wildcard expressions, set `expand_wildcards` to include `hidden` (for example, `open,hidden`).
+
 When management of the index is first taken over by {{ilm-init}}, `explain` shows that the index is managed and in the `new` phase:
 
 ```console-result

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -36,6 +36,18 @@
         "type": "boolean",
         "description": "filters the indices included in the response to ones in an ILM error state, implies only_managed"
       },
+      "expand_wildcards": {
+        "type": "list",
+        "options": [
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default": "open",
+        "description": "Whether wildcard expressions should get expanded to open, closed, or hidden indices (default: open)"
+      },
       "master_timeout": {
         "type": "time",
         "default": "30s",

--- a/x-pack/plugin/ilm/src/yamlRestTest/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
+++ b/x-pack/plugin/ilm/src/yamlRestTest/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
@@ -67,6 +67,14 @@ setup:
           settings:
             index.lifecycle.name: "a_policy_that_doesnt_exist"
 
+  - do:
+      indices.create:
+        index: hidden_index
+        body:
+          settings:
+            index.hidden: true
+            index.lifecycle.name: "my_moveable_timeseries_lifecycle"
+
 ---
 teardown:
 
@@ -90,6 +98,10 @@ teardown:
   - do:
       indices.delete:
         index: index_with_policy_that_doesnt_exist
+
+  - do:
+      indices.delete:
+        index: hidden_index
 
   - do:
       ilm.delete_lifecycle:
@@ -153,3 +165,13 @@ teardown:
   - is_false: indices.my_index
   - is_false: indices.my_index2
   - is_false: indices.another_index
+
+---
+"Test expand_wildcards supports hidden indices":
+
+  - do:
+      ilm.explain_lifecycle:
+        index: "hidden_*"
+        expand_wildcards: open,hidden
+
+  - match: { indices.hidden_index.index: "hidden_index" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [add docs and test for using expand_wildcards (#155660)](https://github.com/elastic/elasticsearch/pull/155660)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)