### PR TITLE
Add integration tests for recovery priorities

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocation
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -34,20 +35,29 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class FilteringAllocationIT extends ESIntegTestCase {
 
     public void testDecommissionNodeNoReplicas() {
         logger.info("--> starting 2 nodes");
-        List<String> nodesIds = internalCluster().startNodes(2);
-        final String node_0 = nodesIds.get(0);
-        final String node_1 = nodesIds.get(1);
+        List<String> nodesNames = internalCluster().startNodes(2);
+        final String node_0 = nodesNames.get(0);
+        final String node_1 = nodesNames.get(1);
         assertThat(cluster().size(), equalTo(2));
 
-        logger.info("--> creating an index with no replicas");
-        createIndex("test", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
+        int numShards = randomIntBetween(5, 10);
+        logger.info("--> creating an index with no replicas and {} shards", numShards);
+        createIndex(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+                .build()
+        );
         ensureGreen("test");
         logger.info("--> index some data");
         for (int i = 0; i < 100; i++) {
@@ -56,12 +66,6 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         indicesAdmin().prepareRefresh().get();
         assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
 
-        final boolean closed = randomBoolean();
-        if (closed) {
-            assertAcked(indicesAdmin().prepareClose("test"));
-            ensureGreen("test");
-        }
-
         logger.info("--> decommission the second node");
         updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", node_1));
         ensureGreen("test");
@@ -69,6 +73,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         logger.info("--> verify all are allocated on node1 now");
         ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            assertThat(indexRoutingTable.size(), equalTo(numShards));
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
                 for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
@@ -77,12 +82,77 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             }
         }
 
-        if (closed) {
-            assertAcked(indicesAdmin().prepareOpen("test"));
+        indicesAdmin().prepareRefresh().get();
+        assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
+
+        List<ShardRouting.RecoveryPriority> shardRecoveryPriorities = retrieveShardRecoveryPriorities("test");
+        assertThat(
+            shardRecoveryPriorities,
+            // The shards which were initially assigned to node_0 should have been recovered there with priority UNASSIGNED_NEW_PRIMARY.
+            // Those which were initially assigned to node_1 should have been recovered on node_0 with priority RELOCATION_CAN_REMAIN_NO.
+            everyItem(
+                anyOf(
+                    equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY),
+                    equalTo(ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO)
+                )
+            )
+        );
+    }
+
+    public void testDecommissionNodeWhileIndexClosedNoReplicas() {
+        logger.info("--> starting 2 nodes");
+        List<String> nodesNames = internalCluster().startNodes(2);
+        final String node_0 = nodesNames.get(0);
+        final String node_1 = nodesNames.get(1);
+        assertThat(cluster().size(), equalTo(2));
+
+        int numShards = randomIntBetween(5, 10);
+        logger.info("--> creating an index with no replicas and {} shards", numShards);
+        createIndex(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+                .build()
+        );
+        ensureGreen("test");
+        logger.info("--> index some data");
+        for (int i = 0; i < 100; i++) {
+            prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
+        indicesAdmin().prepareRefresh().get();
+        assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
+
+        assertAcked(indicesAdmin().prepareClose("test"));
+        ensureGreen("test");
+
+        logger.info("--> decommission the second node");
+        updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", node_1));
+        ensureGreen("test");
+
+        logger.info("--> verify all are allocated on node1 now");
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            assertThat(indexRoutingTable.size(), equalTo(numShards));
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    assertThat(clusterState.nodes().get(indexShardRoutingTable.shard(copy).currentNodeId()).getName(), equalTo(node_0));
+                }
+            }
+        }
+
+        assertAcked(indicesAdmin().prepareOpen("test"));
 
         indicesAdmin().prepareRefresh().get();
         assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
+
+        List<ShardRouting.RecoveryPriority> shardRecoveryPriorities = retrieveShardRecoveryPriorities("test");
+        assertThat(
+            shardRecoveryPriorities,
+            // The shards should all have been recovered with priority UNASSIGNED_EXPECTED when the index was reopened.
+            everyItem(equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED))
+        );
     }
 
     public void testAutoExpandReplicasToFilteredNodes() {
@@ -270,5 +340,16 @@ public class FilteringAllocationIT extends ESIntegTestCase {
                 includeNodes.contains(node)
             );
         }
+    }
+
+    private static List<ShardRouting.RecoveryPriority> retrieveShardRecoveryPriorities(String index) {
+        return admin().indices()
+            .prepareRecoveries(index)
+            .get()
+            .shardRecoveryStates()
+            .get(index)
+            .stream()
+            .map(RecoveryState::getRecoveryPriority)
+            .toList();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/UpdateShardAllocationSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/UpdateShardAllocationSettingsIT.java
@@ -10,15 +10,23 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ESIntegTestCase;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 
 /**
  * An integration test for testing updating shard allocation/routing settings and
@@ -91,6 +99,19 @@ public class UpdateShardAllocationSettingsIT extends ESIntegTestCase {
 
         test = assertAllShardsOnNodes("test", firstNode, secondNode);
         assertThat("index: [test] expected to be rebalanced on both nodes", test.size(), equalTo(2));
+
+        Map<String, List<ShardRouting.RecoveryPriority>> recoveryPrioritiesByTargetNode = admin().indices()
+            .prepareRecoveries("test", "test_1")
+            .get()
+            .shardRecoveryStates()
+            .values()
+            .stream()
+            .flatMap(List::stream)
+            .collect(groupingBy(state -> state.getTargetNode().getName(), mapping(RecoveryState::getRecoveryPriority, toList())));
+        // All shards on firstNode should be from initial creation, and recovered with priority UNASSIGNED_NEW_PRIMARY:
+        assertThat(recoveryPrioritiesByTargetNode.get(firstNode), everyItem(equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY)));
+        // All shards on secondNode should be from rebalancing, and recovered with priority RELOCATE_REBALANCING:
+        assertThat(recoveryPrioritiesByTargetNode.get(secondNode), everyItem(equalTo(ShardRouting.RecoveryPriority.RELOCATE_REBALANCING)));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -48,6 +48,7 @@ import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.store.StoreStats;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.telemetry.Measurement;
@@ -620,7 +621,24 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         ).sorted(comparator).toList();
 
         // The moved shard should be at the head of the sorted list
-        assertThat(movedShardId, equalTo(bestShardsToMove.get(0).shardId().id()));
+        assertThat(movedShardId, equalTo(bestShardsToMove.getFirst().shardId().id()));
+
+        // Assert that the moved shard was recovered with priority RELOCATION_CAN_REMAIN_NOT_PREFERRED:
+        List<RecoveryState> recoveryStatesForMovedShard = admin().indices()
+            .prepareRecoveries(harness.indexName)
+            .get()
+            .shardRecoveryStates()
+            .get(harness.indexName)
+            .stream()
+            .filter(state -> state.getShardId().id() == movedShardId)
+            // We're interesting on the recovery after the move to the second or third node, not the initial creation on the first node:
+            .filter(state -> !state.getTargetNode().getId().equals(harness.firstDataNodeId))
+            .toList();
+        assertThat(recoveryStatesForMovedShard.size(), equalTo(1));
+        assertThat(
+            recoveryStatesForMovedShard.getFirst().getRecoveryPriority(),
+            equalTo(ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NOT_PREFERRED)
+        );
     }
 
     public void testMaxQueueLatencyMetricIsPublished() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -197,7 +197,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         RecoverySource recoverySource,
         boolean primary,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
         assertThat(state.getShardId().getId(), equalTo(shardId));
         assertThat(state.getRecoverySource(), equalTo(recoverySource));
@@ -214,6 +215,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             assertNotNull(state.getTargetNode());
             assertThat(state.getTargetNode().getName(), equalTo(targetNode));
         }
+        assertThat(state.getRecoveryPriority(), equalTo(recoveryPriority));
     }
 
     private void assertRecoveryState(
@@ -223,9 +225,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         boolean primary,
         Stage stage,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
-        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode);
+        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode, recoveryPriority);
         assertThat(state.getStage(), equalTo(stage));
     }
 
@@ -235,9 +238,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         RecoverySource type,
         boolean primary,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
-        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode);
+        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode, recoveryPriority);
         assertThat(state.getStage(), not(equalTo(Stage.DONE)));
     }
 
@@ -364,7 +368,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
         final RecoveryState recoveryState = recoveryStates.getFirst();
 
-        assertRecoveryState(recoveryState, 0, RecoverySource.ExistingStoreRecoverySource.INSTANCE, true, Stage.DONE, null, node);
+        assertRecoveryState(
+            recoveryState,
+            0,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            true,
+            Stage.DONE,
+            null,
+            node,
+            ShardRouting.RecoveryPriority.UNASSIGNED_UNEXPECTED
+        );
 
         validateIndexRecoveryState(recoveryState.getIndex());
     }
@@ -427,12 +440,32 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         } else {
             expectedRecoverySource = RecoverySource.ExistingStoreRecoverySource.INSTANCE;
         }
-        assertRecoveryState(nodeARecoveryState, 0, expectedRecoverySource, true, Stage.DONE, null, nodeA);
+        assertRecoveryState(
+            nodeARecoveryState,
+            0,
+            expectedRecoverySource,
+            true,
+            Stage.DONE,
+            null,
+            nodeA,
+            closedIndex
+                ? ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED // when closed, the primary gets recovered as empty with this priority
+                : ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY // this was the original creation of the primary
+        );
         validateIndexRecoveryState(nodeARecoveryState.getIndex());
 
         // validate node B recovery
         final RecoveryState nodeBRecoveryState = nodeBResponses.getFirst();
-        assertRecoveryState(nodeBRecoveryState, 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeA, nodeB);
+        assertRecoveryState(
+            nodeBRecoveryState,
+            0,
+            PeerRecoverySource.INSTANCE,
+            false,
+            Stage.DONE,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED // this was the replica
+        );
         validateIndexRecoveryState(nodeBRecoveryState.getIndex());
 
         internalCluster().stopNode(nodeA);
@@ -513,7 +546,15 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 final List<RecoveryState> nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
                 assertThat(nodeCRecoveryStates, hasSize(1));
 
-                assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeA, nodeC);
+                assertOnGoingRecoveryState(
+                    nodeCRecoveryStates.getFirst(),
+                    0,
+                    PeerRecoverySource.INSTANCE,
+                    false,
+                    nodeA,
+                    nodeC,
+                    ShardRouting.RecoveryPriority.UNASSIGNED_UNEXPECTED
+                );
                 validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
 
                 return super.onNodeStopped(nodeName);
@@ -575,11 +616,20 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             true,
             Stage.DONE,
             null,
-            nodeA
+            nodeA,
+            ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY // this was the primary of the original newly-created index
         );
         validateIndexRecoveryState(nodeARecoveryStates.getFirst().getIndex());
 
-        assertOnGoingRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, nodeA, nodeB);
+        assertOnGoingRecoveryState(
+            nodeBRecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            true,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO // this is the expected priority for a MoveAllocationCommand
+        );
         validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         logger.info("--> request node recovery stats");
@@ -608,7 +658,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         recoveryStates = getRecoveryStates(INDEX_NAME);
         assertThat(recoveryStates, hasSize(1));
 
-        assertRecoveryState(recoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        assertRecoveryState(
+            recoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            true,
+            Stage.DONE,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(recoveryStates.getFirst().getIndex());
         awaitRecoveryCountStats(Map.of(nodeA, RecoveryStats::noCurrentRecoveries, nodeB, RecoveryStats::noCurrentRecoveries));
 
@@ -638,14 +697,40 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         List<RecoveryState> nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
         assertThat(nodeCRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeARecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeA);
+        assertRecoveryState(
+            nodeARecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            false,
+            Stage.DONE,
+            nodeB,
+            nodeA,
+            ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED // this was the replica that got added
+        );
         validateIndexRecoveryState(nodeARecoveryStates.getFirst().getIndex());
 
-        assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        assertRecoveryState(
+            nodeBRecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            true,
+            Stage.DONE,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         // relocations of replicas are marked as REPLICA and the source node is the node holding the primary (B)
-        assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
+        assertOnGoingRecoveryState(
+            nodeCRecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            false,
+            nodeB,
+            nodeC,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
 
         if (randomBoolean()) {
@@ -662,10 +747,27 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
             assertThat(nodeCRecoveryStates, hasSize(1));
 
-            assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+            assertRecoveryState(
+                nodeBRecoveryStates.getFirst(),
+                0,
+                PeerRecoverySource.INSTANCE,
+                true,
+                Stage.DONE,
+                nodeA,
+                nodeB,
+                ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+            );
             validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
-            assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
+            assertOnGoingRecoveryState(
+                nodeCRecoveryStates.getFirst(),
+                0,
+                PeerRecoverySource.INSTANCE,
+                false,
+                nodeB,
+                nodeC,
+                ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+            );
             validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
         }
 
@@ -682,11 +784,29 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
         assertThat(nodeCRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        assertRecoveryState(
+            nodeBRecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            true,
+            Stage.DONE,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         // relocations of replicas are marked as REPLICA and the source node is the node holding the primary (B)
-        assertRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeC);
+        assertRecoveryState(
+            nodeCRecoveryStates.getFirst(),
+            0,
+            PeerRecoverySource.INSTANCE,
+            false,
+            Stage.DONE,
+            nodeB,
+            nodeC,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
     }
 
@@ -825,7 +945,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         assertNodeThrottleTimeStats(nodeB, true);
     }
 
-    public void testSnapshotRecovery() {
+    public void testSnapshotRecoveryToExistingIndex() {
         logger.info("--> start node A");
         final String nodeA = internalCluster().startNode();
 
@@ -870,7 +990,76 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                     IndexVersion.current(),
                     repositoryData.resolveIndexId(INDEX_NAME)
                 );
-                assertRecoveryState(recoveryState, 0, recoverySource, true, Stage.DONE, null, nodeA);
+                assertRecoveryState(
+                    recoveryState,
+                    0,
+                    recoverySource,
+                    true,
+                    Stage.DONE,
+                    null,
+                    nodeA,
+                    ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED
+                );
+                validateIndexRecoveryState(recoveryState.getIndex());
+            }
+        }
+    }
+
+    public void testSnapshotRecoveryToNewIndex() {
+        logger.info("--> start node A");
+        final String nodeA = internalCluster().startNode();
+
+        logger.info("--> create repository");
+        createRepository(randomBoolean());
+
+        ensureGreen();
+
+        logger.info("--> create index on node: {}", nodeA);
+        String originalIndex = "test-idx-original";
+        createAndPopulateIndex(originalIndex, 1, SHARD_COUNT_1, REPLICA_COUNT_0);
+
+        logger.info("--> snapshot");
+        final CreateSnapshotResponse createSnapshotResponse = createSnapshot(originalIndex);
+
+        logger.info("--> restore");
+        String copyIndex = "test-idx-copy";
+        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(
+            TEST_REQUEST_TIMEOUT,
+            REPO_NAME,
+            SNAP_NAME
+        ).setRenamePattern("original").setRenameReplacement("copy").setWaitForCompletion(true).get();
+        int totalShards = restoreSnapshotResponse.getRestoreInfo().totalShards();
+        assertThat(totalShards, greaterThan(0));
+
+        ensureGreen();
+
+        logger.info("--> request recoveries");
+        final RecoveryResponse response = indicesAdmin().prepareRecoveries(copyIndex).get();
+
+        final Repository repository = internalCluster().getAnyMasterNodeInstance(RepositoriesService.class).repository(REPO_NAME);
+        final RepositoryData repositoryData = AbstractSnapshotIntegTestCase.getRepositoryData(repository);
+        for (Map.Entry<String, List<RecoveryState>> indexRecoveryStates : response.shardRecoveryStates().entrySet()) {
+            assertThat(indexRecoveryStates.getKey(), equalTo(copyIndex));
+            final List<RecoveryState> recoveryStates = indexRecoveryStates.getValue();
+            assertThat(recoveryStates, hasSize(restoreSnapshotResponse.getRestoreInfo().totalShards()));
+
+            for (final RecoveryState recoveryState : recoveryStates) {
+                SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(
+                    ((SnapshotRecoverySource) recoveryState.getRecoverySource()).restoreUUID(),
+                    new Snapshot(REPO_NAME, createSnapshotResponse.getSnapshotInfo().snapshotId()),
+                    IndexVersion.current(),
+                    repositoryData.resolveIndexId(originalIndex)
+                );
+                assertRecoveryState(
+                    recoveryState,
+                    0,
+                    recoverySource,
+                    true,
+                    Stage.DONE,
+                    null,
+                    nodeA,
+                    ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED
+                );
                 validateIndexRecoveryState(recoveryState.getIndex());
             }
         }

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
@@ -34,6 +35,7 @@ import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -353,7 +355,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
         assertBusy(() -> assertNodeShutdownStatus(nodeAId, COMPLETE));
     }
 
-    public void testReallocationForReplicaDuringNodeReplace() throws Exception {
+    public void testReallocationForReplicaDuringNodeReplaceAfterShutdownOfPrimary() throws Exception {
         final String nodeA = internalCluster().startNode();
         final String nodeAId = getNodeId(nodeA);
         createIndex("myindex", 1, 1);
@@ -379,6 +381,45 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
 
         // All shards for the index should be allocated
         ensureGreen("myindex");
+
+        Map<String, ShardRouting.RecoveryPriority> recoveryPriorities = retrieveRecoveryPrioritiesByTargetNodeName("myindex", 0);
+        // Node B got the original replica shard, which should be recovered with UNASSIGNED_EXPECTED priority:
+        assertThat(recoveryPriorities.get(nodeB), equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED));
+        // Node C got the replica shard after node A shutdown and its shard failed, so it should be recovered with UNASSIGNED_UNEXPECTED:
+        assertThat(recoveryPriorities.get(nodeC), equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_UNEXPECTED));
+    }
+
+    public void testReallocationForReplicaDuringNodeReplaceAfterShutdownOfReplica() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        createIndex("myindex", 1, 1);
+        ensureYellow("myindex");
+
+        // Start a second node, so the replica will be on nodeB
+        final String nodeB = internalCluster().startNode();
+        final String nodeBId = getNodeId(nodeB);
+        ensureGreen("myindex");
+
+        final String nodeC = internalCluster().startNode();
+
+        putNodeShutdown(nodeBId, SingleNodeShutdownMetadata.Type.REPLACE, nodeC);
+
+        // Wait for the node replace shutdown to be complete
+        assertBusy(() -> assertNodeShutdownStatus(nodeBId, COMPLETE));
+
+        // Remove nodeB from the cluster (it's been terminated)
+        internalCluster().stopNode(nodeB);
+
+        // Restart nodeC, the replica which failed when nodeB shut down should be assigned to it when it comes up
+        internalCluster().restartNode(nodeC);
+
+        // All shards for the index should be allocated
+        ensureGreen("myindex");
+
+        Map<String, ShardRouting.RecoveryPriority> recoveryPriorities = retrieveRecoveryPrioritiesByTargetNodeName("myindex", 0);
+        // Node A got the original primary shard, which should be recovered with UNASSIGNED_NEW_PRIMARY priority:
+        assertThat(recoveryPriorities.get(nodeA), equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY));
+        // Node C got the replica shard after node B shutdown and its shard failed, so it should be recovered with UNASSIGNED_UNEXPECTED:
+        assertThat(recoveryPriorities.get(nodeC), equalTo(ShardRouting.RecoveryPriority.UNASSIGNED_UNEXPECTED));
     }
 
     /**
@@ -602,5 +643,16 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     private void assertIndexSetting(String index, String setting, String expectedValue) {
         var response = indicesAdmin().prepareGetSettings(TEST_REQUEST_TIMEOUT, index).get();
         assertThat(response.getSetting(index, setting), equalTo(expectedValue));
+    }
+
+    private static Map<String, ShardRouting.RecoveryPriority> retrieveRecoveryPrioritiesByTargetNodeName(String index, int id) {
+        return admin().indices()
+            .prepareRecoveries(index)
+            .get()
+            .shardRecoveryStates()
+            .get(index)
+            .stream()
+            .filter(state -> state.getShardId().id() == id)
+            .collect(Collectors.toMap(shard -> shard.getTargetNode().getName(), RecoveryState::getRecoveryPriority));
     }
 }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/RerouteIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/RerouteIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
@@ -101,11 +102,20 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             true,
             RecoveryState.Stage.DONE,
             null,
-            nodeA
+            nodeA,
+            ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY // this is the creation of the original primary
         );
         validateIndexRecoveryState(nodeARecoveryStates.get(0).getIndex());
 
-        assertOnGoingRecoveryState(nodeBRecoveryStates.get(0), 0, RecoverySource.PeerRecoverySource.INSTANCE, true, nodeA, nodeB);
+        assertOnGoingRecoveryState(
+            nodeBRecoveryStates.get(0),
+            0,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            true,
+            nodeA,
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO // this is the expected priority for a MoveAllocationCommand
+        );
         validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
 
         logger.info("--> request node recovery stats");
@@ -143,7 +153,8 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             true,
             RecoveryState.Stage.DONE,
             nodeA,
-            nodeB
+            nodeB,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
         );
         validateIndexRecoveryState(recoveryStates.get(0).getIndex());
         assertBusy(() -> assertNodeHasNoCurrentRecoveries(nodeA));
@@ -202,7 +213,8 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             true,
             RecoveryState.Stage.DONE,
             null,
-            nodeA
+            nodeA,
+            ShardRouting.RecoveryPriority.UNASSIGNED_NEW_PRIMARY // this is the creation of the original primary
         );
         validateIndexRecoveryState(nodeARecoveryStates.get(0).getIndex());
 
@@ -213,11 +225,20 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             false,
             RecoveryState.Stage.DONE,
             nodeA,
-            nodeB
+            nodeB,
+            ShardRouting.RecoveryPriority.UNASSIGNED_EXPECTED // this is the creation of the original replica
         );
         validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
 
-        assertOnGoingRecoveryState(nodeCRecoveryStates.get(0), 0, RecoverySource.PeerRecoverySource.INSTANCE, false, nodeA, nodeC);
+        assertOnGoingRecoveryState(
+            nodeCRecoveryStates.get(0),
+            0,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            false,
+            nodeA,
+            nodeC,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+        );
         validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
 
         if (randomBoolean()) {
@@ -235,7 +256,15 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
             assertThat(nodeCRecoveryStates.size(), equalTo(1));
 
-            assertOnGoingRecoveryState(nodeCRecoveryStates.get(0), 0, RecoverySource.PeerRecoverySource.INSTANCE, false, nodeA, nodeC);
+            assertOnGoingRecoveryState(
+                nodeCRecoveryStates.get(0),
+                0,
+                RecoverySource.PeerRecoverySource.INSTANCE,
+                false,
+                nodeA,
+                nodeC,
+                ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+            );
             validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
         }
 
@@ -260,7 +289,8 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             false,
             RecoveryState.Stage.DONE,
             nodeA,
-            nodeC
+            nodeC,
+            ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
         );
         validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
     }
@@ -272,9 +302,10 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
         boolean primary,
         RecoveryState.Stage stage,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
-        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode);
+        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode, recoveryPriority);
         assertThat(state.getStage(), equalTo(stage));
     }
 
@@ -284,9 +315,10 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
         RecoverySource type,
         boolean primary,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
-        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode);
+        assertRecoveryStateWithoutStage(state, shardId, type, primary, sourceNode, targetNode, recoveryPriority);
         assertThat(state.getStage(), not(equalTo(RecoveryState.Stage.DONE)));
     }
 
@@ -296,7 +328,8 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
         RecoverySource recoverySource,
         boolean primary,
         String sourceNode,
-        String targetNode
+        String targetNode,
+        ShardRouting.RecoveryPriority recoveryPriority
     ) {
         assertThat(state.getShardId().getId(), equalTo(shardId));
         assertThat(state.getRecoverySource(), equalTo(recoverySource));
@@ -313,6 +346,7 @@ public class RerouteIT extends AbstractStatelessPluginIntegTestCase {
             assertNotNull(state.getTargetNode());
             assertThat(state.getTargetNode().getName(), equalTo(targetNode));
         }
+        assertThat(state.getRecoveryPriority(), equalTo(recoveryPriority));
     }
 
     private void validateIndexRecoveryState(RecoveryState.Index indexState) {


### PR DESCRIPTION
This adds coverage in internal cluster tests for the changes in are used in various scenarios.

Where possible, the assertions are added to existing tests, to avoid adding too much test execution time. New tests are added for the cases where I couldn't find coverage.

Closes elastic/elasticsearch-team#2918