### PR TITLE
[CI] Increase ensureGreen timeout in OldMappingsIT tests

### DIFF
--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/DocValueOnlyFieldsIT.java
@@ -77,13 +77,27 @@ public class DocValueOnlyFieldsIT extends ESClientYamlSuiteTestCase {
     @Override
     protected Settings restClientSettings() {
         String token = basicAuthHeaderValue("admin", new SecureString("admin-password".toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+        return Settings.builder()
+            .put(ThreadContext.PREFIX + ".Authorization", token)
+            // increase the socket timeout so it doesn't fire before the increased ensureGreen timeout below;
+            // waiting on cluster health after restoring/recovering the archived index can take longer than
+            // the default 30s/60s on busy/contended CI hosts (see ParameterizedRollingUpgradeTestCase).
+            .put(CLIENT_SOCKET_TIMEOUT, "90s")
+            .build();
     }
 
     @Override
     protected boolean skipSetupSections() {
         // setup in the YAML file is replaced by the method below
         return true;
+    }
+
+    @Override
+    protected String getEnsureGreenTimeout() {
+        // restoring a snapshot into a fresh cluster (and, after a restart, recovering it from disk) can take
+        // longer than the default 30s on busy/contended CI hosts; align with the timeout used by other
+        // BWC-style tests that wait on cluster health (see ParameterizedRollingUpgradeTestCase).
+        return "70s";
     }
 
     @Before

--- a/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldMappingsIT.java
+++ b/x-pack/qa/repository-old-versions/src/yamlRestTest/java/org/elasticsearch/oldrepos/OldMappingsIT.java
@@ -99,7 +99,21 @@ public class OldMappingsIT extends ESRestTestCase {
     @Override
     protected Settings restClientSettings() {
         String token = basicAuthHeaderValue("admin", new SecureString("admin-password".toCharArray()));
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+        return Settings.builder()
+            .put(ThreadContext.PREFIX + ".Authorization", token)
+            // increase the socket timeout so it doesn't fire before the increased ensureGreen timeout below;
+            // waiting on cluster health after restoring/recovering the archived indices can take longer than
+            // the default 30s/60s on busy/contended CI hosts (see ParameterizedRollingUpgradeTestCase).
+            .put(CLIENT_SOCKET_TIMEOUT, "90s")
+            .build();
+    }
+
+    @Override
+    protected String getEnsureGreenTimeout() {
+        // restoring a snapshot into a fresh cluster (and, after a restart, recovering it from disk) can take
+        // longer than the default 30s on busy/contended CI hosts; align with the timeout used by other
+        // BWC-style tests that wait on cluster health (see ParameterizedRollingUpgradeTestCase).
+        return "70s";
     }
 
     @Before


### PR DESCRIPTION
OldMappingsIT and DocValueOnlyFieldsIT restore a snapshot taken
on a genuinely old Elasticsearch cluster and, in the restart
path, recover it again from disk after a hard-kill restart.
On contended CI hosts (aarch64 periodic runs, retried PR
builds) this can exceed the default 30s ensureGreen timeout
even though the cluster is healthy and just slow to converge,
causing sporadic failures such as #155702.

Override getEnsureGreenTimeout() to 70s in both classes,
matching the pattern already used by
ParameterizedRollingUpgradeTestCase for similar BWC-style
tests. Also raise the REST client socket timeout to 90s so it
does not fire before the increased server-side wait.

Closes #155702