### PR TITLE
Enable chunked fetch phase by default

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -269,7 +269,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope,
         Property.Dynamic
     );
-    
+
     public static final Setting<Boolean> FETCH_PHASE_CHUNKED_ENABLED = Setting.boolSetting(
         "search.fetch_phase_chunked_enabled",
         true,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -269,12 +269,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope,
         Property.Dynamic
     );
-
-    private static final boolean CHUNKED_FETCH_PHASE_FEATURE_FLAG = new FeatureFlag("chunked_fetch_phase_enabled").isEnabled();
-
+    
     public static final Setting<Boolean> FETCH_PHASE_CHUNKED_ENABLED = Setting.boolSetting(
         "search.fetch_phase_chunked_enabled",
-        CHUNKED_FETCH_PHASE_FEATURE_FLAG,
+        true,
         Property.NodeScope,
         Property.Dynamic
     );


### PR DESCRIPTION
Removes the `chunked_fetch_phase_enabled` feature flag and flips the default of the dynamic `search.fetch_phase_chunked_enabled` setting from feature-flag-gated to `true`.

The chunked fetch phase has been running in nightlies for the last several months and has been enabled by default across all serverless environments for more than a month, with minimal regressions observed. Given this bake time, the feature flag gate is no longer needed and the setting can default to enabled while remaining dynamically configurable (e.g. for rollback via `search.fetch_phase_chunked_enabled: false`) if needed.