### PR TITLE
Rename the various bit-packing methods to a more consistent naming scheme

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/Pack1BitValuesBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/Pack1BitValuesBenchmark.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 4, time = 1)
 // real iterations. not useful to spend tons of time here, better to fork more
 @Measurement(iterations = 5, time = 1)
-public class PackAsBinaryBenchmark {
+public class Pack1BitValuesBenchmark {
 
     static {
         Utils.configureBenchmarkLogging();

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/PackAsBinaryBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/PackAsBinaryBenchmark.java
@@ -82,7 +82,7 @@ public class PackAsBinaryBenchmark {
     @Benchmark
     public void packAsBinary(Blackhole bh) {
         for (int i = 0; i < numVectors; i++) {
-            impl.packAsBinary(qVectors[i], packed);
+            impl.pack1BitValues(qVectors[i], packed);
             bh.consume(packed);
         }
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/Stride4BitValuesBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/Stride4BitValuesBenchmark.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 4, time = 1)
 // real iterations. not useful to spend tons of time here, better to fork more
 @Measurement(iterations = 5, time = 1)
-public class TransposeHalfByteBenchmark {
+public class Stride4BitValuesBenchmark {
 
     static {
         Utils.configureBenchmarkLogging();

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/TransposeHalfByteBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/quantization/TransposeHalfByteBenchmark.java
@@ -82,7 +82,7 @@ public class TransposeHalfByteBenchmark {
     @Benchmark
     public void transposeHalfByte(Blackhole bh) {
         for (int i = 0; i < numVectors; i++) {
-            impl.transposeHalfByte(qVectors[i], packed);
+            impl.stride4BitValues(qVectors[i], packed);
             bh.consume(packed);
         }
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
@@ -76,7 +76,7 @@ public class VectorScorerD2Q4StripedOperationBenchmark {
 
     // dataset: numVectors * docBytes laid out contiguously in native memory
     private MemorySegment dataset;
-    // query: queryBytes (4 bit-planes back-to-back, produced by transposeHalfByte-style packing)
+    // query: queryBytes (4 bit-planes back-to-back, produced by strided bit packing)
     private MemorySegment query;
     // shuffled ordinals for the random-access offsets path
     private int[] ordinals;

--- a/libs/native/src/testFixtures/java/org/elasticsearch/nativeaccess/BBQTestUtils.java
+++ b/libs/native/src/testFixtures/java/org/elasticsearch/nativeaccess/BBQTestUtils.java
@@ -12,8 +12,8 @@ package org.elasticsearch.nativeaccess;
 /**
  * Shared test utilities for BBQ vector operations in the {@code STRIPED} (bit-plane) layout —
  * the packing convention consumed by {@code vec_dotdNqM} kernels and produced on disk by the
- * existing OSQ writers via {@code ESVectorUtil.transposeHalfByte}, {@code packDibit}, and
- * {@code packAsBinary}.
+ * existing OSQ writers via {@code ESVectorUtil.stride4BitValues}, {@code stride2BitValues}, and
+ * {@code pack1BitValues}.
  *
  * <p>BBQ striped vectors use two representations:
  * <ul>

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -880,43 +880,47 @@ public class ESVectorUtil {
      * @param vector the int array to pack, must contain only "0" and "1" values.
      * @param packed the byte array to store the packed result, must be large enough to hold the packed data.
      */
-    public static void packAsBinary(int[] vector, byte[] packed) {
+    public static void pack1BitValues(int[] vector, byte[] packed) {
         if (packed.length * Byte.SIZE < vector.length) {
             throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE + " < " + vector.length);
         }
-        IMPL.packAsBinary(vector, packed);
-    }
-
-    public static void packDibit(int[] vector, byte[] packed) {
-        if (packed.length * Byte.SIZE / 2 < vector.length) {
-            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE / 2 + " < " + vector.length);
-        }
-        IMPL.packDibit(vector, packed);
-    }
-
-    public static void packDibitQuad(int[] vector, byte[] packed) {
-        if (packed.length * Byte.SIZE / 2 < vector.length) {
-            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE / 2 + " < " + vector.length);
-        }
-        IMPL.packDibitQuad(vector, packed);
+        IMPL.pack1BitValues(vector, packed);
     }
 
     /**
-     * The idea here is to organize the query vector bits such that the first bit
-     * of every dimension is in the first set dimensions bits, or (dimensions/8) bytes. The second,
-     * third, and fourth bits are in the second, third, and fourth set of dimensions bits,
-     * respectively. This allows for direct bitwise comparisons with the stored index vectors through
-     * summing the bitwise results with the relative required bit shifts.
-     *
-     * @param q the query vector, assumed to be half-byte quantized with values between 0 and 15
-     * @param quantQueryByte the byte array to store the transposed query vector.
-     *
-     **/
-    public static void transposeHalfByte(int[] q, byte[] quantQueryByte) {
-        if (quantQueryByte.length * Byte.SIZE < 4 * q.length) {
-            throw new IllegalArgumentException("packed array is too small: " + quantQueryByte.length * Byte.SIZE + " < " + 4 * q.length);
+     * Stride 2-bit values into a byte array
+     * @param vector    The input vector, each value should be 0-3
+     * @param packed    The output bytes - the first MSB of all values first, followed by the second MSB
+     */
+    public static void stride2BitValues(int[] vector, byte[] packed) {
+        if (packed.length * Byte.SIZE / 2 < vector.length) {
+            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE / 2 + " < " + vector.length);
         }
-        IMPL.transposeHalfByte(q, quantQueryByte);
+        IMPL.stride2BitValues(vector, packed);
+    }
+
+    /**
+     * Pack 2-bit values into a byte array
+     * @param vector    The input vector, each value should be 0-3
+     * @param packed    The output packed bytes, each byte containing 4 values concatenated together
+     */
+    public static void pack2BitValues(int[] vector, byte[] packed) {
+        if (packed.length * Byte.SIZE / 2 < vector.length) {
+            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE / 2 + " < " + vector.length);
+        }
+        IMPL.pack2BitValues(vector, packed);
+    }
+
+    /**
+     * Stride 4-bit values into a byte array
+     * @param vector    The input vector, each value should be 0-15
+     * @param packed    The output bytes - the first MSB of all values first, followed by the second MSB, then the third, and the fourth
+     */
+    public static void stride4BitValues(int[] vector, byte[] packed) {
+        if (packed.length * Byte.SIZE < 4 * vector.length) {
+            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE + " < " + 4 * vector.length);
+        }
+        IMPL.stride4BitValues(vector, packed);
     }
 
     /**

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -478,7 +478,7 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
      * of the array are the initial bits of each of the {@code n} vector dimensions; the next {@code n}
      * bits are the second bits of each of the {@code n} vector dimensions, and so on
      * (this algorithm is only valid for vectors with dimensions a multiple of 8).
-     * The striping is usually done by {@code ESVectorUtil.transposeHalfByte}.
+     * The striping is usually done by {@code ESVectorUtil.stride4BitValues}.
      * <p>
      * The data vector should be single-bit quantized.
      *
@@ -491,7 +491,7 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
      * <h4>The algorithm</h4>
      *
      * The transposition already applied to the query vector ensures there's a 1-to-1 correspondence
-     * between the data vector bits and query vector bits (see {@code ESVectorUtil.transposeHalfByte)};
+     * between the data vector bits and query vector bits (see {@code ESVectorUtil.stride4BitValues)};
      * this means we can use a bitwise {@code &} to keep only the bits of the vector elements we want to sum.
      * Essentially, the data vector is used as a selector for each of the striped bits of each vector dimension
      * as stored, concatenated together, in {@code q}.
@@ -502,7 +502,7 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
      * the result of each stripe of {@code n} bits can be added together by shifting the value {@code s} bits to the left,
      * where {@code s} is the stripe number (0-3), then adding to the overall result. Any carry is handled by the add operation.
      *
-     * @param q query vector, {@link #B_QUERY}-bit quantized and striped (see {@code ESVectorUtil.transposeHalfByte})
+     * @param q query vector, {@link #B_QUERY}-bit quantized and striped (see {@code ESVectorUtil.stride4BitValues})
      * @param d data vector, 1-bit quantized
      * @return  inner product result
      */

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -678,28 +678,11 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
     }
 
     @Override
-    public void packDibit(int[] vector, byte[] packed) {
-        packDibitImpl(vector, packed);
+    public void stride2BitValues(int[] vector, byte[] packed) {
+        stride2BitValuesImpl(vector, packed);
     }
 
-    @Override
-    public void packDibitQuad(int[] vector, byte[] packed) {
-        packDibitQuadImpl(vector, packed);
-    }
-
-    @Override
-    public void packAsBinary(int[] vector, byte[] packed) {
-        packAsBinaryImpl(vector, packed);
-    }
-
-    /**
-     * Packs two bit vector (values 0-3) into a byte array with lower bits first.
-     * The striding is similar to transposeHalfByte
-     *
-     * @param vector the input vector with values 0-3
-     * @param packed the output packed byte array
-     */
-    public static void packDibitImpl(int[] vector, byte[] packed) {
+    public static void stride2BitValuesImpl(int[] vector, byte[] packed) {
         int limit = vector.length - 7;
         int i = 0;
         int index = 0;
@@ -734,7 +717,12 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
         packed[index + packed.length / 2] = (byte) upperByte;
     }
 
-    public static void packDibitQuadImpl(int[] vector, byte[] packed) {
+    @Override
+    public void pack2BitValues(int[] vector, byte[] packed) {
+        pack2BitValuesImpl(vector, packed);
+    }
+
+    public static void pack2BitValuesImpl(int[] vector, byte[] packed) {
         int limit = vector.length - 3;
         int i = 0;
         int index = 0;
@@ -757,7 +745,12 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
         packed[index] = (byte) packedByte;
     }
 
-    public static void packAsBinaryImpl(int[] vector, byte[] packed) {
+    @Override
+    public void pack1BitValues(int[] vector, byte[] packed) {
+        pack1BitValuesImpl(vector, packed);
+    }
+
+    public static void pack1BitValuesImpl(int[] vector, byte[] packed) {
         int limit = vector.length - 7;
         int i = 0;
         int index = 0;
@@ -786,11 +779,11 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
     }
 
     @Override
-    public void transposeHalfByte(int[] q, byte[] quantQueryByte) {
-        transposeHalfByteImpl(q, quantQueryByte);
+    public void stride4BitValues(int[] vector, byte[] packed) {
+        stride4BitValuesImpl(vector, packed);
     }
 
-    public static void transposeHalfByteImpl(int[] q, byte[] quantQueryByte) {
+    public static void stride4BitValuesImpl(int[] q, byte[] quantQueryByte) {
         int limit = q.length - 7;
         int i = 0;
         int index = 0;

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -168,13 +168,13 @@ public interface ESVectorUtilSupport {
         float[] distances
     );
 
-    void packAsBinary(int[] vector, byte[] packed);
+    void pack1BitValues(int[] vector, byte[] packed);
 
-    void packDibit(int[] vector, byte[] packed);
+    void stride2BitValues(int[] vector, byte[] packed);
 
-    void packDibitQuad(int[] vector, byte[] packed);
+    void pack2BitValues(int[] vector, byte[] packed);
 
-    void transposeHalfByte(int[] q, byte[] quantQueryByte);
+    void stride4BitValues(int[] vector, byte[] packed);
 
     int indexOf(byte[] bytes, int offset, int length, byte marker);
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -76,7 +76,7 @@ public interface ESVectorUtilSupport {
 
     /**
      * Compute dot product between {@code q} and {@code d}
-     * @param q query vector, {@link #B_QUERY}-bit quantized and striped (see {@code ESVectorUtil.transposeHalfByte})
+     * @param q query vector, {@link #B_QUERY}-bit quantized and striped (see {@code ESVectorUtil.stride4BitValues})
      * @param d data vector, 1-bit quantized
      */
     long ipByteBinByte(byte[] q, byte[] d);

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -2385,22 +2385,22 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
     }
 
     @Override
-    public void packAsBinary(int[] vector, byte[] packed) {
+    public void pack1BitValues(int[] vector, byte[] packed) {
         // 128 / 32 == 4
         if (vector.length >= 8 && HAS_FAST_INTEGER_VECTORS) {
             // TODO: can we optimize for >= 512?
             if (VECTOR_BITSIZE >= 256) {
-                packAsBinary256(vector, packed);
+                pack1BitValues256(vector, packed);
                 return;
             } else if (VECTOR_BITSIZE == 128) {
-                packAsBinary128(vector, packed);
+                pack1BitValues128(vector, packed);
                 return;
             }
         }
-        DefaultESVectorUtilSupport.packAsBinaryImpl(vector, packed);
+        DefaultESVectorUtilSupport.pack1BitValuesImpl(vector, packed);
     }
 
-    private void packAsBinary256(int[] vector, byte[] packed) {
+    private void pack1BitValues256(int[] vector, byte[] packed) {
         final int limit = INT_SPECIES_256.loopBound(vector.length);
         int i = 0;
         int index = 0;
@@ -2420,7 +2420,7 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
         packed[index] = result;
     }
 
-    private void packAsBinary128(int[] vector, byte[] packed) {
+    private void pack1BitValues128(int[] vector, byte[] packed) {
         final int limit = INT_SPECIES_128.loopBound(vector.length) - INT_SPECIES_128.length();
         int i = 0;
         int index = 0;
@@ -2444,31 +2444,31 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
     }
 
     @Override
-    public void packDibit(int[] vector, byte[] packed) {
-        DefaultESVectorUtilSupport.packDibitImpl(vector, packed);
+    public void stride2BitValues(int[] vector, byte[] packed) {
+        DefaultESVectorUtilSupport.stride2BitValuesImpl(vector, packed);
     }
 
     @Override
-    public void packDibitQuad(int[] vector, byte[] packed) {
-        DefaultESVectorUtilSupport.packDibitQuadImpl(vector, packed);
+    public void pack2BitValues(int[] vector, byte[] packed) {
+        DefaultESVectorUtilSupport.pack2BitValuesImpl(vector, packed);
     }
 
     @Override
-    public void transposeHalfByte(int[] q, byte[] quantQueryByte) {
+    public void stride4BitValues(int[] vector, byte[] packed) {
         // 128 / 32 == 4
-        if (q.length >= 8 && HAS_FAST_INTEGER_VECTORS) {
+        if (vector.length >= 8 && HAS_FAST_INTEGER_VECTORS) {
             if (VECTOR_BITSIZE >= 256) {
-                transposeHalfByte256(q, quantQueryByte);
+                stride4BitValues256(vector, packed);
                 return;
             } else if (VECTOR_BITSIZE == 128) {
-                transposeHalfByte128(q, quantQueryByte);
+                stride4BitValues128(vector, packed);
                 return;
             }
         }
-        DefaultESVectorUtilSupport.transposeHalfByteImpl(q, quantQueryByte);
+        DefaultESVectorUtilSupport.stride4BitValuesImpl(vector, packed);
     }
 
-    private void transposeHalfByte256(int[] q, byte[] quantQueryByte) {
+    private void stride4BitValues256(int[] q, byte[] quantQueryByte) {
         final int limit = INT_SPECIES_256.loopBound(q.length);
         int i = 0;
         int index = 0;
@@ -2505,7 +2505,7 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
         quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
     }
 
-    private void transposeHalfByte128(int[] q, byte[] quantQueryByte) {
+    private void stride4BitValues128(int[] q, byte[] quantQueryByte) {
         final int limit = INT_SPECIES_128.loopBound(q.length) - INT_SPECIES_128.length();
         int i = 0;
         int index = 0;

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -787,7 +787,7 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         assertArrayEquals(new byte[] { 10, 20, 99 }, dst);
     }
 
-    public void testPackAsBinary() {
+    public void testPack1BitValues() {
         int dims = randomIntBetween(16, 2048);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -796,38 +796,38 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = BQVectorUtils.discretize(dims, 64) / 8;
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        defaultedProvider.getVectorUtilSupport().packAsBinary(toPack, packedLegacy);
-        panamaProvider.getVectorUtilSupport().packAsBinary(toPack, packed);
+        defaultedProvider.getVectorUtilSupport().pack1BitValues(toPack, packedLegacy);
+        panamaProvider.getVectorUtilSupport().pack1BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testPackAsBinaryCorrectness() {
+    public void testPack1BitValuesCorrectness() {
         // 5 bits
         int[] toPack = new int[] { 1, 1, 0, 0, 1 };
         byte[] packed = new byte[1];
-        ESVectorUtil.packAsBinary(toPack, packed);
+        ESVectorUtil.pack1BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001000 }, packed);
 
         // 8 bits
         toPack = new int[] { 1, 1, 0, 0, 1, 0, 1, 0 };
         packed = new byte[1];
-        ESVectorUtil.packAsBinary(toPack, packed);
+        ESVectorUtil.pack1BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001010 }, packed);
 
         // 10 bits
         toPack = new int[] { 1, 1, 0, 0, 1, 0, 1, 0, 1, 1 };
         packed = new byte[2];
-        ESVectorUtil.packAsBinary(toPack, packed);
+        ESVectorUtil.pack1BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001010, (byte) 0b11000000 }, packed);
 
         // 16 bits
         toPack = new int[] { 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0 };
         packed = new byte[2];
-        ESVectorUtil.packAsBinary(toPack, packed);
+        ESVectorUtil.pack1BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001010, (byte) 0b11100110 }, packed);
     }
 
-    public void testPackAsBinaryDuel() {
+    public void testPack1BitValuesDuel() {
         int dims = random().nextInt(16, 2049);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -836,12 +836,12 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = BQVectorUtils.discretize(dims, 64) / 8;
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        packAsBinaryLegacy(toPack, packedLegacy);
-        ESVectorUtil.packAsBinary(toPack, packed);
+        pack1BitValuesLegacy(toPack, packedLegacy);
+        ESVectorUtil.pack1BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testIntegerTransposeHalfByte() {
+    public void testStride4BitValuesDuel() {
         int dims = randomIntBetween(16, 2048);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -850,12 +850,12 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = 4 * BQVectorUtils.discretize(dims, 64) / 8;
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        transposeHalfByteLegacy(toPack, packedLegacy);
-        ESVectorUtil.transposeHalfByte(toPack, packed);
+        stride4BitValuesLegacy(toPack, packedLegacy);
+        ESVectorUtil.stride4BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testTransposeHalfByte() {
+    public void testStride4BitValues() {
         int dims = randomIntBetween(16, 2048);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -864,12 +864,12 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = 4 * BQVectorUtils.discretize(dims, 64) / 8;
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        defaultedProvider.getVectorUtilSupport().transposeHalfByte(toPack, packedLegacy);
-        panamaProvider.getVectorUtilSupport().transposeHalfByte(toPack, packed);
+        defaultedProvider.getVectorUtilSupport().stride4BitValues(toPack, packedLegacy);
+        panamaProvider.getVectorUtilSupport().stride4BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testPackAsDibit() {
+    public void testStride2BitValues() {
         int dims = randomIntBetween(16, 2048);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -878,12 +878,12 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = ES940DiskBBQVectorsFormat.QuantEncoding.TWO_BIT_4BIT_QUERY_STRIPED.getDocPackedLength(dims);
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        defaultedProvider.getVectorUtilSupport().packDibit(toPack, packedLegacy);
-        panamaProvider.getVectorUtilSupport().packDibit(toPack, packed);
+        defaultedProvider.getVectorUtilSupport().stride2BitValues(toPack, packedLegacy);
+        panamaProvider.getVectorUtilSupport().stride2BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testPackAsDibitPacked() {
+    public void testPack2BitValues() {
         int dims = randomIntBetween(16, 2048);
         int[] toPack = new int[dims];
         for (int i = 0; i < dims; i++) {
@@ -892,19 +892,19 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         int length = ES940DiskBBQVectorsFormat.QuantEncoding.TWO_BIT_4BIT_QUERY_PACKED.getDocPackedLength(dims);
         byte[] packed = new byte[length];
         byte[] packedLegacy = new byte[length];
-        defaultedProvider.getVectorUtilSupport().packDibitQuad(toPack, packedLegacy);
-        panamaProvider.getVectorUtilSupport().packDibitQuad(toPack, packed);
+        defaultedProvider.getVectorUtilSupport().pack2BitValues(toPack, packedLegacy);
+        panamaProvider.getVectorUtilSupport().pack2BitValues(toPack, packed);
         assertArrayEquals(packedLegacy, packed);
     }
 
-    public void testPackDibitCorrectness() {
+    public void testStride2BitValuesCorrectness() {
         // 5 bits
         // binary lower bits 1 1 0 0 1
         // binary upper bits 0 1 1 0 0
         // resulting dibit 1 3 2 0 1
         int[] toPack = new int[] { 1, 3, 2, 0, 1 };
         byte[] packed = new byte[2];
-        ESVectorUtil.packDibit(toPack, packed);
+        ESVectorUtil.stride2BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001000, (byte) 0b01100000 }, packed);
 
         // 8 bits
@@ -913,19 +913,19 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         // resulting dibit 1 3 2 0 1 2 1 2
         toPack = new int[] { 1, 3, 2, 0, 1, 2, 1, 2 };
         packed = new byte[2];
-        ESVectorUtil.packDibit(toPack, packed);
+        ESVectorUtil.stride2BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b11001010, (byte) 0b01100101 }, packed);
     }
 
-    public void testpackDibitQuadCorrectness() {
+    public void testPack2BitValuesCorrectness() {
         int[] toPack = new int[] { 1, 3, 2, 0, 1 };
         byte[] packed = new byte[2];
-        ESVectorUtil.packDibitQuad(toPack, packed);
+        ESVectorUtil.pack2BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b01111000, (byte) 0b01000000 }, packed);
 
         toPack = new int[] { 1, 3, 2, 0, 1, 2, 1, 2 };
         packed = new byte[2];
-        ESVectorUtil.packDibitQuad(toPack, packed);
+        ESVectorUtil.pack2BitValues(toPack, packed);
         assertArrayEquals(new byte[] { (byte) 0b01111000, (byte) 0b01100110 }, packed);
     }
 
@@ -1362,7 +1362,7 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         return -1;
     }
 
-    private static void packAsBinaryLegacy(int[] vector, byte[] packed) {
+    private static void pack1BitValuesLegacy(int[] vector, byte[] packed) {
         for (int i = 0; i < vector.length;) {
             byte result = 0;
             for (int j = 7; j >= 0 && i < vector.length; j--) {
@@ -1376,25 +1376,25 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         }
     }
 
-    private static void transposeHalfByteLegacy(int[] q, byte[] quantQueryByte) {
-        for (int i = 0; i < q.length;) {
-            assert q[i] >= 0 && q[i] <= 15;
+    private static void stride4BitValuesLegacy(int[] vector, byte[] packed) {
+        for (int i = 0; i < vector.length;) {
+            assert vector[i] >= 0 && vector[i] <= 15;
             int lowerByte = 0;
             int lowerMiddleByte = 0;
             int upperMiddleByte = 0;
             int upperByte = 0;
-            for (int j = 7; j >= 0 && i < q.length; j--) {
-                lowerByte |= (q[i] & 1) << j;
-                lowerMiddleByte |= ((q[i] >> 1) & 1) << j;
-                upperMiddleByte |= ((q[i] >> 2) & 1) << j;
-                upperByte |= ((q[i] >> 3) & 1) << j;
+            for (int j = 7; j >= 0 && i < vector.length; j--) {
+                lowerByte |= (vector[i] & 1) << j;
+                lowerMiddleByte |= ((vector[i] >> 1) & 1) << j;
+                upperMiddleByte |= ((vector[i] >> 2) & 1) << j;
+                upperByte |= ((vector[i] >> 3) & 1) << j;
                 i++;
             }
             int index = ((i + 7) / 8) - 1;
-            quantQueryByte[index] = (byte) lowerByte;
-            quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
-            quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
-            quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
+            packed[index] = (byte) lowerByte;
+            packed[index + packed.length / 4] = (byte) lowerMiddleByte;
+            packed[index + packed.length / 2] = (byte) upperMiddleByte;
+            packed[index + 3 * packed.length / 4] = (byte) upperByte;
         }
     }
 

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES91OSQVectorScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES91OSQVectorScorerTests.java
@@ -89,7 +89,7 @@ public class ES91OSQVectorScorerTests extends BaseVectorizationTests {
                         (byte) 1,
                         centroid
                     );
-                    ESVectorUtil.packAsBinary(scratch, qVector);
+                    ESVectorUtil.pack1BitValues(scratch, qVector);
                     out.writeBytes(qVector, 0, qVector.length);
                     out.writeInt(Float.floatToIntBits(result.lowerInterval()));
                     out.writeInt(Float.floatToIntBits(result.upperInterval()));
@@ -107,7 +107,7 @@ public class ES91OSQVectorScorerTests extends BaseVectorizationTests {
                 centroid
             );
             final byte[] quantizeQuery = new byte[4 * length];
-            ESVectorUtil.transposeHalfByte(scratch, quantizeQuery);
+            ESVectorUtil.stride4BitValues(scratch, quantizeQuery);
             final float centroidDp = VectorUtil.dotProduct(centroid, centroid);
             final float[] floatScratch = new float[3];
             try (IndexInput in = dir.openInput("testScore.bin", IOContext.DEFAULT)) {
@@ -188,7 +188,7 @@ public class ES91OSQVectorScorerTests extends BaseVectorizationTests {
                     for (int j = 0; j < bulkSize; j++) {
                         VectorScorerTestUtils.randomVector(random(), vectors[i + j], similarityFunction);
                         results[j] = quantizer.scalarQuantize(vectors[i + j], residualScratch, scratch, (byte) 1, centroid);
-                        ESVectorUtil.packAsBinary(scratch, qVector);
+                        ESVectorUtil.pack1BitValues(scratch, qVector);
                         out.writeBytes(qVector, 0, qVector.length);
                     }
                     writeCorrections(results, out);
@@ -204,7 +204,7 @@ public class ES91OSQVectorScorerTests extends BaseVectorizationTests {
                 centroid
             );
             final byte[] quantizeQuery = new byte[4 * length];
-            ESVectorUtil.transposeHalfByte(scratch, quantizeQuery);
+            ESVectorUtil.stride4BitValues(scratch, quantizeQuery);
             final float centroidDp = VectorUtil.dotProduct(centroid, centroid);
             final float[] scoresDefault = new float[bulkSize];
             final float[] scoresPanama = new float[bulkSize];

--- a/libs/simdvec/src/testFixtures/java/org/elasticsearch/simdvec/internal/vectorization/VectorScorerTestUtils.java
+++ b/libs/simdvec/src/testFixtures/java/org/elasticsearch/simdvec/internal/vectorization/VectorScorerTestUtils.java
@@ -84,7 +84,7 @@ public class VectorScorerTestUtils {
             centroid
         );
         // pack and store document bit vector
-        ESVectorUtil.packAsBinary(quantizationScratch, toIndex);
+        ESVectorUtil.pack1BitValues(quantizationScratch, toIndex);
 
         assert r.quantizedComponentSum() >= 0 && r.quantizedComponentSum() <= 0xffff;
 
@@ -113,7 +113,7 @@ public class VectorScorerTestUtils {
         );
 
         // pack and store the 4bit query vector
-        ESVectorUtil.transposeHalfByte(quantizationScratch, toQuery);
+        ESVectorUtil.stride4BitValues(quantizationScratch, toQuery);
         assert r.quantizedComponentSum() >= 0 && r.quantizedComponentSum() <= 0xffff;
 
         return new VectorData(toQuery, r.lowerInterval(), r.upperInterval(), r.additionalCorrection(), (short) r.quantizedComponentSum());
@@ -251,9 +251,9 @@ public class VectorScorerTestUtils {
         );
         final byte[] quantizeQuery = new byte[queryVectorPackedLengthInBytes];
         if (indexBits == 1 && queryBits == 1) {
-            ESVectorUtil.packAsBinary(scratch, quantizeQuery);
+            ESVectorUtil.pack1BitValues(scratch, quantizeQuery);
         } else if ((indexBits == 2 || indexBits == 4) && bitEncoding == ES940OSQVectorsScorer.BitEncoding.STRIPED) {
-            ESVectorUtil.transposeHalfByte(scratch, quantizeQuery);
+            ESVectorUtil.stride4BitValues(scratch, quantizeQuery);
         } else {
             ES940DiskBBQVectorsFormat.QuantEncoding.fromBits(indexBits).packQuery(scratch, quantizeQuery);
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
@@ -33,7 +33,7 @@ import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
 import static org.elasticsearch.index.codec.vectors.BQVectorUtils.discretize;
 import static org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer.DEFAULT_LAMBDA;
 import static org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat.BULK_SIZE;
-import static org.elasticsearch.simdvec.ESVectorUtil.transposeHalfByte;
+import static org.elasticsearch.simdvec.ESVectorUtil.stride4BitValues;
 
 /**
  * Default implementation of {@link IVFVectorsReader}. It scores the posting lists centroids using
@@ -421,7 +421,7 @@ public class ES920DiskBBQVectorsReader extends IVFVectorsReader<IVFVectorsReader
         void quantizeQueryIfNecessary() throws IOException {
             if (this.nextCentroidOrdinal != currentCentroidOrdinal) {
                 queryCorrections = quantizer.scalarQuantize(target, scratch, quantizationScratch, (byte) 4, currentCentroid);
-                transposeHalfByte(quantizationScratch, quantizedQuery);
+                stride4BitValues(quantizationScratch, quantizedQuery);
                 currentCentroidOrdinal = this.nextCentroidOrdinal;
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsWriter.java
@@ -253,7 +253,7 @@ public class ES920DiskBBQVectorsWriter extends IVFVectorsWriter<ES920DiskBBQVect
                     (byte) 1,
                     centroid
                 );
-                ESVectorUtil.packAsBinary(quantized, binary);
+                ESVectorUtil.pack1BitValues(quantized, binary);
                 writeQuantizedValue(quantizedVectorsTemp, binary, result);
 
                 var overspills = overspillAssignments.getAssignmentsFor(i);
@@ -266,7 +266,7 @@ public class ES920DiskBBQVectorsWriter extends IVFVectorsWriter<ES920DiskBBQVect
                         (byte) 1,
                         centroidSupplier.centroid(overspills.nextInt())
                     );
-                    ESVectorUtil.packAsBinary(quantized, binary);
+                    ESVectorUtil.pack1BitValues(quantized, binary);
                     writeQuantizedValue(quantizedVectorsTemp, binary, result);
                     assert !overspills.hasNext();
                 } else {
@@ -772,7 +772,7 @@ public class ES920DiskBBQVectorsWriter extends IVFVectorsWriter<ES920DiskBBQVect
             int ord = ordTransformer.apply(currOrd);
             float[] vector = vectorValues.vectorValue(ord);
             corrections = quantizer.scalarQuantize(vector, floatVectorScratch, quantizedVectorScratch, (byte) 1, currentCentroid);
-            ESVectorUtil.packAsBinary(quantizedVectorScratch, quantizedVector);
+            ESVectorUtil.pack1BitValues(quantizedVectorScratch, quantizedVector);
             return quantizedVector;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/QuantEncoding.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/QuantEncoding.java
@@ -15,23 +15,23 @@ public enum QuantEncoding {
     ONE_BIT_4BIT_QUERY(0, (byte) 1, (byte) 4) {
         @Override
         public void pack(int[] quantized, byte[] destination) {
-            ESVectorUtil.packAsBinary(quantized, destination);
+            ESVectorUtil.pack1BitValues(quantized, destination);
         }
 
         @Override
         public void packQuery(int[] quantized, byte[] destination) {
-            ESVectorUtil.transposeHalfByte(quantized, destination);
+            ESVectorUtil.stride4BitValues(quantized, destination);
         }
     },
     TWO_BIT_4BIT_QUERY(1, (byte) 2, (byte) 4) {
         @Override
         public void pack(int[] quantized, byte[] destination) {
-            ESVectorUtil.packDibitQuad(quantized, destination);
+            ESVectorUtil.pack2BitValues(quantized, destination);
         }
 
         @Override
         public void packQuery(int[] quantized, byte[] destination) {
-            packDibitQueryByStripe(quantized, destination);
+            stripe4Values(quantized, destination);
         }
 
         @Override
@@ -53,7 +53,7 @@ public enum QuantEncoding {
 
         @Override
         public void pack(int[] quantized, byte[] destination) {
-            packNibbles(quantized, destination);
+            pack4BitValues(quantized, destination);
         }
 
         @Override
@@ -102,16 +102,16 @@ public enum QuantEncoding {
     ONE_BIT_1BIT_QUERY(5, (byte) 1, (byte) 1) {
         @Override
         public void pack(int[] quantized, byte[] destination) {
-            ESVectorUtil.packAsBinary(quantized, destination);
+            ESVectorUtil.pack1BitValues(quantized, destination);
         }
 
         @Override
         public void packQuery(int[] quantized, byte[] destination) {
-            ESVectorUtil.packAsBinary(quantized, destination);
+            ESVectorUtil.pack1BitValues(quantized, destination);
         }
     };
 
-    private static void packNibbles(int[] quantized, byte[] destination) {
+    private static void pack4BitValues(int[] quantized, byte[] destination) {
         assert quantized.length == destination.length * 2;
         int packedLength = destination.length;
         for (int i = 0; i < packedLength; i++) {
@@ -119,7 +119,10 @@ public enum QuantEncoding {
         }
     }
 
-    private static void packDibitQueryByStripe(int[] quantized, byte[] destination) {
+    /**
+     * Moves 4 successive byte values into striped format - all the first bytes first, then all the second bytes, then third, then fourth
+     */
+    private static void stripe4Values(int[] quantized, byte[] destination) {
         assert quantized.length == destination.length;
         assert destination.length % 4 == 0;
         int packedLength = destination.length / 4;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/es94/ES940DiskBBQVectorsFormat.java
@@ -103,23 +103,23 @@ public class ES940DiskBBQVectorsFormat extends KnnVectorsFormat {
         ONE_BIT_4BIT_QUERY(0, (byte) 1, (byte) 4) {
             @Override
             public void pack(int[] quantized, byte[] destination) {
-                ESVectorUtil.packAsBinary(quantized, destination);
+                ESVectorUtil.pack1BitValues(quantized, destination);
             }
 
             @Override
             public void packQuery(int[] quantized, byte[] destination) {
-                ESVectorUtil.transposeHalfByte(quantized, destination);
+                ESVectorUtil.stride4BitValues(quantized, destination);
             }
         },
         TWO_BIT_4BIT_QUERY_STRIPED(1, (byte) 2, (byte) 4) {
             @Override
             public void pack(int[] quantized, byte[] destination) {
-                ESVectorUtil.packDibit(quantized, destination);
+                ESVectorUtil.stride2BitValues(quantized, destination);
             }
 
             @Override
             public void packQuery(int[] quantized, byte[] destination) {
-                ESVectorUtil.transposeHalfByte(quantized, destination);
+                ESVectorUtil.stride4BitValues(quantized, destination);
             }
 
             @Override
@@ -145,7 +145,7 @@ public class ES940DiskBBQVectorsFormat extends KnnVectorsFormat {
         TWO_BIT_4BIT_QUERY_PACKED(5, (byte) 2, (byte) 4) {
             @Override
             public void pack(int[] quantized, byte[] destination) {
-                ESVectorUtil.packDibitQuad(quantized, destination);
+                ESVectorUtil.pack2BitValues(quantized, destination);
             }
 
             @Override
@@ -167,12 +167,12 @@ public class ES940DiskBBQVectorsFormat extends KnnVectorsFormat {
         FOUR_BIT_SYMMETRIC_STRIPED(2, (byte) 4, (byte) 4) {
             @Override
             public void packQuery(int[] quantized, byte[] destination) {
-                ESVectorUtil.transposeHalfByte(quantized, destination);
+                ESVectorUtil.stride4BitValues(quantized, destination);
             }
 
             @Override
             public void pack(int[] quantized, byte[] destination) {
-                ESVectorUtil.transposeHalfByte(quantized, destination);
+                ESVectorUtil.stride4BitValues(quantized, destination);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es816/BinaryQuantizer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es816/BinaryQuantizer.java
@@ -226,7 +226,7 @@ public class BinaryQuantizer {
 
         // q¯ = Δ · q¯𝑢 + 𝑣𝑙 · 1𝐷
         // q¯ is an approximation of q′ (scalar quantized approximation)
-        ESVectorUtil.transposeHalfByte(byteQuery, queryDestination);
+        ESVectorUtil.stride4BitValues(byteQuery, queryDestination);
         QueryFactors factors = new QueryFactors(quantResult.quantizedSum, distToC, lower, width, normVmC, vDotC);
         final float[] indexCorrections;
         if (similarityFunction == EUCLIDEAN) {
@@ -367,7 +367,7 @@ public class BinaryQuantizer {
 
         // q¯ = Δ · q¯𝑢 + 𝑣𝑙 · 1𝐷
         // q¯ is an approximation of q′ (scalar quantized approximation)
-        ESVectorUtil.transposeHalfByte(byteQuery, destination);
+        ESVectorUtil.stride4BitValues(byteQuery, destination);
 
         QueryFactors factors;
         if (similarityFunction != EUCLIDEAN) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryFlatVectorsScorer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryFlatVectorsScorer.java
@@ -79,7 +79,7 @@ public class ES818BinaryFlatVectorsScorer implements FlatVectorsScorer {
                 (byte) 4,
                 centroid
             );
-            ESVectorUtil.transposeHalfByte(initial, quantized);
+            ESVectorUtil.stride4BitValues(initial, quantized);
             var scorer = ESVectorUtil.getES93BinaryQuantizedVectorScorer(
                 binarizedVectors.slice,
                 binarizedVectors.dimension(),

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
@@ -474,7 +474,7 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
             );
             docsWithField.add(docV);
             // pack and store the 4bit query vector
-            ESVectorUtil.transposeHalfByte(quantizationScratch, toQuery);
+            ESVectorUtil.stride4BitValues(quantizationScratch, toQuery);
             binarizedQueryData.writeBytes(toQuery, toQuery.length);
             binarizedQueryData.writeInt(Float.floatToIntBits(r.lowerInterval()));
             binarizedQueryData.writeInt(Float.floatToIntBits(r.upperInterval()));

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
@@ -202,7 +202,7 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
                 (byte) 1,
                 clusterCenter
             );
-            ESVectorUtil.packAsBinary(quantizationScratch, vector);
+            ESVectorUtil.pack1BitValues(quantizationScratch, vector);
             binarizedVectorData.writeBytes(vector, vector.length);
             binarizedVectorData.writeInt(Float.floatToIntBits(corrections.lowerInterval()));
             binarizedVectorData.writeInt(Float.floatToIntBits(corrections.upperInterval()));
@@ -252,7 +252,7 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
                 (byte) 1,
                 clusterCenter
             );
-            ESVectorUtil.packAsBinary(quantizationScratch, vector);
+            ESVectorUtil.pack1BitValues(quantizationScratch, vector);
             binarizedVectorData.writeBytes(vector, vector.length);
             binarizedVectorData.writeInt(Float.floatToIntBits(corrections.lowerInterval()));
             binarizedVectorData.writeInt(Float.floatToIntBits(corrections.upperInterval()));
@@ -614,7 +614,7 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
 
         private void binarize(int ord) throws IOException {
             corrections = quantizer.scalarQuantize(values.vectorValue(ord), scratch, initQuantized, (byte) 1, centroid);
-            ESVectorUtil.packAsBinary(initQuantized, binarized);
+            ESVectorUtil.pack1BitValues(initQuantized, binarized);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
@@ -216,7 +216,7 @@ public class ES818BinaryQuantizedVectorsFormatTests extends BaseFlatQuantizedKnn
                             (byte) 1,
                             centroid
                         );
-                        ESVectorUtil.packAsBinary(quantizedVector, expectedVector);
+                        ESVectorUtil.pack1BitValues(quantizedVector, expectedVector);
                         assertArrayEquals(expectedVector, qvectorValues.vectorValue(docIndexIterator.index()));
                         assertQuantizationResultEquals(corrections, qvectorValues.getCorrectiveTerms(docIndexIterator.index()));
                     }


### PR DESCRIPTION
Make the various names consistent in `ESVectorUtil`