### PR TITLE
ESQL: Gate nullify FIRST/LAST csv tests on fn capabilities

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -1491,6 +1491,7 @@ c:long
 statsNullifiedFirst
 required_capability: optional_fields_nullify_tech_preview
 required_capability: fix_agg_on_null_by_replacing_with_eval
+required_capability: fn_first
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -1504,6 +1505,7 @@ null
 statsNullifiedLast
 required_capability: optional_fields_nullify_tech_preview
 required_capability: fix_agg_on_null_by_replacing_with_eval
+required_capability: fn_last
 
 SET unmapped_fields="nullify"\;
 FROM employees


### PR DESCRIPTION
## Why

The `unmapped-nullify` csv-spec tests `statsNullifiedFirst` / `statsNullifiedLast` use the `FIRST` / `LAST` aggs, which were snapshot-only on 9.3.x. They gated only on feature caps that old nodes *do* advertise, so mixed-cluster BWC runs executed the query against a 9.3 node and failed with `Unknown function [FIRST]` (#156026, #156027).

## Fix

Gate each test on the function's own auto-registered `fn_<name>` capability (`fn_first` / `fn_last`). An old node lacking the function never advertises that cap, and the mixed-cluster runner only runs a test when every node reports all required caps — so the test now skips against such nodes.

<details>
<summary>Verification</summary>

- Adversarial review confirmed `fn_first`/`fn_last` is the exact base capability, the runner AND-gates on the old node (`AbstractMixedClusterEsqlSpecIT.shouldSkipTest` → `hasCapabilities(oldNodeClient(), …)`), and FIRST/LAST were snapshot-only on 9.3 (`snapshotFunctions()`).
- Audited every other agg in the per-function block (ABSENT, PRESENT, SAMPLE, TOP, …): all were GA in 9.3, so no sibling test has the same latent gap. SPARKLINE is newer but already self-skips via `fn_sparkline_null_alongside`.
- `statsNullifiedLast` runs green on a single-node cluster (spec still parses, test passes where the function exists).

</details>

Closes #156026
Closes #156027
