### PR TITLE
Simplify columnar randomization in rolling upgrade tests

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -80,8 +80,11 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
     private static final ExternalResource columnarRandomizer = new ExternalResource() {
         @Override
         protected void before() {
-            Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
-            columnarEnabled = randomizeColumnarIndexMode && oldVersion.onOrAfter(Version.fromString("9.5.0")) && randomBoolean();
+            String oldVersionProp = System.getProperty("tests.old_cluster_version");
+            columnarEnabled = randomizeColumnarIndexMode
+                && oldVersionProp != null
+                && Version.fromString(oldVersionProp).onOrAfter(Version.fromString("9.5.0"))
+                && randomBoolean();
         }
 
         @Override

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -80,7 +80,10 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
     private static final ExternalResource columnarRandomizer = new ExternalResource() {
         @Override
         protected void before() {
-            columnarEnabled = randomizeColumnarIndexMode && randomBoolean();
+            Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
+            columnarEnabled = randomizeColumnarIndexMode
+                && oldVersion.onOrAfter(Version.fromString("9.5.0"))
+                && randomBoolean();
         }
 
         @Override

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -81,9 +81,7 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
         @Override
         protected void before() {
             Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
-            columnarEnabled = randomizeColumnarIndexMode
-                && oldVersion.onOrAfter(Version.fromString("9.5.0"))
-                && randomBoolean();
+            columnarEnabled = randomizeColumnarIndexMode && oldVersion.onOrAfter(Version.fromString("9.5.0")) && randomBoolean();
         }
 
         @Override

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -33,8 +33,8 @@ public class Clusters {
      */
     public static ElasticsearchCluster oldVersionCluster(String user, String pass, Supplier<Boolean> columnar) {
         var cluster = clusterBuilder(user, pass);
-        Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
-        if (oldVersion.onOrAfter(Version.fromString("9.5.0"))) {
+        String oldVersionProp = System.getProperty("tests.old_cluster_version");
+        if (oldVersionProp != null && Version.fromString(oldVersionProp).onOrAfter(Version.fromString("9.5.0"))) {
             cluster.setting("cluster.logsdb_columnar.enabled", () -> Boolean.toString(columnar.get()));
         }
         return cluster.build();

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -26,14 +26,20 @@ public class Clusters {
      * Creates an old-version cluster whose {@code logsdb_columnar} index mode is controlled by
      * the {@code columnar} supplier. The supplier is evaluated lazily when the cluster starts, so
      * callers can resolve the value (e.g. via {@code randomBoolean()}) after this method returns.
-     * The setting is only applied when the old cluster version supports it
-     * (≥ 9.5.0); when the version predates that the supplier is never called.
+     * <p>
+     * Callers must ensure the supplier never returns {@code true} for old cluster versions that
+     * predate {@code logsdb_columnar} support (≥ 9.5.0); passing {@code true} for an unsupported
+     * version will trigger an assertion
      */
     public static ElasticsearchCluster oldVersionCluster(String user, String pass, Supplier<Boolean> columnar) {
         var cluster = clusterBuilder(user, pass);
-        if (supportsColumnar(Version.fromString(System.getProperty("tests.old_cluster_version")))) {
-            cluster.setting("cluster.logsdb_columnar.enabled", () -> Boolean.toString(columnar.get()));
-        }
+        Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
+        cluster.setting("cluster.logsdb_columnar.enabled", () -> {
+            boolean use_columnar = columnar.get();
+            assert use_columnar == false || oldVersion.onOrAfter(Version.fromString("9.5.0"))
+                : "columnar=true for old cluster " + oldVersion + " which does not support logsdb_columnar (requires >= 9.5.0)";
+            return Boolean.toString(use_columnar);
+        });
         return cluster.build();
     }
 
@@ -84,10 +90,6 @@ public class Clusters {
         }
 
         return cluster;
-    }
-
-    private static boolean supportsColumnar(Version version) {
-        return version.onOrAfter(Version.fromString("9.5.0"));
     }
 
     private static boolean supportRetryOnShardFailures(Version version) {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -27,19 +27,16 @@ public class Clusters {
      * the {@code columnar} supplier. The supplier is evaluated lazily when the cluster starts, so
      * callers can resolve the value (e.g. via {@code randomBoolean()}) after this method returns.
      * <p>
-     * Callers must ensure the supplier never returns {@code true} for old cluster versions that
-     * predate {@code logsdb_columnar} support (≥ 9.5.0); passing {@code true} for an unsupported
-     * version will trigger an assertion
+     * The {@code logsdb_columnar} setting is only applied when the old cluster version already
+     * supports it (≥ 9.5.0). For older versions the supplier is ignored and the setting is not
+     * applied.
      */
     public static ElasticsearchCluster oldVersionCluster(String user, String pass, Supplier<Boolean> columnar) {
         var cluster = clusterBuilder(user, pass);
         Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
-        cluster.setting("cluster.logsdb_columnar.enabled", () -> {
-            boolean use_columnar = columnar.get();
-            assert use_columnar == false || oldVersion.onOrAfter(Version.fromString("9.5.0"))
-                : "columnar=true for old cluster " + oldVersion + " which does not support logsdb_columnar (requires >= 9.5.0)";
-            return Boolean.toString(use_columnar);
-        });
+        if (oldVersion.onOrAfter(Version.fromString("9.5.0"))) {
+            cluster.setting("cluster.logsdb_columnar.enabled", () -> Boolean.toString(columnar.get()));
+        }
         return cluster.build();
     }
 


### PR DESCRIPTION
We were splitting the handling of randomization across test rules and cluster launching, which meant that tests could believe that columnar mode had been enabled when it was in fact disabled due to the older cluster not being able to support it.  This moves the version checking directly into the test rule.