### PR TITLE
[8.19] Fix cloud-ess docker build with docker-container buildx driver (#155985)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
@@ -25,6 +25,7 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -37,9 +38,13 @@ import org.gradle.workers.WorkerExecutor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -82,6 +87,8 @@ public abstract class DockerBuildTask extends DefaultTask {
             params.getBaseImages().set(Arrays.asList(baseImages));
             params.getBuildArgs().set(buildArgs);
             params.getPlatforms().set(getPlatforms());
+            params.getOciImageLayout().set(getOciImageLayout());
+            params.getBuildContexts().set(getBuildContexts());
         });
     }
 
@@ -143,6 +150,31 @@ public abstract class DockerBuildTask extends DefaultTask {
     @Input
     @Optional
     public abstract Property<Boolean> getPush();
+
+    /**
+     * Optional directory into which the built image is additionally exported as an OCI image
+     * layout. This makes the image consumable by other {@link DockerBuildTask}s via a named
+     * build context (see {@link #getBuildContexts()}), independently of the docker daemon's
+     * image store. This matters for buildx builders using the isolated docker-container
+     * driver, which cannot resolve locally-tagged daemon images in FROM instructions.
+     * Only used on the buildx (cross-platform) code path.
+     */
+    @OutputDirectory
+    @Optional
+    public abstract DirectoryProperty getOciImageLayout();
+
+    /**
+     * Named build contexts, passed to buildx as {@code --build-context name=value}. A context
+     * whose name matches an image reference in a FROM instruction overrides that reference,
+     * allowing a Dockerfile to build FROM a locally-built image that only exists as an OCI
+     * image layout on disk (value {@code oci-layout:///path/to/layout}) rather than in a
+     * registry or the docker daemon. Values using the {@code oci-layout://} scheme without an
+     * explicit digest are resolved to the layout's manifest digest at execution time.
+     * Only used on the buildx (cross-platform) code path.
+     */
+    @Input
+    @Optional
+    public abstract MapProperty<String, String> getBuildContexts();
 
     @OutputFile
     public RegularFileProperty getMarkerFile() {
@@ -216,6 +248,11 @@ public abstract class DockerBuildTask extends DefaultTask {
 
                 if (isCrossPlatform) {
                     spec.args("--platform", parameters.getPlatforms().get().stream().collect(Collectors.joining(",")));
+                    // Named build contexts are only supported by buildx; the non-buildx path resolves
+                    // locally-tagged base images against the daemon's image store, so it doesn't need them.
+                    parameters.getBuildContexts()
+                        .get()
+                        .forEach((name, value) -> spec.args("--build-context", name + "=" + resolveBuildContext(value)));
                 }
 
                 if (parameters.getNoCache().get()) {
@@ -229,16 +266,30 @@ public abstract class DockerBuildTask extends DefaultTask {
                 if (parameters.getPush().getOrElse(false)) {
                     spec.args("--push");
                 } else if (parameters.getPlatforms().get().size() == 1) {
-                    // Add --load to ensure the image ends up in the local Docker daemon as a
-                    // regular image, not a manifest list. This is required for any
-                    // single-platform build (including cross-platform builds for a single
-                    // foreign architecture, e.g. aarch64 on x86): with the docker-container
-                    // buildx driver the result otherwise remains only in the build cache and
-                    // the subsequent `docker inspect` for the image checksum fails with
-                    // "no such object". It also prevents issues with newer Docker versions
-                    // (23.0+) that may create manifest lists even for single-platform builds
-                    // when BuildKit is enabled.
-                    spec.args("--load");
+                    if (isCrossPlatform && parameters.getOciImageLayout().isPresent()) {
+                        // Load the image into the daemon (see the --load comment below) and additionally
+                        // export an OCI image layout to disk, so that derived images (e.g. cloud-ess,
+                        // which builds FROM the locally-tagged wolfi image) can resolve this image via a
+                        // named build context. This is required with the docker-container buildx driver,
+                        // whose isolated image store cannot see daemon images in FROM instructions.
+                        // Multiple --output flags require buildx >= 0.13.
+                        spec.args("--output", "type=docker");
+                        spec.args(
+                            "--output",
+                            "type=oci,tar=false,dest=" + parameters.getOciImageLayout().get().getAsFile().getAbsolutePath()
+                        );
+                    } else {
+                        // Add --load to ensure the image ends up in the local Docker daemon as a
+                        // regular image, not a manifest list. This is required for any
+                        // single-platform build (including cross-platform builds for a single
+                        // foreign architecture, e.g. aarch64 on x86): with the docker-container
+                        // buildx driver the result otherwise remains only in the build cache and
+                        // the subsequent `docker inspect` for the image checksum fails with
+                        // "no such object". It also prevents issues with newer Docker versions
+                        // (23.0+) that may create manifest lists even for single-platform builds
+                        // when BuildKit is enabled.
+                        spec.args("--load");
+                    }
                 }
             });
 
@@ -254,6 +305,32 @@ public abstract class DockerBuildTask extends DefaultTask {
                 Files.writeString(parameters.getMarkerFile().getAsFile().get().toPath(), checksum + "\n");
             } catch (IOException e) {
                 throw new RuntimeException("Failed to write marker file", e);
+            }
+        }
+
+        /**
+         * Resolves an {@code oci-layout://} build context value to a digest-qualified reference.
+         * Buildx resolves OCI layout contexts by tag or digest within the layout; the tag recorded
+         * in the layout's index is not always what buildx looks up by default, so pinning the
+         * manifest digest from {@code index.json} is the most robust way to reference the
+         * (single-image) layouts we export.
+         */
+        private static String resolveBuildContext(String value) {
+            String prefix = "oci-layout://";
+            if (value.startsWith(prefix) == false || value.contains("@")) {
+                return value;
+            }
+            Path indexJson = Path.of(value.substring(prefix.length()), "index.json");
+            try {
+                // The exported layouts contain a single manifest, so plucking the first digest is
+                // sufficient and avoids a JSON parser dependency in this worker action.
+                Matcher matcher = Pattern.compile("sha256:[a-f0-9]{64}").matcher(Files.readString(indexJson));
+                if (matcher.find() == false) {
+                    throw new GradleException("No manifest digest found in OCI image layout index [" + indexJson + "]");
+                }
+                return value + "@" + matcher.group();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read OCI image layout index [" + indexJson + "]", e);
             }
         }
 
@@ -295,5 +372,9 @@ public abstract class DockerBuildTask extends DefaultTask {
         SetProperty<String> getPlatforms();
 
         Property<Boolean> getPush();
+
+        DirectoryProperty getOciImageLayout();
+
+        MapProperty<String, String> getBuildContexts();
     }
 }

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -443,6 +443,14 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       )
       onlyIf("$architecture supported") { serviceProvider.get().isArchitectureSupported(architecture) }
 
+      if (base == DockerBase.WOLFI) {
+        // The cloud-ess image builds FROM the locally-tagged wolfi image. When the wolfi image is
+        // built via buildx (cross-platform, e.g. aarch64 on x86 CI agents), it must additionally be
+        // exported as an OCI image layout so that the cloud-ess build can resolve it via a named
+        // build context: the docker-container buildx driver's isolated image store cannot see
+        // locally-tagged daemon images in FROM instructions. Only used on the buildx code path.
+        ociImageLayout = layout.buildDirectory.dir("oci-image-layouts/elasticsearch${base.suffix}-${architecture.classifier}")
+      }
     }
 
   if (base != DockerBase.IRON_BANK && base != DockerBase.CLOUD_ESS) {
@@ -515,6 +523,14 @@ void addBuildCloudDockerImageTasks(Architecture architecture) {
       )
       onlyIf("$architecture supported") { serviceProvider.get().isArchitectureSupported(architecture) }
 
+      // Dockerfile.ess builds FROM elasticsearch-wolfi:<arch>, a tag that only exists locally.
+      // On the buildx (cross-platform) code path the isolated docker-container driver cannot
+      // resolve that tag against the daemon's image store, so resolve it via a named build
+      // context pointing at the OCI image layout exported by the wolfi image build instead.
+      buildContexts.put(
+        "elasticsearch${DockerBase.WOLFI.suffix}:${architecture.classifier}".toString(),
+        buildBaseTask.flatMap { it.ociImageLayout }.map { "oci-layout://${it.asFile.absolutePath}".toString() }
+      )
     }
 
   tasks.named("assemble").configure {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix cloud-ess docker build with docker-container buildx driver (#155985)](https://github.com/elastic/elasticsearch/pull/155985)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)