### PR TITLE
[9.4] Fix NullPointerException in LongComparator caused by null search_after values (#132434)

### DIFF
--- a/docs/changelog/132434.yaml
+++ b/docs/changelog/132434.yaml
@@ -1,0 +1,6 @@
+pr: 132434
+summary: Fix NullPointerException in LongComparator caused by null search_after values
+area: Search
+type: bug
+issues:
+ - 132370

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -135,6 +135,17 @@ public class SearchAfterIT extends ESIntegTestCase {
                 assertThat(failure.toString(), containsString("Failed to parse search_after value for field [field1]."));
             }
         }
+
+        {
+            SearchPhaseExecutionException e = expectThrows(
+                SearchPhaseExecutionException.class,
+                prepareSearch("test").setQuery(matchAllQuery()).addSort("field1", SortOrder.ASC).searchAfter(new Object[] { null })
+            );
+            assertTrue(e.shardFailures().length > 0);
+            for (ShardSearchFailure failure : e.shardFailures()) {
+                assertThat(failure.toString(), containsString("cannot be null for sort field [field1]"));
+            }
+        }
     }
 
     public void testWithNullStrings() throws InterruptedException {

--- a/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
@@ -117,7 +117,20 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
             if (values[i] != null) {
                 fieldValues[i] = convertValueFromSortField(values[i], sortField, format);
             } else {
-                fieldValues[i] = null;
+                SortField.Type sortType = extractSortType(sortField);
+                if (sortType == SortField.Type.STRING || sortType == SortField.Type.STRING_VAL) {
+                    fieldValues[i] = null;
+                } else {
+                    throw new IllegalArgumentException(
+                        "[search_after] value at position "
+                            + i
+                            + " cannot be null for sort field ["
+                            + sortField.getField()
+                            + "] of type ["
+                            + sortType
+                            + "]."
+                    );
+                }
             }
         }
         /*

--- a/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -70,8 +70,8 @@ public class SearchAfterBuilderTests extends ESTestCase {
                 case 6 -> values[i] = randomByte();
                 case 7 -> values[i] = randomShort();
                 case 8 -> values[i] = new Text(randomAlphaOfLengthBetween(5, 20));
-                case 9 -> values[i] = null;
-                case 10 -> values[i] = randomBigInteger();
+                case 9 -> values[i] = randomBigInteger();
+                case 10 -> values[i] = null;
             }
         }
         searchAfterBuilder.setSortValues(values);
@@ -279,5 +279,41 @@ public class SearchAfterBuilderTests extends ESTestCase {
             "collapse_field"
         );
         assertEquals(fieldDoc.toString(), new FieldDoc(Integer.MAX_VALUE, 0, new Object[] { new BytesRef("foo") }).toString());
+    }
+
+    /**
+     * Test that buildFieldDoc rejects null values
+     */
+    public void testBuildFieldDocRejectsNull() {
+        for (SortField.Type type : new SortField.Type[] {
+            SortField.Type.LONG,
+            SortField.Type.INT,
+            SortField.Type.DOUBLE,
+            SortField.Type.FLOAT,
+            SortField.Type.DOC }) {
+            SortField sortField = new SortField("field", type, true);
+            Sort sort = new Sort(sortField);
+            DocValueFormat[] formats = { DocValueFormat.RAW };
+            SortAndFormats sortAndFormats = new SortAndFormats(sort, formats);
+
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
+                SearchAfterBuilder.buildFieldDoc(sortAndFormats, new Object[] { null }, null);
+            });
+            assertThat(e.getMessage(), containsString("cannot be null"));
+            assertThat(e.getMessage(), containsString(type.name()));
+        }
+    }
+
+    /**
+     * Test that buildFieldDoc allows null values for string sort types
+     */
+    public void testBuildFieldDocAllowsNullForStringSort() {
+        for (SortField sortField : new SortField[] {
+            new SortedSetSortField("field", false),
+            new SortField("field", SortField.Type.STRING_VAL) }) {
+            SortAndFormats sortAndFormats = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+            FieldDoc fieldDoc = SearchAfterBuilder.buildFieldDoc(sortAndFormats, new Object[] { null }, null);
+            assertNull(fieldDoc.fields[0]);
+        }
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix NullPointerException in LongComparator caused by null search_after values (#132434)](https://github.com/elastic/elasticsearch/pull/132434)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)