### PR TITLE
[8.19] Limit number_of_fragments in highlighting to prevent OOM crash (#155507)

### DIFF
--- a/docs/reference/search/search-your-data/highlighting.asciidoc
+++ b/docs/reference/search/search-your-data/highlighting.asciidoc
@@ -243,7 +243,7 @@ number of fragments is set to 0, no fragments are returned. Instead,
 the entire field contents are highlighted and returned. This can be
 handy when you need to highlight short texts such as a title or
 address, but fragmentation is not required. If `number_of_fragments`
-is 0, `fragment_size` is ignored. Defaults to 5.
+is 0, `fragment_size` is ignored. Defaults to 5. Cannot exceed 100000.
 
 order:: Sorts highlighted fragments by score when set to `score`. By default,
 fragments will be output in the order they appear in the field (order: `none`).

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
@@ -1,0 +1,68 @@
+---
+setup:
+  - requires:
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: GET
+          path: /_search
+          capabilities: [ highlight_number_of_fragments_bounded ]
+      reason: number_of_fragments is bounded to reject oversized highlighter allocations
+
+  - do:
+      indices.create:
+          index: test1
+          body:
+              settings:
+                  number_of_shards: 1
+              mappings:
+                  properties:
+                      field1:
+                          type: text
+
+  - do:
+      index:
+          index: test1
+          id:    "1"
+          body:
+              "field1" : "The quick brown fox"
+
+  - do:
+      indices.refresh: {}
+
+---
+"number_of_fragments above the maximum should FAIL":
+
+  - do:
+      catch: bad_request
+      search:
+          rest_total_hits_as_int: true
+          index: test1
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10001, "fields" : {"field1" : {}}}}
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "x_content_parse_exception" }
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }
+
+---
+"number_of_fragments at the maximum should SUCCEED":
+
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: test1
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10000, "fields" : {"field1" : {}}}}
+  - match: { hits.hits.0.highlight.field1.0: "The quick brown <em>fox</em>" }
+
+---
+"negative number_of_fragments should FAIL":
+
+  - do:
+      catch: bad_request
+      search:
+          rest_total_hits_as_int: true
+          index: test1
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : -1, "fields" : {"field1" : {}}}}
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "x_content_parse_exception" }
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
@@ -37,11 +37,11 @@ setup:
       search:
           rest_total_hits_as_int: true
           index: test1
-          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10001, "fields" : {"field1" : {}}}}
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 100001, "fields" : {"field1" : {}}}}
   - match: { status: 400 }
   - match: { error.root_cause.0.type: "x_content_parse_exception" }
   - match: { error.caused_by.type: "illegal_argument_exception" }
-  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [100000]" }
 
 ---
 "number_of_fragments at the maximum should SUCCEED":
@@ -50,7 +50,7 @@ setup:
       search:
           rest_total_hits_as_int: true
           index: test1
-          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10000, "fields" : {"field1" : {}}}}
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 100000, "fields" : {"field1" : {}}}}
   - match: { hits.hits.0.highlight.field1.0: "The quick brown <em>fox</em>" }
 
 ---
@@ -65,4 +65,4 @@ setup:
   - match: { status: 400 }
   - match: { error.root_cause.0.type: "x_content_parse_exception" }
   - match: { error.caused_by.type: "illegal_argument_exception" }
-  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [100000]" }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -43,6 +43,9 @@ public final class SearchCapabilities {
     private static final String OPTIMIZED_SCALAR_QUANTIZATION_BBQ = "optimized_scalar_quantization_bbq";
     private static final String KNN_QUANTIZED_VECTOR_RESCORE_OVERSAMPLE = "knn_quantized_vector_rescore_oversample";
 
+    /** {@code number_of_fragments} is bounded to reject oversized highlighter allocations. */
+    private static final String HIGHLIGHT_NUMBER_OF_FRAGMENTS_BOUNDED = "highlight_number_of_fragments_bounded";
+
     private static final String INDEX_SELECTOR_SYNTAX = "index_expression_selectors";
 
     private static final String SIGNIFICANT_TERMS_BACKGROUND_FILTER_AS_SUB = "significant_terms_background_filter_as_sub";
@@ -67,6 +70,7 @@ public final class SearchCapabilities {
         capabilities.add(K_DEFAULT_TO_SIZE);
         capabilities.add(KQL_QUERY_SUPPORTED);
         capabilities.add(RRF_WINDOW_SIZE_SUPPORT_DEPRECATED);
+        capabilities.add(HIGHLIGHT_NUMBER_OF_FRAGMENTS_BOUNDED);
         capabilities.add(INDEX_SELECTOR_SYNTAX);
         capabilities.add(SIGNIFICANT_TERMS_BACKGROUND_FILTER_AS_SUB);
         capabilities.add(SIGNIFICANT_TERMS_ON_NESTED_FIELDS);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -271,7 +271,8 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
     }
 
     /**
-     * Set the number of fragments, defaults to {@link HighlightBuilder#DEFAULT_NUMBER_OF_FRAGMENTS}
+     * Set the number of fragments, defaults to {@link HighlightBuilder#DEFAULT_NUMBER_OF_FRAGMENTS}. Must be between
+     * {@code 0} and {@link HighlightBuilder#MAX_NUMBER_OF_FRAGMENTS}; this is enforced when parsing a request.
      */
     @SuppressWarnings("unchecked")
     public HB numOfFragments(Integer numOfFragments) {
@@ -663,7 +664,14 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         parser.declareString(HB::order, ORDER_FIELD);
         parser.declareBoolean(HB::highlightFilter, HIGHLIGHT_FILTER_FIELD);
         parser.declareInt(HB::fragmentSize, FRAGMENT_SIZE_FIELD);
-        parser.declareInt(HB::numOfFragments, NUMBER_OF_FRAGMENTS_FIELD);
+        parser.declareInt((HB hb, Integer numOfFragments) -> {
+            if (numOfFragments < 0 || numOfFragments > HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS) {
+                throw new IllegalArgumentException(
+                    "[" + NUMBER_OF_FRAGMENTS_FIELD + "] must be between [0] and [" + HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS + "]"
+                );
+            }
+            hb.numOfFragments(numOfFragments);
+        }, NUMBER_OF_FRAGMENTS_FIELD);
         parser.declareString(HB::encoder, ENCODER_FIELD);
         parser.declareString(HB::tagsSchema, TAGS_SCHEMA_FIELD);
         parser.declareBoolean(HB::requireFieldMatch, REQUIRE_FIELD_MATCH_FIELD);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -62,6 +62,8 @@ public final class HighlightBuilder extends AbstractHighlighterBuilder<Highlight
     public static final int DEFAULT_NO_MATCH_SIZE = 0;
     /** the default number of fragments for highlighting */
     public static final int DEFAULT_NUMBER_OF_FRAGMENTS = 5;
+    /** the maximum accepted number of fragments for highlighting */
+    public static final int MAX_NUMBER_OF_FRAGMENTS = 10_000;
     /** the default number of fragments size in characters */
     public static final int DEFAULT_FRAGMENT_CHAR_SIZE = 100;
     /** the default opening tag  */
@@ -247,9 +249,8 @@ public final class HighlightBuilder extends AbstractHighlighterBuilder<Highlight
                 fieldOptionsBuilder.matchedFields(matchedFields);
             }
             transferOptions(field, fieldOptionsBuilder, context);
-            fieldOptions.add(
-                new SearchHighlightContext.Field(field.name(), fieldOptionsBuilder.merge(globalOptionsBuilder.build()).build())
-            );
+            final FieldOptions options = fieldOptionsBuilder.merge(globalOptionsBuilder.build()).build();
+            fieldOptions.add(new SearchHighlightContext.Field(field.name(), options));
         }
         return new SearchHighlightContext(fieldOptions);
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -63,7 +63,7 @@ public final class HighlightBuilder extends AbstractHighlighterBuilder<Highlight
     /** the default number of fragments for highlighting */
     public static final int DEFAULT_NUMBER_OF_FRAGMENTS = 5;
     /** the maximum accepted number of fragments for highlighting */
-    public static final int MAX_NUMBER_OF_FRAGMENTS = 10_000;
+    public static final int MAX_NUMBER_OF_FRAGMENTS = 100_000;
     /** the default number of fragments size in characters */
     public static final int DEFAULT_FRAGMENT_CHAR_SIZE = 100;
     /** the default opening tag  */

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -149,7 +149,12 @@ public class PlainHighlighter implements Highlighter {
                     // can't perform highlighting if the stream has no terms (binary token stream) or no offsets
                     continue;
                 }
-                TextFragment[] bestTextFragments = entry.getBestTextFragments(tokenStream, text, false, numberOfFragments);
+                TextFragment[] bestTextFragments = entry.getBestTextFragments(
+                    tokenStream,
+                    text,
+                    false,
+                    cappedNumberOfFragments(numberOfFragments, textLength)
+                );
                 for (TextFragment bestTextFragment : bestTextFragments) {
                     if (bestTextFragment != null && bestTextFragment.getScore() > 0) {
                         fragsList.add(new OrderedTextFragment(bestTextFragment, bestTextFragment.getFragNum() + fragNumBase));
@@ -239,6 +244,11 @@ public class PlainHighlighter implements Highlighter {
             // We've exhausted the token stream so we should just highlight everything.
             return end;
         }
+    }
+
+    /** Bounds the requested number of fragments to the number of fragments the text could actually produce. */
+    static int cappedNumberOfFragments(int requestedNumberOfFragments, int textLength) {
+        return Math.min(requestedNumberOfFragments, Math.max(1, textLength));
     }
 
     private static Analyzer wrapAnalyzer(Analyzer analyzer, Integer maxAnalyzedOffset) {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -63,6 +63,7 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.search.fetch.subphase.highlight.AbstractHighlighterBuilder.MAX_ANALYZED_OFFSET_FIELD;
+import static org.elasticsearch.search.fetch.subphase.highlight.AbstractHighlighterBuilder.NUMBER_OF_FRAGMENTS_FIELD;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -293,42 +294,7 @@ public class HighlightBuilderTests extends ESTestCase {
     * than what we have in the random {@link HighlightBuilder}
     */
     public void testBuildSearchContextHighlight() throws IOException {
-        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build();
-        Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
-        // shard context will only need indicesQueriesRegistry for building Query objects nested in highlighter
-        SearchExecutionContext mockContext = new SearchExecutionContext(
-            0,
-            0,
-            idxSettings,
-            null,
-            null,
-            null,
-            MappingLookup.EMPTY,
-            null,
-            null,
-            parserConfig(),
-            namedWriteableRegistry,
-            null,
-            null,
-            System::currentTimeMillis,
-            null,
-            null,
-            () -> true,
-            null,
-            emptyMap(),
-            MapperMetrics.NOOP
-        ) {
-            @Override
-            public MappedFieldType getFieldType(String name) {
-                TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
-                    name,
-                    createDefaultIndexAnalyzers(),
-                    SourceFieldMapper.isSynthetic(idxSettings)
-                );
-                return builder.build(MapperBuilderContext.root(false, false)).fieldType();
-            }
-        };
+        SearchExecutionContext mockContext = mockSearchExecutionContext(Settings.EMPTY);
         mockContext.setMapUnmappedFieldAsString(true);
 
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
@@ -581,6 +547,71 @@ public class HighlightBuilderTests extends ESTestCase {
         );
         assertThat(e.getMessage(), containsString("[highlight] failed to parse field [" + MAX_ANALYZED_OFFSET_FIELD.toString() + "]"));
         assertThat(e.getCause().getMessage(), containsString("[max_analyzed_offset] must be a positive integer"));
+    }
+
+    public void testNegativeNumberOfFragments() throws IOException {
+        XContentParseException e = expectParseThrows(
+            XContentParseException.class,
+            "{ \"number_of_fragments\" : " + randomIntBetween(-100, -1) + "}"
+        );
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [" + NUMBER_OF_FRAGMENTS_FIELD.toString() + "]"));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("[number_of_fragments] must be between [0] and [" + HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS + "]")
+        );
+    }
+
+    public void testNumberOfFragmentsAboveMaximum() throws IOException {
+        XContentParseException e = expectParseThrows(
+            XContentParseException.class,
+            "{ \"number_of_fragments\" : " + randomIntBetween(HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS + 1, Integer.MAX_VALUE) + "}"
+        );
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [" + NUMBER_OF_FRAGMENTS_FIELD.toString() + "]"));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("[number_of_fragments] must be between [0] and [" + HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS + "]")
+        );
+    }
+
+    private SearchExecutionContext mockSearchExecutionContext(Settings settings) {
+        Settings indexSettings = Settings.builder()
+            .put(settings)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .build();
+        Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
+        return new SearchExecutionContext(
+            0,
+            0,
+            idxSettings,
+            null,
+            null,
+            null,
+            MappingLookup.EMPTY,
+            null,
+            null,
+            parserConfig(),
+            namedWriteableRegistry,
+            null,
+            null,
+            System::currentTimeMillis,
+            null,
+            null,
+            () -> true,
+            null,
+            emptyMap(),
+            MapperMetrics.NOOP
+        ) {
+            @Override
+            public MappedFieldType getFieldType(String name) {
+                TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
+                    name,
+                    createDefaultIndexAnalyzers(),
+                    SourceFieldMapper.isSynthetic(idxSettings)
+                );
+                return builder.build(MapperBuilderContext.root(false, false)).fieldType();
+            }
+        };
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
@@ -103,6 +103,32 @@ public class PlainHighlighterTests extends HighlighterTestCase {
         }
     }
 
+    public void testCappedNumberOfFragments() {
+        assertEquals(19, PlainHighlighter.cappedNumberOfFragments(HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS, 19));
+        assertEquals(19, PlainHighlighter.cappedNumberOfFragments(1_000_000, 19));
+        assertEquals(3, PlainHighlighter.cappedNumberOfFragments(3, 100));
+        assertEquals(1, PlainHighlighter.cappedNumberOfFragments(5, 0));
+    }
+
+    public void testMaxNumberOfFragmentsHighlightsCorrectly() throws Exception {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "text" : { "type" : "text" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "text" : "some important text" }
+            """));
+
+        SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.matchQuery("text", "important"))
+            .highlighter(
+                new HighlightBuilder().field("text").highlighterType("plain").numOfFragments(HighlightBuilder.MAX_NUMBER_OF_FRAGMENTS)
+            );
+
+        assertHighlights(highlight(mapperService, doc, search), "text", "some <em>important</em> text");
+    }
+
     public void testScriptScoreQuery() throws IOException {
         MapperService mapperService = createMapperService("""
             { "_doc" : { "properties" : {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Limit number_of_fragments in highlighting to prevent OOM crash (#155507)](https://github.com/elastic/elasticsearch/pull/155507)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)