### PR TITLE
[8.19] Fix recurring cluster-formation timeout flakiness in InternalTestCluster (#152751)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -43,9 +43,6 @@ tests:
 - class: org.elasticsearch.index.shard.StoreRecoveryTests
   method: testAddIndices
   issue: https://github.com/elastic/elasticsearch/issues/156123
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/156125
 - class: org.elasticsearch.search.aggregations.metrics.LargeTopHitsIT
   method: test500Queries
   issue: https://github.com/elastic/elasticsearch/issues/148056

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomDisconnectsIT.java
@@ -55,43 +55,52 @@ public class SearchWithRandomDisconnectsIT extends AbstractDisruptionTestCase {
         final AtomicBoolean done = new AtomicBoolean();
         final int concurrentSearches = randomIntBetween(2, 5);
         final List<PlainActionFuture<Void>> futures = new ArrayList<>(concurrentSearches);
-        for (int i = 0; i < concurrentSearches; i++) {
-            final PlainActionFuture<Void> finishFuture = new PlainActionFuture<>();
-            futures.add(finishFuture);
-            prepareRandomSearch().execute(new ActionListener<>() {
-                @Override
-                public void onResponse(SearchResponse searchResponse) {
-                    runMoreSearches();
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    runMoreSearches();
-                }
-
-                private void runMoreSearches() {
-                    if (done.get() == false) {
-                        prepareRandomSearch().execute(this);
-                    } else {
-                        finishFuture.onResponse(null);
+        try {
+            for (int i = 0; i < concurrentSearches; i++) {
+                final PlainActionFuture<Void> finishFuture = new PlainActionFuture<>();
+                futures.add(finishFuture);
+                prepareRandomSearch().execute(new ActionListener<>() {
+                    @Override
+                    public void onResponse(SearchResponse searchResponse) {
+                        runMoreSearches();
                     }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        runMoreSearches();
+                    }
+
+                    private void runMoreSearches() {
+                        if (done.get() == false) {
+                            prepareRandomSearch().execute(this);
+                        } else {
+                            finishFuture.onResponse(null);
+                        }
+                    }
+                });
+            }
+            for (int i = 0, n = randomIntBetween(50, 100); i < n; i++) {
+                NetworkDisruption networkDisruption = new NetworkDisruption(
+                    isolateNode(internalCluster().getRandomNodeName()),
+                    NetworkDisruption.DISCONNECT
+                );
+                setDisruptionScheme(networkDisruption);
+                networkDisruption.startDisrupting();
+                networkDisruption.stopDisrupting();
+                internalCluster().clearDisruptionScheme();
+                ensureFullyConnectedCluster();
+            }
+        } finally {
+            // Stop the background searches before teardown, on every exit path: a search left running
+            // into teardown hits the closing cluster and crashes the whole suite with a fatal AssertionError.
+            done.set(true);
+            for (PlainActionFuture<Void> future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    // best-effort drain
                 }
-            });
-        }
-        for (int i = 0, n = randomIntBetween(50, 100); i < n; i++) {
-            NetworkDisruption networkDisruption = new NetworkDisruption(
-                isolateNode(internalCluster().getRandomNodeName()),
-                NetworkDisruption.DISCONNECT
-            );
-            setDisruptionScheme(networkDisruption);
-            networkDisruption.startDisrupting();
-            networkDisruption.stopDisrupting();
-            internalCluster().clearDisruptionScheme();
-            ensureFullyConnectedCluster();
-        }
-        done.set(true);
-        for (PlainActionFuture<Void> future : futures) {
-            future.get();
+            }
         }
         ensureGreen(new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + 2000L * indexNames.length), indexNames);
         assertAcked(indicesAdmin().prepareDelete(indexNames));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix recurring cluster-formation timeout flakiness in InternalTestCluster (#152751)](https://github.com/elastic/elasticsearch/pull/152751)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)