### PR TITLE
Fix mergeExecutorThreadCount in ThreadPoolMergeExecutorServiceDiskSpaceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
@@ -83,7 +83,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         // use 2 data paths
         String[] paths = new String[] { path.resolve(aPathPart).toString(), path.resolve(bPathPart).toString() };
         // some tests hold one merge thread blocked, and need at least one other runnable
-        mergeExecutorThreadCount = randomIntBetween(2, 9);
+        mergeExecutorThreadCount = randomIntBetween(2, 8);
         Settings.Builder settingsBuilder = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), path)
             .putList(Environment.PATH_DATA_SETTING.getKey(), paths)


### PR DESCRIPTION
## Problem
`randomIntBetween()` includes both bounds, so the test can select one thread more than intended.

## Solution
Cap `mergeExecutorThreadCount` at 8.

## Testing
`./gradlew :server:test --tests org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KZ5KGCPHE24W03H1FR7MTZN3&panel=chat)