### PR TITLE
Don't instantiate StatelessCommitService on search nodes

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessPluginIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessPluginIT.java
@@ -9,9 +9,13 @@ package org.elasticsearch.xpack.stateless;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.injection.guice.ConfigurationException;
+import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 import org.elasticsearch.xpack.stateless.engine.StatelessReaderHeapBreaker;
+import org.elasticsearch.xpack.stateless.utils.StatelessCommitServiceProvider;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class StatelessPluginIT extends AbstractStatelessPluginIntegTestCase {
 
@@ -26,6 +30,22 @@ public class StatelessPluginIT extends AbstractStatelessPluginIntegTestCase {
         final int numSearchNodes = randomIntBetween(0, 5);
         startSearchNodes(numSearchNodes);
         ensureStableCluster(1 + numIndexNodes + numSearchNodes);
+    }
+
+    public void testCommitServiceOnlyInstantiatedOnIndexNodes() {
+        final String indexNode = startMasterAndIndexNode();
+        final String searchNode = startSearchNode();
+
+        // StatelessCommitService must be present on index nodes
+        assertThat(internalCluster().getInstance(StatelessCommitService.class, indexNode), notNullValue());
+        assertThat(internalCluster().getInstance(StatelessCommitServiceProvider.class, indexNode).commitService(), notNullValue());
+
+        // StatelessCommitService must be absent on search nodes
+        assertThrows(
+            AssertionError.class,
+            () -> internalCluster().getInstance(StatelessCommitServiceProvider.class, searchNode).commitService()
+        );
+        expectThrows(ConfigurationException.class, () -> internalCluster().getInstance(StatelessCommitService.class, searchNode));
     }
 
     public void testReaderHeapBreakerLimitIsDynamicallyUpdated() {

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessSearchIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessSearchIT.java
@@ -59,7 +59,6 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.IndicesRequestCacheUtils;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.rest.RestStatus;
@@ -157,18 +156,6 @@ public class StatelessSearchIT extends AbstractStatelessPluginIntegTestCase {
 
         public TestStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/TestStatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/TestStatelessPlugin.java
@@ -11,9 +11,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingService;
 import org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService;
@@ -22,26 +19,10 @@ import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 import org.elasticsearch.xpack.stateless.commits.TestStatelessCommitService;
 import org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService;
 
-import java.util.Collection;
-
 public class TestStatelessPlugin extends TestUtils.StatelessPluginWithTrialLicense {
-
-    static final Logger logger = LogManager.getLogger(TestStatelessPlugin.class);
 
     public TestStatelessPlugin(Settings settings) {
         super(settings);
-    }
-
-    @Override
-    public Collection<Object> createComponents(PluginServices services) {
-        final Collection<Object> components = super.createComponents(services);
-        components.add(
-            new PluginComponentBinding<>(
-                StatelessCommitService.class,
-                components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-            )
-        );
-        return components;
     }
 
     @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessBlobCacheServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessBlobCacheServiceIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.telemetry.TelemetryProvider;
@@ -36,7 +35,6 @@ import org.elasticsearch.xpack.shutdown.ShutdownPlugin;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 import org.elasticsearch.xpack.stateless.TestUtils;
-import org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingService.WarmTarget;
 import org.elasticsearch.xpack.stateless.cache.reader.CacheBlobReader;
 import org.elasticsearch.xpack.stateless.cache.reader.SequentialRangeMissingHandler;
 import org.elasticsearch.xpack.stateless.commits.BlobFile;
@@ -284,18 +282,6 @@ public class StatelessBlobCacheServiceIT extends AbstractStatelessPluginIntegTes
 
         public TestCacheStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(Plugin.PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessOnlinePrewarmingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/StatelessOnlinePrewarmingIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
@@ -40,7 +39,6 @@ import org.elasticsearch.xpack.shutdown.ShutdownPlugin;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 import org.elasticsearch.xpack.stateless.TestUtils;
-import org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingService.WarmTarget;
 import org.elasticsearch.xpack.stateless.commits.BlobFile;
 import org.elasticsearch.xpack.stateless.commits.StatelessCommitCleaner;
 import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
@@ -307,18 +305,6 @@ public class StatelessOnlinePrewarmingIT extends AbstractStatelessPluginIntegTes
 
         public TestCacheStatelessPluginNoRecoveryPrewarming(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(Plugin.PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitNotificationsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitNotificationsIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.index.shard.GlobalCheckpointListeners;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.internal.DocumentParsingProvider;
 import org.elasticsearch.telemetry.TelemetryProvider;
@@ -73,18 +72,6 @@ public class StatelessCommitNotificationsIT extends AbstractStatelessPluginInteg
 
         public TestStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
@@ -58,7 +58,6 @@ import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoveryClusterStateDelayListeners;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -168,18 +167,6 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
 
         public TestStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof StatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
@@ -40,7 +40,6 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.rest.RestStatus;
@@ -144,18 +143,6 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
 
         public TestStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/lucene/GenerationalDocValuesIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/lucene/GenerationalDocValuesIT.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -121,18 +120,6 @@ public class GenerationalDocValuesIT extends AbstractStatelessPluginIntegTestCas
 
         public GenerationalFilesTrackingStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof GenerationalFilesTrackingStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationAvoidListIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationAvoidListIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.IndexShardNotRecoveringException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -485,18 +484,6 @@ public class IndexingShardRelocationAvoidListIT extends AbstractStatelessPluginI
 
         public AvoidListTestStatelessPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof StatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.snapshots.blobstore.SnapshotFiles;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.internal.DocumentParsingProvider;
@@ -1652,18 +1651,6 @@ public class StatelessSnapshotIT extends AbstractStatelessPluginIntegTestCase {
 
         public SnapshotCommitInterceptPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public Collection<Object> createComponents(Plugin.PluginServices services) {
-            final Collection<Object> components = super.createComponents(services);
-            components.add(
-                new PluginComponentBinding<>(
-                    StatelessCommitService.class,
-                    components.stream().filter(c -> c instanceof TestStatelessCommitService).findFirst().orElseThrow()
-                )
-            );
-            return components;
         }
 
         @Override

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexNodeRecoveryListener.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexNodeRecoveryListener.java
@@ -224,12 +224,11 @@ class StatelessIndexNodeRecoveryListener implements IndexEventListener {
 
     @Override
     public void afterIndexShardStarted(IndexShard indexShard) {
-        if (indexShard.routingEntry().isPromotableToPrimary()) {
-            IndexSettings indexSettings = indexShard.indexSettings();
-            IndexReshardingMetadata reshardingMetadata = indexSettings.getIndexMetadata().getReshardingMetadata();
-            if (IndexReshardingMetadata.isSplitSource(indexShard.shardId(), reshardingMetadata)) {
-                splitSourceService.splitSourceShardStarted(indexShard, reshardingMetadata);
-            }
+        assert indexShard.routingEntry().isPromotableToPrimary() : "index shard is not promotable to primary";
+        IndexSettings indexSettings = indexShard.indexSettings();
+        IndexReshardingMetadata reshardingMetadata = indexSettings.getIndexMetadata().getReshardingMetadata();
+        if (IndexReshardingMetadata.isSplitSource(indexShard.shardId(), reshardingMetadata)) {
+            splitSourceService.splitSourceShardStarted(indexShard, reshardingMetadata);
         }
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexNodeRecoveryListener.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessIndexNodeRecoveryListener.java
@@ -224,7 +224,7 @@ class StatelessIndexNodeRecoveryListener implements IndexEventListener {
 
     @Override
     public void afterIndexShardStarted(IndexShard indexShard) {
-        assert indexShard.routingEntry().isPromotableToPrimary() : "index shard is not promotable to primary";
+        assert indexShard.routingEntry().isPromotableToPrimary();
         IndexSettings indexSettings = indexShard.indexSettings();
         IndexReshardingMetadata reshardingMetadata = indexSettings.getIndexMetadata().getReshardingMetadata();
         if (IndexReshardingMetadata.isSplitSource(indexShard.shardId(), reshardingMetadata)) {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -65,6 +65,7 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.DiscoveryModule;
@@ -227,6 +228,7 @@ import org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotSettings;
 import org.elasticsearch.xpack.stateless.snapshots.TransportGetShardSnapshotCommitInfoAction;
 import org.elasticsearch.xpack.stateless.utils.SearchShardSizeCollector;
 import org.elasticsearch.xpack.stateless.utils.SearchShardSizeCollectorProvider;
+import org.elasticsearch.xpack.stateless.utils.StatelessCommitServiceProvider;
 import org.elasticsearch.xpack.stateless.xpack.DummyILMInfoTransportAction;
 import org.elasticsearch.xpack.stateless.xpack.DummyILMUsageTransportAction;
 import org.elasticsearch.xpack.stateless.xpack.DummyMonitoringInfoTransportAction;
@@ -835,24 +837,32 @@ public class StatelessPlugin extends Plugin
             warmingRatioProvider
         );
         setAndGet(this.sharedBlobCacheWarmingService, cacheWarmingService);
-        var commitService = createStatelessCommitService(
-            settings,
-            objectStoreService,
-            clusterService,
-            indicesService,
-            client,
-            commitCleaner,
-            cacheService,
-            cacheWarmingService,
-            services.telemetryProvider()
-        );
-        components.add(commitService);
+
         var clusterStateCleanupService = new StatelessClusterStateCleanupService(threadPool, objectStoreService, clusterService);
         clusterService.addListener(clusterStateCleanupService);
-        // Allow wrapping non-Guiced version for testing
-        commitService = wrapStatelessCommitService(commitService);
-        clusterService.addListener(commitService);
-        setAndGet(this.commitService, commitService);
+        StatelessCommitService commitService = null;
+        if (hasIndexRole) {
+            commitService = createStatelessCommitService(
+                settings,
+                objectStoreService,
+                clusterService,
+                indicesService,
+                client,
+                commitCleaner,
+                cacheService,
+                cacheWarmingService,
+                services.telemetryProvider()
+            );
+            // crateStatelessCommitService may return a subclass, so we bind the component explicitly
+            components.add(new PluginComponentBinding<>(StatelessCommitService.class, commitService));
+        }
+        components.add(new StatelessCommitServiceProvider(commitService));
+        if (commitService != null) {
+            // Allow wrapping non-Guiced version for testing
+            commitService = wrapStatelessCommitService(commitService);
+            setAndGet(this.commitService, commitService);
+            clusterService.addListener(commitService);
+        }
 
         final var snapshotsCommitService = setAndGet(
             this.snapshotsCommitServiceRef,
@@ -898,7 +908,7 @@ public class StatelessPlugin extends Plugin
             objectStoreService,
             cacheWarmingService,
             threadPool,
-            commitService.useReplicatedRanges(),
+            StatelessCommitService.STATELESS_COMMIT_USE_INTERNAL_FILES_REPLICATED_CONTENT.get(settings),
             bccHeaderReadExecutor.get()
         );
         components.add(indexShardCacheWarmer);
@@ -1221,7 +1231,7 @@ public class StatelessPlugin extends Plugin
         ClusterService clusterService,
         IndicesService indicesService,
         ObjectStoreService objectStoreService,
-        StatelessCommitService commitService,
+        @Nullable StatelessCommitService commitService,
         IndexShardCacheWarmer indexShardCacheWarmer,
         ThreadPool threadPool,
         HollowShardsMetrics metrics,

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -853,7 +853,7 @@ public class StatelessPlugin extends Plugin
                 cacheWarmingService,
                 services.telemetryProvider()
             );
-            // crateStatelessCommitService may return a subclass, so we bind the component explicitly
+            // createStatelessCommitService may return a subclass, so we bind the component explicitly
             components.add(new PluginComponentBinding<>(StatelessCommitService.class, commitService));
         }
         components.add(new StatelessCommitServiceProvider(commitService));

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/action/TransportGetVirtualBatchedCompoundCommitChunkAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/action/TransportGetVirtualBatchedCompoundCommitChunkAction.java
@@ -55,7 +55,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 import org.elasticsearch.xpack.stateless.commits.GetVirtualBatchedCompoundCommitChunksPressure;
-import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
+import org.elasticsearch.xpack.stateless.utils.StatelessCommitServiceProvider;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -81,7 +81,7 @@ public class TransportGetVirtualBatchedCompoundCommitChunkAction extends Transpo
         IndicesService indicesService,
         ClusterService clusterService,
         GetVirtualBatchedCompoundCommitChunksPressure vbccChunksPressure,
-        StatelessCommitService statelessCommitService,
+        StatelessCommitServiceProvider statelessCommitServiceProvider,
         ProjectResolver projectResolver
     ) {
         super(NAME, actionFilters, transportService.getTaskManager(), EsExecutors.DIRECT_EXECUTOR_SERVICE);
@@ -104,12 +104,13 @@ public class TransportGetVirtualBatchedCompoundCommitChunkAction extends Transpo
                     final Index index = shardId.getIndex();
                     final IndexShard shard = indicesService.indexServiceSafe(index).getShard(request.getShardId().id());
                     assert shard.routingEntry().primary() : shard + " not primary on node " + transportService.getLocalNode();
+                    final var commitService = statelessCommitServiceProvider.commitService();
                     primaryShardOperation(
                         request,
                         shard,
                         bigArrays,
                         vbccChunksPressure,
-                        statelessCommitService::readVirtualBatchedCompoundCommitChunk,
+                        commitService::readVirtualBatchedCompoundCommitChunk,
                         l
                     );
                 });

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
@@ -368,6 +368,7 @@ public class HollowShardsService extends AbstractLifecycleComponent implements M
     }
 
     protected void unhollow(ShardId shardId) {
+        assert commitService != null : "commit service must be initialized for index nodes";
         var hollowShardInfo = hollowShards.get(shardId);
         if (hollowShardInfo != null && hollowShardInfo.unhollowing.compareAndSet(false, true)) {
             threadPool.generic().execute(new AbstractRunnable() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/TransportStatelessPrimaryRelocationAction.java
@@ -77,6 +77,7 @@ import org.elasticsearch.xpack.stateless.engine.IndexEngine;
 import org.elasticsearch.xpack.stateless.engine.PrimaryTermAndGeneration;
 import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectory;
 import org.elasticsearch.xpack.stateless.recovery.metering.StatelessRecoveryMetricsCollector;
+import org.elasticsearch.xpack.stateless.utils.StatelessCommitServiceProvider;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -128,7 +129,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
     private final IndicesService indicesService;
     private final RecoverySchedulingListener recoverySchedulingListeners;
     private final PeerRecoveryTargetService peerRecoveryTargetService;
-    private final StatelessCommitService statelessCommitService;
+    private final StatelessCommitServiceProvider statelessCommitServiceProvider;
     private final Executor recoveryExecutor;
     private final ThreadContext threadContext;
     private final ThreadPool threadPool;
@@ -145,7 +146,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
         IndicesService indicesService,
         CompositeRecoverySchedulingListener recoverySchedulingListeners,
         PeerRecoveryTargetService peerRecoveryTargetService,
-        StatelessCommitService statelessCommitService,
+        StatelessCommitServiceProvider statelessCommitServiceProvider,
         IndexShardCacheWarmer indexShardCacheWarmer,
         HollowShardsService hollowShardsService,
         HollowShardsMetrics hollowShardsMetrics,
@@ -157,7 +158,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
         this.indicesService = indicesService;
         this.recoverySchedulingListeners = recoverySchedulingListeners;
         this.peerRecoveryTargetService = peerRecoveryTargetService;
-        this.statelessCommitService = statelessCommitService;
+        this.statelessCommitServiceProvider = statelessCommitServiceProvider;
         this.indexShardCacheWarmer = indexShardCacheWarmer;
         this.hollowShardsService = hollowShardsService;
 
@@ -270,6 +271,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
     private void initiatePrewarm(Task task, StatelessPrimaryRelocationAction.Request request) {
         try {
             final ShardId shardId = request.shardId();
+            final StatelessCommitService statelessCommitService = statelessCommitServiceProvider.commitService();
             final BatchedCompoundCommit latestBcc = statelessCommitService.getLatestUploadedBcc(shardId);
             if (latestBcc == null) {
                 logger.trace("{} no uploaded BCC found, skipping initiate prewarm", shardId);
@@ -470,6 +472,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
                 final var latestBccBlobLength = new AtomicLong(-1L);
                 final var otherBlobFilesCount = new AtomicLong(-1L);
                 final var markedShardAsRelocating = new SubscribableListener<Void>();
+                final StatelessCommitService statelessCommitService = statelessCommitServiceProvider.commitService();
                 ActionListener<Void> handoffCompleteListener = statelessCommitService.markRelocating(
                     indexShard.shardId(),
                     lastFlushedGeneration,
@@ -637,7 +640,7 @@ public class TransportStatelessPrimaryRelocationAction extends TransportAction<
     private void handlePrimaryContextHandoff(PrimaryContextHandoffRequest request, ActionListener<Void> listener) {
         // executed remotely by `TransportStatelessPrimaryRelocationAction#handleStartRelocation` (i.e. we are on the target node here)
         logger.debug("[{}] received primary context", request.shardId());
-
+        final var statelessCommitService = statelessCommitServiceProvider.commitService();
         final var indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
         final var indexShard = indexService.getShard(request.shardId().id());
         statelessCommitService.setTrackedSearchNodesPerCommitOnRelocationTarget(request.shardId(), request.searchNodesPerCommit());

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
@@ -178,6 +178,7 @@ public class SplitSourceService {
         long targetPrimaryTerm,
         ActionListener<Releasable> listener
     ) {
+        assert commitService != null : "commit service must be initialized for index nodes";
         Index index = targetShardId.getIndex();
 
         var indexMetadata = clusterService.state().metadata().projectFor(index).getIndexSafe(index);
@@ -425,6 +426,7 @@ public class SplitSourceService {
     }
 
     public void stopCopyingNewCommits(ShardId targetShardId) {
+        assert commitService != null : "commit service must be initialized for index nodes";
         commitService.markSplitEnding(getSplitSource(targetShardId), targetShardId, false);
     }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
@@ -15,9 +15,15 @@ import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 /// [StatelessCommitService] exists only on index nodes; search nodes do not have one.
 /// Because Guice cannot express optional bindings, this record acts as an indirection: the plugin
 /// registers it with a `null` commit service on search nodes, and call sites unwrap the value via [#commitService()].
-public record StatelessCommitServiceProvider(StatelessCommitService commitService) {
+public class StatelessCommitServiceProvider() {
 
-    @Override
+    private final StatelessCommitService commitService;
+
+    public StatelessCommitServiceProvider(final StatelessCommitService commitService) {
+        this.commitService = commitService;
+    }
+
+    /// The commit service should never be null on index nodes, but may be null on search nodes where should not be called.
     public StatelessCommitService commitService() {
         assert commitService != null : "commit service must be initialized for index nodes";
         return commitService;

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.stateless.utils;
 
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 
 /// Carrier that lets Guice inject an optionally-present [StatelessCommitService] into transport actions that are instantiated on every
@@ -16,7 +15,7 @@ import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 /// [StatelessCommitService] exists only on index nodes; search nodes do not have one.
 /// Because Guice cannot express optional bindings, this record acts as an indirection: the plugin
 /// registers it with a `null` commit service on search nodes, and call sites unwrap the value via [#commitService()].
-public record StatelessCommitServiceProvider(@Nullable StatelessCommitService commitService) {
+public record StatelessCommitServiceProvider(StatelessCommitService commitService) {
 
     @Override
     public StatelessCommitService commitService() {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 /// [StatelessCommitService] exists only on index nodes; search nodes do not have one.
 /// Because Guice cannot express optional bindings, this record acts as an indirection: the plugin
 /// registers it with a `null` commit service on search nodes, and call sites unwrap the value via [#commitService()].
-public class StatelessCommitServiceProvider() {
+public class StatelessCommitServiceProvider {
 
     private final StatelessCommitService commitService;
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/utils/StatelessCommitServiceProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.utils;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
+
+/// Carrier that lets Guice inject an optionally-present [StatelessCommitService] into transport actions that are instantiated on every
+/// node, such as [org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrimaryRelocationAction].
+///
+/// [StatelessCommitService] exists only on index nodes; search nodes do not have one.
+/// Because Guice cannot express optional bindings, this record acts as an indirection: the plugin
+/// registers it with a `null` commit service on search nodes, and call sites unwrap the value via [#commitService()].
+public record StatelessCommitServiceProvider(@Nullable StatelessCommitService commitService) {
+
+    @Override
+    public StatelessCommitService commitService() {
+        assert commitService != null : "commit service must be initialized for index nodes";
+        return commitService;
+    }
+}

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotResiliencyTests.java
@@ -152,6 +152,7 @@ import org.elasticsearch.xpack.stateless.reshard.ReshardSearchFilters;
 import org.elasticsearch.xpack.stateless.reshard.SplitSourceService;
 import org.elasticsearch.xpack.stateless.reshard.SplitTargetService;
 import org.elasticsearch.xpack.stateless.utils.SearchShardSizeCollector;
+import org.elasticsearch.xpack.stateless.utils.StatelessCommitServiceProvider;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -506,7 +507,7 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
                         indicesService,
                         new CompositeRecoverySchedulingListener(),
                         peerRecoveryTargetService,
-                        testStatelessPlugin.statelessCommitService,
+                        new StatelessCommitServiceProvider(testStatelessPlugin.statelessCommitService),
                         mock(IndexShardCacheWarmer.class),
                         testStatelessPlugin.hollowShardsService,
                         HollowShardsMetrics.NOOP,
@@ -544,7 +545,7 @@ public class StatelessSnapshotResiliencyTests extends SnapshotResiliencyTests {
                         indicesService,
                         clusterService(),
                         mock(GetVirtualBatchedCompoundCommitChunksPressure.class),
-                        testStatelessPlugin.statelessCommitService,
+                        new StatelessCommitServiceProvider(testStatelessPlugin.statelessCommitService),
                         projectResolver
                     ),
                     TransportGetShardSnapshotCommitInfoAction.TYPE,


### PR DESCRIPTION
`StatelessCommitService `is not needed on search nodes, and its instantiation should be avoided.

Due to Guice constraints, transport actions (which are always instantiated) require `StatelessCommitService` to be present, previously forcing its instantiation across all nodes.

Attempting to retrieve `StatelessCommitService` via `IndexEngine` was unreliable because the engine is not always started yet when `commitService` is needed. 

**To resolve this, I introduced a lightweight wrapper** (`StatelessCommitServiceProvider`) to safely handle nullability and restricted `StatelessCommitService` instantiation to index-only nodes.

Additionally, I updated `StatelessPlugin` to use explicit `PluginComponentBinding` for commit service. This fixes an underlying issue where overriding `StatelessPlugin.createStatelessCommitService` resulted in invalid component registration. This change also simplifies testing by eliminating the need to re-bind components (sorry for so many file changes, but it's due to this simplification).

There will be a follow up PR with more cleanup, but I don't want to overwhelm the reader with so many changes at once.

Relates: elastic/elasticsearch-team#4375