### PR TITLE
Fix columnar 290 yaml tests for stateless: use number_of_replicas: 1

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/290_columnar.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/290_columnar.yml
@@ -18,7 +18,7 @@ setup:
             index:
               mode: columnar
               number_of_shards: 2
-              number_of_replicas: 0
+              number_of_replicas: 1
           mappings:
             properties:
               "@timestamp":
@@ -90,7 +90,7 @@ setup:
             settings:
               index:
                 mode: columnar
-                number_of_replicas: 0
+                number_of_replicas: 1
             mappings:
               properties:
                 "@timestamp":
@@ -151,7 +151,7 @@ setup:
             settings:
               index:
                 mode: columnar
-                number_of_replicas: 0
+                number_of_replicas: 1
             mappings:
               properties:
                 "@timestamp":
@@ -209,7 +209,7 @@ setup:
             index:
               mode: logsdb_columnar
               number_of_shards: 2
-              number_of_replicas: 0
+              number_of_replicas: 1
           mappings:
             properties:
               "@timestamp":
@@ -292,7 +292,7 @@ setup:
             settings:
               index:
                 mode: logsdb_columnar
-                number_of_replicas: 0
+                number_of_replicas: 1
             mappings:
               properties:
                 "@timestamp":
@@ -357,7 +357,7 @@ setup:
             settings:
               index:
                 mode: logsdb_columnar
-                number_of_replicas: 0
+                number_of_replicas: 1
             mappings:
               properties:
                 "@timestamp":
@@ -422,7 +422,7 @@ setup:
           settings:
             index:
               mode: columnar
-              number_of_replicas: 0
+              number_of_replicas: 1
           mappings:
             properties:
               agent_id:
@@ -445,7 +445,7 @@ setup:
           settings:
             index:
               mode: logsdb_columnar
-              number_of_replicas: 0
+              number_of_replicas: 1
           mappings:
             properties:
               agent_id:


### PR DESCRIPTION
The `data_stream/290_columnar` YAML REST tests all use `number_of_replicas: 0`. In stateless, this produces only `INDEX_ONLY` shards (no `SEARCH_ONLY` shards), so the index has no searchable shards. Any read operation fails with `NoShardAvailableActionException` (HTTP 503). Changed to `number_of_replicas: 1`.

Relates to elastic/elasticsearch-serverless#6635
Sniffer fix: elastic/elasticsearch#156274

## Test plan
- [ ] `./gradlew :modules:data-streams:yamlRestTest -Dtests.rest.filter="data_stream/290_columnar*"` passes