### PR TITLE
[9.5][ES|QL] Log lookup-join missing-index failures at DEBUG instead of ERROR (#155804)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeBase.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeBase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
@@ -37,21 +38,30 @@ public abstract class BidirectionalBatchExchangeBase implements Releasable {
     protected final Settings settings;
 
     /**
-     * Logs an exchange failure at {@code nonCancellationLevel}, unless it is a cancellation. Cancellations are
-     * expected teardown (for example the query reached its LIMIT and the exchange was closed early via a
-     * synthesized "client stopped" error, or the task was cancelled), so they are logged at DEBUG to keep
-     * genuine failures visible. Shared by the client, the server, and the operator driving them, so the caller
-     * supplies its own logger.
+     * Logs an exchange failure at {@code nonCancellationLevel}, unless it is one of the expected, transient
+     * conditions that are downgraded to DEBUG to keep genuine failures visible:
+     * <ul>
+     *     <li>Cancellations - expected teardown (for example the query reached its LIMIT and the exchange was
+     *     closed early via a synthesized "client stopped" error, or the task was cancelled).</li>
+     *     <li>{@link IndexNotFoundException} - the lookup target index was not available on the routed node, for
+     *     example during a rolling restart, or before the index has recovered/propagated. This is a transient,
+     *     self-healing condition and the failure is still propagated to the coordinator, so logging it at a higher
+     *     level only produces spurious noise (and, in Serverless, trips promotion quality-gate log-error-rate
+     *     checks during routine node churn).</li>
+     * </ul>
+     * Shared by the client, the server, and the operator driving them, so the caller supplies its own logger.
      *
      * @param logger               the logger to log to (the caller's own logger)
-     * @param nonCancellationLevel the level to log at when the failure is not a cancellation
-     * @param failure              the failure that decides the log level (cancellations are logged at DEBUG)
+     * @param nonCancellationLevel the level to log at when the failure is not a cancellation or a missing index
+     * @param failure              the failure that decides the log level (cancellations and missing index at DEBUG)
      * @param message              a parameterized log message template
      * @param params               the parameters for the message template; a trailing {@link Throwable} is logged with its stack trace
      */
     @SuppressLoggerChecks(reason = "safely delegates to logger with a caller-supplied message and params")
     public static void logExchangeFailure(Logger logger, Level nonCancellationLevel, Exception failure, String message, Object... params) {
-        if (failure != null && ExceptionsHelper.isTaskCancelledException(failure)) {
+        if (failure != null
+            && (ExceptionsHelper.isTaskCancelledException(failure)
+                || ExceptionsHelper.unwrap(failure, IndexNotFoundException.class) != null)) {
             logger.debug(message, params);
         } else {
             logger.log(nonCancellationLevel, message, params);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/BidirectionalBatchExchangeTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.tasks.TaskCancelledException;
@@ -395,6 +396,31 @@ public class BidirectionalBatchExchangeTests extends ESTestCase {
         )) {
             assertExchangeFailureLoggedAt(Level.ERROR, failure);
             assertExchangeFailureLoggedAt(Level.WARN, failure);
+        }
+    }
+
+    /**
+     * A lookup-join whose target index is transiently unavailable on the routed node (for example during a
+     * rolling restart, or before the index has recovered/propagated) fails with {@link IndexNotFoundException},
+     * including when wrapped by transport ({@link RemoteTransportException}), which is the shape that reaches
+     * the setup/status callbacks. The failure is still propagated to the coordinator, so these are downgraded to
+     * DEBUG (not ERROR or WARN) regardless of the non-cancellation level the caller asked for, to avoid spurious
+     * noise and Serverless promotion quality-gate log-error-rate trips.
+     */
+    public void testIndexNotFoundIsLoggedAtDebugNotError() {
+        for (Exception failure : List.of(
+            new IndexNotFoundException(".entities.v2.latest.security_default-00001"),
+            new RemoteTransportException("node", new IndexNotFoundException(".entities.v2.latest.security_default-00001"))
+        )) {
+            Logger clientLogger = LogManager.getLogger(BidirectionalBatchExchangeClient.class);
+            String loggerName = BidirectionalBatchExchangeClient.class.getCanonicalName();
+            MockLog.assertThatLogger(
+                () -> BidirectionalBatchExchangeBase.logExchangeFailure(clientLogger, Level.ERROR, failure, "failure: {}", "msg"),
+                BidirectionalBatchExchangeClient.class,
+                new MockLog.SeenEventExpectation("logged at DEBUG", loggerName, Level.DEBUG, "failure: msg"),
+                new MockLog.UnseenEventExpectation("not logged at ERROR", loggerName, Level.ERROR, "*"),
+                new MockLog.UnseenEventExpectation("not logged at WARN", loggerName, Level.WARN, "*")
+            );
         }
     }
 


### PR DESCRIPTION
Manual backport of #155804 to `9.5`.

The auto-backport failed because the merged commit's diff is entangled with the circuit-breaker logging refactor (#155375), which lives on `main` but not on `9.5`. This PR contains only the change from #155804, resolved to the form appropriate for `9.5` (the pre-refactor single-method `logExchangeFailure`): `IndexNotFoundException` (matched anywhere in the cause chain) is downgraded to DEBUG alongside the existing cancellation downgrade. No circuit-breaker code is introduced here.

## Test plan
- `:x-pack:plugin:esql:compute:compileJava/compileTestJava/spotlessJavaCheck` — green.
- `:x-pack:plugin:esql:compute:test --tests "*BidirectionalBatchExchangeTests"` — green (includes `testIndexNotFoundIsLoggedAtDebugNotError`).

Made with [Cursor](https://cursor.com)