### PR TITLE
[9.4] [ML] Stash ML_ORIGIN for hasIlm GetIndex during daily maintenance (#148554)

### DIFF
--- a/docs/changelog/148554.yaml
+++ b/docs/changelog/148554.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 148554
+summary: Stash ML_ORIGIN for `hasIlm` `GetIndex` during daily maintenance
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Predicates;
@@ -444,17 +445,19 @@ public class MlDailyMaintenanceService implements Releasable {
         request.indices(indexName);
         request.includeDefaults(true); // Request index settings, mappings and aliases
 
-        GetIndexResponse response = client.admin().indices().getIndex(request).actionGet();
+        try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
+            GetIndexResponse response = client.admin().indices().getIndex(request).actionGet();
 
-        Settings settings = response.getSettings().get(indexName);
+            Settings settings = response.getSettings().get(indexName);
 
-        if (settings != null) {
-            String ilmPolicyName = settings.get("index.lifecycle.name");
-            // If the setting is present and not empty, ILM is in force
-            return ilmPolicyName != null && ilmPolicyName.isEmpty() == false;
+            if (settings != null) {
+                String ilmPolicyName = settings.get("index.lifecycle.name");
+                // If the setting is present and not empty, ILM is in force
+                return ilmPolicyName != null && ilmPolicyName.isEmpty() == false;
+            }
+
+            return false;
         }
-
-        return false;
     }
 
     private void triggerRollIndicesIfNecessaryTask(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceServiceTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -50,6 +51,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -309,6 +311,57 @@ public class MlDailyMaintenanceServiceTests extends ESTestCase {
             MlDailyMaintenanceService service = createService(indexName, testCase.hasIlmPolicy, testCase.isIlmEnabled);
             assertThat(testCase.description, service.hasIlm(indexName), equalTo(testCase.expected));
         }
+    }
+
+    /**
+     * Regression: {@link MlDailyMaintenanceService#hasIlm} must call {@code GetIndex} under
+     * {@link org.elasticsearch.xpack.core.ClientHelper#ML_ORIGIN}. Security authorizes internal ML actions via the origin on the
+     * thread context; without it the admin client runs as {@code _system} and {@code indices:admin/get} fails during nightly
+     * rollover checks.
+     */
+    public void testHasIlmInvokesGetIndexWithMlOriginInThreadContext() {
+        String indexName = randomAlphaOfLength(10);
+
+        AdminClient adminClient = mock(AdminClient.class);
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        @SuppressWarnings("unchecked")
+        ActionFuture<GetIndexResponse> actionFuture = mock(ActionFuture.class);
+
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+
+        Settings indexSettings = Settings.builder().put("index.lifecycle.name", "ml-policy").build();
+        GetIndexResponse getIndexResponse = new GetIndexResponse(
+            new String[] { indexName },
+            Map.of(),
+            Map.of(),
+            Map.of(indexName, indexSettings),
+            Map.of(),
+            Map.of()
+        );
+        when(actionFuture.actionGet()).thenReturn(getIndexResponse);
+
+        doAnswer(invocation -> {
+            assertThat(threadPool.getThreadContext().getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME), equalTo(ML_ORIGIN));
+            return actionFuture;
+        }).when(indicesAdminClient).getIndex(any());
+
+        MlDailyMaintenanceService service = new MlDailyMaintenanceService(
+            Settings.EMPTY,
+            threadPool,
+            client,
+            clusterService,
+            mlAssignmentNotifier,
+            () -> TimeValue.timeValueDays(1),
+            TestIndexNameExpressionResolver.newInstance(),
+            true,
+            true,
+            true,
+            true
+        );
+
+        assertThat(service.hasIlm(indexName), equalTo(true));
+        verify(indicesAdminClient).getIndex(any());
     }
 
     private MlDailyMaintenanceService createService(String indexName, boolean hasIlmPolicy, boolean isIlmEnabled) {


### PR DESCRIPTION
Backport of #148554 to `9.4`.

## Why
#148554 fixed the ML daily-maintenance `hasIlm` check calling `GetIndex` (`indices:admin/get`) without stamping `ML_ORIGIN` on the thread context, which under Security surfaces as `ElasticsearchSecurityException` for `_system`. It was labelled `v9.4.1` and `v9.3.5` but the backports never actually landed — the commit is present only in `v9.5.0`. Every `9.4.x` release through 9.4.4 still has the unstashed `getIndex` in `hasIlm`.

This resurfaced recently: a fresh 9.4.2 install logs the `indices:admin/get` unauthorized error daily during the `roll-results-indices` / `roll-state-indices` maintenance tasks (stack trace: `MlDailyMaintenanceService.hasIlm -> IndicesAdminClient.getIndex`). Impact is limited (maintenance continues; ML results/state indices don't get size-based rollover; noisy WARN), but it should be fixed on the 9.4 line.

## Changes
- Cherry-pick of `8718b67` (`MlDailyMaintenanceService#hasIlm` runs `getIndex` under `ML_ORIGIN`).
- Regression test adapted to the 9.4 `MlDailyMaintenanceService` constructor (no `auditor` parameter on this branch).

Original PR: #148554 — original issue: #9936.

Made with [Cursor](https://cursor.com)