### PR TITLE
Support columnar batch mapping for pattern_text

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/LuceneBinaryColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/LuceneBinaryColumn.java
@@ -92,12 +92,6 @@ public final class LuceneBinaryColumn extends BinaryColumn implements LuceneColu
                 // Lucene's Field(String, BytesRef, FieldType) constructor rejects tokenized+indexed
                 // field types ("cannot set a BytesRef value on a tokenized field"). Indexed tokenized
                 // fields require a String so Lucene can run an analyzer over them.
-                //
-                // However, Lucene's Field(String, CharSequence, FieldType) constructor rejects fields
-                // that are neither stored nor indexed — it has no doc-values check. If a field is
-                // tokenized but not indexed (doc-values-only), the BytesRef constructor is used instead;
-                // its tokenized check only fires when indexOptions != NONE, so doc-values-only tokenized
-                // fields are accepted there.
                 if (fieldType().tokenized() && fieldType().indexOptions() != IndexOptions.NONE) {
                     out.add(new Field(name(), cursor.value().utf8ToString(), fieldType()));
                 } else {

--- a/server/src/main/java/org/elasticsearch/escf/LuceneBinaryColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/LuceneBinaryColumn.java
@@ -14,6 +14,7 @@ import org.apache.lucene.document.column.BinaryColumn;
 import org.apache.lucene.document.column.BytesRefValuesCursor;
 import org.apache.lucene.document.column.Column;
 import org.apache.lucene.document.column.ObjectTupleCursor;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
@@ -87,7 +88,21 @@ public final class LuceneBinaryColumn extends BinaryColumn implements LuceneColu
                 // called more than once for the same document and every emitted field is retained in
                 // the caller's list, so a single reused field object would collapse all values to the
                 // last one. cursor.value() already returns a fresh BytesRef per element.
-                out.add(new Field(name(), cursor.value(), fieldType()));
+                //
+                // Lucene's Field(String, BytesRef, FieldType) constructor rejects tokenized+indexed
+                // field types ("cannot set a BytesRef value on a tokenized field"). Indexed tokenized
+                // fields require a String so Lucene can run an analyzer over them.
+                //
+                // However, Lucene's Field(String, CharSequence, FieldType) constructor rejects fields
+                // that are neither stored nor indexed — it has no doc-values check. If a field is
+                // tokenized but not indexed (doc-values-only), the BytesRef constructor is used instead;
+                // its tokenized check only fires when indexOptions != NONE, so doc-values-only tokenized
+                // fields are accepted there.
+                if (fieldType().tokenized() && fieldType().indexOptions() != IndexOptions.NONE) {
+                    out.add(new Field(name(), cursor.value().utf8ToString(), fieldType()));
+                } else {
+                    out.add(new Field(name(), cursor.value(), fieldType()));
+                }
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -2033,6 +2033,15 @@ public final class KeywordFieldMapper extends FieldMapper {
         return new KeywordField(fieldType().name(), binaryValue, fieldType);
     }
 
+    /**
+     * Returns the Lucene {@link FieldType} carried by the fields this mapper emits.
+     * Needed by mappers that delegate part of their columnar output to keyword sub-fields
+     * and must produce a byte-identical field type for the {@code _template_id} column.
+     */
+    public FieldType luceneFieldType() {
+        return fieldType;
+    }
+
     @Override
     public void doValidate(MappingLookup lookup) {
         if (fieldType().isDimension() && null != lookup.nestedLookup().getNestedParent(fullPath())) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -2033,11 +2033,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         return new KeywordField(fieldType().name(), binaryValue, fieldType);
     }
 
-    /**
-     * Returns the Lucene {@link FieldType} carried by the fields this mapper emits.
-     * Needed by mappers that delegate part of their columnar output to keyword sub-fields
-     * and must produce a byte-identical field type for the {@code _template_id} column.
-     */
     public FieldType luceneFieldType() {
         return fieldType;
     }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/Arg.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/Arg.java
@@ -26,8 +26,9 @@ public class Arg {
 
     private static final String SPACE = " ";
     private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
-    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
-    private static int VINT_MAX_BYTES = 5;
+    static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    /** Maximum bytes a single vint can occupy. */
+    static final int VINT_MAX_BYTES = 5;
 
     public enum Type {
         GENERIC(0);
@@ -95,6 +96,43 @@ public class Arg {
         int size = dataInput.getPosition();
         byte[] data = Arrays.copyOfRange(buffer, 0, size);
         return ENCODER.encodeToString(data);
+    }
+
+    /**
+     * Byte-level variant of {@link #encodeInfo(List)} for the columnar batch path.
+     * Writes the base64url encoding of {@code count} arg offsets into {@code dest} and returns the
+     * number of bytes written. All arg types are assumed to be {@link Type#GENERIC}.
+     *
+     * @param offsets     UTF-16 template offsets for each arg (indices 0..count-1 are used)
+     * @param count       number of args to encode (may be zero)
+     * @param rawScratch  scratch buffer for the binary vint step; length must be ≥
+     *                    {@code VINT_MAX_BYTES + count * 2 * VINT_MAX_BYTES}
+     * @param dest        destination for base64url bytes; length must be ≥
+     *                    {@link #argsInfoMaxBase64Bytes(int)} with this {@code count}
+     * @return number of bytes written to {@code dest}
+     */
+    static int encodeInfoBytes(int[] offsets, int count, byte[] rawScratch, byte[] dest) throws IOException {
+        var out = new ByteArrayDataOutput(rawScratch);
+        out.writeVInt(count);
+        int prev = 0;
+        for (int i = 0; i < count; i++) {
+            out.writeVInt(Type.GENERIC.toCode()); // always 0
+            out.writeVInt(offsets[i] - prev);
+            prev = offsets[i];
+        }
+        int rawLen = out.getPosition();
+        // Encode only the written prefix [0, rawLen). Arrays.copyOfRange allocates a small
+        // (<100 bytes for typical log lines) intermediate array — the larger allocation savings
+        // come from the caller avoiding String, Pattern.split, ArrayList, and StringBuilder.
+        return ENCODER.encode(Arrays.copyOfRange(rawScratch, 0, rawLen), dest);
+    }
+
+    /**
+     * Maximum number of base64url bytes that {@link #encodeInfoBytes} can write for {@code count} args.
+     */
+    static int argsInfoMaxBase64Bytes(int count) {
+        int rawMax = VINT_MAX_BYTES + count * 2 * VINT_MAX_BYTES;
+        return ((rawMax + 2) / 3) * 4;
     }
 
     static List<Info> decodeInfo(String encoded) throws IOException {

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/Arg.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/Arg.java
@@ -27,7 +27,6 @@ public class Arg {
     private static final String SPACE = " ";
     private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
     static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
-    /** Maximum bytes a single vint can occupy. */
     static final int VINT_MAX_BYTES = 5;
 
     public enum Type {
@@ -99,20 +98,14 @@ public class Arg {
     }
 
     /**
-     * Byte-level variant of {@link #encodeInfo(List)} for the columnar batch path.
-     * Writes the base64url encoding of {@code count} arg offsets into {@code dest} and returns the
-     * number of bytes written. All arg types are assumed to be {@link Type#GENERIC}.
+     * Byte-level equivalent of {@link #encodeInfo(List)} for the columnar path: writes base64url
+     * bytes into {@code dest} and returns their length.
      *
-     * @param offsets     UTF-16 template offsets for each arg (indices 0..count-1 are used)
-     * @param count       number of args to encode (may be zero)
-     * @param rawScratch  scratch buffer for the binary vint step; length must be ≥
-     *                    {@code VINT_MAX_BYTES + count * 2 * VINT_MAX_BYTES}
-     * @param dest        destination for base64url bytes; length must be ≥
-     *                    {@link #argsInfoMaxBase64Bytes(int)} with this {@code count}
-     * @return number of bytes written to {@code dest}
+     * <p>{@code out} is a caller-owned, reusable {@link ByteArrayDataOutput}, reset onto
+     * {@code rawScratch} on every call so that it is not allocated per document.
      */
-    static int encodeInfoBytes(int[] offsets, int count, byte[] rawScratch, byte[] dest) throws IOException {
-        var out = new ByteArrayDataOutput(rawScratch);
+    static int encodeInfoBytes(int[] offsets, int count, ByteArrayDataOutput out, byte[] rawScratch, byte[] dest) throws IOException {
+        out.reset(rawScratch);
         out.writeVInt(count);
         int prev = 0;
         for (int i = 0; i < count; i++) {
@@ -127,9 +120,6 @@ public class Arg {
         return ENCODER.encode(Arrays.copyOfRange(rawScratch, 0, rawLen), dest);
     }
 
-    /**
-     * Maximum number of base64url bytes that {@link #encodeInfoBytes} can write for {@code count} args.
-     */
     static int argsInfoMaxBase64Bytes(int count) {
         int rawMax = VINT_MAX_BYTES + count * 2 * VINT_MAX_BYTES;
         return ((rawMax + 2) / 3) * 4;

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
@@ -13,14 +13,24 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnData;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.EscfColumnTransforms;
+import org.elasticsearch.escf.LuceneBinaryColumn;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.BatchMappingContext;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
@@ -34,6 +44,7 @@ import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.StringStoredFieldFieldLoader;
 import org.elasticsearch.index.mapper.TextParams;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -236,6 +247,13 @@ public class PatternTextFieldMapper extends FieldMapper {
     private final String indexOptions;
     private final FieldType fieldType;
     private final KeywordFieldMapper templateIdMapper;
+    /**
+     * The Lucene {@link FieldType} carried by the template-id keyword field. Captured once at
+     * construction time so {@link #mapColumnBatch} can emit the {@code .template_id} column with
+     * the exact same field-type the row path produces, without going through a per-doc
+     * {@link KeywordFieldMapper#buildKeywordField} call.
+     */
+    private final FieldType templateIdFieldType;
     private final boolean useBinaryDocValueArgs;
     private final boolean useBinaryDocValuesForRawText;
 
@@ -256,6 +274,7 @@ public class PatternTextFieldMapper extends FieldMapper {
         this.indexSettings = builder.indexSettings;
         this.indexOptions = builder.indexOptions.getValue();
         this.templateIdMapper = templateIdMapper;
+        this.templateIdFieldType = templateIdMapper.luceneFieldType();
         this.useBinaryDocValueArgs = builder.useBinaryDocValuesForArgsColumn();
         this.useBinaryDocValuesForRawText = builder.useBinaryDocValuesForRawText;
     }
@@ -349,6 +368,170 @@ public class PatternTextFieldMapper extends FieldMapper {
     private static boolean useBinaryDocValuesForRawText(IndexSettings indexSettings) {
         return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.STORE_PATTERN_TEXT_FIELDS_IN_BINARY_DOC_VALUES)
             && indexSettings.useTimeSeriesDocValuesFormat();
+    }
+
+    // ── Columnar batch mapping ────────────────────────────────────────────────────────────────
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings settings) {
+        // Only activate on strict-columnar index modes (COLUMNAR / LOGSDB_COLUMNAR), which
+        // guarantee useBinaryDocValuesForRawText == true (via USE_TIME_SERIES_DOC_VALUES_FORMAT).
+        // We require it explicitly here rather than implicitly to make the invariant visible.
+        return settings.getMode().isStrictColumnar()
+            && useBinaryDocValueArgs            // only the binary-doc-values args encoding is handled
+            && useBinaryDocValuesForRawText     // always true in columnar mode; required for correctness
+            && copyTo().copyToFields().isEmpty()
+            && multiFields().iterator().hasNext() == false
+            && fieldType().isWithinMultiField() == false;
+    }
+
+    /**
+     * Maps a batch of documents for this {@code pattern_text} field from the supplied ESCF source
+     * column. Produces the same Lucene fields as the per-document row path
+     * ({@link #parseCreateField}) without allocating a {@code String}, running a regex, or
+     * collecting into intermediate lists.
+     *
+     * <p>Up to six columns may be emitted:
+     * <ol>
+     *   <li>Analyzed value (inverted index) — always, zero-copy when the source is a plain STRING
+     *       column.</li>
+     *   <li>{@code .template_id} — always (even for length-exceeded values).</li>
+     *   <li>{@code .template} — for TEMPLATED values only.</li>
+     *   <li>{@code .args_info} — for TEMPLATED values only.</li>
+     *   <li>{@code .args} — for TEMPLATED values with at least one arg.</li>
+     *   <li>{@code .stored} raw text — for length-exceeded values and when
+     *       {@link PatternTextFieldType#disableTemplating()} is {@code true}.</li>
+     * </ol>
+     *
+     * @throws UnsupportedOperationException when a document has more than one value (causes
+     *         {@link org.elasticsearch.index.mapper.ShardBatchMapper} to fall back to the row path
+     *         which raises the per-doc error with the correct {@code on_failure} behaviour)
+     */
+    @Override
+    public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+        final int docCount = ctx.docCount();
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source);
+
+        // Zero-copy path: when the source is a plain STRING column (no UNION wrapper for nulls)
+        // the analyzed column can share the column data directly. A builder is allocated lazily
+        // only when the source is UNION/other kind.
+        final EscfColumnBuilder analyzedBuilder = source.leafValueKind() != EscfColumnKind.STRING ? newStringBuilder() : null;
+
+        final EscfColumnBuilder templateIdBuilder = newStringBuilder();
+        // These are allocated when first needed (TEMPLATED path) to avoid waste for
+        // disable_templating=true or all-LENGTH_EXCEEDED batches.
+        EscfColumnBuilder templateBuilder = null;
+        EscfColumnBuilder argsInfoBuilder = null;
+        EscfColumnBuilder argsBuilder = null;
+        EscfColumnBuilder rawTextBuilder = null;
+
+        final PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        boolean valuesProduced = false;
+        int currentDoc = -1;
+        boolean valueSeenThisDoc = false;
+
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                break;
+            }
+            if (nextDoc != currentDoc) {
+                currentDoc = nextDoc;
+                valueSeenThisDoc = false;
+            }
+
+            final BytesRef v = cursor.value();
+            if (v == null) {
+                // JSON null: no fields emitted, mirroring the row path's textOrNull() == null check.
+                continue;
+            }
+
+            if (valueSeenThisDoc) {
+                // pattern_text is single-valued; bail so ShardBatchMapper falls back to the
+                // row path which raises the correct per-doc error (on_failure=FAIL).
+                throw new UnsupportedOperationException(
+                    "mapColumnBatch: pattern_text field [" + fullPath() + "] has more than one value for doc [" + currentDoc + "]"
+                );
+            }
+            valueSeenThisDoc = true;
+            valuesProduced = true;
+
+            // Populate the analyzed column builder when we are not on the zero-copy path.
+            if (analyzedBuilder != null) {
+                analyzedBuilder.setString(currentDoc, v);
+            }
+
+            if (fieldType().disableTemplating()) {
+                // Templating disabled: emit the analyzed value and the full raw text only.
+                rawTextBuilder = lazyBuilder(rawTextBuilder);
+                rawTextBuilder.setString(currentDoc, v);
+                continue;
+            }
+
+            // Run the byte-level split.
+            final PatternTextUtf8Splitter.Result result = splitter.split(v);
+
+            templateIdBuilder.setString(currentDoc, splitter.templateId());
+
+            if (result == PatternTextUtf8Splitter.Result.LENGTH_EXCEEDED) {
+                // Value exceeds the length limit: store the full original value as raw text.
+                rawTextBuilder = lazyBuilder(rawTextBuilder);
+                rawTextBuilder.setString(currentDoc, v);
+            } else {
+                // TEMPLATED: emit template, args_info, and (if present) args.
+                templateBuilder = lazyBuilder(templateBuilder);
+                templateBuilder.setString(currentDoc, splitter.template());
+
+                argsInfoBuilder = lazyBuilder(argsInfoBuilder);
+                argsInfoBuilder.setString(currentDoc, splitter.argsInfo());
+
+                if (splitter.argCount() > 0) {
+                    argsBuilder = lazyBuilder(argsBuilder);
+                    argsBuilder.setString(currentDoc, splitter.joinedArgs());
+                }
+            }
+        }
+
+        if (valuesProduced == false) {
+            return;
+        }
+
+        // Emit the analyzed column (zero-copy when source is plain STRING).
+        final EscfColumnData analyzedData = analyzedBuilder != null ? analyzedBuilder.finish(docCount) : source.columnData();
+        ctx.addColumn(LuceneBinaryColumn.of(analyzedData, fieldType().name(), fieldType));
+
+        if (fieldType().disableTemplating() == false) {
+            ctx.addColumn(
+                LuceneBinaryColumn.of(templateIdBuilder.finish(docCount), fieldType().templateIdFieldName(), templateIdFieldType)
+            );
+        }
+
+        if (templateBuilder != null) {
+            ctx.addColumn(
+                LuceneBinaryColumn.of(templateBuilder.finish(docCount), fieldType().templateFieldName(), SortedSetDocValuesField.TYPE)
+            );
+        }
+        if (argsInfoBuilder != null) {
+            ctx.addColumn(
+                LuceneBinaryColumn.of(argsInfoBuilder.finish(docCount), fieldType().argsInfoFieldName(), SortedSetDocValuesField.TYPE)
+            );
+        }
+        if (argsBuilder != null) {
+            ctx.addColumn(LuceneBinaryColumn.of(argsBuilder.finish(docCount), fieldType().argsFieldName(), BinaryDocValuesField.TYPE));
+        }
+        if (rawTextBuilder != null) {
+            ctx.addColumn(LuceneBinaryColumn.of(rawTextBuilder.finish(docCount), fieldType().storedNamed(), BinaryDocValuesField.TYPE));
+        }
+    }
+
+    private static EscfColumnBuilder newStringBuilder() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.STRING);
+        return b;
+    }
+
+    private static EscfColumnBuilder lazyBuilder(EscfColumnBuilder existing) {
+        return existing != null ? existing : newStringBuilder();
     }
 
     @Override

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
@@ -247,12 +247,6 @@ public class PatternTextFieldMapper extends FieldMapper {
     private final String indexOptions;
     private final FieldType fieldType;
     private final KeywordFieldMapper templateIdMapper;
-    /**
-     * The Lucene {@link FieldType} carried by the template-id keyword field. Captured once at
-     * construction time so {@link #mapColumnBatch} can emit the {@code .template_id} column with
-     * the exact same field-type the row path produces, without going through a per-doc
-     * {@link KeywordFieldMapper#buildKeywordField} call.
-     */
     private final FieldType templateIdFieldType;
     private final boolean useBinaryDocValueArgs;
     private final boolean useBinaryDocValuesForRawText;
@@ -370,8 +364,6 @@ public class PatternTextFieldMapper extends FieldMapper {
             && indexSettings.useTimeSeriesDocValuesFormat();
     }
 
-    // ── Columnar batch mapping ────────────────────────────────────────────────────────────────
-
     @Override
     public boolean supportsColumnarParse(IndexSettings settings) {
         // Only activate on strict-columnar index modes (COLUMNAR / LOGSDB_COLUMNAR), which
@@ -387,9 +379,7 @@ public class PatternTextFieldMapper extends FieldMapper {
 
     /**
      * Maps a batch of documents for this {@code pattern_text} field from the supplied ESCF source
-     * column. Produces the same Lucene fields as the per-document row path
-     * ({@link #parseCreateField}) without allocating a {@code String}, running a regex, or
-     * collecting into intermediate lists.
+     * column.
      *
      * <p>Up to six columns may be emitted:
      * <ol>
@@ -417,7 +407,8 @@ public class PatternTextFieldMapper extends FieldMapper {
         // only when the source is UNION/other kind.
         final EscfColumnBuilder analyzedBuilder = source.leafValueKind() != EscfColumnKind.STRING ? newStringBuilder() : null;
 
-        final EscfColumnBuilder templateIdBuilder = newStringBuilder();
+        // Never written when templating is disabled, so do not allocate it in that case.
+        final EscfColumnBuilder templateIdBuilder = fieldType().disableTemplating() ? null : newStringBuilder();
         // These are allocated when first needed (TEMPLATED path) to avoid waste for
         // disable_templating=true or all-LENGTH_EXCEEDED batches.
         EscfColumnBuilder templateBuilder = null;
@@ -449,6 +440,7 @@ public class PatternTextFieldMapper extends FieldMapper {
             if (valueSeenThisDoc) {
                 // pattern_text is single-valued; bail so ShardBatchMapper falls back to the
                 // row path which raises the correct per-doc error (on_failure=FAIL).
+                // TODO: Improve and handle this here.
                 throw new UnsupportedOperationException(
                     "mapColumnBatch: pattern_text field [" + fullPath() + "] has more than one value for doc [" + currentDoc + "]"
                 );

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
@@ -218,7 +218,7 @@ final class PatternTextUtf8Splitter {
                     isArg = true;
                 } else if (sawNonAscii) {
                     // TODO: Consider if we need to make this work directly on bytes. Pathological non-ASCII data will allocate a
-                    //  ton of strings.
+                    // ton of strings.
                     runStr = new String(src, runStart, runLen, StandardCharsets.UTF_8);
                     isArg = Arg.isArg(runStr);
                 } else {

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb.patterntext;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.hash.MurmurHash3;
+import org.elasticsearch.common.util.ByteUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Byte-level equivalent of {@link PatternTextValueProcessor#split(String)} for the columnar batch
+ * indexing path.
+ *
+ * <p>Accepts a UTF-8 {@link BytesRef} and scans it directly for the pattern-text delimiters
+ * ({@code \t \n \x0B \f \r space [ ]}) without allocating a {@code String}, running a regex, or
+ * collecting into {@code List} or {@code StringBuilder}. Results are exposed via {@link BytesRef}
+ * views into reused internal scratch buffers; they are valid only until the next call to
+ * {@link #split(BytesRef)}.
+ *
+ * <p>Produces results that are byte-identical to the row path: same template bytes, same
+ * {@code templateId}, same base64url-encoded {@code argsInfo}, and the same space-joined args.
+ *
+ * <h2>Delimiter set</h2>
+ * All delimiters are ASCII (≤ 0x7F), so they can never appear as a UTF-8 continuation byte
+ * (0x80–0xBF). A raw byte scan therefore cannot false-positive inside a multi-byte character.
+ *
+ * <h2>arg detection</h2>
+ * A token is an arg when {@link Arg#isArg(String)} would return {@code true}: at least one
+ * {@code Character.isDigit(char)} call on a UTF-16 code unit of the token returns true. For the
+ * byte-level path:
+ * <ul>
+ *   <li>ASCII bytes 0x30–0x39 ('0'–'9'): fast-path digit check.</li>
+ *   <li>2- and 3-byte sequences: decode the code point and apply
+ *       {@link Character#isDigit(int)}.</li>
+ *   <li>4-byte sequences (supplementary): the two surrogates are never digits, so the result
+ *       is always {@code false}, matching {@code Character.isDigit(char surrogate) == false}.
+ *   </li>
+ * </ul>
+ *
+ * <h2>{@code Arg.Info} offsets</h2>
+ * {@code Arg.Info.offsetInTemplate} is a UTF-16 char offset in the template string. These are
+ * tracked incrementally here: ASCII runs and 2-/3-byte runs each contribute one UTF-16 unit per
+ * byte sequence, while a 4-byte (supplementary) run contributes two UTF-16 units. The on-disk
+ * encoding is therefore bit-identical to the row path's output.
+ *
+ * <h2>Values over {@value PatternTextValueProcessor#MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE} chars</h2>
+ * The length limit is in UTF-16 units. A fast check on the UTF-8 byte count avoids creating a
+ * {@code String} for the common case (ASCII log lines, where byte count equals char count). When
+ * truncation is required, the method goes through {@code String.substring} + {@code getBytes} to
+ * reproduce the row path's lone-surrogate {@code '?'} replacement, then returns
+ * {@link Result#LENGTH_EXCEEDED}. Only {@link #templateId()} is valid in that case.
+ */
+final class PatternTextUtf8Splitter {
+
+    /**
+     * Result of a {@link #split(BytesRef)} call.
+     */
+    enum Result {
+        /**
+         * The value was processed normally. All getters are valid.
+         */
+        TEMPLATED,
+        /**
+         * The value exceeded {@value PatternTextValueProcessor#MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE}
+         * UTF-16 chars. Only {@link #templateId()} is valid; the caller must store the full
+         * original value as raw text.
+         */
+        LENGTH_EXCEEDED
+    }
+
+    // Lookup table for the 8 delimiter bytes, all of which are < 0x80.
+    private static final boolean[] IS_DELIMITER = new boolean[128];
+    static {
+        IS_DELIMITER['\t'] = true;  // 0x09
+        IS_DELIMITER['\n'] = true;  // 0x0A
+        IS_DELIMITER[0x0B] = true;  // vertical tab
+        IS_DELIMITER['\f'] = true;  // 0x0C
+        IS_DELIMITER['\r'] = true;  // 0x0D
+        IS_DELIMITER[' '] = true;   // 0x20
+        IS_DELIMITER['['] = true;   // 0x5B
+        IS_DELIMITER[']'] = true;   // 0x5D
+    }
+
+    // Reusable buffers — grown with ArrayUtil.oversize to amortize reallocations.
+    private byte[] templateBuf;
+    private byte[] hashBuf;       // 8 bytes (MurmurHash3 h1, little-endian)
+    private byte[] templateIdBuf; // 11 bytes (base64url of hashBuf, no padding)
+    private byte[] argsBuf;       // space-joined arg bytes
+    private int[] argOffsets;     // UTF-16 template offsets of each arg
+    private byte[] argsInfoRawScratch; // scratch for the binary vint encoding
+    private byte[] argsInfoBuf;   // base64url-encoded args info
+
+    // Per-split output lengths.
+    private int templateLen;
+    private int argsLen;
+    private int argsInfoLen;
+    private int argCount;
+
+    // Stable BytesRef views into the buffers above.
+    private final BytesRef templateRef = new BytesRef();
+    private final BytesRef templateIdRef = new BytesRef();
+    private final BytesRef argsInfoRef = new BytesRef();
+    private final BytesRef joinedArgsRef = new BytesRef();
+
+    PatternTextUtf8Splitter() {
+        templateBuf = new byte[256];
+        hashBuf = new byte[8];
+        templateIdBuf = new byte[11];
+        argsBuf = new byte[64];
+        argOffsets = new int[8];
+        argsInfoRawScratch = new byte[Arg.VINT_MAX_BYTES];
+        argsInfoBuf = new byte[8]; // base64url of [0x00] fits in 2 bytes; start small
+    }
+
+    /**
+     * Splits the UTF-8 value into template and args components.
+     *
+     * <p>The internally-used {@link java.io.IOException} from {@link Arg#encodeInfoBytes} is a
+     * nominal declaration: {@link org.apache.lucene.store.ByteArrayDataOutput} never actually
+     * throws when writing to a pre-sized byte array. Any unexpected IOException is wrapped in an
+     * {@link UncheckedIOException} so callers need not declare checked exceptions.
+     *
+     * @return {@link Result#TEMPLATED} when all getters are valid; {@link Result#LENGTH_EXCEEDED}
+     *         when the value exceeded the length limit (only {@link #templateId()} is valid)
+     */
+    Result split(BytesRef utf8) {
+        final byte[] src = utf8.bytes;
+        final int start = utf8.offset;
+        final int end = utf8.offset + utf8.length;
+
+        // Fast path: UTF-16 length ≤ UTF-8 byte length, so if byte length ≤ limit we're safe.
+        if (utf8.length <= PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE) {
+            return splitBytes(src, start, end);
+        }
+
+        // Need to count UTF-16 code units. Decode to String once.
+        final String s = new String(src, start, utf8.length, StandardCharsets.UTF_8);
+        if (s.length() <= PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE) {
+            // Multi-byte-heavy value that fits within the char limit — proceed with byte scan.
+            return splitBytes(src, start, end);
+        }
+
+        // Value exceeds the limit. Truncate exactly as the row path does:
+        // PatternTextValueProcessor.split → CharBuffer.subSequence(0, 8192) → splitInternal
+        // → Parts.lengthExceeded(text.toString()) → templateId(text.toString())
+        //
+        // Going through String.substring / getBytes is deliberate: it faithfully reproduces
+        // CharBuffer.subSequence splitting a surrogate pair at index 8192, with the resulting
+        // lone surrogate encoded as '?' (0x3F) by the JDK UTF-8 encoder — the same replacement
+        // a hand-rolled byte-level truncation would get wrong.
+        final byte[] truncated = s.substring(0, PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE)
+            .getBytes(StandardCharsets.UTF_8);
+        computeTemplateId(truncated, 0, truncated.length);
+        // Update only the templateId ref; other refs are not valid for LENGTH_EXCEEDED.
+        templateIdRef.bytes = templateIdBuf;
+        templateIdRef.offset = 0;
+        templateIdRef.length = templateIdBuf.length;
+        return Result.LENGTH_EXCEEDED;
+    }
+
+    // ── Result accessors ──────────────────────────────────────────────────────────────────────
+
+    /** The template bytes. Only valid when {@link #split} returned {@link Result#TEMPLATED}. */
+    BytesRef template() {
+        return templateRef;
+    }
+
+    /**
+     * The 11-byte base64url-encoded template ID (no padding). Valid for both
+     * {@link Result#TEMPLATED} and {@link Result#LENGTH_EXCEEDED}.
+     */
+    BytesRef templateId() {
+        return templateIdRef;
+    }
+
+    /**
+     * The base64url-encoded args-info bytes. Byte-identical to
+     * {@link Arg#encodeInfo(java.util.List)} on the same args. Only valid when
+     * {@link #split} returned {@link Result#TEMPLATED}.
+     */
+    BytesRef argsInfo() {
+        return argsInfoRef;
+    }
+
+    /**
+     * The space-joined arg bytes. Only valid when {@link #split} returned
+     * {@link Result#TEMPLATED} and {@link #argCount()} is greater than zero.
+     */
+    BytesRef joinedArgs() {
+        return joinedArgsRef;
+    }
+
+    /** Number of args in the current result. Only valid when {@link #split} returned {@link Result#TEMPLATED}. */
+    int argCount() {
+        return argCount;
+    }
+
+    // ── Core byte scan ────────────────────────────────────────────────────────────────────────
+
+    private Result splitBytes(byte[] src, int start, int end) {
+        templateLen = 0;
+        argsLen = 0;
+        argCount = 0;
+        int templateUtf16Len = 0;
+
+        int pos = start;
+        while (pos < end) {
+            final int b0 = src[pos] & 0xFF;
+            if (b0 < 0x80 && IS_DELIMITER[b0]) {
+                // Delimiter: always copies to template. All delimiters are ASCII (1 UTF-16 unit).
+                if (templateLen == templateBuf.length) {
+                    templateBuf = Arrays.copyOf(templateBuf, ArrayUtil.oversize(templateLen + 1, Byte.BYTES));
+                }
+                templateBuf[templateLen++] = (byte) b0;
+                templateUtf16Len++;
+                pos++;
+            } else {
+                // Non-delimiter run: find its end, check for digit presence.
+                final int runStart = pos;
+                boolean sawAsciiDigit = false;
+                boolean sawNonAscii = false;
+                while (pos < end) {
+                    final int rb = src[pos] & 0xFF;
+                    if (rb < 0x80) {
+                        if (IS_DELIMITER[rb]) break;
+                        if (rb >= '0' && rb <= '9') sawAsciiDigit = true;
+                        pos++;
+                    } else {
+                        sawNonAscii = true;
+                        // Advance past the multi-byte sequence without validating each byte.
+                        if ((rb & 0xE0) == 0xC0) {
+                            pos += 2; // 2-byte
+                        } else if ((rb & 0xF0) == 0xE0) {
+                            pos += 3; // 3-byte
+                        } else {
+                            pos += 4; // 4-byte (supplementary)
+                        }
+                    }
+                }
+                final int runEnd = pos;
+                final int runLen = runEnd - runStart;
+
+                // A run is an arg when any UTF-16 code unit in it is a Unicode digit.
+                // ASCII digit check is the fast path; the slow path handles BMP non-ASCII digits.
+                final boolean isArg = sawAsciiDigit || (sawNonAscii && slowIsArg(src, runStart, runEnd));
+
+                if (isArg) {
+                    // Record the arg's UTF-16 offset in the (in-progress) template.
+                    if (argCount == argOffsets.length) {
+                        argOffsets = Arrays.copyOf(argOffsets, ArrayUtil.oversize(argCount + 1, Integer.BYTES));
+                    }
+                    argOffsets[argCount++] = templateUtf16Len;
+
+                    // Append " arg" to the joined-args buffer (space-separated).
+                    final int needed = (argCount > 1 ? 1 : 0) + runLen;
+                    if (argsLen + needed > argsBuf.length) {
+                        argsBuf = Arrays.copyOf(argsBuf, ArrayUtil.oversize(argsLen + needed, Byte.BYTES));
+                    }
+                    if (argCount > 1) {
+                        argsBuf[argsLen++] = ' ';
+                    }
+                    System.arraycopy(src, runStart, argsBuf, argsLen, runLen);
+                    argsLen += runLen;
+                    // templateUtf16Len does NOT advance — the arg is NOT copied into the template.
+                } else {
+                    // Non-arg run: copy to template and track UTF-16 length.
+                    if (templateLen + runLen > templateBuf.length) {
+                        templateBuf = Arrays.copyOf(templateBuf, ArrayUtil.oversize(templateLen + runLen, Byte.BYTES));
+                    }
+                    System.arraycopy(src, runStart, templateBuf, templateLen, runLen);
+                    templateLen += runLen;
+                    // UTF-16 length: ASCII-only runs contribute runLen units; runs with multi-byte
+                    // characters require counting lead bytes explicitly.
+                    if (sawNonAscii) {
+                        templateUtf16Len += countUtf16Units(src, runStart, runEnd);
+                    } else {
+                        templateUtf16Len += runLen;
+                    }
+                }
+            }
+        }
+
+        computeTemplateId(templateBuf, 0, templateLen);
+        encodeArgsInfo();
+        updateRefs();
+        return Result.TEMPLATED;
+    }
+
+    // ── Template ID ──────────────────────────────────────────────────────────────────────────
+
+    private void computeTemplateId(byte[] bytes, int offset, int length) {
+        final MurmurHash3.Hash128 hash = new MurmurHash3.Hash128();
+        MurmurHash3.hash128(bytes, offset, length, 0, hash);
+        ByteUtils.writeLongLE(hash.h1, hashBuf, 0);
+        Arg.ENCODER.encode(hashBuf, templateIdBuf);
+    }
+
+    // ── Args-info encoding ───────────────────────────────────────────────────────────────────
+
+    private void encodeArgsInfo() {
+        // Always encode, even for 0 args: the row path always emits the argsInfo column and
+        // Arg.encodeInfo([]) produces base64url([0x00]) = "AA".
+        final int rawMax = Arg.VINT_MAX_BYTES + argCount * 2 * Arg.VINT_MAX_BYTES;
+        if (argsInfoRawScratch.length < rawMax) {
+            argsInfoRawScratch = new byte[rawMax];
+        }
+        final int base64Max = Arg.argsInfoMaxBase64Bytes(argCount);
+        if (argsInfoBuf.length < base64Max) {
+            argsInfoBuf = new byte[base64Max];
+        }
+        try {
+            argsInfoLen = Arg.encodeInfoBytes(argOffsets, argCount, argsInfoRawScratch, argsInfoBuf);
+        } catch (IOException e) {
+            // ByteArrayDataOutput.writeVInt never actually throws — this branch is unreachable.
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // ── BytesRef view updates ────────────────────────────────────────────────────────────────
+
+    private void updateRefs() {
+        templateRef.bytes = templateBuf;
+        templateRef.offset = 0;
+        templateRef.length = templateLen;
+
+        templateIdRef.bytes = templateIdBuf;
+        templateIdRef.offset = 0;
+        templateIdRef.length = templateIdBuf.length; // always 11
+
+        argsInfoRef.bytes = argsInfoBuf;
+        argsInfoRef.offset = 0;
+        argsInfoRef.length = argsInfoLen;
+
+        joinedArgsRef.bytes = argsBuf;
+        joinedArgsRef.offset = 0;
+        joinedArgsRef.length = argsLen;
+    }
+
+    // ── UTF-16 / digit helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns {@code true} if any code point decoded from the UTF-8 bytes {@code src[start, end)}
+     * satisfies {@link Character#isDigit(int)}, following the same rules as the row path's
+     * {@link Arg#isArg(String)}:
+     * <ul>
+     *   <li>2- and 3-byte sequences: decoded code point is tested with {@code Character.isDigit(int)}.</li>
+     *   <li>4-byte sequences: the two surrogates are not digits, so always {@code false}.</li>
+     * </ul>
+     * This method is only invoked when the run contains at least one non-ASCII byte.
+     */
+    private static boolean slowIsArg(byte[] src, int start, int end) {
+        int pos = start;
+        while (pos < end) {
+            final int b0 = src[pos] & 0xFF;
+            if (b0 < 0x80) {
+                // ASCII bytes are already checked for digit status in the fast path, but handle
+                // them here for correctness in case this is called on a mixed run.
+                if (Character.isDigit(b0)) return true;
+                pos++;
+            } else if ((b0 & 0xE0) == 0xC0) {
+                final int cp = ((b0 & 0x1F) << 6) | (src[pos + 1] & 0x3F);
+                if (Character.isDigit(cp)) return true;
+                pos += 2;
+            } else if ((b0 & 0xF0) == 0xE0) {
+                final int cp = ((b0 & 0x0F) << 12) | ((src[pos + 1] & 0x3F) << 6) | (src[pos + 2] & 0x3F);
+                if (Character.isDigit(cp)) return true;
+                pos += 3;
+            } else {
+                // 4-byte (supplementary) sequence. The row path calls Character.isDigit(char)
+                // on each UTF-16 code unit; surrogates are never Unicode digits, so skip.
+                pos += 4;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Counts the number of UTF-16 code units encoded in {@code src[start, end)}.
+     * Each ASCII and 2-/3-byte sequence contributes 1 unit; each 4-byte (supplementary) sequence
+     * contributes 2 units (a surrogate pair).
+     */
+    private static int countUtf16Units(byte[] src, int start, int end) {
+        int count = 0;
+        for (int pos = start; pos < end; pos++) {
+            final int b = src[pos] & 0xFF;
+            // Count lead bytes (not continuation bytes 0x80–0xBF).
+            if ((b & 0xC0) != 0x80) {
+                count++;
+                if ((b & 0xF8) == 0xF0) {
+                    // 4-byte lead: supplementary code point encodes as two UTF-16 units.
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8Splitter.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.logsdb.patterntext;
 
+import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.hash.MurmurHash3;
@@ -19,67 +20,40 @@ import java.util.Arrays;
 
 /**
  * Byte-level equivalent of {@link PatternTextValueProcessor#split(String)} for the columnar batch
- * indexing path.
+ * indexing path: scans a UTF-8 {@link BytesRef} directly instead of building a {@code String} and
+ * running a regex over it. Output is byte-identical to the row path.
  *
- * <p>Accepts a UTF-8 {@link BytesRef} and scans it directly for the pattern-text delimiters
- * ({@code \t \n \x0B \f \r space [ ]}) without allocating a {@code String}, running a regex, or
- * collecting into {@code List} or {@code StringBuilder}. Results are exposed via {@link BytesRef}
- * views into reused internal scratch buffers; they are valid only until the next call to
- * {@link #split(BytesRef)}.
+ * <p>Results are exposed as {@link BytesRef} views that may point into splitter scratch or
+ * <em>into the source bytes</em>. They are valid until the next {@link #split(BytesRef)} call or
+ * until the caller's source {@code BytesRef} is invalidated, whichever comes first, so each result
+ * must be consumed before calling {@link #split} again.
  *
- * <p>Produces results that are byte-identical to the row path: same template bytes, same
- * {@code templateId}, same base64url-encoded {@code argsInfo}, and the same space-joined args.
+ * <p>All delimiters ({@code \t \n \x0B \f \r space [ ]}) are ASCII, so they can never appear as a
+ * UTF-8 continuation byte and a raw byte scan cannot false-positive mid-character. And the template
+ * is exactly the source with the arg runs deleted and every delimiter left in place, so template
+ * slices are the complements of the arg runs: the scan records arg boundaries only, and
+ * {@link #template()} and {@link #joinedArgs()} point straight into the source whenever the result
+ * is a single contiguous slice.
  *
- * <h2>Delimiter set</h2>
- * All delimiters are ASCII (≤ 0x7F), so they can never appear as a UTF-8 continuation byte
- * (0x80–0xBF). A raw byte scan therefore cannot false-positive inside a multi-byte character.
- *
- * <h2>arg detection</h2>
- * A token is an arg when {@link Arg#isArg(String)} would return {@code true}: at least one
- * {@code Character.isDigit(char)} call on a UTF-16 code unit of the token returns true. For the
- * byte-level path:
- * <ul>
- *   <li>ASCII bytes 0x30–0x39 ('0'–'9'): fast-path digit check.</li>
- *   <li>2- and 3-byte sequences: decode the code point and apply
- *       {@link Character#isDigit(int)}.</li>
- *   <li>4-byte sequences (supplementary): the two surrogates are never digits, so the result
- *       is always {@code false}, matching {@code Character.isDigit(char surrogate) == false}.
- *   </li>
- * </ul>
- *
- * <h2>{@code Arg.Info} offsets</h2>
- * {@code Arg.Info.offsetInTemplate} is a UTF-16 char offset in the template string. These are
- * tracked incrementally here: ASCII runs and 2-/3-byte runs each contribute one UTF-16 unit per
- * byte sequence, while a 4-byte (supplementary) run contributes two UTF-16 units. The on-disk
- * encoding is therefore bit-identical to the row path's output.
- *
- * <h2>Values over {@value PatternTextValueProcessor#MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE} chars</h2>
- * The length limit is in UTF-16 units. A fast check on the UTF-8 byte count avoids creating a
- * {@code String} for the common case (ASCII log lines, where byte count equals char count). When
- * truncation is required, the method goes through {@code String.substring} + {@code getBytes} to
- * reproduce the row path's lone-surrogate {@code '?'} replacement, then returns
- * {@link Result#LENGTH_EXCEEDED}. Only {@link #templateId()} is valid in that case.
+ * <p>{@code Arg.Info.offsetInTemplate} is a UTF-16 offset rather than a byte offset, so the scan
+ * also tracks the template's UTF-16 length as it goes.
  */
 final class PatternTextUtf8Splitter {
 
-    /**
-     * Result of a {@link #split(BytesRef)} call.
-     */
+    /** Outcome of a {@link #split(BytesRef)} call. */
     enum Result {
-        /**
-         * The value was processed normally. All getters are valid.
-         */
+        /** All getters are valid. */
         TEMPLATED,
         /**
          * The value exceeded {@value PatternTextValueProcessor#MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE}
-         * UTF-16 chars. Only {@link #templateId()} is valid; the caller must store the full
-         * original value as raw text.
+         * UTF-16 chars. Only {@link #templateId()} is valid; the caller stores the raw value instead.
          */
         LENGTH_EXCEEDED
     }
 
-    // Lookup table for the 8 delimiter bytes, all of which are < 0x80.
-    private static final boolean[] IS_DELIMITER = new boolean[128];
+    // Sized 256 rather than 128 so scans can index it with an unsigned byte and skip a `b < 0x80`
+    // branch; every entry at or above 0x80 is false.
+    private static final boolean[] IS_DELIMITER = new boolean[256];
     static {
         IS_DELIMITER['\t'] = true;  // 0x09
         IS_DELIMITER['\n'] = true;  // 0x0A
@@ -91,22 +65,27 @@ final class PatternTextUtf8Splitter {
         IS_DELIMITER[']'] = true;   // 0x5D
     }
 
-    // Reusable buffers — grown with ArrayUtil.oversize to amortize reallocations.
-    private byte[] templateBuf;
-    private byte[] hashBuf;       // 8 bytes (MurmurHash3 h1, little-endian)
-    private byte[] templateIdBuf; // 11 bytes (base64url of hashBuf, no padding)
-    private byte[] argsBuf;       // space-joined arg bytes
-    private int[] argOffsets;     // UTF-16 template offsets of each arg
-    private byte[] argsInfoRawScratch; // scratch for the binary vint encoding
-    private byte[] argsInfoBuf;   // base64url-encoded args info
+    // Reusable scratch, grown with ArrayUtil.oversize.
+    private byte[] templateBuf;         // multi-slice template assembly
+    private final byte[] hashBuf;       // 8 bytes: MurmurHash3 h1, little-endian
+    private final byte[] templateIdBuf; // 11 bytes: unpadded base64url of hashBuf
+    private byte[] argsBuf;             // multi-arg joined-args assembly
+    private byte[] argsInfoRawScratch;  // args info as binary vints, pre-base64
+    private byte[] argsInfoBuf;         // base64url args info
 
-    // Per-split output lengths.
-    private int templateLen;
-    private int argsLen;
+    // Arg boundaries recorded by the scan. Kept at the same length and grown together.
+    private int[] argOffsets;           // UTF-16 offset of each arg within the template
+    private int[] argRunStarts;         // byte offset in src where the arg begins
+    private int[] argRunEnds;           // byte offset in src where the arg ends (exclusive)
+
+    // Held as fields so that neither is allocated per document.
+    private final MurmurHash3.Hash128 templateHash = new MurmurHash3.Hash128();
+    private final ByteArrayDataOutput argsInfoOut = new ByteArrayDataOutput();
+
     private int argsInfoLen;
     private int argCount;
 
-    // Stable BytesRef views into the buffers above.
+    // Output views; see the class Javadoc for their lifetime.
     private final BytesRef templateRef = new BytesRef();
     private final BytesRef templateIdRef = new BytesRef();
     private final BytesRef argsInfoRef = new BytesRef();
@@ -118,20 +97,17 @@ final class PatternTextUtf8Splitter {
         templateIdBuf = new byte[11];
         argsBuf = new byte[64];
         argOffsets = new int[8];
+        argRunStarts = new int[8];
+        argRunEnds = new int[8];
         argsInfoRawScratch = new byte[Arg.VINT_MAX_BYTES];
         argsInfoBuf = new byte[8]; // base64url of [0x00] fits in 2 bytes; start small
     }
 
     /**
-     * Splits the UTF-8 value into template and args components.
+     * Splits the UTF-8 value into its template and args components.
      *
-     * <p>The internally-used {@link java.io.IOException} from {@link Arg#encodeInfoBytes} is a
-     * nominal declaration: {@link org.apache.lucene.store.ByteArrayDataOutput} never actually
-     * throws when writing to a pre-sized byte array. Any unexpected IOException is wrapped in an
-     * {@link UncheckedIOException} so callers need not declare checked exceptions.
-     *
-     * @return {@link Result#TEMPLATED} when all getters are valid; {@link Result#LENGTH_EXCEEDED}
-     *         when the value exceeded the length limit (only {@link #templateId()} is valid)
+     * @return {@link Result#TEMPLATED} when all getters are valid, {@link Result#LENGTH_EXCEEDED}
+     *         when only {@link #templateId()} is
      */
     Result split(BytesRef utf8) {
         final byte[] src = utf8.bytes;
@@ -150,82 +126,65 @@ final class PatternTextUtf8Splitter {
             return splitBytes(src, start, end);
         }
 
-        // Value exceeds the limit. Truncate exactly as the row path does:
-        // PatternTextValueProcessor.split → CharBuffer.subSequence(0, 8192) → splitInternal
-        // → Parts.lengthExceeded(text.toString()) → templateId(text.toString())
-        //
-        // Going through String.substring / getBytes is deliberate: it faithfully reproduces
-        // CharBuffer.subSequence splitting a surrogate pair at index 8192, with the resulting
-        // lone surrogate encoded as '?' (0x3F) by the JDK UTF-8 encoder — the same replacement
-        // a hand-rolled byte-level truncation would get wrong.
+        // Truncate via String.substring / getBytes deliberately: that reproduces the row path's
+        // CharBuffer.subSequence splitting a surrogate pair at the limit, leaving a lone surrogate
+        // that the JDK UTF-8 encoder replaces with '?' (0x3F). Byte-level truncation gets this wrong.
+        // The row path discards the split output for over-long values, so no split is run here.
         final byte[] truncated = s.substring(0, PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE)
             .getBytes(StandardCharsets.UTF_8);
         computeTemplateId(truncated, 0, truncated.length);
-        // Update only the templateId ref; other refs are not valid for LENGTH_EXCEEDED.
         templateIdRef.bytes = templateIdBuf;
         templateIdRef.offset = 0;
         templateIdRef.length = templateIdBuf.length;
         return Result.LENGTH_EXCEEDED;
     }
 
-    // ── Result accessors ──────────────────────────────────────────────────────────────────────
-
-    /** The template bytes. Only valid when {@link #split} returned {@link Result#TEMPLATED}. */
+    /** Template bytes; valid on {@link Result#TEMPLATED}. May point into the source. */
     BytesRef template() {
         return templateRef;
     }
 
-    /**
-     * The 11-byte base64url-encoded template ID (no padding). Valid for both
-     * {@link Result#TEMPLATED} and {@link Result#LENGTH_EXCEEDED}.
-     */
+    /** The 11-byte unpadded base64url template ID. Valid on both results. */
     BytesRef templateId() {
         return templateIdRef;
     }
 
     /**
-     * The base64url-encoded args-info bytes. Byte-identical to
-     * {@link Arg#encodeInfo(java.util.List)} on the same args. Only valid when
-     * {@link #split} returned {@link Result#TEMPLATED}.
+     * Base64url args info, byte-identical to {@link Arg#encodeInfo(java.util.List)} on the same args.
+     * Valid on {@link Result#TEMPLATED}.
      */
     BytesRef argsInfo() {
         return argsInfoRef;
     }
 
     /**
-     * The space-joined arg bytes. Only valid when {@link #split} returned
-     * {@link Result#TEMPLATED} and {@link #argCount()} is greater than zero.
+     * Space-joined args; valid on {@link Result#TEMPLATED} when {@link #argCount()} is non-zero.
+     * May point into the source.
      */
     BytesRef joinedArgs() {
         return joinedArgsRef;
     }
 
-    /** Number of args in the current result. Only valid when {@link #split} returned {@link Result#TEMPLATED}. */
+    /** Number of args in the current result. */
     int argCount() {
         return argCount;
     }
 
-    // ── Core byte scan ────────────────────────────────────────────────────────────────────────
-
     private Result splitBytes(byte[] src, int start, int end) {
-        templateLen = 0;
-        argsLen = 0;
         argCount = 0;
         int templateUtf16Len = 0;
 
         int pos = start;
         while (pos < end) {
-            final int b0 = src[pos] & 0xFF;
-            if (b0 < 0x80 && IS_DELIMITER[b0]) {
-                // Delimiter: always copies to template. All delimiters are ASCII (1 UTF-16 unit).
-                if (templateLen == templateBuf.length) {
-                    templateBuf = Arrays.copyOf(templateBuf, ArrayUtil.oversize(templateLen + 1, Byte.BYTES));
-                }
-                templateBuf[templateLen++] = (byte) b0;
-                templateUtf16Len++;
-                pos++;
+            if (IS_DELIMITER[src[pos] & 0xFF]) {
+                // Delimiters are ASCII, so the run's byte count is also its UTF-16 unit count.
+                final int delimStart = pos;
+                do {
+                    pos++;
+                } while (pos < end && IS_DELIMITER[src[pos] & 0xFF]);
+                templateUtf16Len += pos - delimStart;
             } else {
-                // Non-delimiter run: find its end, check for digit presence.
+                // Non-delimiter run: find its end, noting whether it holds ASCII digits or non-ASCII.
                 final int runStart = pos;
                 boolean sawAsciiDigit = false;
                 boolean sawNonAscii = false;
@@ -250,65 +209,163 @@ final class PatternTextUtf8Splitter {
                 final int runEnd = pos;
                 final int runLen = runEnd - runStart;
 
-                // A run is an arg when any UTF-16 code unit in it is a Unicode digit.
-                // ASCII digit check is the fast path; the slow path handles BMP non-ASCII digits.
-                final boolean isArg = sawAsciiDigit || (sawNonAscii && slowIsArg(src, runStart, runEnd));
+                // Non-ASCII runs delegate to Arg.isArg(String), which also yields the UTF-16 length via
+                // String.length(). The decode is deferred past sawAsciiDigit because an ASCII digit
+                // already settles isArg and that branch never needs the decoded form.
+                final boolean isArg;
+                String runStr = null;
+                if (sawAsciiDigit) {
+                    isArg = true;
+                } else if (sawNonAscii) {
+                    // TODO: Consider if we need to make this work directly on bytes. Pathological non-ASCII data will allocate a
+                    //  ton of strings.
+                    runStr = new String(src, runStart, runLen, StandardCharsets.UTF_8);
+                    isArg = Arg.isArg(runStr);
+                } else {
+                    isArg = false;
+                }
 
                 if (isArg) {
-                    // Record the arg's UTF-16 offset in the (in-progress) template.
                     if (argCount == argOffsets.length) {
-                        argOffsets = Arrays.copyOf(argOffsets, ArrayUtil.oversize(argCount + 1, Integer.BYTES));
+                        final int newCap = ArrayUtil.oversize(argCount + 1, Integer.BYTES);
+                        argOffsets = Arrays.copyOf(argOffsets, newCap);
+                        argRunStarts = Arrays.copyOf(argRunStarts, newCap);
+                        argRunEnds = Arrays.copyOf(argRunEnds, newCap);
                     }
-                    argOffsets[argCount++] = templateUtf16Len;
-
-                    // Append " arg" to the joined-args buffer (space-separated).
-                    final int needed = (argCount > 1 ? 1 : 0) + runLen;
-                    if (argsLen + needed > argsBuf.length) {
-                        argsBuf = Arrays.copyOf(argsBuf, ArrayUtil.oversize(argsLen + needed, Byte.BYTES));
-                    }
-                    if (argCount > 1) {
-                        argsBuf[argsLen++] = ' ';
-                    }
-                    System.arraycopy(src, runStart, argsBuf, argsLen, runLen);
-                    argsLen += runLen;
-                    // templateUtf16Len does NOT advance — the arg is NOT copied into the template.
+                    argOffsets[argCount] = templateUtf16Len;
+                    argRunStarts[argCount] = runStart;
+                    argRunEnds[argCount] = runEnd;
+                    argCount++;
+                    // templateUtf16Len does not advance: the arg is not part of the template.
                 } else {
-                    // Non-arg run: copy to template and track UTF-16 length.
-                    if (templateLen + runLen > templateBuf.length) {
-                        templateBuf = Arrays.copyOf(templateBuf, ArrayUtil.oversize(templateLen + runLen, Byte.BYTES));
-                    }
-                    System.arraycopy(src, runStart, templateBuf, templateLen, runLen);
-                    templateLen += runLen;
-                    // UTF-16 length: ASCII-only runs contribute runLen units; runs with multi-byte
-                    // characters require counting lead bytes explicitly.
-                    if (sawNonAscii) {
-                        templateUtf16Len += countUtf16Units(src, runStart, runEnd);
-                    } else {
-                        templateUtf16Len += runLen;
-                    }
+                    templateUtf16Len += runStr != null ? runStr.length() : runLen;
                 }
             }
         }
 
-        computeTemplateId(templateBuf, 0, templateLen);
+        materializeTemplate(src, start, end);
+        materializeArgs(src);
         encodeArgsInfo();
-        updateRefs();
+
+        templateIdRef.bytes = templateIdBuf;
+        templateIdRef.offset = 0;
+        templateIdRef.length = templateIdBuf.length; // always 11
+
+        argsInfoRef.bytes = argsInfoBuf;
+        argsInfoRef.offset = 0;
+        argsInfoRef.length = argsInfoLen;
+
         return Result.TEMPLATED;
     }
 
-    // ── Template ID ──────────────────────────────────────────────────────────────────────────
+    /**
+     * Sets {@link #templateRef} to the complement of the arg runs. When that complement is a single
+     * contiguous slice the ref points into {@code src} and nothing is copied; otherwise the slices are
+     * assembled into {@link #templateBuf}.
+     */
+    private void materializeTemplate(byte[] src, int start, int end) {
+        int nonEmptySlices = 0;
+        int singleSliceStart = start; // the sole non-empty slice, when there is only one
+        int singleSliceEnd = start;
+        int lastArgEnd = start;
+        for (int i = 0; i < argCount; i++) {
+            final int sliceEnd = argRunStarts[i];
+            if (sliceEnd > lastArgEnd) {
+                nonEmptySlices++;
+                singleSliceStart = lastArgEnd;
+                singleSliceEnd = sliceEnd;
+            }
+            lastArgEnd = argRunEnds[i];
+        }
+        if (end > lastArgEnd) {
+            nonEmptySlices++;
+            singleSliceStart = lastArgEnd;
+            singleSliceEnd = end;
+        }
+
+        if (nonEmptySlices <= 1) {
+            // Zero copies: hash straight out of src, leaving templateBuf untouched.
+            computeTemplateId(src, singleSliceStart, singleSliceEnd - singleSliceStart);
+            templateRef.bytes = src;
+            templateRef.offset = singleSliceStart;
+            templateRef.length = singleSliceEnd - singleSliceStart;
+        } else {
+            int totalLen = 0;
+            lastArgEnd = start;
+            for (int i = 0; i < argCount; i++) {
+                totalLen += argRunStarts[i] - lastArgEnd;
+                lastArgEnd = argRunEnds[i];
+            }
+            totalLen += end - lastArgEnd;
+
+            if (totalLen > templateBuf.length) {
+                templateBuf = new byte[ArrayUtil.oversize(totalLen, Byte.BYTES)];
+            }
+            int written = 0;
+            lastArgEnd = start;
+            for (int i = 0; i < argCount; i++) {
+                final int sliceLen = argRunStarts[i] - lastArgEnd;
+                if (sliceLen > 0) {
+                    System.arraycopy(src, lastArgEnd, templateBuf, written, sliceLen);
+                    written += sliceLen;
+                }
+                lastArgEnd = argRunEnds[i];
+            }
+            final int tailLen = end - lastArgEnd;
+            if (tailLen > 0) {
+                System.arraycopy(src, lastArgEnd, templateBuf, written, tailLen);
+                written += tailLen;
+            }
+
+            computeTemplateId(templateBuf, 0, written);
+            templateRef.bytes = templateBuf;
+            templateRef.offset = 0;
+            templateRef.length = written;
+        }
+    }
+
+    /**
+     * Sets {@link #joinedArgsRef}. A single arg points into {@code src}; multiple args are joined into
+     * {@link #argsBuf} with one space between each pair.
+     */
+    private void materializeArgs(byte[] src) {
+        if (argCount == 0) {
+            joinedArgsRef.bytes = argsBuf; // valid non-null backing; length is 0
+            joinedArgsRef.offset = 0;
+            joinedArgsRef.length = 0;
+        } else if (argCount == 1) {
+            joinedArgsRef.bytes = src;
+            joinedArgsRef.offset = argRunStarts[0];
+            joinedArgsRef.length = argRunEnds[0] - argRunStarts[0];
+        } else {
+            int totalLen = argCount - 1; // space separators
+            for (int i = 0; i < argCount; i++) {
+                totalLen += argRunEnds[i] - argRunStarts[i];
+            }
+            if (totalLen > argsBuf.length) {
+                argsBuf = new byte[ArrayUtil.oversize(totalLen, Byte.BYTES)];
+            }
+            int written = 0;
+            for (int i = 0; i < argCount; i++) {
+                if (i > 0) argsBuf[written++] = ' ';
+                final int runLen = argRunEnds[i] - argRunStarts[i];
+                System.arraycopy(src, argRunStarts[i], argsBuf, written, runLen);
+                written += runLen;
+            }
+            joinedArgsRef.bytes = argsBuf;
+            joinedArgsRef.offset = 0;
+            joinedArgsRef.length = written;
+        }
+    }
 
     private void computeTemplateId(byte[] bytes, int offset, int length) {
-        final MurmurHash3.Hash128 hash = new MurmurHash3.Hash128();
-        MurmurHash3.hash128(bytes, offset, length, 0, hash);
-        ByteUtils.writeLongLE(hash.h1, hashBuf, 0);
+        MurmurHash3.hash128(bytes, offset, length, 0, templateHash);
+        ByteUtils.writeLongLE(templateHash.h1, hashBuf, 0);
         Arg.ENCODER.encode(hashBuf, templateIdBuf);
     }
 
-    // ── Args-info encoding ───────────────────────────────────────────────────────────────────
-
     private void encodeArgsInfo() {
-        // Always encode, even for 0 args: the row path always emits the argsInfo column and
+        // Always encode, even for 0 args: the row path always emits the argsInfo column, where
         // Arg.encodeInfo([]) produces base64url([0x00]) = "AA".
         final int rawMax = Arg.VINT_MAX_BYTES + argCount * 2 * Arg.VINT_MAX_BYTES;
         if (argsInfoRawScratch.length < rawMax) {
@@ -319,89 +376,10 @@ final class PatternTextUtf8Splitter {
             argsInfoBuf = new byte[base64Max];
         }
         try {
-            argsInfoLen = Arg.encodeInfoBytes(argOffsets, argCount, argsInfoRawScratch, argsInfoBuf);
+            argsInfoLen = Arg.encodeInfoBytes(argOffsets, argCount, argsInfoOut, argsInfoRawScratch, argsInfoBuf);
         } catch (IOException e) {
             // ByteArrayDataOutput.writeVInt never actually throws — this branch is unreachable.
             throw new UncheckedIOException(e);
         }
-    }
-
-    // ── BytesRef view updates ────────────────────────────────────────────────────────────────
-
-    private void updateRefs() {
-        templateRef.bytes = templateBuf;
-        templateRef.offset = 0;
-        templateRef.length = templateLen;
-
-        templateIdRef.bytes = templateIdBuf;
-        templateIdRef.offset = 0;
-        templateIdRef.length = templateIdBuf.length; // always 11
-
-        argsInfoRef.bytes = argsInfoBuf;
-        argsInfoRef.offset = 0;
-        argsInfoRef.length = argsInfoLen;
-
-        joinedArgsRef.bytes = argsBuf;
-        joinedArgsRef.offset = 0;
-        joinedArgsRef.length = argsLen;
-    }
-
-    // ── UTF-16 / digit helpers ────────────────────────────────────────────────────────────────
-
-    /**
-     * Returns {@code true} if any code point decoded from the UTF-8 bytes {@code src[start, end)}
-     * satisfies {@link Character#isDigit(int)}, following the same rules as the row path's
-     * {@link Arg#isArg(String)}:
-     * <ul>
-     *   <li>2- and 3-byte sequences: decoded code point is tested with {@code Character.isDigit(int)}.</li>
-     *   <li>4-byte sequences: the two surrogates are not digits, so always {@code false}.</li>
-     * </ul>
-     * This method is only invoked when the run contains at least one non-ASCII byte.
-     */
-    private static boolean slowIsArg(byte[] src, int start, int end) {
-        int pos = start;
-        while (pos < end) {
-            final int b0 = src[pos] & 0xFF;
-            if (b0 < 0x80) {
-                // ASCII bytes are already checked for digit status in the fast path, but handle
-                // them here for correctness in case this is called on a mixed run.
-                if (Character.isDigit(b0)) return true;
-                pos++;
-            } else if ((b0 & 0xE0) == 0xC0) {
-                final int cp = ((b0 & 0x1F) << 6) | (src[pos + 1] & 0x3F);
-                if (Character.isDigit(cp)) return true;
-                pos += 2;
-            } else if ((b0 & 0xF0) == 0xE0) {
-                final int cp = ((b0 & 0x0F) << 12) | ((src[pos + 1] & 0x3F) << 6) | (src[pos + 2] & 0x3F);
-                if (Character.isDigit(cp)) return true;
-                pos += 3;
-            } else {
-                // 4-byte (supplementary) sequence. The row path calls Character.isDigit(char)
-                // on each UTF-16 code unit; surrogates are never Unicode digits, so skip.
-                pos += 4;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Counts the number of UTF-16 code units encoded in {@code src[start, end)}.
-     * Each ASCII and 2-/3-byte sequence contributes 1 unit; each 4-byte (supplementary) sequence
-     * contributes 2 units (a surrogate pair).
-     */
-    private static int countUtf16Units(byte[] src, int start, int end) {
-        int count = 0;
-        for (int pos = start; pos < end; pos++) {
-            final int b = src[pos] & 0xFF;
-            // Count lead bytes (not continuation bytes 0x80–0xBF).
-            if ((b & 0xC0) != 0x80) {
-                count++;
-                if ((b & 0xF8) == 0xF0) {
-                    // 4-byte lead: supplementary code point encodes as two UTF-16 units.
-                    count++;
-                }
-            }
-        }
-        return count;
     }
 }

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperColumnarCompatibilityTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperColumnarCompatibilityTests.java
@@ -19,12 +19,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * Parity tests for {@link PatternTextFieldMapper#mapColumnBatch} against the row path.
- * The {@link AbstractColumnarMapperCompatibilityTestCase} harness drives the mapper through both
- * paths and compares the resulting Lucene fields as order-independent multisets, covering the
- * {@code MappedColumns#rowCursor()} and {@code MappedColumns#toColumnBatch()} representations.
- */
 public class PatternTextFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
 
     private static final String FIELD = "f";
@@ -93,8 +87,6 @@ public class PatternTextFieldMapperColumnarCompatibilityTests extends AbstractCo
             )
         );
     }
-
-    // ── Field absent for some docs (sparse) ──────────────────────────────────────────────────
 
     public void testFieldAbsentInSomeDocs() throws IOException {
         assertColumnarMatchesXContent(

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperColumnarCompatibilityTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapperColumnarCompatibilityTests.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb.patterntext;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.AbstractColumnarMapperCompatibilityTestCase;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.logsdb.LogsDBPlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Parity tests for {@link PatternTextFieldMapper#mapColumnBatch} against the row path.
+ * The {@link AbstractColumnarMapperCompatibilityTestCase} harness drives the mapper through both
+ * paths and compares the resulting Lucene fields as order-independent multisets, covering the
+ * {@code MappedColumns#rowCursor()} and {@code MappedColumns#toColumnBatch()} representations.
+ */
+public class PatternTextFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
+
+    private static final String FIELD = "f";
+
+    @Override
+    protected Collection<Plugin> getPlugins() {
+        return List.of(new LogsDBPlugin(Settings.EMPTY));
+    }
+
+    private static Settings columnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    public void testSingleValueWithArgs() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("single value with args", 1L, doc("d1", 1L, "{\"f\":\"Error 123 at line 456\"}"))
+        );
+    }
+
+    public void testSingleValueNoArgs() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("single value no args", 1L, doc("d1", 1L, "{\"f\":\"No numbers here\"}"))
+        );
+    }
+
+    public void testSingleValueAllArgs() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("all args", 1L, doc("d1", 1L, "{\"f\":\"123 456 789\"}"))
+        );
+    }
+
+    public void testMultiDocBatch() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "multi-doc batch",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123 occurred\"}"),
+                doc("d2", 2L, "{\"f\":\"Warning 456 at line 789\"}"),
+                doc("d3", 3L, "{\"f\":\"No numbers here\"}")
+            )
+        );
+    }
+
+    public void testDocsWithSharedTemplate() throws IOException {
+        // Multiple docs sharing the same template — common for log data sorted by template_id.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "shared template",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Connection refused: 127.0.0.1:8080\"}"),
+                doc("d2", 2L, "{\"f\":\"Connection refused: 10.0.0.1:443\"}"),
+                doc("d3", 3L, "{\"f\":\"Connection refused: 192.168.1.1:22\"}")
+            )
+        );
+    }
+
+    // ── Field absent for some docs (sparse) ──────────────────────────────────────────────────
+
+    public void testFieldAbsentInSomeDocs() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "sparse docs",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"Warning 456\"}"),
+                doc("d4", 4L, "{}"),
+                doc("d5", 5L, "{\"f\":\"Info 789\"}")
+            )
+        );
+    }
+
+    public void testExplicitNull() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("explicit null", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{\"f\":\"Value 42\"}"), doc("d3", 3L, "{\"f\":null}"))
+        );
+    }
+
+    public void testLeadingTrailingDelimiters() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "leading trailing delimiters",
+                1L,
+                doc("d1", 1L, "{\"f\":\"  leading 123\"}"),
+                doc("d2", 2L, "{\"f\":\"trailing 456  \"}"),
+                doc("d3", 3L, "{\"f\":\"[bracket 789]\"}")
+            )
+        );
+    }
+
+    public void testConsecutiveDelimiters() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("consecutive delimiters", 1L, doc("d1", 1L, "{\"f\":\"a  b  c 42\"}"), doc("d2", 2L, "{\"f\":\"x\\ty\\n99\"}"))
+        );
+    }
+
+    public void testNonAsciiValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "non-ascii",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Ошибка 123 в строке 456\"}"),  // Cyrillic with digits
+                doc("d2", 2L, "{\"f\":\"错误 789\"}"),                    // CJK with digits
+                doc("d3", 3L, "{\"f\":\"café au lait\"}")               // Latin extended, no digits
+            )
+        );
+    }
+
+    public void testIndexOptionsPositions() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").field("index_options", "positions").endObject()),
+            columnarSettings(),
+            batch(
+                "positions",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123 at line 456\"}"),
+                doc("d2", 2L, "{\"f\":\"Warning: no numbers here\"}")
+            )
+        );
+    }
+
+    public void testDisableTemplating() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").field("disable_templating", true).endObject()),
+            columnarSettings(),
+            batch(
+                "disable templating",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123 occurred\"}"),
+                doc("d2", 2L, "{\"f\":\"No numbers here\"}"),
+                doc("d3", 3L, "{\"f\":null}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testStandardAnalyzer() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").field("analyzer", "standard").endObject()),
+            columnarSettings(),
+            batch(
+                "standard analyzer",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123 occurred\"}"),
+                doc("d2", 2L, "{\"f\":\"Warning at line 456\"}")
+            )
+        );
+    }
+
+    /**
+     * Verifies the LENGTH_EXCEEDED path for values over 8 192 UTF-16 chars. These docs must emit
+     * {@code template_id} and raw text ({@code .stored}), but no template/args columns.
+     * A batch that mixes normal and over-limit docs exercises the sparse column layout.
+     */
+    public void testMixedNormalAndLengthExceeded() throws IOException {
+        // Build a value that exceeds the 8192-char limit.
+        String longValue = "token ".repeat(1500); // ~9000 chars, no args, prefix "token " is non-arg
+        // Also build a longer value with digits to test the args path for exceeded values.
+        String longValueWithDigit = "x 42 " + "token ".repeat(1500);
+
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "mixed normal and length exceeded",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Error 123 at line 456\"}"),            // TEMPLATED
+                doc("d2", 2L, "{\"f\":\"" + longValue.trim() + "\"}"),          // LENGTH_EXCEEDED
+                doc("d3", 3L, "{\"f\":\"Warning 789\"}"),                       // TEMPLATED
+                doc("d4", 4L, "{\"f\":\"" + longValueWithDigit.trim() + "\"}"), // LENGTH_EXCEEDED
+                doc("d5", 5L, "{\"f\":\"Info 0 at startup\"}")                  // TEMPLATED
+            )
+        );
+    }
+
+    public void testAllLengthExceeded() throws IOException {
+        String longValue = "word ".repeat(2000); // ~10000 chars
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "all length exceeded",
+                1L,
+                doc("d1", 1L, "{\"f\":\"" + longValue.trim() + "\"}"),
+                doc("d2", 2L, "{\"f\":\"" + longValue.trim() + "  extra\"}")
+            )
+        );
+    }
+
+    public void testManyArgs() throws IOException {
+        // A log line with many numeric tokens exercises the arg-offset buffer growth.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch("many args", 1L, doc("d1", 1L, "{\"f\":\"a 1 b 2 c 3 d 4 e 5 f 6 g 7 h 8 i 9 j 10\"}"))
+        );
+    }
+
+    public void testFullMix() throws IOException {
+        // A batch that exercises many code paths at once.
+        String longValue = "word ".repeat(2000);
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "pattern_text").endObject()),
+            columnarSettings(),
+            batch(
+                "full mix",
+                2L, // non-trivial primary term
+                doc("d1", 1L, "{\"f\":\"Error 123 at line 456\"}"),
+                doc("d2", 2L, "{\"f\":\"No numbers here\"}"),
+                doc("d3", 3L, "{}"),
+                doc("d4", 4L, "{\"f\":null}"),
+                doc("d5", 5L, "{\"f\":\"  leading 789  \"}"),
+                doc("d6", 6L, "{\"f\":\"" + longValue.trim() + "\"}"),
+                doc("d7", 7L, "{\"f\":\"Ошибка 42\"}")
+            )
+        );
+    }
+}

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8SplitterTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8SplitterTests.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb.patterntext;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Verifies that {@link PatternTextUtf8Splitter} produces results that are byte-identical to the
+ * row-path code ({@link PatternTextValueProcessor}, {@link Arg}).
+ *
+ * <p>Each test constructs an input string, runs both the byte-level and the string-based paths,
+ * and asserts parity via the differential assertions in {@link #assertMatchesRowPath}.
+ */
+public class PatternTextUtf8SplitterTests extends ESTestCase {
+
+    // ── Differential helper ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Asserts that {@link PatternTextUtf8Splitter#split} produces the same results as
+     * {@link PatternTextValueProcessor#split} for the given string.
+     */
+    private static void assertMatchesRowPath(String input) throws IOException {
+        final PatternTextValueProcessor.Parts parts = PatternTextValueProcessor.split(input);
+        final PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        final PatternTextUtf8Splitter.Result result = splitter.split(new BytesRef(input));
+
+        // Both agree on whether the value exceeded the length limit.
+        assertEquals(parts.useBinaryDocValuesForRawText(), result == PatternTextUtf8Splitter.Result.LENGTH_EXCEEDED);
+
+        // templateId must match in both cases (including the truncation/lone-surrogate case).
+        assertEquals("templateId mismatch for: " + input, parts.templateId(), splitter.templateId().utf8ToString());
+
+        if (result == PatternTextUtf8Splitter.Result.TEMPLATED) {
+            // Template bytes.
+            assertBytesEqual("template", parts.template(), splitter.template());
+
+            // argsInfo bytes.
+            String expectedArgsInfo = Arg.encodeInfo(parts.argsInfo());
+            assertEquals("argsInfo mismatch for: " + input, expectedArgsInfo, splitter.argsInfo().utf8ToString());
+
+            // joinedArgs: only meaningful when there are args.
+            if (splitter.argCount() > 0) {
+                String expectedJoined = Arg.encodeRemainingArgs(parts);
+                assertEquals("joinedArgs mismatch for: " + input, expectedJoined, splitter.joinedArgs().utf8ToString());
+            } else {
+                assertEquals("argCount should be 0 when row path has no args for: " + input, 0, parts.args().size());
+            }
+        }
+    }
+
+    private static void assertBytesEqual(String label, String expectedUtf8String, BytesRef actual) {
+        byte[] expected = expectedUtf8String.getBytes(StandardCharsets.UTF_8);
+        byte[] got = Arrays.copyOfRange(actual.bytes, actual.offset, actual.offset + actual.length);
+        assertArrayEquals(label + " bytes mismatch", expected, got);
+    }
+
+    // ── Basic cases ───────────────────────────────────────────────────────────────────────────
+
+    public void testSimpleLogLine() throws IOException {
+        assertMatchesRowPath("Error 123 at line 456");
+    }
+
+    public void testNoArgs() throws IOException {
+        assertMatchesRowPath("No numbers here at all");
+    }
+
+    public void testAllArgs() throws IOException {
+        assertMatchesRowPath("123 456 789");
+    }
+
+    public void testEmptyString() throws IOException {
+        assertMatchesRowPath("");
+    }
+
+    public void testSingleWord() throws IOException {
+        assertMatchesRowPath("hello");
+    }
+
+    public void testSingleDigit() throws IOException {
+        assertMatchesRowPath("5");
+    }
+
+    public void testSingleDelimiter() throws IOException {
+        assertMatchesRowPath(" ");
+    }
+
+    public void testAllDelimiters() throws IOException {
+        assertMatchesRowPath("   \t\n\r");
+    }
+
+    // ── Delimiter varieties ───────────────────────────────────────────────────────────────────
+
+    public void testEveryDelimiterChar() throws IOException {
+        // Each of the 8 delimiter characters in isolation.
+        assertMatchesRowPath(" space");
+        assertMatchesRowPath("\ttab");
+        assertMatchesRowPath("\nnewline");
+        assertMatchesRowPath("vertical");
+        assertMatchesRowPath("\fformfeed");
+        assertMatchesRowPath("\rcarriage");
+        assertMatchesRowPath("[bracket");
+        assertMatchesRowPath("]bracket");
+    }
+
+    public void testBrackets() throws IOException {
+        assertMatchesRowPath("Error [123] occurred");
+        assertMatchesRowPath("[key=val] message");
+        assertMatchesRowPath("msg [id=42][code=0]");
+    }
+
+    public void testLeadingDelimiters() throws IOException {
+        assertMatchesRowPath("  leading");
+        assertMatchesRowPath("  leading 123");
+        assertMatchesRowPath("\t\tleading");
+    }
+
+    public void testTrailingDelimiters() throws IOException {
+        assertMatchesRowPath("trailing  ");
+        assertMatchesRowPath("trailing 123  ");
+    }
+
+    public void testConsecutiveDelimiters() throws IOException {
+        assertMatchesRowPath("a  b  c");
+        assertMatchesRowPath("x\t\ty");
+    }
+
+    public void testOnlyDelimiters() throws IOException {
+        assertMatchesRowPath("   ");
+        assertMatchesRowPath("[ ]");
+        assertMatchesRowPath("\t \r\n");
+    }
+
+    // ── Arg detection ─────────────────────────────────────────────────────────────────────────
+
+    public void testPureDigitToken() throws IOException {
+        assertMatchesRowPath("value 42");
+        assertMatchesRowPath("value 0");
+        assertMatchesRowPath("val 9999");
+    }
+
+    public void testMixedAlphaDigit() throws IOException {
+        assertMatchesRowPath("id abc123");
+        assertMatchesRowPath("tag v1.2.3");
+    }
+
+    public void testNoDigits() throws IOException {
+        assertMatchesRowPath("abc def ghi");
+    }
+
+    // ── Non-ASCII text ────────────────────────────────────────────────────────────────────────
+
+    public void testNonAsciiNoDigits() throws IOException {
+        // Multi-byte sequences with no digit code points.
+        assertMatchesRowPath("Привет мир");    // Cyrillic (3-byte sequences)
+        assertMatchesRowPath("你好世界");          // CJK (3-byte sequences)
+        assertMatchesRowPath("café latte");   // Latin extended (2-byte sequences)
+    }
+
+    public void testBmpNonAsciiDigits() throws IOException {
+        // Arabic-Indic digits (U+0660–0669): should be treated as args.
+        assertMatchesRowPath("count ١٢٣");  // ١٢٣
+        // Fullwidth digits (U+FF10–FF19): should be treated as args.
+        assertMatchesRowPath("id １２３");     // １２３
+    }
+
+    public void testSupplementaryDigitsNotArgs() throws IOException {
+        // U+1D7CE MATHEMATICAL BOLD DIGIT ZERO is a supplementary (4-byte) code point.
+        // The row path calls Character.isDigit(char) on each UTF-16 code unit (two surrogates),
+        // and surrogates are never digits, so this token is NOT an arg.
+        // U+1D7CE = surrogate pair U+D835 U+DFCE.
+        String supplementaryDigit = new String(Character.toChars(0x1D7CE));
+        // Put it as a standalone token.
+        String input = "prefix " + supplementaryDigit + " suffix";
+        assertMatchesRowPath(input);
+        // Verify our conclusion: the row path also says it's NOT an arg.
+        PatternTextValueProcessor.Parts parts = PatternTextValueProcessor.split(input);
+        assertEquals("supplementary digit token should not be an arg", 0, parts.args().size());
+    }
+
+    public void testEmoji() throws IOException {
+        assertMatchesRowPath("error 😀 occurred");  // emoji (4-byte, surrogates)
+        assertMatchesRowPath("🚀 launch 42");
+    }
+
+    // ── Buffer reuse ──────────────────────────────────────────────────────────────────────────
+
+    public void testBufferReuseAcrossCalls() throws IOException {
+        // Ensure the splitter correctly resets its state between calls.
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // First call: many args and a long template.
+        String first = "a 1 b 2 c 3 d 4 e 5";
+        splitter.split(new BytesRef(first));
+        assertEquals(5, splitter.argCount());
+        String t1 = splitter.template().utf8ToString();
+        String ai1 = splitter.argsInfo().utf8ToString();
+
+        // Second call: no args.
+        String second = "no args here at all";
+        splitter.split(new BytesRef(second));
+        assertEquals(0, splitter.argCount());
+        String t2 = splitter.template().utf8ToString();
+
+        // Third call: same as the first — must match.
+        splitter.split(new BytesRef(first));
+        assertEquals(5, splitter.argCount());
+        assertEquals(t1, splitter.template().utf8ToString());
+        assertEquals(ai1, splitter.argsInfo().utf8ToString());
+
+        // Differential check for all three.
+        assertMatchesRowPath(first);
+        assertMatchesRowPath(second);
+
+        // The second call's template should match the second input (no args left over from first).
+        assertEquals(second, t2);
+    }
+
+    // ── Length limit ──────────────────────────────────────────────────────────────────────────
+
+    public void testExactlyAtLimit() throws IOException {
+        // Exactly MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE ASCII chars → TEMPLATED.
+        String atLimit = "a".repeat(PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE);
+        assertMatchesRowPath(atLimit);
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        assertEquals(PatternTextUtf8Splitter.Result.TEMPLATED, splitter.split(new BytesRef(atLimit)));
+    }
+
+    public void testOneOverLimit() throws IOException {
+        // MAX + 1 ASCII chars → LENGTH_EXCEEDED.
+        String overLimit = "a".repeat(PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE + 1);
+        assertMatchesRowPath(overLimit);
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        assertEquals(PatternTextUtf8Splitter.Result.LENGTH_EXCEEDED, splitter.split(new BytesRef(overLimit)));
+    }
+
+    public void testMultiByteAtLimitCharsButOverLimitBytes() throws IOException {
+        // Build a value that is exactly MAX chars but has some 2-byte sequences so the byte
+        // count exceeds MAX. This exercises the "byte count > limit but char count ≤ limit"
+        // branch — the value should be TEMPLATED.
+        int max = PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE;
+        // Use café-style é (U+00E9, 2 bytes) to exceed the byte limit while staying under char limit.
+        // Each é is 2 bytes but 1 char. We'll mix some to ensure byte count > max.
+        String base = "é".repeat(max); // max chars, 2*max bytes
+        assertMatchesRowPath(base);
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        assertEquals(PatternTextUtf8Splitter.Result.TEMPLATED, splitter.split(new BytesRef(base)));
+    }
+
+    public void testMultiByteOverLimit() throws IOException {
+        // More than MAX chars of multi-byte text → LENGTH_EXCEEDED.
+        String overLimit = "é".repeat(PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE + 1);
+        assertMatchesRowPath(overLimit);
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        assertEquals(PatternTextUtf8Splitter.Result.LENGTH_EXCEEDED, splitter.split(new BytesRef(overLimit)));
+    }
+
+    public void testSurrogatePairStraddlingTruncationPoint() throws IOException {
+        // Build a string of exactly MAX chars where the last char before the limit is the high
+        // surrogate of a supplementary code point (the pair straddles the truncation boundary).
+        // The row path calls CharBuffer.subSequence(0, 8192) which cuts the pair, leaving a lone
+        // high surrogate, and String.getBytes(UTF_8) encodes it as '?' (0x3F).
+        // Our byte path must produce the same templateId.
+        int max = PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE;
+        // Fill max-1 ASCII chars, then one supplementary code point (2 UTF-16 units = 4 UTF-8 bytes).
+        // Total chars = (max-1) + 2 = max+1, which exceeds the limit; truncation cuts at max,
+        // leaving max-1 ASCII + the high surrogate.
+        StringBuilder sb = new StringBuilder(max + 2);
+        for (int i = 0; i < max - 1; i++) {
+            sb.append('a');
+        }
+        sb.appendCodePoint(0x1F600); // U+1F600 GRINNING FACE, surrogate pair: D83D DE00
+        String input = sb.toString();
+        assertEquals(max + 1, input.length()); // max-1 + 2 surrogates
+        assertMatchesRowPath(input);
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        assertEquals(PatternTextUtf8Splitter.Result.LENGTH_EXCEEDED, splitter.split(new BytesRef(input)));
+    }
+
+    public void testSupplementaryCharEndingBeforeTruncationPoint() throws IOException {
+        // Supplementary char fits fully inside the truncation window: no lone surrogate, no '?'.
+        int max = PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE;
+        // max-2 ASCII + 1 supplementary (2 chars) + extra chars to trigger LENGTH_EXCEEDED.
+        StringBuilder sb = new StringBuilder(max + 5);
+        for (int i = 0; i < max - 2; i++) {
+            sb.append('b');
+        }
+        sb.appendCodePoint(0x1F600); // fits at positions max-2 and max-1 → fully inside window
+        sb.append("extra"); // push total length over the limit
+        String input = sb.toString();
+        assertTrue(input.length() > max);
+        assertMatchesRowPath(input);
+    }
+
+    // ── Randomized fuzz ───────────────────────────────────────────────────────────────────────
+
+    public void testRandomLogLines() throws IOException {
+        for (int i = 0; i < 200; i++) {
+            String input = randomLogLine();
+            assertMatchesRowPath(input);
+        }
+    }
+
+    public void testRandomRealisticUnicode() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            // Use ESTestCase's realistic unicode generator (may produce multi-byte characters).
+            String input = randomRealisticUnicodeOfLength(randomIntBetween(0, 200));
+            assertMatchesRowPath(input);
+        }
+    }
+
+    public void testRandomNearLimitStrings() throws IOException {
+        int max = PatternTextValueProcessor.MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE;
+        for (int i = 0; i < 50; i++) {
+            int len = randomIntBetween(max - 5, max + 5);
+            // ASCII only, to ensure byte count equals char count for controlled length.
+            String input = "a".repeat(len);
+            assertMatchesRowPath(input);
+        }
+    }
+
+    // ── argsInfo when there are no args ───────────────────────────────────────────────────────
+
+    public void testArgsInfoEmptyArgs() throws IOException {
+        // The row path always emits argsInfo even for no-args values. Verify byte parity.
+        PatternTextValueProcessor.Parts parts = PatternTextValueProcessor.split("no args here");
+        assertEquals(List.of(), parts.args());
+
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+        splitter.split(new BytesRef("no args here"));
+
+        String expectedArgsInfo = Arg.encodeInfo(parts.argsInfo());
+        assertEquals("argsInfo for empty args should match", expectedArgsInfo, splitter.argsInfo().utf8ToString());
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    /** Generates a random log-like string mixing words, numbers, and delimiters. */
+    private String randomLogLine() {
+        StringBuilder sb = new StringBuilder();
+        int wordCount = randomIntBetween(0, 15);
+        for (int i = 0; i < wordCount; i++) {
+            if (i > 0) {
+                // Random delimiter
+                sb.append(randomFrom(' ', '\t', '\n', '[', ']'));
+            }
+            if (randomBoolean()) {
+                // A "number-ish" arg token
+                sb.append(randomIntBetween(0, 999999));
+            } else {
+                // A plain word (letters only)
+                int wlen = randomIntBetween(1, 12);
+                for (int j = 0; j < wlen; j++) {
+                    sb.append((char) ('a' + randomIntBetween(0, 25)));
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8SplitterTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextUtf8SplitterTests.java
@@ -15,16 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Verifies that {@link PatternTextUtf8Splitter} produces results that are byte-identical to the
- * row-path code ({@link PatternTextValueProcessor}, {@link Arg}).
- *
- * <p>Each test constructs an input string, runs both the byte-level and the string-based paths,
- * and asserts parity via the differential assertions in {@link #assertMatchesRowPath}.
- */
 public class PatternTextUtf8SplitterTests extends ESTestCase {
-
-    // ── Differential helper ───────────────────────────────────────────────────────────────────
 
     /**
      * Asserts that {@link PatternTextUtf8Splitter#split} produces the same results as
@@ -65,8 +56,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         assertArrayEquals(label + " bytes mismatch", expected, got);
     }
 
-    // ── Basic cases ───────────────────────────────────────────────────────────────────────────
-
     public void testSimpleLogLine() throws IOException {
         assertMatchesRowPath("Error 123 at line 456");
     }
@@ -98,8 +87,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
     public void testAllDelimiters() throws IOException {
         assertMatchesRowPath("   \t\n\r");
     }
-
-    // ── Delimiter varieties ───────────────────────────────────────────────────────────────────
 
     public void testEveryDelimiterChar() throws IOException {
         // Each of the 8 delimiter characters in isolation.
@@ -141,8 +128,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         assertMatchesRowPath("\t \r\n");
     }
 
-    // ── Arg detection ─────────────────────────────────────────────────────────────────────────
-
     public void testPureDigitToken() throws IOException {
         assertMatchesRowPath("value 42");
         assertMatchesRowPath("value 0");
@@ -157,8 +142,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
     public void testNoDigits() throws IOException {
         assertMatchesRowPath("abc def ghi");
     }
-
-    // ── Non-ASCII text ────────────────────────────────────────────────────────────────────────
 
     public void testNonAsciiNoDigits() throws IOException {
         // Multi-byte sequences with no digit code points.
@@ -193,8 +176,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         assertMatchesRowPath("🚀 launch 42");
     }
 
-    // ── Buffer reuse ──────────────────────────────────────────────────────────────────────────
-
     public void testBufferReuseAcrossCalls() throws IOException {
         // Ensure the splitter correctly resets its state between calls.
         PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
@@ -225,8 +206,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         // The second call's template should match the second input (no args left over from first).
         assertEquals(second, t2);
     }
-
-    // ── Length limit ──────────────────────────────────────────────────────────────────────────
 
     public void testExactlyAtLimit() throws IOException {
         // Exactly MAX_LOG_LEN_TO_STORE_AS_DOC_VALUE ASCII chars → TEMPLATED.
@@ -302,8 +281,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         assertMatchesRowPath(input);
     }
 
-    // ── Randomized fuzz ───────────────────────────────────────────────────────────────────────
-
     public void testRandomLogLines() throws IOException {
         for (int i = 0; i < 200; i++) {
             String input = randomLogLine();
@@ -329,8 +306,6 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         }
     }
 
-    // ── argsInfo when there are no args ───────────────────────────────────────────────────────
-
     public void testArgsInfoEmptyArgs() throws IOException {
         // The row path always emits argsInfo even for no-args values. Verify byte parity.
         PatternTextValueProcessor.Parts parts = PatternTextValueProcessor.split("no args here");
@@ -343,7 +318,149 @@ public class PatternTextUtf8SplitterTests extends ESTestCase {
         assertEquals("argsInfo for empty args should match", expectedArgsInfo, splitter.argsInfo().utf8ToString());
     }
 
-    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+    // ── Zero-copy fast paths ──────────────────────────────────────────────────────────────────
+    //
+    // These tests verify that template() / joinedArgs() point directly into the source BytesRef
+    // (assertSame on the backing array) when the single-slice fast path applies, and that the
+    // fallback path (assertNotSame) is taken when multiple non-empty complement slices exist.
+    //
+    // For "123 456" the template is just the space " " — a single contiguous slice — so it IS
+    // zero-copy even though there are two args.
+    // For "[42]" the template is "[" and "]" — two non-contiguous slices — so it is NOT.
+
+    public void testTemplateSingleSliceZeroCopy() throws IOException {
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // "Error 123": template = "Error " — one non-empty slice before the single arg.
+        BytesRef v = new BytesRef("Error 123");
+        splitter.split(v);
+        assertSame("template should point into source for single-slice case", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("Error 123");
+
+        // " 42": template = " " — one non-empty slice before the arg.
+        v = new BytesRef(" 42");
+        splitter.split(v);
+        assertSame("template should point into source for single-slice case", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath(" 42");
+
+        // "42 ": template = " " — one non-empty slice after the arg.
+        v = new BytesRef("42 ");
+        splitter.split(v);
+        assertSame("template should point into source for single-slice case", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("42 ");
+
+        // "123 456": template = " " (the space between two args) — one non-empty slice.
+        v = new BytesRef("123 456");
+        splitter.split(v);
+        assertSame("template should point into source for single-slice case", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("123 456");
+
+        // "No numbers here": no args, template == whole input — one non-empty slice.
+        v = new BytesRef("No numbers here");
+        splitter.split(v);
+        assertSame("template should point into source when no args", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("No numbers here");
+    }
+
+    public void testTemplateZeroLengthZeroCopy() throws IOException {
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // "123": all-arg, template is empty — zero non-empty slices, still zero-copy path.
+        BytesRef v = new BytesRef("123");
+        splitter.split(v);
+        assertSame("template should point into source even when template is empty", v.bytes, splitter.template().bytes);
+        assertEquals(0, splitter.template().length);
+        assertMatchesRowPath("123");
+
+        // "": empty input — template is empty.
+        v = new BytesRef("");
+        splitter.split(v);
+        assertSame("template should point into source for empty input", v.bytes, splitter.template().bytes);
+        assertEquals(0, splitter.template().length);
+        assertMatchesRowPath("");
+    }
+
+    public void testTemplateMultiSliceFallback() throws IOException {
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // "Error 123 at line 456": two args → three template slices ("Error ", " at line ", "")
+        // = two non-empty slices → fallback path.
+        BytesRef v = new BytesRef("Error 123 at line 456");
+        splitter.split(v);
+        assertNotSame("template should use scratch buffer for multi-slice case", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("Error 123 at line 456");
+
+        // "[42]": template = "[" and "]" — two non-empty slices → fallback path.
+        v = new BytesRef("[42]");
+        splitter.split(v);
+        assertNotSame("template should use scratch buffer for [42] (two non-empty slices)", v.bytes, splitter.template().bytes);
+        assertMatchesRowPath("[42]");
+    }
+
+    public void testArgsSingleArgZeroCopy() throws IOException {
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // Single arg: joinedArgs() should point into the source.
+        BytesRef v = new BytesRef("abc 42");
+        splitter.split(v);
+        assertEquals(1, splitter.argCount());
+        assertSame("joinedArgs should point into source for single arg", v.bytes, splitter.joinedArgs().bytes);
+        assertMatchesRowPath("abc 42");
+
+        v = new BytesRef("42");
+        splitter.split(v);
+        assertEquals(1, splitter.argCount());
+        assertSame("joinedArgs should point into source for bare single arg", v.bytes, splitter.joinedArgs().bytes);
+        assertMatchesRowPath("42");
+    }
+
+    public void testArgsMultiArgFallback() throws IOException {
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // Multiple args: joinedArgs() must use internal scratch.
+        BytesRef v = new BytesRef("a 1 b 2");
+        splitter.split(v);
+        assertEquals(2, splitter.argCount());
+        assertNotSame("joinedArgs should use scratch buffer for multiple args", v.bytes, splitter.joinedArgs().bytes);
+        assertMatchesRowPath("a 1 b 2");
+    }
+
+    public void testZeroCopyThenFallbackThenZeroCopyReuse() throws IOException {
+        // Verifies that templateRef is correctly reset on each call: a zero-copy ref from call N
+        // must not bleed into call N+1, and the fallback buffer must not corrupt call N+2's
+        // zero-copy ref.
+        PatternTextUtf8Splitter splitter = new PatternTextUtf8Splitter();
+
+        // Call 1: single-slice zero-copy.
+        BytesRef v1 = new BytesRef("Error 123");
+        splitter.split(v1);
+        assertSame(v1.bytes, splitter.template().bytes);
+        String t1 = splitter.template().utf8ToString(); // capture before next call
+
+        // Call 2: multi-slice fallback.
+        BytesRef v2 = new BytesRef("Error 123 at line 456");
+        splitter.split(v2);
+        assertNotSame(v2.bytes, splitter.template().bytes);
+        // Also must not still point at v1's bytes.
+        assertNotSame(v1.bytes, splitter.template().bytes);
+        String t2 = splitter.template().utf8ToString();
+
+        // Call 3: single-slice zero-copy again — must point at v3, not v1 or templateBuf.
+        BytesRef v3 = new BytesRef("Warning 789");
+        splitter.split(v3);
+        assertSame(v3.bytes, splitter.template().bytes);
+        String t3 = splitter.template().utf8ToString();
+
+        // Parity checks.
+        assertMatchesRowPath("Error 123");
+        assertMatchesRowPath("Error 123 at line 456");
+        assertMatchesRowPath("Warning 789");
+
+        // The captured strings must also match the row path individually.
+        assertEquals(PatternTextValueProcessor.split("Error 123").template(), t1);
+        assertEquals(PatternTextValueProcessor.split("Error 123 at line 456").template(), t2);
+        assertEquals(PatternTextValueProcessor.split("Warning 789").template(), t3);
+    }
 
     /** Generates a random log-like string mixing words, numbers, and delimiters. */
     private String randomLogLine() {


### PR DESCRIPTION
pattern_text left supportsColumnarParse at false, forcing any batch
containing such a field onto the row path, which converts each value
to a String and runs Pattern.split over it.

PatternTextUtf8Splitter splits template and args directly on the ESCF
column's UTF-8 bytes. Template slices are the complements of the arg
runs, so the scan records only arg boundaries and returns BytesRefs
into the source when the result is one contiguous slice. Tests verify
byte-identical output against the row path.