### PR TITLE
ESQL: Fix ROUND of whole numbers with negative decimals

### DIFF
--- a/docs/changelog/156196.yaml
+++ b/docs/changelog/156196.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 156195
+pr: 156196
+summary: Fix ROUND of whole numbers with negative decimals
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -755,6 +755,32 @@ x:ul
 9223372036854775800
 ;
 
+roundNegativeDecimalsRoundsUpToNextPowerOfTen
+required_capability: fn_round_negative_decimals_round_up
+// a leading digit of 5 or more rounds up to the next power of ten rather than down to zero
+row a = round(5, -1), b = round(9, -1), c = round(50, -2), d = round(99, -2), e = round(-5, -1), f = round(-50, -2);
+
+a:integer | b:integer | c:integer | d:integer | e:integer | f:integer
+10        | 10        | 100       | 100       | -10       | -100
+;
+
+roundNegativeDecimalsBelowHalfTheScale
+required_capability: fn_round_negative_decimals_round_up
+row a = round(4, -1), b = round(49, -2), c = round(499, -3), d = round(-4, -1);
+
+a:integer | b:integer | c:integer | d:integer
+0         | 0         | 0         | 0
+;
+
+roundNegativeDecimalsMatchesDoubles
+required_capability: fn_round_negative_decimals_round_up
+// the same value must round the same way whether it is a whole number or a double
+row i = round(5, -1), l = round(5::long, -1), d = round(5.0, -1);
+
+i:integer | l:long | d:double
+10        | 10     | 10.0
+;
+
 roundUL
 row x = round(9223372036854775808, -1);
 

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundLongEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
@@ -55,7 +56,7 @@ public final class RoundLongEvaluator implements ExpressionEvaluator {
         if (decimalsVector == null) {
           return eval(page.getPositionCount(), valBlock, decimalsBlock);
         }
-        return eval(page.getPositionCount(), valVector, decimalsVector).asBlock();
+        return eval(page.getPositionCount(), valVector, decimalsVector);
       }
     }
   }
@@ -97,18 +98,28 @@ public final class RoundLongEvaluator implements ExpressionEvaluator {
         }
         long val = valBlock.getLong(valBlock.getFirstValueIndex(p));
         long decimals = decimalsBlock.getLong(decimalsBlock.getFirstValueIndex(p));
-        result.appendLong(Round.process(val, decimals));
+        try {
+          result.appendLong(Round.process(val, decimals));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }
   }
 
-  public LongVector eval(int positionCount, LongVector valVector, LongVector decimalsVector) {
-    try(LongVector.FixedBuilder result = driverContext.blockFactory().newLongVectorFixedBuilder(positionCount)) {
+  public LongBlock eval(int positionCount, LongVector valVector, LongVector decimalsVector) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
         long val = valVector.getLong(p);
         long decimals = decimalsVector.getLong(p);
-        result.appendLong(p, Round.process(val, decimals));
+        try {
+          result.appendLong(Round.process(val, decimals));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/Maths.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/Maths.java
@@ -15,6 +15,12 @@ import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeToInt
 
 public final class Maths {
 
+    /**
+     * Half of 10^19, the smallest power of ten that does not fit into a long. A long rounded at that
+     * scale is either zero or +/-10^19, so this is the only threshold needed to tell the two apart.
+     */
+    private static final long HALF_OF_TEN_POW_19 = 5_000_000_000_000_000_000L;
+
     public static Number round(Number n, long precision) throws ArithmeticException {
         if (n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte) {
             return convertToIntegerType(round(n.longValue(), precision), n.getClass());
@@ -69,34 +75,48 @@ public final class Maths {
         return middleResult.multiply(tenAtScale);
     }
 
+    /**
+     * Rounds {@code n} half away from zero at a scale of {@code 10^-precision}.
+     * <p>
+     * Note there is deliberately no shortcut for numbers with fewer digits than the scale: a leading
+     * digit of 5 or more rounds up to the next power of ten rather than to zero, so {@code ROUND(5, -1)}
+     * is 10 and not 0. Only truncation may take that shortcut, and {@link #truncate} still does.
+     *
+     * @throws ArithmeticException if the rounded value does not fit into a long
+     */
     public static Long round(long n, long precision) throws ArithmeticException {
         if (n == 0L || precision >= 0) {
             return n;
         }
-
-        long digitsToRound = -precision;
-        int digits = (int) (Math.log10(Math.abs((double) n)) + 1);
-        if (digits <= digitsToRound) {
+        // Every long is below 10^19, so at a scale of 10^20 or more it is smaller than half of the scale
+        // and rounds to zero. Testing before negating also keeps -Long.MIN_VALUE from overflowing back
+        // to a negative value, which would leave the scale nonsensical.
+        if (precision <= -20) {
             return 0L;
         }
 
-        long tenAtScaleMinusOne = (long) tenPower(digitsToRound - 1);
-        long tenAtScale = tenAtScaleMinusOne * 10;
+        int digitsToRound = (int) -precision;
+        if (digitsToRound == 19) {
+            // the result is either zero or +/-10^19, and 10^19 does not fit into a long
+            if (n >= HALF_OF_TEN_POW_19 || n <= -HALF_OF_TEN_POW_19) {
+                throw new ArithmeticException("long overflow");
+            }
+            return 0L;
+        }
+
+        long tenAtScale = (long) tenPower(digitsToRound);
         long middleResult = n / tenAtScale;
         long remainder = n % tenAtScale; // TODO: vs.: n - middleResult * tenAtScale
-        long halving = 5 * tenAtScaleMinusOne;
+        long halving = tenAtScale / 2;
         if (remainder >= halving) {
             middleResult++;
         } else if (remainder <= -halving) {
             middleResult--;
         }
 
-        long result = middleResult * tenAtScale;
-        if (Long.signum(result) == Long.signum(n)) {
-            return result;
-        } else {
-            throw new ArithmeticException("long overflow");
-        }
+        // multiplyExact reports the overflow that a signum comparison cannot, since a legitimate
+        // result of zero is indistinguishable from a wrapped one by sign alone
+        return Math.multiplyExact(middleResult, tenAtScale);
     }
 
     public static Number truncate(Number n, Number precision) {
@@ -105,6 +125,12 @@ public final class Maths {
             long nLong = n.longValue();
             if (nLong == 0L || longPrecision >= 0) {
                 return n;
+            }
+            // Every long is below 10^19, so truncating at that scale or beyond always yields zero.
+            // Testing before negating also keeps -Long.MIN_VALUE from overflowing back to a negative
+            // value, which would drive tenPower() to zero and divide by zero below.
+            if (longPrecision <= -19) {
+                return convertToIntegerType(0L, n.getClass());
             }
 
             long digitsToTruncate = -longPrecision;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
@@ -51,7 +51,8 @@ public class Round extends EsqlScalarFunction implements OptionalArgument, AnyNu
         .capabilities(
             // Fixes on function {@code ROUND} that avoid it throwing exceptions on runtime for unsigned long cases.
             "ul_fixes",
-            "int_overflow_warns"
+            "int_overflow_warns",
+            "negative_decimals_round_up"
         )
         .name("round");
 
@@ -146,7 +147,9 @@ public class Round extends EsqlScalarFunction implements OptionalArgument, AnyNu
         return Math.toIntExact(Maths.round(val, decimals));
     }
 
-    @Evaluator(extraName = "Long")
+    // rounding a long up at a negative precision can exceed Long.MAX_VALUE, which is reported the same
+    // way the unsigned_long path reports it: a warning and a null rather than a failed query
+    @Evaluator(extraName = "Long", warnExceptions = ArithmeticException.class)
     static long process(long val, long decimals) {
         return Maths.round(val, decimals);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/MathsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/MathsTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.core.expression.predicate.operator.math;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+/**
+ * Tests {@link Maths#round} and {@link Maths#truncate} for whole numbers with a negative precision.
+ *
+ * <p>Rounding at a negative precision used to take a truncation shortcut: a number with no more digits
+ * than the scale was assumed to round to zero. That holds for truncation, but not for rounding, because
+ * a leading digit of 5 or more rounds up to the next power of ten. {@code ROUND(5, -1)} returned 0
+ * rather than 10, while {@code ROUND(5.0, -1)} - which never used that shortcut - returned 10.0.
+ */
+public class MathsTests extends ESTestCase {
+
+    public void testRoundsUpToTheNextPowerOfTen() {
+        assertEquals(10L, (long) Maths.round(5L, -1));
+        assertEquals(10L, (long) Maths.round(9L, -1));
+        assertEquals(100L, (long) Maths.round(50L, -2));
+        assertEquals(100L, (long) Maths.round(99L, -2));
+        assertEquals(1000L, (long) Maths.round(999L, -3));
+    }
+
+    public void testRoundsDownWhenBelowHalfTheScale() {
+        assertEquals(0L, (long) Maths.round(4L, -1));
+        assertEquals(0L, (long) Maths.round(49L, -2));
+        assertEquals(0L, (long) Maths.round(499L, -3));
+    }
+
+    /**
+     * Rounding is half away from zero, so negative values round away from zero too.
+     */
+    public void testRoundsNegativeValuesAwayFromZero() {
+        assertEquals(-10L, (long) Maths.round(-5L, -1));
+        assertEquals(-10L, (long) Maths.round(-9L, -1));
+        assertEquals(-100L, (long) Maths.round(-50L, -2));
+        assertEquals(0L, (long) Maths.round(-4L, -1));
+    }
+
+    /**
+     * Values with more digits than the scale never took the shortcut and were already correct. They are
+     * covered here because the fix reworked the arithmetic they run through.
+     */
+    public void testRoundsValuesLongerThanTheScale() {
+        assertEquals(20L, (long) Maths.round(15L, -1));
+        assertEquals(12000L, (long) Maths.round(12345L, -3));
+        assertEquals(0L, (long) Maths.round(12345L, -10));
+        assertEquals(-20L, (long) Maths.round(-15L, -1));
+    }
+
+    /**
+     * The same value must round identically whether it arrives as a whole number or as a double.
+     * These disagreed before the fix: the long path returned 0 and the double path returned 10.0.
+     */
+    public void testWholeNumbersAgreeWithDoubles() {
+        for (long value : new long[] { 5L, 9L, 50L, 99L, 999L, -5L, -50L, 4L, 15L }) {
+            for (int precision : new int[] { -1, -2, -3 }) {
+                double asDouble = Maths.round(Double.valueOf(value), precision).doubleValue();
+                long asLong = Maths.round(value, precision);
+                assertEquals("ROUND(" + value + ", " + precision + ")", asDouble, asLong, 0.0);
+            }
+        }
+    }
+
+    public void testThrowsWhenTheRoundedValueDoesNotFitInALong() {
+        // rounds to 9223372036854775810, one step beyond Long.MAX_VALUE
+        expectThrows(ArithmeticException.class, () -> Maths.round(Long.MAX_VALUE, -1));
+        // rounds to +/-10^19, which no long can hold
+        expectThrows(ArithmeticException.class, () -> Maths.round(5_000_000_000_000_000_000L, -19));
+        expectThrows(ArithmeticException.class, () -> Maths.round(Long.MIN_VALUE, -19));
+    }
+
+    public void testRoundsToZeroBelowHalfOfTenPowNineteen() {
+        assertEquals(0L, (long) Maths.round(4_999_999_999_999_999_999L, -19));
+        assertEquals(0L, (long) Maths.round(-4_999_999_999_999_999_999L, -19));
+    }
+
+    /**
+     * {@code -Long.MIN_VALUE} overflows back to {@code Long.MIN_VALUE}, which used to leave the scale
+     * negative: rounding then skipped its zero shortcut and returned a value built from a wrapped scale,
+     * and truncating divided by zero.
+     */
+    public void testHandlesPrecisionOfLongMinValue() {
+        assertEquals(0L, (long) Maths.round(12345L, Long.MIN_VALUE));
+        assertEquals(0L, (long) Maths.round(-12345L, Long.MIN_VALUE));
+        assertEquals(0L, (long) Maths.round(1L, Long.MIN_VALUE));
+        assertEquals(0L, (Maths.truncate(12345L, Long.MIN_VALUE)).longValue());
+        assertEquals(0L, (Maths.truncate(-12345L, Long.MIN_VALUE)).longValue());
+    }
+
+    /**
+     * Truncation genuinely does drop to zero once the scale covers every digit, so the shortcut the
+     * rounding path lost is still correct here.
+     */
+    public void testTruncateStillDropsToZero() {
+        assertEquals(0L, (Maths.truncate(5L, -1)).longValue());
+        assertEquals(0L, (Maths.truncate(9L, -1)).longValue());
+        assertEquals(0L, (Maths.truncate(99L, -2)).longValue());
+        assertEquals(12000L, (Maths.truncate(12345L, -3)).longValue());
+    }
+
+    /**
+     * Compares against {@link BigDecimal} with {@link RoundingMode#HALF_UP}, which is half away from
+     * zero and so matches the documented behaviour of {@code ROUND}.
+     */
+    public void testMatchesBigDecimalForRandomValues() {
+        for (int i = 0; i < 2000; i++) {
+            long value = switch (between(0, 2)) {
+                case 0 -> randomLong();
+                case 1 -> between(-100_000, 100_000);
+                default -> randomLongBetween(-1_000_000_000L, 1_000_000_000L);
+            };
+            if (value == 0) {
+                continue;
+            }
+            int precision = between(-19, 0);
+
+            BigInteger expected = new BigDecimal(BigInteger.valueOf(value)).setScale(precision, RoundingMode.HALF_UP).toBigInteger();
+            boolean fits = expected.bitLength() <= 63;
+
+            String description = "ROUND(" + value + ", " + precision + ")";
+            if (fits) {
+                assertEquals(description, expected.longValueExact(), (long) Maths.round(value, precision));
+            } else {
+                expectThrows(ArithmeticException.class, description, () -> Maths.round(value, precision));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
@@ -303,6 +303,8 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
         );
         suppliers.add(
             new TestCaseSupplier(
+                // rounds up to 10^19, which does not fit into a long, so it overflows rather than
+                // dropping to zero - compare with <max unsigned_long>, <-19> above, where 10^19 fits
                 "<max long>, <-19>",
                 List.of(DataType.LONG, DataType.LONG),
                 () -> new TestCaseSupplier.TestCase(
@@ -312,8 +314,9 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
                     ),
                     "RoundLongEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
                     DataType.LONG,
-                    equalTo(0L)
-                )
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: long overflow")
             )
         );
         suppliers.add(
@@ -407,9 +410,23 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
         suppliers.add(supplier(Long.MAX_VALUE, 5, Long.MAX_VALUE));
         suppliers.add(supplier(Long.MIN_VALUE, 5, Long.MIN_VALUE));
 
+        // a leading digit of 5 or more rounds up to the next power of ten instead of down to zero
+        suppliers.add(supplier(5L, -1, 10));
+        suppliers.add(supplier(9L, -1, 10));
+        suppliers.add(supplier(4L, -1, 0));
+        suppliers.add(supplier(50L, -2, 100));
+        suppliers.add(supplier(99L, -2, 100));
+        suppliers.add(supplier(49L, -2, 0));
+        suppliers.add(supplier(500L, -3, 1000));
+        suppliers.add(supplier(-5L, -1, -10));
+        suppliers.add(supplier(-50L, -2, -100));
+
         suppliers.add(supplier(0, 0, 0));
         suppliers.add(supplier(123, 2, 123));
         suppliers.add(supplier(123, -1, 120));
+        suppliers.add(supplier(5, -1, 10));
+        suppliers.add(supplier(-5, -1, -10));
+        suppliers.add(supplier(99, -2, 100));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(
             (nullPosition, nullValueDataType, original) -> nullPosition == 0 ? nullValueDataType : original.expectedType(),


### PR DESCRIPTION
Closes #156195

`ROUND(5, -1)` returned 0 instead of 10. When a whole number had no more digits than the rounding scale, `ROUND` dropped it to zero rather than rounding up to the next power of ten — so the result depended on the type of the input, since the double path was already correct:

| expression | integer / long | double | expected |
| --- | --- | --- | --- |
| `ROUND(5, -1)` | **0** | 10.0 | 10 |
| `ROUND(99, -2)` | **0** | 100.0 | 100 |
| `ROUND(-5, -1)` | **0** | -10.0 | -10 |
| `ROUND(15, -1)` | 20 | 20.0 | 20 |

### Root cause

`Maths#round(long, long)` took a truncation shortcut before rounding:

```java
int digits = (int) (Math.log10(Math.abs((double) n)) + 1);
if (digits <= digitsToRound) {
    return 0L;
}
```

Fewer digits than the scale does mean zero when truncating — and `TRUNCATE(5, -1)` is legitimately 0, which this PR keeps — but not when rounding, because a leading digit of 5 or more carries up to the next power of ten. `Maths#round(Number, long)` never had the shortcut, which is why doubles were right and `RoundTests` already asserted `round(999.0, -1) -> 1000.0`.

Removing the shortcut required reworking the surrounding arithmetic:

- the scale is now `10^digitsToRound` directly rather than `10^(digitsToRound-1) * 10`, so `halving` is just `tenAtScale / 2`;
- overflow is reported by `Math.multiplyExact` instead of comparing the sign of the result against the sign of the input. The sign check could not distinguish a legitimate zero from a wrapped one, which is precisely why the shortcut had to return early;
- `digitsToRound == 19` is handled separately: the result is either zero or ±10^19, and 10^19 does not fit into a long.

### Two related defects on the same path

`-precision` overflows when `precision` is `Long.MIN_VALUE`, because `-Long.MIN_VALUE` is itself. The scale was left negative, so the zero shortcut was skipped and the result was built from a wrapped scale: `ROUND(12345, -9223372036854775808)` returned 12340 instead of 0, and `TRUNCATE` on the same input drove `tenPower()` to `0.0` and threw `ArithmeticException: / by zero`. Both now test the precision before negating it.

Rounding a long up at a negative precision can also exceed `Long.MAX_VALUE`. The `Long` evaluator declared no `warnExceptions`, so that would have failed the query outright; it now reports a warning and a null, matching how the `unsigned_long` path already behaves.

### One existing assertion changed — please look at this

`RoundTests` asserted `ROUND(Long.MAX_VALUE, -19) == 0`. That expectation encoded the bug: rounding 9223372036854775807 at a scale of 10^19 carries up to 10^19, which no long can hold. It is now a warning and a null, consistent with the `<max unsigned_long>, <-19>` case directly above it in the same file, where 10^19 does fit and is returned.

### Not fixed here

`Round#process(int, long)` calls `.intValue()` on a long result, so `ROUND(2147483647, -1)` returns **-2147483646** — a positive input yielding a negative output. It is independent of this change (that path never took the shortcut), and fixing it means adding `warnExceptions` to the `Int` evaluator and regenerating evaluators. I left it out to keep this reviewable and am happy to follow up.

The legacy `x-pack/plugin/ql` copy of `Maths` has the identical shortcut, so SQL's `ROUND` is likely affected too. This PR changes only the ES|QL copy.

### Compatibility

The behaviour change is gated behind the `fn_round_negative_decimals_round_up` function capability, so mixed-version clusters do not run the new expectations.

### Tests

New `MathsTests` covers each shape directly, plus a randomized comparison against `BigDecimal` with `RoundingMode.HALF_UP` — half away from zero, which is what the docs describe. New `RoundTests` suppliers and three `math.csv-spec` blocks cover it end to end, including that a whole number and a double now agree.

I verified the tests actually catch the bug rather than passing vacuously: with the fix reverted, 6 of the 9 `MathsTests` fail along with every new `RoundTests` case, and the 3 that still pass are exactly the ones the old code already handled correctly (values longer than the scale, values below half the scale, and truncation).

Before writing the fix I fuzzed the released implementation against `BigDecimal` over 400,660 value/precision pairs and found 9,947 mismatches; the same fuzz over the fixed version reports zero.
