### PR TITLE
[9.4] Limit number_of_fragments in highlighting - update hard cap

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/highlighting-settings.md
+++ b/docs/reference/elasticsearch/rest-apis/highlighting-settings.md
@@ -106,7 +106,7 @@ For the `fvh` highlighter:
     $$$number_of_fragments$$$
 
     number_of_fragments {applies_to}`stack: ga 9.3+`
-    :   The maximum number of fragments to return. If the number of fragments is set to 0, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is 0, `fragment_size` is ignored. Defaults to 5. Cannot exceed 100000.
+    :   The maximum number of fragments to return. If the number of fragments is set to 0, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is 0, `fragment_size` is ignored. Defaults to 5. Cannot exceed 10000.
 
     order
     :   Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores. See the document [How highlighters work internally](how-es-highlighters-work-internally.md) for more details how different highlighters find the best fragments.

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/70_number_of_fragments.yml
@@ -37,11 +37,11 @@ setup:
       search:
           rest_total_hits_as_int: true
           index: test1
-          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 100001, "fields" : {"field1" : {}}}}
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10001, "fields" : {"field1" : {}}}}
   - match: { status: 400 }
   - match: { error.root_cause.0.type: "x_content_parse_exception" }
   - match: { error.caused_by.type: "illegal_argument_exception" }
-  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [100000]" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }
 
 ---
 "number_of_fragments at the maximum should SUCCEED":
@@ -50,7 +50,7 @@ setup:
       search:
           rest_total_hits_as_int: true
           index: test1
-          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 100000, "fields" : {"field1" : {}}}}
+          body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "number_of_fragments" : 10000, "fields" : {"field1" : {}}}}
   - match: { hits.hits.0.highlight.field1.0: "The quick brown <em>fox</em>" }
 
 ---
@@ -65,4 +65,4 @@ setup:
   - match: { status: 400 }
   - match: { error.root_cause.0.type: "x_content_parse_exception" }
   - match: { error.caused_by.type: "illegal_argument_exception" }
-  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [100000]" }
+  - match: { error.caused_by.reason: "[number_of_fragments] must be between [0] and [10000]" }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -62,7 +62,7 @@ public final class HighlightBuilder extends AbstractHighlighterBuilder<Highlight
     /** the default number of fragments for highlighting */
     public static final int DEFAULT_NUMBER_OF_FRAGMENTS = 5;
     /** the maximum accepted number of fragments for highlighting */
-    public static final int MAX_NUMBER_OF_FRAGMENTS = 100_000;
+    public static final int MAX_NUMBER_OF_FRAGMENTS = 10_000;
     /** the default number of fragments size in characters */
     public static final int DEFAULT_FRAGMENT_CHAR_SIZE = 100;
     /** the default opening tag  */


### PR DESCRIPTION
Backports the following commits to 9.4:

 - Limit number_of_fragments in highlighting to prevent OOM crash (#155507)