### PR TITLE
[9.5] [CI] Add required Quemu setup for dra builds (#155789)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -58,6 +58,9 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
   VERSION_QUALIFIER_ARG="-Dbuild.version_qualifier=$VERSION_QUALIFIER"
 fi
 
+echo --- install qemu for aarch64 docker image builds
+docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+
 echo --- Building release artifacts
 
 .ci/scripts/run-gradle.sh -Ddra.artifacts=true \


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [CI] Add required Quemu setup for dra builds (#155789)