### PR TITLE
[9.5] Remove flaky randomization from OperationalRoutingTests.testARSStatsAdjustment (#156000)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -733,9 +733,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.EsqlSecurityIT
   method: testEnrich
   issue: https://github.com/elastic/elasticsearch/issues/155672
-- class: org.elasticsearch.cluster.routing.OperationRoutingTests
-  method: testARSStatsAdjustment
-  issue: https://github.com/elastic/elasticsearch/issues/155673
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/155532

--- a/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -400,20 +400,13 @@ public class OperationRoutingTests extends ESTestCase {
         collector.addNodeStatistics("node_0", 1, TimeValue.timeValueMillis(50).nanos(), TimeValue.timeValueMillis(40).nanos());
         collector.addNodeStatistics("node_1", 2, TimeValue.timeValueMillis(100).nanos(), TimeValue.timeValueMillis(60).nanos());
 
-        // Check the first node is usually selected, if it's stats don't change much
+        // Check the first node is always selected if it's stats don't change.
         for (int i = 0; i < 10; i++) {
             groupIterator = opRouting.searchShards(project, indexNames, null, null, collector, new HashMap<>(), true);
             ShardRouting shardChoice = groupIterator.get(0).nextOrNull();
             assertThat(shardChoice.currentNodeId(), equalTo("node_0"));
 
-            int responseTime = 50 + randomInt(5);
-            int serviceTime = 40 + randomInt(5);
-            collector.addNodeStatistics(
-                "node_0",
-                1,
-                TimeValue.timeValueMillis(responseTime).nanos(),
-                TimeValue.timeValueMillis(serviceTime).nanos()
-            );
+            collector.addNodeStatistics("node_0", 1, TimeValue.timeValueMillis(50).nanos(), TimeValue.timeValueMillis(40).nanos());
         }
 
         // Check that we try the second when the first node slows down more


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Remove flaky randomization from OperationalRoutingTests.testARSStatsAdjustment (#156000)

Resolves https://github.com/elastic/elasticsearch/issues/155673