### PR TITLE
Audit workload-identity token mints

### DIFF
--- a/modules/workload-identity/spi/src/main/java/module-info.java
+++ b/modules/workload-identity/spi/src/main/java/module-info.java
@@ -9,6 +9,7 @@
 
 module org.elasticsearch.workloadidentity.spi {
     requires org.elasticsearch.server;
+    requires org.elasticsearch.base;
 
     exports org.elasticsearch.workloadidentity.spi;
 }

--- a/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/DataSourceAuditListener.java
+++ b/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/DataSourceAuditListener.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.workloadidentity.spi;
+
+import org.elasticsearch.core.Nullable;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Receiver for audit events on the ES|QL data source path: per-query data source access (all
+ * auth modes) and the workload-identity token mints backing federated ("keyless") access.
+ *
+ * <p>Neither event is visible to the transport-action audit machinery: token minting has no
+ * inbound principal, and which data sources a query exercised is known only to ES|QL at
+ * completion. This listener lets the emitters hand events to whichever plugin owns the audit
+ * trail without a dependency in that direction.
+ *
+ * <p>Implementations must be thread-safe and must not throw. Events never carry token material.
+ */
+public interface DataSourceAuditListener {
+
+    /** A listener that discards every event; installed while no audit consumer has registered. */
+    DataSourceAuditListener NOOP = new DataSourceAuditListener() {
+        @Override
+        public void tokenIssued(TokenIssuance issuance) {}
+
+        @Override
+        public void tokenIssuanceFailed(TokenIssuanceFailure failure) {}
+
+        @Override
+        public void dataSourceAccess(DataSourceAccess access) {}
+    };
+
+    /**
+     * A workload-identity JWT was minted: one event per real fetch (first use or re-fetch after
+     * eviction), never for cache hits. Credential <em>use</em> is audited via
+     * {@link #dataSourceAccess}.
+     */
+    void tokenIssued(TokenIssuance issuance);
+
+    /** A JWT mint failed after the retry budget: one event per failed fetch, not per attempt. */
+    void tokenIssuanceFailed(TokenIssuanceFailure failure);
+
+    /**
+     * A query accessed (or failed to access) a registered data source: one event per data source
+     * per query, any auth mode, emitted at query completion. Implementations read the
+     * authenticated user from the calling thread's context.
+     */
+    void dataSourceAccess(DataSourceAccess access);
+
+    /**
+     * A successful JWT mint.
+     *
+     * @param audience  the requested {@code aud} claim
+     * @param issuer    the issuer endpoint the token was fetched from
+     * @param subject   the decoded {@code sub} claim (e.g. {@code deployment:abc}), or {@code null}
+     * @param sessionId the decoded {@code jti} claim (per-token session id), or {@code null}
+     * @param expiresAt the issuer-reported expiry
+     */
+    record TokenIssuance(String audience, String issuer, @Nullable String subject, @Nullable String sessionId, Instant expiresAt) {
+        public TokenIssuance {
+            Objects.requireNonNull(audience, "audience must not be null");
+            Objects.requireNonNull(issuer, "issuer must not be null");
+            Objects.requireNonNull(expiresAt, "expiresAt must not be null");
+        }
+    }
+
+    /**
+     * A failed JWT mint.
+     *
+     * @param audience the requested {@code aud} claim
+     * @param issuer   the issuer endpoint the fetch was sent to
+     * @param cause    the terminal failure
+     */
+    record TokenIssuanceFailure(String audience, String issuer, Exception cause) {
+        public TokenIssuanceFailure {
+            Objects.requireNonNull(audience, "audience must not be null");
+            Objects.requireNonNull(issuer, "issuer must not be null");
+            Objects.requireNonNull(cause, "cause must not be null");
+        }
+    }
+
+    /**
+     * A query's use of one registered data source. The identity fields are federated-only:
+     * static credentials are classified secret and never described.
+     *
+     * @param dataSourceName    the registered data source name
+     * @param dataSourceType    the data source type (e.g. {@code s3})
+     * @param auth              the resolved auth mode ({@code federated_identity},
+     *                          {@code static_credentials}, {@code managed_identity}, {@code anonymous})
+     * @param identity          the federated target identity (e.g. an IAM role ARN), or {@code null}
+     * @param audience          the effective federated {@code jwt_audience}, joining this event to
+     *                          {@link TokenIssuance} events, or {@code null}
+     * @param sessionId         best-effort session id of the cached token for {@code audience} at
+     *                          completion time, or {@code null}
+     * @param granted           {@code true} when the credential phase was not the cause of failure;
+     *                          {@code false} when it was
+     * @param credentialFailure the credential-phase failure when not granted; {@code null} otherwise
+     */
+    record DataSourceAccess(
+        String dataSourceName,
+        String dataSourceType,
+        String auth,
+        @Nullable String identity,
+        @Nullable String audience,
+        @Nullable String sessionId,
+        boolean granted,
+        @Nullable Exception credentialFailure
+    ) {
+        public DataSourceAccess {
+            Objects.requireNonNull(dataSourceName, "dataSourceName must not be null");
+            Objects.requireNonNull(dataSourceType, "dataSourceType must not be null");
+            Objects.requireNonNull(auth, "auth must not be null");
+            if (granted == false && credentialFailure == null) {
+                throw new IllegalArgumentException("credentialFailure must be provided when access was not granted");
+            }
+            if (granted && credentialFailure != null) {
+                throw new IllegalArgumentException("credentialFailure must be null when access was granted");
+            }
+        }
+    }
+}

--- a/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/WorkloadIdentityIssuerClient.java
+++ b/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/WorkloadIdentityIssuerClient.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.workloadidentity.spi;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.Nullable;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -62,6 +63,30 @@ public interface WorkloadIdentityIssuerClient {
      */
     default boolean isEnabled() {
         return true;
+    }
+
+    /**
+     * Non-secret identifiers of the token currently cached for {@code audience}, or {@code null}
+     * if none. Best-effort, for audit correlation: lets the ES|QL completion path stamp
+     * {@link DataSourceAuditListener.DataSourceAccess} events with the session id without
+     * threading token material through cloud SDK credential providers.
+     */
+    @Nullable
+    default IssuedTokenInfo peekTokenInfo(String audience) {
+        return null;
+    }
+
+    /**
+     * Non-secret identifiers decoded from an issued token; carries no token material.
+     *
+     * @param subject   the {@code sub} claim, or {@code null}
+     * @param sessionId the {@code jti} claim (per-token session id), or {@code null}
+     * @param expiresAt the issuer-reported expiry
+     */
+    record IssuedTokenInfo(@Nullable String subject, @Nullable String sessionId, Instant expiresAt) {
+        public IssuedTokenInfo {
+            Objects.requireNonNull(expiresAt, "expiresAt must not be null");
+        }
     }
 
     /**

--- a/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/WorkloadIdentityRegistry.java
+++ b/modules/workload-identity/spi/src/main/java/org/elasticsearch/workloadidentity/spi/WorkloadIdentityRegistry.java
@@ -28,6 +28,10 @@ public final class WorkloadIdentityRegistry {
     // for tests that construct multiple plugin instances.
     private static volatile WorkloadIdentityIssuerClient issuerClient;
 
+    // NOOP default rather than null: emitters fire unconditionally; clusters without an audit
+    // consumer discard the events.
+    private static volatile DataSourceAuditListener auditListener = DataSourceAuditListener.NOOP;
+
     private WorkloadIdentityRegistry() {}
 
     /**
@@ -56,6 +60,20 @@ public final class WorkloadIdentityRegistry {
         issuerClient = client;
     }
 
+    /** @return the node-wide {@link DataSourceAuditListener}; {@link DataSourceAuditListener#NOOP} until one registers. */
+    public static DataSourceAuditListener getAuditListener() {
+        return auditListener;
+    }
+
+    /**
+     * Publish the node-wide audit listener, invoked by the security plugin's
+     * {@code createComponents}. Events emitted before registration are discarded by the NOOP
+     * default; no user-driven traffic occurs that early.
+     */
+    public static void setAuditListener(DataSourceAuditListener listener) {
+        auditListener = listener == null ? DataSourceAuditListener.NOOP : listener;
+    }
+
     /**
      * Clear the slot so a subsequent {@link #setIssuerClient} call publishes a new client. The
      * workload-identity plugin's constructor calls this so that constructing a second plugin
@@ -64,5 +82,6 @@ public final class WorkloadIdentityRegistry {
      */
     public static void reset() {
         issuerClient = null;
+        auditListener = DataSourceAuditListener.NOOP;
     }
 }

--- a/modules/workload-identity/src/main/java/org/elasticsearch/workloadidentity/HttpsWorkloadIdentityIssuerClient.java
+++ b/modules/workload-identity/src/main/java/org/elasticsearch/workloadidentity/HttpsWorkloadIdentityIssuerClient.java
@@ -29,7 +29,9 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.workloadidentity.spi.DataSourceAuditListener;
 import org.elasticsearch.workloadidentity.spi.WorkloadIdentityIssuerClient;
+import org.elasticsearch.workloadidentity.spi.WorkloadIdentityRegistry;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -48,6 +50,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -155,6 +158,13 @@ public final class HttpsWorkloadIdentityIssuerClient implements WorkloadIdentity
      */
     private final ConcurrentMap<IssueTokenRequest, SubscribableListener<IssueTokenResponse>> tokens = ConcurrentCollections
         .newConcurrentMap();
+
+    /**
+     * Decoded identifiers of the most recently cached token per audience, serving
+     * {@link #peekTokenInfo}. Populated on the cached-mint path only; removed by the same task
+     * that evicts the token, conditionally so eviction racing a re-mint keeps the newer entry.
+     */
+    private final ConcurrentMap<String, IssuedTokenInfo> tokenInfoByAudience = ConcurrentCollections.newConcurrentMap();
 
     /**
      * Single-shot guard so that the WARN log in {@link #issueToken} fires at most once per
@@ -328,8 +338,12 @@ public final class HttpsWorkloadIdentityIssuerClient implements WorkloadIdentity
 
     private void startFetch(IssueTokenRequest request, SubscribableListener<IssueTokenResponse> listener) {
         fetchToken(request, ActionListener.wrap(response -> {
+            final TokenClaims claims = TokenClaims.decode(response.token());
+            final IssuedTokenInfo info = new IssuedTokenInfo(claims.subject(), claims.sessionId(), response.expiresAt());
+            // publish before completing so an immediate peek sees this token
+            tokenInfoByAudience.put(request.audience(), info);
             listener.onResponse(response);
-            scheduleEviction(request, listener, response);
+            scheduleEviction(request, listener, response, info);
         }, failure -> {
             // Don't cache failures; let the next caller retry.
             tokens.remove(request, listener);
@@ -337,16 +351,30 @@ public final class HttpsWorkloadIdentityIssuerClient implements WorkloadIdentity
         }));
     }
 
-    private void scheduleEviction(IssueTokenRequest request, SubscribableListener<IssueTokenResponse> entry, IssueTokenResponse response) {
+    @Override
+    public IssuedTokenInfo peekTokenInfo(String audience) {
+        return tokenInfoByAudience.get(audience);
+    }
+
+    private void scheduleEviction(
+        IssueTokenRequest request,
+        SubscribableListener<IssueTokenResponse> entry,
+        IssueTokenResponse response,
+        IssuedTokenInfo info
+    ) {
         // toEpochMilli() is safe here by construction: every cached response has passed
         // validateExpiry, which caps expiresAt within MAX_TOKEN_LIFETIME_SECONDS of now.
         final long delayMillis = Math.max(0L, response.expiresAt().toEpochMilli() - System.currentTimeMillis() - refreshBeforeExpiryMillis);
         try {
-            threadPool.schedule(() -> tokens.remove(request, entry), TimeValue.timeValueMillis(delayMillis), threadPool.generic());
+            threadPool.schedule(() -> {
+                tokens.remove(request, entry);
+                tokenInfoByAudience.remove(request.audience(), info);
+            }, TimeValue.timeValueMillis(delayMillis), threadPool.generic());
         } catch (Exception e) {
             // If scheduling fails (e.g. shutting-down thread pool), evict immediately rather than
             // leaving a stale entry behind. The next caller will refetch.
             tokens.remove(request, entry);
+            tokenInfoByAudience.remove(request.audience(), info);
             logger.debug("failed to schedule workload-identity cache eviction; evicting immediately", e);
         }
     }
@@ -360,7 +388,48 @@ public final class HttpsWorkloadIdentityIssuerClient implements WorkloadIdentity
      * cache's {@link SubscribableListener}.
      */
     private void fetchToken(IssueTokenRequest request, ActionListener<IssueTokenResponse> listener) {
-        new IssueTokenRetrier(request, listener).run();
+        new IssueTokenRetrier(request, withAuditNotification(request, listener)).run();
+    }
+
+    /**
+     * Publishes one audit event per completed fetch (after retries, not per attempt), covering
+     * both the cached-mint and cache-bypass paths; cache hits never reach here. Fail-open: a
+     * listener bug must not fail token issuance.
+     */
+    private ActionListener<IssueTokenResponse> withAuditNotification(
+        IssueTokenRequest request,
+        ActionListener<IssueTokenResponse> listener
+    ) {
+        return ActionListener.wrap(response -> {
+            notifyAuditListener(auditListener -> {
+                final TokenClaims claims = TokenClaims.decode(response.token());
+                auditListener.tokenIssued(
+                    new DataSourceAuditListener.TokenIssuance(
+                        request.audience(),
+                        tokenEndpoint.toString(),
+                        claims.subject(),
+                        claims.sessionId(),
+                        response.expiresAt()
+                    )
+                );
+            });
+            listener.onResponse(response);
+        }, failure -> {
+            notifyAuditListener(
+                auditListener -> auditListener.tokenIssuanceFailed(
+                    new DataSourceAuditListener.TokenIssuanceFailure(request.audience(), tokenEndpoint.toString(), failure)
+                )
+            );
+            listener.onFailure(failure);
+        });
+    }
+
+    private static void notifyAuditListener(Consumer<DataSourceAuditListener> event) {
+        try {
+            event.accept(WorkloadIdentityRegistry.getAuditListener());
+        } catch (Exception e) {
+            logger.warn("failed to publish workload-identity audit event", e);
+        }
     }
 
     /**

--- a/modules/workload-identity/src/main/java/org/elasticsearch/workloadidentity/TokenClaims.java
+++ b/modules/workload-identity/src/main/java/org/elasticsearch/workloadidentity/TokenClaims.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.workloadidentity;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * Best-effort extraction of non-secret identifier claims from a compact JWT, for audit
+ * correlation only: no signature verification (the token arrives from our issuer over mTLS) and
+ * nothing grants on these values. Malformed input yields {@code null} fields, never an error.
+ *
+ * @param subject   the {@code sub} claim, or {@code null}
+ * @param sessionId the {@code jti} claim (the issuer's per-token session id), or {@code null}
+ */
+record TokenClaims(@Nullable String subject, @Nullable String sessionId) {
+
+    static final TokenClaims EMPTY = new TokenClaims(null, null);
+
+    /** Decodes the payload segment of {@code token}; returns {@link #EMPTY} on any parse failure. */
+    static TokenClaims decode(String token) {
+        try {
+            final int firstDot = token.indexOf('.');
+            final int secondDot = token.indexOf('.', firstDot + 1);
+            if (firstDot < 0 || secondDot < 0) {
+                return EMPTY;
+            }
+            final byte[] payload = Base64.getUrlDecoder().decode(token.substring(firstDot + 1, secondDot));
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, payload)) {
+                final Map<String, Object> claims = parser.map();
+                return new TokenClaims(stringClaim(claims, "sub"), stringClaim(claims, "jti"));
+            }
+        } catch (Exception e) {
+            return EMPTY;
+        }
+    }
+
+    @Nullable
+    private static String stringClaim(Map<String, Object> claims, String name) {
+        return claims.get(name) instanceof String value && value.isEmpty() == false ? value : null;
+    }
+}

--- a/modules/workload-identity/src/test/java/org/elasticsearch/workloadidentity/HttpsWorkloadIdentityIssuerClientTests.java
+++ b/modules/workload-identity/src/test/java/org/elasticsearch/workloadidentity/HttpsWorkloadIdentityIssuerClientTests.java
@@ -39,9 +39,11 @@ import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.workloadidentity.spi.DataSourceAuditListener;
 import org.elasticsearch.workloadidentity.spi.WorkloadIdentityIssuerClient.IssueTokenRequest;
 import org.elasticsearch.workloadidentity.spi.WorkloadIdentityIssuerClient.IssueTokenResponse;
 import org.elasticsearch.workloadidentity.spi.WorkloadIdentityIssuerClient.WorkloadIdentityIssuerException;
+import org.elasticsearch.workloadidentity.spi.WorkloadIdentityRegistry;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,8 +59,10 @@ import java.nio.file.StandardCopyOption;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -129,6 +133,11 @@ public class HttpsWorkloadIdentityIssuerClientTests extends ESTestCase {
     @After
     public void resetHandler() {
         handler = exchange -> {};
+    }
+
+    @After
+    public void resetAuditListener() {
+        WorkloadIdentityRegistry.reset();
     }
 
     private static SSLContext buildServerSslContext() throws Exception {
@@ -486,6 +495,138 @@ public class HttpsWorkloadIdentityIssuerClientTests extends ESTestCase {
             final IssueTokenResponse second = awaitToken(harness, request);
             assertEquals("second issuance must come from the cache", 1, callCount.get());
             assertEquals(first, second);
+        }
+    }
+
+    /**
+     * Every real mint publishes one {@link DataSourceAuditListener#tokenIssued} event with
+     * the identifier claims decoded from the token, cache hits publish nothing, and
+     * {@link HttpsWorkloadIdentityIssuerClient#peekTokenInfo} serves the same identifiers for
+     * audit correlation by the ES|QL completion path.
+     */
+    public void testMintPublishesAuditEventAndPeekableTokenInfo() throws Exception {
+        final long expiresAtSeconds = (System.currentTimeMillis() / 1000) + 3_600;
+        final String payload = Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString("{\"sub\":\"deployment:abc\",\"jti\":\"session-1\"}".getBytes(StandardCharsets.UTF_8));
+        handler = exchange -> {
+            try {
+                final byte[] bytes = ("{\"token\":\"h." + payload + ".sig\",\"expires_at\":" + expiresAtSeconds + "}").getBytes(
+                    StandardCharsets.UTF_8
+                );
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            } catch (IOException e) {
+                throw new AssertionError("failed writing mock response", e);
+            }
+        };
+
+        final List<DataSourceAuditListener.TokenIssuance> issued = new CopyOnWriteArrayList<>();
+        WorkloadIdentityRegistry.setAuditListener(new DataSourceAuditListener() {
+            @Override
+            public void tokenIssued(TokenIssuance issuance) {
+                issued.add(issuance);
+            }
+
+            @Override
+            public void tokenIssuanceFailed(TokenIssuanceFailure failure) {
+                throw new AssertionError("unexpected failure event: " + failure.cause());
+            }
+
+            @Override
+            public void dataSourceAccess(DataSourceAccess access) {
+                throw new AssertionError("unexpected access event");
+            }
+        });
+
+        try (ClientHarness harness = new ClientHarness(clientSettingsWithIssuerUrl().build())) {
+            final IssueTokenRequest request = new IssueTokenRequest("aud-1");
+            awaitToken(harness, request);
+            awaitToken(harness, request);
+
+            assertEquals("cache hit must not publish an audit event", 1, issued.size());
+            final DataSourceAuditListener.TokenIssuance issuance = issued.get(0);
+            assertEquals("aud-1", issuance.audience());
+            assertEquals("deployment:abc", issuance.subject());
+            assertEquals("session-1", issuance.sessionId());
+            assertEquals(expiresAtSeconds, issuance.expiresAt().getEpochSecond());
+            assertThat(issuance.issuer(), containsString("/token"));
+
+            final var info = harness.client.peekTokenInfo("aud-1");
+            assertNotNull(info);
+            assertEquals("deployment:abc", info.subject());
+            assertEquals("session-1", info.sessionId());
+            assertNull("un-minted audiences have no peekable token", harness.client.peekTokenInfo("aud-other"));
+        }
+    }
+
+    /** A failed mint (after retries) publishes one {@link DataSourceAuditListener#tokenIssuanceFailed} event. */
+    public void testFailedMintPublishesAuditFailureEvent() throws Exception {
+        handler = exchange -> {
+            try {
+                exchange.sendResponseHeaders(403, -1);
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        };
+
+        final List<DataSourceAuditListener.TokenIssuanceFailure> failures = new CopyOnWriteArrayList<>();
+        WorkloadIdentityRegistry.setAuditListener(new DataSourceAuditListener() {
+            @Override
+            public void tokenIssued(TokenIssuance issuance) {
+                throw new AssertionError("unexpected success event");
+            }
+
+            @Override
+            public void tokenIssuanceFailed(TokenIssuanceFailure failure) {
+                failures.add(failure);
+            }
+
+            @Override
+            public void dataSourceAccess(DataSourceAccess access) {
+                throw new AssertionError("unexpected access event");
+            }
+        });
+
+        try (ClientHarness harness = new ClientHarness(clientSettingsWithIssuerUrl().build())) {
+            final PlainActionFuture<IssueTokenResponse> future = new PlainActionFuture<>();
+            harness.client.issueToken(new IssueTokenRequest("aud-denied"), future);
+            expectThrows(ExecutionException.class, () -> future.get(10, TimeUnit.SECONDS));
+
+            assertEquals("one event per completed fetch, not per retry attempt", 1, failures.size());
+            assertEquals("aud-denied", failures.get(0).audience());
+            assertThat(failures.get(0).cause(), instanceOf(WorkloadIdentityIssuerException.class));
+            assertNull("failed mints leave no peekable token", harness.client.peekTokenInfo("aud-denied"));
+        }
+    }
+
+    /** A throwing audit listener must not fail token issuance: the audit path is fail-open. */
+    public void testThrowingAuditListenerDoesNotFailIssuance() throws Exception {
+        final long farFutureEpochSecond = (System.currentTimeMillis() / 1000) + 3_600;
+        handler = exchange -> respondWithToken(exchange, farFutureEpochSecond);
+        WorkloadIdentityRegistry.setAuditListener(new DataSourceAuditListener() {
+            @Override
+            public void tokenIssued(TokenIssuance issuance) {
+                throw new RuntimeException("audit listener bug");
+            }
+
+            @Override
+            public void tokenIssuanceFailed(TokenIssuanceFailure failure) {
+                throw new RuntimeException("audit listener bug");
+            }
+
+            @Override
+            public void dataSourceAccess(DataSourceAccess access) {
+                throw new RuntimeException("audit listener bug");
+            }
+        });
+
+        try (ClientHarness harness = new ClientHarness(clientSettingsWithIssuerUrl().build())) {
+            final IssueTokenResponse response = awaitToken(harness, new IssueTokenRequest("aud"));
+            assertEquals("header.payload.sig", response.token());
         }
     }
 

--- a/modules/workload-identity/src/test/java/org/elasticsearch/workloadidentity/TokenClaimsTests.java
+++ b/modules/workload-identity/src/test/java/org/elasticsearch/workloadidentity/TokenClaimsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.workloadidentity;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class TokenClaimsTests extends ESTestCase {
+
+    public void testDecodesSubjectAndJti() {
+        TokenClaims claims = TokenClaims.decode(jwt("{\"sub\":\"deployment:abc\",\"jti\":\"session-1\"}"));
+        assertEquals("deployment:abc", claims.subject());
+        assertEquals("session-1", claims.sessionId());
+    }
+
+    public void testNoSessionClaim() {
+        TokenClaims claims = TokenClaims.decode(jwt("{\"sub\":\"deployment:abc\"}"));
+        assertEquals("deployment:abc", claims.subject());
+        assertNull(claims.sessionId());
+    }
+
+    public void testNonStringAndEmptyClaimsIgnored() {
+        TokenClaims claims = TokenClaims.decode(jwt("{\"sub\":42,\"jti\":[\"x\"]}"));
+        assertNull(claims.subject());
+        assertNull(claims.sessionId());
+        assertNull(TokenClaims.decode(jwt("{\"jti\":\"\"}")).sessionId());
+    }
+
+    public void testMalformedInputsYieldEmpty() {
+        for (String malformed : new String[] {
+            "",
+            "not-a-jwt",
+            "one.dot",
+            "a.!!!not-base64!!!.c",
+            "a." + base64Url("{\"sub\":") + ".c",
+            "a." + base64Url("[1,2]") + ".c" }) {
+            assertEquals("input: " + malformed, TokenClaims.EMPTY, TokenClaims.decode(malformed));
+        }
+    }
+
+    private static String jwt(String payloadJson) {
+        return base64Url("{\"alg\":\"RS256\"}") + "." + base64Url(payloadJson) + ".signature";
+    }
+
+    private static String base64Url(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Publish one audit event per real JWT mint from the workload-identity issuer client, through a new `FederatedIdentityAuditListener` SPI slot in `WorkloadIdentityRegistry`. The deployment itself is the principal: the sub, jti, and expiry claims are decoded from the token for correlation with issuer- and CSP-side logs.

Also adds `peekTokenInfo(audience)` to the issuer-client SPI so the ES|QL query-completion audit path can stamp per-query events with the session id of the token in effect without threading token material through cloud SDK credential providers.