### PR TITLE
[9.5] Fix ensureExchangesAreReleased in CCS tests (#156093)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -677,15 +677,6 @@ tests:
   method: test {csv-spec:spatial.centroidFromAirportsFilteredCountry}
   issue: https://github.com/elastic/elasticsearch/issues/155030
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testRemoteFailureSkipUnavailableTrue
-  issue: https://github.com/elastic/elasticsearch/issues/155120
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testCCSExecutionOnSearchesWithLimit0
-  issue: https://github.com/elastic/elasticsearch/issues/155121
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testExplainCCS
-  issue: https://github.com/elastic/elasticsearch/issues/155122
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
   method: testNoBothIncludeCcsMetadataAndIncludeExecutionMetadata
   issue: https://github.com/elastic/elasticsearch/issues/155123
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
@@ -27,11 +28,13 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.FailingFieldPlugin;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction;
 import org.junit.After;
 import org.junit.Before;
 
@@ -89,7 +92,11 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
 
     @Override
     protected Settings nodeSettings() {
-        return Settings.builder().put(super.nodeSettings()).put(EsqlPlugin.QUERY_ALLOW_PARTIAL_RESULTS.getKey(), false).build();
+        return Settings.builder()
+            .put(super.nodeSettings())
+            .put(EsqlPlugin.QUERY_ALLOW_PARTIAL_RESULTS.getKey(), false)
+            .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueSeconds(10))
+            .build();
     }
 
     public static class InternalExchangePlugin extends Plugin {
@@ -98,7 +105,7 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
             return List.of(
                 Setting.timeSetting(
                     ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING,
-                    TimeValue.timeValueSeconds(30),
+                    TimeValue.timeValueSeconds(10),
                     Setting.Property.NodeScope
                 )
             );
@@ -135,6 +142,26 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
         SimplePauseFieldPlugin.release();
         FailingPauseFieldPlugin.release();
         CrossClusterAsyncQueryIT.CountingPauseFieldPlugin.release();
+    }
+
+    @After
+    public void ensureExchangesAreReleased() throws Exception {
+        for (Map.Entry<String, InternalTestCluster> entry : clusters().entrySet()) {
+            String clusterAlias = entry.getKey();
+            InternalTestCluster testCluster = entry.getValue();
+            for (String node : testCluster.getNodeNames()) {
+                TransportEsqlQueryAction esqlQueryAction = testCluster.getInstance(TransportEsqlQueryAction.class, node);
+                ExchangeService exchangeService = esqlQueryAction.exchangeService();
+                assertBusy(() -> {
+                    if (exchangeService.lifecycleState() == Lifecycle.State.STARTED) {
+                        assertTrue(
+                            "Leftover exchanges " + exchangeService + " on node " + node + " in cluster " + clusterAlias,
+                            exchangeService.isEmpty()
+                        );
+                    }
+                }, 60, TimeUnit.SECONDS);
+            }
+        }
     }
 
     protected void assertClusterInfoSuccess(EsqlExecutionInfo.Cluster cluster, int numShards) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
@@ -15,11 +15,9 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.lucene.query.DataPartitioning;
 import org.elasticsearch.compute.operator.DriverProfile;
-import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -33,8 +31,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
-import org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction;
-import org.junit.After;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,26 +66,6 @@ import static org.hamcrest.Matchers.not;
 public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
     protected static final String IDX_ALIAS = "alias1";
     protected static final String FILTERED_IDX_ALIAS = "alias-filtered-1";
-
-    @After
-    public void ensureExchangesAreReleased() throws Exception {
-        for (Map.Entry<String, InternalTestCluster> entry : clusters().entrySet()) {
-            String clusterAlias = entry.getKey();
-            InternalTestCluster testCluster = entry.getValue();
-            for (String node : testCluster.getNodeNames()) {
-                TransportEsqlQueryAction esqlQueryAction = testCluster.getInstance(TransportEsqlQueryAction.class, node);
-                ExchangeService exchangeService = esqlQueryAction.exchangeService();
-                assertBusy(() -> {
-                    if (exchangeService.lifecycleState() == Lifecycle.State.STARTED) {
-                        assertTrue(
-                            "Leftover exchanges " + exchangeService + " on node " + node + " in cluster " + clusterAlias,
-                            exchangeService.isEmpty()
-                        );
-                    }
-                }, 5, TimeUnit.SECONDS);
-            }
-        }
-    }
 
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix ensureExchangesAreReleased in CCS tests (#156093)](https://github.com/elastic/elasticsearch/pull/156093)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)