### PR TITLE
DO NOT MERGE: probe flakiness-detection compile gate (latest)

### DIFF
--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -178,6 +178,7 @@ Derived in priority order by `analyzer/outcome.ts` (`deriveOutcome`):
 | `hang`          | `rc == 0` but zero recorded test cases                                          |
 | `clean_pass`    | `rc == 0` with recorded cases and no real failures                              |
 | `not_applicable`| assigned upstream (not by `deriveOutcome`) for a test that could not be re-run at all, e.g. a BWC qa project whose bare task is disabled - "nothing to re-run", excluded from the false-failure metric |
+| `build_failed`  | assigned upstream when the pre-flight compile gate fails: the PR did not compile, so the re-run batches were skipped. One record stands in for the skipped batches; excluded from the false-failure metric (the PR is already red from its main build) |
 
 `timedOut` is reported alongside `outcome` so the two timeout shapes stay
 distinguishable: a job that times out **with** a real failure is

--- a/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/outcome.ts
@@ -2,7 +2,7 @@
 // analyze step (which classifies every batch job from its rc + JUnit XML) and
 // its unit tests.
 
-export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail" | "not_applicable";
+export type FlakinessOutcome = "clean_pass" | "flaky_detected" | "timeout" | "hang" | "infra_fail" | "not_applicable" | "build_failed";
 
 export interface OutcomeInput {
   // Wrapped command's return code (124 = our SIGTERM timeout, 137 = SIGKILL).

--- a/.buildkite/scripts/flakiness-detection/analyzer/render.test.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/render.test.ts
@@ -72,4 +72,20 @@ describe("renderMarkdown / severity", () => {
     expect(severity({ batches: [], perTest: [], totals: { iterations: 1, realFailures: 0, suiteTimeoutMarkers: 1, successfulCases: 0 } })).toBe("warning");
     expect(severity({ batches: [], perTest: [], totals: { iterations: 1, realFailures: 0, suiteTimeoutMarkers: 0, successfulCases: 1 } })).toBe("success");
   });
+
+  test("a compile-gate failure is a warning (orange), not a false-green", () => {
+    const clean = { batches: [], perTest: [], totals: { iterations: 0, realFailures: 0, suiteTimeoutMarkers: 0, successfulCases: 0 } };
+    // Without the gate signal the empty report would read as success.
+    expect(severity(clean)).toBe("success");
+    expect(severity(clean, true)).toBe("warning");
+  });
+
+  test("renders the compile-gate notice and does not read as a clean pass when buildFailed", () => {
+    const clean = { batches: [], perTest: [], totals: { iterations: 0, realFailures: 0, suiteTimeoutMarkers: 0, successfulCases: 0 } };
+    const md = renderMarkdown(clean, true);
+    expect(md).toContain("failed to compile");
+    expect(md).toContain("re-runs were skipped");
+    // The banner is absent unless the gate actually failed.
+    expect(renderMarkdown(clean)).not.toContain("failed to compile");
+  });
 });

--- a/.buildkite/scripts/flakiness-detection/analyzer/render.ts
+++ b/.buildkite/scripts/flakiness-detection/analyzer/render.ts
@@ -22,11 +22,21 @@ function summarizeKinds(kinds: FailureKind[]): string {
   return [...counts.entries()].map(([k, n]) => (n > 1 ? `${k} x${n}` : k)).join(", ");
 }
 
-export function renderMarkdown(report: FlakinessReport): string {
+export function renderMarkdown(report: FlakinessReport, buildFailed = false): string {
   const { totals } = report;
   const lines: string[] = [];
   lines.push("## Flakiness summary");
   lines.push("");
+  // The pre-flight compile gate failed, so every batch was skipped and the
+  // totals below are all zero. Explain that up front so the run does not read
+  // as a clean pass.
+  if (buildFailed) {
+    lines.push("> ⚠️ One or more of the affected test source sets failed to compile, so *all*");
+    lines.push("> flakiness re-runs were skipped - they share a single pre-flight compile gate.");
+    lines.push("> See the precompile step's log for the specific compile error; this makes no");
+    lines.push("> claim about the rest of the build.");
+    lines.push("");
+  }
   lines.push(`- Iterations attempted: ${totals.iterations}`);
   lines.push(`- Successful cases: ${totals.successfulCases}`);
   lines.push(`- Real failures: ${totals.realFailures}`);
@@ -78,7 +88,10 @@ export function renderMarkdown(report: FlakinessReport): string {
   return body.slice(0, MAX_ANNOTATION_BYTES - TRUNCATION_MARKER.length) + TRUNCATION_MARKER;
 }
 
-export function severity(report: FlakinessReport): "error" | "warning" | "success" {
+export function severity(report: FlakinessReport, buildFailed = false): "error" | "warning" | "success" {
+  // A compile-gate failure is not the PR's flakiness problem (the batches never
+  // ran), so it is a warning (orange), not an error - and never a false-green.
+  if (buildFailed) return "warning";
   if (report.totals.realFailures > 0) return "error";
   if (report.totals.suiteTimeoutMarkers > 0) return "warning";
   return "success";

--- a/.buildkite/scripts/flakiness-detection/commands.test.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.test.ts
@@ -5,9 +5,33 @@ import {
   deduplicateYamlRunners,
   generateBatchCommand,
   buildCommands,
+  compileTasksFor,
 } from "./commands.ts";
 import type { ClassifiedTest } from "./domain.ts";
 import { DEFAULT_BATCHING_CONFIG } from "./domain.ts";
+
+describe("compileTasksFor", () => {
+  test("maps each source set to its compile task, de-duplicated per project", () => {
+    const tests: ClassifiedTest[] = [
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.ATests" },
+      { gradleProject: ":server", kind: "test", sourceSet: "test", fqcn: "a.BTests" },
+      { gradleProject: ":server", kind: "internalClusterTest", sourceSet: "internalClusterTest", fqcn: "a.CIT" },
+      { gradleProject: ":x-pack:plugin:ml", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "a.DIT" },
+      { gradleProject: ":x-pack:plugin:ml", kind: "yamlRestTestRunner", sourceSet: "yamlRestTest" },
+    ];
+
+    expect(compileTasksFor(tests)).toEqual([
+      ":server:compileTestJava",
+      ":server:compileInternalClusterTestJava",
+      ":x-pack:plugin:ml:compileJavaRestTestJava",
+      ":x-pack:plugin:ml:compileYamlRestTestJava",
+    ]);
+  });
+
+  test("empty for no tests", () => {
+    expect(compileTasksFor([])).toEqual([]);
+  });
+});
 
 describe("collapseYamlSuites", () => {
   test("collapses multiple YAML files in same directory", () => {

--- a/.buildkite/scripts/flakiness-detection/commands.ts
+++ b/.buildkite/scripts/flakiness-detection/commands.ts
@@ -8,6 +8,31 @@ import { KIND_KEYS, KIND_LABELS, KIND_ORDER } from "./domain.ts";
 // preserves each iteration's JUnit XML.
 const REPEAT_REST_TEST = ".buildkite/scripts/flakiness-detection/runners/repeat-rest-test.sh";
 
+// Maps a source set to the Gradle task that compiles it. Used by the pre-flight
+// compile gate so a PR that does not compile is caught once, up front, instead
+// of failing every re-run batch identically.
+const SOURCE_SET_COMPILE_TASK: Record<string, string> = {
+  test: "compileTestJava",
+  internalClusterTest: "compileInternalClusterTestJava",
+  javaRestTest: "compileJavaRestTestJava",
+  yamlRestTest: "compileYamlRestTestJava",
+};
+
+/**
+ * The unique `:project:compile<SourceSet>Java` tasks covering every runnable
+ * test's source set, e.g. `:server:compileTestJava`. Compiling these transitively
+ * builds their dependencies, so a green result means the batches can at least be
+ * enumerated and started.
+ */
+export function compileTasksFor(tests: ClassifiedTest[]): string[] {
+  const tasks = new Set<string>();
+  for (const t of tests) {
+    const compileTask = SOURCE_SET_COMPILE_TASK[t.sourceSet];
+    if (compileTask) tasks.add(`${t.gradleProject}:${compileTask}`);
+  }
+  return [...tasks];
+}
+
 export function dedupeTests(tests: ClassifiedTest[]): ClassifiedTest[] {
   const seen = new Set<string>();
   const result: ClassifiedTest[] = [];

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { ClassifiedTest } from "../domain.ts";
 
-import { notApplicablePayload } from "./analyze.ts";
+import { buildFailedPayload, notApplicablePayload } from "./analyze.ts";
 
 describe("notApplicablePayload", () => {
   test("maps a skipped BWC javaRestTest to a zeroed not_applicable record", () => {
@@ -42,5 +42,24 @@ describe("notApplicablePayload", () => {
     expect(payload.outcome).toBe("not_applicable");
     expect(payload.jobId).toContain("org.elasticsearch.SomeYamlIT.test {yaml=10_basic/Foo}");
     expect(payload.stepKey).toBe("flakiness-detection:yaml-case");
+  });
+});
+
+describe("buildFailedPayload", () => {
+  test("is a single build_failed record attributed to the precompile gate", () => {
+    expect(buildFailedPayload()).toEqual({
+      jobId: "build-failed:precompile",
+      stepKey: "flakiness-detection:precompile",
+      kind: "",
+      rc: 1,
+      durationSec: 0,
+      realFailures: 0,
+      suiteTimeouts: 0,
+      totalCases: 0,
+      outcome: "build_failed",
+      timedOut: false,
+      failingClasses: [],
+      reason: "compile",
+    });
   });
 });

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { ClassifiedTest } from "../domain.ts";
 
-import { buildFailedPayload, notApplicablePayload } from "./analyze.ts";
+import { buildFailedPayload, isPrecompileFailure, notApplicablePayload } from "./analyze.ts";
 
 describe("notApplicablePayload", () => {
   test("maps a skipped BWC javaRestTest to a zeroed not_applicable record", () => {
@@ -59,7 +59,29 @@ describe("buildFailedPayload", () => {
       outcome: "build_failed",
       timedOut: false,
       failingClasses: [],
-      reason: "compile",
+      reason: "precompile",
     });
+  });
+});
+
+describe("isPrecompileFailure", () => {
+  test("true for the marker the gate writes on failure", () => {
+    expect(isPrecompileFailure('{"outcome":"build_failed","reason":"precompile"}')).toBe(true);
+    // reason is not part of the decision - only the outcome is
+    expect(isPrecompileFailure('{"outcome":"build_failed"}')).toBe(true);
+  });
+
+  test("false when the marker is absent (gate passed or never ran)", () => {
+    expect(isPrecompileFailure(null)).toBe(false);
+  });
+
+  test("false for any other outcome", () => {
+    expect(isPrecompileFailure('{"outcome":"clean_pass"}')).toBe(false);
+    expect(isPrecompileFailure("{}")).toBe(false);
+  });
+
+  test("false for malformed or empty marker content", () => {
+    expect(isPrecompileFailure("not json")).toBe(false);
+    expect(isPrecompileFailure("")).toBe(false);
   });
 });

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
@@ -43,6 +43,11 @@ const OUTCOMES_ARTIFACT_FILE = "flakiness-outcomes.json";
 // runners/buildkite.ts and entrypoints/pr.ts.
 const SKIPPED_FILE = "flakiness-skipped.json";
 
+// Written by the pre-flight compile step only when compilation fails; folded in
+// as a single `build_failed` outcome (the skipped batches produce none). Keep in
+// sync with FLAKINESS_PRECOMPILE_ARTIFACT in runners/buildkite.ts.
+const PRECOMPILE_FILE = "flakiness-precompile.json";
+
 // Self-reported by each batch job's never-fail wrapper (runners/buildkite.ts).
 interface JobStatus {
   jobId: string;
@@ -195,6 +200,35 @@ export function notApplicablePayload(t: ClassifiedTest): FlakinessPayload {
   };
 }
 
+// True when the pre-flight compile step left a failure marker.
+async function precompileFailed(): Promise<boolean> {
+  try {
+    const parsed = JSON.parse(await readFile(join(PROJECT_ROOT, PRECOMPILE_FILE), "utf8"));
+    return parsed?.outcome === "build_failed";
+  } catch {
+    return false;
+  }
+}
+
+// A single record standing in for the batches that were skipped because the PR
+// did not compile.
+export function buildFailedPayload(): FlakinessPayload {
+  return {
+    jobId: "build-failed:precompile",
+    stepKey: "flakiness-detection:precompile",
+    kind: "",
+    rc: 1,
+    durationSec: 0,
+    realFailures: 0,
+    suiteTimeouts: 0,
+    totalCases: 0,
+    outcome: "build_failed",
+    timedOut: false,
+    failingClasses: [],
+    reason: "compile",
+  };
+}
+
 function annotate(context: string, style: string, body: string): void {
   try {
     execSync(`buildkite-agent annotate --style "${style}" --context "${context}"`, {
@@ -230,6 +264,14 @@ async function run(): Promise<void> {
   }
   if (skipped.length > 0) {
     console.log(`Recorded ${skipped.length} not_applicable (BWC, not re-runnable via the bare task).`);
+  }
+
+  // If the pre-flight compile gate failed, the batches were skipped and produced
+  // no statuses; record a single `build_failed` so a non-compiling PR does not
+  // read as zero problems.
+  if (await precompileFailed()) {
+    payloads.push(buildFailedPayload());
+    console.log("Recorded build_failed (PR did not compile; re-runs were skipped).");
   }
 
   if (process.env.CI && payloads.length > 0) {

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
@@ -289,7 +289,8 @@ async function run(): Promise<void> {
   // If the pre-flight compile gate failed, the batches were skipped and produced
   // no statuses; record a single `build_failed` so a non-compiling PR does not
   // read as zero problems.
-  if (await precompileFailed()) {
+  const buildFailed = await precompileFailed();
+  if (buildFailed) {
     payloads.push(buildFailedPayload());
     console.log("Recorded build_failed (PR did not compile; re-runs were skipped).");
   }
@@ -306,10 +307,10 @@ async function run(): Promise<void> {
 
   // Human-readable report aggregated across every downloaded job.
   const report = await analyzeReports([JOBS_DIR]);
-  const md = renderMarkdown(report);
+  const md = renderMarkdown(report, buildFailed);
   console.log(md);
   if (process.env.CI) {
-    annotate("flakiness-detection-report", severity(report), md);
+    annotate("flakiness-detection-report", severity(report, buildFailed), md);
   }
 }
 

--- a/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/analyze.ts
@@ -200,18 +200,38 @@ export function notApplicablePayload(t: ClassifiedTest): FlakinessPayload {
   };
 }
 
-// True when the pre-flight compile step left a failure marker.
-async function precompileFailed(): Promise<boolean> {
+// Pure: does the pre-flight compile step's marker signal a build failure?
+// `markerText` is the marker file's contents, or `null` when the file is absent.
+// Absent, unreadable, malformed, or any non-`build_failed` outcome all mean "no".
+export function isPrecompileFailure(markerText: string | null): boolean {
+  if (markerText === null) {
+    return false;
+  }
   try {
-    const parsed = JSON.parse(await readFile(join(PROJECT_ROOT, PRECOMPILE_FILE), "utf8"));
+    const parsed = JSON.parse(markerText);
     return parsed?.outcome === "build_failed";
   } catch {
     return false;
   }
 }
 
-// A single record standing in for the batches that were skipped because the PR
-// did not compile.
+// True when the pre-flight compile step left a failure marker. A missing file
+// (the gate passed or never ran) reads as `null` -> not failed.
+async function precompileFailed(): Promise<boolean> {
+  let markerText: string | null = null;
+  try {
+    markerText = await readFile(join(PROJECT_ROOT, PRECOMPILE_FILE), "utf8");
+  } catch {
+    markerText = null;
+  }
+  return isPrecompileFailure(markerText);
+}
+
+// A single record standing in for the batches that were skipped because the
+// pre-flight compile gate failed. `reason` names the gate, not a specific cause:
+// the gate exits non-zero on a genuine compile error but also on an infra failure
+// within it (dependency download, build-scan upload, OOM), and it does not read
+// its own log to tell them apart.
 export function buildFailedPayload(): FlakinessPayload {
   return {
     jobId: "build-failed:precompile",
@@ -225,7 +245,7 @@ export function buildFailedPayload(): FlakinessPayload {
     outcome: "build_failed",
     timedOut: false,
     failingClasses: [],
-    reason: "compile",
+    reason: "precompile",
   };
 }
 

--- a/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
+++ b/.buildkite/scripts/flakiness-detection/entrypoints/pr.ts
@@ -5,7 +5,7 @@ import { resolve } from "path";
 import { classifyChangedFiles } from "../detectors/changed-files.ts";
 import { partitionByBwc, defaultBuildScriptReader } from "../detectors/bwc.ts";
 import { findUnmutedTests, type UnmuteDetectionResult } from "../detectors/unmutes.ts";
-import { buildCommands, dedupeTests } from "../commands.ts";
+import { buildCommands, compileTasksFor, dedupeTests } from "../commands.ts";
 import { uploadBuildkitePipeline } from "../runners/buildkite.ts";
 import { DEFAULT_AGENT_CONFIG, DEFAULT_BATCHING_CONFIG, type ClassifiedTest } from "../domain.ts";
 
@@ -174,7 +174,7 @@ export function run(): void {
   uploadBuildkitePipeline(
     buildCommands(runnable, DEFAULT_BATCHING_CONFIG),
     DEFAULT_AGENT_CONFIG,
-    { hasNotApplicable: notApplicable.length > 0 }
+    { hasNotApplicable: notApplicable.length > 0, compileTasks: compileTasksFor(runnable) }
   );
 }
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -285,3 +285,59 @@ describe("toBuildkitePipeline", () => {
     expect(pipeline.steps[0].steps).toEqual([]);
   });
 });
+
+describe("toBuildkitePipeline compile gate", () => {
+  const cmds: RunnableCommand[] = [
+    { kind: "test", label: "unit tests", key: "flakiness-detection:unit", command: "cmd" },
+  ];
+
+  test("prepends a precompile step the batches hard-depend on", () => {
+    const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG, {
+      compileTasks: [":server:compileTestJava", ":x-pack:plugin:ml:compileJavaRestTestJava"],
+    });
+    const steps = pipeline.steps[0].steps;
+
+    // precompile first, then the batch, then analyze.
+    expect(steps.map((s) => s.key)).toEqual([
+      "flakiness-detection:precompile",
+      "flakiness-detection:unit",
+      "flakiness-detection:analyze",
+    ]);
+
+    const [precompile, batch, analyze] = steps;
+    // Compiles the requested tasks via the gradle wrapper and uploads the marker.
+    expect(precompile.command).toContain(
+      ".ci/scripts/run-gradle.sh :server:compileTestJava :x-pack:plugin:ml:compileJavaRestTestJava"
+    );
+    expect(precompile.command).toContain('> "flakiness-precompile.json"');
+    expect(precompile.command).toContain("exit $$rc");
+    expect(precompile.artifact_paths).toBe("flakiness-precompile.json");
+    expect(precompile.agents?.provider).toBe("gcp");
+
+    // Batch hard-depends on the gate (allow_failure false → skipped on failure).
+    expect(batch.depends_on).toEqual([{ step: "flakiness-detection:precompile", allow_failure: false }]);
+
+    // Analyze depends on the gate with allow_failure so it still records
+    // build_failed when the gate fails and the batches are skipped.
+    expect(analyze.depends_on).toContainEqual({ step: "flakiness-detection:precompile", allow_failure: true });
+    expect(analyze.command).toContain('buildkite-agent artifact download "flakiness-precompile.json" . || true');
+  });
+
+  test("no precompile step when compileTasks is empty", () => {
+    const pipeline = toBuildkitePipeline(cmds, DEFAULT_AGENT_CONFIG, { compileTasks: [] });
+    const keys = pipeline.steps[0].steps.map((s) => s.key);
+    expect(keys).not.toContain("flakiness-detection:precompile");
+    expect(pipeline.steps[0].steps[0].depends_on).toBeUndefined();
+  });
+
+  test("no precompile step when there are no batches (all not_applicable)", () => {
+    // Nothing to compile even though compileTasks were computed from a now-empty
+    // runnable set.
+    const pipeline = toBuildkitePipeline([], DEFAULT_AGENT_CONFIG, {
+      hasNotApplicable: true,
+      compileTasks: [":server:compileTestJava"],
+    });
+    const keys = pipeline.steps[0].steps.map((s) => s.key);
+    expect(keys).toEqual(["flakiness-detection:analyze"]);
+  });
+});

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -311,6 +311,9 @@ describe("toBuildkitePipeline compile gate", () => {
     );
     expect(precompile.command).toContain('> "flakiness-precompile.json"');
     expect(precompile.command).toContain("exit $$rc");
+    // The gate no longer posts its own annotation; the analyze step folds the
+    // failure into the single flakiness summary annotation instead.
+    expect(precompile.command).not.toContain("buildkite-agent annotate");
 
     // Constraint: Gradle's exit code is captured immediately, before the
     // marker/annotate side-effects, and is what the step finally exits with - so

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.test.ts
@@ -311,6 +311,19 @@ describe("toBuildkitePipeline compile gate", () => {
     );
     expect(precompile.command).toContain('> "flakiness-precompile.json"');
     expect(precompile.command).toContain("exit $$rc");
+
+    // Constraint: Gradle's exit code is captured immediately, before the
+    // marker/annotate side-effects, and is what the step finally exits with - so
+    // a real compile failure can never be masked by a side-effect succeeding.
+    const cmd = precompile.command;
+    const gradleAt = cmd.indexOf(".ci/scripts/run-gradle.sh");
+    const captureAt = cmd.indexOf("rc=$?");
+    const markerAt = cmd.indexOf('> "flakiness-precompile.json"');
+    const exitAt = cmd.indexOf("exit $$rc");
+    expect(captureAt).toBeGreaterThan(gradleAt);
+    expect(markerAt).toBeGreaterThan(captureAt);
+    expect(exitAt).toBeGreaterThan(markerAt);
+
     expect(precompile.artifact_paths).toBe("flakiness-precompile.json");
     expect(precompile.agents?.provider).toBe("gcp");
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -149,6 +149,38 @@ const FLAKINESS_OUTCOMES_ARTIFACT = "flakiness-outcomes.json";
 // and the bootstrap step's `artifact_paths` in pipelines/pull-request/flakiness-detection.yml.
 const FLAKINESS_SKIPPED_ARTIFACT = "flakiness-skipped.json";
 
+// Written by the pre-flight compile step (below) only when compilation fails, so
+// the analyze step can record a single `build_failed` outcome instead of the
+// batches (which are skipped) producing none. Keep in sync with entrypoints/analyze.ts.
+const FLAKINESS_PRECOMPILE_ARTIFACT = "flakiness-precompile.json";
+
+// Pre-flight compile gate. A PR that does not compile otherwise fails every
+// re-run batch identically (up to 100x fan-out), which wastes CI and floods the
+// metric with `infra_fail`. This step compiles the affected source sets once;
+// batch steps hard-depend on it (allow_failure: false) so Buildkite skips them
+// when it fails. It is intentionally NOT never-fail wrapped: it must exit
+// non-zero to make Buildkite skip the batches. That turns the step red, but only
+// ever on a PR that genuinely does not compile - which is already red from its
+// main build - so it never introduces a false failure on an otherwise-green PR.
+const PRECOMPILE_KEY = "flakiness-detection:precompile";
+const PRECOMPILE_TIMEOUT_MINUTES = 30;
+
+function precompileCommand(compileTasks: string[]): string {
+  return [
+    "set +e",
+    `.ci/scripts/run-gradle.sh ${compileTasks.join(" ")}`,
+    "rc=$?",
+    // On failure, leave a marker the analyze step folds in as `build_failed`,
+    // and annotate. `$$rc` defers past Buildkite's upload-time interpolation.
+    `if [ "$$rc" -ne 0 ]; then`,
+    `  printf '{"outcome":"build_failed","reason":"compile"}' > "${FLAKINESS_PRECOMPILE_ARTIFACT}" || true`,
+    `  buildkite-agent annotate --style error --context "flakiness-detection-precompile" "Flakiness detection could not compile the affected test source sets, so the re-runs were skipped. This reflects only the flakiness precompile step (see its log for the compile error); it makes no claim about the rest of the build." || true`,
+    "fi",
+    // Propagate the real exit code so dependent batch steps are skipped on failure.
+    "exit $$rc",
+  ].join("\n");
+}
+
 interface PipelineGroup {
   group: string;
   steps: PipelineStep[];
@@ -165,10 +197,11 @@ interface Pipeline {
 export function toBuildkitePipeline(
   commands: RunnableCommand[],
   cfg: AgentConfig,
-  // When there are BWC (`not_applicable`) tests to report, the analyze step is
-  // emitted even with zero batch steps so those records still reach the outcomes
-  // artifact.
-  opts: { hasNotApplicable?: boolean } = {}
+  // `hasNotApplicable`: emit the analyze step even with zero batch steps so BWC
+  // `not_applicable` records still reach the outcomes artifact.
+  // `compileTasks`: when non-empty, prepend a pre-flight compile gate the batch
+  // steps hard-depend on.
+  opts: { hasNotApplicable?: boolean; compileTasks?: string[] } = {}
 ): Pipeline {
   const byKey = new Map<string, RunnableCommand[]>();
   for (const c of commands) {
@@ -176,6 +209,10 @@ export function toBuildkitePipeline(
     if (list) list.push(c);
     else byKey.set(c.key, [c]);
   }
+
+  // Only gate on compile when there are batches to gate. All-BWC builds (no
+  // batches) have nothing to compile.
+  const gateOnCompile = (opts.compileTasks?.length ?? 0) > 0 && byKey.size > 0;
 
   const steps: PipelineStep[] = [];
   for (const [key, batches] of byKey) {
@@ -206,10 +243,32 @@ export function toBuildkitePipeline(
       step.parallelism = batches.length;
       step.env = env;
     }
+
+    // Hard dependency (allow_failure omitted = false) so a compile failure skips
+    // the re-run batches instead of running them all doomed.
+    if (gateOnCompile) {
+      step.depends_on = [{ step: PRECOMPILE_KEY, allow_failure: false }];
+    }
     steps.push(step);
   }
 
+  // Prepend the compile gate ahead of the batch steps it guards.
+  if (gateOnCompile) {
+    steps.unshift({
+      label: "precompile",
+      key: PRECOMPILE_KEY,
+      command: precompileCommand(opts.compileTasks!),
+      timeout_in_minutes: PRECOMPILE_TIMEOUT_MINUTES,
+      agents: { ...cfg.agents },
+      artifact_paths: FLAKINESS_PRECOMPILE_ARTIFACT,
+      retry: NO_AUTO_RETRY,
+    });
+  }
+
   if (steps.length > 0 || opts.hasNotApplicable) {
+    // allow_failure: true so the report still runs when a batch fails, is
+    // skipped (compile gate failed), or the gate itself fails - it must record
+    // the `build_failed`/`not_applicable` outcomes in those cases.
     const deps = steps.map((s) => ({ step: s.key, allow_failure: true }));
     steps.push({
       label: "flakiness report",
@@ -226,6 +285,7 @@ export function toBuildkitePipeline(
         [
           `buildkite-agent artifact download "${FLAKINESS_STATUS_ARTIFACTS}" . || true`,
           `buildkite-agent artifact download "${FLAKINESS_SKIPPED_ARTIFACT}" . || true`,
+          `buildkite-agent artifact download "${FLAKINESS_PRECOMPILE_ARTIFACT}" . || true`,
           "node .buildkite/scripts/flakiness-detection/entrypoints/analyze.ts",
         ].join("\n"),
         "flakiness-detection:analyze",
@@ -253,10 +313,12 @@ export function toBuildkitePipeline(
 export function uploadBuildkitePipeline(
   commands: RunnableCommand[],
   cfg: AgentConfig,
-  opts: { hasNotApplicable?: boolean; cwd?: string } = {}
+  opts: { hasNotApplicable?: boolean; compileTasks?: string[]; cwd?: string } = {}
 ): void {
   const cwd = opts.cwd ?? PROJECT_ROOT;
-  const yaml = stringify(toBuildkitePipeline(commands, cfg, { hasNotApplicable: opts.hasNotApplicable }));
+  const yaml = stringify(
+    toBuildkitePipeline(commands, cfg, { hasNotApplicable: opts.hasNotApplicable, compileTasks: opts.compileTasks })
+  );
   console.log("--- Generated pipeline");
   console.log(yaml);
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -173,7 +173,7 @@ function precompileCommand(compileTasks: string[]): string {
     // On failure, leave a marker the analyze step folds in as `build_failed`,
     // and annotate. `$$rc` defers past Buildkite's upload-time interpolation.
     `if [ "$$rc" -ne 0 ]; then`,
-    `  printf '{"outcome":"build_failed","reason":"compile"}' > "${FLAKINESS_PRECOMPILE_ARTIFACT}" || true`,
+    `  printf '{"outcome":"build_failed","reason":"precompile"}' > "${FLAKINESS_PRECOMPILE_ARTIFACT}" || true`,
     `  buildkite-agent annotate --style error --context "flakiness-detection-precompile" "Flakiness detection could not compile the affected test source sets, so the re-runs were skipped. This reflects only the flakiness precompile step (see its log for the compile error); it makes no claim about the rest of the build." || true`,
     "fi",
     // Propagate the real exit code so dependent batch steps are skipped on failure.

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -170,11 +170,12 @@ function precompileCommand(compileTasks: string[]): string {
     "set +e",
     `.ci/scripts/run-gradle.sh ${compileTasks.join(" ")}`,
     "rc=$?",
-    // On failure, leave a marker the analyze step folds in as `build_failed`,
-    // and annotate. `$$rc` defers past Buildkite's upload-time interpolation.
+    // On failure, leave a marker the analyze step folds into the flakiness
+    // summary annotation as `build_failed` (the analyze step owns the single
+    // developer-facing annotation). `$$rc` defers past Buildkite's upload-time
+    // interpolation.
     `if [ "$$rc" -ne 0 ]; then`,
     `  printf '{"outcome":"build_failed","reason":"precompile"}' > "${FLAKINESS_PRECOMPILE_ARTIFACT}" || true`,
-    `  buildkite-agent annotate --style error --context "flakiness-detection-precompile" "Flakiness detection could not compile the affected test source sets, so the re-runs were skipped. This reflects only the flakiness precompile step (see its log for the compile error); it makes no claim about the rest of the build." || true`,
     "fi",
     // Propagate the real exit code so dependent batch steps are skipped on failure.
     "exit $$rc",

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/FlakinessGateProbeTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/FlakinessGateProbeTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.dissect;
+
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * THROWAWAY probe for verifying the flakiness-detection pre-flight compile gate on a real build.
+ *
+ * This file intentionally does NOT compile: it references an undefined symbol so that
+ * {@code :libs:dissect:compileTestJava} fails. The flakiness detector picks up this newly added
+ * {@code *Tests.java}, the pre-flight compile gate compiles the affected source set, and the compile
+ * fails - which is exactly the scenario under test. Do not merge; delete once the build is observed.
+ */
+public class FlakinessGateProbeTests extends ESTestCase {
+
+    public void testCompileGateTripsOnPurpose() {
+        // `thisSymbolDoesNotExist` is undefined on purpose, so compilation fails.
+        assertEquals("flakiness-gate-probe", thisSymbolDoesNotExist);
+    }
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE / DO NOT REVIEW.** Throwaway verification PR. Carries the latest pre-flight compile gate work from #153806.

## Purpose

Re-verify the pre-flight compile gate end-to-end on a real build, against the **latest** version of the code - the runtime Buildkite behaviour the unit tests cannot cover, plus the two changes made since the earlier probe (#154112):

- the `build_failed` record now uses `reason: precompile` (was `compile`);
- the gate no longer posts its own error annotation - the analyze step folds the compile notice into the single **flakiness summary** annotation and colours it **orange** (`warning`).

## How

Adds `libs/dissect/src/test/java/.../FlakinessGateProbeTests.java` that intentionally references an undefined symbol, so `:libs:dissect:compileTestJava` fails. The flakiness detector picks the new test up, the compile gate runs it, and it fails.

## What to check on this build's `flakiness-detection` group

1. The `flakiness-detection:precompile` step is **red** (compile error).
2. The re-run batch step(s) are **skipped** (hard `depends_on`, `allow_failure: false`).
3. The **analyze step still runs** (`allow_failure: true` on all deps) and its `flakiness-outcomes.json` artifact contains a single `build_failed` record: `jobId: build-failed:precompile`, **`reason: precompile`**.
4. There is **one** annotation (`flakiness-detection-report`), it is **orange** (warning), and it contains the notice: *"One or more of the affected test source sets failed to compile, so all flakiness re-runs were skipped …"*. There should be **no** separate `flakiness-detection-precompile` annotation.

If (3) does not happen (analyze skipped, no artifact), the `allow_dependency_failure` assumption is wrong. If (4) still shows a separate red precompile annotation or a green summary, the annotation-folding change did not take effect.

Close this PR once observed.
