### PR TITLE
[9.5] [Build] Enforce Unix line endings in spotless to fix Windows CI flakiness (#154258)

### DIFF
--- a/.buildkite/hooks/pre-command.bat
+++ b/.buildkite/hooks/pre-command.bat
@@ -1,6 +1,12 @@
 @ECHO OFF
 SETLOCAL EnableDelayedExpansion
 
+REM Bootstrap workaround for a git checkout-ordering gap: renormalize tracked
+REM *.java files to LF before anything (spotless, etc.) reads them. See the
+REM script for why this is needed and when it can be removed.
+bash.exe -c "bash .buildkite/scripts/windows-renormalize-java-line-endings.sh"
+if errorlevel 1 exit /b 1
+
 FOR /F "tokens=* eol=#" %%i in ('type .ci\java-versions.properties') do set %%i
 
 SET JAVA_HOME=%USERPROFILE%\.java\%ES_BUILD_JAVA%

--- a/.buildkite/scripts/windows-renormalize-java-line-endings.sh
+++ b/.buildkite/scripts/windows-renormalize-java-line-endings.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Bootstrap workaround for a git checkout-ordering gap on Windows CI agents.
+#
+# *.java and *.java.st are declared `text eol=lf` in .gitattributes so
+# spotless (configured with LineEnding.UNIX) always sees LF regardless of
+# host OS, and so *.java files generated at build time from *.java.st
+# templates (StringTemplateTask copies the template's line endings verbatim
+# into its output) inherit LF too. That works for any file whose content
+# differs between the two commits, because git rewrites it against the
+# (now-correct) attribute during checkout. It does NOT help files unchanged
+# between commits: the Windows agent's initial `git clone` checks out the
+# target branch's current HEAD *before* this rule existed there,
+# autocrlf/core.eol on the agent writes those files as CRLF, and a later
+# `git checkout -f <pr-commit>` skips them entirely -- git's checkout only
+# rewrites paths whose content actually differs, and CRLF-on-disk
+# clean-filters back to the same LF blob, so it's considered unmodified and
+# left untouched. Result: every *.java/*.java.st file present before this PR
+# keeps stale CRLF forever on Windows, and spotlessJavaCheck
+# (LineEnding.UNIX) flags all of them -- including files generated from a
+# still-CRLF *.java.st template.
+#
+# Fix up the working tree here, once per job, right after checkout: reset the
+# line-ending config to match .gitattributes, then force git to rewrite every
+# tracked *.java/*.java.st file from HEAD by deleting it from disk first
+# (checkout skips files it still considers unmodified, so simply re-running
+# `checkout` without deleting first is not sufficient).
+#
+# This becomes a fast no-op once these .gitattributes rules are merged to
+# `main`, since fresh clones will then already materialize LF from the
+# start. Remove this script (and its invocation from pre-command.bat) at
+# that point.
+
+set -euo pipefail
+
+git config core.autocrlf false
+git config core.eol lf
+
+file_count=$(git ls-files -- '*.java' '*.java.st' | wc -l | tr -d ' ')
+
+if [[ "$file_count" -gt 0 ]]; then
+  echo "Renormalizing line endings for $file_count tracked *.java/*.java.st file(s)"
+  git ls-files -z -- '*.java' '*.java.st' | xargs -0 rm -f --
+  git checkout -f -- '*.java' '*.java.st'
+else
+  echo "No tracked *.java/*.java.st files found, nothing to renormalize"
+fi

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,16 @@
 CHANGELOG.asciidoc  merge=union
 
+# Java sources are stored with LF. Force LF on checkout so Windows agents don't
+# materialize CRLF (which spotless, configured with LineEnding.UNIX, rejects).
+*.java text eol=lf
+
+# StringTemplate sources used by StringTemplateTask to generate *.java files
+# (e.g. x-pack/plugin/esql/**). The generated output copies the template's
+# line endings verbatim, so these need the same eol=lf treatment as *.java
+# itself, or generated sources can end up CRLF on Windows even though the
+# template is otherwise unrelated to this file's own format violations.
+*.java.st text eol=lf
+
 # These files contain expected text output, and should not be changed on
 # Windows
 build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/*.asciidoc text eol=lf

--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -84,6 +84,10 @@ dependencies {
   api(buildLibs.spotless.plugin) {
     exclude module: "groovy-xml"
   }
+  // spotless-lib (the core spotless library) is an implementation dependency of
+  // spotless-plugin-gradle and is therefore not exposed on our compile classpath.
+  // We need it explicitly so FormattingPrecommitPlugin can reference LineEnding directly.
+  compileOnly buildLibs.spotless.lib
 }
 
 project.getPlugins().withType(JavaBasePlugin.class) {

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.internal.conventions.precommit;
 
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.gradle.spotless.SpotlessPlugin;
+import com.diffplug.spotless.LineEnding;
 
 import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.gradle.api.Plugin;
@@ -75,6 +76,12 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 String formatterConfigPath = "build-conventions/formatterConfig.xml";
 
                 java.target("src/**/*.java");
+                // Enforce Unix (LF) line endings unconditionally. Without this, spotless falls back
+                // to LineEnding.GIT_ATTRIBUTES which resolves to PLATFORM_NATIVE (CRLF) on Windows
+                // for files that have no explicit eol attribute in .gitattributes. That causes the
+                // formatter to emit CRLF output while the repository stores LF, producing spurious
+                // format violations on Windows CI agents and making the spotless cache platform-specific.
+                java.setLineEndings(LineEnding.UNIX);
                 java.removeUnusedImports();
 
                 // We enforce a standard order for imports

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/StringTemplateTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/StringTemplateTask.java
@@ -80,7 +80,12 @@ public abstract class StringTemplateTask extends DefaultTask {
                         st.add(entry.getKey(), entry.getValue());
                     }
                 }
-                String output = st.render();
+                // ST's default AutoIndentWriter renders newlines using the platform's
+                // line.separator, so on Windows the output is CRLF regardless of the
+                // input template's own (LF) line endings. Normalize to LF explicitly so
+                // generated sources are consistent across OSes and match what spotless
+                // (configured with LineEnding.UNIX) expects.
+                String output = st.render().replace("\r\n", "\n");
                 Files.createDirectories(outputRootFolder.toPath().resolve(spec.outputFile).getParent());
                 Files.writeString(new File(outputRootFolder, spec.outputFile).toPath(), output, UTF_8);
                 getLogger().info("StringTemplateTask generated {}", spec.outputFile);

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -46,6 +46,7 @@ snakeyaml = { group = "org.yaml", name = "snakeyaml", version = { strictly = "2.
 spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
 spock-junit4 = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
 spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
+spotless-lib = "com.diffplug.spotless:spotless-lib:2.45.0"
 spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
 wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
 xmlunit-core = "org.xmlunit:xmlunit-core:2.8.2"


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [Build] Enforce Unix line endings in spotless to fix Windows CI flakiness (#154258)