### PR TITLE
Blob cache: cleanup settings default to CBP setting

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.fs.FsBlobContainer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -399,16 +398,10 @@ public abstract class AbstractStatelessPluginIntegTestCase extends ESIntegTestCa
             builder.put(SharedBlobCacheWarmingService.SEARCH_OFFLINE_WARMING_ENABLED_SETTING.getKey(), randomBoolean());
         }
         builder.put(SearchCommitPrefetcherDynamicSettings.STATELESS_SEARCH_USE_INTERNAL_FILES_REPLICATED_CONTENT.getKey(), randomBoolean());
-        // Sometimes explicitly set a setting to its default value, which doubles as a test for the setting being registered
-        for (Setting<Boolean> cacheSetting : List.of(
-            StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
-            StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING,
-            StatelessSharedBlobCacheService.STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING,
-            StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING
-        )) {
-            if (randomBoolean()) {
-                builder.put(cacheSetting.getKey(), cacheSetting.getDefault(Settings.EMPTY));
-            }
+        // Sometimes explicitly set the setting to its default value, which doubles as a test for the setting being registered.
+        if (randomBoolean()) {
+            var cacheBoostPreference = StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING;
+            builder.put(cacheBoostPreference.getKey(), cacheBoostPreference.getDefault(Settings.EMPTY));
         }
         return builder;
     }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/BoostedDataEvictionIT.java
@@ -476,21 +476,19 @@ public class BoostedDataEvictionIT extends AbstractStatelessPluginIntegTestCase 
     }
 
     private static Settings demoteClosedShardRegionsTestSettings() {
-        return maybeEnableCacheBoostPreference(
-            smallCacheSettings().put(
-                StatelessSharedBlobCacheService.STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING.getKey(),
-                true
-            )
-        ).build();
+        final var builder = maybeEnableCacheBoostPreference(smallCacheSettings());
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING.getKey(), true);
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING.getKey(), false);
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING.getKey(), false);
+        return builder.build();
     }
 
     private static Settings evictDeletedIndexRegionsTestSettings() {
-        return maybeEnableCacheBoostPreference(
-            smallCacheSettings().put(
-                StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING.getKey(),
-                true
-            )
-        ).build();
+        final var builder = maybeEnableCacheBoostPreference(smallCacheSettings());
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING.getKey(), true);
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING.getKey(), false);
+        builder.put(StatelessSharedBlobCacheService.STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING.getKey(), false);
+        return builder.build();
     }
 
     /// Creates a one-replica index whose search shard is kept off `excludedSearchNode`, then searches it so that the search shard on

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
@@ -150,9 +150,10 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
     /// (and, if necessary, disabled) at runtime on its own. Obsolete-region eviction keys off active/inactive regions per
     /// batched-compound-commit generation and needs neither content timestamps nor the pinned-window eviction policy, so
     /// unlike the boost-preference flag it needs no validator and a dynamic flip can never leave the cache in an invalid state.
+    /// Defaults to [#STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING], but an explicit value wins.
     public static final Setting<Boolean> STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING = Setting.boolSetting(
         "stateless.cache.evict_obsolete_regions.enabled",
-        false,
+        STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
         Setting.Property.OperatorDynamic,
         Setting.Property.NodeScope
     );
@@ -162,9 +163,10 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
     /// being evicted, so they are the first eviction candidates while remaining usable if the shard relocates and relocates back.
     /// Index deletion and node shutdown are handled separately.
     /// A flip takes effect on the next store close; a demotion already submitted still runs.
+    /// Defaults to [#STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING], but an explicit value wins.
     public static final Setting<Boolean> STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING = Setting.boolSetting(
         "stateless.cache.demote_closed_shard_regions.enabled",
-        false,
+        STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
         Setting.Property.OperatorDynamic,
         Setting.Property.NodeScope
     );
@@ -172,9 +174,10 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
     /// Setting gating force-eviction of a deleted index's cache regions (see [SharedBlobCacheService#forceEvictAsync]). The regions of a
     /// deleted index can never be read again, so they are dropped as soon as the index is removed rather than left for the LFU to
     /// reclaim. A flip takes effect on the next index removal; an eviction already submitted still runs.
+    /// Defaults to [#STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING], but an explicit value wins.
     public static final Setting<Boolean> STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING = Setting.boolSetting(
         "stateless.cache.evict_deleted_index_regions.enabled",
-        false,
+        STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING,
         Setting.Property.OperatorDynamic,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheServiceTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.blobcache.shared.SharedBytes;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.stateless.lucene.BlobStoreCacheDirectoryMetrics;
 import org.elasticsearch.xpack.stateless.lucene.FileCacheKey;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,6 +56,7 @@ import static org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTestUtils
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheServiceTestUtils.maybeScheduleDecayAndNewEpoch;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.elasticsearch.xpack.stateless.TestUtils.newCacheService;
+import static org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService.STATELESS_CACHE_BOOST_PREFERENCE_EVICTION_POLICY_SEARCH_SETTING;
 import static org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService.STATELESS_CACHE_EVICTION_POLICY_DEGRADATION_THRESHOLD_SETTING;
 import static org.hamcrest.Matchers.equalTo;
@@ -62,6 +65,13 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class StatelessSharedBlobCacheServiceTests extends ESTestCase {
+
+    /// The cache maintenance settings, all of which fall back to the cache boost preference setting.
+    private static final List<Setting<Boolean>> CACHE_MAINTENANCE_SETTINGS = List.of(
+        StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_OBSOLETE_REGIONS_ENABLED_SETTING,
+        StatelessSharedBlobCacheService.STATELESS_CACHE_DEMOTE_CLOSED_SHARD_REGIONS_ENABLED_SETTING,
+        StatelessSharedBlobCacheService.STATELESS_CACHE_EVICT_DELETED_INDEX_REGIONS_ENABLED_SETTING
+    );
 
     public void testDemoteAllSkippedWhenShardLocallyAllocatedAtTaskExecution() throws IOException {
         runDemoteAllTest(true, false);
@@ -440,6 +450,54 @@ public class StatelessSharedBlobCacheServiceTests extends ESTestCase {
             );
 
             assertThat(getDelegatePolicy(getEvictionPolicy(cacheService)), instanceOf(IndexAgeEvictionPolicy.class));
+        }
+    }
+
+    public void testCacheMaintenanceSettingsFallBackToCacheBoostPreference() {
+        for (boolean cacheBoostPreferenceEnabled : new boolean[] { true, false }) {
+            final var settings = Settings.builder()
+                .put(STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING.getKey(), cacheBoostPreferenceEnabled)
+                .build();
+            for (Setting<Boolean> maintenanceSetting : CACHE_MAINTENANCE_SETTINGS) {
+                assertThat(maintenanceSetting.get(settings), equalTo(cacheBoostPreferenceEnabled));
+            }
+        }
+        for (Setting<Boolean> maintenanceSetting : CACHE_MAINTENANCE_SETTINGS) {
+            assertThat("unset boost preference leaves the maintenance settings off", maintenanceSetting.get(Settings.EMPTY), is(false));
+        }
+    }
+
+    public void testExplicitCacheMaintenanceSettingOverridesCacheBoostPreference() {
+        for (boolean cacheBoostPreferenceEnabled : new boolean[] { true, false }) {
+            for (Setting<Boolean> overriddenSetting : CACHE_MAINTENANCE_SETTINGS) {
+                final var settings = Settings.builder()
+                    .put(STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING.getKey(), cacheBoostPreferenceEnabled)
+                    .put(overriddenSetting.getKey(), cacheBoostPreferenceEnabled == false)
+                    .build();
+                assertThat(overriddenSetting.get(settings), equalTo(cacheBoostPreferenceEnabled == false));
+                for (Setting<Boolean> otherSetting : CACHE_MAINTENANCE_SETTINGS) {
+                    if (otherSetting.getKey().equals(overriddenSetting.getKey()) == false) {
+                        assertThat(otherSetting.get(settings), equalTo(cacheBoostPreferenceEnabled));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Removing a cluster-level override must return the setting to the value derived from the node's boost preference, not to `false`.
+    public void testCacheMaintenanceSettingResetsToCacheBoostPreferenceDerivedValue() {
+        final var nodeSettings = Settings.builder().put(STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING.getKey(), true).build();
+        for (Setting<Boolean> maintenanceSetting : CACHE_MAINTENANCE_SETTINGS) {
+            final var clusterSettings = createClusterSettings(nodeSettings);
+            final var enabled = new AtomicBoolean();
+            clusterSettings.initializeAndWatch(maintenanceSetting, enabled::set);
+            assertTrue(enabled.get());
+
+            clusterSettings.applySettings(Settings.builder().put(maintenanceSetting.getKey(), false).build());
+            assertFalse(enabled.get());
+
+            clusterSettings.applySettings(Settings.EMPTY);
+            assertTrue(enabled.get());
         }
     }
 


### PR DESCRIPTION
- Incremental cache cleanup improvements get a default of `STATELESS_CACHE_BOOST_PREFERENCE_ENABLED_SETTING`, but they can be set explicitly to override.

Closes elastic/elasticsearch-team#4336