### PR TITLE
[9.5] Separate deltas from reduced states in rate (#154649)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IncreaseExponentialHistogramGroupingAggregatorFunction.java
@@ -88,6 +88,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
+    private ObjectArray<DeltaState> deltaStates;
     private final IntervalBuffer intervalBuffer;
     private final Warnings warnings;
     private final ExponentialHistogramMerger.Factory mergerFactory;
@@ -109,6 +110,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             intervalBuffer = new IntervalBuffer(driverContext.blockFactory());
             mergerFactory = ExponentialHistogramMerger.createFactory(histoBreaker);
             this.reducedStates = bigArrays.newObjectArray(256);
+            this.deltaStates = bigArrays.newObjectArray(256);
             this.rawBuffer = rawBuffer;
             rawBuffer = null;
             this.intervalBuffer = intervalBuffer;
@@ -201,7 +203,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
     ) {
         int lastGroup = -1;
         Temporality temporality = null;
-        ReducedState currentDeltaState = null;
+        DeltaState deltaState = null;
         ExponentialHistogramScratch scratch = new ExponentialHistogramScratch();
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
@@ -231,15 +233,15 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
                         rawBuffer.prepareForAppend(groupId, 1, timestamp);
                         rawBuffer.appendWithoutResize(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState = getOrInitializeReducedState(groupId);
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState = getOrInitializeDeltaState(groupId);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                     lastGroup = groupId;
                 } else {
                     if (temporality == Temporality.CUMULATIVE) {
                         rawBuffer.maybeResizeAndAppend(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                 }
             }
@@ -305,7 +307,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueBlock, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             state.appendDeltaSubRange(from, to, timestampVector, valueBlock);
         }
     }
@@ -352,9 +354,19 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
         }
     }
 
+    private DeltaState getOrInitializeDeltaState(int groupId) {
+        deltaStates = bigArrays.grow(deltaStates, groupId + 1);
+        var state = deltaStates.get(groupId);
+        if (state == null) {
+            state = new DeltaState();
+            deltaStates.set(groupId, state);
+        }
+        return state;
+    }
+
     private ReducedState getOrInitializeReducedState(int groupId) {
         reducedStates = bigArrays.grow(reducedStates, groupId + 1);
-        ReducedState state = reducedStates.get(groupId);
+        var state = reducedStates.get(groupId);
         if (state == null) {
             state = new ReducedState();
             reducedStates.set(groupId, state);
@@ -441,10 +453,18 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
         for (int i = 0; i < reducedStates.size(); i++) {
             Releasables.close(reducedStates.get(i));
         }
-        Releasables.close(reducedStates, rawBuffer, intervalBuffer, mergerFactory);
+        for (int i = 0; i < deltaStates.size(); i++) {
+            Releasables.close(deltaStates.get(i));
+        }
+        Releasables.close(reducedStates, rawBuffer, intervalBuffer, mergerFactory, deltaStates);
     }
 
     void flushRawBuffers() {
+        flushCumulativeRawBuffers();
+        flushDeltaStates();
+    }
+
+    void flushCumulativeRawBuffers() {
         if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
@@ -462,6 +482,27 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             }
         }
         rawBuffer.clearBuffers();
+    }
+
+    void flushDeltaStates() {
+        for (long groupId = 0; groupId < deltaStates.size(); groupId++) {
+            DeltaState delta = deltaStates.getAndSet(groupId, null);
+            if (delta == null || delta.samples == 0) {
+                Releasables.close(delta);
+                continue;
+            }
+            try {
+                ReducedState state = getOrInitializeReducedState(Math.toIntExact(groupId));
+                // empty lastValue forces resets to drive the increase; resets already holds the summed deltas
+                state.appendInterval(delta.deltaLastTs, ExponentialHistogram.empty(), delta.deltaFirstTs, delta.deltaFirstValue.accessor());
+                state.samples += delta.samples;
+                if (delta.resets != null) {
+                    state.addToResets(delta.resets.get());
+                }
+            } finally {
+                Releasables.close(delta);
+            }
+        }
     }
 
     static final class ExponentialHistogramRawBuffer extends RawBuffer {
@@ -788,25 +829,7 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
         // first)
         int[] intervals = EMPTY_INTERVALS;
 
-        // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
-        // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
-        long deltaFirstTs = Long.MAX_VALUE;
-        CompressedExponentialHistogramHolder deltaFirstValue;
-        long deltaLastTs = Long.MIN_VALUE;
-
-        boolean hasDelta() {
-            return deltaLastTs >= deltaFirstTs;
-        }
-
-        void appendInterval(long lastTs, ExponentialHistogram lastValue, long firstTs, ExponentialHistogram firstValue) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
-            int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
-        }
-
         void appendIntervalsFromBlocks(LongBlock ts, ExponentialHistogramBlock vs, int position) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
             int currentSize = intervals.length;
@@ -816,6 +839,12 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             }
         }
 
+        void appendInterval(long lastTs, ExponentialHistogram lastValue, long firstTs, ExponentialHistogram firstValue) {
+            int currentSize = intervals.length;
+            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
+        }
+
         void writeIntervalsToBlocks(
             LongBlock.Builder timestamps,
             ExponentialHistogramBlock.Builder values,
@@ -823,80 +852,28 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
         ) {
             timestamps.beginPositionEntry();
             values.beginPositionEntry();
-            if (hasDelta()) {
-                // delta data gets converted to a single, cumulative interval
-                timestamps.appendLong(lastTs());
-                timestamps.appendLong(firstTs());
-                values.append(lastValue(scratch));
-                values.append(firstValue(scratch));
-            } else {
-                for (int intervalId : intervals) {
-                    timestamps.appendLong(intervalBuffer.lastTs(intervalId));
-                    timestamps.appendLong(intervalBuffer.firstTs(intervalId));
-                    values.append(intervalBuffer.lastValue(intervalId, scratch));
-                    values.append(intervalBuffer.firstValue(intervalId, scratch));
-                }
+            for (int intervalId : intervals) {
+                timestamps.appendLong(intervalBuffer.lastTs(intervalId));
+                timestamps.appendLong(intervalBuffer.firstTs(intervalId));
+                values.append(intervalBuffer.lastValue(intervalId, scratch));
+                values.append(intervalBuffer.firstValue(intervalId, scratch));
             }
             timestamps.endPositionEntry();
             values.endPositionEntry();
         }
 
-        public void appendDeltaValue(long timestamp, ExponentialHistogram value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
-            samples++;
-            addToResets(value);
-            deltaLastTs = Math.max(deltaLastTs, timestamp);
-            if (timestamp < deltaFirstTs) {
-                deltaFirstTs = timestamp;
-                if (deltaFirstValue == null) {
-                    deltaFirstValue = CompressedExponentialHistogramHolder.create(histoBreaker);
-                }
-                deltaFirstValue.set(value);
-            }
-        }
-
-        public void appendDeltaSubRange(int from, int to, LongVector timestampVector, ExponentialHistogramBlock valueBlock) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
-            int minTsPos = -1;
-            long minTs = Long.MAX_VALUE;
-            ExponentialHistogramScratch scratch = new ExponentialHistogramScratch();
-            for (int i = from; i < to; i++) {
-                if (valueBlock.isNull(i)) {
-                    continue;
-                }
-                long ts = timestampVector.getLong(i);
-                if (ts < minTs) {
-                    minTs = ts;
-                    minTsPos = i;
-                }
-                samples++;
-                addToResets(valueBlock.getExponentialHistogram(valueBlock.getFirstValueIndex(i), scratch));
-                deltaLastTs = Math.max(deltaLastTs, ts);
-            }
-            if (minTs < deltaFirstTs) {
-                deltaFirstTs = minTs;
-                if (deltaFirstValue == null) {
-                    deltaFirstValue = CompressedExponentialHistogramHolder.create(histoBreaker);
-                }
-                deltaFirstValue.set(valueBlock.getExponentialHistogram(valueBlock.getFirstValueIndex(minTsPos), scratch));
-            }
-        }
-
         void combineIntervals() {
-            // only applies to cumulative metrics, we don't need to do anything for delta
-            if (hasDelta() == false) {
-                // Sort the intervals by the lastTs (most recent first) for the final evaluation
-                sortIntervals();
-                ExponentialHistogramScratch prevScratch = new ExponentialHistogramScratch();
-                ExponentialHistogramScratch nextScratch = new ExponentialHistogramScratch();
-                for (int i = 1; i < intervals.length; i++) {
-                    int nextInterval = intervals[i - 1]; // reversed
-                    int prevInterval = intervals[i];
-                    ExponentialHistogram prevLast = intervalBuffer.lastValue(prevInterval, prevScratch);
-                    ExponentialHistogram nextFirst = intervalBuffer.firstValue(nextInterval, nextScratch);
-                    if (nextFirst.valueCount() < prevLast.valueCount()) {
-                        addToResets(prevLast);
-                    }
+            // Sort the intervals by the lastTs (most recent first) for the final evaluation
+            sortIntervals();
+            ExponentialHistogramScratch prevScratch = new ExponentialHistogramScratch();
+            ExponentialHistogramScratch nextScratch = new ExponentialHistogramScratch();
+            for (int i = 1; i < intervals.length; i++) {
+                int nextInterval = intervals[i - 1]; // reversed
+                int prevInterval = intervals[i];
+                ExponentialHistogram prevLast = intervalBuffer.lastValue(prevInterval, prevScratch);
+                ExponentialHistogram nextFirst = intervalBuffer.firstValue(nextInterval, nextScratch);
+                if (nextFirst.valueCount() < prevLast.valueCount()) {
+                    addToResets(prevLast);
                 }
             }
         }
@@ -933,34 +910,83 @@ public final class IncreaseExponentialHistogramGroupingAggregatorFunction extend
             }.sort(0, intervals.length);
         }
 
-        // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
+        // The accessor methods first*/last* must only be called after combineIntervals().
         long lastTs() {
-            if (hasDelta()) {
-                return deltaLastTs;
-            }
             return intervalBuffer.lastTs(intervals[0]);
         }
 
         ExponentialHistogram lastValue(ExponentialHistogramScratch scratch) {
-            if (hasDelta()) {
-                // We use 0 as lastvalue for delta to force resets, the reset counter already has the real value in it
-                return ExponentialHistogram.empty();
-            }
             return intervalBuffer.lastValue(intervals[0], scratch);
         }
 
         long firstTs() {
-            if (hasDelta()) {
-                return deltaFirstTs;
-            }
             return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         ExponentialHistogram firstValue(ExponentialHistogramScratch scratch) {
-            if (hasDelta()) {
-                return deltaFirstValue.accessor();
-            }
             return intervalBuffer.firstValue(intervals[intervals.length - 1], scratch);
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(resets);
+        }
+    }
+
+    final class DeltaState implements Releasable {
+        long samples;
+        ExponentialHistogramMerger resets;
+        long deltaFirstTs = Long.MAX_VALUE;
+        CompressedExponentialHistogramHolder deltaFirstValue;
+        long deltaLastTs = Long.MIN_VALUE;
+
+        void addToResets(ExponentialHistogram value) {
+            if (value.isEmpty()) {
+                return;
+            }
+            if (resets == null) {
+                resets = mergerFactory.createMerger();
+            }
+            resets.add(value);
+        }
+
+        void appendDeltaValue(long timestamp, ExponentialHistogram value) {
+            samples++;
+            addToResets(value);
+            deltaLastTs = Math.max(deltaLastTs, timestamp);
+            if (timestamp < deltaFirstTs) {
+                deltaFirstTs = timestamp;
+                if (deltaFirstValue == null) {
+                    deltaFirstValue = CompressedExponentialHistogramHolder.create(histoBreaker);
+                }
+                deltaFirstValue.set(value);
+            }
+        }
+
+        void appendDeltaSubRange(int from, int to, LongVector timestampVector, ExponentialHistogramBlock valueBlock) {
+            int minTsPos = -1;
+            long minTs = Long.MAX_VALUE;
+            ExponentialHistogramScratch scratch = new ExponentialHistogramScratch();
+            for (int i = from; i < to; i++) {
+                if (valueBlock.isNull(i)) {
+                    continue;
+                }
+                long ts = timestampVector.getLong(i);
+                if (ts < minTs) {
+                    minTs = ts;
+                    minTsPos = i;
+                }
+                samples++;
+                addToResets(valueBlock.getExponentialHistogram(valueBlock.getFirstValueIndex(i), scratch));
+                deltaLastTs = Math.max(deltaLastTs, ts);
+            }
+            if (minTs < deltaFirstTs) {
+                deltaFirstTs = minTs;
+                if (deltaFirstValue == null) {
+                    deltaFirstValue = CompressedExponentialHistogramHolder.create(histoBreaker);
+                }
+                deltaFirstValue.set(valueBlock.getExponentialHistogram(valueBlock.getFirstValueIndex(minTsPos), scratch));
+            }
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -84,6 +84,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
+    private ObjectArray<DeltaState> deltaStates;
+
     private final IntervalBuffer intervalBuffer;
     private final boolean isRateOverTime;
     private final double dateFactor;
@@ -111,6 +113,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             rawBuffer = new DoubleRawBuffer(driverContext.breaker());
             intervalBuffer = new IntervalBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
+            this.deltaStates = bigArrays.newObjectArray(1);
             this.rawBuffer = rawBuffer;
             rawBuffer = null;
             this.intervalBuffer = intervalBuffer;
@@ -206,7 +209,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     ) {
         int lastGroup = -1;
         Temporality temporality = null;
-        ReducedState currentDeltaState = null;
+        DeltaState deltaState = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -235,15 +238,15 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                         rawBuffer.prepareForAppend(groupId, 1, timestamp);
                         rawBuffer.appendWithoutResize(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState = getOrInitializeReducedState(groupId);
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState = getOrInitializeDeltaState(groupId);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                     lastGroup = groupId;
                 } else {
                     if (temporality == Temporality.CUMULATIVE) {
                         rawBuffer.maybeResizeAndAppend(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                 }
             }
@@ -349,7 +352,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueVector, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 state.appendDeltaValue(timestampVector.getLong(pos), valueVector.getDouble(pos));
             }
@@ -375,7 +378,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueBlock, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 if (valueBlock.isNull(pos)) {
                     continue;
@@ -426,9 +429,19 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
     }
 
+    private DeltaState getOrInitializeDeltaState(int groupId) {
+        deltaStates = bigArrays.grow(deltaStates, groupId + 1);
+        var state = deltaStates.get(groupId);
+        if (state == null) {
+            state = new DeltaState();
+            deltaStates.set(groupId, state);
+        }
+        return state;
+    }
+
     private ReducedState getOrInitializeReducedState(int groupId) {
         reducedStates = bigArrays.grow(reducedStates, groupId + 1);
-        ReducedState state = reducedStates.get(groupId);
+        var state = reducedStates.get(groupId);
         if (state == null) {
             state = new ReducedState();
             reducedStates.set(groupId, state);
@@ -509,10 +522,15 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, intervalBuffer);
+        Releasables.close(reducedStates, rawBuffer, intervalBuffer, deltaStates);
     }
 
     void flushRawBuffers() {
+        flushCumulativeRawBuffers();
+        flushDeltaStates();
+    }
+
+    void flushCumulativeRawBuffers() {
         if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
@@ -526,10 +544,26 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
+                assert groupId >= deltaStates.size() || deltaStates.get(groupId) == null
+                    : "group cannot have both delta and cumulative state";
                 flushGroup(state, rawBuffer, flushQueue);
             }
         }
         rawBuffer.clearBuffers();
+    }
+
+    void flushDeltaStates() {
+        for (long groupId = 0; groupId < deltaStates.size(); groupId++) {
+            DeltaState delta = deltaStates.getAndSet(groupId, null);
+            if (delta == null || delta.samples == 0) {
+                continue;
+            }
+            ReducedState state = getOrInitializeReducedState(Math.toIntExact(groupId));
+            // lastValue 0 forces resets to drive the increase; resets already holds the summed deltas
+            state.appendInterval(delta.deltaLastTs, 0, delta.deltaFirstTs, delta.deltaFirstValue);
+            state.samples += delta.samples;
+            state.resets += delta.resets;
+        }
     }
 
     static final class DoubleRawBuffer extends RawBuffer {
@@ -807,31 +841,18 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         private static final int[] EMPTY_INTERVALS = new int[0];
         long samples;
         double resets;
-
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
         int[] intervals = EMPTY_INTERVALS;
 
-        // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
-        // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
-        long deltaFirstTs = Long.MAX_VALUE;
-        double deltaFirstValue;
-        long deltaLastTs = Long.MIN_VALUE;
-
-        boolean hasDelta() {
-            return deltaLastTs >= deltaFirstTs;
-        }
-
         void appendInterval(long lastTs, double lastValue, long firstTs, double firstValue) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int currentSize = intervals.length;
             this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
             this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, DoubleBlock vs, int position) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
             int currentSize = intervals.length;
@@ -844,46 +865,24 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         void writeIntervalsToBlocks(LongBlock.Builder timestamps, DoubleBlock.Builder values) {
             timestamps.beginPositionEntry();
             values.beginPositionEntry();
-            if (hasDelta()) {
-                // delta data gets converted to a single, cumulative interval
-                timestamps.appendLong(lastTs());
-                timestamps.appendLong(firstTs());
-                values.appendDouble(lastValue());
-                values.appendDouble(firstValue());
-            } else {
-                for (int intervalId : intervals) {
-                    timestamps.appendLong(intervalBuffer.lastTs(intervalId));
-                    timestamps.appendLong(intervalBuffer.firstTs(intervalId));
-                    values.appendDouble(intervalBuffer.lastValue(intervalId));
-                    values.appendDouble(intervalBuffer.firstValue(intervalId));
-                }
+            for (int intervalId : intervals) {
+                timestamps.appendLong(intervalBuffer.lastTs(intervalId));
+                timestamps.appendLong(intervalBuffer.firstTs(intervalId));
+                values.appendDouble(intervalBuffer.lastValue(intervalId));
+                values.appendDouble(intervalBuffer.firstValue(intervalId));
             }
             timestamps.endPositionEntry();
             values.endPositionEntry();
         }
 
-        public void appendDeltaValue(long timestamp, double value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
-            samples++;
-            resets += value;
-            deltaLastTs = Math.max(deltaLastTs, timestamp);
-            if (timestamp < deltaFirstTs) {
-                deltaFirstTs = timestamp;
-                deltaFirstValue = value;
-            }
-        }
-
         void combineIntervals() {
-            // only applies to cumulative metrics, we don't need to do anything for delta
-            if (hasDelta() == false) {
-                // Sort the intervals by the lastTs (most recent first) for the final evaluation
-                sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
-                    int next = intervals[i - 1]; // reversed
-                    int prev = intervals[i];
-                    if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
-                        resets += intervalBuffer.lastValue(prev);
-                    }
+            // Sort the intervals by the lastTs (most recent first) for the final evaluation
+            sortIntervals();
+            for (int i = 1; i < intervals.length; i++) {
+                int next = intervals[i - 1]; // reversed
+                int prev = intervals[i];
+                if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
+                    resets += intervalBuffer.lastValue(prev);
                 }
             }
         }
@@ -920,34 +919,38 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             }.sort(0, intervals.length);
         }
 
-        // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
         long lastTs() {
-            if (hasDelta()) {
-                return deltaLastTs;
-            }
             return intervalBuffer.lastTs(intervals[0]);
         }
 
         double lastValue() {
-            if (hasDelta()) {
-                // We use 0 as lastvalue for delta to force resets, the reset counter already has the real value in it
-                return 0;
-            }
             return intervalBuffer.lastValue(intervals[0]);
         }
 
         long firstTs() {
-            if (hasDelta()) {
-                return deltaFirstTs;
-            }
             return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         double firstValue() {
-            if (hasDelta()) {
-                return deltaFirstValue;
-            }
             return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+        }
+    }
+
+    final class DeltaState {
+        long samples;
+        double resets;
+        long deltaFirstTs = Long.MAX_VALUE;
+        double deltaFirstValue;
+        long deltaLastTs = Long.MIN_VALUE;
+
+        void appendDeltaValue(long timestamp, double value) {
+            samples++;
+            resets += value;
+            deltaLastTs = Math.max(deltaLastTs, timestamp);
+            if (timestamp < deltaFirstTs) {
+                deltaFirstTs = timestamp;
+                deltaFirstValue = value;
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -84,6 +84,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
+    private ObjectArray<DeltaState> deltaStates;
+
     private final IntervalBuffer intervalBuffer;
     private final boolean isRateOverTime;
     private final double dateFactor;
@@ -111,6 +113,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             rawBuffer = new IntRawBuffer(driverContext.breaker());
             intervalBuffer = new IntervalBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
+            this.deltaStates = bigArrays.newObjectArray(1);
             this.rawBuffer = rawBuffer;
             rawBuffer = null;
             this.intervalBuffer = intervalBuffer;
@@ -206,7 +209,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     ) {
         int lastGroup = -1;
         Temporality temporality = null;
-        ReducedState currentDeltaState = null;
+        DeltaState deltaState = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -235,15 +238,15 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                         rawBuffer.prepareForAppend(groupId, 1, timestamp);
                         rawBuffer.appendWithoutResize(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState = getOrInitializeReducedState(groupId);
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState = getOrInitializeDeltaState(groupId);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                     lastGroup = groupId;
                 } else {
                     if (temporality == Temporality.CUMULATIVE) {
                         rawBuffer.maybeResizeAndAppend(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                 }
             }
@@ -349,7 +352,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueVector, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 state.appendDeltaValue(timestampVector.getLong(pos), valueVector.getInt(pos));
             }
@@ -375,7 +378,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueBlock, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 if (valueBlock.isNull(pos)) {
                     continue;
@@ -426,9 +429,19 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
     }
 
+    private DeltaState getOrInitializeDeltaState(int groupId) {
+        deltaStates = bigArrays.grow(deltaStates, groupId + 1);
+        var state = deltaStates.get(groupId);
+        if (state == null) {
+            state = new DeltaState();
+            deltaStates.set(groupId, state);
+        }
+        return state;
+    }
+
     private ReducedState getOrInitializeReducedState(int groupId) {
         reducedStates = bigArrays.grow(reducedStates, groupId + 1);
-        ReducedState state = reducedStates.get(groupId);
+        var state = reducedStates.get(groupId);
         if (state == null) {
             state = new ReducedState();
             reducedStates.set(groupId, state);
@@ -509,10 +522,15 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, intervalBuffer);
+        Releasables.close(reducedStates, rawBuffer, intervalBuffer, deltaStates);
     }
 
     void flushRawBuffers() {
+        flushCumulativeRawBuffers();
+        flushDeltaStates();
+    }
+
+    void flushCumulativeRawBuffers() {
         if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
@@ -526,10 +544,26 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
+                assert groupId >= deltaStates.size() || deltaStates.get(groupId) == null
+                    : "group cannot have both delta and cumulative state";
                 flushGroup(state, rawBuffer, flushQueue);
             }
         }
         rawBuffer.clearBuffers();
+    }
+
+    void flushDeltaStates() {
+        for (long groupId = 0; groupId < deltaStates.size(); groupId++) {
+            DeltaState delta = deltaStates.getAndSet(groupId, null);
+            if (delta == null || delta.samples == 0) {
+                continue;
+            }
+            ReducedState state = getOrInitializeReducedState(Math.toIntExact(groupId));
+            // lastValue 0 forces resets to drive the increase; resets already holds the summed deltas
+            state.appendInterval(delta.deltaLastTs, 0, delta.deltaFirstTs, delta.deltaFirstValue);
+            state.samples += delta.samples;
+            state.resets += delta.resets;
+        }
     }
 
     static final class IntRawBuffer extends RawBuffer {
@@ -807,31 +841,18 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         private static final int[] EMPTY_INTERVALS = new int[0];
         long samples;
         double resets;
-
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
         int[] intervals = EMPTY_INTERVALS;
 
-        // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
-        // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
-        long deltaFirstTs = Long.MAX_VALUE;
-        int deltaFirstValue;
-        long deltaLastTs = Long.MIN_VALUE;
-
-        boolean hasDelta() {
-            return deltaLastTs >= deltaFirstTs;
-        }
-
         void appendInterval(long lastTs, int lastValue, long firstTs, int firstValue) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int currentSize = intervals.length;
             this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
             this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, IntBlock vs, int position) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
             int currentSize = intervals.length;
@@ -844,46 +865,24 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         void writeIntervalsToBlocks(LongBlock.Builder timestamps, IntBlock.Builder values) {
             timestamps.beginPositionEntry();
             values.beginPositionEntry();
-            if (hasDelta()) {
-                // delta data gets converted to a single, cumulative interval
-                timestamps.appendLong(lastTs());
-                timestamps.appendLong(firstTs());
-                values.appendInt(lastValue());
-                values.appendInt(firstValue());
-            } else {
-                for (int intervalId : intervals) {
-                    timestamps.appendLong(intervalBuffer.lastTs(intervalId));
-                    timestamps.appendLong(intervalBuffer.firstTs(intervalId));
-                    values.appendInt(intervalBuffer.lastValue(intervalId));
-                    values.appendInt(intervalBuffer.firstValue(intervalId));
-                }
+            for (int intervalId : intervals) {
+                timestamps.appendLong(intervalBuffer.lastTs(intervalId));
+                timestamps.appendLong(intervalBuffer.firstTs(intervalId));
+                values.appendInt(intervalBuffer.lastValue(intervalId));
+                values.appendInt(intervalBuffer.firstValue(intervalId));
             }
             timestamps.endPositionEntry();
             values.endPositionEntry();
         }
 
-        public void appendDeltaValue(long timestamp, int value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
-            samples++;
-            resets += value;
-            deltaLastTs = Math.max(deltaLastTs, timestamp);
-            if (timestamp < deltaFirstTs) {
-                deltaFirstTs = timestamp;
-                deltaFirstValue = value;
-            }
-        }
-
         void combineIntervals() {
-            // only applies to cumulative metrics, we don't need to do anything for delta
-            if (hasDelta() == false) {
-                // Sort the intervals by the lastTs (most recent first) for the final evaluation
-                sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
-                    int next = intervals[i - 1]; // reversed
-                    int prev = intervals[i];
-                    if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
-                        resets += intervalBuffer.lastValue(prev);
-                    }
+            // Sort the intervals by the lastTs (most recent first) for the final evaluation
+            sortIntervals();
+            for (int i = 1; i < intervals.length; i++) {
+                int next = intervals[i - 1]; // reversed
+                int prev = intervals[i];
+                if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
+                    resets += intervalBuffer.lastValue(prev);
                 }
             }
         }
@@ -920,34 +919,38 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             }.sort(0, intervals.length);
         }
 
-        // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
         long lastTs() {
-            if (hasDelta()) {
-                return deltaLastTs;
-            }
             return intervalBuffer.lastTs(intervals[0]);
         }
 
         int lastValue() {
-            if (hasDelta()) {
-                // We use 0 as lastvalue for delta to force resets, the reset counter already has the real value in it
-                return 0;
-            }
             return intervalBuffer.lastValue(intervals[0]);
         }
 
         long firstTs() {
-            if (hasDelta()) {
-                return deltaFirstTs;
-            }
             return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         int firstValue() {
-            if (hasDelta()) {
-                return deltaFirstValue;
-            }
             return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+        }
+    }
+
+    final class DeltaState {
+        long samples;
+        double resets;
+        long deltaFirstTs = Long.MAX_VALUE;
+        int deltaFirstValue;
+        long deltaLastTs = Long.MIN_VALUE;
+
+        void appendDeltaValue(long timestamp, int value) {
+            samples++;
+            resets += value;
+            deltaLastTs = Math.max(deltaLastTs, timestamp);
+            if (timestamp < deltaFirstTs) {
+                deltaFirstTs = timestamp;
+                deltaFirstValue = value;
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -84,6 +84,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
     private ObjectArray<ReducedState> reducedStates;
+    private ObjectArray<DeltaState> deltaStates;
+
     private final IntervalBuffer intervalBuffer;
     private final boolean isRateOverTime;
     private final double dateFactor;
@@ -111,6 +113,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             rawBuffer = new LongRawBuffer(driverContext.breaker());
             intervalBuffer = new IntervalBuffer(driverContext.breaker());
             this.reducedStates = bigArrays.newObjectArray(256);
+            this.deltaStates = bigArrays.newObjectArray(1);
             this.rawBuffer = rawBuffer;
             rawBuffer = null;
             this.intervalBuffer = intervalBuffer;
@@ -206,7 +209,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     ) {
         int lastGroup = -1;
         Temporality temporality = null;
-        ReducedState currentDeltaState = null;
+        DeltaState deltaState = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -235,15 +238,15 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                         rawBuffer.prepareForAppend(groupId, 1, timestamp);
                         rawBuffer.appendWithoutResize(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState = getOrInitializeReducedState(groupId);
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState = getOrInitializeDeltaState(groupId);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                     lastGroup = groupId;
                 } else {
                     if (temporality == Temporality.CUMULATIVE) {
                         rawBuffer.maybeResizeAndAppend(timestamp, value);
                     } else if (temporality == Temporality.DELTA) {
-                        currentDeltaState.appendDeltaValue(timestamp, value);
+                        deltaState.appendDeltaValue(timestamp, value);
                     }
                 }
             }
@@ -349,7 +352,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueVector, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 state.appendDeltaValue(timestampVector.getLong(pos), valueVector.getLong(pos));
             }
@@ -375,7 +378,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
             rawBuffer.appendRange(from, to, valueBlock, timestampVector);
         } else {
-            ReducedState state = getOrInitializeReducedState(group);
+            DeltaState state = getOrInitializeDeltaState(group);
             for (int pos = from; pos < to; pos++) {
                 if (valueBlock.isNull(pos)) {
                     continue;
@@ -426,9 +429,19 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
     }
 
+    private DeltaState getOrInitializeDeltaState(int groupId) {
+        deltaStates = bigArrays.grow(deltaStates, groupId + 1);
+        var state = deltaStates.get(groupId);
+        if (state == null) {
+            state = new DeltaState();
+            deltaStates.set(groupId, state);
+        }
+        return state;
+    }
+
     private ReducedState getOrInitializeReducedState(int groupId) {
         reducedStates = bigArrays.grow(reducedStates, groupId + 1);
-        ReducedState state = reducedStates.get(groupId);
+        var state = reducedStates.get(groupId);
         if (state == null) {
             state = new ReducedState();
             reducedStates.set(groupId, state);
@@ -509,10 +522,15 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
 
     @Override
     public void close() {
-        Releasables.close(reducedStates, rawBuffer, intervalBuffer);
+        Releasables.close(reducedStates, rawBuffer, intervalBuffer, deltaStates);
     }
 
     void flushRawBuffers() {
+        flushCumulativeRawBuffers();
+        flushDeltaStates();
+    }
+
+    void flushCumulativeRawBuffers() {
         if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
@@ -526,10 +544,26 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
+                assert groupId >= deltaStates.size() || deltaStates.get(groupId) == null
+                    : "group cannot have both delta and cumulative state";
                 flushGroup(state, rawBuffer, flushQueue);
             }
         }
         rawBuffer.clearBuffers();
+    }
+
+    void flushDeltaStates() {
+        for (long groupId = 0; groupId < deltaStates.size(); groupId++) {
+            DeltaState delta = deltaStates.getAndSet(groupId, null);
+            if (delta == null || delta.samples == 0) {
+                continue;
+            }
+            ReducedState state = getOrInitializeReducedState(Math.toIntExact(groupId));
+            // lastValue 0 forces resets to drive the increase; resets already holds the summed deltas
+            state.appendInterval(delta.deltaLastTs, 0, delta.deltaFirstTs, delta.deltaFirstValue);
+            state.samples += delta.samples;
+            state.resets += delta.resets;
+        }
     }
 
     static final class LongRawBuffer extends RawBuffer {
@@ -807,31 +841,18 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         private static final int[] EMPTY_INTERVALS = new int[0];
         long samples;
         double resets;
-
         // Points to offsets into IntervalBuffer for the intervals belonging to this group
         // Once sorted (after calling combineIntervals()), the intervals will be stored in reverse chronological order (highest timestamp
         // first)
         int[] intervals = EMPTY_INTERVALS;
 
-        // Delta tracking fields: in contrast to cumulative intervals, they need to be mutable
-        // We use deltaLastTs >= deltaFirstTs as indicator delta data exists.
-        long deltaFirstTs = Long.MAX_VALUE;
-        long deltaFirstValue;
-        long deltaLastTs = Long.MIN_VALUE;
-
-        boolean hasDelta() {
-            return deltaLastTs >= deltaFirstTs;
-        }
-
         void appendInterval(long lastTs, long lastValue, long firstTs, long firstValue) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int currentSize = intervals.length;
             this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
             this.intervals[currentSize] = intervalBuffer.appendInterval(lastTs, lastValue, firstTs, firstValue);
         }
 
         void appendIntervalsFromBlocks(LongBlock ts, LongBlock vs, int position) {
-            assert hasDelta() == false : "cannot append intervals while delta data is pending";
             int intervalCount = ts.getValueCount(position) / 2;
             int firstIntervalId = intervalBuffer.appendIntervalsFromBlocks(ts, vs, position);
             int currentSize = intervals.length;
@@ -844,46 +865,24 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         void writeIntervalsToBlocks(LongBlock.Builder timestamps, LongBlock.Builder values) {
             timestamps.beginPositionEntry();
             values.beginPositionEntry();
-            if (hasDelta()) {
-                // delta data gets converted to a single, cumulative interval
-                timestamps.appendLong(lastTs());
-                timestamps.appendLong(firstTs());
-                values.appendLong(lastValue());
-                values.appendLong(firstValue());
-            } else {
-                for (int intervalId : intervals) {
-                    timestamps.appendLong(intervalBuffer.lastTs(intervalId));
-                    timestamps.appendLong(intervalBuffer.firstTs(intervalId));
-                    values.appendLong(intervalBuffer.lastValue(intervalId));
-                    values.appendLong(intervalBuffer.firstValue(intervalId));
-                }
+            for (int intervalId : intervals) {
+                timestamps.appendLong(intervalBuffer.lastTs(intervalId));
+                timestamps.appendLong(intervalBuffer.firstTs(intervalId));
+                values.appendLong(intervalBuffer.lastValue(intervalId));
+                values.appendLong(intervalBuffer.firstValue(intervalId));
             }
             timestamps.endPositionEntry();
             values.endPositionEntry();
         }
 
-        public void appendDeltaValue(long timestamp, long value) {
-            assert intervals.length == 0 : "cannot append delta data when intervals already exist";
-            samples++;
-            resets += value;
-            deltaLastTs = Math.max(deltaLastTs, timestamp);
-            if (timestamp < deltaFirstTs) {
-                deltaFirstTs = timestamp;
-                deltaFirstValue = value;
-            }
-        }
-
         void combineIntervals() {
-            // only applies to cumulative metrics, we don't need to do anything for delta
-            if (hasDelta() == false) {
-                // Sort the intervals by the lastTs (most recent first) for the final evaluation
-                sortIntervals();
-                for (int i = 1; i < intervals.length; i++) {
-                    int next = intervals[i - 1]; // reversed
-                    int prev = intervals[i];
-                    if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
-                        resets += intervalBuffer.lastValue(prev);
-                    }
+            // Sort the intervals by the lastTs (most recent first) for the final evaluation
+            sortIntervals();
+            for (int i = 1; i < intervals.length; i++) {
+                int next = intervals[i - 1]; // reversed
+                int prev = intervals[i];
+                if (intervalBuffer.lastValue(prev) > intervalBuffer.firstValue(next)) {
+                    resets += intervalBuffer.lastValue(prev);
                 }
             }
         }
@@ -920,34 +919,38 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             }.sort(0, intervals.length);
         }
 
-        // The accessor methods first*/last* must only be called after combineIntervals() for non-delta states!
         long lastTs() {
-            if (hasDelta()) {
-                return deltaLastTs;
-            }
             return intervalBuffer.lastTs(intervals[0]);
         }
 
         long lastValue() {
-            if (hasDelta()) {
-                // We use 0 as lastvalue for delta to force resets, the reset counter already has the real value in it
-                return 0;
-            }
             return intervalBuffer.lastValue(intervals[0]);
         }
 
         long firstTs() {
-            if (hasDelta()) {
-                return deltaFirstTs;
-            }
             return intervalBuffer.firstTs(intervals[intervals.length - 1]);
         }
 
         long firstValue() {
-            if (hasDelta()) {
-                return deltaFirstValue;
-            }
             return intervalBuffer.firstValue(intervals[intervals.length - 1]);
+        }
+    }
+
+    final class DeltaState {
+        long samples;
+        double resets;
+        long deltaFirstTs = Long.MAX_VALUE;
+        long deltaFirstValue;
+        long deltaLastTs = Long.MIN_VALUE;
+
+        void appendDeltaValue(long timestamp, long value) {
+            samples++;
+            resets += value;
+            deltaLastTs = Math.max(deltaLastTs, timestamp);
+            if (timestamp < deltaFirstTs) {
+                deltaFirstTs = timestamp;
+                deltaFirstValue = value;
+            }
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Separate deltas from reduced states in rate (#154649)](https://github.com/elastic/elasticsearch/pull/154649)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)