### PR TITLE
Add ThreadLeakFilter to telemetry tests as well as logging

### DIFF
--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractTelemetryIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractTelemetryIT.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.test.apmintegration;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -25,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
+@ThreadLeakFilters(filters = { GrpcThreadsFilter.class })
 public abstract class AbstractTelemetryIT extends ESRestTestCase {
     private static final Logger logger = LogManager.getLogger(AbstractTelemetryIT.class);
 

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/GrpcThreadsFilter.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/GrpcThreadsFilter.java
@@ -22,6 +22,8 @@ public class GrpcThreadsFilter implements ThreadFilter {
     @Override
     public boolean reject(Thread t) {
         String name = t.getName();
-        return name.startsWith("grpc-default-executor-") || name.startsWith("grpc-shared-destroyer-");
+        return name.startsWith("grpc-default-executor-")
+            || name.startsWith("grpc-shared-destroyer-")
+            || name.startsWith("grpc-nio-");
     }
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/GrpcThreadsFilter.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/GrpcThreadsFilter.java
@@ -22,8 +22,6 @@ public class GrpcThreadsFilter implements ThreadFilter {
     @Override
     public boolean reject(Thread t) {
         String name = t.getName();
-        return name.startsWith("grpc-default-executor-")
-            || name.startsWith("grpc-shared-destroyer-")
-            || name.startsWith("grpc-nio-");
+        return name.startsWith("grpc-default-executor-") || name.startsWith("grpc-shared-destroyer-") || name.startsWith("grpc-nio-");
     }
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelLoggingIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelLoggingIT.java
@@ -11,8 +11,6 @@ package org.elasticsearch.test.apmintegration;
 
 import io.opentelemetry.proto.common.v1.ArrayValue;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
-
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.common.logging.activity.QueryLogging;
@@ -44,7 +42,6 @@ import static org.hamcrest.Matchers.equalTo;
  * programmatically by {@code OtelSdkExportLogsSupplier}) → {@code SdkLoggerProvider} →
  * {@code OtlpGrpcLogRecordExporter} → gRPC recording server.
  */
-@ThreadLeakFilters(filters = { GrpcThreadsFilter.class })
 public class OtelLoggingIT extends AbstractTelemetryIT {
 
     private static final Logger logger = LogManager.getLogger(OtelLoggingIT.class);


### PR DESCRIPTION
`GrpcThreadsFilter` already existed but was only applied to `OtelLoggingIT`. tes (without the filter) could fail—especially under CI load.
This PR applies `GrpcThreadsFilter` on `AbstractTelemetryIT` so every APM integration IT ignores these known leftovers, and also ignore `grpc-nio-*` event-loop threads from the same server transport.


Closes: #155668