### PR TITLE
Filter zero metric async counters with OTel SDK

### DIFF
--- a/docs/changelog/155949.yaml
+++ b/docs/changelog/155949.yaml
@@ -1,0 +1,5 @@
+area: Infra/Metrics
+issues: []
+pr: 155949
+summary: Filter zero metric async counters with OTel SDK
+type: enhancement

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleAsyncCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleAsyncCounterAdapter.java
@@ -50,7 +50,7 @@ public class DoubleAsyncCounterAdapter extends AbstractAsyncInstrument<Observabl
                 .setDescription(description)
                 .setUnit(unit)
                 .ofDoubles()
-                .buildWithCallback(OtelHelper.doubleMeasurementCallback(name, observer));
+                .buildWithCallback(OtelHelper.doubleCounterMeasurementCallback(name, observer));
         }
     }
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongAsyncCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongAsyncCounterAdapter.java
@@ -49,7 +49,7 @@ public class LongAsyncCounterAdapter extends AbstractAsyncInstrument<ObservableL
                 .counterBuilder(name)
                 .setDescription(description)
                 .setUnit(unit)
-                .buildWithCallback(OtelHelper.longMeasurementCallback(name, observer));
+                .buildWithCallback(OtelHelper.longCounterMeasurementCallback(name, observer));
         }
     }
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/OtelHelper.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/OtelHelper.java
@@ -63,6 +63,23 @@ class OtelHelper {
         String metricName,
         Supplier<Collection<DoubleWithAttributes>> observer
     ) {
+        return doubleCallback(metricName, observer, false);
+    }
+
+    // Async counters skip 0-valued observations: an unobserved series is dropped by the SDK, matching the APM agent (which did
+    // not emit idle counters). Gauges keep 0, since for a gauge 0 is a real value.
+    static Consumer<ObservableDoubleMeasurement> doubleCounterMeasurementCallback(
+        String metricName,
+        Supplier<Collection<DoubleWithAttributes>> observer
+    ) {
+        return doubleCallback(metricName, observer, true);
+    }
+
+    private static Consumer<ObservableDoubleMeasurement> doubleCallback(
+        String metricName,
+        Supplier<Collection<DoubleWithAttributes>> observer,
+        boolean suppressZeroValues
+    ) {
         return measurement -> {
             Collection<DoubleWithAttributes> observations;
             try {
@@ -77,6 +94,9 @@ class OtelHelper {
             }
             for (DoubleWithAttributes observation : observations) {
                 if (observation != null) {
+                    if (suppressZeroValues && observation.value() == 0.0) {
+                        continue;
+                    }
                     measurement.record(observation.value(), OtelHelper.fromMap(metricName, observation.attributes()));
                 }
             }
@@ -86,6 +106,21 @@ class OtelHelper {
     static Consumer<ObservableLongMeasurement> longMeasurementCallback(
         String metricName,
         Supplier<Collection<LongWithAttributes>> observer
+    ) {
+        return longCallback(metricName, observer, false);
+    }
+
+    static Consumer<ObservableLongMeasurement> longCounterMeasurementCallback(
+        String metricName,
+        Supplier<Collection<LongWithAttributes>> observer
+    ) {
+        return longCallback(metricName, observer, true);
+    }
+
+    private static Consumer<ObservableLongMeasurement> longCallback(
+        String metricName,
+        Supplier<Collection<LongWithAttributes>> observer,
+        boolean suppressZeroValues
     ) {
         return measurement -> {
             Collection<LongWithAttributes> observations;
@@ -101,6 +136,9 @@ class OtelHelper {
             }
             for (LongWithAttributes observation : observations) {
                 if (observation != null) {
+                    if (suppressZeroValues && observation.value() == 0L) {
+                        continue;
+                    }
                     measurement.record(observation.value(), OtelHelper.fromMap(metricName, observation.attributes()));
                 }
             }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/AsyncCountersAdapterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/AsyncCountersAdapterTests.java
@@ -102,6 +102,26 @@ public class AsyncCountersAdapterTests extends ESTestCase {
         assertThat(metrics, hasSize(0));
     }
 
+    public void testZeroValuedAsyncCountersAreNotRecorded() {
+        LongAsyncCounter longCounter = registry.registerLongAsyncCounter(
+            "es.test.long.total",
+            "desc",
+            "unit",
+            () -> new LongWithAttributes(0L)
+        );
+        DoubleAsyncCounter doubleCounter = registry.registerDoubleAsyncCounter(
+            "es.test.double.total",
+            "desc",
+            "unit",
+            () -> new DoubleWithAttributes(0.0)
+        );
+
+        otelMeter.collectMetrics();
+
+        assertThat(otelMeter.getRecorder().getMeasurements(longCounter), hasSize(0));
+        assertThat(otelMeter.getRecorder().getMeasurements(doubleCounter), hasSize(0));
+    }
+
     public void testLongWithInvalidAttribute() {
         registry.registerLongAsyncCounter("es.test.name.total", "desc", "unit", () -> new LongWithAttributes(1, Map.of("index", "index1")));
 

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
@@ -103,6 +103,21 @@ public class GaugeAdapterTests extends ESTestCase {
         assertThat(metrics, hasSize(0));
     }
 
+    public void testZeroValuedGaugesAreRecorded() {
+        LongGauge longGauge = registry.registerLongGauge("es.test.long.current", "desc", "unit", () -> new LongWithAttributes(0L));
+        DoubleGauge doubleGauge = registry.registerDoubleGauge(
+            "es.test.double.current",
+            "desc",
+            "unit",
+            () -> new DoubleWithAttributes(0.0)
+        );
+
+        otelMeter.collectMetrics();
+
+        assertThat(otelMeter.getRecorder().getMeasurements(longGauge), hasSize(1));
+        assertThat(otelMeter.getRecorder().getMeasurements(doubleGauge), hasSize(1));
+    }
+
     public void testNullGaugeRecord() throws Exception {
         DoubleGauge dgauge = registry.registerDoubleGauge(
             "es.test.name.total",


### PR DESCRIPTION
Aligns with previous APM agent behaviour, skip recording 0 observations for async long/double counters.

Relates to: elastic/elasticsearch-team#4391