### PR TITLE
Clarify cluster health timeout parameter

### DIFF
--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -80,8 +80,12 @@ The cluster health API accepts the following request parameters:
     `lt(N)` notation.
 
 `timeout`::
-    A time based parameter controlling how long to wait if one of
-    the wait_for_XXX are provided. Defaults to `30s`.
+    A time based parameter controlling the maximum time to wait for
+    one of the wait_for_XXX conditions to be met. If the condition is
+    met sooner, the API returns immediately; if it is not met within
+    this time, the API returns anyway with the current cluster state.
+    Only has an effect if one of the wait_for_XXX parameters is
+    provided. Defaults to `30s`.
 
 
 The following is an example of getting the cluster health at the


### PR DESCRIPTION
## Problem
The cluster health timeout description can be read as requiring the requested status to remain stable for the timeout duration.

## Solution
Clarify that `timeout` is the maximum wait, the API returns immediately when conditions are met, and otherwise returns the current state.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KZ5KM7B0ZQHH6S3NY54MCNPV&panel=chat)