### PR TITLE
Make entitlement JDK diff tooling fail loudly

### DIFF
--- a/libs/entitlement/tools/jdk-api-extractor/README.md
+++ b/libs/entitlement/tools/jdk-api-extractor/README.md
@@ -46,3 +46,21 @@ If `-Druntime.java` is not provided, the bundled JDK is used.
 ```bash
 ./gradlew :libs:entitlement:tools:jdk-api-extractor:run -Druntime.java=24 --args="deprecations-jdk24.tsv --deprecations-only"
 ```
+
+### Comparing two patch releases of the same major version
+
+`-Druntime.java` takes a **major** version and resolves it through the Gradle toolchain service, so
+it cannot select between two patch releases of the same major — `-Druntime.java=26` may resolve to
+any JDK 26 build present in the toolchain cache. Comparing, say, 26.0.1 against 26.0.2 with
+`-Druntime.java=26` will silently scan the same JDK twice and produce an empty diff that looks like
+a clean result.
+
+To pin an exact build, extract each JDK and point `RUNTIME_JAVA_HOME` at it:
+
+```bash
+RUNTIME_JAVA_HOME=/path/to/jdk-26.0.1 ./gradlew :libs:entitlement:tools:jdk-api-extractor:run --args="api-jdk26.0.1.tsv"
+RUNTIME_JAVA_HOME=/path/to/jdk-26.0.2 ./gradlew :libs:entitlement:tools:jdk-api-extractor:run --args="api-jdk26.0.2.tsv"
+```
+
+Each run prints `Writing result for <version>`. Check that line reports the JDK you intended before
+trusting the diff — it is the only confirmation that the runtime was actually switched.

--- a/libs/entitlement/tools/public-callers-finder/src/main/java/org/elasticsearch/entitlement/tools/publiccallersfinder/Main.java
+++ b/libs/entitlement/tools/public-callers-finder/src/main/java/org/elasticsearch/entitlement/tools/publiccallersfinder/Main.java
@@ -40,6 +40,9 @@ public class Main {
 
     private static final String SEPARATOR = "\t";
 
+    private static final String COVERED = "COVERED";
+    private static final String MISSING = "MISSING";
+
     private static String TRANSITIVE = "--transitive";
     private static String CHECK_INSTRUMENTATION = "--check-instrumentation";
     private static String INCLUDE_INCUBATOR = "--include-incubator";
@@ -48,6 +51,14 @@ public class Main {
 
     private static final Set<MethodDescriptor> INSTRUMENTED_METHODS = new HashSet<>();
     private static final Set<MethodDescriptor> ACCESSIBLE_JDK_METHODS = new HashSet<>();
+
+    /**
+     * Counters backing the summary printed at the end of a run. Finding no callers is a legitimate
+     * result, but it is indistinguishable from a misconfigured run unless the tool says so explicitly.
+     */
+    private static int inputMethodCount = 0;
+    private static int reportedCallerCount = 0;
+    private static int missingInstrumentationCount = 0;
 
     record CallChain(EntryPoint entryPoint, CallChain next) {
         boolean isPublic() {
@@ -163,6 +174,10 @@ public class Main {
             SEPARATOR,
             () -> Stream.concat(Arrays.stream(entryPointColumns), Arrays.stream(originalEntryPointColumns)).iterator()
         );
+        reportedCallerCount++;
+        if (Arrays.asList(entryPointColumns).contains(MISSING)) {
+            missingInstrumentationCount++;
+        }
         out.println(row);
     }
 
@@ -185,7 +200,7 @@ public class Main {
                 e.method().methodName(),
                 e.method().methodDescriptor(),
                 ExternalAccess.toString(e.access()),
-                INSTRUMENTED_METHODS.contains(e.method()) ? "COVERED" : "MISSING" };
+                INSTRUMENTED_METHODS.contains(e.method()) ? COVERED : MISSING };
         }
     }
 
@@ -203,6 +218,7 @@ public class Main {
 
     private static void parseCsv(Path csvPath, MethodDescriptorConsumer methodConsumer) throws IOException {
         var lines = Files.readAllLines(csvPath);
+        inputMethodCount = lines.size();
         for (var l : lines) {
             var tokens = l.split(SEPARATOR);
             var moduleName = tokens[0];
@@ -278,5 +294,25 @@ public class Main {
             csvFilePath,
             (method, module, access) -> identifyTopLevelEntryPoints(modulePredicate, method, module, access, bubbleUpFromPublic, out)
         );
+        printSummary(checkInstrumentation);
+    }
+
+    /**
+     * Reports what the run actually did, on stderr so it does not corrupt the CSV on stdout.
+     * Without this an empty result is ambiguous: it looks the same whether no callers exist or the
+     * tool was pointed at the wrong JDK or an empty input file.
+     */
+    @SuppressForbidden(reason = "cli tool printing to standard err/out")
+    private static void printSummary(boolean checkInstrumentation) {
+        var summary = new StringBuilder("Scanned ").append(Runtime.version())
+            .append(": ")
+            .append(inputMethodCount)
+            .append(" input method(s), ")
+            .append(reportedCallerCount)
+            .append(" public caller(s) found");
+        if (checkInstrumentation) {
+            summary.append(", ").append(missingInstrumentationCount).append(" requiring instrumentation (MISSING)");
+        }
+        System.err.println(summary);
     }
 }


### PR DESCRIPTION
Doing the API/entitlements review for a JDK patch upgrade (26.0.1 → 26.0.2) surfaced two ways these tools report a clean result when they have actually done nothing useful. In this workflow "no output" is both the expected answer and the most common failure mode, so that is easy to miss.

`public-callers-finder` printed nothing when it found no callers. That is a legitimate result, but it looks identical to pointing the tool at the wrong JDK or handing it an empty input file. It now prints a summary to stderr, leaving stdout as pure CSV:

```
Scanned 26.0.2+10-55: 3 input method(s), 0 public caller(s) found, 0 requiring instrumentation (MISSING)
```

The `MISSING` count is omitted without `--check-instrumentation`. Including the runtime version means one line confirms both that the tool ran and that it ran on the intended JDK.

`jdk-api-extractor`'s README documents `-Druntime.java=<major>` for producing the inputs to a diff, but that property resolves through the Gradle toolchain service by major version and cannot distinguish two patch releases of the same major. Comparing 26.0.1 to 26.0.2 that way scans whichever JDK 26 is cached, twice, and yields an empty diff that reads as "no API changes" — on my machine the cached build was `26+35`, neither version I was comparing. The README now covers `RUNTIME_JAVA_HOME` for pinning an exact build, and points at the existing `Writing result for <version>` line as the check that the runtime really switched. (The real diff was not empty: 26.0.2 adds three method overrides, one of them the implementation of a CVE fix that appears in no published bug list.)

Also hoists the `COVERED`/`MISSING` literals into constants, since the new counter compares against one.