### PR TITLE
 [9.5][Test] Fix flaky S3ObjectStoreTests#testUploadIndicesDataWithRetries (#155889)

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/S3ObjectStoreTests.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/S3ObjectStoreTests.java
@@ -16,6 +16,8 @@ import com.sun.net.httpserver.HttpHandler;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
+import org.elasticsearch.blobcache.shared.SharedBytes;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.project.ProjectResolver;
@@ -32,7 +34,6 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -52,7 +53,6 @@ import org.elasticsearch.xpack.stateless.TestUtils;
 import org.elasticsearch.xpack.stateless.action.NewCommitNotificationRequest;
 import org.elasticsearch.xpack.stateless.action.TransportNewCommitNotificationAction;
 import org.elasticsearch.xpack.stateless.commits.StatelessCompoundCommit;
-import org.elasticsearch.xpack.stateless.engine.IndexEngine;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -464,7 +464,7 @@ public class S3ObjectStoreTests extends AbstractMockObjectStoreIntegTestCase {
 
     public void testUploadIndicesDataWithRetries() throws Exception {
         s3HttpHandler.setInterceptor(new Interceptor() {
-            private final int errorsPerRequest = randomIntBetween(3, 5);
+            private final int errorsPerRequest = maxRetries + randomIntBetween(2, 3);
             private final Map<String, AtomicInteger> requestPathErrorCount = ConcurrentCollections.newConcurrentMap();
 
             @SuppressForbidden(reason = "this test uses a HttpServer to emulate an S3 endpoint")
@@ -513,7 +513,22 @@ public class S3ObjectStoreTests extends AbstractMockObjectStoreIntegTestCase {
             }
         });
 
-        final Settings nodeSettings = disableIndexingDiskAndMemoryControllersNodeSettings();
+        // Use random but sufficiently large cache settings. The default random cache configuration can produce a cache smaller than the
+        // region size, resulting in zero usable regions and every read going through the mock HTTP handler which is too slow to complete
+        // within the ensureGreen timeout.
+        var regionPages = randomIntBetween(16, 64); // 64kb to 256kb regions
+        var cachePages = regionPages * randomIntBetween(64, 256); // 64 to 256 regions, giving at least 4mb of cache
+        final Settings nodeSettings = Settings.builder()
+            .put(disableIndexingDiskAndMemoryControllersNodeSettings())
+            .put(
+                SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(),
+                ByteSizeValue.ofBytes((long) regionPages * SharedBytes.PAGE_SIZE)
+            )
+            .put(
+                SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(),
+                ByteSizeValue.ofBytes((long) cachePages * SharedBytes.PAGE_SIZE)
+            )
+            .build();
         final String masterAndIndexNode = startMasterAndIndexNode(nodeSettings);
         final String searchNode = startSearchNode(nodeSettings);
 
@@ -521,8 +536,6 @@ public class S3ObjectStoreTests extends AbstractMockObjectStoreIntegTestCase {
             final String indexName = randomIdentifier();
             createIndex(indexName, indexSettings(1, 0).build());
             ensureGreen(indexName);
-            IndexShard indexShard = findIndexShard(indexName);
-            IndexEngine shardEngine = getShardEngine(indexShard, IndexEngine.class);
 
             // Index enough 1 MiB documents to produce a >5MiB Lucene compound segment file, to ensure S3 multi-part upload
             int numDocs = randomIntBetween(8, 10);


### PR DESCRIPTION
Backport of #155889 for 9.5.

The test creates 8-10 MiB documents producing multi-megabyte   segments.
The default random cache configuration in the base class can produce a
cache smaller than the region size, resulting in zero usable   cache
regions. With no cache, every read during search replica recovery goes
through the mock S3 HTTP handler, which is too slow to complete within
the default ensureGreen timeout.

Fix by overriding the cache settings with random but sufficiently large values. Also align errorsPerRequest with maxRetries, matching the pattern used by the other retry tests in the class.

Closes #155680
