### PR TITLE
Clarify cluster health timeout documentation

### DIFF
--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -74,8 +74,9 @@ The cluster health API accepts the following request parameters:
     `lt(N)` notation.
 
 `timeout`::
-    A time based parameter controlling how long to wait if one of
-    the wait_for_XXX are provided. Defaults to `30s`.
+    The maximum amount of time to wait for any `wait_for_XXX` condition.
+    If the condition is met before the timeout expires, the request returns
+    immediately. Defaults to `30s`.
 
 
 The following is an example of getting the cluster health at the


### PR DESCRIPTION
## Solution
Clarifies that `timeout` is the maximum wait for a cluster-health condition and that the API returns immediately when the condition is met.

## Testing
`git diff --check`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KZ5JWRCMZBY0ZCMQCTQY1NBB&panel=chat)