### PR TITLE
Fix missed relocateShard RecoveryPriority in tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -545,8 +545,24 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
                 clusterState = withRoutingAllocation(clusterState, alloc -> {
                     final var primary = soleStartedPrimaryShard(alloc, shardId);
                     final var startedReplica = soleStartedReplicaShard(alloc, shardId);
-                    alloc.routingNodes().relocateShard(primary, primaryTargetNode, 0, "test", alloc.changes());
-                    alloc.routingNodes().relocateShard(startedReplica, replicaTargetNode, 0, "test", alloc.changes());
+                    alloc.routingNodes()
+                        .relocateShard(
+                            primary,
+                            primaryTargetNode,
+                            0,
+                            "test",
+                            alloc.changes(),
+                            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+                        );
+                    alloc.routingNodes()
+                        .relocateShard(
+                            startedReplica,
+                            replicaTargetNode,
+                            0,
+                            "test",
+                            alloc.changes(),
+                            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+                        );
                 });
 
                 final var primaryTarget = primaryShard(clusterState, 0).getTargetRelocatingShard();
@@ -574,7 +590,15 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
                 final String replicaTargetNode = randomFrom(freeNodes);
                 clusterState = withRoutingAllocation(clusterState, alloc -> {
                     final var startedReplica = soleStartedReplicaShard(alloc, shardId);
-                    alloc.routingNodes().relocateShard(startedReplica, replicaTargetNode, 0, "test", alloc.changes());
+                    alloc.routingNodes()
+                        .relocateShard(
+                            startedReplica,
+                            replicaTargetNode,
+                            0,
+                            "test",
+                            alloc.changes(),
+                            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+                        );
                 });
 
                 final var relocationTarget = soleReplicaShard(clusterState, 0).getTargetRelocatingShard();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingNodesTests.java
@@ -537,8 +537,22 @@ public class RoutingNodesTests extends ESAllocationTestCase {
             .build();
 
         final var routingNodes = clusterState.getRoutingNodes().mutableCopy();
-        routingNodes.relocateShard(routingNodes.node("node-1").getByShardId(shardId), "node-3", 0L, "test", RoutingChangesObserver.NOOP);
-        routingNodes.relocateShard(routingNodes.node("node-2").getByShardId(shardId), "node-4", 0L, "test", RoutingChangesObserver.NOOP);
+        routingNodes.relocateShard(
+            routingNodes.node("node-1").getByShardId(shardId),
+            "node-3",
+            0L,
+            "test",
+            RoutingChangesObserver.NOOP,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
+        routingNodes.relocateShard(
+            routingNodes.node("node-2").getByShardId(shardId),
+            "node-4",
+            0L,
+            "test",
+            RoutingChangesObserver.NOOP,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
 
         final var primaryTarget = routingNodes.node("node-3").getByShardId(shardId);
         routingNodes.startShard(primaryTarget, RoutingChangesObserver.NOOP, primaryTarget.getExpectedShardSize());


### PR DESCRIPTION
#155002 added a `RecoveryPriority` parameter to
`RoutingNodes.relocateShard` and updated existing call sites, but #155837 merged shortly before and added new tests that still used the old five-argument signature. The squash merge of #155002 did not pick up those new call sites, breaking `:server:compileTestJava`.

Pass `RELOCATION_CAN_REMAIN_NO` in the remaining test call sites in `RoutingNodesTests` and `MaxRetryAllocationDeciderTests`.
