### PR TITLE
[CI] Load single-platform cross-arch Docker builds

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
@@ -244,11 +244,16 @@ public abstract class DockerBuildTask extends DefaultTask {
 
                 if (parameters.getPush().getOrElse(false)) {
                     spec.args("--push");
-                } else if (!isCrossPlatform) {
-                    // For single-platform builds, add --load to ensure the image is loaded into
-                    // the local Docker daemon as a regular image, not a manifest list.
-                    // This prevents issues with newer Docker versions (23.0+) that may create
-                    // manifest lists even for single-platform builds when BuildKit is enabled.
+                } else if (parameters.getPlatforms().get().size() == 1) {
+                    // Add --load to ensure the image ends up in the local Docker daemon as a
+                    // regular image, not a manifest list. This is required for any
+                    // single-platform build (including cross-platform builds for a single
+                    // foreign architecture, e.g. aarch64 on x86): with the docker-container
+                    // buildx driver the result otherwise remains only in the build cache and
+                    // the subsequent `docker inspect` for the image checksum fails with
+                    // "no such object". It also prevents issues with newer Docker versions
+                    // (23.0+) that may create manifest lists even for single-platform builds
+                    // when BuildKit is enabled.
                     spec.args("--load");
                 }
             });


### PR DESCRIPTION
## Problem

`buildAarch64DockerImage`, `buildAarch64WolfiDockerImage`, and `buildAarch64CloudEssFipsDockerImage` fail on the DRA workflow after switching to the `docker-container` buildx driver (05d969a43dca):

```
> Task :distribution:docker:buildAarch64DockerImage FAILED
error: no such object: elasticsearch:aarch64
```

Example: https://buildkite.com/elastic/elasticsearch-dra-workflow/builds/95512#019fcce4-b99d-47c2-90ed-179acf9823ea

The stack trace pins it to `DockerBuildTask$DockerBuildAction.getImageChecksum` — the post-build `docker inspect <tag>` call. The build itself succeeds; the log shows buildx's own warning right before it:

```
WARNING: No output specified with docker-container driver. Build result will
only remain in the build cache. To push result image into registry use --push
or to load image into docker use --load
```

## Root cause

`DockerBuildTask.DockerBuildAction.execute()` only adds `--load` when the build is **not** cross-platform:

```java
} else if (!isCrossPlatform) {
    spec.args("--load");
}
```

Building `linux/arm64` on an `x86_64` host is "cross-platform" by that check, so `--load` was never passed. With the previous default `docker` buildx driver this didn't matter — it writes results straight into the local image store regardless. The `docker-container` driver (now used everywhere per 05d969a43dca / elastic/ci-agent-images#2907) does not: without `--push` or `--load` the result stays only in the builder's cache, so the following `docker inspect` can't find it.

These are all still single-platform builds (just for a foreign architecture), so `--load` is valid and sufficient here — it only becomes invalid for genuine multi-platform (`linux/amd64,linux/arm64`) manifest-list builds, which is the case this task correctly continues to skip (falling through to the existing `pullBaseImage` special-case for multi-platform + push).

## Fix

Key the `--load` condition on platform count instead of cross-platform-ness:

```java
} else if (parameters.getPlatforms().get().size() == 1) {
    spec.args("--load");
}
```

## Note

This is one of two failure modes seen in build 95512; the other (`buildAarch64IronBankDockerImage` failing with `tar: ...: Cannot open: Invalid argument` under QEMU emulation) is a separate qemu/binfmt bug (tonistiigi/binfmt#285) addressed by #155888 (bumping the pinned binfmt QEMU tag). Both fixes are needed for the DRA workflow to go green again.