### PR TITLE
[9.5] Parallelize ES|QL QA REST tests (#156112)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -65,12 +65,12 @@ buildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseN
   def javaRestTest = tasks.register("v${bwcVersion}#javaRestTest", StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
-    maxParallelForks = 1
   }
 
   def csvSpecTest = tasks.register("v${bwcVersion}#csvSpecTests", StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    // AbstractMixedClusterEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
     maxParallelForks = 1
     testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
     classpath = sourceSets.csvSpecTest.runtimeClasspath

--- a/x-pack/plugin/esql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-node/build.gradle
@@ -108,7 +108,6 @@ tasks.named('processJavaRestTestResources').configure {
 tasks.named('javaRestTest') {
   dependsOn generateParquetFixtures
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
 
   systemProperty 'tests.rest.client_timeout', '60'
   systemProperty 'tests.rest.socket_timeout', '60'
@@ -116,6 +115,7 @@ tasks.named('javaRestTest') {
 
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // AbstractEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
   maxParallelForks = 1
 
   systemProperty 'tests.rest.client_timeout', '60'

--- a/x-pack/plugin/esql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/single-node/build.gradle
@@ -53,12 +53,12 @@ restResources {
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
 }
 
 def csvSpecTests = tasks.register('csvSpecTests', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // AbstractEsqlSpecIT declares its cluster with shared(true), which is incompatible with parallel forks
   maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
@@ -73,6 +73,7 @@ tasks.named('check').configure { dependsOn csvSpecTests }
 // system properties. No test classes are modified.
 tasks.register('javaRestTestSecure', StandaloneRestIntegTestTask) {
   usesDefaultDistribution("to be triaged")
+  // Runs the csvSpecTest source set, whose cluster is shared(true)
   maxParallelForks = 1
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
@@ -88,7 +89,6 @@ tasks.register('javaRestTestSecure', StandaloneRestIntegTestTask) {
 
 tasks.named('yamlRestTest') {
   usesDefaultDistribution("to be triaged")
-  maxParallelForks = 1
 }
 
 // Uncomment this to start automatically running this as part of CI


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Parallelize ES|QL QA REST tests (#156112)