### PR TITLE
[9.5] Clamp merge scheduler thread count when it exceeds max merge count (#155693)

### DIFF
--- a/docs/changelog/155693.yaml
+++ b/docs/changelog/155693.yaml
@@ -1,0 +1,7 @@
+area: Search
+issues:
+ - 96594
+ - 155678
+pr: 155693
+summary: Clamp merge scheduler thread count when it exceeds max merge count
+type: bug

--- a/docs/reference/elasticsearch/index-settings/merge.md
+++ b/docs/reference/elasticsearch/index-settings/merge.md
@@ -31,7 +31,12 @@ This is in order to prevent that the temporary disk space, which is required whi
 The merge scheduler supports the following *dynamic* settings:
 
 `index.merge.scheduler.max_thread_count`
-:   The maximum number of threads on a **single** shard that may be merging at once. Defaults to `Math.max(1, Math.min(4, <<node.processors, node.processors>> / 2))` which works well for a good solid-state-disk (SSD). If your index is on spinning platter drives instead, decrease this to 1.
+:   The maximum number of threads on a **single** shard that may be merging at once. Defaults to half the number of processors the JVM sees on the node, with a minimum of 1, which works well for a good solid-state-disk (SSD). If your index is on spinning platter drives instead, decrease this to 1. This default is independent of [`node.processors`](/reference/elasticsearch/configuration-reference/thread-pool-settings.md#node.processors). With `include_defaults`, the reported default is the unclamped value computed on the responding node; it may differ from the value a data node actually uses after clamping to `max_merge_count`, and from data nodes with a different processor count.
+
+    If `max_thread_count` would exceed `index.merge.scheduler.max_merge_count`, Elasticsearch reduces it to `max_merge_count` when the index is opened or its settings change, and logs a warning. That can happen when `max_thread_count` is left unset and `max_merge_count` is set explicitly, especially across nodes with different processor counts, or when both are set with `max_thread_count` greater than `max_merge_count`.
+
+`index.merge.scheduler.max_merge_count`
+:   The maximum number of merges that may be running or waiting on a **single** shard at once. Defaults to `index.merge.scheduler.max_thread_count + 5`.
 
 `indices.merge.disk.check_interval`
 :   The time interval for checking the available disk space. Defaults to `5s`.

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/40_merge_scheduler.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_settings/40_merge_scheduler.yml
@@ -1,0 +1,28 @@
+---
+"Accepts inverted merge scheduler settings":
+  - requires:
+      cluster_features: ["index.merge_scheduler_clamps_max_thread_count"]
+      reason: "inverted merge scheduler settings are clamped, not rejected"
+
+  - do:
+      indices.create:
+        index: merge-scheduler-clamp
+        body:
+          settings:
+            number_of_replicas: 0
+            index.merge.scheduler.max_merge_count: 4
+
+  - do:
+      indices.put_settings:
+        index: merge-scheduler-clamp
+        body:
+          index.merge.scheduler.max_thread_count: 10
+
+  - do:
+      indices.get_settings:
+        index: merge-scheduler-clamp
+        flat_settings: true
+
+  # Metadata keeps the requested values; the scheduler clamps at apply time.
+  - match: { merge-scheduler-clamp.settings.index\.merge\.scheduler\.max_thread_count: "10" }
+  - match: { merge-scheduler-clamp.settings.index\.merge\.scheduler\.max_merge_count: "4" }

--- a/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexFeatures.java
@@ -51,6 +51,13 @@ public class IndexFeatures implements FeatureSpecification {
         "constant_field_type.normalized_wildcard_query_support"
     );
 
+    /**
+     * Inverted {@code max_thread_count}/{@code max_merge_count} pairs are clamped instead of rejected.
+     */
+    private static final NodeFeature MERGE_SCHEDULER_CLAMPS_MAX_THREAD_COUNT = new NodeFeature(
+        "index.merge_scheduler_clamps_max_thread_count"
+    );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
         Set<NodeFeature> features = new HashSet<>(
@@ -66,7 +73,8 @@ public class IndexFeatures implements FeatureSpecification {
                 SHADOWING_DIMENSIONS_AND_METRICS_IS_VALID_IN_NON_TSDB,
                 InferenceMetadataFieldsMapper.INFERENCE_FIELDS_GET_VIA_SOURCE_INCLUDES,
                 CONSTANT_FIELD_TYPE_NORMALIZED_WILDCARD_QUERY_SUPPORT,
-                InferenceMetadataFieldsMapper.INFERENCE_FIELDS_GET_VIA_SOURCE_EXCLUDE_VECTORS
+                InferenceMetadataFieldsMapper.INFERENCE_FIELDS_GET_VIA_SOURCE_EXCLUDE_VECTORS,
+                MERGE_SCHEDULER_CLAMPS_MAX_THREAD_COUNT
             )
         );
         if (SliceIndexing.SLICE_FEATURE_FLAG.isEnabled()) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1645,7 +1645,10 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(
             MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
             MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
-            mergeSchedulerConfig::setMaxThreadAndMergeCount
+            (maxThreadCount, maxMergeCount) -> {
+                mergeSchedulerConfig.setMaxThreadAndMergeCount(maxThreadCount, maxMergeCount);
+                warnIfMergeSchedulerMaxThreadCountClamped();
+            }
         );
         scopedSettings.addSettingsUpdateConsumer(MergeSchedulerConfig.AUTO_THROTTLE_SETTING, mergeSchedulerConfig::setAutoThrottle);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_DURABILITY_SETTING, this::setTranslogDurability);
@@ -1981,6 +1984,15 @@ public final class IndexSettings {
      */
     public MergeSchedulerConfig getMergeSchedulerConfig() {
         return mergeSchedulerConfig;
+    }
+
+    /**
+     * Logs when an applied {@code max_thread_count} was clamped to {@code max_merge_count}.
+     * Call only from paths that own a live index (create or a real settings update), not from
+     * throwaway {@link IndexSettings} constructions used for validation.
+     */
+    public void warnIfMergeSchedulerMaxThreadCountClamped() {
+        mergeSchedulerConfig.warnIfMaxThreadCountClamped(logger);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/MergeSchedulerConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergeSchedulerConfig.java
@@ -9,11 +9,10 @@
 
 package org.elasticsearch.index;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 
 /**
  * The merge scheduler (<code>ConcurrentMergeScheduler</code>) controls the execution of
@@ -27,9 +26,10 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
  * <li> <code>index.merge.scheduler.max_thread_count</code>:
  *
  *     The maximum number of threads that may be merging at once. Defaults to
- *     <code>Math.max(1, {@link EsExecutors#allocatedProcessors(Settings)} / 2)</code>
+ *     half of {@link Runtime#availableProcessors()}, with a minimum of 1,
  *     which works well for a good non-volatile memory express (NVMe) solid-state-disk (SSD).
  *     If your index is on spinning platter drives instead, decrease this to 1.
+ *     This default is independent of {@code node.processors}.
  *
  * <li><code>index.merge.scheduler.auto_throttle</code>:
  *
@@ -45,7 +45,7 @@ public final class MergeSchedulerConfig {
 
     public static final Setting<Integer> MAX_THREAD_COUNT_SETTING = new Setting<>(
         "index.merge.scheduler.max_thread_count",
-        (s) -> Integer.toString(Math.max(1, EsExecutors.allocatedProcessors(s) / 2)),
+        (s) -> Integer.toString(Math.max(1, Runtime.getRuntime().availableProcessors() / 2)),
         (s) -> Setting.parseInt(s, 1, "index.merge.scheduler.max_thread_count"),
         Property.Dynamic,
         Property.IndexScope
@@ -64,14 +64,20 @@ public final class MergeSchedulerConfig {
         Property.IndexScope
     );
 
+    /**
+     * Snapshot of the last applied merge-scheduler thread/merge counts.
+     */
+    record AppliedCounts(int requestedMaxThreadCount, int maxThreadCount, int maxMergeCount) {
+        boolean isMaxThreadCountClamped() {
+            return maxThreadCount < requestedMaxThreadCount;
+        }
+    }
+
     private volatile boolean autoThrottle;
-    private volatile int maxThreadCount;
-    private volatile int maxMergeCount;
+    private volatile AppliedCounts appliedCounts;
 
     MergeSchedulerConfig(IndexSettings indexSettings) {
-        int maxThread = indexSettings.getValue(MAX_THREAD_COUNT_SETTING);
-        int maxMerge = indexSettings.getValue(MAX_MERGE_COUNT_SETTING);
-        setMaxThreadAndMergeCount(maxThread, maxMerge);
+        setMaxThreadAndMergeCount(indexSettings.getValue(MAX_THREAD_COUNT_SETTING), indexSettings.getValue(MAX_MERGE_COUNT_SETTING));
         this.autoThrottle = indexSettings.getValue(AUTO_THROTTLE_SETTING);
     }
 
@@ -95,12 +101,29 @@ public final class MergeSchedulerConfig {
      * Returns {@code maxThreadCount}.
      */
     public int getMaxThreadCount() {
-        return maxThreadCount;
+        return appliedCounts.maxThreadCount();
     }
 
     /**
-     * Expert: directly set the maximum number of merge threads and
-     * simultaneous merges allowed.
+     * Returns {@code maxMergeCount}.
+     */
+    public int getMaxMergeCount() {
+        return appliedCounts.maxMergeCount();
+    }
+
+    /**
+     * Returns the last applied counts snapshot.
+     */
+    AppliedCounts getAppliedCounts() {
+        return appliedCounts;
+    }
+
+    /**
+     * Expert: set the maximum number of merge threads and simultaneous merges allowed.
+     * {@code maxThreadCount} is capped at {@code maxMergeCount} so cluster-state application
+     * cannot fail when a node-local default exceeds a published setting. Callers that own a
+     * live index should log when the applied counts are clamped; throwaway
+     * {@link IndexSettings} constructions must stay silent.
      */
     void setMaxThreadAndMergeCount(int maxThreadCount, int maxMergeCount) {
         if (maxThreadCount < 1) {
@@ -109,19 +132,24 @@ public final class MergeSchedulerConfig {
         if (maxMergeCount < 1) {
             throw new IllegalArgumentException("maxMergeCount should be at least 1");
         }
-        if (maxThreadCount > maxMergeCount) {
-            throw new IllegalArgumentException(
-                "maxThreadCount (= " + maxThreadCount + ") should be <= maxMergeCount (= " + maxMergeCount + ")"
-            );
-        }
-        this.maxThreadCount = maxThreadCount;
-        this.maxMergeCount = maxMergeCount;
+        this.appliedCounts = new AppliedCounts(maxThreadCount, Math.min(maxThreadCount, maxMergeCount), maxMergeCount);
     }
 
     /**
-     * Returns {@code maxMergeCount}.
+     * Logs when the current applied counts had {@code max_thread_count} clamped to {@code max_merge_count}.
      */
-    public int getMaxMergeCount() {
-        return maxMergeCount;
+    void warnIfMaxThreadCountClamped(Logger logger) {
+        final AppliedCounts counts = this.appliedCounts;
+        if (counts.isMaxThreadCountClamped() == false) {
+            return;
+        }
+        logger.warn(
+            "[{}] (= {}) exceeds [{}] (= {}); using {}",
+            MAX_THREAD_COUNT_SETTING.getKey(),
+            counts.requestedMaxThreadCount(),
+            MAX_MERGE_COUNT_SETTING.getKey(),
+            counts.maxMergeCount(),
+            counts.maxThreadCount()
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -738,6 +738,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 indexingMemoryController
             );
         }
+        indexService.getIndexSettings().warnIfMergeSchedulerMaxThreadCountClamped();
         boolean success = false;
         try {
             if (writeDanglingIndices && nodeWriteDanglingIndicesInfo) {

--- a/server/src/test/java/org/elasticsearch/index/MergeSchedulerClampTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergeSchedulerClampTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.MockLog;
+
+import static org.elasticsearch.index.MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING;
+import static org.elasticsearch.index.MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING;
+
+/**
+ * Verifies that opening an index with an inverted merge-scheduler pair clamps and warns once
+ * from {@code IndicesService.createIndex}.
+ */
+public class MergeSchedulerClampTests extends ESSingleNodeTestCase {
+
+    public void testCreateIndexWarnsWhenMaxThreadCountClamped() {
+        final Settings settings = indexSettings(1, 0).put(MAX_THREAD_COUNT_SETTING.getKey(), 10)
+            .put(MAX_MERGE_COUNT_SETTING.getKey(), 4)
+            .build();
+        MockLog.assertThatLogger(() -> {
+            IndexService indexService = createIndex("merge-scheduler-clamp", settings);
+            assertEquals(4, indexService.getIndexSettings().getMergeSchedulerConfig().getMaxThreadCount());
+            assertEquals(4, indexService.getIndexSettings().getMergeSchedulerConfig().getMaxMergeCount());
+            assertTrue(indexService.getIndexSettings().getMergeSchedulerConfig().getAppliedCounts().isMaxThreadCountClamped());
+        },
+            IndexSettings.class,
+            new MockLog.SeenEventExpectation(
+                "warn when createIndex clamps max_thread_count",
+                IndexSettings.class.getCanonicalName(),
+                Level.WARN,
+                "[" + MAX_THREAD_COUNT_SETTING.getKey() + "] (= 10) exceeds [" + MAX_MERGE_COUNT_SETTING.getKey() + "] (= 4); using 4"
+            )
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/MergeSchedulerSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergeSchedulerSettingsTests.java
@@ -19,12 +19,13 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 
 import static org.elasticsearch.common.util.concurrent.EsExecutors.NODE_PROCESSORS_SETTING;
 import static org.elasticsearch.index.IndexSettingsTests.newIndexMeta;
 import static org.elasticsearch.index.MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING;
 import static org.elasticsearch.index.MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING;
-import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class MergeSchedulerSettingsTests extends ESTestCase {
     private static class MockAppender extends AbstractAppender {
@@ -117,7 +118,7 @@ public class MergeSchedulerSettingsTests extends ESTestCase {
         }
     }
 
-    private static IndexMetadata createMetadata(int maxThreadCount, int maxMergeCount, int numProc) {
+    private static IndexMetadata createMetadata(int maxThreadCount, int maxMergeCount) {
         Settings.Builder builder = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current());
         if (maxThreadCount != -1) {
             builder.put(MAX_THREAD_COUNT_SETTING.getKey(), maxThreadCount);
@@ -125,45 +126,94 @@ public class MergeSchedulerSettingsTests extends ESTestCase {
         if (maxMergeCount != -1) {
             builder.put(MAX_MERGE_COUNT_SETTING.getKey(), maxMergeCount);
         }
-        if (numProc != -1) {
-            builder.put(NODE_PROCESSORS_SETTING.getKey(), numProc);
-        }
         return newIndexMeta("index", builder.build());
     }
 
     public void testMaxThreadAndMergeCount() {
-        IllegalArgumentException exc = expectThrows(
-            IllegalArgumentException.class,
-            () -> new MergeSchedulerConfig(new IndexSettings(createMetadata(10, 4, -1), Settings.EMPTY))
-        );
-        assertThat(exc.getMessage(), containsString("maxThreadCount (= 10) should be <= maxMergeCount (= 4)"));
+        // Inverted pairs must still construct successfully (and clamp) so cluster-state application cannot hang.
+        IndexSettings settings = new IndexSettings(createMetadata(10, 4), Settings.EMPTY);
+        assertEquals(4, settings.getMergeSchedulerConfig().getMaxThreadCount());
+        assertEquals(4, settings.getMergeSchedulerConfig().getMaxMergeCount());
+        assertTrue(settings.getMergeSchedulerConfig().getAppliedCounts().isMaxThreadCountClamped());
+        assertEquals(10, settings.getMergeSchedulerConfig().getAppliedCounts().requestedMaxThreadCount());
 
-        IndexSettings settings = new IndexSettings(createMetadata(-1, -1, 2), Settings.EMPTY);
-        assertEquals(1, settings.getMergeSchedulerConfig().getMaxThreadCount());
-        assertEquals(6, settings.getMergeSchedulerConfig().getMaxMergeCount());
-
-        settings = new IndexSettings(createMetadata(4, 10, -1), Settings.EMPTY);
+        settings = new IndexSettings(createMetadata(4, 10), Settings.EMPTY);
         assertEquals(4, settings.getMergeSchedulerConfig().getMaxThreadCount());
         assertEquals(10, settings.getMergeSchedulerConfig().getMaxMergeCount());
-        IndexMetadata newMetadata = createMetadata(15, 20, -1);
+        assertFalse(settings.getMergeSchedulerConfig().getAppliedCounts().isMaxThreadCountClamped());
 
-        settings.updateIndexMetadata(newMetadata);
+        settings.updateIndexMetadata(createMetadata(15, 20));
         assertEquals(15, settings.getMergeSchedulerConfig().getMaxThreadCount());
         assertEquals(20, settings.getMergeSchedulerConfig().getMaxMergeCount());
 
-        settings.updateIndexMetadata(createMetadata(40, 50, -1));
+        settings.updateIndexMetadata(createMetadata(40, 50));
         assertEquals(40, settings.getMergeSchedulerConfig().getMaxThreadCount());
         assertEquals(50, settings.getMergeSchedulerConfig().getMaxMergeCount());
 
-        settings.updateIndexMetadata(createMetadata(40, -1, -1));
+        settings.updateIndexMetadata(createMetadata(40, -1));
         assertEquals(40, settings.getMergeSchedulerConfig().getMaxThreadCount());
         assertEquals(45, settings.getMergeSchedulerConfig().getMaxMergeCount());
 
-        final IndexSettings finalSettings = settings;
-        exc = expectThrows(IllegalArgumentException.class, () -> finalSettings.updateIndexMetadata(createMetadata(40, 30, -1)));
-        assertThat(exc.getMessage(), containsString("maxThreadCount (= 40) should be <= maxMergeCount (= 30)"));
+        settings.updateIndexMetadata(createMetadata(40, 30));
+        assertEquals(30, settings.getMergeSchedulerConfig().getMaxThreadCount());
+        assertEquals(30, settings.getMergeSchedulerConfig().getMaxMergeCount());
+        assertTrue(settings.getMergeSchedulerConfig().getAppliedCounts().isMaxThreadCountClamped());
+    }
 
-        exc = expectThrows(IllegalArgumentException.class, () -> finalSettings.updateIndexMetadata(createMetadata(-1, 3, 8)));
-        assertThat(exc.getMessage(), containsString("maxThreadCount (= 4) should be <= maxMergeCount (= 3)"));
+    public void testDefaultMaxThreadCountIndependentOfNodeProcessors() {
+        assumeTrue(
+            "need more than 2 processors so availableProcessors()/2 differs from node.processors=1",
+            Runtime.getRuntime().availableProcessors() > 2
+        );
+        final int expected = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        IndexSettings settings = new IndexSettings(
+            createMetadata(-1, -1),
+            Settings.builder().put(NODE_PROCESSORS_SETTING.getKey(), 1).build()
+        );
+        assertEquals(expected, settings.getMergeSchedulerConfig().getMaxThreadCount());
+        assertEquals(expected + 5, settings.getMergeSchedulerConfig().getMaxMergeCount());
+    }
+
+    public void testClampsWhenDefaultExceedsExplicitMaxMergeCount() {
+        // max_merge_count=1 exercises the invariant on every host; on hosts with default > 1 it also clamps.
+        IndexSettings settings = new IndexSettings(createMetadata(-1, 1), Settings.EMPTY);
+        assertThat(
+            settings.getMergeSchedulerConfig().getMaxThreadCount(),
+            lessThanOrEqualTo(settings.getMergeSchedulerConfig().getMaxMergeCount())
+        );
+        assertEquals(1, settings.getMergeSchedulerConfig().getMaxMergeCount());
+    }
+
+    public void testConstructionDoesNotWarnWhenClamping() {
+        MockLog.assertThatLogger(() -> {
+            IndexSettings settings = new IndexSettings(createMetadata(10, 4), Settings.EMPTY);
+            assertTrue(settings.getMergeSchedulerConfig().getAppliedCounts().isMaxThreadCountClamped());
+            new IndexSettings(createMetadata(-1, 1), Settings.EMPTY);
+        },
+            IndexSettings.class,
+            new MockLog.UnseenEventExpectation(
+                "no warn on throwaway IndexSettings construction",
+                IndexSettings.class.getCanonicalName(),
+                Level.WARN,
+                "*" + MAX_THREAD_COUNT_SETTING.getKey() + "*"
+            )
+        );
+    }
+
+    public void testWarnsWhenMaxThreadCountIsClampedOnSettingsUpdate() {
+        IndexSettings settings = new IndexSettings(createMetadata(4, 10), Settings.EMPTY);
+        MockLog.assertThatLogger(() -> {
+            settings.updateIndexMetadata(createMetadata(40, 30));
+            assertEquals(30, settings.getMergeSchedulerConfig().getMaxThreadCount());
+            assertEquals(30, settings.getMergeSchedulerConfig().getMaxMergeCount());
+        },
+            IndexSettings.class,
+            new MockLog.SeenEventExpectation(
+                "warn on update when max_thread_count is clamped",
+                IndexSettings.class.getCanonicalName(),
+                Level.WARN,
+                "[" + MAX_THREAD_COUNT_SETTING.getKey() + "] (= 40) exceeds [" + MAX_MERGE_COUNT_SETTING.getKey() + "] (= 30); using 30"
+            )
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
@@ -225,7 +225,7 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
 
     private void testIndexingThrottlingWhenSubmittingMerges(boolean withDiskIOThrottlingEnabled) {
         final int maxThreadCount = randomIntBetween(1, 5);
-        // settings validation requires maxMergeCount >= maxThreadCount
+        // keep maxMergeCount >= maxThreadCount so the test exercises the configured thread count
         final int maxMergeCount = maxThreadCount + randomIntBetween(0, 5);
         List<MergeTask> submittedMergeTasks = new ArrayList<>();
         AtomicBoolean isUsingMaxTargetIORate = new AtomicBoolean(false);
@@ -293,7 +293,7 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
 
     public void testIndexingThrottlingWhileMergesAreRunning() {
         final int maxThreadCount = randomIntBetween(1, 5);
-        // settings validation requires maxMergeCount >= maxThreadCount
+        // keep maxMergeCount >= maxThreadCount so the test exercises the configured thread count
         final int maxMergeCount = maxThreadCount + randomIntBetween(0, 5);
         List<MergeTask> submittedMergeTasks = new ArrayList<>();
         List<MergeTask> scheduledToRunMergeTasks = new ArrayList<>();


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Clamp merge scheduler thread count when it exceeds max merge count (#155693)