### PR TITLE
Remove write_load weight for index tier allocation target node iteration

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/StatelessBalancingWeightsFactory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/StatelessBalancingWeightsFactory.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.THRESHOLD_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.WRITE_LOAD_BALANCE_FACTOR_SETTING;
 import static org.elasticsearch.xpack.stateless.StatelessPlugin.STATELESS_SHARD_ROLES;
 
 public class StatelessBalancingWeightsFactory implements BalancingWeightsFactory {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/StatelessBalancingWeightsFactory.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/StatelessBalancingWeightsFactory.java
@@ -56,7 +56,7 @@ public class StatelessBalancingWeightsFactory implements BalancingWeightsFactory
 
     public static final Setting<Float> INDEXING_TIER_WRITE_LOAD_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "stateless.cluster.routing.allocation.balance.write_load.indexing_tier",
-        WRITE_LOAD_BALANCE_FACTOR_SETTING,
+        0.0f,
         0.0f,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope


### PR DESCRIPTION
Write load weights proved too volatile and most shards would have
values of zero with a handful of high value acitve shards at most
times, leading to piling up shards on single nodes and performance
being vulnerable when load shifted to other indices/shards..

Closes elastic/elasticsearch-team#4704