### PR TITLE
Rename blob cache metric file parameter

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -31,8 +31,8 @@ public class BlobCacheMetrics {
     private final LongCounter cacheMissCounter;
     private final LongCounter evictedCountNonZeroFrequency;
     private final LongHistogram cacheMissLoadTimes;
+    private LongCounter cachePopulationBytes;
     private final DoubleHistogram cachePopulationThroughput;
-    private final LongCounter cachePopulationBytes;
     private final LongCounter cachePopulationTime;
 
     public enum CachePopulationReason {
@@ -118,20 +118,20 @@ public class BlobCacheMetrics {
     /**
      * Record the various cache population metrics after a chunk is copied to the cache
      *
-     * @param blobName The file that was requested and triggered the cache population.
+     * @param fileName The file that was requested and triggered the cache population.
      * @param bytesCopied The number of bytes copied
      * @param copyTimeNanos The time taken to copy the bytes in nanoseconds
      * @param cachePopulationReason The reason for the cache being populated
      * @param cachePopulationSource The source from which the data is being loaded
      */
     public void recordCachePopulationMetrics(
-        String blobName,
+        String fileName,
         int bytesCopied,
         long copyTimeNanos,
         CachePopulationReason cachePopulationReason,
         CachePopulationSource cachePopulationSource
     ) {
-        LuceneFilesExtensions luceneFilesExtensions = LuceneFilesExtensions.fromFile(blobName);
+        LuceneFilesExtensions luceneFilesExtensions = LuceneFilesExtensions.fromFile(fileName);
         String blobFileExtension = luceneFilesExtensions != null ? luceneFilesExtensions.getExtension() : NON_LUCENE_EXTENSION_TO_RECORD;
         Map<String, Object> metricAttributes = Map.of(
             CACHE_POPULATION_REASON_ATTRIBUTE_KEY,

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -31,8 +31,8 @@ public class BlobCacheMetrics {
     private final LongCounter cacheMissCounter;
     private final LongCounter evictedCountNonZeroFrequency;
     private final LongHistogram cacheMissLoadTimes;
-    private LongCounter cachePopulationBytes;
     private final DoubleHistogram cachePopulationThroughput;
+    private final LongCounter cachePopulationBytes;
     private final LongCounter cachePopulationTime;
 
     public enum CachePopulationReason {


### PR DESCRIPTION
## Solution
Rename `recordCachePopulationMetrics`'s `blobName` parameter to `fileName` so its Lucene filename semantics are clear.

## Testing
`./gradlew :x-pack:plugin:blob-cache:test --tests org.elasticsearch.blobcache.BlobCacheMetricsTests`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.staging.augmentcode.com/session?agentId=01KZ5MZ6CX30JCJAZHCAT59A7Y&panel=chat)