### PR TITLE
Update AI index datastream template to remove columnar mode

### DIFF
--- a/docs/changelog/156056.yaml
+++ b/docs/changelog/156056.yaml
@@ -1,4 +1,4 @@
-area: Templates
+area: Indices APIs
 issues: []
 pr: 156056
 summary: Update AI index datastream template to remove columnar mode

--- a/docs/changelog/156056.yaml
+++ b/docs/changelog/156056.yaml
@@ -1,0 +1,5 @@
+area: Templates
+issues: []
+pr: 156056
+summary: Update AI index datastream template to remove columnar mode
+type: bug

--- a/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index@ds-settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ai-index/ai-index@ds-settings.json
@@ -2,7 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "mode": "columnar",
         "sort": {
           "field": "@timestamp",
           "order": "desc"

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistry.java
@@ -33,10 +33,10 @@ import java.util.Map;
 public class AiIndexTemplateRegistry extends IndexTemplateRegistry {
 
     // This number must be incremented when we make changes to built-in templates.
-    static final int REGISTRY_VERSION = 1;
+    static final int REGISTRY_VERSION = 2;
 
     // The computed checksum of all templates and components that are registered in this registry.
-    static final String COMPUTED_CHECKSUM = "27635e19";
+    static final String COMPUTED_CHECKSUM = "6a0a136a";
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.ai-index.template.version";
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/AiIndexTemplateRegistryTests.java
@@ -117,7 +117,7 @@ public class AiIndexTemplateRegistryTests extends ESTestCase {
         ComponentTemplate dsSettings = registry.getComponentTemplateConfigs().get(AI_INDEX_DS_SETTINGS_COMPONENT_NAME);
         assertThat(dsSettings, notNullValue());
         Settings settings = dsSettings.template().settings();
-        assertThat(settings.get("index.mode"), equalTo("columnar"));
+        assertThat(settings.get("index.mode"), nullValue());
         assertThat(settings.get("index.sort.field"), equalTo("@timestamp"));
     }
 


### PR DESCRIPTION
Updates the AI index datastream template to remove columnar mode, as this can break use cases that copy the template and append runtime fields, which columnar mode does not allow. 

Followup to https://github.com/elastic/elasticsearch/pull/154594