### PR TITLE
Reset thread context for bulk timeout task cancellation

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -627,6 +627,12 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             final CountDownLatch readyForCancellation = new CountDownLatch(1);
             final AtomicBoolean childTaskBanned = new AtomicBoolean(false);
+            // Checks that Handler#cancel stashes the context before propagating the cancellation, so
+            // internal:admin/tasks/ban is sent without caller-owned authentication headers. Without the
+            // stash, any header present when cancel() is called (or preserved into the timeout lambda by
+            // ThreadPool#schedule) would be carried into the ban request, causing the security layer to
+            // deny it because internal actions must run as the system user.
+            final AtomicBoolean banSentInUserlessContext = new AtomicBoolean(false);
 
             IncrementalBulkService.Handler handler2 = incrementalBulkService.newBulkRequest();
 
@@ -636,11 +642,17 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             refCounted.incRef();
             handler2.addItems(List.of(notCancelled), refCounted::decRef, () -> {
-                // Verify child task banned.
+                // Verify child task banned and that the ban is sent in a user-less context.
                 primaryTransportService.addRequestHandlingBehavior(
                     TaskCancellationService.BAN_PARENT_ACTION_NAME,
                     (transportRequestHandler, request, channel, task) -> {
                         childTaskBanned.set(true);
+                        // The ban must arrive without the "test.ban.sentinel" header that was put
+                        // in the caller's context before cancel(). If Handler#cancel stashes correctly,
+                        // the ban is sent from a clean context and the header is absent on the receiver.
+                        banSentInUserlessContext.set(
+                            primaryTransportService.getThreadPool().getThreadContext().getHeader("test.ban.sentinel") == null
+                        );
                         transportRequestHandler.messageReceived(request, channel, task);
                     }
                 );
@@ -673,11 +685,19 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
                 assertThat(handler2.getBulkSessionTask().getAction(), is("internal:bulk"));
                 assertThat(handler2.getBulkSessionTask().getType(), is("bulk"));
+                // Put a sentinel header that simulates a caller's authentication surviving
+                // ThreadPool#schedule's preserveContext. Handler#cancel must stash before sending the
+                // ban so the header is absent from the transport request on the receiver.
+                primaryTransportService.getThreadPool().getThreadContext().putHeader("test.ban.sentinel", "fake-auth");
                 handler2.cancel("after first additem() before second TransportShardBulkAction submit to write thread pool", () -> {});
             });
 
             BulkResponse bulkResponse = future2.actionGet();
             assertThat(childTaskBanned.get(), is(true));
+            assertTrue(
+                "ban was sent with caller header in context; stashContext() missing from Handler#cancel",
+                banSentInUserlessContext.get()
+            );
             assertThat(bulkResponse.getItems().length, is(3));
             assertThat(bulkResponse.getItems()[0].getFailure(), nullValue());
             assertThat(bulkResponse.getItems()[0].isFailed(), is(false));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -627,11 +627,6 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             final CountDownLatch readyForCancellation = new CountDownLatch(1);
             final AtomicBoolean childTaskBanned = new AtomicBoolean(false);
-            // Checks that Handler#cancel stashes the context before propagating the cancellation, so
-            // internal:admin/tasks/ban is sent without caller-owned authentication headers. Without the
-            // stash, any header present when cancel() is called (or preserved into the timeout lambda by
-            // ThreadPool#schedule) would be carried into the ban request, causing the security layer to
-            // deny it because internal actions must run as the system user.
             final AtomicBoolean banSentInUserlessContext = new AtomicBoolean(false);
 
             IncrementalBulkService.Handler handler2 = incrementalBulkService.newBulkRequest();
@@ -642,14 +637,11 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             refCounted.incRef();
             handler2.addItems(List.of(notCancelled), refCounted::decRef, () -> {
-                // Verify child task banned and that the ban is sent in a user-less context.
+                // Verify child task banned and that the ban is sent without caller-owned headers.
                 primaryTransportService.addRequestHandlingBehavior(
                     TaskCancellationService.BAN_PARENT_ACTION_NAME,
                     (transportRequestHandler, request, channel, task) -> {
                         childTaskBanned.set(true);
-                        // The ban must arrive without the "test.ban.sentinel" header that was put
-                        // in the caller's context before cancel(). If Handler#cancel stashes correctly,
-                        // the ban is sent from a clean context and the header is absent on the receiver.
                         banSentInUserlessContext.set(
                             primaryTransportService.getThreadPool().getThreadContext().getHeader("test.ban.sentinel") == null
                         );
@@ -685,9 +677,6 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
                 assertThat(handler2.getBulkSessionTask().getAction(), is("internal:bulk"));
                 assertThat(handler2.getBulkSessionTask().getType(), is("bulk"));
-                // Put a sentinel header that simulates a caller's authentication surviving
-                // ThreadPool#schedule's preserveContext. Handler#cancel must stash before sending the
-                // ban so the header is absent from the transport request on the receiver.
                 primaryTransportService.getThreadPool().getThreadContext().putHeader("test.ban.sentinel", "fake-auth");
                 handler2.cancel("after first additem() before second TransportShardBulkAction submit to write thread pool", () -> {});
             });

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -281,27 +281,13 @@ public class IncrementalBulkService {
         }
 
         /**
-         * Cancels the bulk session task and propagates the cancellation ban to every node holding a
-         * descendant task.
-         *
-         * <p>Stashes the thread context before cancelling. Propagating a cancellation sends
-         * {@code internal:admin/tasks/ban} (and later the matching unban) to peer nodes. Those actions
-         * can never be granted to a user — they must run as the system user. When the bulk timeout
-         * fires, {@link ThreadPool#schedule} preserves the REST caller's context (including any
-         * authentication) into the timeout lambda without the originating-action transient that
-         * would normally cause the security interceptor to swap to the system user. Stashing here
-         * produces a user-less context so the interceptor can swap correctly. The same pattern is
-         * applied in {@link org.elasticsearch.tasks.TaskCancellationService} when sending
-         * {@code internal:admin/tasks/cancel_child}.
-         *
-         * <p>The stash is sufficient for both the ban and the unban: the unban is scheduled via
-         * {@link ThreadContext#preserveContext} on the context active when
-         * {@code cancelTaskAndDescendants} is invoked, so using this stashed context as the base
-         * means the unban inherits a user-less context too.
+         * Stashes the thread context before propagating the cancellation. {@code internal:admin/tasks/ban}
+         * (and its matching unban) can never be granted to a user and must run as the system user.
+         * {@link ThreadPool#schedule} preserves the REST caller's context into the timeout lambda, so
+         * without the stash the security interceptor would deny the ban request. Mirrors
+         * {@link org.elasticsearch.tasks.TaskCancellationService} sending {@code cancel_child}.
          */
         public void cancel(String reason, Runnable listener) {
-            // internal:admin/tasks/ban cannot be granted to a user; stash to let the security
-            // interceptor run it as the system user instead of denying it.
             try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
                 taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
             }

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -279,8 +280,31 @@ public class IncrementalBulkService {
             }
         }
 
+        /**
+         * Cancels the bulk session task and propagates the cancellation ban to every node holding a
+         * descendant task.
+         *
+         * <p>Stashes the thread context before cancelling. Propagating a cancellation sends
+         * {@code internal:admin/tasks/ban} (and later the matching unban) to peer nodes. Those actions
+         * can never be granted to a user — they must run as the system user. When the bulk timeout
+         * fires, {@link ThreadPool#schedule} preserves the REST caller's context (including any
+         * authentication) into the timeout lambda without the originating-action transient that
+         * would normally cause the security interceptor to swap to the system user. Stashing here
+         * produces a user-less context so the interceptor can swap correctly. The same pattern is
+         * applied in {@link org.elasticsearch.tasks.TaskCancellationService} when sending
+         * {@code internal:admin/tasks/cancel_child}.
+         *
+         * <p>The stash is sufficient for both the ban and the unban: the unban is scheduled via
+         * {@link ThreadContext#preserveContext} on the context active when
+         * {@code cancelTaskAndDescendants} is invoked, so using this stashed context as the base
+         * means the unban inherits a user-less context too.
+         */
         public void cancel(String reason, Runnable listener) {
-            taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
+            // internal:admin/tasks/ban cannot be granted to a user; stash to let the security
+            // interceptor run it as the system user instead of denying it.
+            try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
+                taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
+            }
         }
 
         public IndexingPressure.Incremental getIncrementalOperation() {
@@ -388,12 +412,7 @@ public class IncrementalBulkService {
                 releasables.forEach(Releasable::close);
                 releasables.clear();
                 if (taskManager.getCancellableTask(bulkSessionTask.getId()) != null) {
-                    taskManager.cancelTaskAndDescendants(
-                        bulkSessionTask,
-                        "handler closed",
-                        false,
-                        ActionListener.running(() -> taskManager.unregister(bulkSessionTask))
-                    );
+                    cancel("handler closed", () -> taskManager.unregister(bulkSessionTask));
                 }
             }
         }


### PR DESCRIPTION
Stashes the thread context before propagating the cancellation.  `internal:admin/tasks/ban` can never be granted to a user and must run as the system user.