### PR TITLE
[9.5] Charge fuzzy queries for their term expansions in the request breaker (#155485)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyQueryCostEstimatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyQueryCostEstimatorBenchmark.java
@@ -9,8 +9,28 @@
 
 package org.elasticsearch.benchmark.search.fuzzy;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermStates;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOSupplier;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.lucene.search.cost.FuzzyQueryCostEstimator;
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -24,11 +44,18 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Fork(1)
@@ -39,6 +66,18 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @SuppressWarnings("unused") // invoked by JMH
 public class FuzzyQueryCostEstimatorBenchmark {
+
+    static {
+        LogConfigurator.setNodeName("benchmark");
+    }
+
+    static final String FIELD = "f";
+
+    /** ASCII letters/digits used to synthesise within-edit-distance neighbours of the query term. */
+    private static final String REPLACEMENT_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /** Upper bound on the seeded vocabulary size; comfortably above the largest {@code maxExpansions}. */
+    private static final int MAX_VOCABULARY = 1024;
 
     public enum Alphabet {
         SINGLE_CHAR {
@@ -75,6 +114,14 @@ public class FuzzyQueryCostEstimatorBenchmark {
         abstract String generate(int n, Random r);
     }
 
+    public enum TermFanout {
+        ALL,
+        SPARSE
+    }
+
+    /** Number of segments a term is written into under {@link TermFanout#SPARSE}, capped at {@link #segments}. */
+    private static final int SPARSE_SEGMENTS_PER_TERM = 2;
+
     @Param({ "5", "20", "50", "200", "1024" })
     public int termLength;
 
@@ -90,23 +137,44 @@ public class FuzzyQueryCostEstimatorBenchmark {
     @Param({ "SINGLE_CHAR", "ASCII_LETTERS", "UNICODE_BMP" })
     public Alphabet alphabet;
 
+    @Param({ "10", "50", "200" })
+    public int maxExpansions;
+
+    @Param({ "1", "4", "16", "64", "128" })
+    public int segments;
+
+    @Param({ "ALL", "SPARSE" })
+    public TermFanout termFanout;
+
     private String term;
     private int termByteLength;
     private int distinctUtf8Bytes;
+
+    private Directory directory;
+    private DirectoryReader reader;
+    private IndexSearcher searcher;
+    private FuzzyQuery fuzzyQuery;
+
     private long precomputedEstimate;
+    private long precomputedAutomaton;
+    private long precomputedRewrite;
     private long precomputedMeasured;
+    private int precomputedExpandedTerms;
     private double precomputedRatio;
 
     @AuxCounters(AuxCounters.Type.EVENTS)
     @State(Scope.Thread)
     public static class Metrics {
         public double estimatedBytes;
+        public double automatonBytes;
+        public double rewriteBytes;
         public double measuredBytes;
+        public double expandedTerms;
         public double estimateOverMeasuredRatio;
     }
 
     @Setup(Level.Trial)
-    public void setupTrial() {
+    public void setupTrial() throws IOException {
         if (prefixLength > termLength) {
             term = null;
             return;
@@ -116,9 +184,64 @@ public class FuzzyQueryCostEstimatorBenchmark {
         byte[] utf8 = term.getBytes(StandardCharsets.UTF_8);
         termByteLength = utf8.length;
         distinctUtf8Bytes = countDistinctUtf8Bytes(utf8);
-        precomputedEstimate = new FuzzyQueryCostEstimator(termByteLength, distinctUtf8Bytes, maxEdits, prefixLength).estimate();
-        precomputedMeasured = sumRamBytes(term, maxEdits, prefixLength, transpositions);
+
+        directory = new ByteBuffersDirectory();
+        List<String> vocabulary = new ArrayList<>(buildVocabulary(term, prefixLength));
+        if (vocabulary.isEmpty()) {
+            throw new IllegalStateException("empty vocabulary for term length " + termLength + " / prefix " + prefixLength);
+        }
+
+        int segmentsPerTerm = termFanout == TermFanout.ALL ? segments : SPARSE_SEGMENTS_PER_TERM;
+        List<Set<String>> vocabularyBySegment = assignVocabularyToSegments(vocabulary, segments, segmentsPerTerm);
+
+        IndexWriterConfig writerConfig = new IndexWriterConfig(null).setMergePolicy(NoMergePolicy.INSTANCE).setUseCompoundFile(false);
+        try (IndexWriter writer = new IndexWriter(directory, writerConfig)) {
+            for (int s = 0; s < segments; s++) {
+                for (String neighbour : vocabularyBySegment.get(s)) {
+                    Document doc = new Document();
+                    doc.add(new StringField(FIELD, neighbour, Field.Store.NO));
+                    writer.addDocument(doc);
+                }
+                writer.flush();
+            }
+            writer.commit();
+        }
+        reader = DirectoryReader.open(directory);
+        if (reader.leaves().size() != segments) {
+            throw new IllegalStateException(
+                "expected index with " + segments + " segments but reader has " + reader.leaves().size() + " leaves"
+            );
+        }
+        searcher = new IndexSearcher(reader);
+
+        fuzzyQuery = new FuzzyQuery(new Term(FIELD, term), maxEdits, prefixLength, maxExpansions, transpositions);
+
+        precomputedEstimate = new FuzzyQueryCostEstimator(
+            termByteLength,
+            distinctUtf8Bytes,
+            maxEdits,
+            prefixLength,
+            maxExpansions,
+            segments
+        ).estimate();
+        precomputedAutomaton = sumRamBytes(term, maxEdits, prefixLength, transpositions);
+        Set<Term> expanded = collectExpandedTerms(searcher, fuzzyQuery);
+        precomputedExpandedTerms = expanded.size();
+        precomputedRewrite = measureRewriteRam(searcher, fuzzyQuery, expanded);
+        precomputedMeasured = precomputedAutomaton + precomputedRewrite;
         precomputedRatio = precomputedMeasured == 0 ? 0.0 : (double) precomputedEstimate / (double) precomputedMeasured;
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownTrial() throws IOException {
+        if (reader != null) {
+            reader.close();
+            reader = null;
+        }
+        if (directory != null) {
+            directory.close();
+            directory = null;
+        }
     }
 
     @Benchmark
@@ -127,11 +250,11 @@ public class FuzzyQueryCostEstimatorBenchmark {
             return 0L;
         }
         publish(metrics);
-        return new FuzzyQueryCostEstimator(termByteLength, distinctUtf8Bytes, maxEdits, prefixLength).estimate();
+        return new FuzzyQueryCostEstimator(termByteLength, distinctUtf8Bytes, maxEdits, prefixLength, maxExpansions, segments).estimate();
     }
 
     @Benchmark
-    public long measureBuild(Metrics metrics) {
+    public long measureAutomaton(Metrics metrics) {
         if (term == null) {
             return 0L;
         }
@@ -139,9 +262,21 @@ public class FuzzyQueryCostEstimatorBenchmark {
         return sumRamBytes(term, maxEdits, prefixLength, transpositions);
     }
 
+    @Benchmark
+    public long measureRewrite(Metrics metrics) throws IOException {
+        if (term == null) {
+            return 0L;
+        }
+        publish(metrics);
+        return measureRewriteRam(searcher, fuzzyQuery, collectExpandedTerms(searcher, fuzzyQuery));
+    }
+
     private void publish(Metrics metrics) {
         metrics.estimatedBytes = precomputedEstimate;
+        metrics.automatonBytes = precomputedAutomaton;
+        metrics.rewriteBytes = precomputedRewrite;
         metrics.measuredBytes = precomputedMeasured;
+        metrics.expandedTerms = precomputedExpandedTerms;
         metrics.estimateOverMeasuredRatio = precomputedRatio;
     }
 
@@ -152,6 +287,96 @@ public class FuzzyQueryCostEstimatorBenchmark {
             sum += ca.ramBytesUsed();
         }
         return sum;
+    }
+
+    private static Set<Term> collectExpandedTerms(IndexSearcher searcher, FuzzyQuery query) throws IOException {
+        Query rewritten = searcher.rewrite(query);
+        Set<Term> terms = new LinkedHashSet<>();
+        rewritten.visit(new QueryVisitor() {
+            @Override
+            public void consumeTerms(Query q, Term... ts) {
+                Collections.addAll(terms, ts);
+            }
+
+            @Override
+            public boolean acceptField(String field) {
+                return true;
+            }
+
+            @Override
+            public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
+                return this;
+            }
+        });
+        return terms;
+    }
+
+    private static long measureRewriteRam(IndexSearcher searcher, FuzzyQuery query, Set<Term> expanded) throws IOException {
+        long total = RamUsageEstimator.sizeOf(searcher.rewrite(query));
+        for (Term term : expanded) {
+            total += measureTermStatesRam(searcher, term);
+        }
+        return total;
+    }
+
+    private static long measureTermStatesRam(IndexSearcher searcher, Term term) throws IOException {
+        List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+        TermStates termStates = TermStates.build(searcher, term, true);
+        long total = RamUsageEstimator.shallowSizeOf(termStates) + RamUsageEstimator.shallowSizeOf(new TermState[leaves.size()]);
+        for (LeafReaderContext ctx : leaves) {
+            IOSupplier<TermState> supplier = termStates.get(ctx);
+            if (supplier == null) {
+                // Cheap negative check: the term is absent from this leaf, so no TermState is retained for it.
+                continue;
+            }
+            TermState state = supplier.get();
+            if (state != null) {
+                total += RamUsageEstimator.shallowSizeOf(state);
+            }
+        }
+        return total;
+    }
+
+    private static List<Set<String>> assignVocabularyToSegments(List<String> vocabulary, int segments, int segmentsPerTerm) {
+        List<Set<String>> vocabularyBySegment = new ArrayList<>(segments);
+        for (int s = 0; s < segments; s++) {
+            vocabularyBySegment.add(new LinkedHashSet<>());
+        }
+        int fanout = Math.min(segments, segmentsPerTerm);
+        for (int i = 0; i < vocabulary.size(); i++) {
+            String neighbour = vocabulary.get(i);
+            for (int j = 0; j < fanout; j++) {
+                vocabularyBySegment.get((i + j) % segments).add(neighbour);
+            }
+        }
+        return vocabularyBySegment;
+    }
+
+    private static Set<String> buildVocabulary(String term, int prefixLength) {
+        Set<String> vocabulary = new LinkedHashSet<>();
+        int length = term.length();
+        // Substitutions in the fuzzy suffix.
+        for (int pos = prefixLength; pos < length && vocabulary.size() < MAX_VOCABULARY; pos++) {
+            for (int i = 0; i < REPLACEMENT_ALPHABET.length() && vocabulary.size() < MAX_VOCABULARY; i++) {
+                char c = REPLACEMENT_ALPHABET.charAt(i);
+                if (c != term.charAt(pos)) {
+                    vocabulary.add(term.substring(0, pos) + c + term.substring(pos + 1));
+                }
+            }
+        }
+        // Insertions in the fuzzy suffix (produces length+1 neighbours).
+        for (int pos = prefixLength; pos <= length && vocabulary.size() < MAX_VOCABULARY; pos++) {
+            for (int i = 0; i < REPLACEMENT_ALPHABET.length() && vocabulary.size() < MAX_VOCABULARY; i++) {
+                char c = REPLACEMENT_ALPHABET.charAt(i);
+                vocabulary.add(term.substring(0, pos) + c + term.substring(pos));
+            }
+        }
+        // Deletions in the fuzzy suffix (produces length-1 neighbours).
+        for (int pos = prefixLength; pos < length && vocabulary.size() < MAX_VOCABULARY; pos++) {
+            vocabulary.add(term.substring(0, pos) + term.substring(pos + 1));
+        }
+        vocabulary.remove(term);
+        return vocabulary;
     }
 
     private static int countDistinctUtf8Bytes(byte[] utf8) {

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -122,7 +122,8 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
         MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(
             IndexSearcher.getMaxClauseCount(),
             context.getCircuitBreaker(),
-            context::isQueryMemoryPreCharged
+            context::isQueryMemoryPreCharged,
+            MaxClauseCountQueryVisitor.segmentCountOrDefault(context.getIndexReader())
         );
         Query query = toQuery(context, visitor);
         if (query != null) {

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -357,7 +357,8 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         MaxClauseCountQueryVisitor clauseVisitor = new MaxClauseCountQueryVisitor(
             IndexSearcher.getMaxClauseCount(),
             context.getCircuitBreaker(),
-            context::isQueryMemoryPreCharged
+            context::isQueryMemoryPreCharged,
+            MaxClauseCountQueryVisitor.segmentCountOrDefault(context.getIndexReader())
         );
         Set<Query> deduplicate = new HashSet<>();
         for (QueryBuilder query : clauses) {

--- a/server/src/main/java/org/elasticsearch/lucene/search/FuzzyQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/FuzzyQueries.java
@@ -12,6 +12,7 @@ package org.elasticsearch.lucene.search;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.TopTermsRewrite;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.core.Nullable;
@@ -25,10 +26,13 @@ import java.util.BitSet;
  * retained {@link #queryRamBytes(FuzzyQuery)} and the parameter-driven
  * {@link FuzzyQueryCostEstimator} estimate are accumulated by {@code MaxClauseCountQueryVisitor}
  * during the once-per-phase walk in {@code AbstractQueryBuilder#toQuery}, alongside prefix,
- * wildcard, regexp, and range queries. Use {@link #estimateBytes(FuzzyQuery)} when accounting
+ * wildcard, regexp, and range queries. Use {@link #estimateBytes(FuzzyQuery, int)} when accounting
  * outside that walk (e.g. ad-hoc field-type callers) needs the same total.
  */
 public final class FuzzyQueries {
+
+    /** Segment-count fallback for {@link FuzzyQueryCostEstimator} when the real leaf count isn't available. */
+    public static final int DEFAULT_SEGMENT_COUNT_WHEN_UNKNOWN = 16;
 
     private FuzzyQueries() {}
 
@@ -57,16 +61,47 @@ public final class FuzzyQueries {
         return new FuzzyQuery(term, maxEdits, prefixLength, maxExpansions, transpositions, effectiveRewrite);
     }
 
+    public static long estimateBytes(FuzzyQuery query) {
+        return estimateBytes(query, DEFAULT_SEGMENT_COUNT_WHEN_UNKNOWN);
+    }
+
     /**
      * Total bytes the request circuit breaker should be charged for {@code query}: the retained
      * RAM of the query object plus the parameter-driven {@link FuzzyQueryCostEstimator} estimate.
      * Used by {@code MaxClauseCountQueryVisitor} for fuzzy clauses during the once-per-phase walk.
      */
-    public static long estimateBytes(FuzzyQuery query) {
+    public static long estimateBytes(FuzzyQuery query, int segmentCount) {
         BytesRef bytes = query.getTerm().bytes();
-        long cost = new FuzzyQueryCostEstimator(bytes.length, countDistinctUtf8Bytes(bytes), query.getMaxEdits(), query.getPrefixLength())
-            .estimate();
+        long cost = new FuzzyQueryCostEstimator(
+            bytes.length,
+            countDistinctUtf8Bytes(bytes),
+            query.getMaxEdits(),
+            query.getPrefixLength(),
+            effectiveMaxExpansions(query),
+            segmentCount
+        ).estimate();
         return queryRamBytes(query) + cost;
+    }
+
+    /**
+     * Effective expansion count for the breaker charge: a {@link TopTermsRewrite}'s configured size,
+     * {@link FuzzyQueryCostEstimator#MAX_CHARGED_EXPANSIONS} for the boolean-producing rewrites that
+     * can expand up to {@code IndexSearcher.getMaxClauseCount()} (which is never lower, since
+     * {@code SearchUtils.calculateMaxClauseValue} floors it at that same value), or
+     * {@link FuzzyQuery#defaultMaxExpansions} otherwise; clamped to
+     * {@code [1, }{@link FuzzyQueryCostEstimator#MAX_CHARGED_EXPANSIONS}{@code ]}.
+     */
+    private static int effectiveMaxExpansions(FuzzyQuery query) {
+        MultiTermQuery.RewriteMethod rewrite = query.getRewriteMethod();
+        final int requested;
+        if (rewrite instanceof TopTermsRewrite<?> topTerms) {
+            requested = topTerms.getSize();
+        } else if (rewrite == MultiTermQuery.SCORING_BOOLEAN_REWRITE || rewrite == MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE) {
+            requested = FuzzyQueryCostEstimator.MAX_CHARGED_EXPANSIONS;
+        } else {
+            requested = FuzzyQuery.defaultMaxExpansions;
+        }
+        return Math.clamp(requested, 1, FuzzyQueryCostEstimator.MAX_CHARGED_EXPANSIONS);
     }
 
     /** RAM bytes retained by the {@link FuzzyQuery} object (excluding compiled automata). */

--- a/server/src/main/java/org/elasticsearch/lucene/search/cost/FuzzyQueryCostEstimator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/cost/FuzzyQueryCostEstimator.java
@@ -32,10 +32,33 @@ public final class FuzzyQueryCostEstimator implements QueryCostEstimator {
     /** Multiplier applied when the alphabet is wider than {@link #WIDE_ALPHABET_THRESHOLD}. */
     public static final long WIDE_ALPHABET_FACTOR = 2L;
 
+    /**
+     * Flat per-expanded-term add-on, charged once per {@code maxExpansions} regardless of
+     * {@code segmentCount}. Covers the fixed share of retained rewrite RAM (the rewritten
+     * {@code Query} object itself, plus each expansion's baseline {@link org.apache.lucene.index.TermStates}
+     * bookkeeping) that doesn't grow with the number of index segments a term appears in. See
+     * {@link #EXPANSION_BYTES_PER_SEGMENT_PER_TERM} for the part that does.
+     */
+    public static final long EXPANSION_BYTES_PER_TERM = 2500L;
+
+    /**
+     * Per-expanded-term, per-segment add-on, charged once per {@code maxExpansions · segmentCount}.
+     * {@code TermStates} retains one {@code TermState} per leaf a term matches, so its RAM grows
+     * roughly linearly with the number of index segments; {@code FuzzyQueryCostEstimatorBenchmark}
+     * measured this growth at ~84 bytes/segment/term (flat across 1-128 segments), and this constant
+     * keeps that measurement, plus margin, as a ceiling.
+     */
+    public static final long EXPANSION_BYTES_PER_SEGMENT_PER_TERM = 97L;
+
+    /** Maximum number of expansions charged per clause */
+    public static final int MAX_CHARGED_EXPANSIONS = 1024;
+
     private final int termByteLength;
     private final int distinctUtf8Bytes;
     private final int maxEdits;
     private final int prefixByteLength;
+    private final int maxExpansions;
+    private final int segmentCount;
 
     /**
      * @param termByteLength    UTF-8 byte length of the term. Must be {@code >= 0}.
@@ -45,8 +68,23 @@ public final class FuzzyQueryCostEstimator implements QueryCostEstimator {
      * @param maxEdits          {@code [0, MAXIMUM_SUPPORTED_DISTANCE]}.
      * @param prefixByteLength  UTF-8 byte length of the common non-fuzzy prefix; clamped to
      *                          {@code termByteLength}. Must be {@code >= 0}.
+     * @param maxExpansions     maximum number of index terms this clause rewrites to; the
+     *                          downstream rewrite/expansion cost is bounded by it. Must be
+     *                          {@code > 0}.
+     * @param segmentCount      number of index segments each expanded term is charged against,
+     *                          driving the per-segment share of the expansion cost (see
+     *                          {@link #EXPANSION_BYTES_PER_SEGMENT_PER_TERM}). Callers without a
+     *                          live index (or targeting an unknown/future segment layout) should
+     *                          pass a conservative assumed value. Must be {@code >= 0}.
      */
-    public FuzzyQueryCostEstimator(int termByteLength, int distinctUtf8Bytes, int maxEdits, int prefixByteLength) {
+    public FuzzyQueryCostEstimator(
+        int termByteLength,
+        int distinctUtf8Bytes,
+        int maxEdits,
+        int prefixByteLength,
+        int maxExpansions,
+        int segmentCount
+    ) {
         if (termByteLength < 0) {
             throw new IllegalArgumentException("termByteLength must be >= 0, got: " + termByteLength);
         }
@@ -61,10 +99,18 @@ public final class FuzzyQueryCostEstimator implements QueryCostEstimator {
         if (prefixByteLength < 0) {
             throw new IllegalArgumentException("prefixByteLength must be >= 0, got: " + prefixByteLength);
         }
+        if (maxExpansions <= 0) {
+            throw new IllegalArgumentException("maxExpansions must be > 0, got: " + maxExpansions);
+        }
+        if (segmentCount < 0) {
+            throw new IllegalArgumentException("segmentCount must be >= 0, got: " + segmentCount);
+        }
         this.termByteLength = termByteLength;
         this.distinctUtf8Bytes = distinctUtf8Bytes;
         this.maxEdits = maxEdits;
         this.prefixByteLength = prefixByteLength;
+        this.maxExpansions = maxExpansions;
+        this.segmentCount = segmentCount;
     }
 
     /**
@@ -78,7 +124,10 @@ public final class FuzzyQueryCostEstimator implements QueryCostEstimator {
      *              + BYTES_PER_BYTE
      *                · effectiveBytes
      *                · (2 · maxEdits + 1)
-     *                · alphabetFactor,                                    otherwise
+     *                · alphabetFactor
+     *              + (EXPANSION_BYTES_PER_TERM
+     *                 + EXPANSION_BYTES_PER_SEGMENT_PER_TERM · segmentCount)
+     *                · maxExpansions,                                    otherwise
      *
      *     effectiveBytes = max(0, termByteLength - prefixByteLength)
      *     alphabetFactor = (distinctUtf8Bytes &gt; WIDE_ALPHABET_THRESHOLD) ? WIDE_ALPHABET_FACTOR : 1
@@ -98,6 +147,11 @@ public final class FuzzyQueryCostEstimator implements QueryCostEstimator {
         long alphabetFactor = distinctUtf8Bytes > WIDE_ALPHABET_THRESHOLD ? WIDE_ALPHABET_FACTOR : 1L;
         long stateProxy = effectiveBytes * (2L * maxEdits + 1L);
         long dynamic = Math.multiplyExact(Math.multiplyExact(BYTES_PER_BYTE, stateProxy), alphabetFactor);
-        return Math.addExact(BASE_BYTES, dynamic);
+        long perTermBytes = Math.addExact(
+            EXPANSION_BYTES_PER_TERM,
+            Math.multiplyExact(EXPANSION_BYTES_PER_SEGMENT_PER_TERM, (long) segmentCount)
+        );
+        long expansion = Math.multiplyExact(perTermBytes, (long) maxExpansions);
+        return Math.addExact(Math.addExact(BASE_BYTES, dynamic), expansion);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.search.internal;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.FuzzyQuery;
@@ -61,6 +62,12 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
     @Nullable
     private final Predicate<Query> preCharged;
 
+    /**
+     * Index segment count charged against fuzzy clauses' per-segment expansion cost; see
+     * {@link FuzzyQueries#estimateBytes(FuzzyQuery, int)}.
+     */
+    private final int segmentCount;
+
     public MaxClauseCountQueryVisitor(int maxClauseCount) {
         this(maxClauseCount, null);
     }
@@ -70,9 +77,23 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
     }
 
     public MaxClauseCountQueryVisitor(int maxClauseCount, @Nullable CircuitBreaker breaker, @Nullable Predicate<Query> preCharged) {
+        this(maxClauseCount, breaker, preCharged, FuzzyQueries.DEFAULT_SEGMENT_COUNT_WHEN_UNKNOWN);
+    }
+
+    public MaxClauseCountQueryVisitor(
+        int maxClauseCount,
+        @Nullable CircuitBreaker breaker,
+        @Nullable Predicate<Query> preCharged,
+        int segmentCount
+    ) {
         this.maxClauseCount = maxClauseCount;
         this.breaker = breaker;
         this.preCharged = preCharged;
+        this.segmentCount = segmentCount;
+    }
+
+    public static int segmentCountOrDefault(@Nullable IndexReader reader) {
+        return reader == null ? FuzzyQueries.DEFAULT_SEGMENT_COUNT_WHEN_UNKNOWN : reader.leaves().size();
     }
 
     public int getMaxClauseCount() {
@@ -131,7 +152,7 @@ public final class MaxClauseCountQueryVisitor extends QueryVisitor {
 
         long bytes;
         if (query instanceof FuzzyQuery fq) {
-            bytes = FuzzyQueries.estimateBytes(fq);
+            bytes = FuzzyQueries.estimateBytes(fq, segmentCount);
         } else if (query instanceof PointRangeQuery prq) {
             bytes = new PointRangeQueryCostEstimator(prq.getNumDims(), prq.getBytesPerDim()).estimate();
         } else if (query instanceof Accountable a) {

--- a/server/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.lucene.search.cost.FuzzyQueryCostEstimator;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -337,6 +338,19 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
         });
     }
 
+    public void testDeepBoolTowerOfCheapFuzzyClausesTripsBreaker() {
+        assertCircuitBreakerTripsOnQueryConstruction("1mb", () -> {
+            QueryBuilder tower = new FuzzyQueryBuilder(TEXT_FIELD_NAME, "abc").fuzziness(Fuzziness.ONE).prefixLength(3);
+            for (int i = 0; i < 150; i++) {
+                BoolQueryBuilder level = new BoolQueryBuilder();
+                level.must(tower);
+                level.should(new FuzzyQueryBuilder(TEXT_FIELD_NAME, "abc").fuzziness(Fuzziness.ONE).prefixLength(3));
+                tower = level;
+            }
+            return tower;
+        });
+    }
+
     public void testSingleFuzzyClauseTripsCircuitBreakerAtConstruction() throws IOException {
         CircuitBreaker cb = createCircuitBreakerService("2kb");
         SearchExecutionContext context = new SearchExecutionContext(createSearchExecutionContext(), cb);
@@ -503,6 +517,63 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
         assertTrue(
             "larger prefix must reduce the cost estimate (" + longerTermOneEdit + " vs " + longerTermLargePrefix + ")",
             longerTermLargePrefix < longerTermOneEdit
+        );
+    }
+
+    public void testFuzzyCostEstimateScalesWithTopTermsRewriteSize() {
+        Term term = new Term(TEXT_FIELD_NAME, "value");
+        FuzzyQuery few = new FuzzyQuery(term, 1, 0, 10, true);
+        FuzzyQuery many = new FuzzyQuery(term, 1, 0, 200, true);
+
+        long fewBytes = FuzzyQueries.estimateBytes(few);
+        long manyBytes = FuzzyQueries.estimateBytes(many);
+
+        assertTrue(
+            "a larger top-terms expansion cap must yield a larger cost estimate (" + fewBytes + " vs " + manyBytes + ")",
+            manyBytes > fewBytes
+        );
+    }
+
+    public void testFuzzyCostEstimateForBooleanRewritesIgnoresMaxExpansionsAndUsesMaxCharged() {
+        Term term = new Term(TEXT_FIELD_NAME, "value");
+        FuzzyQuery smallDeclared = new FuzzyQuery(term, 1, 0, 10, true, MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+        FuzzyQuery largeDeclared = new FuzzyQuery(term, 1, 0, 500, true, MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+        FuzzyQuery constantScoreBoolean = new FuzzyQuery(term, 1, 0, 10, true, MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE);
+        FuzzyQuery topTermsAtMaxCharged = new FuzzyQuery(term, 1, 0, FuzzyQueryCostEstimator.MAX_CHARGED_EXPANSIONS, true);
+
+        long smallDeclaredBytes = FuzzyQueries.estimateBytes(smallDeclared);
+        long largeDeclaredBytes = FuzzyQueries.estimateBytes(largeDeclared);
+        long constantScoreBooleanBytes = FuzzyQueries.estimateBytes(constantScoreBoolean);
+        long topTermsAtMaxChargedBytes = FuzzyQueries.estimateBytes(topTermsAtMaxCharged);
+
+        assertEquals(
+            "scoring_boolean must charge the same regardless of the query's declared maxExpansions",
+            smallDeclaredBytes,
+            largeDeclaredBytes
+        );
+        assertEquals("scoring_boolean and constant_score_boolean must charge identically", smallDeclaredBytes, constantScoreBooleanBytes);
+        assertEquals(
+            "a boolean rewrite must charge exactly as much as a top-terms rewrite capped at MAX_CHARGED_EXPANSIONS",
+            topTermsAtMaxChargedBytes,
+            smallDeclaredBytes
+        );
+    }
+
+    public void testFuzzyCostEstimateForConstantScoreRewritesUsesDefaultMaxExpansions() {
+        Term term = new Term(TEXT_FIELD_NAME, "value");
+        FuzzyQuery constantScore = new FuzzyQuery(term, 1, 0, 10, true, MultiTermQuery.CONSTANT_SCORE_REWRITE);
+        FuzzyQuery constantScoreBlended = new FuzzyQuery(term, 1, 0, 500, true, MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE);
+        FuzzyQuery topTermsAtDefault = new FuzzyQuery(term, 1, 0, FuzzyQuery.defaultMaxExpansions, true);
+
+        long constantScoreBytes = FuzzyQueries.estimateBytes(constantScore);
+        long constantScoreBlendedBytes = FuzzyQueries.estimateBytes(constantScoreBlended);
+        long topTermsAtDefaultBytes = FuzzyQueries.estimateBytes(topTermsAtDefault);
+
+        assertEquals("constant_score and constant_score_blended must charge identically", constantScoreBytes, constantScoreBlendedBytes);
+        assertEquals(
+            "a constant-score rewrite must charge exactly as much as a top-terms rewrite at the default cap",
+            topTermsAtDefaultBytes,
+            constantScoreBytes
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -480,4 +480,11 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         query.lenient(true);
         assertThat(query.toQuery(context), Matchers.instanceOf(MatchNoDocsQuery.class));
     }
+
+    public void testMultiMatchFuzzyCircuitBreakerTripsOnExpansionFloorForCheapClauses() {
+        assertCircuitBreakerTripsOnQueryConstruction(
+            "64kb",
+            () -> new MultiMatchQueryBuilder("abc", TEXT_FIELD_NAME, KEYWORD_FIELD_NAME).fuzziness(Fuzziness.ONE).prefixLength(3)
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/lucene/search/cost/FuzzyQueryCostEstimatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/cost/FuzzyQueryCostEstimatorTests.java
@@ -22,60 +22,93 @@ import static org.hamcrest.Matchers.greaterThan;
 
 public class FuzzyQueryCostEstimatorTests extends ESTestCase {
 
+    private static final int MAX_EXPANSIONS = 50;
+
+    /** Fixed segment count used by tests that aren't specifically exercising segment-count scaling. */
+    private static final int SEGMENT_COUNT = 4;
+
     public void testZeroEditsReturnsZero() {
-        assertEquals(0L, new FuzzyQueryCostEstimator(0, 0, 0, 0).estimate());
-        assertEquals(0L, new FuzzyQueryCostEstimator(50, 1, 0, 0).estimate());
-        assertEquals(0L, new FuzzyQueryCostEstimator(50, 1, 0, 5).estimate());
+        assertEquals(0L, new FuzzyQueryCostEstimator(0, 0, 0, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate());
+        assertEquals(0L, new FuzzyQueryCostEstimator(50, 1, 0, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate());
+        assertEquals(0L, new FuzzyQueryCostEstimator(50, 1, 0, 5, MAX_EXPANSIONS, SEGMENT_COUNT).estimate());
     }
 
     public void testEstimateIsMonotonicInTermLength() {
-        long shorter = new FuzzyQueryCostEstimator(10, 10, 2, 0).estimate();
-        long longer = new FuzzyQueryCostEstimator(50, 10, 2, 0).estimate();
-        long longest = new FuzzyQueryCostEstimator(200, 10, 2, 0).estimate();
+        long shorter = new FuzzyQueryCostEstimator(10, 10, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long longer = new FuzzyQueryCostEstimator(50, 10, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long longest = new FuzzyQueryCostEstimator(200, 10, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
         assertTrue(shorter < longer);
         assertTrue(longer < longest);
     }
 
     public void testEstimateIsMonotonicInMaxEdits() {
-        long e1 = new FuzzyQueryCostEstimator(20, 20, 1, 0).estimate();
-        long e2 = new FuzzyQueryCostEstimator(20, 20, 2, 0).estimate();
+        long e1 = new FuzzyQueryCostEstimator(20, 20, 1, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long e2 = new FuzzyQueryCostEstimator(20, 20, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
         assertTrue("expected estimate to grow with maxEdits", e1 < e2);
     }
 
+    public void testEstimateIsMonotonicInMaxExpansions() {
+        long few = new FuzzyQueryCostEstimator(20, 20, 2, 0, 10, SEGMENT_COUNT).estimate();
+        long more = new FuzzyQueryCostEstimator(20, 20, 2, 0, 50, SEGMENT_COUNT).estimate();
+        long most = new FuzzyQueryCostEstimator(20, 20, 2, 0, 200, SEGMENT_COUNT).estimate();
+        assertTrue("expected estimate to grow with maxExpansions", few < more);
+        assertTrue("expected estimate to grow with maxExpansions", more < most);
+    }
+
+    public void testEstimateIsMonotonicInSegmentCount() {
+        long fewSegments = new FuzzyQueryCostEstimator(20, 20, 2, 0, MAX_EXPANSIONS, 1).estimate();
+        long moreSegments = new FuzzyQueryCostEstimator(20, 20, 2, 0, MAX_EXPANSIONS, 16).estimate();
+        long mostSegments = new FuzzyQueryCostEstimator(20, 20, 2, 0, MAX_EXPANSIONS, 128).estimate();
+        assertTrue("expected estimate to grow with segmentCount", fewSegments < moreSegments);
+        assertTrue("expected estimate to grow with segmentCount", moreSegments < mostSegments);
+    }
+
     public void testWideAlphabetEstimateIsHigherThanNarrow() {
-        long narrow = new FuzzyQueryCostEstimator(20, 20, 2, 0).estimate();
-        long wide = new FuzzyQueryCostEstimator(20, 200, 2, 0).estimate();
+        long narrow = new FuzzyQueryCostEstimator(20, 20, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long wide = new FuzzyQueryCostEstimator(20, 200, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
         assertTrue("wide alphabet (above WIDE_ALPHABET_THRESHOLD) must charge more than ASCII-shaped input", narrow < wide);
     }
 
     public void testNarrowAlphabetIsFlat() {
-        long bd1 = new FuzzyQueryCostEstimator(20, 1, 2, 0).estimate();
-        long bd26 = new FuzzyQueryCostEstimator(20, 26, 2, 0).estimate();
-        long bd64 = new FuzzyQueryCostEstimator(20, 64, 2, 0).estimate();
+        long bd1 = new FuzzyQueryCostEstimator(20, 1, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long bd26 = new FuzzyQueryCostEstimator(20, 26, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long bd64 = new FuzzyQueryCostEstimator(20, 64, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
         assertEquals(bd1, bd26);
         assertEquals(bd1, bd64);
     }
 
     public void testPrefixLengthShrinksEstimate() {
-        long noPrefix = new FuzzyQueryCostEstimator(60, 60, 2, 0).estimate();
-        long withPrefix = new FuzzyQueryCostEstimator(60, 60, 2, 5).estimate();
+        long noPrefix = new FuzzyQueryCostEstimator(60, 60, 2, 0, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long withPrefix = new FuzzyQueryCostEstimator(60, 60, 2, 5, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
         assertTrue("prefix should reduce the suffix-driven cost", withPrefix < noPrefix);
     }
 
     public void testPrefixLongerThanTermIsClampedNotNegative() {
-        long allPrefix = new FuzzyQueryCostEstimator(5, 5, 2, 100).estimate();
-        assertEquals(FuzzyQueryCostEstimator.BASE_BYTES, allPrefix);
+        long allPrefix = new FuzzyQueryCostEstimator(5, 5, 2, 100, MAX_EXPANSIONS, SEGMENT_COUNT).estimate();
+        long perTermBytes = FuzzyQueryCostEstimator.EXPANSION_BYTES_PER_TERM + FuzzyQueryCostEstimator.EXPANSION_BYTES_PER_SEGMENT_PER_TERM
+            * SEGMENT_COUNT;
+        long expected = FuzzyQueryCostEstimator.BASE_BYTES + perTermBytes * MAX_EXPANSIONS;
+        assertEquals(expected, allPrefix);
     }
 
     public void testConstructorRejectsNegativeArguments() {
-        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(-1, 0, 1, 0));
-        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, -1, 1, 0));
-        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, -1, 0));
-        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 1, -1));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(-1, 0, 1, 0, MAX_EXPANSIONS, SEGMENT_COUNT));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, -1, 1, 0, MAX_EXPANSIONS, SEGMENT_COUNT));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, -1, 0, MAX_EXPANSIONS, SEGMENT_COUNT));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 1, -1, MAX_EXPANSIONS, SEGMENT_COUNT));
+    }
+
+    public void testConstructorRejectsNonPositiveMaxExpansions() {
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 1, 0, 0, SEGMENT_COUNT));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 1, 0, -1, SEGMENT_COUNT));
     }
 
     public void testConstructorRejectsMaxEditsAboveLuceneLimit() {
-        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 99, 0));
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 99, 0, MAX_EXPANSIONS, SEGMENT_COUNT));
+    }
+
+    public void testConstructorRejectsNegativeSegmentCount() {
+        expectThrows(IllegalArgumentException.class, () -> new FuzzyQueryCostEstimator(10, 10, 1, 0, MAX_EXPANSIONS, -1));
     }
 
     public void testEstimateIsCeilingOnMeasuredAutomataRam() {
@@ -99,7 +132,14 @@ public class FuzzyQueryCostEstimatorTests extends ESTestCase {
                             byte[] utf8 = term.getBytes(StandardCharsets.UTF_8);
                             int distinctUtf8Bytes = countDistinctUtf8Bytes(utf8);
 
-                            long estimated = new FuzzyQueryCostEstimator(utf8.length, distinctUtf8Bytes, maxEdits, prefix).estimate();
+                            long estimated = new FuzzyQueryCostEstimator(
+                                utf8.length,
+                                distinctUtf8Bytes,
+                                maxEdits,
+                                prefix,
+                                MAX_EXPANSIONS,
+                                SEGMENT_COUNT
+                            ).estimate();
                             long measured = sumCompiledAutomataRamBytes(term, maxEdits, prefix, transpositions);
 
                             double ratio = measured == 0L ? Double.POSITIVE_INFINITY : (double) estimated / (double) measured;

--- a/server/src/test/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitorTests.java
@@ -9,8 +9,13 @@
 
 package org.elasticsearch.search.internal;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -22,6 +27,8 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
@@ -32,10 +39,12 @@ import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.lucene.search.cost.PointRangeQueryCostEstimator;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.lucene.search.Queries.ALL_DOCS_INSTANCE;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class MaxClauseCountQueryVisitorTests extends ESTestCase {
@@ -85,6 +94,27 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
         );
     }
 
+    public void testBooleanOfFuzzyClausesSumsPerClauseEstimates() {
+        MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount());
+        int clauses = randomIntBetween(2, 20);
+
+        BooleanQuery.Builder bool = new BooleanQuery.Builder();
+        long expected = 0L;
+        for (int i = 0; i < clauses; i++) {
+            FuzzyQuery fq = new FuzzyQuery(new Term("field", "value" + i), 2, 1, 50, true);
+            bool.add(fq, BooleanClause.Occur.SHOULD);
+            expected += FuzzyQueries.estimateBytes(fq);
+        }
+        bool.build().visit(visitor);
+
+        assertEquals(
+            "each fuzzy clause must be visited and summed by FuzzyQueries.estimateBytes, not floored once",
+            expected,
+            visitor.getEstimatedBytes()
+        );
+        assertEquals(clauses, visitor.getNumClauses());
+    }
+
     public void testFuzzyQueryVisitDoesNotInvokeAutomatonSupplier() {
         MaxClauseCountQueryVisitor visitor = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount());
         AtomicInteger supplierInvocations = new AtomicInteger();
@@ -116,6 +146,45 @@ public class MaxClauseCountQueryVisitorTests extends ESTestCase {
             FuzzyQueries.estimateBytes(fq),
             visitor.getEstimatedBytes()
         );
+    }
+
+    public void testFuzzyClauseChargeGrowsWithSegmentCount() {
+        FuzzyQuery fq = new FuzzyQuery(new Term("field", "value0"), 2, 1, 50, true);
+
+        MaxClauseCountQueryVisitor singleSegment = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount(), null, null, 1);
+        MaxClauseCountQueryVisitor manySegments = new MaxClauseCountQueryVisitor(IndexSearcher.getMaxClauseCount(), null, null, 128);
+
+        fq.visit(singleSegment);
+        fq.visit(manySegments);
+
+        assertEquals(FuzzyQueries.estimateBytes(fq, 1), singleSegment.getEstimatedBytes());
+        assertEquals(FuzzyQueries.estimateBytes(fq, 128), manySegments.getEstimatedBytes());
+        assertThat(
+            "a fuzzy clause charged against a 128-segment reader must cost strictly more than against a 1-segment reader",
+            manySegments.getEstimatedBytes(),
+            greaterThan(singleSegment.getEstimatedBytes())
+        );
+    }
+
+    public void testSegmentCountOrDefaultFallsBackToDefaultWhenReaderIsNull() {
+        assertEquals(FuzzyQueries.DEFAULT_SEGMENT_COUNT_WHEN_UNKNOWN, MaxClauseCountQueryVisitor.segmentCountOrDefault(null));
+    }
+
+    public void testSegmentCountOrDefaultUsesRealReaderLeafCount() throws IOException {
+        int segments = randomIntBetween(2, 5);
+        try (Directory directory = new ByteBuffersDirectory()) {
+            IndexWriterConfig writerConfig = new IndexWriterConfig(null).setMergePolicy(NoMergePolicy.INSTANCE);
+            try (IndexWriter writer = new IndexWriter(directory, writerConfig)) {
+                for (int i = 0; i < segments; i++) {
+                    writer.addDocument(new Document());
+                    writer.flush();
+                }
+                writer.commit();
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                assertEquals(segments, MaxClauseCountQueryVisitor.segmentCountOrDefault(reader));
+            }
+        }
     }
 
     public void testChargesPointRangeQueryStructuralOnly() {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Charge fuzzy queries for their term expansions in the request breaker (#155485)