### PR TITLE
[9.4] [CI] Create docker-container buildx builder for multi-platform DRA builds (#155826)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -60,6 +60,7 @@ fi
 
 echo --- install qemu for aarch64 docker image builds
 docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+docker buildx create --driver docker-container --use --bootstrap
 
 echo --- Building release artifacts
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[CI] Create docker-container buildx builder for multi-platform DRA builds (#155826)](https://github.com/elastic/elasticsearch/pull/155826)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)