### PR TITLE
Fix inverted comparator in IndirectSorter, add ASH reconstruction tests

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AsymmetricHashingScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AsymmetricHashingScorerTests.java
@@ -195,12 +195,7 @@ public class AsymmetricHashingScorerTests extends ESTestCase {
 
             float reconstructed = AsymmetricHashingScorer.scoreOneVector(queryTransformed, queryDotCentroid, encodedVector, 1.0f, offset);
 
-            assertEquals(
-                "Mismatch at iter " + iter + " dim=" + dim,
-                trueDot,
-                reconstructed,
-                Math.max(1e-3f, Math.abs(trueDot) * 1e-4f)
-            );
+            assertEquals("Mismatch at iter " + iter + " dim=" + dim, trueDot, reconstructed, Math.max(1e-3f, Math.abs(trueDot) * 1e-4f));
         }
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AsymmetricHashingScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AsymmetricHashingScorerTests.java
@@ -152,4 +152,55 @@ public class AsymmetricHashingScorerTests extends ESTestCase {
         // dot = 0, result = 0 * 2.0 + 1.5 + 0.3 = 1.8
         assertEquals(1.8f, score, 1e-6f);
     }
+
+    public void testReconstructedDotProductApproximatesTrueDotProduct() {
+        // With an identity projection (nDims == originalDim, W = I) and an *unquantized* encoded
+        // vector (scale = 1, encodedVector = the exact residual), the scorer's formula is an exact
+        // algebraic identity:
+        //
+        // dot(query, vector) = dot(query - centroid, vector - centroid) + dot(query, centroid) + offset
+        //
+        // where offset = dot(vector, centroid) - dot(centroid, centroid). This verifies the scorer
+        // reconstructs the true dot product between the original (un-centered, un-projected)
+        // vectors, up to floating-point rounding.
+        //
+        // Note: we deliberately don't layer real (lossy) quantization on top here. Once the
+        // residual is quantized down to a handful of bits per dimension, the worst-case
+        // reconstruction error grows linearly with the dimension and can dwarf the true dot
+        // product whenever it happens to be small -- the same reason the full-pipeline test in
+        // AsymmetricHashingQuantizerTests only checks rank correlation, not closeness, once real
+        // quantization is involved.
+        for (int iter = 0; iter < 50; iter++) {
+            int dim = randomIntBetween(1, 64);
+
+            float[] query = new float[dim];
+            float[] vector = new float[dim];
+            float[] centroid = new float[dim];
+            for (int d = 0; d < dim; d++) {
+                query[d] = (float) random().nextGaussian();
+                vector[d] = (float) random().nextGaussian();
+                centroid[d] = (float) random().nextGaussian();
+            }
+
+            float trueDot = ESVectorUtil.dotProduct(query, vector, dim);
+
+            float[] queryTransformed = new float[dim];
+            float[] encodedVector = new float[dim];
+            for (int d = 0; d < dim; d++) {
+                queryTransformed[d] = query[d] - centroid[d];
+                encodedVector[d] = vector[d] - centroid[d];
+            }
+            float queryDotCentroid = ESVectorUtil.dotProduct(query, centroid, dim);
+            float offset = ESVectorUtil.dotProduct(vector, centroid, dim) - ESVectorUtil.dotProduct(centroid, centroid, dim);
+
+            float reconstructed = AsymmetricHashingScorer.scoreOneVector(queryTransformed, queryDotCentroid, encodedVector, 1.0f, offset);
+
+            assertEquals(
+                "Mismatch at iter " + iter + " dim=" + dim,
+                trueDot,
+                reconstructed,
+                Math.max(1e-3f, Math.abs(trueDot) * 1e-4f)
+            );
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/IndirectSorter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/IndirectSorter.java
@@ -64,7 +64,7 @@ final class IndirectSorter {
 
             @Override
             protected int comparePivot(int j) {
-                return Double.compare(keys[indices[j]], keys[pivotIdx]);
+                return Double.compare(keys[pivotIdx], keys[indices[j]]);
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AshSphericalScalarQuantizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AshSphericalScalarQuantizerTests.java
@@ -164,6 +164,87 @@ public class AshSphericalScalarQuantizerTests extends ESTestCase {
         assertTrue("Expected positive correlation, got " + correlation, correlation > 0.3);
     }
 
+    public void testGeneralPathMatchesBruteForceOptimum() {
+        // Regression test for a bug where the general (bitsPerDim >= 3) quantization path relied on
+        // a mis-sorted event order and could land on a strictly suboptimal level assignment -- e.g.
+        // it once returned all-base-level codes even though better assignments were reachable within
+        // the same level budget. Brute force is only tractable for small d and bitsPerDim, so we
+        // restrict this test to those.
+        for (int bitsPerDim = 3; bitsPerDim <= 4; bitsPerDim++) {
+            int numAbsLevels = 1 << (bitsPerDim - 1);
+            AshSphericalScalarQuantizer ssq = new AshSphericalScalarQuantizer(bitsPerDim);
+            int d = 4;
+            for (int iter = 0; iter < 20; iter++) {
+                float[] z = randomGaussianVector(d);
+                AshSphericalScalarQuantizer.SingleQuantizeResult result = ssq.encodeOne(z);
+                double greedyCos = dotProduct(z, result.centeredCode()) / result.codeNorm();
+
+                double bestCos = bruteForceBestCosSimilarity(z, numAbsLevels);
+
+                assertEquals("Mismatch at bitsPerDim=" + bitsPerDim + " iter=" + iter, bestCos, greedyCos, 1e-4);
+            }
+        }
+    }
+
+    public void testCosineSimilarityImprovesMonotonicallyWithMoreBits() {
+        // A quantizer's level set at bitsPerDim=b is a strict subset of the level set at any b' > b
+        // (magnitudes {0.5, ..., 0.5+2^(b-1)-1} vs {0.5, ..., 0.5+2^(b'-1)-1}), so the achievable
+        // cosine similarity between a vector and its quantized code can only improve (never worsen)
+        // as bitsPerDim increases. This was violated by the sort-direction bug above.
+        int d = 128;
+        for (int iter = 0; iter < 10; iter++) {
+            float[] z = randomGaussianVector(d);
+            double previousCos = -1;
+            for (int bitsPerDim = 1; bitsPerDim <= 8; bitsPerDim++) {
+                AshSphericalScalarQuantizer ssq = new AshSphericalScalarQuantizer(bitsPerDim);
+                AshSphericalScalarQuantizer.SingleQuantizeResult result = ssq.encodeOne(z);
+                double cos = dotProduct(z, result.centeredCode()) / result.codeNorm();
+                assertTrue(
+                    "cos similarity regressed going from fewer to more bits at bitsPerDim=" + bitsPerDim + ": " + cos + " < "
+                        + previousCos,
+                    cos >= previousCos - 1e-6
+                );
+                previousCos = cos;
+            }
+        }
+    }
+
+    private static double bruteForceBestCosSimilarity(float[] z, int numAbsLevels) {
+        int d = z.length;
+        float[] absZ = new float[d];
+        for (int j = 0; j < d; j++) {
+            absZ[j] = Math.abs(z[j]);
+        }
+        return bruteForceRecurse(absZ, new int[d], 0, numAbsLevels);
+    }
+
+    private static double bruteForceRecurse(float[] absZ, int[] levels, int idx, int numAbsLevels) {
+        if (idx == absZ.length) {
+            double dot = 0;
+            double normSq = 0;
+            for (int j = 0; j < absZ.length; j++) {
+                double mag = 0.5 + levels[j];
+                dot += absZ[j] * mag;
+                normSq += mag * mag;
+            }
+            return dot / Math.sqrt(normSq);
+        }
+        double best = -1;
+        for (int l = 0; l < numAbsLevels; l++) {
+            levels[idx] = l;
+            best = Math.max(best, bruteForceRecurse(absZ, levels, idx + 1, numAbsLevels));
+        }
+        return best;
+    }
+
+    private static double dotProduct(float[] a, float[] b) {
+        double dot = 0;
+        for (int j = 0; j < a.length; j++) {
+            dot += (double) a[j] * b[j];
+        }
+        return dot;
+    }
+
     private float[] randomGaussianVector(int d) {
         float[] v = new float[d];
         for (int j = 0; j < d; j++) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AshSphericalScalarQuantizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AshSphericalScalarQuantizerTests.java
@@ -200,8 +200,7 @@ public class AshSphericalScalarQuantizerTests extends ESTestCase {
                 AshSphericalScalarQuantizer.SingleQuantizeResult result = ssq.encodeOne(z);
                 double cos = dotProduct(z, result.centeredCode()) / result.codeNorm();
                 assertTrue(
-                    "cos similarity regressed going from fewer to more bits at bitsPerDim=" + bitsPerDim + ": " + cos + " < "
-                        + previousCos,
+                    "cos similarity regressed going from fewer to more bits at bitsPerDim=" + bitsPerDim + ": " + cos + " < " + previousCos,
                     cos >= previousCos - 1e-6
                 );
                 previousCos = cos;

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizerTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.elasticsearch.simdvec.AsymmetricHashingScorer;
+import org.elasticsearch.simdvec.ESVectorUtil;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Random;
@@ -197,6 +198,83 @@ public class AsymmetricHashingQuantizerTests extends ESTestCase {
         double correlation = computeRankCorrelation(vectors, query, scores);
         // With learned method, expect reasonable correlation
         assertTrue("Expected positive rank correlation, got " + correlation, correlation > 0.3);
+    }
+
+    public void testReconstructedDotProductApproximatesTrueDotProduct() {
+        // With no dimensionality reduction (projectedDimsFraction=1.0, so nDims == originalDim and W
+        // is a random orthogonal matrix -- a pure rotation, not a projection), the only source of
+        // reconstruction error is the quantization of the residual (vector - centroid). This
+        // isolates the quantizer's fidelity, matching the near-linear ⟨q, x⟩ ~ ⟨q, quant(x)⟩
+        // relationship reported for ASH (see https://arxiv.org/pdf/2606.07870, Figure 4 and the
+        // surrounding "estimator bias" discussion, which notes the fit is not exact -- there's a
+        // small, bitsPerDim-dependent bias -- but the pairs are tightly clustered around the line).
+        //
+        // Thresholds below were calibrated empirically (aggregate relative RMSE over many random
+        // query/vector/centroid trials, stable across seeds) with a safety margin of roughly 2x
+        // (4 bits) to 5x (8 bits) over the observed values, to catch a real regression without being
+        // flaky.
+        int dim = 128;
+        int nVectors = 200;
+        Random rng = new Random(2026);
+
+        for (var config : new Object[][] { { 4, 0.35 }, { 8, 0.05 } }) {
+            int bitsPerDim = (int) config[0];
+            double relRmseThreshold = (double) config[1];
+
+            AsymmetricHashingQuantizer quantizer = new AsymmetricHashingQuantizer(
+                1.0f,
+                bitsPerDim,
+                AsymmetricHashingQuantizer.Method.RANDOM,
+                0,
+                1,
+                42L
+            );
+            float[][] w = quantizer.train(new float[][] { new float[dim] }, i -> new float[dim]);
+
+            float[] centroid = new float[dim];
+            float[] query = new float[dim];
+            for (int d = 0; d < dim; d++) {
+                centroid[d] = (float) rng.nextGaussian();
+                query[d] = (float) rng.nextGaussian();
+            }
+            float[] queryTransformed = new float[dim];
+            for (int j = 0; j < dim; j++) {
+                double sum = 0;
+                for (int d = 0; d < dim; d++) {
+                    sum = Math.fma((double) (query[d] - centroid[d]), w[d][j], sum);
+                }
+                queryTransformed[j] = (float) sum;
+            }
+            float queryDotCentroid = ESVectorUtil.dotProduct(query, centroid, dim);
+
+            double sumSqErr = 0;
+            double sumSqTrue = 0;
+            for (int i = 0; i < nVectors; i++) {
+                float[] vector = new float[dim];
+                for (int d = 0; d < dim; d++) {
+                    vector[d] = (float) rng.nextGaussian();
+                }
+                float trueDot = ESVectorUtil.dotProduct(query, vector, dim);
+
+                AsymmetricHashingQuantizer.EncodedVector enc = quantizer.encodeOne(vector, centroid, w);
+                float reconstructed = AsymmetricHashingScorer.scoreOneVector(
+                    queryTransformed,
+                    queryDotCentroid,
+                    enc.xEnc(),
+                    enc.scale(),
+                    enc.offset()
+                );
+
+                double err = reconstructed - trueDot;
+                sumSqErr += err * err;
+                sumSqTrue += (double) trueDot * trueDot;
+            }
+            double relRmse = Math.sqrt(sumSqErr / sumSqTrue);
+            assertTrue(
+                "bitsPerDim=" + bitsPerDim + " relative RMSE too high: " + relRmse + " (threshold " + relRmseThreshold + ")",
+                relRmse < relRmseThreshold
+            );
+        }
     }
 
     public void testScorerSingleVector() {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/IndirectSorterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/IndirectSorterTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors.ash;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+
+/**
+ * Tests for {@link IndirectSorter}.
+ * <p>
+ * Regression coverage for a bug where {@code sortAscendingByDouble}'s pivot comparison had its
+ * operands swapped, causing it to silently sort in descending order instead of ascending. That bug
+ * was invisible to {@code sortDescendingByFloat} (used only by the 2-bit quantization path) because
+ * the same swapped-operand mistake happens to produce the intended descending order there, but it
+ * broke {@link AshSphericalScalarQuantizer}'s general (bitsPerDim &gt;= 3) quantization path, which
+ * relies on events being processed in ascending order to greedily improve on the base assignment.
+ */
+public class IndirectSorterTests extends ESTestCase {
+
+    public void testSortAscendingByDoubleSmall() {
+        double[] keys = { 5.0, 1.0, 3.0, 2.0, 4.0 };
+        int[] indices = { 0, 1, 2, 3, 4 };
+        IndirectSorter.sortAscendingByDouble(indices, keys, indices.length);
+        assertSortedAscending(keys, indices);
+        assertPermutation(indices, 5);
+    }
+
+    public void testSortDescendingByFloatSmall() {
+        float[] keys = { 5.0f, 1.0f, 3.0f, 2.0f, 4.0f };
+        int[] indices = { 0, 1, 2, 3, 4 };
+        IndirectSorter.sortDescendingByFloat(indices, keys, indices.length);
+        assertSortedDescending(keys, indices);
+        assertPermutation(indices, 5);
+    }
+
+    public void testSortAscendingByDoubleRandomized() {
+        for (int iter = 0; iter < 50; iter++) {
+            // Cover both the insertion-sort path (small ranges) and the quicksort/heapsort path.
+            int n = randomIntBetween(1, 300);
+            double[] keys = new double[n];
+            for (int i = 0; i < n; i++) {
+                keys[i] = random().nextGaussian();
+            }
+            int[] indices = new int[n];
+            Arrays.setAll(indices, i -> i);
+
+            IndirectSorter.sortAscendingByDouble(indices, keys, n);
+
+            assertSortedAscending(keys, indices);
+            assertPermutation(indices, n);
+        }
+    }
+
+    public void testSortDescendingByFloatRandomized() {
+        for (int iter = 0; iter < 50; iter++) {
+            int n = randomIntBetween(1, 300);
+            float[] keys = new float[n];
+            for (int i = 0; i < n; i++) {
+                keys[i] = (float) random().nextGaussian();
+            }
+            int[] indices = new int[n];
+            Arrays.setAll(indices, i -> i);
+
+            IndirectSorter.sortDescendingByFloat(indices, keys, n);
+
+            assertSortedDescending(keys, indices);
+            assertPermutation(indices, n);
+        }
+    }
+
+    public void testSortAscendingByDoubleWithDuplicates() {
+        for (int iter = 0; iter < 20; iter++) {
+            int n = randomIntBetween(5, 100);
+            double[] keys = new double[n];
+            for (int i = 0; i < n; i++) {
+                // Small value range to force many duplicate keys / ties.
+                keys[i] = randomIntBetween(0, 4);
+            }
+            int[] indices = new int[n];
+            Arrays.setAll(indices, i -> i);
+
+            IndirectSorter.sortAscendingByDouble(indices, keys, n);
+
+            assertSortedAscending(keys, indices);
+            assertPermutation(indices, n);
+        }
+    }
+
+    public void testSortEmptyAndSingleton() {
+        double[] emptyKeys = new double[0];
+        int[] emptyIndices = new int[0];
+        IndirectSorter.sortAscendingByDouble(emptyIndices, emptyKeys, 0);
+        assertEquals(0, emptyIndices.length);
+
+        double[] oneKey = { 42.0 };
+        int[] oneIndex = { 0 };
+        IndirectSorter.sortAscendingByDouble(oneIndex, oneKey, 1);
+        assertArrayEquals(new int[] { 0 }, oneIndex);
+    }
+
+    private static void assertSortedAscending(double[] keys, int[] indices) {
+        for (int i = 0; i + 1 < indices.length; i++) {
+            assertTrue(
+                "Expected ascending order at position " + i + ": " + keys[indices[i]] + " > " + keys[indices[i + 1]],
+                keys[indices[i]] <= keys[indices[i + 1]]
+            );
+        }
+    }
+
+    private static void assertSortedDescending(float[] keys, int[] indices) {
+        for (int i = 0; i + 1 < indices.length; i++) {
+            assertTrue(
+                "Expected descending order at position " + i + ": " + keys[indices[i]] + " < " + keys[indices[i + 1]],
+                keys[indices[i]] >= keys[indices[i + 1]]
+            );
+        }
+    }
+
+    private static void assertPermutation(int[] indices, int n) {
+        boolean[] seen = new boolean[n];
+        for (int idx : indices) {
+            assertFalse("Index " + idx + " appeared more than once", seen[idx]);
+            seen[idx] = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a test to `AsymmetricHashingScorerTests` verifying that `scoreOneVector`'s `dot*scale + queryDotCentroid + offset` formula reconstructs the true dot product of the original (uncentered, unprojected) vectors, using an independent oracle rather than re-deriving the same formula for the expected value.
- While calibrating a similar test against the real quantizer, found that reconstructed dot products were wildly off from ground truth for `bitsPerDim >= 3`. Root-caused this to an inverted comparator in `IndirectSorter.sortAscendingByDouble`: it compared `keys[indices[j]]` against `keys[pivotIdx]` instead of the reverse, so it silently sorted **descending** under the "ascending" name.
  - This broke `AshSphericalScalarQuantizer`'s general quantization path (`bitsPerDim >= 3`), which relies on ascending event-time order to greedily improve on the base-level code assignment. With the sort reversed, the greedy search could land on a strictly suboptimal (sometimes even all-base-level) code.
  - Confirmed via brute force on small cases, and via cosine similarity to the true latent vector regressing *non-monotonically* as `bitsPerDim` increased (worse at 3/4/6/8 bits than at 2 bits) — impossible for a correct greedy search, since every lower-bit level set is a strict subset of a higher-bit one.
  - `sortDescendingByFloat` (used only by the specialized 2-bit path) has the identical swapped-operand bug, but it happens to still produce the intended descending order, so it was unaffected.
- Fixes the comparator (one-line change) and adds regression coverage:
  - `IndirectSorterTests`: direct correctness checks for both sort directions, randomized across sizes (covering both the insertion-sort and quicksort/heapsort code paths) and with duplicate keys.
  - `AshSphericalScalarQuantizerTests`: a brute-force optimality check and a monotonicity-with-bits check.
  - `AsymmetricHashingQuantizerTests`: a full-pipeline test verifying reconstructed dot products track true dot products within an empirically calibrated tolerance (relative RMSE), using the real encoder/quantizer end to end.

All new tests were verified to fail against the pre-fix comparator and pass with the fix.

## Impact

This bug affects every `AsymmetricHashingQuantizer` configuration using `bitsPerDim >= 3` (i.e. more than 2 bits per projected dimension), silently degrading quantization fidelity and therefore recall wherever ASH is used at those bit depths.

## Test plan

- [x] `./gradlew :libs:simdvec:test --tests "org.elasticsearch.simdvec.AsymmetricHashingScorerTests"`
- [x] `./gradlew :server:test --tests "org.elasticsearch.index.codec.vectors.ash.*"`
- [x] Verified each new/changed test fails on the pre-fix code and passes after the fix