### PR TITLE
Simplify columnar randomization in rolling upgrade tests (#156033)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -760,9 +760,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
   issue: https://github.com/elastic/elasticsearch/issues/155922
-- class: org.elasticsearch.xpack.logsdb.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/155958
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterStats}
   issue: https://github.com/elastic/elasticsearch/issues/156013

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -80,7 +80,11 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
     private static final ExternalResource columnarRandomizer = new ExternalResource() {
         @Override
         protected void before() {
-            columnarEnabled = randomizeColumnarIndexMode && randomBoolean();
+            String oldVersionProp = System.getProperty("tests.old_cluster_version");
+            columnarEnabled = randomizeColumnarIndexMode
+                && oldVersionProp != null
+                && Version.fromString(oldVersionProp).onOrAfter(Version.fromString("9.5.0"))
+                && randomBoolean();
         }
 
         @Override

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -26,12 +26,15 @@ public class Clusters {
      * Creates an old-version cluster whose {@code logsdb_columnar} index mode is controlled by
      * the {@code columnar} supplier. The supplier is evaluated lazily when the cluster starts, so
      * callers can resolve the value (e.g. via {@code randomBoolean()}) after this method returns.
-     * The setting is only applied when the old cluster version supports it
-     * (≥ 9.5.0); when the version predates that the supplier is never called.
+     * <p>
+     * The {@code logsdb_columnar} setting is only applied when the old cluster version already
+     * supports it (≥ 9.5.0). For older versions the supplier is ignored and the setting is not
+     * applied.
      */
     public static ElasticsearchCluster oldVersionCluster(String user, String pass, Supplier<Boolean> columnar) {
         var cluster = clusterBuilder(user, pass);
-        if (supportsColumnar(Version.fromString(System.getProperty("tests.old_cluster_version")))) {
+        String oldVersionProp = System.getProperty("tests.old_cluster_version");
+        if (oldVersionProp != null && Version.fromString(oldVersionProp).onOrAfter(Version.fromString("9.5.0"))) {
             cluster.setting("cluster.logsdb_columnar.enabled", () -> Boolean.toString(columnar.get()));
         }
         return cluster.build();
@@ -84,10 +87,6 @@ public class Clusters {
         }
 
         return cluster;
-    }
-
-    private static boolean supportsColumnar(Version version) {
-        return version.onOrAfter(Version.fromString("9.5.0"));
     }
 
     private static boolean supportRetryOnShardFailures(Version version) {


### PR DESCRIPTION
We were splitting the handling of randomization across test rules and cluster launching, which meant that tests could believe that columnar mode had been enabled when it was in fact disabled due to the older cluster not being able to support it.  This moves the version checking directly into the test rule.

Fixes #155958