### PR TITLE
[CI] Create docker-container buildx builder for multi-platform DRA builds

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -60,6 +60,7 @@ fi
 
 echo --- install qemu for aarch64 docker image builds
 docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+docker buildx create --driver docker-container --use --bootstrap
 
 echo --- Building release artifacts
 


### PR DESCRIPTION
## Summary

- Follows up on #155789 which added QEMU binfmt registration for aarch64 Docker builds
- Adds `docker buildx create --driver docker-container --use --bootstrap` so that `docker buildx build --platform linux/arm64` uses a BuildKit worker container rather than the default `docker` driver
- The `--bootstrap` flag starts the BuildKit worker immediately (while binfmt/QEMU is already registered) so it correctly detects the available platforms

## Background

The ci-agent-images change ([bd12964](https://github.com/elastic/ci-agent-images/commit/bd1296451acfdcff593ebcac304fb152083d9bf6)) replaced the old `qemu-user-static` + `binfmt-support` setup (which persisted across reboots via a systemd service) with `tonistiigi/binfmt`, which only registers in `/proc/sys/fs/binfmt_misc` (kernel runtime state, does not survive reboots). This broke DRA aarch64 Docker image builds (`buildAarch64IronBankDockerImage`) starting from build [#95471](https://buildkite.com/elastic/elasticsearch-dra-workflow/builds/95471).

The ci-agent-images commit explicitly documents that jobs needing multi-platform builds must run both steps at job time. This PR adds the missing second step.