### PR TITLE
ESQL: Fix FUSE plan nodes ignoring fields in equals

### DIFF
--- a/docs/changelog/156188.yaml
+++ b/docs/changelog/156188.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 156187
+pr: 156188
+summary: Fix FUSE plan nodes ignoring fields in equals
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEval.java
@@ -122,8 +122,12 @@ public class FuseScoreEval extends UnaryPlan
             return false;
         }
 
-        FuseScoreEval rrf = (FuseScoreEval) obj;
-        return child().equals(rrf.child()) && scoreAttr.equals(rrf.score()) && discriminatorAttr.equals(discriminator());
+        FuseScoreEval other = (FuseScoreEval) obj;
+        return child().equals(other.child())
+            && scoreAttr.equals(other.score())
+            && discriminatorAttr.equals(other.discriminator())
+            && fuseType == other.fuseType
+            && Objects.equals(options, other.options);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FuseScoreEvalExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FuseScoreEvalExec.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class FuseScoreEvalExec extends UnaryExec {
     private final Attribute scoreAttr;
@@ -63,5 +64,26 @@ public class FuseScoreEvalExec extends UnaryExec {
     @Override
     protected AttributeSet computeReferences() {
         return AttributeSet.of(scoreAttr, discriminatorAttr);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), scoreAttr, discriminatorAttr, fuseConfig);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        FuseScoreEvalExec other = (FuseScoreEvalExec) obj;
+        return child().equals(other.child())
+            && Objects.equals(scoreAttr, other.scoreAttr)
+            && Objects.equals(discriminatorAttr, other.discriminatorAttr)
+            && Objects.equals(fuseConfig, other.fuseConfig);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEvalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEvalTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.fuse;
+
+import org.elasticsearch.compute.operator.fuse.RrfConfig;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.MapExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.relation;
+
+/**
+ * Equality tests for {@link FuseScoreEval}.
+ *
+ * <p>{@code equals} must take every field into account: the logical plan optimizer decides whether a
+ * rule changed anything by comparing the plan before and after the rule ran ({@code RuleExecutor}),
+ * so a field that {@code equals} ignores makes a rewrite of that field invisible. {@code hashCode}
+ * already hashes all of them, so an under-comparing {@code equals} would additionally break the
+ * equals/hashCode contract.
+ *
+ * <p>Note the shared {@link #child} below: {@code EsqlTestUtils.relation()} builds a relation over a
+ * random index name, so two separate calls are not equal to each other. Every instance built here
+ * therefore reuses one child, leaving the field under test as the only difference.
+ */
+public class FuseScoreEvalTests extends ESTestCase {
+
+    private final LogicalPlan child = relation();
+    private final Attribute score = referenceAttribute("_score", DataType.DOUBLE);
+    private final Attribute discriminator = referenceAttribute("_fork", DataType.KEYWORD);
+
+    private static MapExpression options(double rankConstant) {
+        return new MapExpression(Source.EMPTY, List.of(of(RrfConfig.RANK_CONSTANT), of(rankConstant)));
+    }
+
+    private FuseScoreEval fuse(Attribute scoreAttr, Attribute discriminatorAttr, Fuse.FuseType type, MapExpression options) {
+        return new FuseScoreEval(Source.EMPTY, child, scoreAttr, discriminatorAttr, type, options);
+    }
+
+    public void testEqualsForIdenticalFields() {
+        FuseScoreEval a = fuse(score, discriminator, Fuse.FuseType.RRF, options(60));
+        FuseScoreEval b = fuse(score, discriminator, Fuse.FuseType.RRF, options(60));
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    /**
+     * The discriminator used to be compared against {@code this} rather than against the other
+     * instance, which made the clause unconditionally true.
+     */
+    public void testDiscriminatorIsCompared() {
+        Attribute otherDiscriminator = referenceAttribute("_other_fork", DataType.KEYWORD);
+        assertNotEquals(
+            fuse(score, discriminator, Fuse.FuseType.RRF, options(60)),
+            fuse(score, otherDiscriminator, Fuse.FuseType.RRF, options(60))
+        );
+    }
+
+    public void testScoreIsCompared() {
+        Attribute otherScore = referenceAttribute("_other_score", DataType.DOUBLE);
+        assertNotEquals(
+            fuse(score, discriminator, Fuse.FuseType.RRF, options(60)),
+            fuse(otherScore, discriminator, Fuse.FuseType.RRF, options(60))
+        );
+    }
+
+    public void testFuseTypeIsCompared() {
+        assertNotEquals(
+            fuse(score, discriminator, Fuse.FuseType.RRF, options(60)),
+            fuse(score, discriminator, Fuse.FuseType.LINEAR, options(60))
+        );
+    }
+
+    public void testOptionsAreCompared() {
+        assertNotEquals(
+            fuse(score, discriminator, Fuse.FuseType.RRF, options(60)),
+            fuse(score, discriminator, Fuse.FuseType.RRF, options(10))
+        );
+    }
+
+    /**
+     * {@code options} is nullable - FUSE without an options map produces a null here.
+     */
+    public void testNullOptionsAreCompared() {
+        assertNotEquals(fuse(score, discriminator, Fuse.FuseType.RRF, null), fuse(score, discriminator, Fuse.FuseType.RRF, options(60)));
+        assertEquals(fuse(score, discriminator, Fuse.FuseType.RRF, null), fuse(score, discriminator, Fuse.FuseType.RRF, null));
+    }
+
+    /**
+     * Every field that participates in {@code hashCode} must also participate in {@code equals},
+     * otherwise instances that compare equal can land in different hash buckets.
+     */
+    public void testEqualInstancesShareHashCode() {
+        FuseScoreEval a = fuse(score, discriminator, Fuse.FuseType.LINEAR, options(42));
+        FuseScoreEval b = fuse(score, discriminator, Fuse.FuseType.LINEAR, options(42));
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FuseScoreEvalExecTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FuseScoreEvalExecTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.compute.operator.fuse.FuseConfig;
+import org.elasticsearch.compute.operator.fuse.LinearConfig;
+import org.elasticsearch.compute.operator.fuse.RrfConfig;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+
+/**
+ * Equality tests for {@link FuseScoreEvalExec}.
+ *
+ * <p>{@code UnaryExec} compares the child only, so a subclass carrying extra state has to override
+ * {@code equals}/{@code hashCode} - as {@code EvalExec}, {@code FilterExec}, {@code LimitExec} and
+ * {@code TopNExec} all do. Without the override two FUSE nodes differing only in their fuse config
+ * (RRF vs LINEAR, different rank constants or weights) compare equal, which hides a rewrite from the
+ * physical plan optimizer's before/after comparison.
+ */
+public class FuseScoreEvalExecTests extends ESTestCase {
+
+    private final PhysicalPlan child = AbstractPhysicalPlanSerializationTests.randomChild(0);
+    private final Attribute score = referenceAttribute("_score", DataType.DOUBLE);
+    private final Attribute discriminator = referenceAttribute("_fork", DataType.KEYWORD);
+
+    private FuseScoreEvalExec fuse(Attribute scoreAttr, Attribute discriminatorAttr, FuseConfig config) {
+        return new FuseScoreEvalExec(Source.EMPTY, child, scoreAttr, discriminatorAttr, config);
+    }
+
+    public void testEqualsForIdenticalFields() {
+        FuseScoreEvalExec a = fuse(score, discriminator, RrfConfig.DEFAULT_CONFIG);
+        FuseScoreEvalExec b = fuse(score, discriminator, RrfConfig.DEFAULT_CONFIG);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    public void testFuseConfigIsCompared() {
+        assertNotEquals(fuse(score, discriminator, RrfConfig.DEFAULT_CONFIG), fuse(score, discriminator, LinearConfig.DEFAULT_CONFIG));
+    }
+
+    public void testRankConstantIsCompared() {
+        assertNotEquals(fuse(score, discriminator, new RrfConfig(60d, Map.of())), fuse(score, discriminator, new RrfConfig(10d, Map.of())));
+    }
+
+    public void testWeightsAreCompared() {
+        assertNotEquals(
+            fuse(score, discriminator, new RrfConfig(60d, Map.of("a", 1.0))),
+            fuse(score, discriminator, new RrfConfig(60d, Map.of("a", 2.0)))
+        );
+    }
+
+    public void testScoreIsCompared() {
+        Attribute otherScore = referenceAttribute("_other_score", DataType.DOUBLE);
+        assertNotEquals(fuse(score, discriminator, RrfConfig.DEFAULT_CONFIG), fuse(otherScore, discriminator, RrfConfig.DEFAULT_CONFIG));
+    }
+
+    public void testDiscriminatorIsCompared() {
+        Attribute otherDiscriminator = referenceAttribute("_other_fork", DataType.KEYWORD);
+        assertNotEquals(fuse(score, discriminator, RrfConfig.DEFAULT_CONFIG), fuse(score, otherDiscriminator, RrfConfig.DEFAULT_CONFIG));
+    }
+}


### PR DESCRIPTION
Closes #156187

Both plan nodes behind `FUSE` compared incorrectly, so plans that differ semantically compared equal.

### `FuseScoreEval` (logical)

`equals` compared the discriminator against `this` instead of against the other instance:

```java
discriminatorAttr.equals(discriminator())   // discriminator() returns this.discriminatorAttr
```

That clause was unconditionally true, so the discriminator was never really compared. The method also ignored `fuseType` and `options`, both of which `hashCode` already hashes — so two nodes differing only in RRF vs LINEAR, or in `rank_constant`, compared equal but hashed differently, breaking the `equals`/`hashCode` contract.

Fixed by comparing against the other instance and including the two missing fields. I also renamed the downcast local from `rrf` to `other`, which matches the sibling plan nodes and makes a missing receiver visible at a glance.

### `FuseScoreEvalExec` (physical)

This class carries `scoreAttr`, `discriminatorAttr` and `fuseConfig` but overrode neither `equals` nor `hashCode`, so it inherited `UnaryExec`'s child-only comparison and ignored all three. Two FUSE nodes differing in their entire fuse config compared equal.

Added both overrides, matching what `EvalExec`, `FilterExec`, `LimitExec` and `TopNExec` already do.

### Why it matters

`RuleExecutor` decides whether a rule changed anything by comparing the plan before and after (`RuleExecutor.java:131`), and that result drives the fixed-point loop. A field that `equals` ignores makes a rewrite of that field invisible to the optimizer.

To be precise about severity: I did not find a rule in `main` today that demonstrably rewrites one of these fields, so this is not a fix for currently-wrong query results. It repairs the change-detection and the `equals`/`hashCode` contract before a future rule steps on the trap. Both classes are live, not dead code — `Analyzer.java:2026` builds a `FuseScoreEval` for every `FUSE` query, `MapperUtils.java:222` maps it to `FuseScoreEvalExec`, and `LocalExecutionPlanner.java:468` plans it into the operator.

### Tests

New `FuseScoreEvalTests` (7 tests) and `FuseScoreEvalExecTests` (6 tests), covering each field individually plus the null-`options` case and hash-code agreement.

I verified the tests actually catch the bugs rather than passing vacuously: with both production changes reverted, 9 of the 13 fail, and the 4 that still pass are exactly the cases the original code already handled correctly.

One detail worth flagging for review: `EsqlTestUtils.relation()` builds a relation over a random index name and `EsRelation#equals` compares the index pattern, so two separate calls are not equal to each other. Each test class shares a single child instance so the field under test is the only difference — otherwise every `assertNotEquals` would pass for the wrong reason and hide the bug. This is called out in the class javadoc.

`AnalyzerTests`, `LogicalPlanOptimizerTests` and `PhysicalPlanOptimizerTests` still pass, so the stricter equality does not disturb existing plan assertions.
