### PR TITLE
[Transform] Validate security headers

### DIFF
--- a/docs/changelog/156222.yaml
+++ b/docs/changelog/156222.yaml
@@ -1,0 +1,5 @@
+area: Transform
+issues: []
+pr: 156222
+summary: Validate security headers
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -62,6 +62,8 @@ public class TransformMessages {
 
     public static final String TRANSFORM_CANNOT_START_WITHOUT_PERMISSIONS = "Cannot start transform [{0}] because user lacks required "
         + "permissions, see privileges_check_failed issue for more details";
+    public static final String TRANSFORM_CANNOT_START_WITHOUT_CREDENTIALS =
+        "Cannot start transform [{0}] because user lacks required permissions. Call /_transform/{0}/_update to reset permissions.";
     public static final String TRANSFORM_CONFIGURATION_BAD_FUNCTION_COUNT = "Transform configuration must specify exactly 1 function";
     public static final String TRANSFORM_CONFIGURATION_PIVOT_NO_GROUP_BY = "Pivot transform configuration must specify at least 1 group_by";
     public static final String TRANSFORM_CONFIGURATION_PIVOT_NO_AGGREGATION =

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
@@ -28,7 +28,10 @@ import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.core.transform.TransformDeprecations;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
@@ -127,6 +130,20 @@ public class TransportValidateTransformAction extends HandledTransportAction<Req
                         config.getVersion(),
                         TransformDeprecations.MIN_TRANSFORM_VERSION
                     )
+                )
+            );
+            return;
+        }
+
+        // Fail closed when security is on but the config has neither stored headers nor a UIAM
+        // credential id — empty headers fall through to TRANSFORM_ORIGIN and bypass DLS.
+        // Checked even when deferValidation is true: an unsafe config must not be waved through.
+        if (XPackSettings.SECURITY_ENABLED.get(nodeSettings)
+            && config.getCredentialId() == null
+            && ClientHelper.filterSecurityHeaders(config.getHeaders()).isEmpty()) {
+            listener.onFailure(
+                Exceptions.authorizationError(
+                    TransformMessages.getMessage(TransformMessages.TRANSFORM_CANNOT_START_WITHOUT_CREDENTIALS, config.getId())
                 )
             );
             return;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -51,6 +51,7 @@ import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.security.cloud.CloudCredentialManager;
 import org.elasticsearch.xpack.core.security.cloud.PersistedCloudCredential;
@@ -138,7 +139,9 @@ class ClientTransformIndexer extends TransformIndexer {
             transformProgress,
             lastCheckpoint,
             nextCheckpoint,
-            context
+            context,
+            // ClusterService mocks in unit tests often leave getSettings() unstubbed (null).
+            clusterService.getSettings() != null && XPackSettings.SECURITY_ENABLED.get(clusterService.getSettings())
         );
         this.client = ExceptionsHelper.requireNonNull(client, "client");
         this.credentialManager = transformExtension.getCloudCredentialManager();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -31,9 +31,11 @@ import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
@@ -101,6 +103,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     private final ThreadPool threadPool;
     private final boolean supportsMultipleProjects;
+    private final boolean securityEnabled;
     protected final TransformConfigManager transformsConfigManager;
     private final CheckpointProvider checkpointProvider;
     protected final TransformFailureHandler failureHandler;
@@ -141,7 +144,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     protected volatile boolean indexerThreadShuttingDown = false;
     protected volatile boolean saveStateRequestedDuringIndexerThreadShutdown = false;
 
-    @SuppressWarnings("this-escape")
     public TransformIndexer(
         ThreadPool threadPool,
         TransformServices transformServices,
@@ -155,11 +157,42 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         TransformCheckpoint nextCheckpoint,
         TransformContext context
     ) {
+        this(
+            threadPool,
+            transformServices,
+            checkpointProvider,
+            transformConfig,
+            initialState,
+            initialPosition,
+            jobStats,
+            transformProgress,
+            lastCheckpoint,
+            nextCheckpoint,
+            context,
+            false
+        );
+    }
+
+    public TransformIndexer(
+        ThreadPool threadPool,
+        TransformServices transformServices,
+        CheckpointProvider checkpointProvider,
+        TransformConfig transformConfig,
+        AtomicReference<IndexerState> initialState,
+        TransformIndexerPosition initialPosition,
+        TransformIndexerStats jobStats,
+        TransformProgress transformProgress,
+        TransformCheckpoint lastCheckpoint,
+        TransformCheckpoint nextCheckpoint,
+        TransformContext context,
+        boolean securityEnabled
+    ) {
         // important: note that we pass the context object as lock object
         super(threadPool, initialState, initialPosition, jobStats, context);
         this.threadPool = threadPool;
         ExceptionsHelper.requireNonNull(transformServices, "transformServices");
         this.supportsMultipleProjects = transformServices.projectResolver().supportsMultipleProjects();
+        this.securityEnabled = securityEnabled;
         this.transformsConfigManager = transformServices.configManager();
         this.checkpointProvider = ExceptionsHelper.requireNonNull(checkpointProvider, "checkpointProvider");
         this.auditor = transformServices.auditor();
@@ -180,7 +213,9 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         if (transformConfig.getSettings() != null && transformConfig.getSettings().getDocsPerSecond() != null) {
             docsPerSecond = transformConfig.getSettings().getDocsPerSecond();
         }
-        this.lastSaveStateMilliseconds = TimeUnit.NANOSECONDS.toMillis(getTimeNanos());
+        // Use System.nanoTime() directly — do not call overridable getTimeNanos() from a ctor
+        // (that triggers JDK this-escape / -Werror).
+        this.lastSaveStateMilliseconds = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
     }
 
     abstract void doGetInitialProgress(SearchRequest request, ActionListener<SearchResponse> responseListener);
@@ -310,6 +345,19 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             listener.onFailure(
                 new ElasticsearchSecurityException(
                     TransformMessages.getMessage(TransformMessages.TRANSFORM_CANNOT_START_WITHOUT_PERMISSIONS, getConfig().getId())
+                )
+            );
+            return;
+        }
+
+        // Fail closed when security is on but the config has neither stored headers nor a UIAM
+        // credential id — empty headers fall through to TRANSFORM_ORIGIN and bypass DLS.
+        if (securityEnabled
+            && getConfig().getCredentialId() == null
+            && ClientHelper.filterSecurityHeaders(getConfig().getHeaders()).isEmpty()) {
+            listener.onFailure(
+                Exceptions.authorizationError(
+                    TransformMessages.getMessage(TransformMessages.TRANSFORM_CANNOT_START_WITHOUT_CREDENTIALS, getConfig().getId())
                 )
             );
             return;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -453,6 +453,10 @@ public class TransformIndexerStateTests extends ESTestCase {
             context
         );
 
+        // Align lastSaveState with the fake clock. Construction uses System.nanoTime() (must not call
+        // overridable getTimeNanos from a ctor); seed persistence at t=0 so the timeline below holds.
+        indexer.setTimeMillis(0);
+        indexer.doSaveState(IndexerState.INDEXING, null, () -> {});
         assertFalse(indexer.triggerSaveState());
         // simple: advancing the time should trigger state persistence
         indexer.setTimeMillis(80_000);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -38,6 +38,8 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.QueryConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
@@ -81,7 +83,9 @@ import java.util.stream.Stream;
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfigTests.randomPivotConfig;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.oneOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -129,6 +133,32 @@ public class TransformIndexerTests extends ESTestCase {
             TransformIndexerStats jobStats,
             TransformContext context
         ) {
+            this(
+                numberOfLoops,
+                threadPool,
+                transformServices,
+                checkpointProvider,
+                transformConfig,
+                initialState,
+                initialPosition,
+                jobStats,
+                context,
+                false
+            );
+        }
+
+        MockedTransformIndexer(
+            int numberOfLoops,
+            ThreadPool threadPool,
+            TransformServices transformServices,
+            CheckpointProvider checkpointProvider,
+            TransformConfig transformConfig,
+            AtomicReference<IndexerState> initialState,
+            TransformIndexerPosition initialPosition,
+            TransformIndexerStats jobStats,
+            TransformContext context,
+            boolean securityEnabled
+        ) {
             super(
                 threadPool,
                 transformServices,
@@ -140,7 +170,8 @@ public class TransformIndexerTests extends ESTestCase {
                 /* TransformProgress */ null,
                 TransformCheckpoint.EMPTY,
                 TransformCheckpoint.EMPTY,
-                context
+                context,
+                securityEnabled
             );
             this.threadPool = threadPool;
             this.numberOfLoops = numberOfLoops;
@@ -340,6 +371,128 @@ public class TransformIndexerTests extends ESTestCase {
     @After
     public void tearDownClient() {
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    public void testOnStartFailsWhenSecurityEnabledAndCredentialsMissing() throws Exception {
+        TransformConfig config = new TransformConfig.Builder().setId("missing-creds")
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setPivotConfig(randomPivotConfig())
+            .setHeaders(Collections.emptyMap())
+            .build();
+        assertOnStartFailsForMissingCredentials(config, "missing-creds");
+    }
+
+    public void testOnStartFailsWhenSecurityEnabledAndOnlyNonSecurityHeaders() throws Exception {
+        TransformConfig config = new TransformConfig.Builder().setId("non-security-headers")
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setPivotConfig(randomPivotConfig())
+            .setHeaders(Map.of("x-trace-id", "trace-1"))
+            .build();
+        assertOnStartFailsForMissingCredentials(config, "non-security-headers");
+    }
+
+    public void testOnStartSucceedsWhenSecurityEnabledAndHeadersPresent() throws Exception {
+        TransformConfig config = new TransformConfig.Builder().setId("with-headers")
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setPivotConfig(randomPivotConfig())
+            .setHeaders(Map.of(AuthenticationField.AUTHENTICATION_KEY, "encoded-auth"))
+            .build();
+        assertOnStartDoesNotFailForMissingCredentials(config, true);
+    }
+
+    public void testOnStartSucceedsWhenSecurityEnabledAndCredentialIdPresent() throws Exception {
+        TransformConfig config = new TransformConfig.Builder().setId("with-credential")
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setPivotConfig(randomPivotConfig())
+            .setCredentialId("cloud-token-id")
+            .build();
+        assertOnStartDoesNotFailForMissingCredentials(config, true);
+    }
+
+    public void testOnStartAllowsMissingCredentialsWhenSecurityDisabled() throws Exception {
+        TransformConfig config = new TransformConfig.Builder().setId("security-off")
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setPivotConfig(randomPivotConfig())
+            .setHeaders(Collections.emptyMap())
+            .build();
+        assertOnStartDoesNotFailForMissingCredentials(config, false);
+    }
+
+    private void assertOnStartFailsForMissingCredentials(TransformConfig config, String transformId) throws Exception {
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+        MockedTransformIndexer indexer = createMockIndexer(
+            1,
+            config,
+            new AtomicReference<>(IndexerState.STARTED),
+            null,
+            threadPool,
+            auditor,
+            new TransformIndexerStats(),
+            context,
+            true
+        );
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        indexer.onStart(System.currentTimeMillis(), ActionListener.wrap(r -> latch.countDown(), e -> {
+            failure.set(e);
+            latch.countDown();
+        }));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(failure.get());
+        assertThat(failure.get(), instanceOf(org.elasticsearch.ElasticsearchSecurityException.class));
+        assertThat(
+            failure.get().getMessage(),
+            equalTo(TransformMessages.getMessage(TransformMessages.TRANSFORM_CANNOT_START_WITHOUT_CREDENTIALS, transformId))
+        );
+    }
+
+    private void assertOnStartDoesNotFailForMissingCredentials(TransformConfig config, boolean securityEnabled) throws Exception {
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+        MockedTransformIndexer indexer = createMockIndexer(
+            1,
+            config,
+            new AtomicReference<>(IndexerState.STARTED),
+            null,
+            threadPool,
+            auditor,
+            new TransformIndexerStats(),
+            context,
+            securityEnabled
+        );
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        AtomicBoolean succeeded = new AtomicBoolean(false);
+        // onStart continues into async config reload; we only assert the missing-credentials gate did not fail.
+        indexer.onStart(System.currentTimeMillis(), ActionListener.wrap(r -> {
+            succeeded.set(true);
+            latch.countDown();
+        }, e -> {
+            failure.set(e);
+            latch.countDown();
+        }));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        if (failure.get() != null) {
+            assertThat(
+                failure.get().getMessage(),
+                org.hamcrest.Matchers.not(
+                    equalTo(TransformMessages.getMessage(TransformMessages.TRANSFORM_CANNOT_START_WITHOUT_CREDENTIALS, config.getId()))
+                )
+            );
+        } else {
+            assertTrue(succeeded.get());
+        }
     }
 
     public void testRetentionPolicyExecution() throws Exception {
@@ -896,6 +1049,20 @@ public class TransformIndexerTests extends ESTestCase {
         TransformIndexerStats jobStats,
         TransformContext context
     ) {
+        return createMockIndexer(numberOfLoops, config, state, failureConsumer, threadPool, transformAuditor, jobStats, context, false);
+    }
+
+    private MockedTransformIndexer createMockIndexer(
+        int numberOfLoops,
+        TransformConfig config,
+        AtomicReference<IndexerState> state,
+        Consumer<String> failureConsumer,
+        ThreadPool threadPool,
+        TransformAuditor transformAuditor,
+        TransformIndexerStats jobStats,
+        TransformContext context,
+        boolean securityEnabled
+    ) {
         CheckpointProvider checkpointProvider = new MockTimebasedCheckpointProvider(config);
         transformConfigManager.putTransformConfiguration(config, ActionListener.noop());
         TransformServices transformServices = new TransformServices(
@@ -919,7 +1086,8 @@ public class TransformIndexerTests extends ESTestCase {
             state,
             null,
             jobStats,
-            context
+            context,
+            securityEnabled
         );
 
         indexer.initialize();


### PR DESCRIPTION
When security is enabled, validate security headers are present on the Transform, both during validation and during indexing, with a more helpful error message when they are missing.
