### PR TITLE
Reserve a new base for the current branch when generating an initial patch version

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionFuncTest.groovy
@@ -83,14 +83,9 @@ class GenerateInitialTransportVersionFuncTest extends AbstractTransportVersionFu
         assertUpperBound("9.2", "existing_92,8123000")
     }
 
-    def "patch also updates current upper bound in the same base"() {
-        given: "a minor was branched, moving the current upper bound to that minor's initial version"
-        execute("git checkout main")
-        // version properties will be updated by release automation before running initial version generation
-        versionPropertiesFile.text = versionPropertiesFile.text.replace("9.2.0", "9.3.0")
-        assertGenerateSuccess(runGenerateTask("--stack-version", "9.2.0").build())
-        execute("git add .")
-        execute('git commit -m Feature-freeze-9.2')
+    def "patch reserves a new base for the current branch in the same base"() {
+        given:
+        featureFreezeNewMinor()
 
         when: "the minor is finalized, generating the initial transport version for its first patch release"
         def result = runGenerateAndValidateTask("--stack-version", "9.2.1").build()
@@ -99,9 +94,67 @@ class GenerateInitialTransportVersionFuncTest extends AbstractTransportVersionFu
         assertGenerateAndValidateSuccess(result)
         assertUnreferableDefinition("initial_9.2.1", "8124001")
         assertUpperBound("9.2", "initial_9.2.1,8124001")
-        // no new transport version has been added since the branch was cut, so the current upper bound still points at
-        // initial_9.2.0 in the same base, and must move forward with the patch id to remain the latest for that base
-        assertUpperBound("9.3", "initial_9.2.1,8124001")
+        // no transport version has been added to the current branch since the minor was branched, so its upper bound
+        // still points at initial_9.2.0 in the same base. The patch id cannot be adopted here, so a new base is
+        // reserved for the current branch instead.
+        assertUnreferableDefinition("placeholder_9.3.0", "8125000")
+        assertUpperBound("9.3", "placeholder_9.3.0,8125000")
+    }
+
+    def "patch of the current minor does not reserve a base"() {
+        when: "the release branch generates the initial version for its own next patch release"
+        def result = runGenerateAndValidateTask("--stack-version", "9.2.1").build()
+
+        then: "its upper bound is the patch id itself, and no base is reserved"
+        assertGenerateAndValidateSuccess(result)
+        assertUnreferableDefinition("initial_9.2.1", "8123001")
+        assertUpperBound("9.2", "initial_9.2.1,8123001")
+        file("myserver/src/main/resources/transport/definitions/unreferable/placeholder_9.2.0.csv").exists() == false
+    }
+
+    def "transport version generated after a reserved base gets a base id"() {
+        given:
+        featureFreezeNewMinor()
+        assertGenerateSuccess(runGenerateTask("--stack-version", "9.2.1").build())
+        execute("git add .")
+        execute('git commit -m Finalize-9.2.0')
+
+        when: "a transport version is added to the current branch"
+        referencedTransportVersion("new_tv")
+        def result = gradleRunner(
+            ":myserver:validateTransportVersionResources",
+            ":myserver:generateTransportVersion",
+            "--name",
+            "new_tv"
+        ).build()
+
+        then: "it increments from the reserved base, rather than from a patch id"
+        result.task(":myserver:generateTransportVersion").outcome == TaskOutcome.SUCCESS
+        assertValidateSuccess(result)
+        assertReferableDefinition("new_tv", "8126000")
+        assertUpperBound("9.3", "new_tv,8126000")
+    }
+
+    /**
+     * Cuts a release branch for 9.2 the way release automation does, leaving the current branch at 9.3.0 with its upper
+     * bound pointing at the initial version of the minor that was just branched.
+     */
+    private void featureFreezeNewMinor() {
+        execute("git checkout main")
+        // version properties will be updated by release automation before running initial version generation
+        versionPropertiesFile.text = versionPropertiesFile.text.replace("9.2.0", "9.3.0")
+        // the branch has moved on to 9.3.0, so that is the upper bound the transport version tasks work against
+        file("myserver/build.gradle") << """
+            tasks.named('generateTransportVersion') {
+                currentUpperBoundName = '9.3'
+            }
+            tasks.named('validateTransportVersionResources') {
+                currentUpperBoundName = '9.3'
+            }
+        """
+        assertGenerateSuccess(runGenerateTask("--stack-version", "9.2.0").build())
+        execute("git add .")
+        execute('git commit -m Feature-freeze-9.2')
     }
 
     def "cannot create upper bound file for patch"() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
@@ -56,18 +56,24 @@ public abstract class GenerateInitialTransportVersionTask extends DefaultTask {
             var newUpperBound = new TransportVersionUpperBound(upperBoundName, initialDefinitionName, id);
             resources.writeUpperBound(newUpperBound);
 
-            String currentUpperBoundName = getUpperBoundName(getCurrentVersion().get());
+            Version currentVersion = getCurrentVersion().get();
+            String currentUpperBoundName = getUpperBoundName(currentVersion);
             if (stackVersion.getRevision() == 0) {
                 // a minor creates a new base, which the current branch must also point at
                 resources.writeUpperBound(new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id));
-            } else {
+            } else if (currentUpperBoundName.equals(upperBoundName) == false) {
                 // A patch adds an id to an existing base. If the current branch's upper bound still points into that
-                // same base, it is no longer the latest id for the base, so it has to move forward with the patch id.
-                // This is the case when no new transport version has been added to the current branch since the minor
-                // being patched was branched, ie the current upper bound is still that minor's initial version.
+                // same base, that patch id is now the latest id for the base, which the current branch cannot adopt:
+                // ids in the current upper bound must be base ids so that generating a transport version here keeps
+                // creating a new base. Reserve the next base for the current branch instead, held by a placeholder
+                // definition. This is the case when no transport version has been added to the current branch since
+                // the minor being patched was branched, ie the current upper bound is that minor's initial version.
                 TransportVersionUpperBound currentUpperBound = resources.getUpperBoundFromGitBase(currentUpperBoundName);
                 if (currentUpperBound != null && currentUpperBound.definitionId().base() == id.base()) {
-                    resources.writeUpperBound(new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id));
+                    var reservedId = TransportVersionId.fromInt(id.base() + 1000);
+                    String reservedName = "placeholder_" + currentVersion;
+                    resources.writeDefinition(new TransportVersionDefinition(reservedName, List.of(reservedId), false));
+                    resources.writeUpperBound(new TransportVersionUpperBound(currentUpperBoundName, reservedName, reservedId));
                 }
             }
         }


### PR DESCRIPTION
Follow up to #156094, addressing @rjernst's review comment there.

That PR pointed the current branch's upper bound at the new patch id, which leaves the upper bound on
a non-base id. The rest of the tooling does not expect that. `createTargetId` derives a new primary
id by incrementing the current upper bound's *complete* id, so the next transport version generated
on the branch inherits the patch part, and validation rejects it:

```
Transport version definition file [.../definitions/referable/new_tv.csv] has patch version 8125001 as
primary id
```

That would block the first transport version added to the branch after any release finalization,
which is worse than the problem #156094 set out to fix.

### The fix

Reserve the next base for the current branch instead of adopting the patch id, held by a placeholder
unreferable definition, so that ids in the current upper bound stay base ids. Finalizing 9.6.0 with
main at 9.7.0, where `9.7.csv` still points at `initial_9.6.0,9492000`, now produces:

| file | before | after |
| --- | --- | --- |
| `definitions/unreferable/initial_9.6.1.csv` | — | `9492001` |
| `upper_bounds/9.6.csv` | `initial_9.6.0,9492000` | `initial_9.6.1,9492001` |
| `definitions/unreferable/placeholder_9.7.0.csv` | — | `9493000` |
| `upper_bounds/9.7.csv` | `initial_9.6.0,9492000` | `placeholder_9.7.0,9493000` |

The next transport version on main then lands on `9494000` rather than `9493001`.

Release branches are unaffected: there the upper bound being written is already the current one, so
the new `currentUpperBoundName.equals(upperBoundName)` guard skips this path, and a patch id remains
correct for a release branch's own upper bound.
