### PR TITLE
[9.5] Filter scoped tests.rest.suite on explicit-paths yaml suites (#155864)

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Runs a suite of yaml tests shared with all the official Elasticsearch
@@ -252,10 +253,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths      list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(Map<String, Object> yamlParameters, String... testPaths) throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
-        return createParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, testPaths);
+        return createExplicitPathParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, testPaths);
     }
 
     /**
@@ -263,10 +261,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(String... testPaths) throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
-        return createParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), testPaths);
+        return createExplicitPathParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), testPaths);
     }
 
     /**
@@ -278,10 +273,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      */
     public static Iterable<Object[]> createParameters(NamedXContentRegistry executeableSectionRegistry, String... testPaths)
         throws Exception {
-        if (resolveRestTestsSuiteProperty() != null) {
-            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
-        }
-        return createParameters(executeableSectionRegistry, Map.of(), testPaths);
+        return createExplicitPathParameters(executeableSectionRegistry, Map.of(), testPaths);
     }
 
     /**
@@ -302,7 +294,15 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
             throw new IllegalArgumentException("testPaths cannot be null");
         }
 
-        Map<String, Set<Path>> yamlSuites = loadSuites(testPaths);
+        return buildParameters(executeableSectionRegistry, yamlParameters, loadSuites(testPaths));
+    }
+
+    /** Build the parameterized test candidates from an already-resolved set of yaml suites. */
+    private static Iterable<Object[]> buildParameters(
+        NamedXContentRegistry executeableSectionRegistry,
+        Map<String, ?> yamlParameters,
+        Map<String, Set<Path>> yamlSuites
+    ) throws Exception {
         List<ClientYamlTestSuite> suites = new ArrayList<>();
         IllegalArgumentException validationException = null;
         // yaml suites are grouped by directory (effectively by api)
@@ -344,6 +344,96 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         // sort the candidates so they will always be in the same order before being shuffled, for repeatability
         tests.sort(Comparator.comparing(o -> ((ClientYamlTestCandidate) o[0]).getTestPath()));
         return tests;
+    }
+
+    /**
+     * Entry point for the explicit-paths {@link #createParameters} overloads. Resolves the suite-selection
+     * system properties and builds the test candidates accordingly.
+     *
+     * When the per-task scoped {@code tests.rest.suite.<task path>} property is set, the suite's declared
+     * {@code testPaths} are intersected (at the resolved-file level) with the requested suites, so per-task
+     * tooling (e.g. the flakiness-detection re-run pipeline) can re-run just the changed subset; an empty
+     * intersection yields zero candidates. A bare, unscoped {@code tests.rest.suite} is unsupported on an
+     * explicit-paths suite and fails. When neither is set, the declared {@code testPaths} are run as-is.
+     *
+     * The property resolution is kept separate from {@link #explicitPathParameters} (which takes the
+     * resolved values as arguments) only so the behaviour above can be unit-tested without mutating
+     * global state.
+     */
+    private static Iterable<Object[]> createExplicitPathParameters(
+        NamedXContentRegistry executeableSectionRegistry,
+        Map<String, ?> yamlParameters,
+        String... testPaths
+    ) throws Exception {
+        String task = System.getProperty("tests.task");
+        String scoped = task == null ? null : System.getProperty(REST_TESTS_SUITE + "." + task);
+        String global = System.getProperty(REST_TESTS_SUITE);
+        return explicitPathParameters(executeableSectionRegistry, yamlParameters, scoped, global, testPaths);
+    }
+
+    /**
+     * Builds the candidates for an explicit-paths suite from already-resolved suite-selection values.
+     *
+     * @param scoped the value of the per-task scoped {@code tests.rest.suite.<task>} property, or {@code null}
+     * @param global the value of the bare {@code tests.rest.suite} property, or {@code null}
+     */
+    // pkg private for tests
+    static Iterable<Object[]> explicitPathParameters(
+        NamedXContentRegistry executeableSectionRegistry,
+        Map<String, ?> yamlParameters,
+        String scoped,
+        String global,
+        String... testPaths
+    ) throws Exception {
+        if (testPaths == null) {
+            throw new IllegalArgumentException("testPaths cannot be null");
+        }
+        String[] filter = explicitPathsSuiteFilter(scoped, global);
+        Map<String, Set<Path>> yamlSuites = loadSuites(testPaths);
+        if (filter.length > 0) {
+            yamlSuites = intersectSuites(yamlSuites, loadSuites(filter));
+        }
+        return buildParameters(executeableSectionRegistry, yamlParameters, yamlSuites);
+    }
+
+    /**
+     * The requested suite paths to intersect an explicit-paths suite's declared paths with, or an empty
+     * array when no scoping applies (run the declared paths as-is).
+     *
+     * The per-task scoped {@code tests.rest.suite.<task>} is honored (returned, split on
+     * {@link #PATHS_SEPARATOR}): it is set by tooling that deliberately targets this one task.
+     *
+     * A bare, unscoped {@code tests.rest.suite} is instead rejected with an exception. This is a
+     * deliberate policy choice, not a technical limit - it could be intersected too. But the bare form is
+     * the JVM-wide / CLI knob, and an explicit-paths suite builds its list from code, not the property; so
+     * honoring it here would either be a silent no-op (the value is dropped) or silently narrow the suite
+     * to nothing. Failing loudly forces the caller to use the scoped form (or not set it) instead.
+     */
+    private static String[] explicitPathsSuiteFilter(String scopedValue, String globalValue) {
+        if (scopedValue != null) {
+            return scopedValue.split(PATHS_SEPARATOR);
+        }
+        if (globalValue != null) {
+            throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
+        }
+        return Strings.EMPTY_ARRAY;
+    }
+
+    /**
+     * Intersects two resolved suite maps at the file level: keeps each {@code requested} file that is also
+     * {@code declared}. Because both sides are first resolved by {@link #loadSuites}, directory-vs-file
+     * granularity is handled naturally - a requested {@code painless/10_basic} narrows a declared
+     * {@code painless} down to that one file, and a requested {@code painless} directory keeps only the
+     * declared files under it. An empty result (the requested suite is not among the declared paths)
+     * yields zero test candidates.
+     */
+    private static Map<String, Set<Path>> intersectSuites(Map<String, Set<Path>> declared, Map<String, Set<Path>> requested) {
+        Set<Path> declaredFiles = declared.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
+        return requested.entrySet()
+            .stream()
+            .map(e -> Map.entry(e.getKey(), e.getValue().stream().filter(declaredFiles::contains).collect(Collectors.toSet())))
+            .filter(e -> e.getValue().isEmpty() == false)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
     /** Find all yaml suites that match the given list of paths from the root test path. */

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
@@ -9,15 +9,20 @@
 package org.elasticsearch.test.rest.yaml;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class ESClientYamlSuiteTestCaseTests extends ESTestCase {
@@ -170,6 +175,81 @@ public class ESClientYamlSuiteTestCaseTests extends ESTestCase {
         // then: the typo-guard assertion fires and names both the missing path and the roots searched
         assertThat(error.getMessage(), containsString("missing/never_exists"));
         assertThat(error.getMessage(), containsString("does not exist in any YAML test root"));
+    }
+
+    /**
+     * When the per-task scoped {@code tests.rest.suite.<task>} value names a single file, an explicit-paths
+     * suite that declares the whole directory is narrowed to just that file's test candidates - exercising
+     * the file-level intersection end-to-end (filter, load, intersect, build).
+     */
+    public void testScopedSuiteNarrowsDeclaredDirectoryToRequestedFile() throws Exception {
+        List<ClientYamlTestCandidate> candidates = explicitPathCandidates("suite1/10_basic", null, "suite1");
+        assertThat(suitePaths(candidates), equalTo(Set.of("suite1/10_basic")));
+    }
+
+    /** A scoped group that the explicit-paths suite does not declare is dropped; declared groups survive. */
+    public void testScopedSuiteDropsGroupNotDeclared() throws Exception {
+        List<ClientYamlTestCandidate> candidates = explicitPathCandidates("suite1,suite2", null, "suite1");
+        assertThat(apis(candidates), equalTo(Set.of("suite1")));
+    }
+
+    /** When the scoped request names a suite the declared paths do not include, nothing runs. */
+    public void testScopedSuiteRequestingUndeclaredSuiteRunsNothing() throws Exception {
+        List<ClientYamlTestCandidate> candidates = explicitPathCandidates("suite2", null, "suite1");
+        assertThat(candidates, empty());
+    }
+
+    /** The scoped value takes precedence over a bare global {@code tests.rest.suite} value. */
+    public void testScopedSuiteTakesPrecedenceOverGlobal() throws Exception {
+        List<ClientYamlTestCandidate> candidates = explicitPathCandidates("suite1", "suite2", "suite1", "suite2");
+        assertThat(apis(candidates), equalTo(Set.of("suite1")));
+    }
+
+    /**
+     * A bare, unscoped {@code tests.rest.suite} value on an explicit-paths suite is a hard error - the
+     * requested value would otherwise be silently dropped.
+     */
+    public void testBareGlobalSuiteRejectedForExplicitPaths() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ESClientYamlSuiteTestCase.explicitPathParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), null, "suite1", "suite1")
+        );
+        assertThat(e.getMessage(), containsString("not supported with explicit test paths"));
+    }
+
+    /** With no suite selection set, an explicit-paths suite runs its full declared set. */
+    public void testNoSuiteRunsFullDeclaredSet() throws Exception {
+        List<ClientYamlTestCandidate> candidates = explicitPathCandidates(null, null, "suite1", "suite2");
+        assertThat(apis(candidates), equalTo(Set.of("suite1", "suite2")));
+    }
+
+    /**
+     * Resolves the candidates for an explicit-paths suite from explicit suite-selection values, bypassing
+     * the {@code System.getProperty} reads so no global state is mutated. {@code scoped} is the per-task
+     * {@code tests.rest.suite.<task>} value and {@code global} the bare {@code tests.rest.suite} value;
+     * either may be {@code null}.
+     */
+    private static List<ClientYamlTestCandidate> explicitPathCandidates(String scoped, String global, String... testPaths)
+        throws Exception {
+        return collectCandidates(
+            ESClientYamlSuiteTestCase.explicitPathParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), scoped, global, testPaths)
+        );
+    }
+
+    private static List<ClientYamlTestCandidate> collectCandidates(Iterable<Object[]> parameters) {
+        List<ClientYamlTestCandidate> candidates = new ArrayList<>();
+        for (Object[] parameter : parameters) {
+            candidates.add((ClientYamlTestCandidate) parameter[0]);
+        }
+        return candidates;
+    }
+
+    private static Set<String> apis(List<ClientYamlTestCandidate> candidates) {
+        return candidates.stream().map(ClientYamlTestCandidate::getApi).collect(Collectors.toSet());
+    }
+
+    private static Set<String> suitePaths(List<ClientYamlTestCandidate> candidates) {
+        return candidates.stream().map(ClientYamlTestCandidate::getSuitePath).collect(Collectors.toSet());
     }
 
     private static void assertSingleFile(Map<String, Set<Path>> yamlSuites, String dirName, String fileName) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Filter scoped tests.rest.suite on explicit-paths yaml suites (#155864)