### PR TITLE
[9.5] Migrate ccs-rolling-upgrade to JUnit clusters (#156092)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -42,7 +42,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:multi-node-tests");
 
         // Projects that apply LegacyRestTestBasePlugin transitively via the standalone-rest-test plugin.
-        map.put(LegacyRestTestBasePlugin.class, ":qa:ccs-rolling-upgrade-remote-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":qa:mixed-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":qa:rolling-upgrade-legacy");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:rolling-upgrade");

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -7,83 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
-apply plugin: 'elasticsearch.rest-resources'
+
+// Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
+// so a phase that passed must still run when a later phase is retried.
+smartRetry.pruneIndividualTests = false
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
-
-  /**
-   * We execute tests 3 times.
-   * - The local cluster is unchanged and it consists of an old version node and a new version node.
-   * - Nodes in the remote cluster are upgraded one by one in three steps.
-   * - Only node-0 and node-2 of the remote cluster can accept remote connections. This can creates a test
-   *   scenario where a query request and fetch request are sent via **proxy nodes** that have different version.
-   */
-  def localCluster = testClusters.register("${baseName}-local") {
-    numberOfNodes = 2
-    versions = [bwcVersion.toString(), project.version]
-    setting 'cluster.remote.node.attr', 'gateway'
-    setting 'xpack.security.enabled', 'false'
-  }
-  def remoteCluster = testClusters.register("${baseName}-remote") {
-    numberOfNodes = 3
-    versions = [bwcVersion.toString(), project.version]
-    firstNode.setting 'node.attr.gateway', 'true'
-    lastNode.setting 'node.attr.gateway', 'true'
-    setting 'xpack.security.enabled', 'false'
-  }
-
-
-  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
-    useCluster localCluster
-    useCluster remoteCluster
-    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(localCluster.name).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.rest.remote_cluster', getClusterInfo(remoteCluster.name).map { it.allHttpSocketURI.join(",") })
-
-    def fipsDisabled = buildParams.inFipsJvm == false
-    onlyIf("FIPS mode disabled") { fipsDisabled }
-  }
-
-  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
-    dependsOn "processTestResources"
-    mustRunAfter("precommit")
-    doFirst {
-      def cluster = localCluster.get()
-      cluster.nodes.forEach { node ->
-        node.getAllTransportPortURI()
-      }
-      getRegistry().get().nextNodeToNextVersion(cluster)
-    }
-  }
-
-  tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#oldClusterTest"
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(remoteCluster)
-    }
-  }
-
-  tasks.register("${baseName}#twoThirdUpgraded", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#oneThirdUpgraded"
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(remoteCluster)
-    }
-  }
-
-  tasks.register("${baseName}#fullUpgraded", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#twoThirdUpgraded"
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(remoteCluster)
-    }
-  }
-
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn tasks.named("${baseName}#fullUpgraded")
+  tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.upgrade_from_version", bwcVersion.toString().replace('-SNAPSHOT', ''))
+    buildParams.withFipsEnabledOnly(it)
   }
 }

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractCcsRollingUpgradeTestCase.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractCcsRollingUpgradeTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.upgrades;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Base class for the CCS rolling-upgrade suites in this project.
+ * <p>
+ * The local (querying) cluster consists of 2 nodes, one on the old version and one on the current version, and is
+ * never upgraded during the suite. The remote cluster consists of 3 nodes, all initially on the old version, and is
+ * rolled forward one node at a time across upgrade phases. Only node-0 and node-2 of the remote cluster have the
+ * {@code gateway} node attribute and can accept remote connections; this creates a scenario where a query request
+ * and its fetch requests can be routed through proxy nodes running different versions.
+ * <p>
+ * Each suite is run once per upgrade phase, from a fully old remote cluster through to a fully upgraded one, so a
+ * project hosting such a suite must opt out of smart retry's individual test pruning in its {@code build.gradle}:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
+ */
+public abstract class AbstractCcsRollingUpgradeTestCase extends ESRestTestCase {
+
+    protected static final int REMOTE_NODE_NUM = 3;
+
+    private static final String OLD_CLUSTER_VERSION = System.getProperty("tests.upgrade_from_version");
+    private static final Set<Integer> upgradedRemoteNodes = new HashSet<>();
+
+    private static final ElasticsearchCluster remoteCluster = ElasticsearchCluster.local()
+        .name("remote")
+        // Nodes here start on a prior Elasticsearch version, which requires the default distribution type.
+        .distribution(DistributionType.DEFAULT)
+        .version(OLD_CLUSTER_VERSION, isOldClusterDetachedVersion())
+        .nodes(REMOTE_NODE_NUM)
+        .setting("xpack.security.enabled", "false")
+        .node(0, spec -> spec.setting("node.attr.gateway", "true"))
+        .node(REMOTE_NODE_NUM - 1, spec -> spec.setting("node.attr.gateway", "true"))
+        .build();
+
+    private static final ElasticsearchCluster localCluster = ElasticsearchCluster.local()
+        .name("local")
+        // Node 0 starts on a prior Elasticsearch version, which requires the default distribution type.
+        .distribution(DistributionType.DEFAULT)
+        .nodes(2)
+        .setting("cluster.remote.node.attr", "gateway")
+        .setting("xpack.security.enabled", "false")
+        .node(0, spec -> spec.version(OLD_CLUSTER_VERSION, isOldClusterDetachedVersion()))
+        .build();
+
+    @ClassRule
+    public static TestRule clusterRule = RuleChain.outerRule(remoteCluster).around(localCluster);
+
+    private final int requestedUpgradedNodes;
+
+    protected AbstractCcsRollingUpgradeTestCase(@Name("upgradedNodes") int upgradedNodes) {
+        this.requestedUpgradedNodes = upgradedNodes;
+    }
+
+    @ParametersFactory(shuffle = false)
+    public static Iterable<Object[]> parameters() {
+        return IntStream.rangeClosed(0, REMOTE_NODE_NUM).boxed().map(n -> new Object[] { n }).toList();
+    }
+
+    @Before
+    public void upgradeRemoteNode() {
+        if (upgradedRemoteNodes.size() < requestedUpgradedNodes) {
+            for (int n = 0; n < requestedUpgradedNodes; n++) {
+                if (upgradedRemoteNodes.add(n)) {
+                    logger.info("Upgrading remote node {} to version {}", n, Version.CURRENT);
+                    remoteCluster.upgradeNodeToVersion(n, Version.CURRENT);
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    public static void resetUpgradedNodes() {
+        upgradedRemoteNodes.clear();
+    }
+
+    protected static String getOldClusterVersion() {
+        return OLD_CLUSTER_VERSION;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return localCluster.getHttpAddresses();
+    }
+
+    protected static String getRemoteClusterRestAddresses() {
+        return remoteCluster.getHttpAddresses();
+    }
+
+    @Override
+    protected final boolean preserveClusterUponCompletion() {
+        return true;
+    }
+}

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/AggregationsIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/AggregationsIT.java
@@ -9,14 +9,14 @@
 
 package org.elasticsearch.upgrades;
 
-import org.apache.http.HttpHost;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.junit.After;
 import org.junit.Before;
@@ -30,14 +30,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
-
 /**
  * This test ensure that we keep the search states of a CCS request correctly when the local and remote clusters
  * have different but compatible versions. See SearchService#createAndPutReaderContext
  */
-public class AggregationsIT extends ESRestTestCase {
+public class AggregationsIT extends AbstractCcsRollingUpgradeTestCase {
 
     private static final String CLUSTER_ALIAS = "remote_cluster";
     private static final String localIndex = "test_bwc_index";
@@ -45,9 +42,8 @@ public class AggregationsIT extends ESRestTestCase {
     private static final String queryIndices = URLEncoder.encode(localIndex + ",remote_cluster:" + remoteIndex, StandardCharsets.UTF_8);
     private static int docs;
 
-    @Override
-    protected boolean preserveClusterUponCompletion() {
-        return true;
+    public AggregationsIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
     }
 
     static List<SearchStatesIT.Node> getNodes(RestClient restClient) throws IOException {
@@ -66,30 +62,12 @@ public class AggregationsIT extends ESRestTestCase {
         return nodes;
     }
 
-    static List<HttpHost> parseHosts(String props) {
-        final String address = System.getProperty(props);
-        assertNotNull("[" + props + "] is not configured", address);
-        String[] stringUrls = address.split(",");
-        List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
-        for (String stringUrl : stringUrls) {
-            int portSeparator = stringUrl.lastIndexOf(':');
-            if (portSeparator < 0) {
-                throw new IllegalArgumentException("Illegal cluster url [" + stringUrl + "]");
-            }
-            String host = stringUrl.substring(0, portSeparator);
-            int port = Integer.parseInt(stringUrl.substring(portSeparator + 1));
-            hosts.add(new HttpHost(host, port, "http"));
-        }
-        assertThat("[" + props + "] is empty", hosts, not(empty()));
-        return hosts;
+    RestClient newLocalClient() {
+        return RestClient.builder(randomFrom(SearchStatesIT.parseHosts(getTestRestCluster()))).build();
     }
 
-    static RestClient newLocalClient() {
-        return RestClient.builder(randomFrom(parseHosts("tests.rest.cluster"))).build();
-    }
-
-    static RestClient newRemoteClient() {
-        return RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build();
+    RestClient newRemoteClient() {
+        return RestClient.builder(randomFrom(SearchStatesIT.parseHosts(getRemoteClusterRestAddresses()))).build();
     }
 
     @Before

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/javaRestTest/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.HttpHost;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,7 +24,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -44,11 +45,15 @@ import static org.hamcrest.Matchers.not;
  * This test ensure that we keep the search states of a CCS request correctly when the local and remote clusters
  * have different but compatible versions. See SearchService#createAndPutReaderContext
  */
-public class SearchStatesIT extends ESRestTestCase {
+public class SearchStatesIT extends AbstractCcsRollingUpgradeTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(SearchStatesIT.class);
-    private static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
+    private static final Version UPGRADE_FROM_VERSION = Version.fromString(getOldClusterVersion());
     private static final String CLUSTER_ALIAS = "remote_cluster";
+
+    public SearchStatesIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
 
     record Node(String id, String name, Version version, String transportAddress, String httpAddress, Map<String, Object> attributes) {}
 
@@ -68,10 +73,9 @@ public class SearchStatesIT extends ESRestTestCase {
         return nodes;
     }
 
-    static List<HttpHost> parseHosts(String props) {
-        final String address = System.getProperty(props);
-        assertNotNull("[" + props + "] is not configured", address);
-        String[] stringUrls = address.split(",");
+    static List<HttpHost> parseHosts(String addresses) {
+        assertNotNull("cluster addresses must not be null", addresses);
+        String[] stringUrls = addresses.split(",");
         List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
         for (String stringUrl : stringUrls) {
             int portSeparator = stringUrl.lastIndexOf(':');
@@ -82,11 +86,11 @@ public class SearchStatesIT extends ESRestTestCase {
             int port = Integer.parseInt(stringUrl.substring(portSeparator + 1));
             hosts.add(new HttpHost(host, port, "http"));
         }
-        assertThat("[" + props + "] is empty", hosts, not(empty()));
+        assertThat("cluster addresses [" + addresses + "] are empty", hosts, not(empty()));
         return hosts;
     }
 
-    public static void configureRemoteClusters(List<Node> remoteNodes) throws Exception {
+    public void configureRemoteClusters(List<Node> remoteNodes) throws Exception {
         assertThat(remoteNodes, hasSize(3));
         final String remoteClusterSettingPrefix = "cluster.remote." + CLUSTER_ALIAS + ".";
         try (RestClient localClient = newLocalClient()) {
@@ -123,15 +127,15 @@ public class SearchStatesIT extends ESRestTestCase {
         }
     }
 
-    static RestClient newLocalClient() {
-        final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
+    RestClient newLocalClient() {
+        final List<HttpHost> hosts = parseHosts(getTestRestCluster());
         final int index = random().nextInt(hosts.size());
         LOGGER.info("Using client node {}", index);
         return RestClient.builder(hosts.get(index)).build();
     }
 
-    static RestClient newRemoteClient() {
-        return RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build();
+    RestClient newRemoteClient() {
+        return RestClient.builder(randomFrom(parseHosts(getRemoteClusterRestAddresses()))).build();
     }
 
     static int indexDocs(RestClient client, String index, int numDocs) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Migrate ccs-rolling-upgrade to JUnit clusters (#156092)