### PR TITLE
[docs] Relocate applies_to tags on GPU vector indexing page

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -721,7 +721,7 @@ POST /my-bit-vectors/_search?filter_path=hits.hits
 
 ## GPU vector indexing
 ```{applies_to}
-stack: preview 9.3
+stack: preview 9.3, ga 9.4
 ```
 
 {{es}} can leverage  [GPU acceleration](gpu-vector-indexing.md)  to speed up the indexing of dense vectors.

--- a/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
+++ b/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
@@ -20,7 +20,7 @@ GPU vector indexing requires the following:
 
 * An [Enterprise subscription](https://www.elastic.co/subscriptions)
 * A supported NVIDIA GPU (Ampere architecture or better, compute capability
-  >= 8.0) with a minimum 8GB of GPU memory
+  \>= 8.0) with a minimum 8GB of GPU memory
 * GPU driver, CUDA and
   [cuVS runtime libraries](https://docs.rapids.ai/api/cuvs/stable/build/)
   installed on the node. Refer to the

--- a/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
+++ b/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
@@ -1,13 +1,10 @@
 ---
 applies_to:
-  stack:
+  stack: preview 9.3, ga 9.4
 navigation_title: "GPU vector indexing"
 ---
 
 # GPU accelerated vector indexing
-```{applies_to}
-stack: preview 9.3, ga 9.4
-```
 
 {{es}} can use GPU acceleration to significantly speed up the indexing of
 dense vectors. GPU indexing is based on the

--- a/docs/reference/elasticsearch/toc.yml
+++ b/docs/reference/elasticsearch/toc.yml
@@ -161,7 +161,8 @@ toc:
           - file: mapping-reference/date.md
           - file: mapping-reference/date_nanos.md
           - file: mapping-reference/dense-vector.md
-          - file: mapping-reference/gpu-vector-indexing.md
+            children:
+              - file: mapping-reference/gpu-vector-indexing.md
           - file: mapping-reference/flattened.md
           - file: mapping-reference/geo-point.md
           - file: mapping-reference/geo-shape.md


### PR DESCRIPTION
Updated the applies_to section to reflect the correct stack versions, removed floating applies_to block

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

