### PR TITLE
[CI] Fix cloud-ess docker build with docker-container buildx driver

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
@@ -26,6 +26,7 @@ import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -38,10 +39,14 @@ import org.gradle.workers.WorkerExecutor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -95,6 +100,8 @@ public abstract class DockerBuildTask extends DefaultTask {
             params.getBuildArgs().set(buildArgs);
             params.getPlatforms().set(getPlatforms());
             params.getDockerExecutable().set(dockerExecutable);
+            params.getOciImageLayout().set(getOciImageLayout());
+            params.getBuildContexts().set(getBuildContexts());
         });
     }
 
@@ -155,6 +162,31 @@ public abstract class DockerBuildTask extends DefaultTask {
     @Input
     @Optional
     public abstract Property<Boolean> getPush();
+
+    /**
+     * Optional directory into which the built image is additionally exported as an OCI image
+     * layout. This makes the image consumable by other {@link DockerBuildTask}s via a named
+     * build context (see {@link #getBuildContexts()}), independently of the docker daemon's
+     * image store. This matters for buildx builders using the isolated docker-container
+     * driver, which cannot resolve locally-tagged daemon images in FROM instructions.
+     * Only used on the buildx (cross-platform) code path.
+     */
+    @OutputDirectory
+    @Optional
+    public abstract DirectoryProperty getOciImageLayout();
+
+    /**
+     * Named build contexts, passed to buildx as {@code --build-context name=value}. A context
+     * whose name matches an image reference in a FROM instruction overrides that reference,
+     * allowing a Dockerfile to build FROM a locally-built image that only exists as an OCI
+     * image layout on disk (value {@code oci-layout:///path/to/layout}) rather than in a
+     * registry or the docker daemon. Values using the {@code oci-layout://} scheme without an
+     * explicit digest are resolved to the layout's manifest digest at execution time.
+     * Only used on the buildx (cross-platform) code path.
+     */
+    @Input
+    @Optional
+    public abstract MapProperty<String, String> getBuildContexts();
 
     @OutputFile
     public RegularFileProperty getMarkerFile() {
@@ -232,6 +264,11 @@ public abstract class DockerBuildTask extends DefaultTask {
 
                 if (isCrossPlatform) {
                     spec.args("--platform", parameters.getPlatforms().get().stream().collect(Collectors.joining(",")));
+                    // Named build contexts are only supported by buildx; the non-buildx path resolves
+                    // locally-tagged base images against the daemon's image store, so it doesn't need them.
+                    parameters.getBuildContexts()
+                        .get()
+                        .forEach((name, value) -> spec.args("--build-context", name + "=" + resolveBuildContext(value)));
                 }
 
                 if (parameters.getNoCache().get()) {
@@ -245,16 +282,30 @@ public abstract class DockerBuildTask extends DefaultTask {
                 if (parameters.getPush().getOrElse(false)) {
                     spec.args("--push");
                 } else if (parameters.getPlatforms().get().size() == 1) {
-                    // Add --load to ensure the image ends up in the local Docker daemon as a
-                    // regular image, not a manifest list. This is required for any
-                    // single-platform build (including cross-platform builds for a single
-                    // foreign architecture, e.g. aarch64 on x86): with the docker-container
-                    // buildx driver the result otherwise remains only in the build cache and
-                    // the subsequent `docker inspect` for the image checksum fails with
-                    // "no such object". It also prevents issues with newer Docker versions
-                    // (23.0+) that may create manifest lists even for single-platform builds
-                    // when BuildKit is enabled.
-                    spec.args("--load");
+                    if (isCrossPlatform && parameters.getOciImageLayout().isPresent()) {
+                        // Load the image into the daemon (see the --load comment below) and additionally
+                        // export an OCI image layout to disk, so that derived images (e.g. cloud-ess,
+                        // which builds FROM the locally-tagged wolfi image) can resolve this image via a
+                        // named build context. This is required with the docker-container buildx driver,
+                        // whose isolated image store cannot see daemon images in FROM instructions.
+                        // Multiple --output flags require buildx >= 0.13.
+                        spec.args("--output", "type=docker");
+                        spec.args(
+                            "--output",
+                            "type=oci,tar=false,dest=" + parameters.getOciImageLayout().get().getAsFile().getAbsolutePath()
+                        );
+                    } else {
+                        // Add --load to ensure the image ends up in the local Docker daemon as a
+                        // regular image, not a manifest list. This is required for any
+                        // single-platform build (including cross-platform builds for a single
+                        // foreign architecture, e.g. aarch64 on x86): with the docker-container
+                        // buildx driver the result otherwise remains only in the build cache and
+                        // the subsequent `docker inspect` for the image checksum fails with
+                        // "no such object". It also prevents issues with newer Docker versions
+                        // (23.0+) that may create manifest lists even for single-platform builds
+                        // when BuildKit is enabled.
+                        spec.args("--load");
+                    }
                 }
             });
 
@@ -270,6 +321,32 @@ public abstract class DockerBuildTask extends DefaultTask {
                 Files.writeString(parameters.getMarkerFile().getAsFile().get().toPath(), checksum + "\n");
             } catch (IOException e) {
                 throw new RuntimeException("Failed to write marker file", e);
+            }
+        }
+
+        /**
+         * Resolves an {@code oci-layout://} build context value to a digest-qualified reference.
+         * Buildx resolves OCI layout contexts by tag or digest within the layout; the tag recorded
+         * in the layout's index is not always what buildx looks up by default, so pinning the
+         * manifest digest from {@code index.json} is the most robust way to reference the
+         * (single-image) layouts we export.
+         */
+        private static String resolveBuildContext(String value) {
+            String prefix = "oci-layout://";
+            if (value.startsWith(prefix) == false || value.contains("@")) {
+                return value;
+            }
+            Path indexJson = Path.of(value.substring(prefix.length()), "index.json");
+            try {
+                // The exported layouts contain a single manifest, so plucking the first digest is
+                // sufficient and avoids a JSON parser dependency in this worker action.
+                Matcher matcher = Pattern.compile("sha256:[a-f0-9]{64}").matcher(Files.readString(indexJson));
+                if (matcher.find() == false) {
+                    throw new GradleException("No manifest digest found in OCI image layout index [" + indexJson + "]");
+                }
+                return value + "@" + matcher.group();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read OCI image layout index [" + indexJson + "]", e);
             }
         }
 
@@ -314,5 +391,9 @@ public abstract class DockerBuildTask extends DefaultTask {
         Property<Boolean> getPush();
 
         Property<String> getDockerExecutable();
+
+        DirectoryProperty getOciImageLayout();
+
+        MapProperty<String, String> getBuildContexts();
     }
 }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -453,6 +453,15 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       } else {
         baseImages = []
       }
+
+      if (base == DockerBase.WOLFI) {
+        // The cloud-ess image builds FROM the locally-tagged wolfi image. When the wolfi image is
+        // built via buildx (cross-platform, e.g. aarch64 on x86 CI agents), it must additionally be
+        // exported as an OCI image layout so that the cloud-ess build can resolve it via a named
+        // build context: the docker-container buildx driver's isolated image store cannot see
+        // locally-tagged daemon images in FROM instructions. Only used on the buildx code path.
+        ociImageLayout = layout.buildDirectory.dir("oci-image-layouts/elasticsearch${base.suffix}-${architecture.classifier}")
+      }
     }
 
   if (base != DockerBase.IRON_BANK && base != DockerBase.CLOUD_ESS) {
@@ -520,6 +529,14 @@ void addBuildCloudDockerImageTasks(Architecture architecture) {
       tags = generateTags(dockerBase, architecture)
       platforms.add(architecture.dockerPlatform)
 
+      // Dockerfile.ess builds FROM elasticsearch-wolfi:<arch>, a tag that only exists locally.
+      // On the buildx (cross-platform) code path the isolated docker-container driver cannot
+      // resolve that tag against the daemon's image store, so resolve it via a named build
+      // context pointing at the OCI image layout exported by the wolfi image build instead.
+      buildContexts.put(
+        "elasticsearch${DockerBase.WOLFI.suffix}:${architecture.classifier}".toString(),
+        buildBaseTask.flatMap { it.ociImageLayout }.map { "oci-layout://${it.asFile.absolutePath}".toString() }
+      )
     }
 
   tasks.named("assemble").configure {


### PR DESCRIPTION
Fixes the deterministic DRA workflow failure in `:distribution:docker:buildAarch64CloudEssDockerImage` on `main` and `9.5` (e.g. [build 95699](https://buildkite.com/elastic/elasticsearch-dra-workflow/builds/95699), [scan](https://gradle-enterprise.elastic.co/s/udkycjbxbd2ui)):

```
#2 ERROR: pull access denied, repository does not exist or may require authorization:
   docker.io/library/elasticsearch-wolfi:aarch64
Dockerfile:29
  29 | >>> FROM elasticsearch-wolfi:aarch64
```

### Root cause

`Dockerfile.ess` builds `FROM elasticsearch-wolfi:<arch>` — a tag that only exists in the **local docker daemon** after `buildAarch64WolfiDockerImage` has run. The DRA workflow creates its buildx builder with the **`docker-container` driver** (`.buildkite/scripts/dra-workflow.sh`), whose isolated image store cannot see locally-tagged daemon images. Buildkit therefore falls back to resolving the tag against `docker.io/library/` and fails.

#155891 fixed the *output* side of cross-arch builds by adding `--load` (standalone aarch64 images build fine since), but derived images consuming a local tag in a `FROM` instruction remained broken.

### Fix

On the buildx (cross-platform) code path:

- `buildAarch64WolfiDockerImage` now additionally exports an **OCI image layout** to disk, using multiple `--output` flags (`type=docker` + `type=oci,tar=false`; requires buildx >= 0.13).
- `buildAarch64CloudEssDockerImage` resolves the wolfi tag via a **named build context** — `--build-context elasticsearch-wolfi:<arch>=oci-layout://<path>@<digest>` — instead of relying on the daemon's image store. The digest is pinned from the layout's `index.json`.

### Scope

- Only the buildx (cross-platform) code path changes; native-arch builds keep using plain `docker build` against the daemon, unchanged.
- Only the wolfi → cloud-ess relationship uses build contexts; all other images build `FROM` registry references and are unaffected.
- `cloud-ess-fips` is not affected — it builds `FROM docker.elastic.co/wolfi/chainguard-base-fips` directly.

### Verification

Reproduced and verified on a CI-equivalent GCP VM (same image family `elasticsearch-ubuntu-2204`, same `custom-32-98304` machine type, same `docker buildx create --driver docker-container` builder as `dra-workflow.sh`):

Build scan: https://gradle-enterprise.elastic.co/s/wfnxp47g5bohk
