### PR TITLE
Unmute SmokeTestMultiNodeClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -598,9 +598,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesLastOverTimeIT
   method: test {csv-spec:k8s-timeseries-last-over-time.last_over_time_of_event}
   issue: https://github.com/elastic/elasticsearch/issues/156131
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=indices.sort/40_high_cardinality/Index sort on high cardinality keyword field - mixed single and multi values}
-  issue: https://github.com/elastic/elasticsearch/issues/156132
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesFirstOverTimeIT
   method: test {csv-spec:k8s-timeseries-first-over-time.first_over_time_of_event}
   issue: https://github.com/elastic/elasticsearch/issues/156159


### PR DESCRIPTION
Timed out due to encryption-at-rest slowness which has nothing to do with the individual muted test.

Resolves #156137