### PR TITLE
[8.19] Handle createLink post security manager in StoreRecoveryTests (#129964)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -37,9 +37,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.highlight/30_max_analyzed_offset/Plain highlighter with max_analyzed_offset < 0 should FAIL}
   issue: https://github.com/elastic/elasticsearch/issues/156122
-- class: org.elasticsearch.index.shard.StoreRecoveryTests
-  method: testAddIndices
-  issue: https://github.com/elastic/elasticsearch/issues/156123
 - class: org.elasticsearch.search.aggregations.metrics.LargeTopHitsIT
   method: test500Queries
   issue: https://github.com/elastic/elasticsearch/issues/148056

--- a/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -254,12 +253,7 @@ public class StoreRecoveryTests extends ESTestCase {
         try {
             Files.createFile(path.resolve("foo.bar"));
             Files.createLink(path.resolve("test"), path.resolve("foo.bar"));
-            BasicFileAttributes destAttr = Files.readAttributes(path.resolve("test"), BasicFileAttributes.class);
-            BasicFileAttributes sourceAttr = Files.readAttributes(path.resolve("foo.bar"), BasicFileAttributes.class);
-            // we won't get here - no permission ;)
-            return destAttr.fileKey() != null && destAttr.fileKey().equals(sourceAttr.fileKey());
-        } catch (SecurityException ex) {
-            return true; // if we run into that situation we know it's supported.
+            return true; // createLink returning without exception means hard links are supported
         } catch (UnsupportedOperationException ex) {
             return false;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Handle createLink post security manager in StoreRecoveryTests (#129964)](https://github.com/elastic/elasticsearch/pull/129964)

This was already marked for backport but the automated backport failed.

Fixes #156123 