### PR TITLE
Columnar mappers: reject unsupported docs late

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
@@ -285,16 +285,21 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
 
     @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
-        // postParse is a no-op when disabled (the common case for non-data-stream indices).
-        // The enabled case validates @timestamp against the index's time bounds, which requires
-        // reading the value a columnar @timestamp field mapper recorded — not yet supported.
-        return enabled == false;
+        // postParse rejects a document with no @timestamp and, only for TIME_SERIES, validates it
+        // against the index time bounds. Neither runs columnar, but refusing whenever enabled is too
+        // blunt: IndexMode#createDefaultMapping enables this mapper on every logsdb_columnar index,
+        // data stream or not. Gating on the mode keeps the bounds check enforced where it applies.
+        //
+        // TODO(columnar): re-instate the missing-@timestamp rejection in postColumnarParse, once
+        // BatchMappingContext exposes the mapped timestamp column.
+        return enabled == false || indexSettings.getMode().shouldValidateTimestamp() == false;
     }
 
     @Override
     public void postColumnarParse(BatchMappingContext context) throws IOException {
         super.postColumnarParse(context);
-        // TODO: Implement validation and enable this mapper once we can map timetstamps
+        // TODO: see the TODO on supportsColumnarParse — the missing-@timestamp check belongs here
+        // once the batch context exposes the mapped timestamp column.
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1274,15 +1274,13 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
-        // Columnar support requires strict-columnar index mode and a plain, single-valued
-        // doc-values-only date field. ignore_malformed is excluded because per-value error
-        // handling (addIgnoredField) is not yet implemented in the columnar path.
+        // Columnar support requires strict-columnar index mode and a plain doc-values-only date
+        // field. doc_values.multi_value and ignore_malformed are not implemented by mapColumnBatch
+        // but are deliberately not rejected here instead rejected at parse time.
         return indexSettings.getMode().isStrictColumnar()
             && docValuesParameters.enabled()
-            && docValuesParameters.multiValue() == false
             && indexed == false
             && store == false
-            && ignoreMalformed == false
             && hasScript() == false
             && copyTo().copyToFields().isEmpty()
             && multiFields().iterator().hasNext() == false

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2870,9 +2870,11 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // Neither doc_values.multi_value nor ignore_malformed is implemented by mapColumnBatch, but
+        // neither is rejected up front either: both only matter for documents the columnar path
+        // already refuses, and refusing late falls back to row path.
         return indexSettings.getMode().isStrictColumnar()
             && docValuesParameters.enabled()
-            && docValuesParameters.multiValue() == false
             && indexed == false
             && stored == false
             && indexTerms == false
@@ -2880,7 +2882,6 @@ public class NumberFieldMapper extends FieldMapper {
             && copyTo().copyToFields().isEmpty()
             && multiFields().iterator().hasNext() == false
             && dimension == false
-            && ignoreMalformed.value() == false
             && indexSettings.getIndexVersionCreated().isLegacyIndexVersion() == false;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
@@ -29,7 +29,6 @@ public class DateFieldMapperColumnarCompatibilityTests extends AbstractColumnarM
         return Settings.builder()
             .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
             .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
-            // DateFieldMapper.supportsColumnarParse requires multiValue == false.
             .put(FieldMapper.DOC_VALUES_MULTI_VALUE_SETTING.getKey(), false)
             .build();
     }
@@ -155,6 +154,84 @@ public class DateFieldMapperColumnarCompatibilityTests extends AbstractColumnarM
                 1L,
                 doc("d1", 1L, "{\"f\":1705320000000}"),
                 doc("d2", 2L, "{\"f\":0}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    /**
+     * Columnar-mode settings leaving {@code doc_values.multi_value} at its default of {@code true},
+     * so array values reach the mapper instead of being rejected at parse time.
+     */
+    private static Settings multiValueColumnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    /**
+     * {@link DateFieldMapper#supportsColumnarParse} accepts {@code doc_values.multi_value=true} —
+     * the setting defaults to {@code true}, so rejecting it would take every date field in a
+     * columnar index off the columnar path. Multi-valued documents themselves are not implemented:
+     * they arrive as an ESCF {@code ARRAY} column and the kind switch in
+     * {@link DateFieldMapper#mapColumnBatch} throws, which makes {@code ShardBatchMapper} fall the
+     * chunk back to the row path. This test pins the gap that fallback papers over.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement multi-valued date fields; ARRAY columns fall back to the row path")
+    public void testMultiValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").endObject()),
+            multiValueColumnarSettings(),
+            // Every present value is an array so the column is a plain ARRAY; mixing in a scalar
+            // would make it a UNION and trip the same switch for a different reason.
+            batch(
+                "multi-value dates",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"2024-01-01T00:00:00.000Z\",\"2024-02-01T00:00:00.000Z\"]}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":[\"2024-03-01T00:00:00.000Z\"]}")
+            )
+        );
+    }
+
+    /**
+     * As {@link #testMultiValue}, for a null value. A null makes the column a UNION rather than a
+     * plain STRING, which the same kind switch rejects.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement null date values; UNION columns fall back to the row path")
+    public void testNullValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("null_value", "2024-01-01T00:00:00.000Z").endObject()),
+            columnarSettings(),
+            batch(
+                "null date value",
+                1L,
+                doc("d1", 1L, "{\"f\":\"2024-05-01T00:00:00.000Z\"}"),
+                doc("d2", 2L, "{\"f\":null}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    /**
+     * {@link DateFieldMapper#supportsColumnarParse} accepts {@code ignore_malformed=true} — the
+     * logsdb index modes default it to {@code true}. Per-value error handling
+     * ({@code addIgnoredField} plus the ignored-source stored copy) is not implemented in
+     * {@code mapColumnBatch}, so an unparseable value throws out of {@code fieldType().parse} in
+     * {@code datesFromStrings} and the chunk falls back to the row path, which applies
+     * {@code ignore_malformed} properly.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement ignore_malformed; malformed dates fall back to the row path")
+    public void testIgnoreMalformed() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("ignore_malformed", true).endObject()),
+            columnarSettings(),
+            batch(
+                "ignore_malformed dates",
+                1L,
+                doc("d1", 1L, "{\"f\":\"2024-01-15T12:00:00.000Z\"}"),
+                doc("d2", 2L, "{\"f\":\"not-a-date\"}"),
                 doc("d3", 3L, "{}")
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperColumnarCompatibilityTests.java
@@ -297,4 +297,85 @@ public class NumberFieldMapperColumnarCompatibilityTests extends AbstractColumna
             batch("half_float string", 1L, doc("d1", 1L, "{\"f\":\"1.5\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"-2.25\"}"))
         );
     }
+
+    /**
+     * Columnar-mode settings leaving {@code doc_values.multi_value} at its default of {@code true},
+     * so array values reach the mapper instead of being rejected at parse time.
+     */
+    private static Settings multiValueColumnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    /**
+     * {@link NumberFieldMapper#supportsColumnarParse} accepts {@code doc_values.multi_value=true} —
+     * the setting defaults to {@code true}, so rejecting it would take every numeric field in a
+     * columnar index off the columnar path. Multi-valued documents themselves are not implemented:
+     * they arrive as an ESCF {@code ARRAY} column and the kind switch in
+     * {@link NumberFieldMapper#mapColumnBatch} throws, which makes {@code ShardBatchMapper} fall the
+     * chunk back to the row path. This test pins the gap that fallback papers over.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement multi-valued numeric fields; ARRAY columns fall back to the row path")
+    public void testLongField_multiValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "long").endObject()),
+            multiValueColumnarSettings(),
+            // Every present value is an array so the column is a plain ARRAY; mixing in a scalar
+            // would make it a UNION and trip the same switch for a different reason.
+            batch("long multi-value", 1L, doc("d1", 1L, "{\"f\":[1,2,3]}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":[7]}"))
+        );
+    }
+
+    /**
+     * As {@link #testLongField_multiValue}, for a null value. A null makes the column a UNION rather
+     * than a plain LONG, which the same kind switch rejects.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement null numeric values; UNION columns fall back to the row path")
+    public void testLongField_nullValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "long").field("null_value", 9).endObject()),
+            columnarSettings(),
+            batch("long null value", 1L, doc("d1", 1L, "{\"f\":1}"), doc("d2", 2L, "{\"f\":null}"), doc("d3", 3L, "{\"f\":3}"))
+        );
+    }
+
+    /**
+     * {@link NumberFieldMapper#supportsColumnarParse} accepts {@code ignore_malformed=true} — the
+     * logsdb index modes default it to {@code true}. Per-value error handling
+     * ({@code addIgnoredField} plus the ignored-source stored copy) is not implemented in
+     * {@code mapColumnBatch}, so an unparseable value throws out of {@code NumberColumnTransform}
+     * and the chunk falls back to the row path, which applies {@code ignore_malformed} properly.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement ignore_malformed; malformed values fall back to the row path")
+    public void testLongField_ignoreMalformed() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "long").field("ignore_malformed", true).endObject()),
+            columnarSettings(),
+            // All values are strings so the column is a plain STRING and the malformed value reaches
+            // the numeric parser; mixing in a JSON number would make it a UNION and fail earlier.
+            batch(
+                "long ignore_malformed",
+                1L,
+                doc("d1", 1L, "{\"f\":\"1\"}"),
+                doc("d2", 2L, "{\"f\":\"not-a-number\"}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    /**
+     * As {@link #testLongField_ignoreMalformed}, for a value that parses but falls outside the
+     * type's range — rejected by {@code NumberColumnTransform#validateLongRange} rather than by the
+     * string parser.
+     */
+    @AwaitsFix(bugUrl = "columnar mapColumnBatch does not implement ignore_malformed; out-of-range values fall back to the row path")
+    public void testByteField_ignoreMalformedOutOfRange() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "byte").field("ignore_malformed", true).endObject()),
+            columnarSettings(),
+            batch("byte ignore_malformed out of range", 1L, doc("d1", 1L, "{\"f\":1}"), doc("d2", 2L, "{\"f\":300}"))
+        );
+    }
 }


### PR DESCRIPTION
supportsColumnarParse was an index-level gate: any setting whose
semantics mapColumnBatch does not implement disabled the columnar path
for that field, and one such field disables it for the whole batch.
Three of those gates fire on defaults, so logsdb_columnar could never
use the columnar path at all.

Move the decision from the index to the document. Every rejected case
already throws inside mapColumnBatch, and ShardBatchMapper re-runs that
chunk on the row path, which handles it correctly.

- NumberFieldMapper, DateFieldMapper: stop requiring
doc_values.multi_value=false and ignore_malformed=false. Multi-valued
docs arrive as ARRAY columns and null ones as UNION columns,
both rejected by the kind switch; malformed values throw in the
transform. A single non-null value is encoded identically to the row
path, which skips the .offsets sidecar for it in strict columnar.

- DataStreamTimestampFieldMapper: gate on shouldValidateTimestamp
instead of enabled. Only TIME_SERIES validates bounds, but
createDefaultMapping enables this mapper on every logsdb_columnar
index. The missing-@timestamp check is still skipped on the batch
path; TODO left on postColumnarParse.