### PR TITLE
[CI] Bump binfmt QEMU to fix arm64 tar extraction

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -59,7 +59,11 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
 fi
 
 echo --- install qemu for aarch64 docker image builds
-docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+# NOTE: qemu-v9.2.2 mishandles openat2(O_NOFOLLOW) on aarch64 (glibc tar's
+# CVE-2025-45582 fix triggers this), causing "tar: ...: Cannot open: Invalid
+# argument" during linux/arm64 cross builds. qemu-v10.2.3 has the upstream
+# fix. See https://github.com/tonistiigi/binfmt/issues/285.
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 docker buildx create --driver docker-container --use --bootstrap
 
 echo --- Building release artifacts

--- a/.buildkite/scripts/fixture-deploy.sh
+++ b/.buildkite/scripts/fixture-deploy.sh
@@ -10,6 +10,10 @@ unset DOCKER_REGISTRY_USERNAME DOCKER_REGISTRY_PASSWORD
 # registration does not survive the image bake -> boot cycle, so it must
 # be redone here on every job run. See
 # https://github.com/elastic/ci-agent-images/pull/2907 for details.
-docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+# NOTE: qemu-v9.2.2 mishandles openat2(O_NOFOLLOW) on aarch64 (glibc tar's
+# CVE-2025-45582 fix triggers this), causing "tar: ...: Cannot open: Invalid
+# argument" during linux/arm64 cross builds. qemu-v10.2.3 has the upstream
+# fix. See https://github.com/tonistiigi/binfmt/issues/285.
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 docker buildx create --driver docker-container --use --bootstrap
 .ci/scripts/run-gradle.sh deployFixtureDockerImages

--- a/.buildkite/scripts/fixture-deploy.sh
+++ b/.buildkite/scripts/fixture-deploy.sh
@@ -10,6 +10,7 @@ unset DOCKER_REGISTRY_USERNAME DOCKER_REGISTRY_PASSWORD
 # registration does not survive the image bake -> boot cycle, so it must
 # be redone here on every job run. See
 # https://github.com/elastic/ci-agent-images/pull/2907 for details.
+#
 # NOTE: qemu-v9.2.2 mishandles openat2(O_NOFOLLOW) on aarch64 (glibc tar's
 # CVE-2025-45582 fix triggers this), causing "tar: ...: Cannot open: Invalid
 # argument" during linux/arm64 cross builds. qemu-v10.2.3 has the upstream


### PR DESCRIPTION
## Problem

`deployIdpDockerImage` (`x-pack:test:idp-fixture`) fails on `linux/arm64` cross-arch buildx builds with a wall of:

```
tar: jetty-distribution-.../...: Cannot open: Invalid argument
```

The `linux/amd64` build of the same layer succeeds; only the emulated `arm64` build fails.

Example: https://gradle-enterprise.elastic.co/s/2ehcq2yqsxv3u
(`elasticsearch-test-fixtures-nightly` #946)

## Root cause

`.buildkite/scripts/fixture-deploy.sh` and `.buildkite/scripts/dra-workflow.sh` register QEMU emulation via `tonistiigi/binfmt:qemu-v9.2.2` before cross-arch `docker buildx` builds. That binfmt release ships a musl-compiled QEMU with a known bug ([tonistiigi/binfmt#285](https://github.com/tonistiigi/binfmt/issues/285), [qemu#3262](https://gitlab.com/qemu-project/qemu/-/issues/3262)): under aarch64 emulation, `openat2()` with `O_NOFOLLOW` gets mistranslated to `O_LARGEFILE` because musl and glibc define `O_LARGEFILE` differently (`0` vs `0400000`).

Modern glibc `tar` (the `eclipse-temurin:11-jre` base image is glibc/Ubuntu-based) started calling `openat2(O_NOFOLLOW)` as part of its CVE-2025-45582 fix, so every file/dir it opens while extracting under `linux/arm64` emulation now fails with `EINVAL`.

QEMU fixed this upstream, and the fix shipped in `tonistiigi/binfmt` starting with `qemu-v10.1.3` (current stable is `qemu-v10.2.3`).

## Fix

Bump the pinned `tonistiigi/binfmt` tag from `qemu-v9.2.2` to `qemu-v10.2.3` in both places that install QEMU ahead of a multi-platform buildx build:

- `.buildkite/scripts/fixture-deploy.sh`
- `.buildkite/scripts/dra-workflow.sh` (same pattern, same latent bug — would affect arm64 DRA release image builds too)

## Verification

- `bash -n` on both scripts.
- Root cause confirmed against the documented upstream QEMU/binfmt issue, matching the exact failure signature (`tar: ...: Cannot open: Invalid argument`, arm64-only, glibc tar, musl QEMU).
- Recommend re-running `elasticsearch-test-fixtures-nightly` / `deploy_testfixture_docker_images` after merge to confirm green.
