### PR TITLE
[9.3] [CI] Create docker-container buildx builder for multi-platform DRA builds (#155826)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -58,6 +58,10 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
   VERSION_QUALIFIER_ARG="-Dbuild.version_qualifier=$VERSION_QUALIFIER"
 fi
 
+echo --- install qemu for aarch64 docker image builds
+docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+docker buildx create --driver docker-container --use --bootstrap
+
 echo --- Building release artifacts
 
 .ci/scripts/run-gradle.sh -Ddra.artifacts=true \


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Create docker-container buildx builder for multi-platform DRA builds (#155826)](https://github.com/elastic/elasticsearch/pull/155826)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)