### PR TITLE
[9.5] Unmute AzureBlobContainerStatsTests.testRetriesAndOperationsAreTrackedSeparately

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -544,9 +544,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testColumnarBadDateTokenNullsCellEagerAndDeferred
   issue: https://github.com/elastic/elasticsearch/issues/153187
-- class: org.elasticsearch.repositories.azure.AzureBlobContainerStatsTests
-  method: testRetriesAndOperationsAreTrackedSeparately
-  issue: https://github.com/elastic/elasticsearch/issues/146899
 - class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
   method: testCacheIsWarmedBeforeSearchShardRecoveryWhenVBCCGetsUploaded
   issue: https://github.com/elastic/elasticsearch/issues/153406


### PR DESCRIPTION
Follows: https://github.com/elastic/elasticsearch/pull/155861

See: https://github.com/elastic/elasticsearch/pull/155726#issuecomment-5175586446 for full explanation.

Will wait for https://github.com/elastic/elasticsearch/pull/155861 to merge before merging this one.
