### PR TITLE
[9.5] Fix false-positive in boolean queries with must_not queries on not indexed fields (#155936)

### DIFF
--- a/docs/changelog/155936.yaml
+++ b/docs/changelog/155936.yaml
@@ -1,0 +1,6 @@
+area: Codec
+issues:
+ - 155653
+pr: 155936
+summary: "Fix false-positive in boolean queries with must_not queries on not indexed fields - #155936"
+type: bug

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -96,7 +96,9 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
 import org.elasticsearch.script.field.TextDocValuesField;
@@ -707,7 +709,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 
@@ -742,7 +744,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
             }
             if (caseInsensitive == false) {
-                return new PrefixQuery(new Term(name(), value), MultiTermQuery.DOC_VALUES_REWRITE);
+                return new PrefixQuery(new Term(name(), value), XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new StringScriptFieldPrefixQuery(
                 new Script(""),
@@ -771,9 +773,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 Term term = new Term(name(), value);
                 if (context.getCircuitBreaker() != null) {
                     Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
-                    return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
-                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new StringScriptFieldWildcardQuery(
                 new Script(""),
@@ -818,7 +820,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     maxDeterminizedStates,
                     context.getCircuitBreaker()
                 );
-                return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new RegexpQuery(
                 new Term(name(), value),
@@ -826,7 +828,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 matchFlags,
                 RegexpQuery.DEFAULT_PROVIDER,
                 maxDeterminizedStates,
-                MultiTermQuery.DOC_VALUES_REWRITE
+                XDocValuesRewriteMethod.DOC_VALUES_REWRITE
             );
         }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiPhraseQuery;
-import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
@@ -64,6 +63,7 @@ import org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper.MatchOnlyT
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
@@ -595,7 +595,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         // SortedSet DV, case-sensitive: native PrefixQuery with DOC_VALUES_REWRITE
         assertThat(
             sortedSet.prefixQuery("foo", null, false, MOCK_CONTEXT),
-            Matchers.equalTo(new PrefixQuery(new Term("field", "foo"), MultiTermQuery.DOC_VALUES_REWRITE))
+            Matchers.equalTo(new PrefixQuery(new Term("field", "foo"), XDocValuesRewriteMethod.DOC_VALUES_REWRITE))
         );
 
         // SortedSet DV, case-insensitive: script-backed query
@@ -620,7 +620,11 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         assertThat(
             sortedSet.wildcardQuery("foo*", null, false, MOCK_CONTEXT),
             Matchers.equalTo(
-                new WildcardQuery(new Term("field", "foo*"), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE)
+                new WildcardQuery(
+                    new Term("field", "foo*"),
+                    Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                    XDocValuesRewriteMethod.DOC_VALUES_REWRITE
+                )
             )
         );
 
@@ -649,7 +653,14 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         assertThat(
             sortedSet.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT),
             Matchers.equalTo(
-                new RegexpQuery(new Term("field", "foo.*"), 0, 0, RegexpQuery.DEFAULT_PROVIDER, 10, MultiTermQuery.DOC_VALUES_REWRITE)
+                new RegexpQuery(
+                    new Term("field", "foo.*"),
+                    0,
+                    0,
+                    RegexpQuery.DEFAULT_PROVIDER,
+                    10,
+                    XDocValuesRewriteMethod.DOC_VALUES_REWRITE
+                )
             )
         );
 
@@ -671,7 +682,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         // SortedSet DV → RegexpQuery with DOC_VALUES_REWRITE and ASCII_CASE_INSENSITIVE matchFlag
         Query q = sortedSetDocValuesOnly().regexpQuery("foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, null, MOCK_CONTEXT);
         assertThat(q, Matchers.instanceOf(RegexpQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
 
         // Binary DV → ScanningBinaryDocValuesRegexpQuery with ASCII_CASE_INSENSITIVE matchFlag
         assertThat(

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -47,6 +46,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFro
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
@@ -485,7 +485,7 @@ public class IpFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesRangeQuery(field, lower, upper, arrayOrderInlineNull);
             } else {
-                return SortedSetDocValuesField.newSlowRangeQuery(field, lower, upper, true, true);
+                return SortedSetDocValuesRangeQuery.newSlowRangeQuery(field, lower, upper, true, true);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -80,7 +80,9 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.SortedBinaryDocValuesStringFieldScript;
@@ -767,7 +769,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 
@@ -807,7 +809,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     includeUpper
                 );
             } else {
-                return SortedSetDocValuesField.newSlowRangeQuery(
+                return SortedSetDocValuesRangeQuery.newSlowRangeQuery(
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),
@@ -848,7 +850,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     prefixLength,
                     maxExpansions,
                     transpositions,
-                    MultiTermQuery.DOC_VALUES_REWRITE,
+                    XDocValuesRewriteMethod.DOC_VALUES_REWRITE,
                     context,
                     name()
                 );
@@ -875,7 +877,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else {
                 if (caseInsensitive == false) {
                     Term prefix = new Term(name(), indexedValueForSearch(value));
-                    return new PrefixQuery(prefix, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new PrefixQuery(prefix, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
                 return new StringScriptFieldPrefixQuery(
                     new Script(""),
@@ -1233,9 +1235,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                     Term term = new Term(name(), value);
                     if (context.getCircuitBreaker() != null) {
                         Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
-                        return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                        return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                     }
-                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
 
                 StringFieldScript.LeafFactory leafFactory = ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
@@ -1267,9 +1269,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                     Term term = new Term(name(), value);
                     if (context.getCircuitBreaker() != null) {
                         Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
-                        return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                        return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                     }
-                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
             }
         }
@@ -1308,7 +1310,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                             maxDeterminizedStates,
                             context.getCircuitBreaker()
                         );
-                        return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                        return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                     }
                     return new RegexpQuery(
                         new Term(name(), indexedValueForSearch(value)),
@@ -1316,7 +1318,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                         matchFlags,
                         RegexpQuery.DEFAULT_PROVIDER,
                         maxDeterminizedStates,
-                        MultiTermQuery.DOC_VALUES_REWRITE
+                        XDocValuesRewriteMethod.DOC_VALUES_REWRITE
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyTypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyTypeFieldMapper.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -64,7 +65,7 @@ public class LegacyTypeFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+            return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
         }
 
         @Override
@@ -81,7 +82,7 @@ public class LegacyTypeFieldMapper extends MetadataFieldMapper {
             boolean includeUpper,
             SearchExecutionContext context
         ) {
-            return SortedSetDocValuesField.newSlowRangeQuery(
+            return SortedSetDocValuesRangeQuery.newSlowRangeQuery(
                 name(),
                 lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                 upperTerm == null ? null : indexedValueForSearch(upperTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -34,7 +34,9 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
 import org.elasticsearch.script.StringFieldScript;
@@ -147,7 +149,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexedNorDocValuesFallback(context);
             if (indexType.hasDocValues()) {
-                return SortedDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             } else {
                 return super.termQuery(value, context);
             }
@@ -174,7 +176,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         ) {
             failIfNotIndexedNorDocValuesFallback(context);
             if (indexType.hasDocValues()) {
-                return SortedDocValuesField.newSlowRangeQuery(
+                return SortedSetDocValuesRangeQuery.newSlowRangeQuery(
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),
@@ -204,7 +206,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                     prefixLength,
                     maxExpansions,
                     transpositions,
-                    MultiTermQuery.DOC_VALUES_REWRITE,
+                    XDocValuesRewriteMethod.DOC_VALUES_REWRITE,
                     context,
                     name()
                 );
@@ -224,7 +226,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
             if (indexType.hasDocValues()) {
                 if (caseInsensitive == false) {
                     Term prefix = new Term(name(), indexedValueForSearch(value));
-                    return new PrefixQuery(prefix, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new PrefixQuery(prefix, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
                 return new StringScriptFieldPrefixQuery(
                     new Script(""),
@@ -256,9 +258,9 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                     Term term = new Term(name(), value);
                     if (context.getCircuitBreaker() != null) {
                         Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
-                        return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                        return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                     }
-                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
 
                 StringFieldScript.LeafFactory leafFactory = ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
@@ -289,7 +291,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                         maxDeterminizedStates,
                         context.getCircuitBreaker()
                     );
-                    return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
                 return new RegexpQuery(
                     term,
@@ -297,7 +299,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                     matchFlags,
                     RegexpQuery.DEFAULT_PROVIDER,
                     maxDeterminizedStates,
-                    MultiTermQuery.DOC_VALUES_REWRITE
+                    XDocValuesRewriteMethod.DOC_VALUES_REWRITE
                 );
             }
             return super.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -90,7 +90,9 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
 import org.elasticsearch.script.field.DelegateDocValuesField;
@@ -980,7 +982,7 @@ public final class TextFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 
@@ -1025,7 +1027,7 @@ public final class TextFieldMapper extends FieldMapper {
                 return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
             }
             if (caseInsensitive == false) {
-                return new PrefixQuery(new Term(name(), value), MultiTermQuery.DOC_VALUES_REWRITE);
+                return new PrefixQuery(new Term(name(), value), XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new StringScriptFieldPrefixQuery(
                 new Script(""),
@@ -1054,9 +1056,9 @@ public final class TextFieldMapper extends FieldMapper {
                 Term term = new Term(name(), value);
                 if (context.getCircuitBreaker() != null) {
                     Automaton dfa = AutomatonQueries.toWildcardAutomaton(term, context.getCircuitBreaker());
-                    return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                    return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
                 }
-                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
+                return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new StringScriptFieldWildcardQuery(
                 new Script(""),
@@ -1101,7 +1103,7 @@ public final class TextFieldMapper extends FieldMapper {
                     maxDeterminizedStates,
                     context.getCircuitBreaker()
                 );
-                return new AutomatonQuery(term, dfa, false, MultiTermQuery.DOC_VALUES_REWRITE);
+                return new AutomatonQuery(term, dfa, false, XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
             }
             return new RegexpQuery(
                 new Term(name(), value),
@@ -1109,7 +1111,7 @@ public final class TextFieldMapper extends FieldMapper {
                 matchFlags,
                 RegexpQuery.DEFAULT_PROVIDER,
                 maxDeterminizedStates,
-                MultiTermQuery.DOC_VALUES_REWRITE
+                XDocValuesRewriteMethod.DOC_VALUES_REWRITE
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper.flattened;
 
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexReader;
@@ -91,6 +90,7 @@ import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.lucene.queries.KeyedArrayOrderInlineNullTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.FlattenedDocValuesField;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
@@ -709,7 +709,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                     }
                     return new ScanningBinaryDocValuesTermQuery(name(), keyedValue, false);
                 } else {
-                    return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                    return SortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
                 }
             } else {
                 return super.termQuery(value, context);

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SortedNumericDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SortedNumericDocValuesRangeQuery.java
@@ -26,9 +26,11 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.lucene.search.XDocValuesRangeIterator;
 
 import java.io.IOException;
 import java.util.function.LongPredicate;
@@ -46,18 +48,14 @@ public final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRang
     public static final FeatureFlag NUMERIC_RANGE_COLLECT_PUSHDOWN = new FeatureFlag("numeric_range_collect_pushdown");
 
     /**
-     * Returns a range query over sorted numeric doc values for the given field.
-     * When {@link #NUMERIC_RANGE_COLLECT_PUSHDOWN} is enabled, returns this Elasticsearch
-     * subclass which supports SIMD-based collect pushdown into TSDB codec blocks.
-     * When disabled, returns Lucene's own (package-private) implementation via
-     * {@link SortedNumericDocValuesField#newSlowRangeQuery} to avoid shipping the
-     * diverged copy of that code on the hot path.
+     * Returns a range query over sorted numeric doc values for the given field, using the fixed
+     * {@link XDocValuesRangeIterator} to avoid the {@code docIDRunEnd()} over-reporting bug in
+     * Lucene 10.5.0 (apache/lucene#16450). Delete this method and revert callers to
+     * {@link SortedNumericDocValuesField#newSlowRangeQuery} when Elasticsearch upgrades to a
+     * Lucene release containing that fix.
      */
     public static Query newRangeQuery(String field, long lowerValue, long upperValue) {
-        if (NUMERIC_RANGE_COLLECT_PUSHDOWN.isEnabled()) {
-            return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue);
-        }
-        return SortedNumericDocValuesField.newSlowRangeQuery(field, lowerValue, upperValue);
+        return new SortedNumericDocValuesRangeQuery(field, lowerValue, upperValue);
     }
 
     public SortedNumericDocValuesRangeQuery(String field, long lowerValue, long upperValue) {
@@ -142,15 +140,30 @@ public final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRang
                 // wraps a TwoPhaseIterator (recovered by fromIterator via TwoPhaseIterator.unwrap) whose
                 // intoBitSet is bounded by upTo, so ESQL DataPartitioning.DOC slices scan only their own
                 // [min, max) window instead of over-scanning past it as a plain DocIdSetIterator did.
-                if (singleton instanceof BlockLoader.OptionalNumericRangeReader rangeReader) {
+                if (NUMERIC_RANGE_COLLECT_PUSHDOWN.isEnabled() && singleton instanceof BlockLoader.OptionalNumericRangeReader rangeReader) {
                     var rangeIterator = rangeReader.tryRangeIterator(lowerValue, upperValue);
                     if (rangeIterator != null) {
                         return ConstantScoreScorerSupplier.fromIterator(rangeIterator, score(), scoreMode, maxDoc);
                     }
                 }
 
-                // 3) Delegate: fall back to Lucene's standard implementation.
-                return delegateWeight.scorerSupplier(context);
+                // 3) Fixed iterator: use XDocValuesRangeIterator to avoid docIDRunEnd()
+                // over-reporting in Lucene 10.5.0 (apache/lucene#16450). Delete when upgrading
+                // past that fix; revert to delegateWeight.scorerSupplier(context).
+                if (singleton != null) {
+                    return ConstantScoreScorerSupplier.fromIterator(
+                        TwoPhaseIterator.asDocIdSetIterator(XDocValuesRangeIterator.forRange(singleton, skipper, lowerValue, upperValue)),
+                        score(),
+                        scoreMode,
+                        maxDoc
+                    );
+                }
+                return ConstantScoreScorerSupplier.fromIterator(
+                    TwoPhaseIterator.asDocIdSetIterator(XDocValuesRangeIterator.forRange(values, skipper, lowerValue, upperValue)),
+                    score(),
+                    scoreMode,
+                    maxDoc
+                );
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SortedSetDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SortedSetDocValuesRangeQuery.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ConstantScoreScorerSupplier;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.lucene.search.XDocValuesRangeIterator;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Fork of Lucene 10.5.0's package-private {@code SortedSetDocValuesRangeQuery}, using
+ * {@link XDocValuesRangeIterator} so that {@code docIDRunEnd()} returns a correct, conservative
+ * run boundary on {@code MAYBE} and {@code YES_IF_PRESENT} blocks.
+ *
+ * <p>The upstream fix is in apache/lucene#16450, which only landed in Lucene 11.0.0. Delete this
+ * class, revert callers to {@link SortedSetDocValuesField#newSlowRangeQuery} and
+ * {@link SortedSetDocValuesField#newSlowExactQuery}, and remove the {@link #newSlowRangeQuery} /
+ * {@link #newSlowExactQuery} statics once Elasticsearch upgrades to a Lucene release containing
+ * that fix.
+ */
+public final class SortedSetDocValuesRangeQuery extends Query {
+
+    /**
+     * Returns a range query equivalent to {@link SortedSetDocValuesField#newSlowRangeQuery} but
+     * backed by the fixed {@link XDocValuesRangeIterator}.
+     */
+    public static Query newSlowRangeQuery(
+        String field,
+        BytesRef lowerValue,
+        BytesRef upperValue,
+        boolean lowerInclusive,
+        boolean upperInclusive
+    ) {
+        return new SortedSetDocValuesRangeQuery(field, lowerValue, upperValue, lowerInclusive, upperInclusive);
+    }
+
+    /**
+     * Returns an exact-match query equivalent to {@link SortedSetDocValuesField#newSlowExactQuery}
+     * but backed by the fixed {@link XDocValuesRangeIterator}.
+     */
+    public static Query newSlowExactQuery(String field, BytesRef value) {
+        return new SortedSetDocValuesRangeQuery(field, value, value, true, true);
+    }
+
+    private final String field;
+    private final BytesRef lowerValue;
+    private final BytesRef upperValue;
+    private final boolean lowerInclusive;
+    private final boolean upperInclusive;
+    // Used for rewrite(), count(), and the dense-primary-sort path; the dense-primary-sort scorer
+    // supplier returns a DocIdSetIterator.range() and never calls docIDRunEnd(), so delegating that
+    // path to Lucene is safe even without the apache/lucene#16450 fix.
+    private final Query delegate;
+
+    private SortedSetDocValuesRangeQuery(
+        String field,
+        BytesRef lowerValue,
+        BytesRef upperValue,
+        boolean lowerInclusive,
+        boolean upperInclusive
+    ) {
+        this.field = Objects.requireNonNull(field);
+        this.lowerValue = lowerValue;
+        this.upperValue = upperValue;
+        this.lowerInclusive = lowerInclusive && lowerValue != null;
+        this.upperInclusive = upperInclusive && upperValue != null;
+        this.delegate = SortedSetDocValuesField.newSlowRangeQuery(field, lowerValue, upperValue, lowerInclusive, upperInclusive);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (sameClassAs(obj) == false) {
+            return false;
+        }
+        SortedSetDocValuesRangeQuery that = (SortedSetDocValuesRangeQuery) obj;
+        return Objects.equals(field, that.field)
+            && Objects.equals(lowerValue, that.lowerValue)
+            && Objects.equals(upperValue, that.upperValue)
+            && lowerInclusive == that.lowerInclusive
+            && upperInclusive == that.upperInclusive;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), field, lowerValue, upperValue, lowerInclusive, upperInclusive);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (this.field.equals(field) == false) {
+            b.append(this.field).append(":");
+        }
+        return b.append(lowerInclusive ? "[" : "{")
+            .append(lowerValue == null ? "*" : lowerValue)
+            .append(" TO ")
+            .append(upperValue == null ? "*" : upperValue)
+            .append(upperInclusive ? "]" : "}")
+            .toString();
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (lowerValue == null && upperValue == null) {
+            return new FieldExistsQuery(field);
+        }
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        Weight delegateWeight = delegate.createWeight(searcher, scoreMode, boost);
+        return new ConstantScoreWeight(this, boost) {
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return DocValues.isCacheable(ctx, field);
+            }
+
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                if (context.reader().getFieldInfos().fieldInfo(field) == null) {
+                    return null;
+                }
+                DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
+                SortedSetDocValues values = DocValues.getSortedSet(context.reader(), field);
+                SortedDocValues singleton = DocValues.unwrapSingleton(values);
+
+                // Dense primary sort path: the scorer supplier returns DocIdSetIterator.range()
+                // directly and never calls docIDRunEnd(), so delegating to Lucene is safe here even
+                // without the apache/lucene#16450 fix in our Lucene version.
+                if (singleton != null && skipper != null && densePrimarySort(context.reader(), skipper) != null) {
+                    return delegateWeight.scorerSupplier(context);
+                }
+
+                final long minOrd = minOrd(values);
+                final long maxOrd = maxOrd(values);
+                int maxDoc = context.reader().maxDoc();
+
+                if (minOrd > maxOrd || (skipper != null && (minOrd > skipper.maxValue() || maxOrd < skipper.minValue()))) {
+                    return null;
+                }
+
+                if (skipper != null && skipper.docCount() == maxDoc && skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
+                    return ConstantScoreScorerSupplier.matchAll(score(), scoreMode, maxDoc);
+                }
+
+                // ConstantScoreScorerSupplier.fromIterator would set cost() = iterator.cost() =
+                // SkipBlockRangeIterator.cost() = NO_MORE_DOCS (Lucene 10.5.0). Mirror Lucene's own
+                // ordinal query which overrides cost() → values.cost() explicitly.
+                final DocIdSetIterator disi = singleton != null
+                    ? TwoPhaseIterator.asDocIdSetIterator(XDocValuesRangeIterator.forOrdinalRange(singleton, skipper, minOrd, maxOrd))
+                    : TwoPhaseIterator.asDocIdSetIterator(XDocValuesRangeIterator.forOrdinalRange(values, skipper, minOrd, maxOrd));
+                return new ConstantScoreScorerSupplier(score(), scoreMode, maxDoc) {
+                    @Override
+                    public DocIdSetIterator iterator(long leadCost) {
+                        return disi;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return values.cost();
+                    }
+                };
+            }
+
+            @Override
+            public int count(LeafReaderContext context) throws IOException {
+                return delegateWeight.count(context);
+            }
+        };
+    }
+
+    private long minOrd(SortedSetDocValues values) throws IOException {
+        if (lowerValue == null) {
+            return 0;
+        }
+        final long ord = values.lookupTerm(lowerValue);
+        if (ord < 0) {
+            return -1 - ord;
+        } else if (lowerInclusive) {
+            return ord;
+        } else {
+            return ord + 1;
+        }
+    }
+
+    private long maxOrd(SortedSetDocValues values) throws IOException {
+        if (upperValue == null) {
+            return values.getValueCount() - 1;
+        }
+        final long ord = values.lookupTerm(upperValue);
+        if (ord < 0) {
+            return -2 - ord;
+        } else if (upperInclusive) {
+            return ord;
+        } else {
+            return ord - 1;
+        }
+    }
+
+    private SortField densePrimarySort(LeafReader reader, DocValuesSkipper skipper) {
+        if (skipper.docCount() != reader.maxDoc()) {
+            return null;
+        }
+        final Sort indexSort = reader.getMetaData().sort();
+        if (indexSort == null || indexSort.getSort().length == 0 || indexSort.getSort()[0].getField().equals(field) == false) {
+            return null;
+        }
+        return indexSort.getSort()[0];
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/search/XDocValuesRangeIterator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/XDocValuesRangeIterator.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search;
+
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.SkipBlockRangeIterator;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOBooleanSupplier;
+import org.apache.lucene.util.LongBitSet;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+
+/**
+ * Fork of Lucene 10.5.0's {@code DocValuesRangeIterator}, fixing {@code docIDRunEnd()} to return
+ * the current doc ID (an empty run) for {@code MAYBE} and {@code YES_IF_PRESENT} blocks, where the
+ * current doc is only an approximation candidate and not a confirmed match.
+ *
+ * <p>The upstream fix is in apache/lucene#16450, which will land in Lucene 10.5.1. Delete this
+ * class and revert callers to Lucene's {@code DocValuesRangeIterator} once Elasticsearch upgrades
+ * to a Lucene release containing that fix.
+ */
+public abstract sealed class XDocValuesRangeIterator extends TwoPhaseIterator {
+
+    static {
+        assert Version.LUCENE_10_5_0.onOrAfter(Version.LATEST) : "Remove this class as fix is part of 10.5.1 and later";
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a NumericDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param min     skip documents with values lower than this
+     * @param max     skip documents with values higher than this
+     */
+    public static XDocValuesRangeIterator forRange(NumericDocValues values, DocValuesSkipper skipper, long min, long max) {
+        IOBooleanSupplier check = () -> {
+            long v = values.longValue();
+            return v >= min && v <= max;
+        };
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 2)
+            : new BulkNumericRangeIterator(values, new SkipBlockRangeIterator(skipper, min, max), check, 2, min, max);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedNumericDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param min     skip documents with all values lower than this
+     * @param max     skip documents with all values higher than this
+     */
+    public static XDocValuesRangeIterator forRange(SortedNumericDocValues values, DocValuesSkipper skipper, long min, long max) {
+        IOBooleanSupplier check = () -> {
+            for (int i = 0; i < values.docValueCount(); i++) {
+                long v = values.nextValue();
+                if (v >= min) {
+                    return v <= max;
+                }
+            }
+            return false;
+        };
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 5)
+            : new BulkSortedNumericRangeIterator(values, new SkipBlockRangeIterator(skipper, min, max), check, 2, min, max);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param min     skip documents with ordinal values lower than this
+     * @param max     skip documents with ordinal values higher than this
+     */
+    public static XDocValuesRangeIterator forOrdinalRange(SortedDocValues values, DocValuesSkipper skipper, long min, long max) {
+        IOBooleanSupplier check = () -> {
+            long ord = values.ordValue();
+            return ord >= min && ord <= max;
+        };
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 2)
+            : new BulkOrdinalRangeIterator(values, new SkipBlockRangeIterator(skipper, min, max), check, 2);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedSetDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param min     skip documents with all ordinal values lower than this
+     * @param max     skip documents with all ordinal values higher than this
+     */
+    public static XDocValuesRangeIterator forOrdinalRange(SortedSetDocValues values, DocValuesSkipper skipper, long min, long max) {
+        IOBooleanSupplier check = () -> {
+            for (int i = 0; i < values.docValueCount(); i++) {
+                long v = values.nextOrd();
+                if (v >= min) {
+                    return v <= max;
+                }
+            }
+            return false;
+        };
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 5)
+            : new BulkOrdinalRangeIterator(values, new SkipBlockRangeIterator(skipper, min, max), check, 5);
+    }
+
+    /**
+     * @param contiguous true iff every ordinal in [min, max] is set, in which case the set is
+     *                   equivalent to the contiguous range [min, max] and a cheaper range check can be used in
+     *                   place of the per-doc bit lookup.
+     */
+    private record OrdinalSet(long min, long max, LongBitSet ords, boolean contiguous) {
+
+        boolean disjoint(DocValuesSkipper skipper) {
+            if (skipper == null) {
+                return false;
+            }
+            return min > skipper.maxValue() || max < skipper.minValue();
+        }
+    }
+
+    private static OrdinalSet buildOrdinalSet(TermsEnum termsEnum, long ordCount) throws IOException {
+        if (termsEnum.next() == null) {
+            return null;
+        }
+        LongBitSet ords = new LongBitSet(ordCount);
+        long min = termsEnum.ord();
+        ords.set(min);
+        long max = min;
+        long distinctCount = 1;
+        while (termsEnum.next() != null) {
+            max = termsEnum.ord();
+            if (ords.getAndSet(max) == false) {
+                distinctCount++;
+            }
+        }
+        return new OrdinalSet(min, max, ords, distinctCount == max - min + 1);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param terms   a TermsEnum containing the ordinal values to match
+     */
+    public static XDocValuesRangeIterator forOrdinalSet(SortedDocValues values, DocValuesSkipper skipper, TermsEnum terms)
+        throws IOException {
+        OrdinalSet ordinalSet = buildOrdinalSet(terms, values.getValueCount());
+        if (ordinalSet == null || ordinalSet.disjoint(skipper)) {
+            return new EmptyRangeIterator();
+        }
+        if (ordinalSet.contiguous) {
+            return forOrdinalRange(values, skipper, ordinalSet.min, ordinalSet.max);
+        }
+        IOBooleanSupplier check = () -> ordinalSet.ords.get(values.ordValue());
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 2)
+            : new DocValuesBlockRangeIterator(values, new SkipBlockRangeIterator(skipper, ordinalSet.min, ordinalSet.max), check, 2);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedSetDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param terms   a TermsEnum containing the ordinal values to match
+     */
+    public static XDocValuesRangeIterator forOrdinalSet(SortedSetDocValues values, DocValuesSkipper skipper, TermsEnum terms)
+        throws IOException {
+        OrdinalSet ordinalSet = buildOrdinalSet(terms, values.getValueCount());
+        return forOrdinalSet(values, skipper, ordinalSet);
+    }
+
+    /**
+     * Creates an XDocValuesRangeIterator over a SortedSetDocValues instance
+     *
+     * @param values  the doc values
+     * @param skipper an optional skipper to exclude non-matching blocks
+     * @param minOrd  skip documents with all ordinal values lower than this
+     * @param maxOrd  skip documents with all ordinal values higher than this
+     * @param ords    skip documents with all values not in this set
+     */
+    public static XDocValuesRangeIterator forOrdinalSet(
+        SortedSetDocValues values,
+        DocValuesSkipper skipper,
+        long minOrd,
+        long maxOrd,
+        LongBitSet ords
+    ) {
+        return forOrdinalSet(values, skipper, new OrdinalSet(minOrd, maxOrd, ords, false));
+    }
+
+    private static XDocValuesRangeIterator forOrdinalSet(SortedSetDocValues values, DocValuesSkipper skipper, OrdinalSet ordinalSet) {
+        if (ordinalSet == null || ordinalSet.disjoint(skipper)) {
+            return new EmptyRangeIterator();
+        }
+        if (ordinalSet.contiguous) {
+            return forOrdinalRange(values, skipper, ordinalSet.min, ordinalSet.max);
+        }
+        IOBooleanSupplier check = () -> {
+            for (int i = 0; i < values.docValueCount(); i++) {
+                long v = values.nextOrd();
+                if (v > ordinalSet.max) {
+                    return false;
+                }
+                if (v >= ordinalSet.min && ordinalSet.ords.get(v)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        return skipper == null
+            ? new DocValuesValueRangeIterator(values, check, 5)
+            : new DocValuesBlockRangeIterator(values, new SkipBlockRangeIterator(skipper, ordinalSet.min, ordinalSet.max), check, 5);
+    }
+
+    /**
+     * Skip-indexed range iterator that confirms every candidate one doc at a time. Used for arbitrary
+     * ordinal sets, where even a YES block may contain docs whose ordinals fall in the gaps of the
+     * set.
+     *
+     * <p>The block-aware bulk variants extend this class and override {@link #matches()},
+     * {@link #docIDRunEnd()} and {@link #intoBitSet} to exploit the block classification.
+     */
+    private static sealed class DocValuesBlockRangeIterator extends XDocValuesRangeIterator {
+
+        final SkipBlockRangeIterator blockIterator;
+        final DocIdSetIterator disi;
+        final IOBooleanSupplier predicate;
+        private final float matchCost;
+
+        private DocValuesBlockRangeIterator(
+            DocIdSetIterator disi,
+            SkipBlockRangeIterator blockIterator,
+            IOBooleanSupplier predicate,
+            float matchCost
+        ) {
+            super(blockIterator);
+            this.disi = disi;
+            this.blockIterator = blockIterator;
+            this.predicate = predicate;
+            this.matchCost = matchCost;
+        }
+
+        final boolean advanceDisi(int target) throws IOException {
+            if (disi.docID() >= target) {
+                return disi.docID() == target;
+            }
+            return disi.advance(target) == target;
+        }
+
+        @Override
+        public boolean matches() throws IOException {
+            return advanceDisi(blockIterator.docID()) && predicate.get();
+        }
+
+        // Note: docIDRunEnd() intentionally inherits TwoPhaseIterator.docIDRunEnd(), which returns
+        // approximation().docID() — an empty run. This fixes the bug in Lucene 10.5.0 where the
+        // override returned blockIterator.docID() + 1, incorrectly claiming the unconfirmed
+        // approximation doc was a match. (apache/lucene#16450)
+
+        @Override
+        public final float matchCost() {
+            return matchCost;
+        }
+    }
+
+    /**
+     * Base class for the block-aware bulk variants: YES runs are set in one shot, YES_IF_PRESENT
+     * runs are marked by presence, and MAYBE runs are confirmed per doc.
+     */
+    private abstract static sealed class BulkBlockRangeIterator extends DocValuesBlockRangeIterator {
+
+        private BulkBlockRangeIterator(
+            DocIdSetIterator disi,
+            SkipBlockRangeIterator blockIterator,
+            IOBooleanSupplier predicate,
+            float matchCost
+        ) {
+            super(disi, blockIterator, predicate, matchCost);
+        }
+
+        @Override
+        public final boolean matches() throws IOException {
+            return switch (blockIterator.getMatch()) {
+                case YES -> true;
+                case YES_IF_PRESENT -> advanceDisi(blockIterator.docID());
+                case MAYBE -> advanceDisi(blockIterator.docID()) && predicate.get();
+            };
+        }
+
+        @Override
+        public final int docIDRunEnd() throws IOException {
+            // docIDRunEnd() may be called on non-matches, so only YES proves that the current doc and
+            // the rest of the run are actual matches. (apache/lucene#16450 fix)
+            return switch (blockIterator.getMatch()) {
+                case YES -> blockIterator.docIDRunEnd();
+                case YES_IF_PRESENT, MAYBE -> blockIterator.docID();
+            };
+        }
+
+        @Override
+        public final void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            while (blockIterator.docID() < upTo) {
+                int blockStart = blockIterator.docID();
+                SkipBlockRangeIterator.Match match = blockIterator.getMatch();
+                // For MAYBE blocks docIDRunEnd() is conservative (doc+1 in Lucene 10.5.0's
+                // SkipBlockRangeIterator), so use the full block boundary to evaluate the whole block.
+                int blockEnd = match == SkipBlockRangeIterator.Match.MAYBE
+                    ? Math.min(upTo, blockIterator.blockEnd())
+                    : Math.min(upTo, blockIterator.docIDRunEnd());
+                switch (match) {
+                    case YES -> bitSet.set(blockStart - offset, blockEnd - offset);
+                    case YES_IF_PRESENT -> {
+                        if (disi.docID() < blockStart) {
+                            disi.advance(blockStart);
+                        }
+                        disi.intoBitSet(blockEnd, bitSet, offset);
+                    }
+                    case MAYBE -> intoMaybeBlock(blockStart, blockEnd, bitSet, offset);
+                }
+                blockIterator.advance(blockEnd);
+            }
+        }
+
+        /** Confirms the docs of a single MAYBE block in {@code [blockStart, blockEnd)}. */
+        abstract void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset) throws IOException;
+    }
+
+    /** Bulk range iterator over single-valued numeric doc values. */
+    private static final class BulkNumericRangeIterator extends BulkBlockRangeIterator {
+
+        private final NumericDocValues numericValues;
+        private final long minValue;
+        private final long maxValue;
+
+        private BulkNumericRangeIterator(
+            NumericDocValues values,
+            SkipBlockRangeIterator blockIterator,
+            IOBooleanSupplier predicate,
+            float matchCost,
+            long minValue,
+            long maxValue
+        ) {
+            super(values, blockIterator, predicate, matchCost);
+            this.numericValues = values;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+        }
+
+        @Override
+        void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset) throws IOException {
+            int from = Math.max(blockStart, numericValues.docID());
+            numericValues.rangeIntoBitSet(from, blockEnd, minValue, maxValue, bitSet, offset);
+        }
+    }
+
+    /** Bulk range iterator over multi-valued sorted-numeric doc values. */
+    private static final class BulkSortedNumericRangeIterator extends BulkBlockRangeIterator {
+
+        private final SortedNumericDocValues sortedNumericValues;
+        private final long minValue;
+        private final long maxValue;
+
+        private BulkSortedNumericRangeIterator(
+            SortedNumericDocValues values,
+            SkipBlockRangeIterator blockIterator,
+            IOBooleanSupplier predicate,
+            float matchCost,
+            long minValue,
+            long maxValue
+        ) {
+            super(values, blockIterator, predicate, matchCost);
+            this.sortedNumericValues = values;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+        }
+
+        @Override
+        void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset) throws IOException {
+            int from = Math.max(blockStart, sortedNumericValues.docID());
+            sortedNumericValues.rangeIntoBitSet(from, blockEnd, minValue, maxValue, bitSet, offset);
+        }
+    }
+
+    /**
+     * Bulk range iterator over ordinal (sorted / sorted-set) doc values. MAYBE blocks confirm the
+     * ordinal predicate one doc at a time.
+     */
+    private static final class BulkOrdinalRangeIterator extends BulkBlockRangeIterator {
+
+        private BulkOrdinalRangeIterator(
+            DocIdSetIterator values,
+            SkipBlockRangeIterator blockIterator,
+            IOBooleanSupplier predicate,
+            float matchCost
+        ) {
+            super(values, blockIterator, predicate, matchCost);
+        }
+
+        @Override
+        void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset) throws IOException {
+            if (disi.docID() < blockStart) {
+                disi.advance(blockStart);
+            }
+            for (int doc = disi.docID(); doc < blockEnd; doc = disi.nextDoc()) {
+                if (predicate.get()) {
+                    bitSet.set(doc - offset);
+                }
+            }
+        }
+    }
+
+    private static final class DocValuesValueRangeIterator extends XDocValuesRangeIterator {
+
+        private final IOBooleanSupplier predicate;
+        private final float matchCost;
+
+        private DocValuesValueRangeIterator(DocIdSetIterator disi, IOBooleanSupplier predicate, float matchCost) {
+            super(disi);
+            this.predicate = predicate;
+            this.matchCost = matchCost;
+        }
+
+        @Override
+        public boolean matches() throws IOException {
+            return predicate.get();
+        }
+
+        @Override
+        public float matchCost() {
+            return matchCost;
+        }
+    }
+
+    private static final class EmptyRangeIterator extends XDocValuesRangeIterator {
+
+        private EmptyRangeIterator() {
+            super(DocIdSetIterator.empty());
+        }
+
+        @Override
+        public boolean matches() throws IOException {
+            return false;
+        }
+
+        @Override
+        public float matchCost() {
+            return 0;
+        }
+    }
+
+    private XDocValuesRangeIterator(DocIdSetIterator approximation) {
+        super(approximation);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/search/XDocValuesRewriteMethod.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/XDocValuesRewriteMethod.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+
+/**
+ * Fork of Lucene 10.5.0's {@code DocValuesRewriteMethod}, using {@link XDocValuesRangeIterator}
+ * for {@code forOrdinalSet} so that {@code docIDRunEnd()} returns a correct, conservative run
+ * boundary on {@code MAYBE} and {@code YES_IF_PRESENT} blocks.
+ *
+ * <p>The upstream fix is in apache/lucene#16450, is available in Lucene 10.5.1. Delete this
+ * class, revert callers to {@link MultiTermQuery#DOC_VALUES_REWRITE}, and remove the
+ * {@link #DOC_VALUES_REWRITE} singleton once Elasticsearch upgrades to a Lucene release containing
+ * that fix.
+ */
+public final class XDocValuesRewriteMethod extends MultiTermQuery.RewriteMethod {
+
+    static {
+        assert Version.LUCENE_10_5_0.onOrAfter(Version.LATEST) : "Remove this class as fix is part of 10.5.1 and later";
+    }
+
+    /** Drop-in replacement for {@link MultiTermQuery#DOC_VALUES_REWRITE}. */
+    public static final MultiTermQuery.RewriteMethod DOC_VALUES_REWRITE = new XDocValuesRewriteMethod();
+
+    private XDocValuesRewriteMethod() {}
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher, MultiTermQuery query) {
+        return new XMultiTermQueryDocValuesWrapper(query);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other != null && getClass() == other.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 641;
+    }
+
+    static class XMultiTermQueryDocValuesWrapper extends Query {
+
+        protected final MultiTermQuery query;
+
+        protected XMultiTermQueryDocValuesWrapper(MultiTermQuery query) {
+            this.query = query;
+        }
+
+        @Override
+        public String toString(String field) {
+            return query.toString(field);
+        }
+
+        @Override
+        public final boolean equals(final Object other) {
+            return sameClassAs(other) && query.equals(((XMultiTermQueryDocValuesWrapper) other).query);
+        }
+
+        @Override
+        public final int hashCode() {
+            return 31 * classHash() + query.hashCode();
+        }
+
+        public final String getField() {
+            return query.getField();
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+            if (visitor.acceptField(query.getField())) {
+                visitor.getSubVisitor(BooleanClause.Occur.FILTER, query);
+            }
+        }
+
+        @Override
+        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+            return new ConstantScoreWeight(this, boost) {
+
+                private TermsEnum getTermsEnum(SortedSetDocValues values) throws IOException {
+                    return query.getTermsEnum(new Terms() {
+
+                        @Override
+                        public TermsEnum iterator() throws IOException {
+                            return values.termsEnum();
+                        }
+
+                        @Override
+                        public long getSumTotalTermFreq() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public long getSumDocFreq() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public int getDocCount() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public long size() {
+                            return -1;
+                        }
+
+                        @Override
+                        public boolean hasFreqs() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean hasOffsets() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean hasPositions() {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean hasPayloads() {
+                            return false;
+                        }
+                    });
+                }
+
+                @Override
+                public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                    final SortedSetDocValues values = DocValues.getSortedSet(context.reader(), query.getField());
+                    if (values.getValueCount() == 0) {
+                        return null;
+                    }
+
+                    return new ScorerSupplier() {
+                        @Override
+                        public ConstantScoreScorer get(long leadCost) throws IOException {
+                            TermsEnum termsEnum = getTermsEnum(values);
+                            assert termsEnum != null;
+                            DocValuesSkipper skipper = context.reader().getDocValuesSkipper(query.getField());
+                            SortedDocValues singleton = DocValues.unwrapSingleton(values);
+                            return singleton == null
+                                ? new ConstantScoreScorer(
+                                    score(),
+                                    scoreMode,
+                                    XDocValuesRangeIterator.forOrdinalSet(values, skipper, termsEnum)
+                                )
+                                : new ConstantScoreScorer(
+                                    score(),
+                                    scoreMode,
+                                    XDocValuesRangeIterator.forOrdinalSet(singleton, skipper, termsEnum)
+                                );
+                        }
+
+                        @Override
+                        public long cost() {
+                            return values.cost();
+                        }
+                    };
+                }
+
+                @Override
+                public boolean isCacheable(LeafReaderContext ctx) {
+                    return DocValues.isCacheable(ctx, query.getField());
+                }
+            };
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -29,7 +29,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
-import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermInSetQuery;
@@ -62,6 +61,8 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.ScriptCompiler;
 
 import java.io.IOException;
@@ -99,7 +100,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         assertEquals(new TermQuery(new Term("field", "foo")), ft.termQuery("foo", MOCK_CONTEXT));
 
         MappedFieldType ft2 = new KeywordFieldType("field", false, true, Map.of());
-        assertEquals(SortedSetDocValuesField.newSlowExactQuery("field", new BytesRef("foo")), ft2.termQuery("foo", MOCK_CONTEXT));
+        assertEquals(SortedSetDocValuesRangeQuery.newSlowExactQuery("field", new BytesRef("foo")), ft2.termQuery("foo", MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new KeywordFieldType("field", false, false, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("bar", MOCK_CONTEXT));
@@ -310,7 +311,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
 
         MappedFieldType ft2 = new KeywordFieldType("field", false, true, Map.of());
         assertEquals(
-            SortedSetDocValuesField.newSlowRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
+            SortedSetDocValuesRangeQuery.newSlowRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
             ft2.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT)
         );
 
@@ -423,7 +424,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType ft = new KeywordFieldType("field", false, true, Map.of());
         Query q = ft.regexpQuery("foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, null, MOCK_CONTEXT);
         assertThat(q, instanceOf(RegexpQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
 
         // Binary DV → ScanningBinaryDocValuesRegexpQuery, which handles matchFlags via RegExp(pattern, syntaxFlags, matchFlags)
         MappedFieldType binaryFt = new KeywordFieldType("field", false, true, true, Map.of());

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 
 import java.util.List;
 
@@ -51,6 +52,8 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
         TermInSetQuery expected = new TermInSetQuery("_routing", List.of(new BytesRef("foo"), new BytesRef("bar")));
         TermInSetQuery actual = (TermInSetQuery) RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.termsQuery(List.of("foo", "bar"), MOCK_CONTEXT);
         assertEquals(expected, actual);
+        // newSlowSetQuery (SortedSetDocValuesSetQuery) is not affected by the docIDRunEnd() bug and
+        // still uses Lucene's own DOC_VALUES_REWRITE singleton.
         assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, actual.getRewriteMethod());
     }
 
@@ -138,7 +141,7 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testPrefixQueryDocValues() {
-        Query expected = new PrefixQuery(new Term("_routing", new BytesRef("foo")), MultiTermQuery.DOC_VALUES_REWRITE);
+        Query expected = new PrefixQuery(new Term("_routing", new BytesRef("foo")), XDocValuesRewriteMethod.DOC_VALUES_REWRITE);
         assertEquals(expected, RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.prefixQuery("foo", null, false, MOCK_CONTEXT));
 
         ElasticsearchException ee = expectThrows(
@@ -155,7 +158,7 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
         Query expected = new WildcardQuery(
             new Term("_routing", new BytesRef("foo*")),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
-            MultiTermQuery.DOC_VALUES_REWRITE
+            XDocValuesRewriteMethod.DOC_VALUES_REWRITE
         );
         assertEquals(expected, RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.wildcardQuery("foo*", null, false, MOCK_CONTEXT));
 
@@ -176,7 +179,7 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
             0,
             50,
             true,
-            MultiTermQuery.DOC_VALUES_REWRITE
+            XDocValuesRewriteMethod.DOC_VALUES_REWRITE
         );
         assertEquals(expected, RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.fuzzyQuery("foo", Fuzziness.ONE, 0, 50, true, MOCK_CONTEXT, null));
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlo
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.search.XDocValuesRewriteMethod;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
@@ -777,7 +778,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         TextFieldType ft = sortedSetDocValuesOnly();
         Query q = ft.prefixQuery("foo", null, false, MOCK_CONTEXT);
         assertThat(q, instanceOf(PrefixQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((PrefixQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((PrefixQuery) q).getRewriteMethod());
 
         // SortedSet DV, case-insensitive → StringScriptFieldPrefixQuery
         q = ft.prefixQuery("foo", null, true, MOCK_CONTEXT);
@@ -816,7 +817,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         TextFieldType ft = sortedSetDocValuesOnly();
         Query q = ft.wildcardQuery("foo*", null, false, MOCK_CONTEXT);
         assertThat(q, instanceOf(WildcardQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((WildcardQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((WildcardQuery) q).getRewriteMethod());
 
         // SortedSet DV, case-insensitive → StringScriptFieldWildcardQuery
         q = ft.wildcardQuery("foo*", null, true, MOCK_CONTEXT);
@@ -853,7 +854,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         TextFieldType ft = sortedSetDocValuesOnly();
         Query q = ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT);
         assertThat(q, instanceOf(RegexpQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
 
         // Binary DV → ScanningBinaryDocValuesRegexpQuery
         TextFieldType binaryFt = binaryDocValuesOnly();
@@ -884,7 +885,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         TextFieldType ft = sortedSetDocValuesOnly();
         Query q = ft.regexpQuery("foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, null, MOCK_CONTEXT);
         assertThat(q, instanceOf(RegexpQuery.class));
-        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
+        assertEquals(XDocValuesRewriteMethod.DOC_VALUES_REWRITE, ((RegexpQuery) q).getRewriteMethod());
 
         // Binary DV → ScanningBinaryDocValuesRegexpQuery with ASCII_CASE_INSENSITIVE matchFlag
         TextFieldType binaryFt = binaryDocValuesOnly();

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper.flattened;
 
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -34,6 +33,7 @@ import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.KeyedFlatte
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.queries.KeyedArrayOrderInlineNullTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xcontent.XContentType;
@@ -188,7 +188,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             false
         );
 
-        Query expected = SortedSetDocValuesField.newSlowExactQuery(ft.name(), new BytesRef("key\0value"));
+        Query expected = SortedSetDocValuesRangeQuery.newSlowExactQuery(ft.name(), new BytesRef("key\0value"));
         assertEquals(expected, ft.termQuery("value", null));
     }
 
@@ -267,7 +267,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         );
 
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        builder.add(SortedSetDocValuesField.newSlowExactQuery(ft.name(), new BytesRef("key\0value")), BooleanClause.Occur.SHOULD);
+        builder.add(SortedSetDocValuesRangeQuery.newSlowExactQuery(ft.name(), new BytesRef("key\0value")), BooleanClause.Occur.SHOULD);
         Query expected = new ConstantScoreQuery(builder.build());
         assertEquals(expected, ft.termsQuery(List.of("value"), null));
     }

--- a/server/src/test/java/org/elasticsearch/search/TsdbBoolMustNotReproductionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/TsdbBoolMustNotReproductionTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.search;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+
+/**
+ * Regression test for the false-positive bug in {@code bool{filter: term, must_not: term}} queries
+ * on TSDB indices ({@code elastic/elasticsearch#155653}).
+ *
+ * <p>Root cause: {@code DocValuesRangeIterator.docIDRunEnd()} over-reports run ends for
+ * {@code MAYBE} and {@code YES_IF_PRESENT} blocks, causing the bulk scorer to skip per-doc
+ * {@code matches()} calls and return false positives. The fix in {@code XDocValuesRangeIterator}
+ * returns {@code approximation().docID()} for those cases, limiting the run to the current doc.
+ */
+public class TsdbBoolMustNotReproductionTests extends ESSingleNodeTestCase {
+
+    /**
+     * Indexes 2048 docs into a single TSDB segment so that the mixed {@code dimension} block has
+     * {@code YES_IF_PRESENT} status. 2046 docs have {@code dimension=required, label=excluded},
+     * one has {@code dimension=required, label=included} (expected hit), and one has
+     * {@code dimension=other, label=included} (false positive without the fix).
+     */
+    public void testBoolMustNotFalsePositive() throws Exception {
+        final String index = "tsdb-bool-repro";
+
+        // LRUQueryCache masks the bug by returning cached results from a prior non-DV execution;
+        // disable it so every search exercises the DocValuesRangeIterator path directly.
+        createIndex(
+            index,
+            Settings.builder()
+                .put(IndexSettings.MODE.getKey(), "time_series")
+                .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dimension")
+                .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "2024-01-01T00:00:00Z")
+                .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "2025-01-01T00:00:00Z")
+                .put("index.queries.cache.enabled", false)
+                .build(),
+            "@timestamp",
+            "type=date",
+            "dimension",
+            "type=keyword,time_series_dimension=true",
+            "label",
+            "type=keyword,index=false"
+        );
+
+        final long baseTs = 1704067200000L; // 2024-01-01T00:00:00Z
+        for (int i = 0; i < 2046; i++) {
+            prepareIndex(index).setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("@timestamp", baseTs + i)
+                    .field("dimension", "required")
+                    .field("label", "excluded")
+                    .endObject()
+            ).get();
+        }
+        prepareIndex(index).setSource(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .field("@timestamp", baseTs + 2046)
+                .field("dimension", "required")
+                .field("label", "included")
+                .endObject()
+        ).get();
+        // This doc must not appear in results (filter: dimension=required does not match).
+        // Without the fix, docIDRunEnd() for the YES_IF_PRESENT mixed block returns the block end,
+        // so the bulk scorer skips matches() and collects this doc as a false positive.
+        prepareIndex(index).setSource(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .field("@timestamp", baseTs + 2047)
+                .field("dimension", "other")
+                .field("label", "included")
+                .endObject()
+        ).get();
+
+        client().admin().indices().prepareRefresh(index).get();
+
+        assertHitCount(
+            client().prepareSearch(index)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termQuery("dimension", "required"))
+                        .mustNot(QueryBuilders.termQuery("label", "excluded"))
+                ),
+            1L
+        );
+    }
+}

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.downsample;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.internal.hppc.IntArrayList;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -45,6 +44,7 @@ import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.lucene.queries.SortedSetDocValuesRangeQuery;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -253,7 +253,7 @@ class DownsampleShardIndexer {
 
     private Query createQuery() {
         if (this.state.started() && this.state.tsid() != null) {
-            return SortedSetDocValuesField.newSlowRangeQuery(TimeSeriesIdFieldMapper.NAME, this.state.tsid(), null, true, false);
+            return SortedSetDocValuesRangeQuery.newSlowRangeQuery(TimeSeriesIdFieldMapper.NAME, this.state.tsid(), null, true, false);
         }
         return Queries.ALL_DOCS_INSTANCE;
     }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.unsignedlong;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
@@ -53,6 +52,7 @@ import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.LongsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.SortedNumericDocValuesRangeQuery;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -392,7 +392,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
             Query query = LongPoint.newRangeQuery(name(), l, u);
             if (hasDocValues()) {
-                Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                Query dvQuery = SortedNumericDocValuesRangeQuery.newRangeQuery(name(), l, u);
                 query = new IndexOrDocValuesQuery(query, dvQuery);
                 if (context.indexSortedOnField(name())) {
                     query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix false-positive in boolean queries with must_not queries on not indexed fields (#155936)](https://github.com/elastic/elasticsearch/pull/155936)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)