### PR TITLE
[9.5] Fix recurring cluster-formation timeout flakiness in InternalTestCluster (#152751)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -472,9 +472,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testUnreferencedCommitsAreReleasedAfterRecovery
   issue: https://github.com/elastic/elasticsearch/issues/152730
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/152734
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/kNN search only}
   issue: https://github.com/elastic/elasticsearch/issues/152784

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
@@ -56,47 +56,56 @@ public class SearchWithRandomDisconnectsIT extends AbstractDisruptionTestCase {
         final AtomicBoolean done = new AtomicBoolean();
         final int concurrentSearches = randomIntBetween(2, 5);
         final List<PlainActionFuture<Void>> futures = new ArrayList<>(concurrentSearches);
-        for (int i = 0; i < concurrentSearches; i++) {
-            final PlainActionFuture<Void> finishFuture = new PlainActionFuture<>();
-            futures.add(finishFuture);
-            prepareRandomSearch().execute(new ActionListener<>() {
-                @Override
-                public void onResponse(SearchResponse searchResponse) {
-                    runMoreSearches();
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    runMoreSearches();
-                }
-
-                private void runMoreSearches() {
-                    while (done.get() == false) {
-                        final ListenableFuture<SearchResponse> f = new ListenableFuture<>();
-                        prepareRandomSearch().execute(f);
-                        if (f.isDone() == false) {
-                            f.addListener(this);
-                            return;
-                        }
+        try {
+            for (int i = 0; i < concurrentSearches; i++) {
+                final PlainActionFuture<Void> finishFuture = new PlainActionFuture<>();
+                futures.add(finishFuture);
+                prepareRandomSearch().execute(new ActionListener<>() {
+                    @Override
+                    public void onResponse(SearchResponse searchResponse) {
+                        runMoreSearches();
                     }
-                    finishFuture.onResponse(null);
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        runMoreSearches();
+                    }
+
+                    private void runMoreSearches() {
+                        while (done.get() == false) {
+                            final ListenableFuture<SearchResponse> f = new ListenableFuture<>();
+                            prepareRandomSearch().execute(f);
+                            if (f.isDone() == false) {
+                                f.addListener(this);
+                                return;
+                            }
+                        }
+                        finishFuture.onResponse(null);
+                    }
+                });
+            }
+            for (int i = 0, n = randomIntBetween(20, 50); i < n; i++) {
+                NetworkDisruption networkDisruption = new NetworkDisruption(
+                    isolateNode(internalCluster().getRandomNodeName()),
+                    NetworkDisruption.DISCONNECT
+                );
+                setDisruptionScheme(networkDisruption);
+                networkDisruption.startDisrupting();
+                networkDisruption.stopDisrupting();
+                internalCluster().clearDisruptionScheme();
+                ensureFullyConnectedCluster();
+            }
+        } finally {
+            // Stop the background searches before teardown, on every exit path: a search left running
+            // into teardown hits the closing cluster and crashes the whole suite with a fatal AssertionError.
+            done.set(true);
+            for (PlainActionFuture<Void> future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    // best-effort drain
                 }
-            });
-        }
-        for (int i = 0, n = randomIntBetween(20, 50); i < n; i++) {
-            NetworkDisruption networkDisruption = new NetworkDisruption(
-                isolateNode(internalCluster().getRandomNodeName()),
-                NetworkDisruption.DISCONNECT
-            );
-            setDisruptionScheme(networkDisruption);
-            networkDisruption.startDisrupting();
-            networkDisruption.stopDisrupting();
-            internalCluster().clearDisruptionScheme();
-            ensureFullyConnectedCluster();
-        }
-        done.set(true);
-        for (PlainActionFuture<Void> future : futures) {
-            future.get();
+            }
         }
         ensureGreen(new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + 2000L * indexNames.length), indexNames);
         assertAcked(indicesAdmin().prepareDelete(indexNames));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix recurring cluster-formation timeout flakiness in InternalTestCluster (#152751)](https://github.com/elastic/elasticsearch/pull/152751)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)