### PR TITLE
[9.4] Fix DOT_PRODUCT and COSINE score clamping in BBQ vector scorer (#156015)

### DIFF
--- a/docs/changelog/156015.yaml
+++ b/docs/changelog/156015.yaml
@@ -1,0 +1,9 @@
+area: Vector Search
+issues:
+ - 156010
+ - 156011
+ - 156009
+ - 156012
+pr: 156015
+summary: Fix DOT_PRODUCT and COSINE score clamping in BBQ vector scorer
+type: bug

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES93BinaryQuantizedVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES93BinaryQuantizedVectorScorer.java
@@ -104,7 +104,7 @@ public abstract class ES93BinaryQuantizedVectorScorer {
             if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
                 return VectorUtil.scaleMaxInnerProductScore(score);
             }
-            return VectorUtil.normalizeToUnitInterval(score);
+            return VectorUtil.normalizeToUnitInterval(Math.clamp(score, -1, 1));
         }
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES93BinaryQuantizedVectorScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES93BinaryQuantizedVectorScorerTests.java
@@ -270,6 +270,85 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
         }
     }
 
+    /**
+     * Regression test: when quantization loss makes the reconstructed dot product
+     * slightly above 1, the default Java scorer must still produce a score in
+     * [0, 1] — matching the native scorer. The native bulk path clamps to
+     * [-1, 1] before normalisation; the Java path must do the same.
+     *
+     * Uses hand-crafted correction values written directly into the index file
+     * so the test is deterministic and platform-independent.
+     *
+     * With the values below (lowerInterval=0.1, upperInterval=0.1, additionalCorrection=0.3,
+     * componentSum=0, all-zero quantized vectors), the scorer computes:
+     *   base_score = ax*ay*dims = 0.1 * 0.1 * 64 = 0.64
+     *   dot_product = 0.64 + 0.3 + 0.3 - 0 = 1.24
+     * Before the fix: normalizeToUnitInterval(1.24) = (1 + 1.24) / 2 = 1.12, which is > 1.
+     * After the fix:  normalizeToUnitInterval(clamp(1.24, -1, 1)) = (1 + 1) / 2 = 1.0.
+     */
+    public void testDotProductScoreBoundedWhenReconstructedScoreExceedsOne() throws IOException {
+        if (similarityFunction != VectorSimilarityFunction.DOT_PRODUCT && similarityFunction != VectorSimilarityFunction.COSINE) {
+            return;
+        }
+        final int dims = 64;
+        final int vectorLengthInBytes = BQVectorUtils.discretize(dims, 64) / 8;
+        final int perVectorBytes = vectorLengthInBytes + 14;  // (Float.BYTES * 3) + Short.BYTES
+
+        final float indexLowerInterval = 0.1f;
+        final float indexUpperInterval = 0.1f;
+        final float indexAdditionalCorrection = 0.3f;
+        final short indexComponentSum = 0;
+
+        final float queryLowerInterval = 0.1f;
+        final float queryUpperInterval = 0.1f;
+        final float queryAdditionalCorrection = 0.3f;
+        final short queryComponentSum = 0;
+
+        byte[] indexVector = new byte[vectorLengthInBytes];
+        int queryVectorLength = (BQVectorUtils.discretize(dims, 64) / 8) * 4;
+        byte[] queryVector = new byte[queryVectorLength];
+
+        try (Directory dir = newParametrizedDirectory()) {
+            try (IndexOutput out = dir.createOutput("testScore.bin", IOContext.DEFAULT)) {
+                out.writeBytes(indexVector, indexVector.length);
+                out.writeInt(Float.floatToIntBits(indexLowerInterval));
+                out.writeInt(Float.floatToIntBits(indexUpperInterval));
+                out.writeInt(Float.floatToIntBits(indexAdditionalCorrection));
+                out.writeShort(indexComponentSum);
+            }
+
+            try (IndexInput in = dir.openInput("testScore.bin", IOContext.DEFAULT)) {
+                var defaultScorer = defaultProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);
+                var panamaScorer = maybePanamaProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);
+
+                float defaultScore = defaultScorer.score(
+                    queryVector,
+                    queryLowerInterval,
+                    queryUpperInterval,
+                    Short.toUnsignedInt(queryComponentSum),
+                    queryAdditionalCorrection,
+                    similarityFunction,
+                    0f,
+                    0
+                );
+                float panamaScore = panamaScorer.score(
+                    queryVector,
+                    queryLowerInterval,
+                    queryUpperInterval,
+                    Short.toUnsignedInt(queryComponentSum),
+                    queryAdditionalCorrection,
+                    similarityFunction,
+                    0f,
+                    0
+                );
+
+                assertTrue(similarityFunction + " score from default scorer must be <= 1.0, got " + defaultScore, defaultScore <= 1.0f);
+                assertTrue(similarityFunction + " score from panama scorer must be <= 1.0, got " + panamaScore, panamaScore <= 1.0f);
+                assertEquals(defaultScore, panamaScore, 1e-2f);
+            }
+        }
+    }
+
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() {
         return () -> Arrays.stream(DirectoryType.values())


### PR DESCRIPTION
## Summary
Backport of #156015 to 9.4 (v9.4.6).

Fixes DOT_PRODUCT and COSINE score clamping in the BBQ vector scorer by clamping to [-1, 1] before normalization, matching the native scorer behavior.

## Test plan
- [ ] CI passes on 9.4 branch


Made with [Cursor](https://cursor.com)