### PR TITLE
Don't re-encode binary doc values that have been filtered by FLS

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
@@ -73,6 +73,9 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
      */
     public static MultiValuedSortedBinaryDocValues fromMultiValued(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
         throws IOException {
+        if (values instanceof DecodedBinaryDocValues decodedBinaryDocValues) {
+            return new DecodedBinary(decodedBinaryDocValues);
+        }
         String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
         NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);
         if (counts == null) {
@@ -235,6 +238,46 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
         @Override
         public ValueMode getValueMode() {
             return ValueMode.SINGLE_VALUED;
+        }
+    }
+
+    /**
+     * Already decoded binary doc values. Useful for things like a security wrapper that drops the values the user is not allowed to access.
+     * Without this, such a producer has to re-encode the values it decoded back into a binary blob, that ultimately needs to get re-decoded
+     * further down the line.
+     */
+    public abstract static class DecodedBinaryDocValues extends BinaryDocValues {
+        /** Valid only after {@link #advanceExact(int)} has returned {@code true} for the current document. */
+        public abstract int docValueCount();
+
+        public abstract BytesRef nextValue() throws IOException;
+    }
+
+    /**
+     * Reads from a producer that has already split the document into individual values, skipping the encode/decode round trip.
+     */
+    private static class DecodedBinary extends MultiValuedSortedBinaryDocValues {
+        private final DecodedBinaryDocValues decodedBinaryDocValues;
+
+        DecodedBinary(DecodedBinaryDocValues decodedBinaryDocValues) {
+            super(decodedBinaryDocValues);
+            this.decodedBinaryDocValues = decodedBinaryDocValues;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+            if (values.advanceExact(doc)) {
+                count = decodedBinaryDocValues.docValueCount();
+                return true;
+            } else {
+                count = 0;
+                return false;
+            }
+        }
+
+        @Override
+        public BytesRef nextValue() throws IOException {
+            return decodedBinaryDocValues.nextValue();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -397,29 +398,32 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
      * Applies a field-level security filter to a single ignored source value.
      * Shared by {@link IgnoredSourceFormat#LEGACY_SINGLE_IGNORED_SOURCE} and {@link IgnoredSourceFormat#DOC_VALUES_IGNORED_SOURCE}.
      */
-    static BytesRef filterLegacyValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException {
-        // for _ignored_source, parse, filter out the field and its contents, and serialize back downstream
-        MappedNameValue mappedNameValue = SingularIgnoredSourceEncoding.decodeAsMap(value);
-        if (mappedNameValue == null) {
+    static BytesRef filterLegacyValue(
+        BytesRef value,
+        Function<Map<String, Object>, Map<String, Object>> filter,
+        Predicate<String> nameFilter
+    ) throws IOException {
+        NameValue nameValue = SingularIgnoredSourceEncoding.decode(value);
+        if (nameValue.hasValue() == false) {
             return null;
         }
+
+        if (XContentDataHelper.isEncodedObject(nameValue.value()) == false) {
+            // A leaf value has no subfields to strip, so the whole entry either survives or it does not, and the field name alone decides
+            // which. This avoids decoding the value into a map only to serialize it straight back.
+            return nameFilter.test(nameValue.name()) ? value : null;
+        }
+
+        // for _ignored_source, parse, filter out the field and its contents, and serialize back downstream
+        MappedNameValue mappedNameValue = nameValueToMapped(nameValue);
         Map<String, Object> transformedField = filter.apply(mappedNameValue.map());
         if (transformedField.isEmpty()) {
             // All values were filtered
             return null;
         }
-        // The unfiltered map contains at least one element, the field name with its value. If the field contains
-        // an object or an array, the value of the first element is a map or a list, respectively. Otherwise,
-        // it's a single leaf value, e.g. a string or a number.
-        var topValue = mappedNameValue.map().values().iterator().next();
-        if (topValue instanceof Map<?, ?> || topValue instanceof List<?>) {
-            // The field contains an object or an array, reconstruct it from the transformed map in case
-            // any subfield has been filtered out.
-            return SingularIgnoredSourceEncoding.encodeFromMap(mappedNameValue.withMap(transformedField));
-        } else {
-            // The field contains a leaf value, and it hasn't been filtered out. It is safe to propagate the original value.
-            return value;
-        }
+
+        // Reconstruct the value from the transformed map in case any subfield has been filtered out.
+        return SingularIgnoredSourceEncoding.encodeFromMap(mappedNameValue.withMap(transformedField));
     }
 
     public enum IgnoredSourceFormat {
@@ -440,7 +444,11 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             }
 
             @Override
-            public BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) {
+            public BytesRef filterValue(
+                BytesRef value,
+                Function<Map<String, Object>, Map<String, Object>> filter,
+                Predicate<String> nameFilter
+            ) {
                 assert false : "cannot filter ignored source with format NO_IGNORED_SOURCE";
                 return null;
             }
@@ -476,8 +484,12 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             }
 
             @Override
-            public BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException {
-                return filterLegacyValue(value, filter);
+            public BytesRef filterValue(
+                BytesRef value,
+                Function<Map<String, Object>, Map<String, Object>> filter,
+                Predicate<String> nameFilter
+            ) throws IOException {
+                return filterLegacyValue(value, filter, nameFilter);
             }
         },
         COALESCED_SINGLE_IGNORED_SOURCE {
@@ -528,7 +540,11 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             }
 
             @Override
-            public BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException {
+            public BytesRef filterValue(
+                BytesRef value,
+                Function<Map<String, Object>, Map<String, Object>> filter,
+                Predicate<String> nameFilter // unused: this format keeps the decode-everything path, see filterLegacyValue
+            ) throws IOException {
                 List<MappedNameValue> mappedNameValues = CoalescedIgnoredSourceEncoding.decodeAsMap(value);
                 List<MappedNameValue> filteredNameValues = new ArrayList<>(mappedNameValues.size());
                 boolean maybeDidFilter = false;
@@ -593,8 +609,12 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             }
 
             @Override
-            public BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException {
-                return filterLegacyValue(value, filter);
+            public BytesRef filterValue(
+                BytesRef value,
+                Function<Map<String, Object>, Map<String, Object>> filter,
+                Predicate<String> nameFilter
+            ) throws IOException {
+                return filterLegacyValue(value, filter, nameFilter);
             }
         };
 
@@ -616,7 +636,18 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
 
         public abstract void writeIgnoredFields(Collection<NameValue> ignoredFieldValues, IndexVersion indexVersion, boolean hasNestedDocs);
 
-        public abstract BytesRef filterValue(BytesRef value, Function<Map<String, Object>, Map<String, Object>> filter) throws IOException;
+        /**
+         * Applies field-level security to a single stored blob of ignored source.
+         *
+         * @param filter     strips the entries and subfields the user may not see from a decoded value; needed only for objects and arrays
+         * @param nameFilter tests a full field path on its own, so entries holding a leaf value can be kept or dropped without decoding
+         * @return the surviving value, the original blob when nothing was removed, or null when the whole blob was filtered out
+         */
+        public abstract BytesRef filterValue(
+            BytesRef value,
+            Function<Map<String, Object>, Map<String, Object>> filter,
+            Predicate<String> nameFilter
+        ) throws IOException;
     }
 
     public IgnoredSourceFormat ignoredSourceFormat() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -290,8 +290,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             return new BytesRef(bytes);
         }
 
-        public static NameValue decode(Object field) {
-            BytesRef ref = (BytesRef) field;
+        public static NameValue decode(BytesRef ref) {
             byte[] bytes = ref.bytes;
             int off = ref.offset;
             int len = ref.length;
@@ -467,7 +466,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
                 }
                 Map<String, List<NameValue>> objectsWithIgnoredFields = new HashMap<>();
                 for (Object value : ignoredStoredValues) {
-                    NameValue nv = SingularIgnoredSourceEncoding.decode(value);
+                    NameValue nv = SingularIgnoredSourceEncoding.decode((BytesRef) value);
                     if (filter != null && filter.isPathFiltered(nv.name(), XContentDataHelper.isEncodedObject(nv.value()))) {
                         continue;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -409,7 +409,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         }
 
         if (XContentDataHelper.isEncodedObject(nameValue.value()) == false) {
-            // A leaf value has no subfields to strip, so the whole entry either survives or it does not, and the field name alone decides
+            // A scalar value has no subfields to strip, so the whole entry either survives or it does not, and the field name alone decides
             // which. This avoids decoding the value into a map only to serialize it straight back.
             return nameFilter.test(nameValue.name()) ? value : null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A {@link FilterLeafReader} that exposes only a subset
@@ -377,7 +378,9 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
         private final BinaryDocValues delegate;
         private final MultiValuedSortedBinaryDocValues multiValues;
         private final IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat;
-        private final CharacterRunAutomaton filter;
+        /** Held rather than built per entry: both capture {@link #filter}, so constructing them in the loop allocates on every value. */
+        private final Function<Map<String, Object>, Map<String, Object>> mapFilter;
+        private final Predicate<String> nameFilter;
 
         private BytesRef filteredValue;
 
@@ -389,7 +392,8 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
         ) throws IOException {
             this.delegate = dv;
             this.ignoredSourceFormat = ignoredSourceFormat;
-            this.filter = filter;
+            this.mapFilter = v -> filter(v, filter, 0);
+            this.nameFilter = filter::run;
             // convert incoming binary doc values to reuse the code provided by MultiValuedSortedBinaryDocValues
             this.multiValues = MultiValuedSortedBinaryDocValues.fromMultiValued(reader, IgnoredSourceFieldMapper.NAME, dv);
         }
@@ -406,7 +410,7 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
             int count = multiValues.docValueCount();
             for (int i = 0; i < count; i++) {
                 BytesRef value = multiValues.nextValue();
-                BytesRef filtered = ignoredSourceFormat.filterValue(value, v -> filter(v, filter, 0));
+                BytesRef filtered = ignoredSourceFormat.filterValue(value, mapFilter, nameFilter);
                 if (filtered != null) {
                     // deep copy because nextValue() reuses an internal scratch buffer
                     filteredValues.add(BytesRef.deepCopyOf(filtered));
@@ -551,7 +555,7 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
             } else if (IgnoredSourceFieldMapper.NAME.equals(fieldInfo.name)) {
                 assert ignoredSourceFormat != IgnoredSourceFieldMapper.IgnoredSourceFormat.NO_IGNORED_SOURCE;
                 BytesRef valueRef = new BytesRef(value);
-                BytesRef filtered = ignoredSourceFormat.filterValue(valueRef, v -> filter(v, filter, 0));
+                BytesRef filtered = ignoredSourceFormat.filterValue(valueRef, v -> filter(v, filter, 0), filter::run);
                 if (filtered != null) {
                     byte[] filteredBytes = ArrayUtil.copyOfSubArray(filtered.bytes, filtered.offset, filtered.offset + filtered.length);
                     visitor.binaryField(fieldInfo, filteredBytes);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -366,14 +366,13 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
     /**
      * Wraps {@link BinaryDocValues} for the {@code _ignored_source} field to apply field-level security filtering.
      * <p>
-     * Per-document values are decoded via {@link MultiValuedSortedBinaryDocValues} (which handles both
-     * {@link MultiValuedBinaryDocValuesField.SeparateCount} and {@link MultiValuedBinaryDocValuesField.IntegratedCount}
-     * formats), filtered through the FLS field automaton, and re-encoded in the
-     * {@link MultiValuedBinaryDocValuesField.IntegratedCount} format so that callers only observe field values
-     * the current user is authorised to see. Returning the integrated-count format allows the caller to treat
-     * the counts numeric field as absent, avoiding stale count mismatches after filtering.
+     * Per-document values are decoded via {@link MultiValuedSortedBinaryDocValues}, filtered through the FLS field automaton, and the
+     * surviving values are stored as a list. Extending {@link MultiValuedSortedBinaryDocValues.DecodedBinaryDocValues} lets
+     * {@link MultiValuedSortedBinaryDocValues#fromMultiValued} read those values directly, avoiding the otherwise-necessary step of
+     * re-encoding them into a blob that the caller would immediately parse apart again. {@link #binaryValue()} encodes on demand as a
+     * fallback for anything that reads this instance as a plain {@link BinaryDocValues}.
      */
-    private static final class FilteredIgnoredSourceDocValues extends BinaryDocValues {
+    private static final class FilteredIgnoredSourceDocValues extends MultiValuedSortedBinaryDocValues.DecodedBinaryDocValues {
 
         private final BinaryDocValues delegate;
         private final MultiValuedSortedBinaryDocValues multiValues;
@@ -381,8 +380,9 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
         /** Held rather than built per entry: both capture {@link #filter}, so constructing them in the loop allocates on every value. */
         private final Function<Map<String, Object>, Map<String, Object>> mapFilter;
         private final Predicate<String> nameFilter;
-
-        private BytesRef filteredValue;
+        private final List<BytesRef> filteredValues = new ArrayList<>();
+        private int nextValueIndex;
+        private BytesRef encodedValue;
 
         FilteredIgnoredSourceDocValues(
             LeafReader reader,
@@ -400,13 +400,13 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
 
         @Override
         public boolean advanceExact(int target) throws IOException {
-            filteredValue = null;
+            clear();
+
             if (multiValues.advanceExact(target) == false) {
                 return false;
             }
 
             // iterate over all ignored-source entries for this document and apply FLS filtering
-            List<BytesRef> filteredValues = new ArrayList<>();
             int count = multiValues.docValueCount();
             for (int i = 0; i < count; i++) {
                 BytesRef value = multiValues.nextValue();
@@ -417,18 +417,32 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
                 }
             }
 
-            if (filteredValues.isEmpty()) {
-                return false;
-            }
+            return filteredValues.isEmpty() == false;
+        }
 
-            // re-encode surviving values into IntegratedCount format
-            filteredValue = MultiValuedBinaryDocValuesField.IntegratedCount.encode(filteredValues);
-            return true;
+        private void clear() {
+            filteredValues.clear();
+            nextValueIndex = 0;
+            encodedValue = null;
+        }
+
+        @Override
+        public int docValueCount() {
+            return filteredValues.size();
+        }
+
+        @Override
+        public BytesRef nextValue() {
+            return filteredValues.get(nextValueIndex++);
         }
 
         @Override
         public BytesRef binaryValue() {
-            return filteredValue;
+            if (encodedValue == null && filteredValues.isEmpty() == false) {
+                // Only for callers that read this as a plain BinaryDocValues; readers of _ignored_source take the decoded path.
+                encodedValue = MultiValuedBinaryDocValuesField.IntegratedCount.encode(filteredValues);
+            }
+            return encodedValue;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -940,6 +940,87 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
         }
     }
 
+    /**
+     * Same shape as {@link #testIgnoredSourceFilteringIntegration()}, but on an index that stores _ignored_source in binary doc values
+     * (logsdb / time-series doc values format) with the SeparateCount framing, and using an FLS automaton built the way roles actually
+     * build it ({@link FieldPermissions#buildPermittedFieldsAutomaton}), which unions in the "_*" metadata automaton and therefore also
+     * exposes the "_ignored_source.counts" companion field to the reader.
+     */
+    public void testIgnoredSourceDocValuesFilteringIntegration() throws Exception {
+        doTestIgnoredSourceDocValuesFilteringIntegration(1);
+    }
+
+    public void testIgnoredSourceDocValuesFilteringIntegrationMultiValue() throws Exception {
+        doTestIgnoredSourceDocValuesFilteringIntegration(2);
+    }
+
+    /**
+     * Nine surviving entries, so the bogus value length read off the blob (9) is large enough that decode() reaches substring() rather
+     * than failing earlier in the String constructor. Reproduces the exact reported signature "Range [0, 1552) out of bounds for length 5".
+     */
+    public void testIgnoredSourceDocValuesFilteringIntegrationManyValues() throws Exception {
+        doTestIgnoredSourceDocValuesFilteringIntegration(9);
+    }
+
+    private void doTestIgnoredSourceDocValuesFilteringIntegration(int survivingCount) throws Exception {
+        IndexVersion indexVersion = IndexVersion.current();
+        assertTrue(indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES));
+        Settings mapperSettings = Settings.builder()
+            .put("index.mapping.total_fields.limit", 1)
+            .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
+            .put("index.mapping.source.mode", "synthetic")
+            .put("index.use_time_series_doc_values_format", true)
+            .build();
+        var indexSettings = createIndexSettings(indexVersion, mapperSettings);
+        var format = IgnoredSourceFieldMapper.ignoredSourceFormat(indexSettings);
+        assertEquals(IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE, format);
+
+        DocumentMapper mapper = createMapperService(indexVersion, mapperSettings, mapping(b -> {
+            b.startObject("foo").field("type", "keyword").endObject();
+        })).documentMapper();
+
+        // A role that grants everything except one field, exactly like the reported "logs-* minus dns.question.*" role.
+        var filter = new CharacterRunAutomaton(
+            FieldPermissions.buildPermittedFieldsAutomaton(new String[] { "*" }, new String[] { "excluded" })
+        );
+
+        // survivingCount == 1: .counts says 1, so the reader takes the count==1 "the whole blob is the value" fast path.
+        // survivingCount > 1: the reader takes the multi-value length-prefixed path and misreads the leading count vInt as a length.
+        // The first entry is always "fieldA": "testA", i.e. a 16-byte singular blob (4 header + 6 name + 6 encoded value).
+        StringBuilder expected = new StringBuilder("{");
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = indexWriterForSyntheticSource(directory);
+            ParsedDocument doc = mapper.parse(source(b -> {
+                b.field("fieldA", "testA");
+                for (int i = 1; i < survivingCount; i++) {
+                    b.field("field" + (char) ('A' + i), "test" + (char) ('A' + i));
+                }
+                if (survivingCount > 1) {
+                    b.field("excluded", "secret");
+                }
+            }));
+            for (int i = 0; i < survivingCount; i++) {
+                char suffix = (char) ('A' + i);
+                expected.append(i == 0 ? "" : ",").append("\"field").append(suffix).append("\":\"test").append(suffix).append('"');
+            }
+            expected.append('}');
+            doc.updateSeqID(0, 0);
+            doc.version().setLongValue(0);
+            iw.addDocuments(doc.docs());
+            iw.close();
+            try (
+                DirectoryReader indexReader = FieldSubsetReader.wrap(
+                    wrapInMockESDirectoryReader(DirectoryReader.open(directory)),
+                    filter,
+                    format,
+                    (fieldName) -> true
+                )
+            ) {
+                assertEquals(expected.toString(), syntheticSource(mapper, indexReader, doc.docs().size() - 1));
+            }
+        }
+    }
+
     public void testVisibilityOriginalFieldNames() throws Exception {
         try (Directory dir = newDirectory()) {
             try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null))) {


### PR DESCRIPTION
While working on https://github.com/elastic/seceng/issues/14839, I noticed that when filtering ignored source, we decode the binary blob, run it through a filter, only to re-encode it again and then re-decode it downstream. This is done to adhere to function signatures, namely `BytesRef` as a return type. As you can imagine, this is quite wasteful.

This PR introduces `DecodedBinary` - a new class which sits next to `IntegratedCount`, `SeparateCount`, and `PlainBinary`. Its purpose is to act as a container for binary doc values that have already been decoded, eliminating the need to perform the extra re-encode + re-decode step mentioned above.