### PR TITLE
[9.5] Fix async search reader context leak after node restart (#154460)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1987,6 +1987,7 @@ public final class InternalTestCluster extends TestCluster {
         nodeAndClient.recreateNode(newSettings, () -> rebuildUnicastHostFiles(Collections.singletonList(nodeAndClient)));
         nodeAndClient.startNode();
         publishNode(nodeAndClient);
+        callback.onNodeStarted(nodeAndClient.name);
 
         if (callback.validateClusterForming() || excludedNodeIds.isEmpty() == false) {
             // we have to validate cluster size to ensure that the restarted node has rejoined the cluster if it was master-eligible;
@@ -2551,13 +2552,19 @@ public final class InternalTestCluster extends TestCluster {
     public static class RestartCallback {
 
         /**
-         * Executed once the give node name has been stopped.
+         * Executed once the given node name has been stopped.
          */
         public Settings onNodeStopped(String nodeName) throws Exception {
             return Settings.EMPTY;
         }
 
         public void onAllNodesStopped() throws Exception {}
+
+        /**
+         * Executed once the given node has started and been published to the cluster, before cluster
+         * formation is validated.
+         */
+        public void onNodeStarted(String nodeName) throws Exception {}
 
         /**
          * Executed for each node before the {@code n + 1} node is restarted. The given client is

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -153,13 +153,17 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         pauseMaintenanceService();
         ensureAllSearchContextsReleased();
 
-        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {});
-        // The restarted node gets a new, unpaused maintenance service that the pre-restart pause did
-        // not cover. It can dispatch a DeleteByQueryRequest to a still-INITIALIZING shard, registering
-        // an async waitForSearchReady callback that opens a reader context only after the shard starts.
-        // Wait for shards to start, then pause and drain any such in-flight contexts before unpausing.
-        ensureYellow(ASYNC_RESULTS_INDEX, indexName);
-        pauseMaintenanceService();
+        internalCluster().restartNode(node.getName(), new InternalTestCluster.RestartCallback() {
+            @Override
+            public void onNodeStarted(String nodeName) {
+                // Pause before the service's first scheduled run to prevent it from opening reader
+                // contexts on still-initializing shards that would outlast the drain below.
+                pauseMaintenanceService();
+            }
+        });
+        // ensureGreen so any waitForSearchReady callbacks registered before the pause have fired
+        // (and opened their contexts) by the time we drain.
+        ensureGreen(ASYNC_RESULTS_INDEX, indexName);
         ensureAllSearchContextsReleased();
         unpauseMaintenanceService();
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix async search reader context leak after node restart (#154460)](https://github.com/elastic/elasticsearch/pull/154460)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)