### PR TITLE
Stream columnar blobs into a reusable BytesRefBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
@@ -285,11 +285,6 @@ public final class EscfColumnBuilder {
         setBytes(row, EscfColumnKind.STRING, value.bytes, value.offset, value.length);
     }
 
-    /**
-     * Sets a string from a sub-range of a caller-owned array. Lets callers that assemble values in a reusable buffer emit a slice
-     * without wrapping it in a {@link BytesRef} first; the bytes are copied out before this returns, so the buffer may be rewritten
-     * immediately.
-     */
     public void setString(int row, byte[] bytes, int offset, int length) {
         setBytes(row, EscfColumnKind.STRING, bytes, offset, length);
     }

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnBuilder.java
@@ -285,6 +285,15 @@ public final class EscfColumnBuilder {
         setBytes(row, EscfColumnKind.STRING, value.bytes, value.offset, value.length);
     }
 
+    /**
+     * Sets a string from a sub-range of a caller-owned array. Lets callers that assemble values in a reusable buffer emit a slice
+     * without wrapping it in a {@link BytesRef} first; the bytes are copied out before this returns, so the buffer may be rewritten
+     * immediately.
+     */
+    public void setString(int row, byte[] bytes, int offset, int length) {
+        setBytes(row, EscfColumnKind.STRING, bytes, offset, length);
+    }
+
     public void setBinary(int row, BytesRef value) {
         setBytes(row, EscfColumnKind.BINARY, value.bytes, value.offset, value.length);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1608,9 +1608,9 @@ public final class KeywordFieldMapper extends FieldMapper {
         final BytesRefBuilder docBlob = emitDvs ? new BytesRefBuilder() : null;
         int pos = 0;
         int docSlotCount = 0;
-        // A lone non-null slot is stored raw, so remember where the first slot's value bytes landed.
-        int firstValueStart = 0;
-        int firstValueLength = 0;
+        // Length of the most recent value slot. Only read when the finished doc holds exactly one slot, in which case
+        // that slot was this one, and it is stored raw without the length prefix appendSlot wrote for it.
+        int lastValueLength = 0;
         // True when the current doc has at least one non-null slot; gates binary dv blob emission.
         boolean hasNonNull = false;
 
@@ -1623,9 +1623,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                     dvCounts.setLong(currentDoc, docSlotCount);
                     if (hasNonNull) {
                         // TODO: considering appending slots straight into the column builder's stream.
-                        // A single non-null slot is stored raw, so skip the length prefix appendSlot wrote for it.
-                        final boolean raw = docSlotCount == 1;
-                        binaryDvs.setString(currentDoc, docBlob.bytes(), raw ? firstValueStart : 0, raw ? firstValueLength : pos);
+                        // A single non-null slot is stored raw, so drop its length prefix; both cases end at pos.
+                        final int length = docSlotCount == 1 ? lastValueLength : pos;
+                        binaryDvs.setString(currentDoc, docBlob.bytes(), pos - length, length);
                     }
                     pos = 0;
                     docSlotCount = 0;
@@ -1688,13 +1688,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                 terms.setString(currentDoc, binaryValue);
             }
             if (binaryDvs != null) {
-                final boolean firstSlot = docSlotCount == 0;
                 pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, binaryValue);
-                if (firstSlot) {
-                    // appendSlot wrote [len+1][value], so the value bytes end at pos.
-                    firstValueLength = binaryValue.length;
-                    firstValueStart = pos - firstValueLength;
-                }
+                lastValueLength = binaryValue.length;
                 docSlotCount++;
                 hasNonNull = true;
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1575,9 +1575,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         // strings. This is possible as an eventual user option.
 
         if (fieldType().usesArrayOrderBinaryDocValues()) {
-            // retainValues=false: mapColumnBatchArrayOrder appends each value to the document blob before the
-            // cursor advances, so no value has to outlive the nextDoc() that moves past it.
-            mapColumnBatchArrayOrder(ctx, EscfColumnTransforms.utf8Cursor(source, false), emitTerms, emitDvs, emitFallback);
+            mapColumnBatchArrayOrder(ctx, source, emitTerms, emitDvs, emitFallback);
         } else {
             mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
         }
@@ -1585,13 +1583,16 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private void mapColumnBatchArrayOrder(
         BatchMappingContext ctx,
-        ObjectTupleCursor<BytesRef> cursor,
+        EscfColumn source,
         boolean emitTerms,
         boolean emitDvs,
         boolean emitFallback
     ) {
         final int docCount = ctx.docCount();
 
+        // retainValues=false: each value is appended to the document blob before the cursor advances, so no
+        // value has to outlive the nextDoc() that moves past it.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
         // TODO: make the batch return these column builders to wire up recycling
         final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
         final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
@@ -1608,8 +1609,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         final BytesRefBuilder docBlob = emitDvs ? new BytesRefBuilder() : null;
         int pos = 0;
         int docSlotCount = 0;
-        // Length of the most recent value slot. Only read when the finished doc holds exactly one slot, in which case
-        // that slot was this one, and it is stored raw without the length prefix appendSlot wrote for it.
         int lastValueLength = 0;
         // True when the current doc has at least one non-null slot; gates binary dv blob emission.
         boolean hasNonNull = false;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -39,10 +39,8 @@ import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.WildcardQuery;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
@@ -1577,9 +1575,9 @@ public final class KeywordFieldMapper extends FieldMapper {
         // strings. This is possible as an eventual user option.
 
         if (fieldType().usesArrayOrderBinaryDocValues()) {
-            // retainValues=true: mapColumnBatchArrayOrder buffers a whole document's values in docSlots[]
-            // and only encodes them once the cursor has advanced to the next doc.
-            mapColumnBatchArrayOrder(ctx, EscfColumnTransforms.utf8Cursor(source, true), emitTerms, emitDvs, emitFallback);
+            // retainValues=false: mapColumnBatchArrayOrder appends each value to the document blob before the
+            // cursor advances, so no value has to outlive the nextDoc() that moves past it.
+            mapColumnBatchArrayOrder(ctx, EscfColumnTransforms.utf8Cursor(source, false), emitTerms, emitDvs, emitFallback);
         } else {
             mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
         }
@@ -1604,13 +1602,15 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         int currentDoc = -1;
         boolean ignoredThisDoc = false;
-        // Per-doc element buffer for blob encoding; null when blob is not emitted.
-        BytesRef[] docSlots = emitDvs ? new BytesRef[4] : null;
-        // Batch-scoped encode buffer. ArrayOrderInlineNull.encode writes each document's blob here and returns a
-        // view over it; binaryDvs.setString copies the bytes out immediately, so the buffer is free to be
-        // overwritten on the next document.
-        final BytesRefBuilder blobScratch = emitDvs ? new BytesRefBuilder() : null;
+        // Buffer null when not emitted. Each document's slots are appended as they are read and
+        // the finished blob is handed to binaryDvs.setString, which copies it out immediately, so the
+        // buffer is free to be rewritten.
+        final BytesRefBuilder docBlob = emitDvs ? new BytesRefBuilder() : null;
+        int pos = 0;
         int docSlotCount = 0;
+        // A lone non-null slot is stored raw, so remember where the first slot's value bytes landed.
+        int firstValueStart = 0;
+        int firstValueLength = 0;
         // True when the current doc has at least one non-null slot; gates binary dv blob emission.
         boolean hasNonNull = false;
 
@@ -1622,13 +1622,12 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (binaryDvs != null && docSlotCount > 0) {
                     dvCounts.setLong(currentDoc, docSlotCount);
                     if (hasNonNull) {
-                        // TODO: let ArrayOrderInlineNull.encode write straight into the column builder's stream. The
-                        // scratch buffer removes the per-document allocation, but the bytes are still copied once.
-                        binaryDvs.setString(
-                            currentDoc,
-                            MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(docSlots, docSlotCount, blobScratch)
-                        );
+                        // TODO: considering appending slots straight into the column builder's stream.
+                        // A single non-null slot is stored raw, so skip the length prefix appendSlot wrote for it.
+                        final boolean raw = docSlotCount == 1;
+                        binaryDvs.setString(currentDoc, docBlob.bytes(), raw ? firstValueStart : 0, raw ? firstValueLength : pos);
                     }
+                    pos = 0;
                     docSlotCount = 0;
                     hasNonNull = false;
                 }
@@ -1650,13 +1649,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                     // Fall through to normal value processing below.
                 } else {
                     if (binaryDvs != null) {
-                        if (docSlotCount == docSlots.length) {
-                            docSlots = Arrays.copyOf(
-                                docSlots,
-                                ArrayUtil.oversize(docSlotCount + 1, RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-                            );
-                        }
-                        docSlots[docSlotCount++] = null;
+                        pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, null);
+                        docSlotCount++;
                         // hasNonNull stays false: null slots do not produce a binary dv blob.
                     }
                     continue;
@@ -1694,10 +1688,14 @@ public final class KeywordFieldMapper extends FieldMapper {
                 terms.setString(currentDoc, binaryValue);
             }
             if (binaryDvs != null) {
-                if (docSlotCount == docSlots.length) {
-                    docSlots = Arrays.copyOf(docSlots, ArrayUtil.oversize(docSlotCount + 1, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
+                final boolean firstSlot = docSlotCount == 0;
+                pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, binaryValue);
+                if (firstSlot) {
+                    // appendSlot wrote [len+1][value], so the value bytes end at pos.
+                    firstValueLength = binaryValue.length;
+                    firstValueStart = pos - firstValueLength;
                 }
-                docSlots[docSlotCount++] = binaryValue;
+                docSlotCount++;
                 hasNonNull = true;
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -37,7 +37,6 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
 
     // vints are unlike normal ints in that they may require 5 bytes instead of 4
     // see BytesStreamOutput.writeVInt()
-    // Public so batch-mapping callers can size a blob buffer up front from the slot count.
     public static final int VINT_MAX_BYTES = 5;
 
     /**
@@ -712,9 +711,6 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
          * <p>Same wire format as {@link #encode(ArrayList, BitSet)}: {@code [valueLen+1][key\0value]}, with
          * {@code [0][key\0]} for a null slot. Every slot carries a VInt prefix (no single-slot raw passthrough);
          * the separator byte is always written; slot order is load-bearing.
-         *
-         * <p>The value bytes are copied immediately, so a caller streaming from a cursor may advance it as soon as
-         * this returns — no value needs to outlive the read.
          */
         public static int appendSlot(BytesRefBuilder blob, int pos, BytesRef keyPrefix, BytesRef value) {
             assert keyPrefix.length > 0 && keyPrefix.bytes[keyPrefix.offset + keyPrefix.length - 1] == 0

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -37,7 +37,8 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
 
     // vints are unlike normal ints in that they may require 5 bytes instead of 4
     // see BytesStreamOutput.writeVInt()
-    private static final int VINT_MAX_BYTES = 5;
+    // Public so batch-mapping callers can size a blob buffer up front from the slot count.
+    public static final int VINT_MAX_BYTES = 5;
 
     /**
      * Controls how values are collected and ordered in a multi-valued binary doc values field.
@@ -526,43 +527,25 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
         }
 
         /**
-         * Array-backed variant of {@link #encode(Collection)} for callers that buffer slots in a
-         * pre-allocated array. Avoids {@link java.util.List} allocation for the common small
-         * multi-value case. A {@code null} element at position {@code i < count} denotes a null slot.
-         * Must only be called when at least one non-null value is present.
+         * Appends one slot to a document blob under construction in {@code blob}, growing it as needed, and returns
+         * the write position just past the slot. A {@code null} {@code value} denotes a null slot. Same wire format
+         * as {@link #encode(Collection)}: {@code [len+1][val]}, with {@code [0]} for a null slot.
          *
-         * <p><b>The returned {@link BytesRef} is a view over {@code scratch} — or, in the single non-null slot
-         * case, over the caller's own value — and is invalidated by the next call.</b> Callers must consume it
-         * (typically by copying it into a column builder) before encoding the next document.
+         * <p>Note this always writes the length prefix, including for the first slot. A document that turns out to
+         * hold exactly one non-null slot is stored raw (see {@link #encode(Collection)}); the caller handles that by
+         * emitting a view that starts after the prefix, which sits at {@code returnedPos - value.length}.
          */
-        public static BytesRef encode(BytesRef[] slots, int count, BytesRefBuilder scratch) {
-            assert count >= 1 : "encode requires at least one slot";
-            if (count == 1) {
-                assert slots[0] != null : "a lone null slot must not write a binary value";
-                return slots[0];
+        public static int appendSlot(BytesRefBuilder blob, int pos, BytesRef value) {
+            final int valueLength = value == null ? 0 : value.length;
+            // grow (not growNoCopy): earlier slots of this document must survive.
+            blob.grow(pos + VINT_MAX_BYTES + valueLength);
+            final byte[] buffer = blob.bytes();
+            pos = StreamOutputHelper.putVInt(buffer, value == null ? 0 : valueLength + 1, pos);
+            if (value != null) {
+                System.arraycopy(value.bytes, value.offset, buffer, pos, valueLength);
+                pos += valueLength;
             }
-            int byteCount = 0;
-            for (int i = 0; i < count; i++) {
-                if (slots[i] != null) {
-                    byteCount += slots[i].length;
-                }
-            }
-            // growNoCopy: the previous document's contents are dead, so there is nothing to preserve.
-            scratch.growNoCopy(byteCount + count * VINT_MAX_BYTES);
-            final byte[] buffer = scratch.bytes();
-            int pos = 0;
-            for (int i = 0; i < count; i++) {
-                BytesRef slot = slots[i];
-                if (slot == null) {
-                    pos = StreamOutputHelper.putVInt(buffer, 0, pos);
-                } else {
-                    pos = StreamOutputHelper.putVInt(buffer, slot.length + 1, pos);
-                    System.arraycopy(slot.bytes, slot.offset, buffer, pos, slot.length);
-                    pos += slot.length;
-                }
-            }
-            scratch.setLength(pos);
-            return scratch.get();
+            return pos;
         }
 
         /**
@@ -722,55 +705,33 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
         }
 
         /**
-         * Encodes keyed slots from an interleaved tuple array. Interleaving: {@code tuples[2*i]} is the
-         * key prefix for slot {@code i} (key bytes + {@code \0}); {@code tuples[2*i+1]} is the value, or
-         * {@code null} for a null slot. Only the first {@code 2*slotCount} entries are read; callers may
-         * reuse an oversized buffer across documents.
+         * Appends one keyed slot to a document blob under construction in {@code blob}, growing it as needed, and
+         * returns the write position just past the slot. {@code keyPrefix} is {@code key\0}; a {@code null}
+         * {@code value} denotes a null slot.
          *
-         * <p>Same wire format as {@link #encode(ArrayList, BitSet)}: {@code [valueLen+1][key\0value]...},
-         * with {@code [0][key\0]} for null slots. Every slot carries a VInt prefix (no single-slot raw
-         * passthrough); the separator byte is always written; slot order is load-bearing.
+         * <p>Same wire format as {@link #encode(ArrayList, BitSet)}: {@code [valueLen+1][key\0value]}, with
+         * {@code [0][key\0]} for a null slot. Every slot carries a VInt prefix (no single-slot raw passthrough);
+         * the separator byte is always written; slot order is load-bearing.
          *
-         * <p><b>The returned {@link BytesRef} is a view over {@code scratch} and is invalidated by the next
-         * call.</b> Callers must consume it (typically by copying it into a column builder) before encoding the
-         * next document.
+         * <p>The value bytes are copied immediately, so a caller streaming from a cursor may advance it as soon as
+         * this returns — no value needs to outlive the read.
          */
-        public static BytesRef encodeTuples(BytesRef[] tuples, int slotCount, BytesRefBuilder scratch) {
-            assert slotCount >= 1 : "encodeTuples requires at least one slot";
-            assert tuples.length >= 2 * slotCount : "tuples array too short: " + tuples.length + " < " + (2 * slotCount);
-            int byteCount = 0;
-            for (int i = 0; i < slotCount; i++) {
-                byteCount += tuples[2 * i].length;
-                BytesRef value = tuples[2 * i + 1];
-                if (value != null) {
-                    byteCount += value.length;
-                }
+        public static int appendSlot(BytesRefBuilder blob, int pos, BytesRef keyPrefix, BytesRef value) {
+            assert keyPrefix.length > 0 && keyPrefix.bytes[keyPrefix.offset + keyPrefix.length - 1] == 0
+                : "key prefix must be non-empty and end with \\0";
+            final int valueLength = value == null ? 0 : value.length;
+            // grow (not growNoCopy): earlier slots of this document must survive.
+            blob.grow(pos + VINT_MAX_BYTES + keyPrefix.length + valueLength);
+            final byte[] buffer = blob.bytes();
+            // Null slot: [0]key\0. Non-null slot: [valueLen+1]key\0value.
+            pos = StreamOutputHelper.putVInt(buffer, value == null ? 0 : valueLength + 1, pos);
+            System.arraycopy(keyPrefix.bytes, keyPrefix.offset, buffer, pos, keyPrefix.length);
+            pos += keyPrefix.length;
+            if (value != null) {
+                System.arraycopy(value.bytes, value.offset, buffer, pos, valueLength);
+                pos += valueLength;
             }
-            // growNoCopy: the previous document's contents are dead, so there is nothing to preserve.
-            scratch.growNoCopy(streamSize(byteCount, slotCount));
-            final byte[] buffer = scratch.bytes();
-            int pos = 0;
-            for (int i = 0; i < slotCount; i++) {
-                BytesRef keyPrefix = tuples[2 * i];
-                BytesRef value = tuples[2 * i + 1];
-                assert keyPrefix.length > 0 && keyPrefix.bytes[keyPrefix.offset + keyPrefix.length - 1] == 0
-                    : "key prefix for slot " + i + " must be non-empty and end with \\0";
-                if (value == null) {
-                    // Null slot: [0]key\0
-                    pos = StreamOutputHelper.putVInt(buffer, 0, pos);
-                } else {
-                    // Non-null slot: [valueLen+1]key\0value
-                    pos = StreamOutputHelper.putVInt(buffer, value.length + 1, pos);
-                }
-                System.arraycopy(keyPrefix.bytes, keyPrefix.offset, buffer, pos, keyPrefix.length);
-                pos += keyPrefix.length;
-                if (value != null) {
-                    System.arraycopy(value.bytes, value.offset, buffer, pos, value.length);
-                    pos += value.length;
-                }
-            }
-            scratch.setLength(pos);
-            return scratch.get();
+            return pos;
         }
 
         private static int streamSize(int byteCount, int slotCount) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1938,12 +1938,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         final EscfColumnBuilder counts = mergeLongColumn();
         final BytesRef nullValueBytes = builder.nullValue.get() != null ? new BytesRef(builder.nullValue.get()) : null;
 
-        // Batch-scoped blob buffer. Each document's slots are appended here as they are read and the finished blob is
-        // handed to keyed.setString, which copies it out immediately — so the buffer is free to be rewritten from
-        // position 0 for the next document.
         final BytesRefBuilder docBlob = new BytesRefBuilder();
-        // Seed the buffer from the first document. Every cursor is parked on its first tuple and value() is a
-        // non-advancing read, so this peeks one slot per key without disturbing the iteration below.
         int seedEstimate = 0;
         for (int k = 0; k < columnCount; k++) {
             if (cursorDocs[k] != DocIdSetIterator.NO_MORE_DOCS) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -31,12 +31,10 @@ import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermRangeQuery;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.IOBooleanSupplier;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -125,7 +123,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1930,9 +1927,9 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         // Doc each cursor is currently positioned on, or NO_MORE_DOCS once drained.
         final int[] cursorDocs = new int[columnCount];
         for (int k = 0; k < columnCount; k++) {
-            // retainValues=true: a document's slots are buffered and only encoded once the cursor has moved on,
-            // so the value BytesRef must stay valid past the nextDoc() call that advances off this document.
-            final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(columns[k], true);
+            // retainValues=false: each value is appended to the document blob before the cursor advances, so no
+            // value has to outlive the nextDoc() that moves past it.
+            final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(columns[k], false);
             cursors.add(cursor);
             cursorDocs[k] = cursor.nextDoc();
         }
@@ -1941,16 +1938,25 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         final EscfColumnBuilder counts = mergeLongColumn();
         final BytesRef nullValueBytes = builder.nullValue.get() != null ? new BytesRef(builder.nullValue.get()) : null;
 
-        // Per-document tuple buffer, reused across documents. Interleaved: tuples[2*i] = keyPrefix, tuples[2*i+1] = value
-        // (null value signals a null slot). No separate null marker is needed: the value's presence or absence carries the
-        // distinction, and the retained cursor BytesRef is valid until the column builder consumes it at end-of-document.
-        BytesRef[] tuples = new BytesRef[8];
-        // Batch-scoped encode buffer. encodeTuples writes each document's blob here and returns a view over it;
-        // keyed.setString copies the bytes out immediately, so the buffer is free to be overwritten next document.
-        final BytesRefBuilder encodeScratch = new BytesRefBuilder();
+        // Batch-scoped blob buffer. Each document's slots are appended here as they are read and the finished blob is
+        // handed to keyed.setString, which copies it out immediately — so the buffer is free to be rewritten from
+        // position 0 for the next document.
+        final BytesRefBuilder docBlob = new BytesRefBuilder();
+        // Seed the buffer from the first document. Every cursor is parked on its first tuple and value() is a
+        // non-advancing read, so this peeks one slot per key without disturbing the iteration below.
+        int seedEstimate = 0;
+        for (int k = 0; k < columnCount; k++) {
+            if (cursorDocs[k] != DocIdSetIterator.NO_MORE_DOCS) {
+                final BytesRef first = cursors.get(k).value();
+                seedEstimate += MultiValuedBinaryDocValuesField.VINT_MAX_BYTES + keyPrefixes[k].length + (first == null ? 0 : first.length);
+            }
+        }
+        // ~1.25x headroom for documents a little wider than the first.
+        docBlob.grow(seedEstimate + (seedEstimate >> 2));
 
         for (int doc = 0; doc < docCount; doc++) {
             int slotCount = 0;
+            int pos = 0;
             // Column-minor within a document: all of key[0]'s values, then key[1]'s, ... See the slot-order note above.
             for (int k = 0; k < columnCount; k++) {
                 final BytesRef keyPrefix = keyPrefixes[k];
@@ -1978,23 +1984,17 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                         }
                     }
 
-                    if (2 * slotCount + 2 > tuples.length) {
-                        tuples = Arrays.copyOf(tuples, 2 * ArrayUtil.oversize(slotCount + 1, RamUsageEstimator.NUM_BYTES_OBJECT_REF * 2));
-                    }
-                    tuples[2 * slotCount] = keyPrefix;
-                    tuples[2 * slotCount + 1] = value;
+                    pos = MultiValuedBinaryDocValuesField.KeyedArrayOrderInlineNull.appendSlot(docBlob, pos, keyPrefix, value);
                     slotCount++;
 
+                    // The value's bytes are already in docBlob, so advancing past it is safe.
                     cursorDocs[k] = cursor.nextDoc();
                 }
             }
 
             if (slotCount > 0) {
                 // Unlike the non-keyed ArrayOrderInlineNull, an all-null document still writes a blob: its null slots carry keys.
-                keyed.setString(
-                    doc,
-                    MultiValuedBinaryDocValuesField.KeyedArrayOrderInlineNull.encodeTuples(tuples, slotCount, encodeScratch)
-                );
+                keyed.setString(doc, docBlob.bytes(), 0, pos);
                 counts.setLong(doc, slotCount);
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -654,12 +654,6 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         assertEquals(appendSlotsInto(new BytesRefBuilder(), shortDoc, 2), second);
     }
 
-    /**
-     * {@code ArrayOrderInlineNull} stores a lone non-null slot raw, with no length prefix. {@code appendSlot} always writes the prefix,
-     * so callers recover the raw value as the sub-range ending at the returned position. {@code KeywordFieldMapper} relies on exactly
-     * this arithmetic ({@code firstValueStart = pos - value.length}) to emit single-slot documents, so pin it here. The long value
-     * forces a multi-byte length prefix, which is where a hand-rolled offset would go wrong.
-     */
     public void testArrayOrderAppendSlotValueEndsAtReturnedPosition() {
         for (BytesRef only : List.of(new BytesRef("solo"), new BytesRef(randomAlphanumericOfLength(500)))) {
             BytesRefBuilder blob = new BytesRefBuilder();

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -421,7 +421,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         BytesRef[] tuples = { keyPrefix, value };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 1);
 
         // then — VInt prefix is valueLen+1 (no single-slot raw passthrough)
         try (var expected = new BytesStreamOutput()) {
@@ -437,7 +437,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         BytesRef[] tuples = { new BytesRef("k1\0"), new BytesRef("a"), new BytesRef("k2\0"), new BytesRef("b"), };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 2, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 2);
 
         // then
         try (var expected = new BytesStreamOutput()) {
@@ -457,7 +457,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         BytesRef[] tuples = { keyPrefix, null };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 1);
 
         // then — the separator byte is always written even for null slots; decoders skip keyLen+1
         try (var expected = new BytesStreamOutput()) {
@@ -483,7 +483,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 2, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 2);
 
         // then
         try (var expected = new BytesStreamOutput()) {
@@ -503,7 +503,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         BytesRef[] tuples = { keyPrefix, value };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 1);
 
         // then — the inner \0 in the value is not confused with the key separator
         try (var expected = new BytesStreamOutput()) {
@@ -522,7 +522,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         BytesRef[] tuples = { keyPrefix, value };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 1);
 
         // then
         try (var expected = new BytesStreamOutput()) {
@@ -549,12 +549,12 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         };
 
         // when
-        BytesRef actual = KeyedArrayOrderInlineNull.encodeTuples(tuples, 2, new BytesRefBuilder());
+        BytesRef actual = encodeTuples(tuples, 2);
 
         // then - result equals encoding only the two valid slots
         BytesRef[] fresh = { new BytesRef("k1\0"), new BytesRef("v1"), new BytesRef("k2\0"), new BytesRef("v2") };
         // A separate scratch buffer: `actual` is a view over the first one and would be overwritten by a second encode into it.
-        assertEquals(KeyedArrayOrderInlineNull.encodeTuples(fresh, 2, new BytesRefBuilder()), actual);
+        assertEquals(encodeTuples(fresh, 2), actual);
     }
 
     /**
@@ -580,7 +580,7 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         };
 
         // when
-        BytesRef fromTuples = KeyedArrayOrderInlineNull.encodeTuples(tuples, 3, new BytesRefBuilder());
+        BytesRef fromTuples = encodeTuples(tuples, 3);
         BytesRef fromLegacy = KeyedArrayOrderInlineNull.encode(legacySlots, legacyNulls);
 
         // then
@@ -588,12 +588,12 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
     }
 
     /**
-     * The scratch buffer is only ever grown, so a short document encoded after a long one leaves the tail of the previous document's
-     * bytes in the array. The returned view must be bounded by the current document's length so those stale bytes are never read.
+     * The blob buffer is only ever grown and is rewritten from position 0 per document, so a short document appended after a long one
+     * leaves the previous document's tail in the array. The emitted view must be bounded by the current document's length.
      */
-    public void testEncodeTuplesScratchReuseDoesNotLeakPreviousDocument() {
-        // given - a long document followed by a much shorter one, sharing a scratch buffer
-        BytesRefBuilder scratch = new BytesRefBuilder();
+    public void testAppendSlotBufferReuseDoesNotLeakPreviousDocument() {
+        // given - a long document followed by a much shorter one, sharing one buffer
+        BytesRefBuilder blob = new BytesRefBuilder();
         BytesRef[] longDoc = {
             new BytesRef("averyveryverylongkeyname\0"),
             new BytesRef("averyveryverylongvaluepayload"),
@@ -601,73 +601,101 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
             new BytesRef("secondlongvaluepayload"), };
         BytesRef[] shortDoc = { new BytesRef("k\0"), new BytesRef("v") };
 
-        // when
-        KeyedArrayOrderInlineNull.encodeTuples(longDoc, 2, scratch);
-        BytesRef second = KeyedArrayOrderInlineNull.encodeTuples(shortDoc, 1, scratch);
+        // when - both documents are appended into the same buffer, each starting from position 0
+        appendTuplesInto(blob, longDoc, 2);
+        BytesRef second = appendTuplesInto(blob, shortDoc, 1);
 
-        // then - the second result must equal an encode of the short document into an untouched buffer
-        assertEquals(KeyedArrayOrderInlineNull.encodeTuples(shortDoc, 1, new BytesRefBuilder()), second);
+        // then
+        assertEquals(encodeTuples(shortDoc, 1), second);
     }
 
-    /** Once grown to the largest blob in a batch, the scratch buffer must be reused rather than reallocated per document. */
-    public void testEncodeTuplesScratchBufferIsReused() {
-        // given - the first encode sizes the buffer
-        BytesRefBuilder scratch = new BytesRefBuilder();
+    /** Once grown to the largest blob in a batch, the buffer must be reused rather than reallocated per document. */
+    public void testAppendSlotReusesBuffer() {
+        // given - the first document sizes the buffer
+        BytesRefBuilder blob = new BytesRefBuilder();
         BytesRef[] tuples = { new BytesRef("key\0"), new BytesRef("value") };
-        KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, scratch);
-        byte[] afterFirst = scratch.bytes();
+        appendTuplesInto(blob, tuples, 1);
+        byte[] afterFirst = blob.bytes();
 
-        // when - a subsequent document of the same shape is encoded
-        KeyedArrayOrderInlineNull.encodeTuples(tuples, 1, scratch);
+        // when - a subsequent document of the same shape is appended
+        appendTuplesInto(blob, tuples, 1);
 
         // then - no reallocation
-        assertSame(afterFirst, scratch.bytes());
+        assertSame(afterFirst, blob.bytes());
     }
 
     /**
-     * Checks that the array-backed encoder produces exactly the same bytes as the row-path collection encoder for identical logical
-     * slots, ensuring the two paths cannot silently diverge.
+     * Checks that appending slots one at a time produces exactly the same bytes as the row-path collection encoder, ensuring the
+     * columnar and row paths cannot silently diverge.
      */
-    public void testArrayOrderEncodeMatchesCollectionEncode() {
+    public void testArrayOrderAppendSlotMatchesCollectionEncode() {
         // given - a null slot between two values
         BytesRef[] slots = { new BytesRef("a"), null, new BytesRef("ccc") };
 
         // when
-        BytesRef fromArray = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(slots, 3, new BytesRefBuilder());
+        BytesRef appended = appendSlotsInto(new BytesRefBuilder(), slots, 3);
         BytesRef fromCollection = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(Arrays.asList(slots));
 
         // then
-        assertEquals(fromCollection, fromArray);
+        assertEquals(fromCollection, appended);
     }
 
-    public void testArrayOrderEncodeScratchReuseDoesNotLeakPreviousDocument() {
+    public void testArrayOrderAppendSlotBufferReuseDoesNotLeakPreviousDocument() {
         // given
-        BytesRefBuilder scratch = new BytesRefBuilder();
+        BytesRefBuilder blob = new BytesRefBuilder();
         BytesRef[] longDoc = { new BytesRef("averyverylongvalue"), new BytesRef("anotherveryverylongvalue") };
         BytesRef[] shortDoc = { new BytesRef("a"), new BytesRef("b") };
 
         // when
-        MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(longDoc, 2, scratch);
-        BytesRef second = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(shortDoc, 2, scratch);
+        appendSlotsInto(blob, longDoc, 2);
+        BytesRef second = appendSlotsInto(blob, shortDoc, 2);
 
-        // then - the second result must equal an encode of the short document into an untouched buffer
-        assertEquals(MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(shortDoc, 2, new BytesRefBuilder()), second);
+        // then
+        assertEquals(appendSlotsInto(new BytesRefBuilder(), shortDoc, 2), second);
     }
 
     /**
-     * A single non-null slot is passed through raw (no VInt prefix), so the scratch buffer must be left out of it entirely and the
-     * caller's own value returned.
+     * {@code ArrayOrderInlineNull} stores a lone non-null slot raw, with no length prefix. {@code appendSlot} always writes the prefix,
+     * so callers recover the raw value as the sub-range ending at the returned position. {@code KeywordFieldMapper} relies on exactly
+     * this arithmetic ({@code firstValueStart = pos - value.length}) to emit single-slot documents, so pin it here. The long value
+     * forces a multi-byte length prefix, which is where a hand-rolled offset would go wrong.
      */
-    public void testArrayOrderEncodeSingleSlotBypassesScratch() {
-        // given
-        BytesRefBuilder scratch = new BytesRefBuilder();
-        BytesRef only = new BytesRef("solo");
-        BytesRef[] slots = { only };
+    public void testArrayOrderAppendSlotValueEndsAtReturnedPosition() {
+        for (BytesRef only : List.of(new BytesRef("solo"), new BytesRef(randomAlphanumericOfLength(500)))) {
+            BytesRefBuilder blob = new BytesRefBuilder();
 
-        // when
-        BytesRef encoded = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(slots, 1, scratch);
+            // when
+            int pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(blob, 0, only);
 
-        // then
-        assertSame(only, encoded);
+            // then - the raw value occupies [pos - length, pos), matching the single-slot passthrough encoding
+            BytesRef raw = new BytesRef(blob.bytes(), pos - only.length, only.length);
+            assertEquals(only, raw);
+            assertEquals(MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.encode(List.of(only)), raw);
+        }
+    }
+
+    /** Builds a keyed blob one slot at a time, mirroring what {@code mapColumnGroupBatch} does per document. */
+    private static BytesRef encodeTuples(BytesRef[] tuples, int slotCount) {
+        return appendTuplesInto(new BytesRefBuilder(), tuples, slotCount);
+    }
+
+    /** As {@link #encodeTuples}, but appending into a caller-supplied buffer so reuse across documents can be asserted. */
+    private static BytesRef appendTuplesInto(BytesRefBuilder blob, BytesRef[] tuples, int slotCount) {
+        int pos = 0;
+        for (int i = 0; i < slotCount; i++) {
+            pos = KeyedArrayOrderInlineNull.appendSlot(blob, pos, tuples[2 * i], tuples[2 * i + 1]);
+        }
+        blob.setLength(pos);
+        return blob.get();
+    }
+
+    /** Builds an unkeyed array-order blob one slot at a time, mirroring what {@code mapColumnBatchArrayOrder} does per document. */
+    private static BytesRef appendSlotsInto(BytesRefBuilder blob, BytesRef[] slots, int count) {
+        int pos = 0;
+        for (int i = 0; i < count; i++) {
+            pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(blob, pos, slots[i]);
+        }
+        blob.setLength(pos);
+        return blob.get();
     }
 }


### PR DESCRIPTION
The columnar batch paths for keyword and flattened fields buffered a
whole document's slots in a growable BytesRef[] and handed the array to
a one-shot encoder. That forced a retaining UTF-8 cursor, since the
buffered BytesRefs had to stay valid past the nextDoc() that moves off
the document, so every value allocated a fresh BytesRef (and a fresh
byte array for cross-chunk values).

Replace ArrayOrderInlineNull.encode(BytesRef[], int, BytesRefBuilder)
and KeyedArrayOrderInlineNull.encodeTuples with appendSlot methods that
write one slot into a batch-scoped BytesRefBuilder and return the new
write position. Value bytes are copied on append, so both call sites
drop the slot arrays and switch to the non-retaining cursor.

The wire format is unchanged. ArrayOrderInlineNull still stores a lone
non-null slot raw, which KeywordFieldMapper now emits as the sub-range
ending at the returned position.