### PR TITLE
Fix flaky StatelessCommitServiceIT deadlock

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -595,12 +595,6 @@ tests:
 - class: org.elasticsearch.search.vectors.IVFKnnByteVectorQueryTests
   method: testRandomWithFilter
   issue: https://github.com/elastic/elasticsearch/issues/155784
-- class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
-  method: testRetainCommitForReadersAfterShardMovedAway
-  issue: https://github.com/elastic/elasticsearch/issues/155833
-- class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
-  method: testRetainCommitForReadersAfterShardReplicasSetToZero
-  issue: https://github.com/elastic/elasticsearch/issues/155567
 - class: org.elasticsearch.xpack.transform.integration.TransformIT
   method: testTransformLifecycleInALoop
   issue: https://github.com/elastic/elasticsearch/issues/155844

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCommitServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessCommitServiceIT.java
@@ -137,7 +137,8 @@ public class StatelessCommitServiceIT extends AbstractStatelessPluginIntegTestCa
 
         // Set up some data to be read.
         final int numDocsToIndex = randomIntBetween(5, 100);
-        indexDocsAndRefresh(indexName, numDocsToIndex);
+        indexDocs(indexName, numDocsToIndex);
+        refresh(indexName);
         flushAndUpdateCommitServiceTrackingAndBlobStoreFiles(indexNode, indexName);
 
         final ShardId shardId = findSearchShard(indexName).shardId();
@@ -164,7 +165,8 @@ public class StatelessCommitServiceIT extends AbstractStatelessPluginIntegTestCa
             // Run some indexing and create a new commit. Then force merge down to a single segment (in another new commit). Newer commits
             // can reference information in older commit, rather than copying everything: force merge will ensure older commits are not
             // retained for this reason.
-            indexDocsAndRefresh(indexName, numDocsToIndex);
+            indexDocs(indexName, numDocsToIndex);
+            refresh(indexName);
             flushAndUpdateCommitServiceTrackingAndBlobStoreFiles(indexNode, indexName);
 
             logger.info("--> Blob store shard commit generations before force-merge: " + listBlobsTermAndGenerations(shardId));


### PR DESCRIPTION
indexDocsAndRefresh randomly uses refresh=WAIT_UNTIL, which waits for a scheduled refresh. With refresh_interval=-1 (needed for deterministic VBCC boundaries), that refresh never runs, so the bulk call hangs until the test times out. Index and refresh explicitly instead.

Closes #155567, #155833