### PR TITLE
Making GetPipelineResponse chunked

### DIFF
--- a/docs/changelog/156211.yaml
+++ b/docs/changelog/156211.yaml
@@ -1,0 +1,5 @@
+area: Ingest Node
+issues: []
+pr: 156211
+summary: Making `GetPipelineResponse` chunked
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -11,21 +11,24 @@ package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class GetPipelineResponse extends ActionResponse implements ToXContentObject {
+public class GetPipelineResponse extends ActionResponse implements ChunkedToXContentObject {
 
     private final List<PipelineConfiguration> pipelines;
     private final boolean summary;
@@ -71,10 +74,21 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
         return isFound() ? RestStatus.OK : RestStatus.NOT_FOUND;
     }
 
+    /**
+     * Renders the response in chunks -- one chunk per pipeline -- so that a large number of (or individually large) pipelines does not
+     * require the entire response to be held in memory at once while it is serialized.
+     */
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        for (PipelineConfiguration pipeline : pipelines) {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
+        return Iterators.concat(
+            ChunkedToXContentHelper.startObject(),
+            Iterators.map(pipelines.iterator(), this::pipelineChunk),
+            ChunkedToXContentHelper.endObject()
+        );
+    }
+
+    private ToXContent pipelineChunk(PipelineConfiguration pipeline) {
+        return (builder, params) -> {
             builder.startObject(pipeline.getId());
             for (final Map.Entry<String, Object> configProperty : (summary ? Map.<String, Object>of() : pipeline.getConfig()).entrySet()) {
                 if (Pipeline.CREATED_DATE_MILLIS.equals(configProperty.getKey())) {
@@ -94,9 +108,8 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
                 }
             }
             builder.endObject();
-        }
-        builder.endObject();
-        return builder;
+            return builder;
+        };
     }
 
     @Override
@@ -131,7 +144,7 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toString(ChunkedToXContentObject.wrapAsToXContentObject(this));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestGetPipelineAction.java
@@ -16,10 +16,11 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,7 +51,13 @@ public class RestGetPipelineAction extends BaseRestHandler {
         return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
             GetPipelineAction.INSTANCE,
             request,
-            new RestToXContentListener<>(channel, GetPipelineResponse::status)
+            // A GET for a specific pipeline id that is not found returns 404, so preserve the response's status rather than always 200.
+            new RestChunkedToXContentListener<>(channel) {
+                @Override
+                protected RestStatus getRestStatus(GetPipelineResponse response) {
+                    return response.status();
+                }
+            }
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
@@ -10,8 +10,10 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -61,7 +63,8 @@ public class GetPipelineResponseTests extends ESTestCase {
     public void testXContentDeserialization() throws IOException {
         Map<String, PipelineConfiguration> pipelinesMap = createPipelineConfigMap();
         GetPipelineResponse response = new GetPipelineResponse(new ArrayList<>(pipelinesMap.values()));
-        XContentBuilder builder = response.toXContent(getRandomXContentBuilder(), ToXContent.EMPTY_PARAMS);
+        XContentBuilder builder = ChunkedToXContentObject.wrapAsToXContentObject(response)
+            .toXContent(getRandomXContentBuilder(), ToXContent.EMPTY_PARAMS);
         GetPipelineResponse parsedResponse;
         try (
             XContentParser parser = builder.generator()
@@ -78,6 +81,13 @@ public class GetPipelineResponseTests extends ESTestCase {
             assertTrue(pipelinesMap.containsKey(pipeline.getId()));
             assertEquals(pipelinesMap.get(pipeline.getId()).getConfig(), pipeline.getConfig());
         }
+    }
+
+    public void testChunkCount() throws IOException {
+        Map<String, PipelineConfiguration> pipelinesMap = createPipelineConfigMap();
+        GetPipelineResponse response = new GetPipelineResponse(new ArrayList<>(pipelinesMap.values()));
+        // One chunk to open the enclosing object, one chunk per pipeline, and one chunk to close it.
+        AbstractChunkedSerializingTestCase.assertChunkCount(response, ignored -> pipelinesMap.size() + 2);
     }
 
     protected GetPipelineResponse doParseInstance(XContentParser parser) throws IOException {


### PR DESCRIPTION
This renders the get pipeline API response in chunks so that responses require less memory.