### PR TITLE
Fix SOAR assignment failure on empty neighborhoods

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -595,9 +595,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecApproximationBucketIncludeEmptyBucketsIT
   method: test {csv-spec:bucket_include_empty_buckets.Large number of buckets doesn't OOM - stats}
   issue: https://github.com/elastic/elasticsearch/issues/155921
-- class: org.elasticsearch.index.codec.vectors.cluster.FloatHierarchicalKMeansTests
-  method: testSoarAssignmentsValidAfterEmptyClusterRemoval
-  issue: https://github.com/elastic/elasticsearch/issues/155931
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=search.highlight/70_number_of_fragments/number_of_fragments at the maximum should SUCCEED}
   issue: https://github.com/elastic/elasticsearch/issues/155969

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/Soar.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/Soar.java
@@ -202,6 +202,10 @@ public abstract class Soar<V> {
         float[] distances,
         CentroidOps<V> ops
     ) {
+        if (centroidCount <= 0) {
+            // no other centroid available to spill to (e.g. an empty neighborhood after empty-cluster removal)
+            return NO_SOAR_ASSIGNMENT;
+        }
         V currentCentroid = centroids[currAssignment];
         float vectorCentroidDist = ops.squareDistance(vector, currentCentroid);
         if (vectorCentroidDist <= SOAR_MIN_DISTANCE) {


### PR DESCRIPTION
## Summary
- `Soar.computeSoarAssignment` could leave `bestAssignment` at `-1` when a centroid's neighborhood was empty (e.g. after aggressive empty-cluster removal during hierarchical k-means), tripping the `"Failed to assign soar vector to centroid"` assertion.
- Return `NO_SOAR_ASSIGNMENT` explicitly when `centroidCount <= 0`, consistent with the existing `SOAR_MIN_DISTANCE` short-circuit right below it.
- Note: in production (assertions disabled), the old code already fell through to `bestAssignment == -1 == NO_SOAR_ASSIGNMENT`, so this is a test-time correctness fix with no production behavior change — it also unmutes the test.

Closes #155931

## Test plan
- [x] Reproduced the original failure locally with the exact seed from the issue (`-Dtests.seed=58DDB35C8C17CF3 -Dtests.locale=nnh -Dtests.timezone=Europe/Kyiv -Druntime.java=26`)
- [x] Confirmed the fix resolves that exact seed
- [x] Ran `FloatHierarchicalKMeansTests` for 30 random-seed iterations (270 sub-tests) — all green
- [x] Ran `ByteHierarchicalKMeansTests` (shares the same test via `AbstractHierarchicalKMeansTestCase`) for 20 random-seed iterations — all green