### PR TITLE
[9.4] [CI] Bump binfmt QEMU to fix arm64 tar extraction (#155888)

### DIFF
--- a/.buildkite/scripts/dra-workflow.sh
+++ b/.buildkite/scripts/dra-workflow.sh
@@ -59,7 +59,11 @@ if [[ -n "${VERSION_QUALIFIER:-}" ]]; then
 fi
 
 echo --- install qemu for aarch64 docker image builds
-docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+# NOTE: qemu-v9.2.2 mishandles openat2(O_NOFOLLOW) on aarch64 (glibc tar's
+# CVE-2025-45582 fix triggers this), causing "tar: ...: Cannot open: Invalid
+# argument" during linux/arm64 cross builds. qemu-v10.2.3 has the upstream
+# fix. See https://github.com/tonistiigi/binfmt/issues/285.
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 docker buildx create --driver docker-container --use --bootstrap
 
 echo --- Building release artifacts

--- a/.buildkite/scripts/fixture-deploy.sh
+++ b/.buildkite/scripts/fixture-deploy.sh
@@ -10,6 +10,11 @@ unset DOCKER_REGISTRY_USERNAME DOCKER_REGISTRY_PASSWORD
 # registration does not survive the image bake -> boot cycle, so it must
 # be redone here on every job run. See
 # https://github.com/elastic/ci-agent-images/pull/2907 for details.
-docker run --privileged --rm tonistiigi/binfmt:qemu-v9.2.2 --install all
+#
+# NOTE: qemu-v9.2.2 mishandles openat2(O_NOFOLLOW) on aarch64 (glibc tar's
+# CVE-2025-45582 fix triggers this), causing "tar: ...: Cannot open: Invalid
+# argument" during linux/arm64 cross builds. qemu-v10.2.3 has the upstream
+# fix. See https://github.com/tonistiigi/binfmt/issues/285.
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 docker buildx create --driver docker-container --use --bootstrap
 .ci/scripts/run-gradle.sh deployFixtureDockerImages


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [CI] Bump binfmt QEMU to fix arm64 tar extraction (#155888)