### PR TITLE
ES|QL [CI] Increase CsvIT suite timeout from 40 min to 60 min

### DIFF
--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -7,8 +7,11 @@
 
 package org.elasticsearch.xpack.esql;
 
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -57,6 +60,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class EsqlSecurityIT extends ESRestTestCase {
     private static final String INDEX_PARTIAL_MAPPING = "index-partial-mapping";
     private static final String INDEX_FULL_MAPPING = "index-full-mapping";

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -130,7 +130,7 @@ import static org.hamcrest.Matchers.hasSize;
  * InternalTestCluster` reuses current jvm. This enables debugging all scenarios from IDE.
  * Test data is loaded lazily in order to facilitate faster startup when running/debugging individual test cases.
  */
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
+@TimeoutSuite(millis = TimeUnits.HOUR)
 public class CsvIT extends ESTestCase {
 
     private static final Logger logger = LogManager.getLogger(CsvIT.class);


### PR DESCRIPTION
## Summary

Two suite-timeout stopgaps for the 9.5 branch, ahead of the structural fix in #154813.

**1. `CsvIT`** — `40 * TimeUnits.MINUTE` → `TimeUnits.HOUR`
The suite has grown to ~8,111 test cases across 181 csv-spec files and intermittently exceeds the 40-minute limit in constrained CI environments (single-processor-node, encryption-at-rest, windows-2022, openjdk25). Main already uses `TimeUnits.HOUR`; this aligns 9.5 with that value.

**2. `EsqlSecurityIT` / `EsqlAsyncSecurityIT`** — add `@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)`
The suite has grown to ~96–97 test methods after recent dataset/datasource additions (~30 new methods) and now exceeds the inherited 20-minute default in the `encryption-at-rest` step. `EsqlAsyncSecurityIT` inherits the annotation from `EsqlSecurityIT`.

In both cases the failing test varies per run — it is whichever test was executing when the timer fired, not a genuine test failure.

## Test plan

- [ ] CI passes for `CsvIT` on 9.5
- [ ] CI passes for `EsqlSecurityIT` / `EsqlAsyncSecurityIT` on 9.5

closes: #155707
closes: #155030
closes: #154921
closes: #153917
closes: #153915
closes: #153594
closes: #153478
closes: #155672
closes: #155671
closes: #155705