### PR TITLE
Add debug logging for timestsamp backfill

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
@@ -147,7 +147,7 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
             return clearOrphans ? SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP : null;
         });
         logger.debug(
-            "{} backfilled [{}] timestamp (clearOrphans=[]) in [{}]",
+            "{} backfilled [{}] timestamps (clearOrphans=[]) in [{}]",
             shardId,
             timestampByCacheKey.size(),
             clearOrphans,

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
@@ -146,13 +146,15 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
             }
             return clearOrphans ? SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP : null;
         });
-        logger.debug(
-            "{} backfilled [{}] timestamps (clearOrphans=[]) in [{}]",
-            shardId,
-            timestampByCacheKey.size(),
-            clearOrphans,
-            TimeValue.timeValueNanos(System.nanoTime() - startTime)
-        );
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                "{} backfilled [{}] timestamps (clearOrphans=[{}]) in [{}]",
+                shardId,
+                timestampByCacheKey.size(),
+                clearOrphans,
+                TimeValue.timeValueNanos(System.nanoTime() - startTime)
+            );
+        }
     }
 
     /**

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectory.java
@@ -22,6 +22,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 import org.elasticsearch.logging.LogManager;
@@ -132,6 +133,7 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
         if (clearOrphans == false && timestampByCacheKey.isEmpty()) {
             return;
         }
+        final long startTime = System.nanoTime();
         cacheService.backfillRegionTimestamps(shardId, key -> {
             assert key.shardId().equals(shardId) : key.shardId() + " != " + shardId;
             Long timestampMillis = timestampByCacheKey.get(key);
@@ -144,6 +146,13 @@ public class SearchDirectory extends BlobStoreCacheDirectory {
             }
             return clearOrphans ? SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP : null;
         });
+        logger.debug(
+            "{} backfilled [{}] timestamp (clearOrphans=[]) in [{}]",
+            shardId,
+            timestampByCacheKey.size(),
+            clearOrphans,
+            TimeValue.timeValueNanos(System.nanoTime() - startTime)
+        );
     }
 
     /**

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stateless.lucene;
 
+import org.apache.logging.log4j.Level;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -35,6 +36,8 @@ import org.elasticsearch.index.store.ThreadLocalDirectoryMetricHolder;
 import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.stateless.TestUtils;
 import org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherDynamicSettings;
@@ -77,6 +80,7 @@ import static org.elasticsearch.blobcache.BlobCacheUtils.toIntBytes;
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.BACKFILL_IN_PROGRESS_TIMESTAMP;
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.MINIMAL_CACHE_TIMESTAMP;
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.UNKNOWN_TIMESTAMP;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.elasticsearch.xpack.stateless.commits.BlobLocationTestUtils.createBlobLocation;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -792,6 +796,7 @@ public class SearchDirectoryTests extends ESTestCase {
      * Recovery-time backfill with {@code clearOrphans=true} must re-stamp orphaned BACKFILL_IN_PROGRESS_TIMESTAMP
      * regions to MINIMAL_CACHE_TIMESTAMP while resolving re-read blobs to their real timestamps.
      */
+    @TestLogging(reason = "testing backfill logging", value = "org.elasticsearch.xpack.stateless.lucene.SearchDirectory:DEBUG")
     public void testRecoveryBackfillClearsOrphanedBackfillInProgressRegions() throws IOException {
         var regionSize = ByteSizeValue.ofBytes(4096);
         var cacheSize = ByteSizeValue.ofBytes(regionSize.getBytes() * 100L);
@@ -866,7 +871,16 @@ public class SearchDirectoryTests extends ESTestCase {
             // A subsequent recovery on the same node re-reads only the latest BCC blob and backfills it with its real timestamp, clearing
             // any orphaned sentinel regions left behind by earlier (unfinished) reads.
             final long reReadTimestamp = randomLongBetween(1L, 1_000_000L);
-            searchDirectory.backfillMetadataReadTimestamps(Map.of(reReadKey, reReadTimestamp), true);
+            assertThatLogger(
+                () -> searchDirectory.backfillMetadataReadTimestamps(Map.of(reReadKey, reReadTimestamp), true),
+                SearchDirectory.class,
+                new MockLog.SeenEventExpectation(
+                    "backfilling log",
+                    SearchDirectory.class.getCanonicalName(),
+                    Level.DEBUG,
+                    node.shardId + " backfilled [1] timestamps (clearOrphans=[true]) in [*s]"
+                )
+            );
 
             assertThat(
                 "the re-read blob's region is resolved to its real timestamp",


### PR DESCRIPTION
We could enable the logging in a few selective projects to get an understanding on how long the backfill takes.

Relates #155517
