### PR TITLE
[DOCS] Use consistent codec casing in data federation docs summary table

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/data-federation/supported-file-formats.md
+++ b/docs/reference/query-languages/esql/_snippets/data-federation/supported-file-formats.md
@@ -1,5 +1,5 @@
 | Format | Schema source | Compression |
 |---|---|---|
-| Parquet | Read from file headers | Internal per column chunk: UNCOMPRESSED, SNAPPY, ZSTD, GZIP |
+| Parquet | Read from file headers | Internal per column chunk: uncompressed, snappy, zstd, gzip |
 | NDJSON | Inferred by sampling rows | gzip, zstd |
 | CSV and TSV | Inferred by sampling rows | gzip, zstd |


### PR DESCRIPTION
## Summary

- use lowercase, human-readable codec names consistently in the ES|QL Data Federation file-format summary
- retain the exact uppercase Parquet enum values in the detailed Parquet section

## Validation

- `git diff --check`
- `vale --output=line docs/reference/query-languages/esql/esql-data-federation-datasets.md docs/reference/query-languages/esql/_snippets/data-federation/supported-file-formats.md` (one unrelated pre-existing warning for `Disable`)