### PR TITLE
ES|QL HIGHLIGHT: Fix multivalued field analysis

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HighlightOperator.java
@@ -10,8 +10,12 @@ package org.elasticsearch.compute.operator;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.FilteringTokenFilter;
+import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.miscellaneous.LimitTokenOffsetFilter;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.memory.MemoryIndex;
@@ -37,13 +41,11 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.lucene.search.uhighlight.BoundedBreakIteratorScanner;
 import org.elasticsearch.lucene.search.uhighlight.CustomPassageFormatter;
 import org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighter;
 import org.elasticsearch.lucene.search.uhighlight.QueryMaxAnalyzedOffset;
 import org.elasticsearch.lucene.search.uhighlight.Snippet;
-import org.elasticsearch.search.fetch.subphase.highlight.LimitTokenOffsetAnalyzer;
 
 import java.io.IOException;
 import java.text.BreakIterator;
@@ -89,7 +91,6 @@ public class HighlightOperator extends AbstractPageMappingOperator {
     private final Query query;
     private final List<String> fieldNames;
     private final Analyzer analyzer;
-    private final Analyzer memoryIndexAnalyzer;
     private final PassageFormatter formatter;
     private final int indexMaxAnalyzedOffset;
     private final QueryMaxAnalyzedOffset queryMaxAnalyzedOffset;
@@ -117,8 +118,6 @@ public class HighlightOperator extends AbstractPageMappingOperator {
         int configuredOffset = config.maxAnalyzedOffset();
         int queryOffset = configuredOffset < 0 ? indexMaxAnalyzedOffset : Math.min(configuredOffset, indexMaxAnalyzedOffset);
         this.queryMaxAnalyzedOffset = QueryMaxAnalyzedOffset.create(queryOffset, indexMaxAnalyzedOffset);
-        Analyzer indexingAnalyzer = analyzer instanceof NamedAnalyzer named ? named.analyzer() : analyzer;
-        this.memoryIndexAnalyzer = new LimitTokenOffsetAnalyzer(indexingAnalyzer, queryMaxAnalyzedOffset.getNotNull());
         // number_of_fragments=0 means whole value; CustomUnifiedHighlighter uses MAX_VALUE-1 for that.
         this.highlighterNumberOfFragments = config.numberOfFragments() > 0 ? config.numberOfFragments() : Integer.MAX_VALUE - 1;
         this.breakIteratorSupplier = breakIterator(
@@ -312,12 +311,13 @@ public class HighlightOperator extends AbstractPageMappingOperator {
             if (field.rowText == null) {
                 continue;
             }
-            if (termsToKeep == null) {
-                memoryIndex.addField(field.name, field.rowText, memoryIndexAnalyzer);
-            } else {
-                TokenStream tokenStream = memoryIndexAnalyzer.tokenStream(field.name, field.rowText);
-                KeepQueryTermsFilter filtered = new KeepQueryTermsFilter(tokenStream, termsToKeep);
-                memoryIndex.addField(field.name, filtered); // addField resets and closes the stream
+            TokenStream tokenStream = new LimitTokenOffsetFilter(rowTokenStream(field), queryMaxAnalyzedOffset.getNotNull(), false);
+            KeepQueryTermsFilter filtered = null;
+            if (termsToKeep != null) {
+                tokenStream = filtered = new KeepQueryTermsFilter(tokenStream, termsToKeep);
+            }
+            memoryIndex.addField(field.name, tokenStream); // addField resets and closes the stream
+            if (filtered != null) {
                 keptToken |= filtered.keptToken;
             }
         }
@@ -352,6 +352,88 @@ public class HighlightOperator extends AbstractPageMappingOperator {
             boolean keep = terms.contains(termAtt.buffer(), 0, termAtt.length());
             keptToken |= keep;
             return keep;
+        }
+    }
+
+    /**
+     * Analyzes the row text of {@code field}. Multi-valued rows are analyzed one value at a time, as they would be
+     * when indexed: the analyzer never sees the separator, the position increment gap keeps phrases from matching
+     * across values, and offsets are rebased onto the joined row text the highlighter cuts passages from.
+     */
+    private TokenStream rowTokenStream(HighlightField field) {
+        int firstValueEnd = field.rowText.indexOf(CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR);
+        if (firstValueEnd < 0) {
+            return analyzer.tokenStream(field.name, field.rowText);
+        }
+        TokenStream firstValue = analyzer.tokenStream(field.name, field.rowText.substring(0, firstValueEnd));
+        return new MultiValueTokenStream(firstValue, analyzer, field.name, field.rowText, firstValueEnd);
+    }
+
+    /**
+     * Port of Lucene's {@code AnalysisOffsetStrategy.MultiValueTokenStream} (private there), which backs the unified
+     * highlighter's ANALYSIS offset source for multi-valued fields. Cannot use {@link MemoryIndex}'s own multi-value
+     * support (one {@code addField} call per value) instead: it only advances its offset base once a value has stored
+     * a token, so a leading value whose tokens are all dropped by {@link KeepQueryTermsFilter} would leave later
+     * values' offsets pointing at the wrong part of the row text.
+     */
+    private static final class MultiValueTokenStream extends TokenFilter {
+        private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+        private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+        private final Analyzer analyzer;
+        private final String fieldName;
+        private final String content;
+        private int valueStart;
+        private int valueEnd;
+        private int pendingPositionIncrement;
+
+        /** {@code firstValue} must be an unconsumed stream over the first value, i.e. {@code content[0, firstValueEnd)}. */
+        MultiValueTokenStream(TokenStream firstValue, Analyzer analyzer, String fieldName, String content, int firstValueEnd) {
+            super(firstValue);
+            this.analyzer = analyzer;
+            this.fieldName = fieldName;
+            this.content = content;
+            this.valueEnd = firstValueEnd;
+        }
+
+        @Override
+        public boolean incrementToken() throws IOException {
+            while (input.incrementToken() == false) {
+                if (valueEnd == content.length()) {
+                    return false;
+                }
+                input.end();
+                pendingPositionIncrement += posIncrAtt.getPositionIncrement() + analyzer.getPositionIncrementGap(fieldName);
+                input.close();
+
+                valueStart = valueEnd + 1;
+                int nextSeparator = content.indexOf(CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR, valueStart);
+                valueEnd = nextSeparator < 0 ? content.length() : nextSeparator;
+                TokenStream next = analyzer.tokenStream(fieldName, content.substring(valueStart, valueEnd));
+                if (next != input) {
+                    // Token attributes live on the reused stream this filter wrapped at construction; a fresh stream
+                    // instance would publish its tokens to attributes this filter cannot see.
+                    throw new IllegalStateException("HIGHLIGHT requires an analyzer with reusable token streams");
+                }
+                next.reset();
+            }
+            posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + pendingPositionIncrement);
+            pendingPositionIncrement = 0;
+            offsetAtt.setOffset(valueStart + offsetAtt.startOffset(), valueStart + offsetAtt.endOffset());
+            return true;
+        }
+
+        @Override
+        public void reset() throws IOException {
+            if (valueStart != 0) {
+                throw new IllegalStateException("multi-value token stream cannot be reused");
+            }
+            super.reset();
+        }
+
+        @Override
+        public void end() throws IOException {
+            super.end();
+            offsetAtt.setOffset(valueStart + offsetAtt.startOffset(), valueStart + offsetAtt.endOffset());
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HighlightOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HighlightOperatorTests.java
@@ -11,6 +11,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.shingle.ShingleFilter;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.synonym.SynonymGraphFilter;
@@ -34,6 +36,8 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.expression.LoadFromPageEvaluator;
 import org.elasticsearch.compute.test.OperatorTestCase;
 import org.elasticsearch.compute.test.operator.blocksource.BytesRefBlockSourceOperator;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.lucene.search.uhighlight.Snippet;
 import org.hamcrest.Matcher;
 
@@ -138,6 +142,99 @@ public class HighlightOperatorTests extends OperatorTestCase {
             BytesRef scratch = new BytesRef();
             assertThat(result.getBytesRef(first, scratch).utf8ToString(), equalTo("Senior Team <em>Lead</em>"));
             assertThat(result.getBytesRef(first + 1, scratch).utf8ToString(), equalTo("<em>Lead</em> Architect"));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testMultiValuedKeywordAnalyzerAnalyzesValuesSeparately() {
+        BytesRefBlock result = highlight(
+            config("foo", 5, 0, 0),
+            contentTerm("foo"),
+            new KeywordAnalyzer(),
+            bytesRefs(List.of(List.of("foo", "bar")))
+        );
+        try {
+            assertThat(value(result, 0), equalTo("<em>foo</em>"));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testMultiValuedAnalyzerDoesNotCreateCrossValueTokens() {
+        BytesRefBlock result = highlight(
+            config("foo bar", 5, 0, 0),
+            contentTerm("foo bar"),
+            shingleAnalyzer(),
+            bytesRefs(List.of(List.of("foo", "bar")))
+        );
+        try {
+            assertThat(result.isNull(0), equalTo(true));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testMaxAnalyzedOffsetAppliesAcrossValues() {
+        BytesRefBlock result = highlight(
+            configWithMaxAnalyzedOffset("foo", 4),
+            contentTerm("foo"),
+            new KeywordAnalyzer(),
+            bytesRefs(List.of(List.of("long", "foo")))
+        );
+        try {
+            assertThat(result.isNull(0), equalTo(true));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testMultiValuedEmptyValuesKeepOffsets() {
+        BytesRefBlock result = highlight(
+            config("foo", 5, 0, 0),
+            contentTerm("foo"),
+            new KeywordAnalyzer(),
+            bytesRefs(List.of(List.of("", "foo", "")))
+        );
+        try {
+            assertThat(value(result, 0), equalTo("<em>foo</em>"));
+        } finally {
+            result.close();
+        }
+    }
+
+    // Without the analyzer's position gap, the phrase matches across the value boundary.
+    public void testMultiValuePositionGapPreventsCrossValuePhraseMatch() {
+        Query phrase = new PhraseQuery(CONTENT_FIELD, "lead", "lead");
+        List<List<String>> rows = List.of(List.of("Senior Team Lead", "Lead Architect"));
+
+        BytesRefBlock withoutGap = highlight(config("\"lead lead\"", 5, 0, 0), phrase, standardAnalyzerWithGap(0), bytesRefs(rows));
+        try {
+            assertThat(withoutGap.isNull(0), equalTo(false));
+        } finally {
+            withoutGap.close();
+        }
+
+        BytesRefBlock withGap = highlight(config("\"lead lead\"", 5, 0, 0), phrase, standardAnalyzerWithGap(100), bytesRefs(rows));
+        try {
+            assertThat(withGap.isNull(0), equalTo(true));
+        } finally {
+            withGap.close();
+        }
+    }
+
+    // The gap must not affect a phrase contained in one value.
+    public void testMultiValuePositionGapKeepsWithinValuePhraseMatch() {
+        Query phrase = new PhraseQuery(CONTENT_FIELD, "team", "lead");
+        BytesRefBlock result = highlight(
+            config("\"team lead\"", 5, 0, 0),
+            phrase,
+            standardAnalyzerWithGap(100),
+            bytesRefs(List.of(List.of("Senior Team Lead", "Lead Architect")))
+        );
+        try {
+            assertThat(result.getValueCount(0), equalTo(1));
+            assertThat(value(result, 0), equalTo("Senior <em>Team Lead</em>"));
         } finally {
             result.close();
         }
@@ -449,6 +546,22 @@ public class HighlightOperatorTests extends OperatorTestCase {
         return new TermQuery(new Term(field, term));
     }
 
+    private static Analyzer standardAnalyzerWithGap(int gap) {
+        return new NamedAnalyzer("standard", AnalyzerScope.GLOBAL, new StandardAnalyzer(), gap);
+    }
+
+    private static Analyzer shingleAnalyzer() {
+        return new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                Tokenizer tokenizer = new StandardTokenizer();
+                ShingleFilter shingles = new ShingleFilter(new LowerCaseFilter(tokenizer), 2, 2);
+                shingles.setOutputUnigrams(false);
+                return new TokenStreamComponents(tokenizer, shingles);
+            }
+        };
+    }
+
     private static Analyzer synonymAnalyzer(SynonymMap synonyms) {
         return new Analyzer() {
             @Override
@@ -580,6 +693,23 @@ public class HighlightOperatorTests extends OperatorTestCase {
             orderByScore,
             null,
             -1
+        );
+    }
+
+    private static HighlightConfig configWithMaxAnalyzedOffset(String queryText, int maxAnalyzedOffset) {
+        return new HighlightConfig(
+            queryText,
+            DEFAULT_PRE_TAG,
+            DEFAULT_POST_TAG,
+            DEFAULT_ENCODER,
+            5,
+            0,
+            0,
+            false,
+            Locale.ROOT,
+            false,
+            null,
+            maxAnalyzedOffset
         );
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -645,6 +645,34 @@ The <em>quick brown fox</em> jumps over the lazy dog.
 ;
 
 
+# A phrase must not match across a multi-value boundary.
+highlightPhraseDoesNotCrossMultiValueBoundary
+required_capability: highlight_v6
+
+ROW positions = ["Senior Team Lead", "Lead Architect"]
+| HIGHLIGHT "\"lead lead\"" ON positions
+| KEEP highlight_positions
+;
+
+highlight_positions:keyword
+null
+;
+
+
+# A phrase contained in one value still matches.
+highlightPhraseMatchesWithinSingleMultiValue
+required_capability: highlight_v6
+
+ROW positions = ["Senior Team Lead", "Principal Architect"]
+| HIGHLIGHT "\"team lead\"" ON positions
+| KEEP highlight_positions
+;
+
+highlight_positions:keyword
+Senior <em>Team Lead</em>
+;
+
+
 # order=score with a number_of_fragments cap keeps the highest-scoring fragment: the last value wins despite its order.
 highlightOrderByScoreWithFragmentCap
 required_capability: highlight_v6

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -19,7 +19,10 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.CoordinatorRewriteContext;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -100,7 +103,9 @@ public class PlannerUtils {
      * {@code HIGHLIGHT} ({@link org.elasticsearch.xpack.esql.plan.logical.Highlight}, {@link HighlightQueryBuilders}) and
      * {@code TOP_SNIPPETS} ({@link org.elasticsearch.xpack.esql.evaluator.EvalMapper}).
      *
-     * @return the resolved {@link Analyzer}, or {@code null} when {@code analyzerName} is {@code null} (no override requested)
+     * @return the resolved analyzer as a {@link NamedAnalyzer} carrying the position increment gap the analyzer would
+     *         have on a mapped text field, or {@code null} when {@code analyzerName} is {@code null} (no override
+     *         requested)
      * @throws InvalidArgumentException if the registry is unavailable, the analyzer fails to load, or no analyzer is
      *                                  registered under {@code analyzerName}
      */
@@ -122,6 +127,12 @@ public class PlannerUtils {
         }
         if (analyzer == null) {
             throw new InvalidArgumentException("[{}] is not a registered analyzer", analyzerName);
+        }
+        if (analyzer instanceof NamedAnalyzer == false) {
+            // Node-level plugin analyzers (AnalysisPlugin#getAnalyzers) resolve to bare Lucene analyzers: the registry
+            // bakes the text-field position increment gap only into prebuilt analyzers. Wrap them the way index
+            // mappings do, so multi-value analysis keeps the gap the same analyzer would have on a mapped field.
+            analyzer = new NamedAnalyzer(analyzerName, AnalyzerScope.GLOBAL, analyzer, TextFieldMapper.Defaults.POSITION_INCREMENT_GAP);
         }
         return analyzer;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuildersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuildersTests.java
@@ -24,11 +24,19 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.indices.analysis.AnalysisModule;
+import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
@@ -39,7 +47,10 @@ import org.elasticsearch.xpack.esql.expression.function.fulltext.QueryString;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,12 +64,31 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 /** Tests query building against {@link RuntimeSearchExecutionContext}. */
 public class HighlightQueryBuildersTests extends ESTestCase {
 
     private static final List<String> TITLE = List.of("title");
     private static final List<String> TITLE_BODY = List.of("title", "body");
+
+    private static AnalysisRegistry analysisRegistry;
+
+    @BeforeClass
+    public static void setupAnalysisRegistry() throws IOException {
+        analysisRegistry = new AnalysisModule(
+            TestEnvironment.newEnvironment(
+                Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build()
+            ),
+            List.of(new CommonAnalysisPlugin()),
+            new StablePluginsRegistry()
+        ).getAnalysisRegistry();
+    }
+
+    @AfterClass
+    public static void tearDownAnalysisRegistry() {
+        analysisRegistry = null;
+    }
 
     private static final NamedAnalyzer STOP_ANALYZER = new NamedAnalyzer(
         "_stop",
@@ -132,6 +162,33 @@ public class HighlightQueryBuildersTests extends ESTestCase {
             () -> HighlightQueryBuilders.verify(of("fox"), TITLE, analyzer)
         );
         assertThat(e.getMessage(), containsString("test analyzer was used"));
+    }
+
+    // The registry hands plugin analyzers (AnalysisPlugin#getAnalyzers) back as bare Lucene analyzers with no position
+    // increment gap; resolution must restore the gap a mapped text field would have, or HIGHLIGHT phrases match across
+    // multi-value boundaries.
+    public void testResolvedPluginAnalyzerCarriesTextFieldPositionIncrementGap() throws IOException {
+        // Precondition: the registry returns this plugin analyzer bare, which is the case this test guards.
+        assertThat(analysisRegistry.getAnalyzer("fingerprint"), not(instanceOf(NamedAnalyzer.class)));
+        NamedAnalyzer named = asInstanceOf(NamedAnalyzer.class, PlannerUtils.resolveAnalyzer("fingerprint", analysisRegistry));
+        assertThat(named.name(), equalTo("fingerprint"));
+        assertThat(named.getPositionIncrementGap("title"), equalTo(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
+    }
+
+    public void testResolvedPrebuiltAnalyzerCarriesTextFieldPositionIncrementGap() {
+        Analyzer analyzer = PlannerUtils.resolveAnalyzer(HighlightQueryBuilders.DEFAULT_ANALYZER_NAME, analysisRegistry);
+        NamedAnalyzer named = asInstanceOf(NamedAnalyzer.class, analyzer);
+        assertThat(named.getPositionIncrementGap("title"), equalTo(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
+    }
+
+    public void testTranslateWithPluginAnalyzerKeepsPositionIncrementGap() {
+        HighlightQueryBuilders.TranslatedQuery translated = HighlightQueryBuilders.translate(
+            of("fox"),
+            TITLE,
+            "fingerprint",
+            analysisRegistry
+        );
+        assertThat(translated.analyzer().getPositionIncrementGap("title"), equalTo(TextFieldMapper.Defaults.POSITION_INCREMENT_GAP));
     }
 
     public void testLiteralLeadingWildcardAllowed() {


### PR DESCRIPTION

## Summary
HIGHLIGHT previously joined multivalued fields before analysis. This lost the analyzer’s position_increment_gap and allowed phrases or analyzer-generated tokens to cross value boundaries.

This PR analyzes each value separately, then combines the token streams into the joined text’s offset space. This matches the DSL highlighter while preserving snippet generation and max_analyzed_offset.

## Tests
Added coverage for:

- Cross-value and within-value phrases
- Keyword and shingle analyzers
- Empty values
- max_analyzed_offset