### PR TITLE
Parallelize ES|QL QA REST tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -65,12 +65,12 @@ buildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseN
   def javaRestTest = tasks.register("v${bwcVersion}#javaRestTest", StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
-    maxParallelForks = 1
   }
 
   def csvSpecTest = tasks.register("v${bwcVersion}#csvSpecTests", StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    // AbstractMixedClusterEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
     maxParallelForks = 1
     testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
     classpath = sourceSets.csvSpecTest.runtimeClasspath

--- a/x-pack/plugin/esql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-node/build.gradle
@@ -108,7 +108,6 @@ tasks.named('processJavaRestTestResources').configure {
 tasks.named('javaRestTest') {
   dependsOn generateParquetFixtures
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
 
   systemProperty 'tests.rest.client_timeout', '60'
   systemProperty 'tests.rest.socket_timeout', '60'
@@ -116,6 +115,7 @@ tasks.named('javaRestTest') {
 
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // AbstractEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
   maxParallelForks = 1
 
   systemProperty 'tests.rest.client_timeout', '60'

--- a/x-pack/plugin/esql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/single-node/build.gradle
@@ -53,12 +53,12 @@ restResources {
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
 }
 
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // AbstractEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
   maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
@@ -73,6 +73,7 @@ tasks.named('check').configure { dependsOn csvSpecTests }
 // system properties. No test classes are modified.
 tasks.register('javaRestTestSecure', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // Runs the csvSpecTest source set, whose cluster is shared(true)
   maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
@@ -88,7 +89,6 @@ tasks.register('javaRestTestSecure', StandaloneRestIntegTestTask) {
 
 tasks.named('yamlRestTest') {
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
 }
 
 // Runs only the CSV spec suite — used by the dedicated releaseTestCheckEsqlQa1 CI job.


### PR DESCRIPTION
`RestTestBasePlugin` already defaults `maxParallelForks` to `maxWorkers / 2` for every `StandaloneRestIntegTestTask`, on the premise that each test class gets its own cluster:

https://github.com/elastic/elasticsearch/blob/main/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java#L180-L181

Setting `maxParallelForks = 1` in a build script is therefore an explicit opt-out, and it is only *required* when a test declares its cluster with `shared(true)` — `LocalClusterSpecBuilder#shared` throws `IllegalStateException` when `tests.max.parallel.forks > 1`, and the message tells you to add exactly this line.

Four tasks in the ES|QL QA server projects carry the opt-out without needing it. Their source sets build a per-class cluster, so nothing stops them running in parallel:

| Task | IT classes | Cluster |
|---|---|---|
| `single-node:javaRestTest` | 31 | `Clusters.testCluster(...)`, `shared` = false |
| `single-node:yamlRestTest` | 4 | `ElasticsearchCluster.local()`, not shared |
| `multi-node:javaRestTest` | 15 | `Clusters.testCluster(...)`, `shared` = false |
| `mixed-cluster:v<ver>#javaRestTest` | 3 | `Clusters.mixedVersionCluster()`, `shared` = false |

The `csvSpecTest` source set genuinely does use `shared(true)` (`AbstractEsqlSpecIT` / `AbstractMixedClusterEsqlSpecIT`), so `csvSpecTests`, `javaRestTestSecure` and `v<ver>#csvSpecTests` keep the override. This PR adds a comment to each of those so the distinction is visible right next to the setting, rather than having to go read the `Clusters` helper to work out why some tasks pin it and others don't.