### PR TITLE
Backport ServiceAccountIT fix and unmute (#156136)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -58,9 +58,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.completion.CompletionOperatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/156135
-- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-  issue: https://github.com/elastic/elasticsearch/issues/156136
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -496,24 +496,17 @@ public class ServiceAccountIT extends ESRestTestCase {
     }
 
     public void testAuthenticateShouldNotFallThroughInCaseOfFailure() throws IOException {
-        final boolean securityIndexExists = randomBoolean();
-        if (securityIndexExists) {
-            final Request createRoleRequest = new Request("POST", "_security/role/dummy_role");
-            createRoleRequest.setJsonEntity("{\"cluster\":[]}");
-            assertOK(adminClient().performRequest(createRoleRequest));
-        }
+        final Request createRoleRequest = new Request("POST", "_security/role/dummy_role");
+        createRoleRequest.setJsonEntity("{\"cluster\":[]}");
+        assertOK(adminClient().performRequest(createRoleRequest));
         final Request request = new Request("GET", "_security/_authenticate");
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + INVALID_SERVICE_TOKEN));
         final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(401));
-        if (securityIndexExists) {
-            assertThat(
-                e.getMessage(),
-                containsString("failed to authenticate service account [elastic/fleet-server] with token name [token1]")
-            );
-        } else {
-            assertThat(e.getMessage(), containsString("no such index [.security]"));
-        }
+        assertThat(
+            e.getMessage(),
+            containsString("failed to authenticate service account [elastic/fleet-server] with token name [token1]")
+        );
     }
 
     public void testAuthenticateShouldWorkWithOAuthBearerToken() throws IOException {


### PR DESCRIPTION
## Summary
- Backport the `ServiceAccountIT.testAuthenticateShouldNotFallThroughInCaseOfFailure` fix from #144650 to 8.19
- Always create the security index before asserting authentication failure, instead of randomly expecting a missing `.security` index
- Unmute the test muted for #156136

Closes #156136

See also #144262 / #144650