### PR TITLE
Unmute CoreWithSecurityClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -763,6 +763,3 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterStats}
   issue: https://github.com/elastic/elasticsearch/issues/156013
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/172_knn_query_base64_vectors/kNN query with base64 float vector}
-  issue: https://github.com/elastic/elasticsearch/issues/156137


### PR DESCRIPTION
Muted due to a timeout in a slow encryption-at-rest environment, which is not a problem in the test.

Resolves #156137