### PR TITLE
[9.5] Avoid unsafe cluster state read in BatchedRerouteService - unmute test (#156156)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -665,140 +665,26 @@ tests:
   method: testConcurrentSnapshotDeleteAndDeleteIndex
   issue: https://github.com/elastic/elasticsearch/issues/154784
 - class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:change_point.values null column}
-  issue: https://github.com/elastic/elasticsearch/issues/154877
-- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
-  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingNarrowsShouldReturnTrue
-  issue: https://github.com/elastic/elasticsearch/issues/154908
-- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
-  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingOmittedShouldReturnFalse
-  issue: https://github.com/elastic/elasticsearch/issues/154909
-- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
-  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingUnchangedShouldReturnFalse
-  issue: https://github.com/elastic/elasticsearch/issues/154910
-- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
-  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingWidensShouldReturnTrue
-  issue: https://github.com/elastic/elasticsearch/issues/154911
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
-  method: test {csv-spec:change_point.not enough buckets per group}
-  issue: https://github.com/elastic/elasticsearch/issues/154932
-- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
-  method: falls back to local gradle build when DRA manifest returns 404
-  issue: https://github.com/elastic/elasticsearch/issues/154979
-- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
-  method: builds distribution from branches via archives extractedAssemble
-  issue: https://github.com/elastic/elasticsearch/issues/154980
-- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
-  method: supports linux aarch distributions
-  issue: https://github.com/elastic/elasticsearch/issues/154982
-- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
-  method: falls back to local build when mode=auto and DRA manifest commit does not match remote tracking ref
-  issue: https://github.com/elastic/elasticsearch/issues/154983
-- class: org.elasticsearch.gradle.internal.precommit.ForbiddenApisPrecommitPluginFuncTest
-  method: selects launcher when minimum runtime differs from current jvm
-  issue: https://github.com/elastic/elasticsearch/issues/154984
-- class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
-  method: testSnapshotUpgrader
-  issue: https://github.com/elastic/elasticsearch/issues/154988
-- class: org.elasticsearch.foreign.DefaultMethodHandleResolverTests
-  method: testDefaultResolverBuildsWorkingMethodHandle
-  issue: https://github.com/elastic/elasticsearch/issues/155012
-- class: org.elasticsearch.xpack.transform.integration.TransformDestIndexIT
-  method: testUnattendedTransformDestIndexCreatedDuringUpdate_EmptySourceIndex_NoDeferValidation
-  issue: https://github.com/elastic/elasticsearch/issues/152599
-- class: org.elasticsearch.compute.operator.topn.GroupedTopNOperatorTests
-  method: testRandomMultipleColumns
-  issue: https://github.com/elastic/elasticsearch/issues/155019
-- class: org.elasticsearch.compute.aggregation.BulkArrowAggregationTests
-  method: testSumIntOverArrowBufferMasked
-  issue: https://github.com/elastic/elasticsearch/issues/153586
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
-  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/153434
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
-  method: test {csv-spec:change_point.values int column with all nulls}
-  issue: https://github.com/elastic/elasticsearch/issues/153656
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/155173
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
-  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/155155
-- class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
-  method: testContinuousEvents
-  issue: https://github.com/elastic/elasticsearch/issues/153782
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceTests
-  method: testPopulateCacheWithSharedSourceInputStreamFactory
-  issue: https://github.com/elastic/elasticsearch/issues/154597
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testPitRelocationDuringReshard
-  issue: https://github.com/elastic/elasticsearch/issues/155284
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
-  method: test {csv-spec:change_point.values int column with all nulls}
-  issue: https://github.com/elastic/elasticsearch/issues/155124
-- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-  method: testFeatureImportanceValues
-  issue: https://github.com/elastic/elasticsearch/issues/155327
-- class: org.elasticsearch.index.reindex.BulkByPaginatedSearchResponseWireSerializingTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/155457
+  method: test {csv-spec:unmapped-load.loadViewWithSubqueryBody_EvalNonExistent}
+  issue: https://github.com/elastic/elasticsearch/issues/154921
+- class: org.elasticsearch.compute.operator.topn.ParallelTopNOperatorTests
+  method: testConcurrentReleaseOfSharedDictionaryThroughRealOperator
+  issue: https://github.com/elastic/elasticsearch/issues/155014
 - class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:ip.conditional}
-  issue: https://github.com/elastic/elasticsearch/issues/155566
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample cartesian_point}
-  issue: https://github.com/elastic/elasticsearch/issues/155625
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample geo_point}
-  issue: https://github.com/elastic/elasticsearch/issues/155626
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testPutDatasetAllowedWithCreateDatasetPrivilege
-  issue: https://github.com/elastic/elasticsearch/issues/155671
-- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
-  method: testEnrich
-  issue: https://github.com/elastic/elasticsearch/issues/155672
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/155532
-- class: org.elasticsearch.packaging.test.PackageTests
-  method: test70RestartServer
-  issue: https://github.com/elastic/elasticsearch/issues/155704
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testPutDataSourceForbiddenWithoutManagePrivilege
-  issue: https://github.com/elastic/elasticsearch/issues/155705
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:mv_union.testMvUnionNullReturnedWhenFirstArgIsNull}
-  issue: https://github.com/elastic/elasticsearch/issues/155707
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldSourceOnlyRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/155541
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample geo_point}
-  issue: https://github.com/elastic/elasticsearch/pull/155536
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample cartesian_point}
-  issue: https://github.com/elastic/elasticsearch/pull/155536
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample geo_point}
-  issue: https://github.com/elastic/elasticsearch/pull/155536
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
-  method: test {csv-spec:stats_sample.sample cartesian_point}
-  issue: https://github.com/elastic/elasticsearch/pull/155536
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
-  method: testLongLivedPitRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/155740
-- class: org.elasticsearch.xpack.stateless.StatelessComponentsOrderIT
-  method: testClosingNodeShouldWaitForOngoingMerge
-  issue: https://github.com/elastic/elasticsearch/issues/155780
-- class: org.elasticsearch.gateway.GatewayServiceIT
-  method: testSettingsAppliedBeforeReroute
-  issue: https://github.com/elastic/elasticsearch/issues/155802
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
-  issue: https://github.com/elastic/elasticsearch/issues/155922
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:inlinestats.afterStats}
-  issue: https://github.com/elastic/elasticsearch/issues/156013
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/172_knn_query_base64_vectors/kNN query with base64 float vector}
-  issue: https://github.com/elastic/elasticsearch/issues/156137
+  method: test {csv-spec:spatial.centroidFromAirportsFilteredCountry}
+  issue: https://github.com/elastic/elasticsearch/issues/155030
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
+  method: testNoBothIncludeCcsMetadataAndIncludeExecutionMetadata
+  issue: https://github.com/elastic/elasticsearch/issues/155123
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
+  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/154157
+- class: org.elasticsearch.xpack.esql.action.CrossClusterLookupJoinFailuresIT
+  method: testLookupDisconnect
+  issue: https://github.com/elastic/elasticsearch/issues/155185
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
+  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
+  issue: https://github.com/elastic/elasticsearch/issues/153902
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
+  method: test {csv-spec:approximation.Rename stats group key}
+  issue: https://github.com/elastic/elasticsearch/issues/155194

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -665,29 +665,65 @@ tests:
   method: testConcurrentSnapshotDeleteAndDeleteIndex
   issue: https://github.com/elastic/elasticsearch/issues/154784
 - class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:unmapped-load.loadViewWithSubqueryBody_EvalNonExistent}
-  issue: https://github.com/elastic/elasticsearch/issues/154921
-- class: org.elasticsearch.compute.operator.topn.ParallelTopNOperatorTests
-  method: testConcurrentReleaseOfSharedDictionaryThroughRealOperator
-  issue: https://github.com/elastic/elasticsearch/issues/155014
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:spatial.centroidFromAirportsFilteredCountry}
-  issue: https://github.com/elastic/elasticsearch/issues/155030
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryIT
-  method: testNoBothIncludeCcsMetadataAndIncludeExecutionMetadata
-  issue: https://github.com/elastic/elasticsearch/issues/155123
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
-  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/154157
-- class: org.elasticsearch.xpack.esql.action.CrossClusterLookupJoinFailuresIT
-  method: testLookupDisconnect
-  issue: https://github.com/elastic/elasticsearch/issues/155185
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFuseIT
-  method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueScoreColumn}
-  issue: https://github.com/elastic/elasticsearch/issues/153902
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
-  method: test {csv-spec:approximation.Rename stats group key}
-  issue: https://github.com/elastic/elasticsearch/issues/155194
+  method: test {csv-spec:change_point.values null column}
+  issue: https://github.com/elastic/elasticsearch/issues/154877
+- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
+  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingNarrowsShouldReturnTrue
+  issue: https://github.com/elastic/elasticsearch/issues/154908
+- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
+  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingOmittedShouldReturnFalse
+  issue: https://github.com/elastic/elasticsearch/issues/154909
+- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
+  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingUnchangedShouldReturnFalse
+  issue: https://github.com/elastic/elasticsearch/issues/154910
+- class: org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests
+  method: testIsUserInitiatedProjectRoutingChangeWhenRoutingWidensShouldReturnTrue
+  issue: https://github.com/elastic/elasticsearch/issues/154911
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
+  method: test {csv-spec:change_point.not enough buckets per group}
+  issue: https://github.com/elastic/elasticsearch/issues/154932
+- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
+  method: falls back to local gradle build when DRA manifest returns 404
+  issue: https://github.com/elastic/elasticsearch/issues/154979
+- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
+  method: builds distribution from branches via archives extractedAssemble
+  issue: https://github.com/elastic/elasticsearch/issues/154980
+- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
+  method: supports linux aarch distributions
+  issue: https://github.com/elastic/elasticsearch/issues/154982
+- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
+  method: falls back to local build when mode=auto and DRA manifest commit does not match remote tracking ref
+  issue: https://github.com/elastic/elasticsearch/issues/154983
+- class: org.elasticsearch.gradle.internal.precommit.ForbiddenApisPrecommitPluginFuncTest
+  method: selects launcher when minimum runtime differs from current jvm
+  issue: https://github.com/elastic/elasticsearch/issues/154984
+- class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
+  method: testSnapshotUpgrader
+  issue: https://github.com/elastic/elasticsearch/issues/154988
+- class: org.elasticsearch.foreign.DefaultMethodHandleResolverTests
+  method: testDefaultResolverBuildsWorkingMethodHandle
+  issue: https://github.com/elastic/elasticsearch/issues/155012
+- class: org.elasticsearch.xpack.transform.integration.TransformDestIndexIT
+  method: testUnattendedTransformDestIndexCreatedDuringUpdate_EmptySourceIndex_NoDeferValidation
+  issue: https://github.com/elastic/elasticsearch/issues/152599
+- class: org.elasticsearch.compute.operator.topn.GroupedTopNOperatorTests
+  method: testRandomMultipleColumns
+  issue: https://github.com/elastic/elasticsearch/issues/155019
+- class: org.elasticsearch.compute.aggregation.BulkArrowAggregationTests
+  method: testSumIntOverArrowBufferMasked
+  issue: https://github.com/elastic/elasticsearch/issues/153586
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsIT
+  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
+  issue: https://github.com/elastic/elasticsearch/issues/153434
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
+  method: test {csv-spec:change_point.values int column with all nulls}
+  issue: https://github.com/elastic/elasticsearch/issues/153656
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testClusterDetailsAfterCCSWithFailuresOnOneClusterOnly_AllowPartialResultsFalse_MinimizeRoundtripsFalse
+  issue: https://github.com/elastic/elasticsearch/issues/155173
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsIT
+  method: test {csv-spec:stats.sumWithOverflowGroupingRow}
+  issue: https://github.com/elastic/elasticsearch/issues/155155
 - class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
   method: testContinuousEvents
   issue: https://github.com/elastic/elasticsearch/issues/153782

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -688,3 +688,81 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
   method: test {csv-spec:approximation.Rename stats group key}
   issue: https://github.com/elastic/elasticsearch/issues/155194
+- class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
+  method: testContinuousEvents
+  issue: https://github.com/elastic/elasticsearch/issues/153782
+- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceTests
+  method: testPopulateCacheWithSharedSourceInputStreamFactory
+  issue: https://github.com/elastic/elasticsearch/issues/154597
+- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
+  method: testPitRelocationDuringReshard
+  issue: https://github.com/elastic/elasticsearch/issues/155284
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
+  method: test {csv-spec:change_point.values int column with all nulls}
+  issue: https://github.com/elastic/elasticsearch/issues/155124
+- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+  method: testFeatureImportanceValues
+  issue: https://github.com/elastic/elasticsearch/issues/155327
+- class: org.elasticsearch.index.reindex.BulkByPaginatedSearchResponseWireSerializingTests
+  method: testEqualsAndHashcode
+  issue: https://github.com/elastic/elasticsearch/issues/155457
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:ip.conditional}
+  issue: https://github.com/elastic/elasticsearch/issues/155566
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample cartesian_point}
+  issue: https://github.com/elastic/elasticsearch/issues/155625
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample geo_point}
+  issue: https://github.com/elastic/elasticsearch/issues/155626
+- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+  method: testPutDatasetAllowedWithCreateDatasetPrivilege
+  issue: https://github.com/elastic/elasticsearch/issues/155671
+- class: org.elasticsearch.xpack.esql.EsqlSecurityIT
+  method: testEnrich
+  issue: https://github.com/elastic/elasticsearch/issues/155672
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/155532
+- class: org.elasticsearch.packaging.test.PackageTests
+  method: test70RestartServer
+  issue: https://github.com/elastic/elasticsearch/issues/155704
+- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+  method: testPutDataSourceForbiddenWithoutManagePrivilege
+  issue: https://github.com/elastic/elasticsearch/issues/155705
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:mv_union.testMvUnionNullReturnedWhenFirstArgIsNull}
+  issue: https://github.com/elastic/elasticsearch/issues/155707
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldSourceOnlyRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/155541
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample geo_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample cartesian_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample geo_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecStatsSampleIT
+  method: test {csv-spec:stats_sample.sample cartesian_point}
+  issue: https://github.com/elastic/elasticsearch/pull/155536
+- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
+  method: testLongLivedPitRelocation
+  issue: https://github.com/elastic/elasticsearch/issues/155740
+- class: org.elasticsearch.xpack.stateless.StatelessComponentsOrderIT
+  method: testClosingNodeShouldWaitForOngoingMerge
+  issue: https://github.com/elastic/elasticsearch/issues/155780
+- class: org.elasticsearch.gateway.GatewayServiceIT
+  method: testSettingsAppliedBeforeReroute
+  issue: https://github.com/elastic/elasticsearch/issues/155802
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
+  issue: https://github.com/elastic/elasticsearch/issues/155922
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:inlinestats.afterStats}
+  issue: https://github.com/elastic/elasticsearch/issues/156013
+- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
+  method: test {yaml=search.vectors/172_knn_query_base64_vectors/kNN query with base64 float vector}
+  issue: https://github.com/elastic/elasticsearch/issues/156137

--- a/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
@@ -136,17 +136,19 @@ public class BatchedRerouteService implements RerouteService {
                             pendingRerouteListeners = null;
                         }
                     }
-                    final ClusterState state = clusterService.state();
                     if (MasterService.isPublishFailureException(e)) {
-                        logger.debug(() -> format("unexpected failure during [%s], current state:\n%s", source, state), e);
+                        logger.debug(() -> format("unexpected failure during [%s]", source), e);
                         // no big deal, the new master will reroute again
-                    } else if (logger.isTraceEnabled()) {
-                        logger.error(() -> format("unexpected failure during [%s], current state:\n%s", source, state), e);
                     } else {
-                        logger.error(
-                            () -> format("unexpected failure during [%s], current state version [%s]", source, state.version()),
-                            e
-                        );
+                        final ClusterState state = clusterService.state();
+                        if (logger.isTraceEnabled()) {
+                            logger.error(() -> format("unexpected failure during [%s], current state:\n%s", source, state), e);
+                        } else {
+                            logger.error(
+                                () -> format("unexpected failure during [%s], current state version [%s]", source, state.version()),
+                                e
+                            );
+                        }
                     }
                     ActionListener.onFailure(currentListeners, e);
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -259,6 +259,14 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                     "unexpected failure"
                 )
             );
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "failure within reroute includes current state",
+                    BatchedRerouteService.class.getCanonicalName(),
+                    Level.ERROR,
+                    "current state"
+                )
+            );
 
             final BatchedRerouteService failingRerouteService = new BatchedRerouteService(clusterService, (s, r, l) -> {
                 throw new ElasticsearchException("simulated");
@@ -299,6 +307,14 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                     "unexpected failure"
                 )
             );
+            mockLog.addExpectation(
+                new MockLog.UnseenEventExpectation(
+                    "publish failure omits current state",
+                    BatchedRerouteService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "current state"
+                )
+            );
 
             final var publishFailureFuture = new PlainActionFuture<Void>();
             batchedRerouteService.reroute("publish failure", randomFrom(EnumSet.allOf(Priority.class)), publishFailureFuture);
@@ -324,11 +340,41 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                     "unexpected failure"
                 )
             );
+            mockLog.addExpectation(
+                new MockLog.UnseenEventExpectation(
+                    "not-master failure omits current state",
+                    BatchedRerouteService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "current state"
+                )
+            );
             final var notMasterFuture = new PlainActionFuture<Void>();
             batchedRerouteService.reroute("not-master failure", randomFrom(EnumSet.allOf(Priority.class)), notMasterFuture);
             expectThrows(ExecutionException.class, NotMasterException.class, () -> notMasterFuture.get(10, TimeUnit.SECONDS));
 
             mockLog.assertAllExpectationsMatched();
         }
+    }
+
+    public void testDoesNotReadClusterStateFromClusterApplierThreadOnRejection() {
+        final BatchedRerouteService batchedRerouteService = new BatchedRerouteService(clusterService, (s, r, l) -> {
+            l.onResponse(null);
+            return s;
+        });
+
+        final PlainActionFuture<Void> rerouteFuture = new PlainActionFuture<>();
+        clusterService.addStateApplier(
+            event -> batchedRerouteService.reroute("from applier", randomFrom(EnumSet.allOf(Priority.class)), rerouteFuture)
+        );
+
+        clusterService.getMasterService().stop();
+        clusterService.getClusterApplierService()
+            .onNewClusterState(
+                "simulated",
+                () -> ClusterState.builder(clusterService.state()).version(clusterService.state().version() + 1).build(),
+                ActionListener.noop()
+            );
+
+        expectThrows(ExecutionException.class, NotMasterException.class, () -> rerouteFuture.get(10, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Avoid unsafe cluster state read in BatchedRerouteService - unmute test (#156156)](https://github.com/elastic/elasticsearch/pull/156156)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)