### PR TITLE
ES|QL: Add double range WITHIN and CONTAINS

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/double_range.csv-spec
@@ -1,5 +1,5 @@
 doubleRangeBlockLoader
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -16,7 +16,7 @@ height_range:double_range | description:keyword
 ;
 
 toRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW from = 1.5, to = 2.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -28,7 +28,7 @@ height_range:double_range
 ;
 
 toRangeNullLeft
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW to = 1.5
 | EVAL height_range = TO_RANGE(null, to)
@@ -40,7 +40,7 @@ null
 ;
 
 toRangeNullRight
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW from = 1.5
 | EVAL height_range = TO_RANGE(from, null)
@@ -52,7 +52,7 @@ null
 ;
 
 toRangeInvalidBounds
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW from = 2.5, to = 1.5
 | EVAL height_range = TO_RANGE(from, to)
@@ -66,7 +66,7 @@ null
 ;
 
 toString
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -84,7 +84,7 @@ height_range_string:keyword | description:keyword
 ;
 
 rangeMinMax
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -102,7 +102,7 @@ height_range:double_range | min_bound:double | max_bound:double | description:ke
 ;
 
 rangeMinMaxRoundTrip
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -115,7 +115,7 @@ height_range:double_range | new_range:double_range
 ;
 
 doubleRangeEquality
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 required_capability: equality_double_range
 
 FROM heights
@@ -128,7 +128,7 @@ Short
 ;
 
 doubleRangeNotEquals
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 required_capability: equality_double_range
 
 FROM heights
@@ -145,7 +145,7 @@ Very Tall
 ;
 
 doubleRangeSelfEquality
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 required_capability: equality_double_range
 
 FROM heights
@@ -164,7 +164,7 @@ Very Tall
 ;
 
 doubleRangeIn
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 required_capability: equality_double_range
 
 FROM heights
@@ -179,7 +179,7 @@ Tall
 ;
 
 mvFirstLastDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -193,7 +193,7 @@ first_range:double_range | last_range:double_range
 ;
 
 mvCountDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -207,7 +207,7 @@ count:integer
 ;
 
 valuesDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -221,7 +221,7 @@ strings:keyword
 ;
 
 valuesDoubleRangeGrouped
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -238,7 +238,7 @@ strings:keyword                  | short:boolean
 ;
 
 mvExpandValuesDoubleRangeGrouped
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE height_range IS NOT NULL
@@ -260,7 +260,7 @@ ranges:double_range | short:boolean | count:integer
 ;
 
 coalesceDoubleRangeField
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -273,7 +273,7 @@ result:double_range
 ;
 
 coalesceDoubleRangeNullFirst
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -287,7 +287,7 @@ result:double_range
 ;
 
 coalesceDoubleRangeMultipleArgs
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -301,7 +301,7 @@ result:double_range
 ;
 
 caseDoubleRangeTrueBranch
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -314,7 +314,7 @@ result:double_range
 ;
 
 caseDoubleRangeFalseBranch
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -327,7 +327,7 @@ result:double_range
 ;
 
 caseDoubleRangeNoElse
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description == "Short"
@@ -339,8 +339,34 @@ result:double_range
 null
 ;
 
+rangeWithinDoubleRange
+required_capability: double_range_field_type_development_v9
+
+FROM heights
+| WHERE RANGE_WITHIN(height_range, TO_RANGE(1.4, 1.9))
+| KEEP description
+| SORT description
+;
+
+description:keyword
+Medium Height
+Short
+;
+
+rangeContainsDouble
+required_capability: double_range_field_type_development_v9
+
+FROM heights
+| WHERE RANGE_CONTAINS(height_range, 1.55)
+| KEEP description
+;
+
+description:keyword
+Short
+;
+
 caseDoubleRangeSelectByDescription
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | WHERE description IN ("Short", "Tall")
@@ -355,7 +381,7 @@ Tall                | 10.0..20.0
 ;
 
 countDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | STATS count = COUNT(height_range)
@@ -366,7 +392,7 @@ count:long
 ;
 
 countDoubleRangeWithFilter
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | STATS count = COUNT(height_range) WHERE description LIKE "*Short*"
@@ -377,7 +403,7 @@ count:long
 ;
 
 countDoubleRangeGrouped
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | EVAL short = description LIKE "*Short*"
@@ -391,7 +417,7 @@ count:long | short:boolean
 ;
 
 presentDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | STATS present = PRESENT(height_range)
@@ -402,7 +428,7 @@ true
 ;
 
 presentDoubleRangeAllNull
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW height_range = TO_RANGE(null, 1.0)
 | STATS present = PRESENT(height_range)
@@ -413,7 +439,7 @@ false
 ;
 
 absentDoubleRange
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 FROM heights
 | STATS absent = ABSENT(height_range)
@@ -424,7 +450,7 @@ false
 ;
 
 absentDoubleRangeAllNull
-required_capability: double_range_field_type_development_v8
+required_capability: double_range_field_type_development_v9
 
 ROW height_range = TO_RANGE(null, 1.0)
 | STATS absent = ABSENT(height_range)

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoublePointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoublePointEvaluator.java
@@ -1,0 +1,140 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.date;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RangeWithin}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RangeWithinDoublePointEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RangeWithinDoublePointEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator point;
+
+  private final ExpressionEvaluator range;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RangeWithinDoublePointEvaluator(Source source, ExpressionEvaluator point,
+      ExpressionEvaluator range, DriverContext driverContext) {
+    this.source = source;
+    this.point = point;
+    this.range = range;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleBlock pointBlock = (DoubleBlock) point.eval(page)) {
+      try (DoubleRangeBlock rangeBlock = (DoubleRangeBlock) range.eval(page)) {
+        return eval(page.getPositionCount(), pointBlock, rangeBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += point.baseRamBytesUsed();
+    baseRamBytesUsed += range.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BooleanBlock eval(int positionCount, DoubleBlock pointBlock, DoubleRangeBlock rangeBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange rangeScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (pointBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (rangeBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        double point = pointBlock.getDouble(pointBlock.getFirstValueIndex(p));
+        DoubleRangeBlockBuilder.DoubleRange range = rangeBlock.getDoubleRange(rangeBlock.getFirstValueIndex(p), rangeScratch);
+        result.appendBoolean(RangeWithin.processPoint(point, range));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RangeWithinDoublePointEvaluator[" + "point=" + point + ", range=" + range + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(point, range);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = driverContext.createWarnings(source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory point;
+
+    private final ExpressionEvaluator.Factory range;
+
+    public Factory(Source source, ExpressionEvaluator.Factory point,
+        ExpressionEvaluator.Factory range) {
+      this.source = source;
+      this.point = point;
+      this.range = range;
+    }
+
+    @Override
+    public RangeWithinDoublePointEvaluator get(DriverContext context) {
+      return new RangeWithinDoublePointEvaluator(source, point.get(context), range.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "RangeWithinDoublePointEvaluator[" + "point=" + point + ", range=" + range + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoubleRangeEvaluator.java
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.date;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link RangeWithin}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class RangeWithinDoubleRangeEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RangeWithinDoubleRangeEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator a;
+
+  private final ExpressionEvaluator b;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public RangeWithinDoubleRangeEvaluator(Source source, ExpressionEvaluator a,
+      ExpressionEvaluator b, DriverContext driverContext) {
+    this.source = source;
+    this.a = a;
+    this.b = b;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (DoubleRangeBlock aBlock = (DoubleRangeBlock) a.eval(page)) {
+      try (DoubleRangeBlock bBlock = (DoubleRangeBlock) b.eval(page)) {
+        return eval(page.getPositionCount(), aBlock, bBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += a.baseRamBytesUsed();
+    baseRamBytesUsed += b.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public BooleanBlock eval(int positionCount, DoubleRangeBlock aBlock, DoubleRangeBlock bBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      DoubleRangeBlockBuilder.DoubleRange aScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      DoubleRangeBlockBuilder.DoubleRange bScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (aBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (bBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        DoubleRangeBlockBuilder.DoubleRange a = aBlock.getDoubleRange(aBlock.getFirstValueIndex(p), aScratch);
+        DoubleRangeBlockBuilder.DoubleRange b = bBlock.getDoubleRange(bBlock.getFirstValueIndex(p), bScratch);
+        result.appendBoolean(RangeWithin.processRange(a, b));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RangeWithinDoubleRangeEvaluator[" + "a=" + a + ", b=" + b + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(a, b);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = driverContext.createWarnings(source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory a;
+
+    private final ExpressionEvaluator.Factory b;
+
+    public Factory(Source source, ExpressionEvaluator.Factory a, ExpressionEvaluator.Factory b) {
+      this.source = source;
+      this.a = a;
+      this.b = b;
+    }
+
+    @Override
+    public RangeWithinDoubleRangeEvaluator get(DriverContext context) {
+      return new RangeWithinDoubleRangeEvaluator(source, a.get(context), b.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "RangeWithinDoubleRangeEvaluator[" + "a=" + a + ", b=" + b + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2142,7 +2142,7 @@ public class EsqlCapabilities {
         /**
          * Support for the DOUBLE_RANGE field type.
          */
-        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8(Build.current().isSnapshot()),
+        DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9(Build.current().isSnapshot()),
 
         /**
          * Network direction function.
@@ -3397,7 +3397,7 @@ public class EsqlCapabilities {
         /**
          * Support for equality ({@code ==}, {@code !=}) and {@code IN} with the {@code double_range} type.
          */
-        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()),
+        EQUALITY_DOUBLE_RANGE(DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()),
 
         /**
          * Fix TopN encoding/decoding of {@code long_range} values.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContains.java
@@ -31,9 +31,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE_RANGE;
 
 /**
- * RANGE_CONTAINS(a, b) -> boolean
+ * {@code RANGE_CONTAINS(a, b) -> boolean}.
  * Returns true if the first argument contains the second.
  * Equivalent to {@code RANGE_WITHIN(b, a)} — this function lowers to {@link RangeWithin} via
  * {@link OnlySurrogateExpression#surrogate()} on the coordinator, so it has no evaluator of its own.
@@ -41,6 +43,8 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
  * <ul>
  *   <li>(date_range, date): range contains point</li>
  *   <li>(date_range, date_range): first range contains second (second fully contained by first)</li>
+ *   <li>(double_range, double): range contains point</li>
+ *   <li>(double_range, double_range): first range contains second (second fully contained by first)</li>
  * </ul>
  */
 public class RangeContains extends EsqlScalarFunction implements OnlySurrogateExpression, AnyNullIsNull {
@@ -69,8 +73,12 @@ public class RangeContains extends EsqlScalarFunction implements OnlySurrogateEx
     )
     public RangeContains(
         Source source,
-        @Param(name = "left", type = { "date_range" }, description = "Container range.") Expression left,
-        @Param(name = "right", type = { "date", "date_range" }, description = "Value to test (point or range).") Expression right
+        @Param(name = "left", type = { "date_range", "double_range" }, description = "Container range.") Expression left,
+        @Param(
+            name = "right",
+            type = { "date", "date_range", "double", "double_range" },
+            description = "Value to test (point or range)."
+        ) Expression right
     ) {
         super(source, List.of(left, right));
         this.left = left;
@@ -106,8 +114,38 @@ public class RangeContains extends EsqlScalarFunction implements OnlySurrogateEx
             return new TypeResolution("Unresolved children");
         }
 
-        TypeResolution first = isType(left, dt -> dt == DATE_RANGE, sourceText(), FIRST, "date_range");
-        TypeResolution second = isType(right, dt -> dt == DATE_RANGE || dt == DATETIME, sourceText(), SECOND, "date", "date_range");
+        TypeResolution first = isType(
+            left,
+            dt -> dt == DATE_RANGE || dt == DOUBLE_RANGE,
+            sourceText(),
+            FIRST,
+            "date_range",
+            "double_range"
+        );
+        DataType expectedScalarType = switch (left.dataType()) {
+            case DATE_RANGE -> DATETIME;
+            case DOUBLE_RANGE -> DOUBLE;
+            default -> null;
+        };
+        TypeResolution second = expectedScalarType == null
+            ? isType(
+                right,
+                dt -> dt == DATE_RANGE || dt == DATETIME || dt == DOUBLE_RANGE || dt == DOUBLE,
+                sourceText(),
+                SECOND,
+                "date",
+                "date_range",
+                "double",
+                "double_range"
+            )
+            : isType(
+                right,
+                dt -> dt == expectedScalarType || dt == left.dataType(),
+                sourceText(),
+                SECOND,
+                expectedScalarType.esType(),
+                left.dataType().esType()
+            );
         return first.and(second);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithin.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
@@ -44,19 +45,23 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE_RANGE;
 import static org.elasticsearch.xpack.esql.expression.Foldables.literalValueOf;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.DEFAULT_DATE_TIME_FORMATTER;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToString;
 
 /**
- * RANGE_WITHIN(value, range) -> boolean
+ * {@code RANGE_WITHIN(value, range) -> boolean}.
  * Returns true if the first argument is within the second (the range).
  * Supported signatures:
  * <ul>
  *   <li>(date, date_range): point within range</li>
  *   <li>(date_range, date_range): first range within second (first fully contained by second)</li>
+ *   <li>(double, double_range): point within range</li>
+ *   <li>(double_range, double_range): first range within second (first fully contained by second)</li>
  * </ul>
- * (date_range, date) and (date, date) are not supported; they do not match "value within range" semantics.
+ * The two arguments must belong to the same range family.
  */
 public class RangeWithin extends EsqlScalarFunction implements TranslationAware, AnyNullIsNull {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -84,8 +89,12 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
     )
     public RangeWithin(
         Source source,
-        @Param(name = "left", type = { "date", "date_range" }, description = "Value to test (point or range).") Expression left,
-        @Param(name = "right", type = { "date_range" }, description = "Container range.") Expression right
+        @Param(
+            name = "left",
+            type = { "date", "date_range", "double", "double_range" },
+            description = "Value to test (point or range)."
+        ) Expression left,
+        @Param(name = "right", type = { "date_range", "double_range" }, description = "Container range.") Expression right
     ) {
         super(source, List.of(left, right));
         this.left = left;
@@ -139,6 +148,12 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
             return null;
         }
 
+        if (right.dataType() == DOUBLE_RANGE) {
+            if (left.dataType() == DOUBLE_RANGE) {
+                return processRange((DoubleRangeBlockBuilder.DoubleRange) leftValue, (DoubleRangeBlockBuilder.DoubleRange) rightValue);
+            }
+            return processPoint((Double) leftValue, (DoubleRangeBlockBuilder.DoubleRange) rightValue);
+        }
         if (left.dataType() == DATE_RANGE) {
             return processRange((LongRangeBlockBuilder.LongRange) leftValue, (LongRangeBlockBuilder.LongRange) rightValue);
         }
@@ -156,14 +171,40 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
         return a.from() >= b.from() && a.to() <= b.to();
     }
 
+    @Evaluator(extraName = "DoublePoint")
+    static boolean processPoint(double point, DoubleRangeBlockBuilder.DoubleRange range) {
+        return point >= range.from() && point < range.to();
+    }
+
+    @Evaluator(extraName = "DoubleRange")
+    static boolean processRange(DoubleRangeBlockBuilder.DoubleRange a, DoubleRangeBlockBuilder.DoubleRange b) {
+        return a.from() >= b.from() && a.to() <= b.to();
+    }
+
     @Override
     protected TypeResolution resolveType() {
         if (childrenResolved() == false) {
             return new TypeResolution("Unresolved children");
         }
 
-        TypeResolution first = isType(left, dt -> dt == DATE_RANGE || dt == DATETIME, sourceText(), FIRST, "date", "date_range");
-        TypeResolution second = isType(right, dt -> dt == DATE_RANGE, sourceText(), SECOND, "date_range");
+        TypeResolution first = isType(
+            left,
+            dt -> isRange(dt) || dt == DATETIME || dt == DOUBLE,
+            sourceText(),
+            FIRST,
+            "date",
+            "date_range",
+            "double",
+            "double_range"
+        );
+        DataType expectedRangeType = switch (left.dataType()) {
+            case DATETIME, DATE_RANGE -> DATE_RANGE;
+            case DOUBLE, DOUBLE_RANGE -> DOUBLE_RANGE;
+            default -> null;
+        };
+        TypeResolution second = expectedRangeType == null
+            ? isType(right, dt -> dt == DATE_RANGE || dt == DOUBLE_RANGE, sourceText(), SECOND, "date_range", "double_range")
+            : isType(right, dt -> dt == expectedRangeType, sourceText(), SECOND, expectedRangeType.esType());
         return first.and(second);
     }
 
@@ -171,6 +212,12 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         var leftEvaluator = toEvaluator.apply(left);
         var rightEvaluator = toEvaluator.apply(right);
+        if (right.dataType() == DOUBLE_RANGE) {
+            if (left.dataType() == DOUBLE_RANGE) {
+                return new RangeWithinDoubleRangeEvaluator.Factory(source(), leftEvaluator, rightEvaluator);
+            }
+            return new RangeWithinDoublePointEvaluator.Factory(source(), leftEvaluator, rightEvaluator);
+        }
         if (left.dataType() == DATE_RANGE) {
             return new RangeWithinRangeEvaluator.Factory(source(), leftEvaluator, rightEvaluator);
         }
@@ -191,6 +238,10 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
         return pushdownPredicates.isPushableFieldAttribute(maybeField) && maybeLiteral.foldable();
     }
 
+    private static boolean isRange(DataType dataType) {
+        return dataType == DATE_RANGE || dataType == DOUBLE_RANGE;
+    }
+
     @Override
     public Query asQuery(LucenePushdownPredicates pushdownPredicates, TranslatorHandler handler) {
         Expression fieldExp;
@@ -208,37 +259,54 @@ public class RangeWithin extends EsqlScalarFunction implements TranslationAware,
         TypedAttribute attribute = LucenePushdownPredicates.checkIsPushableAttribute(fieldExp);
         String name = handler.nameOf(attribute);
         Object value = literalValueOf(literalExp);
-        String format = DEFAULT_DATE_TIME_FORMATTER.pattern();
+        String format = attribute.dataType() == DATETIME || attribute.dataType() == DATE_RANGE
+            ? DEFAULT_DATE_TIME_FORMATTER.pattern()
+            : null;
 
-        if (attribute.dataType() == DATETIME) {
-            // Field is a date; the function shape forces the other side to be a date_range.
-            LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
-            return new RangeQuery(source(), name, dateTimeToString(r.from()), true, dateTimeToString(r.to()), false, format, null);
+        if (isRange(attribute.dataType()) == false) {
+            // The field is a scalar; the function shape forces the other side to be the corresponding range.
+            if (attribute.dataType() == DATETIME) {
+                LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
+                return new RangeQuery(source(), name, dateTimeToString(r.from()), true, dateTimeToString(r.to()), false, format, null);
+            }
+            DoubleRangeBlockBuilder.DoubleRange r = (DoubleRangeBlockBuilder.DoubleRange) value;
+            return new RangeQuery(source(), name, r.from(), true, r.to(), false, null, null);
         }
-        // Field is a date_range. Pick CONTAINS or WITHIN based on which side the field is on.
+        // The field is a range. Pick CONTAINS or WITHIN based on which side the field is on.
         ShapeRelation relation;
         Object lower;
         Object upper;
         boolean includeUpper;
         if (fieldIsLeft) {
-            // RANGE_WITHIN(field_range, literal_range) — field_range is fully contained in literal_range.
-            LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
-            lower = dateTimeToString(r.from());
-            upper = dateTimeToString(r.to());
+            // RANGE_WITHIN(field_range, literal_range) — field_range is fully contained by literal_range.
+            if (attribute.dataType() == DATE_RANGE) {
+                LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
+                lower = dateTimeToString(r.from());
+                upper = dateTimeToString(r.to());
+            } else {
+                DoubleRangeBlockBuilder.DoubleRange r = (DoubleRangeBlockBuilder.DoubleRange) value;
+                lower = r.from();
+                upper = r.to();
+            }
             includeUpper = false;
             relation = ShapeRelation.WITHIN;
-        } else if (literalExp.dataType() == DATETIME) {
-            // RANGE_WITHIN(literal_date, field_range) — field_range contains the literal date.
-            String date = dateTimeToString((Long) value);
-            lower = date;
-            upper = date;
+        } else if (isRange(literalExp.dataType()) == false) {
+            // RANGE_WITHIN(literal_point, field_range) — field_range contains the literal point.
+            lower = literalExp.dataType() == DATETIME ? dateTimeToString((Long) value) : value;
+            upper = lower;
             includeUpper = true;
             relation = ShapeRelation.CONTAINS;
         } else {
             // RANGE_WITHIN(literal_range, field_range) — field_range fully contains the literal range.
-            LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
-            lower = dateTimeToString(r.from());
-            upper = dateTimeToString(r.to());
+            if (attribute.dataType() == DATE_RANGE) {
+                LongRangeBlockBuilder.LongRange r = (LongRangeBlockBuilder.LongRange) value;
+                lower = dateTimeToString(r.from());
+                upper = dateTimeToString(r.to());
+            } else {
+                DoubleRangeBlockBuilder.DoubleRange r = (DoubleRangeBlockBuilder.DoubleRange) value;
+                lower = r.from();
+                upper = r.to();
+            }
             includeUpper = false;
             relation = ShapeRelation.CONTAINS;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1628,7 +1628,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testDoubleRangeUnsupportedOperations() {
-        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled());
+        assumeTrue("Requires DOUBLE_RANGE_FIELD_TYPE capability", EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled());
         analyzer().addIndex("heights", "mapping-heights.json")
             .stripErrorPrefix(true)
             .error("FROM heights | SORT height_range", containsString("cannot sort on double_range"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AbsentTests.java
@@ -56,7 +56,7 @@ public class AbsentTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
-            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()
                 ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s1 -> s1.withAppliesTo(doubleRangeAppliesTo)).toList()
                 : List.<TestCaseSupplier.TypedDataSupplier>of(),
             MultiRowTestCaseSupplier.denseVectorCases(1, 1000),
@@ -111,7 +111,7 @@ public class AbsentTests extends AbstractAggregationTestCase {
             DataType.EXPONENTIAL_HISTOGRAM,
             DataType.TDIGEST
         );
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
         }
         for (var dataType : types) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -58,7 +58,7 @@ public class CountTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.dateCases(1, 1000),
             MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
             MultiRowTestCaseSupplier.dateRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(dateRangeAppliesTo)).toList(),
-            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+            EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()
                 ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s1 -> s1.withAppliesTo(doubleRangeAppliesTo)).toList()
                 : List.<TestCaseSupplier.TypedDataSupplier>of(),
             MultiRowTestCaseSupplier.denseVectorCases(1, 1000),
@@ -107,7 +107,7 @@ public class CountTests extends AbstractAggregationTestCase {
             DataType.UNSIGNED_LONG,
             DataType.AGGREGATE_METRIC_DOUBLE
         );
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
         }
         for (var dataType : types) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PresentTests.java
@@ -45,7 +45,7 @@ public class PresentTests extends AbstractAggregationTestCase {
         FunctionAppliesTo flattenedPreviewAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
-        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()
             ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(doubleRangeAppliesTo)).toList()
             : List.of();
 
@@ -112,7 +112,7 @@ public class PresentTests extends AbstractAggregationTestCase {
             DataType.EXPONENTIAL_HISTOGRAM,
             DataType.TDIGEST
         );
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             types = Stream.concat(types.stream(), Stream.of(DataType.DOUBLE_RANGE)).toList();
         }
         for (var dataType : types) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
@@ -47,7 +47,7 @@ public class ValuesTests extends AbstractAggregationTestCase {
         var suppliers = new ArrayList<TestCaseSupplier>();
         FunctionAppliesTo dateRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.5.0", "", false);
         FunctionAppliesTo doubleRangeAppliesTo = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
-        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+        List<TestCaseSupplier.TypedDataSupplier> doubleRangeCases = EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()
             ? MultiRowTestCaseSupplier.doubleRangeCases(1, 1000).stream().map(s -> s.withAppliesTo(doubleRangeAppliesTo)).toList()
             : List.of();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/CaseTests.java
@@ -45,7 +45,7 @@ public class CaseTests extends AbstractScalarFunctionTestCase {
         .filter(t -> t != DataType.DOC_DATA_TYPE)
         .filter(t -> t != DataType.TSID_DATA_TYPE)
         .filter(t -> t != DataType.DATE_RANGE || EsqlCapabilities.Cap.CASE_DATE_RANGE.isEnabled())
-        .filter(t -> t != DataType.DOUBLE_RANGE || EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled())
+        .filter(t -> t != DataType.DOUBLE_RANGE || EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled())
         .toList();
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsErrorTests.java
@@ -20,12 +20,13 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Error tests for RANGE_CONTAINS(container, value). First argument must be date_range; second must be date or date_range.
+ * Error tests for {@code RANGE_CONTAINS(container, value)}.
  */
 public class RangeContainsErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     @Override
     protected List<TestCaseSupplier> cases() {
         assumeTrue("DATE_RANGE type is only supported in snapshot builds", DataType.DATE_RANGE.supportedVersion().supportedLocally());
+        assumeTrue("DOUBLE_RANGE type is only supported in snapshot builds", DataType.DOUBLE_RANGE.supportedVersion().supportedLocally());
         return paramsToSuppliers(RangeContainsTests.parameters());
     }
 
@@ -36,6 +37,26 @@ public class RangeContainsErrorTests extends ErrorsForCasesWithoutExamplesTestCa
 
     @Override
     protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
-        return equalTo(typeErrorMessage(true, validPerPosition, signature, (v, i) -> i == 0 ? "date_range" : "date or date_range"));
+        return equalTo(
+            typeErrorMessage(
+                true,
+                validPerPosition,
+                signature,
+                (v, i) -> i == 0 ? "date_range or double_range"
+                    : signature.get(0) == DataType.DOUBLE_RANGE ? "double or double_range"
+                    : signature.get(0) == DataType.DATE_RANGE ? "date or date_range"
+                    : "date, date_range, double or double_range",
+                () -> {
+                    String expected = signature.get(0) == DataType.DOUBLE_RANGE ? "double or double_range" : "date or date_range";
+                    return "second argument of ["
+                        + sourceForSignature(signature)
+                        + "] must be ["
+                        + expected
+                        + "], found value [] type ["
+                        + signature.get(1).typeName()
+                        + "]";
+                }
+            )
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
-import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
@@ -35,8 +34,6 @@ import static org.hamcrest.Matchers.equalTo;
  * channel 0 — that's why the matchers below show channel 1 first.
  */
 public class RangeContainsTests extends AbstractScalarFunctionTestCase {
-    private static final FunctionAppliesTo DOUBLE_RANGE_APPLIES_TO = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
-
     public RangeContainsTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
     }
@@ -132,7 +129,9 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
             () -> new TestCaseSupplier.TestCase(
                 List.of(
                     typedDoubleRange(from, to),
-                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(DOUBLE_RANGE_APPLIES_TO)
+                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(
+                        appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false)
+                    )
                 ),
                 "RangeWithinDoublePointEvaluator[point=Attribute[channel=1], range=Attribute[channel=0]]",
                 DataType.BOOLEAN,
@@ -143,7 +142,7 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
 
     private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
         return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range")
-            .withAppliesTo(DOUBLE_RANGE_APPLIES_TO);
+            .withAppliesTo(appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
@@ -16,12 +16,15 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier.appliesTo;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -32,6 +35,8 @@ import static org.hamcrest.Matchers.equalTo;
  * channel 0 — that's why the matchers below show channel 1 first.
  */
 public class RangeContainsTests extends AbstractScalarFunctionTestCase {
+    private static final FunctionAppliesTo DOUBLE_RANGE_APPLIES_TO = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+
     public RangeContainsTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
     }
@@ -59,12 +64,10 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
             // Range is half-open [from, to); date == to is NOT contained. Use 1501 so that 1500 is inside [500, 1501).
             suppliers.add(rangePoint("date just before range end", 500L, 1501L, 1500L, true));
         }
-        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
-            suppliers.add(doubleRangeRange("double range contains range", 0.0, 2.0, 0.5, 1.5, true));
-            suppliers.add(doubleRangeRange("double range does not contain overlap", 0.0, 1.0, 0.5, 1.5, false));
-            suppliers.add(doubleRangePoint("double range contains point", 0.5, 1.5, 1.0, true));
-            suppliers.add(doubleRangePoint("double range excludes end", 0.5, 1.5, 1.5, false));
-        }
+        suppliers.add(doubleRangeRange("double range contains range", 0.0, 2.0, 0.5, 1.5, true));
+        suppliers.add(doubleRangeRange("double range does not contain overlap", 0.0, 1.0, 0.5, 1.5, false));
+        suppliers.add(doubleRangePoint("double range contains point", 0.5, 1.5, 1.0, true));
+        suppliers.add(doubleRangePoint("double range excludes end", 0.5, 1.5, 1.5, false));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
@@ -127,7 +130,10 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
             name,
             List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE),
             () -> new TestCaseSupplier.TestCase(
-                List.of(typedDoubleRange(from, to), new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point")),
+                List.of(
+                    typedDoubleRange(from, to),
+                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(DOUBLE_RANGE_APPLIES_TO)
+                ),
                 "RangeWithinDoublePointEvaluator[point=Attribute[channel=1], range=Attribute[channel=0]]",
                 DataType.BOOLEAN,
                 equalTo(expected)
@@ -136,7 +142,8 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
     }
 
     private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
-        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range");
+        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range")
+            .withAppliesTo(DOUBLE_RANGE_APPLIES_TO);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeContainsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -58,6 +59,12 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
             // Range is half-open [from, to); date == to is NOT contained. Use 1501 so that 1500 is inside [500, 1501).
             suppliers.add(rangePoint("date just before range end", 500L, 1501L, 1500L, true));
         }
+        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            suppliers.add(doubleRangeRange("double range contains range", 0.0, 2.0, 0.5, 1.5, true));
+            suppliers.add(doubleRangeRange("double range does not contain overlap", 0.0, 1.0, 0.5, 1.5, false));
+            suppliers.add(doubleRangePoint("double range contains point", 0.5, 1.5, 1.0, true));
+            suppliers.add(doubleRangePoint("double range excludes end", 0.5, 1.5, 1.5, false));
+        }
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
@@ -93,6 +100,43 @@ public class RangeContainsTests extends AbstractScalarFunctionTestCase {
 
     private static TestCaseSupplier.TypedData typedDateRange(long from, long to) {
         return new TestCaseSupplier.TypedData(new LongRangeBlockBuilder.LongRange(from, to), DataType.DATE_RANGE, "range");
+    }
+
+    private static TestCaseSupplier doubleRangeRange(
+        String name,
+        double containerFrom,
+        double containerTo,
+        double valueFrom,
+        double valueTo,
+        boolean expected
+    ) {
+        return new TestCaseSupplier(
+            name,
+            List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE),
+            () -> new TestCaseSupplier.TestCase(
+                List.of(typedDoubleRange(containerFrom, containerTo), typedDoubleRange(valueFrom, valueTo)),
+                "RangeWithinDoubleRangeEvaluator[a=Attribute[channel=1], b=Attribute[channel=0]]",
+                DataType.BOOLEAN,
+                equalTo(expected)
+            )
+        );
+    }
+
+    private static TestCaseSupplier doubleRangePoint(String name, double from, double to, double point, boolean expected) {
+        return new TestCaseSupplier(
+            name,
+            List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE),
+            () -> new TestCaseSupplier.TestCase(
+                List.of(typedDoubleRange(from, to), new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point")),
+                "RangeWithinDoublePointEvaluator[point=Attribute[channel=1], range=Attribute[channel=0]]",
+                DataType.BOOLEAN,
+                equalTo(expected)
+            )
+        );
+    }
+
+    private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
+        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinErrorTests.java
@@ -20,13 +20,13 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Error tests for RANGE_WITHIN(value, range).
- * First argument must be date or date_range; second argument must be date_range.
+ * Error tests for {@code RANGE_WITHIN(value, range)}.
  */
 public class RangeWithinErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     @Override
     protected List<TestCaseSupplier> cases() {
         assumeTrue("DATE_RANGE type is only supported in snapshot builds", DataType.DATE_RANGE.supportedVersion().supportedLocally());
+        assumeTrue("DOUBLE_RANGE type is only supported in snapshot builds", DataType.DOUBLE_RANGE.supportedVersion().supportedLocally());
         return paramsToSuppliers(RangeWithinTests.parameters());
     }
 
@@ -37,6 +37,28 @@ public class RangeWithinErrorTests extends ErrorsForCasesWithoutExamplesTestCase
 
     @Override
     protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
-        return equalTo(typeErrorMessage(true, validPerPosition, signature, (v, i) -> i == 0 ? "date or date_range" : "date_range"));
+        return equalTo(
+            typeErrorMessage(
+                true,
+                validPerPosition,
+                signature,
+                (v, i) -> i == 0 ? "date, date_range, double or double_range"
+                    : signature.get(0) == DataType.DOUBLE || signature.get(0) == DataType.DOUBLE_RANGE ? "double_range"
+                    : signature.get(0) == DataType.DATETIME || signature.get(0) == DataType.DATE_RANGE ? "date_range"
+                    : "date_range or double_range",
+                () -> {
+                    String expected = signature.get(0) == DataType.DOUBLE || signature.get(0) == DataType.DOUBLE_RANGE
+                        ? "double_range"
+                        : "date_range";
+                    return "second argument of ["
+                        + sourceForSignature(signature)
+                        + "] must be ["
+                        + expected
+                        + "], found value [] type ["
+                        + signature.get(1).typeName()
+                        + "]";
+                }
+            )
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinPushdownTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinPushdownTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 
 import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder.DoubleRange;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder.LongRange;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
@@ -141,6 +142,31 @@ public class RangeWithinPushdownTests extends ESTestCase {
         );
     }
 
+    public void testDoubleFieldWithLiteralRange() {
+        RangeWithin fn = new RangeWithin(Source.EMPTY, doubleField("height"), doubleRangeLiteral(1.5, 2.5));
+        assertThat(
+            fn.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER),
+            equalTo(new RangeQuery(Source.EMPTY, "height", 1.5, true, 2.5, false, null, null))
+        );
+        assertThat(fn.translatable(LucenePushdownPredicates.DEFAULT), equalTo(TranslationAware.Translatable.RECHECK));
+    }
+
+    public void testDoubleRangeFieldWithinLiteralRange() {
+        RangeWithin fn = new RangeWithin(Source.EMPTY, doubleRangeField("height_range"), doubleRangeLiteral(1.5, 2.5));
+        assertThat(
+            fn.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER),
+            equalTo(new RangeQuery(Source.EMPTY, "height_range", 1.5, true, 2.5, false, null, null, ShapeRelation.WITHIN))
+        );
+    }
+
+    public void testDoubleRangeFieldContainsLiteralPoint() {
+        RangeWithin fn = new RangeWithin(Source.EMPTY, doubleLiteral(2.0), doubleRangeField("height_range"));
+        assertThat(
+            fn.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER),
+            equalTo(new RangeQuery(Source.EMPTY, "height_range", 2.0, true, 2.0, true, null, null, ShapeRelation.CONTAINS))
+        );
+    }
+
     private static FieldAttribute dateField(String name) {
         return new FieldAttribute(
             Source.EMPTY,
@@ -157,11 +183,31 @@ public class RangeWithinPushdownTests extends ESTestCase {
         );
     }
 
+    private static FieldAttribute doubleField(String name) {
+        return new FieldAttribute(Source.EMPTY, name, new EsField(name, DataType.DOUBLE, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static FieldAttribute doubleRangeField(String name) {
+        return new FieldAttribute(
+            Source.EMPTY,
+            name,
+            new EsField(name, DataType.DOUBLE_RANGE, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+        );
+    }
+
     private static Literal dateLiteral(long millis) {
         return new Literal(Source.EMPTY, millis, DataType.DATETIME);
     }
 
     private static Literal rangeLiteral(long from, long to) {
         return new Literal(Source.EMPTY, new LongRange(from, to), DataType.DATE_RANGE);
+    }
+
+    private static Literal doubleLiteral(double value) {
+        return new Literal(Source.EMPTY, value, DataType.DOUBLE);
+    }
+
+    private static Literal doubleRangeLiteral(double from, double to) {
+        return new Literal(Source.EMPTY, new DoubleRange(from, to), DataType.DOUBLE_RANGE);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
@@ -16,20 +16,31 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier.appliesTo;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Tests for {@code RANGE_WITHIN(value, range) -> boolean}.
  */
 public class RangeWithinTests extends AbstractScalarFunctionTestCase {
+    private static final FunctionAppliesTo DOUBLE_RANGE_APPLIES_TO = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
+
     public RangeWithinTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
+    }
+
+    @Override
+    protected boolean canSerialize() {
+        return DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()
+            || testCase.getData().stream().noneMatch(data -> data.type() == DataType.DOUBLE_RANGE);
     }
 
     @ParametersFactory
@@ -50,16 +61,14 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
             suppliers.add(rangeWithinRange("equal ranges", 500L, 1500L, 500L, 1500L, true));
             suppliers.add(rangeWithinRange("point range within wider range", 1000L, 1000L, 500L, 1500L, true));
         }
-        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
-            suppliers.add(doublePointInRange("double inside range", 1.0, 0.5, 1.5, true));
-            suppliers.add(doublePointInRange("double outside range", 2.0, 0.5, 1.5, false));
-            suppliers.add(doublePointInRange("double at range start", 0.5, 0.5, 1.5, true));
-            suppliers.add(doublePointInRange("double at range end", 1.5, 0.5, 1.5, false));
+        suppliers.add(doublePointInRange("double inside range", 1.0, 0.5, 1.5, true));
+        suppliers.add(doublePointInRange("double outside range", 2.0, 0.5, 1.5, false));
+        suppliers.add(doublePointInRange("double at range start", 0.5, 0.5, 1.5, true));
+        suppliers.add(doublePointInRange("double at range end", 1.5, 0.5, 1.5, false));
 
-            suppliers.add(doubleRangeWithinRange("double range within range", 0.5, 1.5, 0.0, 2.0, true));
-            suppliers.add(doubleRangeWithinRange("overlapping double range is not within", 0.0, 1.0, 0.5, 1.5, false));
-            suppliers.add(doubleRangeWithinRange("equal double ranges", 0.5, 1.5, 0.5, 1.5, true));
-        }
+        suppliers.add(doubleRangeWithinRange("double range within range", 0.5, 1.5, 0.0, 2.0, true));
+        suppliers.add(doubleRangeWithinRange("overlapping double range is not within", 0.0, 1.0, 0.5, 1.5, false));
+        suppliers.add(doubleRangeWithinRange("equal double ranges", 0.5, 1.5, 0.5, 1.5, true));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }
@@ -106,7 +115,10 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
             name,
             List.of(DataType.DOUBLE, DataType.DOUBLE_RANGE),
             () -> new TestCaseSupplier.TestCase(
-                List.of(new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point"), typedDoubleRange(rangeFrom, rangeTo)),
+                List.of(
+                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(DOUBLE_RANGE_APPLIES_TO),
+                    typedDoubleRange(rangeFrom, rangeTo)
+                ),
                 "RangeWithinDoublePointEvaluator[point=Attribute[channel=0], range=Attribute[channel=1]]",
                 DataType.BOOLEAN,
                 equalTo(expected)
@@ -135,7 +147,8 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
     }
 
     private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
-        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range");
+        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range")
+            .withAppliesTo(DOUBLE_RANGE_APPLIES_TO);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -24,8 +25,7 @@ import java.util.function.Supplier;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Tests for RANGE_WITHIN(value, range) -> boolean for the two supported type combinations:
- * (date, date_range) and (date_range, date_range).
+ * Tests for {@code RANGE_WITHIN(value, range) -> boolean}.
  */
 public class RangeWithinTests extends AbstractScalarFunctionTestCase {
     public RangeWithinTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
@@ -49,6 +49,16 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
             suppliers.add(rangeWithinRange("first not within second (overlap)", 100L, 1000L, 500L, 1500L, false));
             suppliers.add(rangeWithinRange("equal ranges", 500L, 1500L, 500L, 1500L, true));
             suppliers.add(rangeWithinRange("point range within wider range", 1000L, 1000L, 500L, 1500L, true));
+        }
+        if (DataType.DOUBLE_RANGE.supportedVersion().supportedLocally()) {
+            suppliers.add(doublePointInRange("double inside range", 1.0, 0.5, 1.5, true));
+            suppliers.add(doublePointInRange("double outside range", 2.0, 0.5, 1.5, false));
+            suppliers.add(doublePointInRange("double at range start", 0.5, 0.5, 1.5, true));
+            suppliers.add(doublePointInRange("double at range end", 1.5, 0.5, 1.5, false));
+
+            suppliers.add(doubleRangeWithinRange("double range within range", 0.5, 1.5, 0.0, 2.0, true));
+            suppliers.add(doubleRangeWithinRange("overlapping double range is not within", 0.0, 1.0, 0.5, 1.5, false));
+            suppliers.add(doubleRangeWithinRange("equal double ranges", 0.5, 1.5, 0.5, 1.5, true));
         }
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
@@ -89,6 +99,43 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
 
     private static TestCaseSupplier.TypedData typedDateRange(long from, long to) {
         return new TestCaseSupplier.TypedData(new LongRangeBlockBuilder.LongRange(from, to), DataType.DATE_RANGE, "range");
+    }
+
+    private static TestCaseSupplier doublePointInRange(String name, double point, double rangeFrom, double rangeTo, boolean expected) {
+        return new TestCaseSupplier(
+            name,
+            List.of(DataType.DOUBLE, DataType.DOUBLE_RANGE),
+            () -> new TestCaseSupplier.TestCase(
+                List.of(new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point"), typedDoubleRange(rangeFrom, rangeTo)),
+                "RangeWithinDoublePointEvaluator[point=Attribute[channel=0], range=Attribute[channel=1]]",
+                DataType.BOOLEAN,
+                equalTo(expected)
+            )
+        );
+    }
+
+    private static TestCaseSupplier doubleRangeWithinRange(
+        String name,
+        double aFrom,
+        double aTo,
+        double bFrom,
+        double bTo,
+        boolean expected
+    ) {
+        return new TestCaseSupplier(
+            name,
+            List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE),
+            () -> new TestCaseSupplier.TestCase(
+                List.of(typedDoubleRange(aFrom, aTo), typedDoubleRange(bFrom, bTo)),
+                "RangeWithinDoubleRangeEvaluator[a=Attribute[channel=0], b=Attribute[channel=1]]",
+                DataType.BOOLEAN,
+                equalTo(expected)
+            )
+        );
+    }
+
+    private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
+        return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
-import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
@@ -31,8 +30,6 @@ import static org.hamcrest.Matchers.equalTo;
  * Tests for {@code RANGE_WITHIN(value, range) -> boolean}.
  */
 public class RangeWithinTests extends AbstractScalarFunctionTestCase {
-    private static final FunctionAppliesTo DOUBLE_RANGE_APPLIES_TO = appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false);
-
     public RangeWithinTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
     }
@@ -116,7 +113,9 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
             List.of(DataType.DOUBLE, DataType.DOUBLE_RANGE),
             () -> new TestCaseSupplier.TestCase(
                 List.of(
-                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(DOUBLE_RANGE_APPLIES_TO),
+                    new TestCaseSupplier.TypedData(point, DataType.DOUBLE, "point").withAppliesTo(
+                        appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false)
+                    ),
                     typedDoubleRange(rangeFrom, rangeTo)
                 ),
                 "RangeWithinDoublePointEvaluator[point=Attribute[channel=0], range=Attribute[channel=1]]",
@@ -148,7 +147,7 @@ public class RangeWithinTests extends AbstractScalarFunctionTestCase {
 
     private static TestCaseSupplier.TypedData typedDoubleRange(double from, double to) {
         return new TestCaseSupplier.TypedData(new DoubleRangeBlockBuilder.DoubleRange(from, to), DataType.DOUBLE_RANGE, "range")
-            .withAppliesTo(DOUBLE_RANGE_APPLIES_TO);
+            .withAppliesTo(appliesTo(FunctionAppliesToLifecycle.PREVIEW, "9.6.0", "", false));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
@@ -46,7 +46,7 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
         dateTimes(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateNanos(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));
         dateRanges(cases);
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             doubleRanges(cases);
         }
         geoPoints(cases, "mv_count", "MvCount", DataType.INTEGER, (size, values) -> equalTo(Math.toIntExact(values.count())));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
@@ -55,7 +55,7 @@ public class MvFirstTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             doubleRanges(cases);
         }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
@@ -55,7 +55,7 @@ public class MvLastTests extends AbstractMultivalueFunctionTestCase {
         if (EsqlCapabilities.Cap.MV_FIRST_LAST_DATE_RANGE.isEnabled()) {
             dateRanges(cases);
         }
-        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()) {
+        if (EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()) {
             doubleRanges(cases);
         }
         return parameterSuppliersFromTypedDataWithDefaultChecks(false, cases);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -181,8 +181,8 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
         }));
         noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.DOUBLE_RANGE, DataType.DOUBLE_RANGE), () -> {
             assumeTrue(
-                "Requires DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8 capability",
-                EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V8.isEnabled()
+                "Requires DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9 capability",
+                EsqlCapabilities.Cap.DOUBLE_RANGE_FIELD_TYPE_DEVELOPMENT_V9.isEnabled()
             );
             DoubleRangeBlockBuilder.DoubleRange first = randomBoolean() ? null : TestCaseSupplier.randomDoubleRange();
             DoubleRangeBlockBuilder.DoubleRange second = TestCaseSupplier.randomDoubleRange();


### PR DESCRIPTION
Part of #154463

Add `double_range` support to `RANGE_WITHIN` and `RANGE_CONTAINS`, including pushdown.