### PR TITLE
ESQL: Support basic double range aggregates

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
@@ -1,5 +1,5 @@
 doubleRangeBlockLoader
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -16,7 +16,7 @@ height_range:double_range | description:keyword
 ;
 
 toRange
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 ROW from = 1.5, to = 2.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -28,7 +28,7 @@ height_range:double_range
 ;
 
 toRangeNullLeft
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 ROW to = 1.5
 | EVAL height_range = TO_RANGE(null, to)
@@ -40,7 +40,7 @@ null
 ;
 
 toRangeNullRight
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 ROW from = 1.5
 | EVAL height_range = TO_RANGE(from, null)
@@ -52,7 +52,7 @@ null
 ;
 
 toRangeInvalidBounds
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 ROW from = 2.5, to = 1.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -66,7 +66,7 @@ null
 ;
 
 toString
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -84,7 +84,7 @@ height_range_string:keyword | description:keyword
 ;
 
 rangeMinMax
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -102,7 +102,7 @@ height_range:double_range | min_bound:double | max_bound:double | description:ke
 ;
 
 rangeMinMaxRoundTrip
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -115,7 +115,7 @@ height_range:double_range | new_range:double_range
 ;
 
 doubleRangeEquality
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 required_capability: equality_double_range
 
 FROM heights
@@ -128,7 +128,7 @@ Short
 ;
 
 doubleRangeNotEquals
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 required_capability: equality_double_range
 
 FROM heights
@@ -145,7 +145,7 @@ Very Tall
 ;
 
 doubleRangeSelfEquality
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 required_capability: equality_double_range
 
 FROM heights
@@ -164,7 +164,7 @@ Very Tall
 ;
 
 doubleRangeIn
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 required_capability: equality_double_range
 
 FROM heights
@@ -179,7 +179,7 @@ Tall
 ;
 
 mvFirstLastDoubleRange
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -193,7 +193,7 @@ first_range:double_range | last_range:double_range
 ;
 
 mvCountDoubleRange
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -207,7 +207,7 @@ count:integer
 ;
 
 valuesDoubleRange
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -221,7 +221,7 @@ strings:keyword
 ;
 
 valuesDoubleRangeGrouped
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -238,7 +238,7 @@ strings:keyword                  | short:boolean
 ;
 
 mvExpandValuesDoubleRangeGrouped
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -260,7 +260,7 @@ ranges:double_range | short:boolean | count:integer
 ;
 
 coalesceDoubleRangeField
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -273,7 +273,7 @@ result:double_range
 ;
 
 coalesceDoubleRangeNullFirst
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -287,7 +287,7 @@ result:double_range
 ;
 
 coalesceDoubleRangeMultipleArgs
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -301,7 +301,7 @@ result:double_range
 ;
 
 caseDoubleRangeTrueBranch
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -314,7 +314,7 @@ result:double_range
 ;
 
 caseDoubleRangeFalseBranch
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -327,7 +327,7 @@ result:double_range
 ;
 
 caseDoubleRangeNoElse
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description == "Short"
@@ -340,7 +340,7 @@ null
 ;
 
 caseDoubleRangeSelectByDescription
-required_capability: double_range_field_type_development_v7
+required_capability: double_range_field_type_development_v8
 
 FROM heights
 | WHERE description IN ("Short", "Tall")
@@ -352,4 +352,84 @@ FROM heights
 description:keyword | result:double_range
 Short               | 1.5..1.6
 Tall                | 10.0..20.0
+;
+
+countDoubleRange
+required_capability: double_range_field_type_development_v8
+
+FROM heights
+| STATS count = COUNT(height_range)
+;
+
+count:long
+5
+;
+
+countDoubleRangeWithFilter
+required_capability: double_range_field_type_development_v8
+
+FROM heights
+| STATS count = COUNT(height_range) WHERE description LIKE "*Short*"
+;
+
+count:long
+2
+;
+
+countDoubleRangeGrouped
+required_capability: double_range_field_type_development_v8
+
+FROM heights
+| EVAL short = description LIKE "*Short*"
+| STATS count = COUNT(height_range) BY short
+| SORT short
+;
+
+count:long | short:boolean
+3          | false
+2          | true
+;
+
+presentDoubleRange
+required_capability: double_range_field_type_development_v8
+
+FROM heights
+| STATS present = PRESENT(height_range)
+;
+
+present:boolean
+true
+;
+
+presentDoubleRangeAllNull
+required_capability: double_range_field_type_development_v8
+
+ROW height_range = TO_RANGE(null, 1.0)
+| STATS present = PRESENT(height_range)
+;
+
+present:boolean
+false
+;
+
+absentDoubleRange
+required_capability: double_range_field_type_development_v8
+
+FROM heights
+| STATS absent = ABSENT(height_range)
+;
+
+absent:boolean
+false
+;
+
+absentDoubleRangeAllNull
+required_capability: double_range_field_type_development_v8
+
+ROW height_range = TO_RANGE(null, 1.0)
+| STATS absent = ABSENT(height_range)
+;
+
+absent:boolean
+true
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2142,7 +2142,7 @@ public class EsqlCapabilities {
         /**
          * Support for the DOUBLE_RANGE field type.
          */
-        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7(Build.current().isSnapshot()),
+        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8(Build.current().isSnapshot()),
 
         /**
          * Network direction function.
@@ -3391,7 +3391,7 @@ public class EsqlCapabilities {
         /**
          * Support for equality ({@code ==}, {@code !=}) and {@code IN} with the {@code double_range} type.
          */
-        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()),
+        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()),
 
         /**
          * Fix TopN encoding/decoding of {@code long_range} values.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Absent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Absent.java
@@ -78,6 +78,7 @@ public class Absent extends AggregateFunction implements SurrogateExpression, Ag
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -120,6 +120,7 @@ public class Count extends AggregateFunction implements ToAggregator, SurrogateE
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "geo_point",
                 "geo_shape",
                 "geohash",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Present.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Present.java
@@ -79,6 +79,7 @@ public class Present extends AggregateFunction implements ToAggregator, Aggregat
                 "date_range",
                 "dense_vector",
                 "double",
+                "double_range",
                 "flattened",
                 "geo_point",
                 "geo_shape",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1628,7 +1628,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testDoubleRangeUnsupportedOperations() {
-        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled());
+        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled());
         analyzer().addIndex("heights", "mapping-heights.json")
             .stripErrorPrefix(true)
             .error("FROM heights | SORT height_range", containsString("cannot sort on double_range"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentTests.java
@@ -44,6 +44,7 @@ public class AbsentTests extends AbstractAggregationTestCase {
         FunctionAppliesTo histogramGaAppliesTo = appliesTo(FunctionAppliesToLifecycle.GA, "9.4.0", "", true);
         FunctionAppliesTo flattenedPreviewAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
+        FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
 
         Stream.of(
             MultiRowTestCaseSupplier.nullCases(1, 1000),
@@ -55,6 +56,9 @@ public class AbsentTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
+            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+                ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s1 -> s1.withAppliesTo(doubleRangeAppliesTo)).toList()
+                : List.<TestCaseSupplier.TypedDataSupplier>of(),
             MultiRowTestCaseSupplier.denseVectorCases(1, 1000),
             MultiRowTestCaseSupplier.booleanCases(1, 1000),
             MultiRowTestCaseSupplier.ipCases(1, 1000),
@@ -107,6 +111,9 @@ public class AbsentTests extends AbstractAggregationTestCase {
             DataType.EXPONENTIAL_HISTOGRAM,
             DataType.TDIGEST
         );
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+            types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
+        }
         for (var dataType : types) {
             var field = dataType == DataType.EXPONENTIAL_HISTOGRAM || dataType == DataType.TDIGEST
                 ? TestCaseSupplier.TypedData.multiRow(List.of(), dataType, "field")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -46,6 +46,7 @@ public class CountTests extends AbstractAggregationTestCase {
         FunctionAppliesTo histogramPreviewAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.3.0", "", false);
         FunctionAppliesTo histogramGaAppliesTo = appliesTo(FunctionAppliesToLifecycle.GA, "9.4.0", "", true);
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
+        FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
 
         Stream.of(
             MultiRowTestCaseSupplier.nullCases(1, 1000),
@@ -57,6 +58,9 @@ public class CountTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
+            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+                ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s1 -> s1.withAppliesTo(doubleRangeAppliesTo)).toList()
+                : List.<TestCaseSupplier.TypedDataSupplier>of(),
             MultiRowTestCaseSupplier.denseVectorCases(1, 1000),
             MultiRowTestCaseSupplier.booleanCases(1, 1000),
             MultiRowTestCaseSupplier.ipCases(1, 1000),
@@ -81,7 +85,7 @@ public class CountTests extends AbstractAggregationTestCase {
         ).flatMap(List::stream).map(CountTests::makeSupplier).collect(Collectors.toCollection(() -> suppliers));
 
         // No rows
-        for (var dataType : List.of(
+        List<DataType> types = List.of(
             DataType.NULL,
             DataType.INTEGER,
             DataType.LONG,
@@ -102,7 +106,11 @@ public class CountTests extends AbstractAggregationTestCase {
             DataType.CARTESIAN_POINT,
             DataType.UNSIGNED_LONG,
             DataType.AGGREGATE_METRIC_DOUBLE
-        )) {
+        );
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+            types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
+        }
+        for (var dataType : types) {
             var field = dataType == DataType.EXPONENTIAL_HISTOGRAM || dataType == DataType.TDIGEST
                 ? TestCaseSupplier.TypedData.multiRow(List.of(), dataType, "field")
                     .withAppliesTo(histogramPreviewAppliesTo)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentTests.java
@@ -44,6 +44,10 @@ public class PresentTests extends AbstractAggregationTestCase {
         FunctionAppliesTo histogramGaAppliesTo = appliesTo(FunctionAppliesToLifecycle.GA, "9.4.0", "", true);
         FunctionAppliesTo flattenedPreviewAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
+        FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+            ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(doubleRangeAppliesTo)).toList()
+            : List.of();
 
         Stream.of(
             MultiRowTestCaseSupplier.nullCases(1, 1000),
@@ -55,6 +59,7 @@ public class PresentTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
+            doubleRangeCases,
             MultiRowTestCaseSupplier.denseVectorCases(1, 1000),
             MultiRowTestCaseSupplier.booleanCases(1, 1000),
             MultiRowTestCaseSupplier.ipCases(1, 1000),
@@ -107,6 +112,9 @@ public class PresentTests extends AbstractAggregationTestCase {
             DataType.EXPONENTIAL_HISTOGRAM,
             DataType.TDIGEST
         );
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+            types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
+        }
         for (var dataType : types) {
             var field = dataType == DataType.EXPONENTIAL_HISTOGRAM || dataType == DataType.TDIGEST
                 ? TestCaseSupplier.TypedData.multiRow(List.of(), dataType, "field")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
@@ -47,7 +47,7 @@ public class ValuesTests extends AbstractAggregationTestCase {
         var suppliers = new ArrayList<TestCaseSupplier>();
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
-        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()
+        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
             ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(doubleRangeAppliesTo)).toList()
             : List.of();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
@@ -45,7 +45,7 @@ public class CaseTests extends AbstractScalarFunctionTestCase {
         .filter(t -> t != DataType.DOC_DATA_TYPE)
         .filter(t -> t != DataType.TSID_DATA_TYPE)
         .filter(t -> t != DataType.DATE_RANGE || EsqlCapabilities.Cap.CASE_DATE_RANGE.isEnabled())
-        .filter(t -> t != DataType.DOUBLE_RANGE || EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled())
+        .filter(t -> t != DataType.DOUBLE_RANGE || EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled())
         .toList();
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
@@ -46,7 +46,7 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
         dateTimes(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateNanos(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateRanges(cases);
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
             doubleRanges(cases);
         }
         geoPoints(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
@@ -55,7 +55,7 @@ public class MvFirstTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
             doubleRanges(cases);
         }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
@@ -55,7 +55,7 @@ public class MvLastTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
             doubleRanges(cases);
         }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -181,8 +181,8 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
         }));
         noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE), () -> {
             assumeTrue(
-                "Requires DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7 capability",
-                EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V7.isEnabled()
+                "Requires DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8 capability",
+                EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
             );
             DoubleRangeBlockBuilder.DoubleRange first = randomBoolean() ? null : TestCaseSupplier.randomDoubleRange();
             DoubleRangeBlockBuilder.DoubleRange second = TestCaseSupplier.randomDoubleRange();


### PR DESCRIPTION
Part of #154463.

Adds support and tests for `double_range` in `COUNT`, `PRESENT` and `ABSENT`.