### PR TITLE
Implement KnnIndexTester option for stateless-index benchmarking

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -152,15 +152,32 @@ public class KnnIndexTester {
         Directory create(Path indexPath) throws IOException;
     }
 
-    record DirectoryTypeConfig(DirectoryFactory factory, boolean shared, boolean preWarm, BiConsumer<Directory, String> diagnosticLogger) {
+    /**
+     * @param shared             when true a single directory instance serves indexing, merging and searching, instead of one
+     *                           per phase
+     * @param preWarm            when true the directory's cache is filled by reading every file before searching
+     * @param requiresFreshIndex when true the directory cannot reuse an index it did not write itself, so the index is built
+     *                           from scratch on every run and gets an index path of its own
+     */
+    record DirectoryTypeConfig(
+        DirectoryFactory factory,
+        boolean shared,
+        boolean preWarm,
+        BiConsumer<Directory, String> diagnosticLogger,
+        boolean requiresFreshIndex
+    ) {
         private static final BiConsumer<Directory, String> NOOP = (a, b) -> {};
 
         DirectoryTypeConfig(DirectoryFactory factory, boolean shared, boolean preWarm) {
-            this(factory, shared, preWarm, NOOP);
+            this(factory, shared, preWarm, NOOP, false);
+        }
+
+        DirectoryTypeConfig(DirectoryFactory factory, boolean shared, boolean preWarm, BiConsumer<Directory, String> diagnosticLogger) {
+            this(factory, shared, preWarm, diagnosticLogger, false);
         }
     }
 
-    private static final Map<String, DirectoryTypeConfig> directoryTypeRegistry = new ConcurrentHashMap<>(3);
+    private static final Map<String, DirectoryTypeConfig> directoryTypeRegistry = new ConcurrentHashMap<>(4);
 
     static {
         directoryTypeRegistry.put("default", new DirectoryTypeConfig(KnnIndexer::getDirectory, false, false));
@@ -168,6 +185,13 @@ public class KnnIndexTester {
         directoryTypeRegistry.put(
             "stateless",
             new DirectoryTypeConfig(KnnIndexer::openStatelessDirectory, true, true, KnnIndexer::logStatelessCacheStats)
+        );
+        // "stateless-index" uses `shared = true` because the directory only serves reads for files it created itself, and
+        // it wipes the index path when opened: a second instance for the force merge would destroy the index and then find
+        // nothing to merge.
+        directoryTypeRegistry.put(
+            "stateless-index",
+            new DirectoryTypeConfig(KnnIndexer::openStatelessIndexDirectory, true, false, DirectoryTypeConfig.NOOP, true)
         );
     }
 
@@ -179,7 +203,7 @@ public class KnnIndexTester {
         return config;
     }
 
-    private static String formatIndexPath(TestConfiguration args) {
+    private static String formatIndexPath(TestConfiguration args, DirectoryTypeConfig dirConfig) {
         List<String> suffix = new ArrayList<>();
         switch (args.indexType()) {
             case FLAT -> suffix.add("flat");
@@ -206,6 +230,11 @@ public class KnnIndexTester {
                     suffix.add(Integer.toString(args.quantizeBits()));
                 }
             }
+        }
+        if (dirConfig.requiresFreshIndex()) {
+            // These types rebuild the index on every run and wipe the index path doing so, so they must not share it with the
+            // types that can reuse an index built by "default".
+            suffix.add(args.directoryType());
         }
 
         return INDEX_DIR + "/" + args.docVectors().getFirst().getFileName() + "-" + String.join("-", suffix) + ".index";
@@ -419,7 +448,9 @@ public class KnnIndexTester {
         for (TestConfiguration testConfiguration : testConfigurationList) {
             // check this here so IVF/GPUHNSW can guarantee quantizeBits is set properly
             checkQuantizeBits(testConfiguration);
-            String indexPathName = formatIndexPath(testConfiguration);
+            DirectoryTypeConfig dirConfig = getDirectoryTypeConfig(testConfiguration.directoryType());
+            checkCanReuseIndex(testConfiguration, dirConfig);
+            String indexPathName = formatIndexPath(testConfiguration, dirConfig);
             String indexType = testConfiguration.indexType().name().toLowerCase(Locale.ROOT);
             Results indexResults = new Results(indexPathName, indexType, testConfiguration.numDocs());
             Results[] results = new Results[testConfiguration.numberOfSearchRuns()];
@@ -436,7 +467,6 @@ public class KnnIndexTester {
                 Codec codec = createCodec(testConfiguration, exec);
                 Path indexPath = PathUtils.get(indexPathName);
                 MergePolicy mergePolicy = getMergePolicy(testConfiguration);
-                DirectoryTypeConfig dirConfig = getDirectoryTypeConfig(testConfiguration.directoryType());
 
                 runTestConfiguration(
                     testConfiguration,
@@ -682,6 +712,23 @@ public class KnnIndexTester {
             return QuantEncoding.fromBits((byte) docQuantizeBits);
         }
         return QuantEncoding.fromDocAndQueryBits((byte) docQuantizeBits, queryQuantizeBits.byteValue());
+    }
+
+    /**
+     * Fails fast rather than silently reporting nothing. A directory type that only tracks the files it wrote itself cannot see
+     * an index left on disk by a previous run: it would open the empty bootstrap commit, the force merge would find no segments
+     * and report close to zero milliseconds, and the searches would run against no documents.
+     */
+    private static void checkCanReuseIndex(TestConfiguration args, DirectoryTypeConfig dirConfig) {
+        if (dirConfig.requiresFreshIndex() && args.reindex() == false) {
+            throw new IllegalArgumentException(
+                "directory_type '"
+                    + args.directoryType()
+                    + "' cannot reuse an existing index: it only reads files it wrote itself, so an index on disk is invisible to "
+                    + "it and the force merge would silently be a no-op. Set \"reindex\": true. Note this rebuilds, and therefore "
+                    + "wipes, the index path on every run."
+            );
+        }
     }
 
     private static void checkQuantizeBits(TestConfiguration args) {

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
@@ -349,6 +349,36 @@ public class KnnIndexer {
         }
     }
 
+    /**
+     * Opens a stateless <em>indexing-node</em> directory for the given index path. Files are written locally and never
+     * uploaded, so every reopen reads from the local copy. This is the read path a stateless indexing node takes when a merge
+     * reopens a segment file it has just written for scoring.
+     * <p>
+     * The index is always built from scratch: the underlying directory only tracks the files it creates itself, so
+     * {@code indexPath} is wiped when the directory is opened. This is why the {@code stateless-index} directory type
+     * requires {@code reindex: true}.
+     */
+    static Directory openStatelessIndexDirectory(Path indexPath) throws IOException {
+        Path workPath = indexPath.resolveSibling(indexPath.getFileName() + ".stateless_index_work");
+        Files.createDirectories(workPath);
+        logger.info("Opening stateless index directory for index at {} with work path {}", indexPath, workPath);
+        return newStatelessIndexDirectory(indexPath, workPath);
+    }
+
+    /**
+     * Creates a directory backed by stateless indexing-node infrastructure. Loaded via reflection for the same reason as
+     * {@link #newStatelessDirectory}.
+     */
+    private static Directory newStatelessIndexDirectory(Path indexPath, Path workPath) throws IOException {
+        try {
+            Class<?> factoryClass = Class.forName("org.elasticsearch.xpack.stateless.lucene.StatelessDirectoryFactory");
+            var method = factoryClass.getMethod("newIndexDirectory", Path.class, Path.class);
+            return (Directory) method.invoke(null, indexPath, workPath);
+        } catch (Exception e) {
+            throw new IOException("Failed to create stateless index directory. Ensure the stateless test artifact is on the classpath.", e);
+        }
+    }
+
     static void logStatelessCacheStats(Directory dir, String label) {
         try {
             Class<?> factoryClass = Class.forName("org.elasticsearch.xpack.stateless.lucene.StatelessDirectoryFactory");

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/TestConfiguration.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/TestConfiguration.java
@@ -316,7 +316,9 @@ public record TestConfiguration(
             new ParameterHelp(
                 "directory_type",
                 "string",
-                "Directory type: default (mmap), frozen (searchable snapshot), or custom types registered by external wrappers."
+                "Directory type: default (mmap), frozen (searchable snapshot), stateless (stateless search-node read path), "
+                    + "stateless-index (stateless indexing-node read path; requires reindex=true and rebuilds its own index path "
+                    + "on every run), or custom types registered by external wrappers."
             )
         );
 

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
@@ -9,10 +9,8 @@ package org.elasticsearch.xpack.stateless.lucene;
 
 import org.apache.logging.log4j.Level;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
@@ -59,7 +57,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
-import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -215,36 +212,6 @@ public class SearchDirectoryTests extends ESTestCase {
                 return blobContainerWrapper.apply(innerContainer);
             }
         };
-    }
-
-    public void testStatelessDirectory() throws IOException {
-        try (Directory directory = StatelessDirectoryFactory.newSearchDirectory(LuceneTestCase.createTempDir().toAbsolutePath())) {
-            // It's important to close the IndexOutput so the necessary metadata gets updated
-            try (var output = directory.createOutput("vectors", IOContext.DEFAULT)) {
-                output.writeInt(12);
-            }
-
-            var input = directory.openInput("vectors", IOContext.DEFAULT);
-            var value = input.readInt();
-            assertThat(value, equalTo(12));
-            input.close();
-        }
-    }
-
-    /**
-     * We have code (e.g. {@code KnnIndexer}) that reaches {@link StatelessDirectoryFactory} reflectively.
-     * Renaming methods, changing their parameters, or making them non-static breaks that caller at runtime.
-     * This test ensures the API stays stable for these consumers.
-     */
-    public void testReflectiveApiUse() throws Exception {
-        var factoryClass = Class.forName("org.elasticsearch.xpack.stateless.lucene.StatelessDirectoryFactory");
-
-        var newSearchDirectory = factoryClass.getMethod("newSearchDirectory", Path.class, Path.class, Settings.class);
-        assertThat(newSearchDirectory.getReturnType(), equalTo(Directory.class));
-        assertTrue("invoked with a null receiver", Modifier.isStatic(newSearchDirectory.getModifiers()));
-
-        var logCacheStats = factoryClass.getMethod("logCacheStats", Directory.class, String.class);
-        assertTrue("invoked with a null receiver", Modifier.isStatic(logCacheStats.getModifiers()));
     }
 
     /**

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/StatelessDirectoryFactory.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/StatelessDirectoryFactory.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.fs.FsBlobContainer;
 import org.elasticsearch.common.blobstore.fs.FsBlobStore;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.store.FilterIndexOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -73,9 +74,10 @@ import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_C
  *   <li>{@link #newSearchDirectory(Path)} and its overloads reproduce {@link SearchDirectory}: reads of committed files
  *       flow through the stateless blob cache, as on a search node. Writes go to a local NIOFSDirectory, and each file
  *       becomes readable through the cache as soon as it is closed, so nothing is ever read from the local copy.</li>
- *   <li>{@link #newIndexDirectory(Path)} reproduces {@link IndexDirectory}: files are read from the local copy for as long
- *       as they have not been uploaded to the object store, as on an indexing node. Nothing is ever uploaded here, so
- *       reads stay on the local path for the lifetime of the directory.</li>
+ *   <li>{@link #newIndexDirectory(Path, Path)} reproduces {@link IndexDirectory}: files are read from the local copy for as
+ *       long as they have not been uploaded to the object store, as on an indexing node. Nothing is ever uploaded here, so
+ *       reads stay on the local path for the lifetime of the directory. Just like in production code, the index path is
+ *       wiped when the directory is created.</li>
  * </ul>
  */
 public final class StatelessDirectoryFactory {
@@ -131,39 +133,66 @@ public final class StatelessDirectoryFactory {
     }
 
     /**
+     * Creates a directory that keeps the Lucene index, the node environment and the shared cache all under
+     * {@code indexPath}. Fine for a scratch directory nothing else reads. Prefer {@link #newIndexDirectory(Path, Path)}
+     * when {@code indexPath} is also opened as a plain Lucene index, since that keeps the node
+     * environment and cache files out of it.
+     */
+    public static Directory newIndexDirectory(Path indexPath) throws IOException {
+        return newIndexDirectory(indexPath, indexPath);
+    }
+
+    /**
      * Creates an {@link IndexDirectory} whose files are written locally and never uploaded to the object store, so that
      * {@link IndexDirectory#openInput} returns a {@code ReopeningIndexInput} reading from the local file. That is the read
      * path a stateless indexing node takes when it reopens a just-written segment file, for instance when a Lucene merge
      * reopens the flat vector file it has just written.
+     *
+     * <p><b>Any existing index at {@code indexPath} is destroyed.</b> {@link IndexDirectory} tracks only the files it has
+     * itself created: {@link IndexDirectory#listAll()} never reports what is on disk, so pre-existing files would be
+     * invisible to Lucene yet still collide when it creates an output of the same name. {@code indexPath} is therefore
+     * wiped with {@link Lucene#cleanLuceneIndex}, exactly as {@code StatelessPlugin} does before wrapping the directory of
+     * a promotable shard.
      *
      * <p>The directory is wrapped in a {@link StoreMetricsDirectory} to match the input chain a real shard sees (see
      * {@code Store}). The shared blob cache is created because {@link IndexDirectory} requires one, but it is never read
      * from on this path: no blob container is registered and no file is ever marked as uploaded, so
      * {@code IndexBlobStoreCacheDirectory.containsFile} returns {@code false} for every name.
      *
-     * @param indexPath path where index files are written; also holds the node environment and cache files
+     * @param indexPath path where index files are written; wiped before use
+     * @param workPath  scratch directory for the node environment and cache files
      * @return a read-write directory reproducing the stateless indexing-node local read path
      */
-    public static Directory newIndexDirectory(Path indexPath) throws IOException {
-        // The directory is empty at construction, and the cache is never read on this path
-        var infra = Infra.create(indexPath, SHARED_CACHE_REGION_SIZE_SETTING.getDefault(Settings.EMPTY), Settings.EMPTY);
+    public static Directory newIndexDirectory(Path indexPath, Path workPath) throws IOException {
+        var localDirectory = new MMapDirectory(indexPath);
         boolean success = false;
         try {
-            var indexDirectory = new IndexDirectory(
-                new MMapDirectory(indexPath),
-                new IndexBlobStoreCacheDirectory(infra.cacheService(), new ShardId(new Index("index", "_na_"), 0)),
-                null,
-                true
-            );
-            var directory = new IndexNodeDirectory(
-                new StoreMetricsDirectory(indexDirectory, new ThreadLocalDirectoryMetricHolder<>(StoreMetrics::new)),
-                infra
-            );
-            success = true;
-            return directory;
+            // IndexDirectory requires an empty local directory. Wipe before creating the infrastructure, so that
+            // the node environment and cache files are not in the way when indexPath and workPath are the same directory.
+            Lucene.cleanLuceneIndex(localDirectory);
+            // The cache is never read on this path, so a single region is enough
+            var infra = Infra.create(workPath, SHARED_CACHE_REGION_SIZE_SETTING.getDefault(Settings.EMPTY), Settings.EMPTY);
+            try {
+                var indexDirectory = new IndexDirectory(
+                    localDirectory,
+                    new IndexBlobStoreCacheDirectory(infra.cacheService(), new ShardId(new Index("index", "_na_"), 0)),
+                    null,
+                    true
+                );
+                var directory = new IndexNodeDirectory(
+                    new StoreMetricsDirectory(indexDirectory, new ThreadLocalDirectoryMetricHolder<>(StoreMetrics::new)),
+                    infra
+                );
+                success = true;
+                return directory;
+            } finally {
+                if (success == false) {
+                    IOUtils.closeWhileHandlingException(infra);
+                }
+            }
         } finally {
             if (success == false) {
-                IOUtils.closeWhileHandlingException(infra);
+                IOUtils.closeWhileHandlingException(localDirectory);
             }
         }
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/StatelessDirectoryFactoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/StatelessDirectoryFactoryTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.lucene;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.codec.vectors.es94.ES94HnswScalarQuantizedVectorsFormat;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.store.LuceneFilesExtensions;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+public class StatelessDirectoryFactoryTests extends ESTestCase {
+
+    /** The file extensions that hold vector data, i.e. the ones a vector scorer reads through. */
+    private static final Set<LuceneFilesExtensions> VECTOR_DATA_EXTENSIONS = EnumSet.of(
+        LuceneFilesExtensions.VEC,
+        LuceneFilesExtensions.VEQ,
+        LuceneFilesExtensions.VEB
+    );
+
+    public void testSearchDirectoryReadsBackWrittenFile() throws IOException {
+        try (Directory directory = StatelessDirectoryFactory.newSearchDirectory(createTempDir().toAbsolutePath())) {
+            // It's important to close the IndexOutput so the necessary metadata gets updated
+            try (var output = directory.createOutput("vectors", IOContext.DEFAULT)) {
+                output.writeInt(12);
+            }
+
+            var input = directory.openInput("vectors", IOContext.DEFAULT);
+            var value = input.readInt();
+            assertThat(value, equalTo(12));
+            input.close();
+        }
+    }
+
+    /**
+     * We have code (e.g. {@code KnnIndexer}) that reaches {@link StatelessDirectoryFactory} reflectively.
+     * Renaming methods, changing their parameters, or making them non-static breaks that caller at runtime.
+     * This test ensures the API stays stable for these consumers.
+     */
+    public void testReflectiveApiUse() throws Exception {
+        var factoryClass = Class.forName("org.elasticsearch.xpack.stateless.lucene.StatelessDirectoryFactory");
+
+        var newSearchDirectory = factoryClass.getMethod("newSearchDirectory", Path.class, Path.class, Settings.class);
+        assertThat(newSearchDirectory.getReturnType(), equalTo(Directory.class));
+        assertTrue("invoked with a null receiver", Modifier.isStatic(newSearchDirectory.getModifiers()));
+
+        var newIndexDirectory = factoryClass.getMethod("newIndexDirectory", Path.class, Path.class);
+        assertThat(newIndexDirectory.getReturnType(), equalTo(Directory.class));
+        assertTrue("invoked with a null receiver", Modifier.isStatic(newIndexDirectory.getModifiers()));
+
+        var logCacheStats = factoryClass.getMethod("logCacheStats", Directory.class, String.class);
+        assertTrue("invoked with a null receiver", Modifier.isStatic(logCacheStats.getModifiers()));
+    }
+
+    /**
+     * {@link IndexDirectory} only tracks files it created itself, so anything already on disk would be invisible to Lucene yet
+     * still collide when it writes a file of the same name. The factory wipes the index path for this reason.
+     * This test proves that a directory opened over an existing index starts from the empty bootstrap commit.
+     */
+    public void testIndexDirectoryWipesExistingIndex() throws IOException {
+        Path indexPath = createTempDir();
+        try (Directory directory = new MMapDirectory(indexPath); IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig())) {
+            writer.addDocument(new Document());
+            writer.commit();
+        }
+        try (Directory directory = new MMapDirectory(indexPath)) {
+            assertThat(directory.listAll().length, greaterThan(1));
+        }
+
+        try (Directory directory = StatelessDirectoryFactory.newIndexDirectory(indexPath, createTempDir())) {
+            assertThat(directory.listAll(), arrayContaining(EmptyDirectory.INSTANCE.getSegmentsFileName()));
+        }
+    }
+
+    /**
+     * A Lucene merge reopens the flat vector file it has just written through the directory it is writing to, so on an indexing
+     * node those reads go through a {@code ReopeningIndexInput}.
+     */
+    public void testForceMergeReadsVectorsThroughReopeningIndexInput() throws IOException {
+        final int dims = 64;
+        final int docsPerSegment = 200;
+        final int segments = 3;
+
+        Path indexPath = createTempDir();
+        var vectorFilesRead = new LinkedHashSet<String>();
+        var vectorFilesReadWithoutReopening = new LinkedHashSet<String>();
+
+        try (Directory statelessDirectory = StatelessDirectoryFactory.newIndexDirectory(indexPath, createTempDir())) {
+            var recordingDirectory = new FilterDirectory(statelessDirectory) {
+                @Override
+                public IndexInput openInput(String name, IOContext context) throws IOException {
+                    var input = super.openInput(name, context);
+                    if (VECTOR_DATA_EXTENSIONS.contains(LuceneFilesExtensions.fromFile(name))) {
+                        vectorFilesRead.add(name);
+                        if (FilterIndexInput.unwrap(input) instanceof IndexDirectory.ReopeningIndexInput == false) {
+                            vectorFilesReadWithoutReopening.add(name);
+                        }
+                    }
+                    return input;
+                }
+            };
+
+            var config = new IndexWriterConfig().setCodec(
+                TestUtil.alwaysKnnVectorsFormat(
+                    new ES94HnswScalarQuantizedVectorsFormat(16, 100, DenseVectorFieldMapper.ElementType.FLOAT, 4, false)
+                )
+            ).setUseCompoundFile(false);
+            try (IndexWriter writer = new IndexWriter(recordingDirectory, config)) {
+                for (int segment = 0; segment < segments; segment++) {
+                    for (int doc = 0; doc < docsPerSegment; doc++) {
+                        var document = new Document();
+                        document.add(new KnnFloatVectorField("vector", randomVector(dims), VectorSimilarityFunction.DOT_PRODUCT));
+                        writer.addDocument(document);
+                    }
+                    writer.commit();
+                }
+                writer.forceMerge(1);
+            }
+
+            assertThat(
+                "the merge never reopened a vector file, so this no longer covers the read path it is meant to",
+                vectorFilesRead,
+                not(empty())
+            );
+            assertThat(
+                "vector files were read through something other than a ReopeningIndexInput",
+                vectorFilesReadWithoutReopening,
+                empty()
+            );
+
+            // the merged index is readable and returns the vectors that were indexed
+            try (DirectoryReader reader = DirectoryReader.open(recordingDirectory)) {
+                assertThat(reader.leaves(), hasSize(1));
+                assertThat(reader.numDocs(), equalTo(docsPerSegment * segments));
+                var hits = new IndexSearcher(reader).search(new KnnFloatVectorQuery("vector", randomVector(dims), 10), 10);
+                assertThat(hits.scoreDocs.length, equalTo(10));
+            }
+        }
+    }
+
+    private static float[] randomVector(int dims) {
+        var vector = new float[dims];
+        double norm = 0.0;
+        for (int i = 0; i < dims; i++) {
+            vector[i] = randomFloatBetween(-1.0f, 1.0f, true);
+            norm += (double) vector[i] * vector[i];
+        }
+        // DOT_PRODUCT requires unit-length vectors
+        float length = (float) Math.sqrt(norm);
+        for (int i = 0; i < dims; i++) {
+            vector[i] /= length;
+        }
+        return vector;
+    }
+}


### PR DESCRIPTION
Follow up of https://github.com/elastic/elasticsearch/pull/156160

This PR adds a configuration option for KnnIndexTester (`"directory_type" : "stateless-index"`)  so that indexing and force-merge run through the stateless indexing-node directory chain (`StoreMetricsDirectory` → `IndexDirectory` → `ReopeningIndexInput`).

Relates to https://github.com/elastic/elasticsearch/issues/157729