### PR TITLE
[8.19] [CI] Skip node setup on old glibc platforms (#155820)

### DIFF
--- a/.buildkite/scripts/setup_node.sh
+++ b/.buildkite/scripts/setup_node.sh
@@ -2,21 +2,47 @@
 
 cd .buildkite
 
+# Node.js 24 requires glibc >= 2.25. Older Linux platforms tested in
+# maintenance branches (e.g. RHEL 7, OracleLinux 7, SLES 12) ship with
+# glibc 2.17; the node binary exits immediately with missing-symbol errors
+# on those systems, which would abort the pre-command hook. Detect this
+# early and skip node/pnpm setup so the packaging steps can still run
+# (smart retry is simply unavailable on those platforms).
+# Exported so smart-retry.sh can detect the declared skip vs an unexpected failure.
+export SKIP_NODE_SETUP=false
+
 # Don't do this part on Windows
 if ! command -v choco > /dev/null; then
-  if ! command -v nvm > /dev/null; then
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
-    export NVM_DIR="$HOME/.nvm"
-    source "$HOME/.nvm/nvm.sh" --install
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    _glibc=$(ldd --version 2>/dev/null | awk 'NR==1{print $NF}')
+    _major=${_glibc%%.*}
+    _minor=${_glibc##*.}
+    if [[ "$_major" -lt 2 ]] || [[ "$_major" -eq 2 && "$_minor" -lt 25 ]]; then
+      echo "Skipping Node.js setup: glibc ${_glibc} < 2.25 (Node.js 24 requires glibc >= 2.25)"
+      export SKIP_NODE_SETUP=true
+    fi
+    unset _glibc _major _minor
   fi
 
-  nvm install
+  if [[ "$SKIP_NODE_SETUP" != "true" ]]; then
+    if ! command -v nvm > /dev/null; then
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+      export NVM_DIR="$HOME/.nvm"
+      source "$HOME/.nvm/nvm.sh" --install
+    fi
+
+    nvm install
+    command -v node > /dev/null || { echo "ERROR: 'node' not on PATH after nvm install"; exit 1; }
+  fi
 fi
 
-if ! command -v pnpm > /dev/null; then
-  corepack enable pnpm
+# pnpm install runs on all non-skip platforms, including Windows (where nvm is
+# not used but node is pre-installed via the CI agent image).
+if [[ "$SKIP_NODE_SETUP" != "true" ]]; then
+  if ! command -v pnpm > /dev/null; then
+    corepack enable pnpm
+  fi
+  pnpm install
 fi
-
-pnpm install
 
 cd -

--- a/.buildkite/scripts/smart-retry.sh
+++ b/.buildkite/scripts/smart-retry.sh
@@ -5,4 +5,25 @@
 #         BUILDKITE_BUILD_NUMBER, ORIGIN_JOB_ID, TESTS_SEED
 # Writes: .failed-test-history.json, buildkite-agent metadata and annotations
 
-node .buildkite/scripts/smart-retry/main.ts
+# setup_node.sh exports SKIP_NODE_SETUP=true on platforms where Node.js 24
+# cannot run (glibc < 2.25). Skip smart retry gracefully with a Buildkite
+# annotation and metadata so the omission is visible in the build.
+# Any other reason for node to be absent is treated as an unexpected failure.
+if [[ "${SKIP_NODE_SETUP:-false}" == "true" ]]; then
+  reason="Node.js unavailable: glibc too old for Node.js 24"
+  echo "Skipping smart retry: $reason"
+  buildkite-agent annotate --style info --context smart-retry-skip \
+    "Smart retry unavailable: $reason. Tests will run with a fresh seed." 2>/dev/null || true
+  buildkite-agent meta-data set smart-retry-disabled-reason "$reason" 2>/dev/null || true
+  return 0 2>/dev/null || exit 0
+fi
+
+if ! command -v node > /dev/null 2>&1; then
+  echo "ERROR: Node.js expected on PATH but not found; check setup_node.sh"
+  exit 1
+fi
+
+# Resolve paths relative to this script's location, not the caller's CWD. This
+# script is sourced cross-repo, so a CWD-relative path would not resolve.
+SMART_RETRY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "${SMART_RETRY_DIR}/smart-retry/main.ts"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Skip node setup on old glibc platforms (#155820)](https://github.com/elastic/elasticsearch/pull/155820)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)