### PR TITLE
[9.5] Fixing flaky VirtualBatchedCompoundCommitsIT.testVirtualBatchedCompoundCommitChunksPressure() (#155778)

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
@@ -1298,18 +1298,25 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
         assertNoFailures(safeGet(refresh2));
         assertBusy(() -> assertThat(vbccChunksPressure.getCurrentChunksBytes(), equalTo(0L)));
 
-        // Confirm that the pressure metrics were correctly set
+        // Confirm that the pressure metrics were correctly set. Every admitted chunk request records exactly one
+        // +PAGE_SIZE measurement at GetVirtualBatchedCompoundCommitChunksPressure#markChunkStarted and one -PAGE_SIZE
+        // measurement when its releasable runs, so the first refresh (index1) contributes exactly 2 * `pages`
+        // measurements. The two refreshes admit independent numbers of chunk requests, and because of the concurrent
+        // overlap documented below for rejections, either refresh may admit an extra chunk request (a page re-fetched
+        // after a retry) which adds an extra +/-PAGE_SIZE pair. The exact total is therefore not deterministic, so we
+        // assert the invariants that always hold instead of an exact count/order: at least 2 * `pages` + 2 measurements
+        // (the first refresh's exact 2 * `pages`, plus at least one +/-PAGE_SIZE pair from the second refresh, which
+        // reads at least one page), each measurement is +/-PAGE_SIZE, and the additions and removals balance so the
+        // pressure returns to zero.
         final int pages = pagesRead.get();
         var measurements = metricsPlugin.getLongUpDownCounterMeasurement(CURRENT_CHUNKS_BYTES_METRIC);
-        assertThat(measurements.size(), equalTo(pages * 4));
-        for (int p = 0; p < pages; p++) {
-            // The first refresh results in two measurements (one that adds bytes, and one that removes bytes) for each page chunk request
-            assertMeasurement(measurements.get(p * 2), PAGE_SIZE);
-            assertMeasurement(measurements.get(p * 2 + 1), -PAGE_SIZE);
-            // The second refresh had the same amount of measurements, that appear after the first refresh's measurements
-            assertMeasurement(measurements.get(pages * 2 + p * 2), PAGE_SIZE);
-            assertMeasurement(measurements.get(pages * 2 + p * 2 + 1), -PAGE_SIZE);
+        assertThat(measurements.size(), greaterThanOrEqualTo(pages * 2 + 2));
+        long netChunksBytes = 0;
+        for (Measurement measurement : measurements) {
+            assertThat(Math.abs(measurement.getLong()), equalTo((long) PAGE_SIZE));
+            netChunksBytes += measurement.getLong();
         }
+        assertThat("chunk pressure additions and removals must balance out to zero", netChunksBytes, equalTo(0L));
 
         measurements = metricsPlugin.getLongCounterMeasurement(CHUNK_REQUESTS_REJECTED_METRIC);
         // A BCC larger than one PAGE_SIZE produces multiple concurrent valid chunk2 requests. Those may overlap: a


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fixing flaky VirtualBatchedCompoundCommitsIT.testVirtualBatchedCompoundCommitChunksPressure() (#155778)](https://github.com/elastic/elasticsearch/pull/155778)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)