### PR TITLE
Unmute AsyncSearchActionIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -781,15 +781,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterStats}
   issue: https://github.com/elastic/elasticsearch/issues/156013
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testSearchPhaseFailureLeak
-  issue: https://github.com/elastic/elasticsearch/issues/156050
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testRestartAfterCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/156051
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testCancellation
-  issue: https://github.com/elastic/elasticsearch/issues/156052
-- class: org.elasticsearch.xpack.search.AsyncSearchActionIT
-  method: testDeleteCancelRunningTask
-  issue: https://github.com/elastic/elasticsearch/issues/156053


### PR DESCRIPTION
The reader context leak behind these failures was fixed in #154460 and backported to 9.5 in #156061, so the four tests can be unmuted.

Closes #156050
Closes #156051
Closes #156052
Closes #156053
