### PR TITLE
Advance current upper bound when generating an initial patch version

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionFuncTest.groovy
@@ -79,6 +79,29 @@ class GenerateInitialTransportVersionFuncTest extends AbstractTransportVersionFu
         assertGenerateAndValidateSuccess(result)
         assertUnreferableDefinition("initial_9.1.2", "8012002")
         assertUpperBound("9.1", "initial_9.1.2,8012002")
+        // the current upper bound is in a different base, so the patch id does not affect it
+        assertUpperBound("9.2", "existing_92,8123000")
+    }
+
+    def "patch also updates current upper bound in the same base"() {
+        given: "a minor was branched, moving the current upper bound to that minor's initial version"
+        execute("git checkout main")
+        // version properties will be updated by release automation before running initial version generation
+        versionPropertiesFile.text = versionPropertiesFile.text.replace("9.2.0", "9.3.0")
+        assertGenerateSuccess(runGenerateTask("--stack-version", "9.2.0").build())
+        execute("git add .")
+        execute('git commit -m Feature-freeze-9.2')
+
+        when: "the minor is finalized, generating the initial transport version for its first patch release"
+        def result = runGenerateAndValidateTask("--stack-version", "9.2.1").build()
+
+        then:
+        assertGenerateAndValidateSuccess(result)
+        assertUnreferableDefinition("initial_9.2.1", "8124001")
+        assertUpperBound("9.2", "initial_9.2.1,8124001")
+        // no new transport version has been added since the branch was cut, so the current upper bound still points at
+        // initial_9.2.0 in the same base, and must move forward with the patch id to remain the latest for that base
+        assertUpperBound("9.3", "initial_9.2.1,8124001")
     }
 
     def "cannot create upper bound file for patch"() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
@@ -56,11 +56,19 @@ public abstract class GenerateInitialTransportVersionTask extends DefaultTask {
             var newUpperBound = new TransportVersionUpperBound(upperBoundName, initialDefinitionName, id);
             resources.writeUpperBound(newUpperBound);
 
+            String currentUpperBoundName = getUpperBoundName(getCurrentVersion().get());
             if (stackVersion.getRevision() == 0) {
-                Version currentVersion = getCurrentVersion().get();
-                String currentUpperBoundName = getUpperBoundName(currentVersion);
-                var currentUpperBound = new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id);
-                resources.writeUpperBound(currentUpperBound);
+                // a minor creates a new base, which the current branch must also point at
+                resources.writeUpperBound(new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id));
+            } else {
+                // A patch adds an id to an existing base. If the current branch's upper bound still points into that
+                // same base, it is no longer the latest id for the base, so it has to move forward with the patch id.
+                // This is the case when no new transport version has been added to the current branch since the minor
+                // being patched was branched, ie the current upper bound is still that minor's initial version.
+                TransportVersionUpperBound currentUpperBound = resources.getUpperBoundFromGitBase(currentUpperBoundName);
+                if (currentUpperBound != null && currentUpperBound.definitionId().base() == id.base()) {
+                    resources.writeUpperBound(new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id));
+                }
             }
         }
     }


### PR DESCRIPTION
When generating an initial transport version for a patch release we update the upper bound of the
branch being patched, but leave the upper bound of the current branch alone. That is stale whenever
the current upper bound still points into the same base as the new patch id, and
`validateTransportVersionResources` rejects it:

```
Transport version upper bound file [server/src/main/resources/transport/upper_bounds/9.7.csv] has id
9492000 from [initial_9.6.0] with base 9492000 but another id 9492001 from [initial_9.6.1] is later
for that base
```

### How we get there

1. Feature freeze of 9.6.0 generates `initial_9.6.0` in a new base and, because the revision is 0,
   writes **two** upper bounds: `9.6.csv` and — since main is now 9.7.0 — `9.7.csv`, both naming
   `initial_9.6.0`.
2. Release finalization generates the initial version for the first patch release on every branch it
   bumps, including main: `generateInitialTransportVersion --stack-version=9.6.1`. That adds
   `9492001` to the same base and updates `9.6.csv`, but the current upper bound write is guarded by
   `if (stackVersion.getRevision() == 0)`, so `9.7.csv` is left naming `initial_9.6.0`.
3. `9.7.csv` is no longer the latest id for base 9492000, so validation fails on main.

This normally goes unnoticed because a new transport version is usually added to main between
feature freeze and GA. That allocates a new base and moves main's upper bound off the minor's initial
version, at which point the patch id no longer shares its base. A shorter feature freeze period
makes it more likely. It also isn't self-correcting: until something moves main's upper bound to a
new base, every subsequent patch finalization on main fails the same way.

### The fix

Advance the current branch's upper bound along with the patch id when it points into the same base,
and leave it untouched otherwise. The base is unchanged by this write, so it doesn't trip the
"modifies base id" check.
