### PR TITLE
[9.5] Exclude non-metadata _type from default search hit fields (#155706)

### DIFF
--- a/docs/changelog/155706.yaml
+++ b/docs/changelog/155706.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 110438
+pr: 155706
+summary: Exclude non-metadata `_type` from default search hit fields
+type: bug

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -161,3 +161,128 @@ teardown:
           mappings:
             properties:
               join_field: { "type": "join", "relations": { "parent": "child", "child": "grand_child" }, "fields": {"keyword": {"type": "keyword"}} }
+
+---
+"join field named _type is not returned as root metadata":
+  - requires:
+      cluster_features: ["search.fetch_fields.excludes_non_metadata_type"]
+      reason: "fix for user-mapped _type field appearing in hit root metadata"
+
+  - do:
+      indices.create:
+        index: type-join
+        body:
+          mappings:
+            properties:
+              text: { "type": "keyword" }
+              _type: { "type": "join", "relations": { "question": "answer" } }
+
+  - do:
+      bulk:
+        index: type-join
+        refresh: true
+        body:
+          - '{ "index": {"_id": "1"}}'
+          - '{ "text": "What species does chewbacca belong to?", "_type": { "name": "question" }}'
+          - '{ "index": {"_id": "2"}}'
+          - '{ "text": "How did Yoda die?", "_type": { "name": "question" }}'
+          - '{ "index": {"_id": "3", "routing": "1"}}'
+          - '{ "text": "Wookie", "_type": { "name": "answer", "parent": "1" }}'
+          - '{ "index": {"_id": "4", "routing": "2"}}'
+          - '{ "text": "Old age", "_type": { "name": "answer", "parent": "2" }}'
+
+  - do:
+      search:
+        index: type-join
+        body:
+          sort: [ "text" ]
+          query: { match_all: { } }
+
+  - match: { hits.total.value: 4 }
+
+  - match: { hits.hits.0._id: "2" }
+  - is_false: hits.hits.0._type
+  - match: { hits.hits.0._source._type.name: "question" }
+  - match: { hits.hits.0._source.text: "How did Yoda die?" }
+
+  - match: { hits.hits.1._id: "4" }
+  - is_false: hits.hits.1._type
+  - match: { hits.hits.1._source._type.name: "answer" }
+  - match: { hits.hits.1._source._type.parent: "2" }
+  - match: { hits.hits.1._source.text: "Old age" }
+
+  - match: { hits.hits.2._id: "1" }
+  - is_false: hits.hits.2._type
+  - match: { hits.hits.2._source._type.name: "question" }
+  - match: { hits.hits.2._source.text: "What species does chewbacca belong to?" }
+
+  - match: { hits.hits.3._id: "3" }
+  - is_false: hits.hits.3._type
+  - match: { hits.hits.3._source._type.name: "answer" }
+  - match: { hits.hits.3._source._type.parent: "1" }
+  - match: { hits.hits.3._source.text: "Wookie" }
+
+  - do:
+      search:
+        index: type-join
+        body:
+          sort: [ "text" ]
+          query: { ids: { values: [ "1", "3" ] } }
+          fields: [ "_type" ]
+
+  - match: { hits.total.value: 2 }
+  - is_false: hits.hits.0._type
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0.fields._type.0.name: "question" }
+  - is_false: hits.hits.1._type
+  - match: { hits.hits.1._id: "3" }
+  - match: { hits.hits.1.fields._type.0.name: "answer" }
+  - match: { hits.hits.1.fields._type.0.parent: "1" }
+
+---
+"keyword field named _type is not returned as root metadata":
+  - requires:
+      cluster_features: ["search.fetch_fields.excludes_non_metadata_type"]
+      reason: "fix applies to any mapper type named _type, not only join"
+
+  - do:
+      indices.create:
+        index: type-keyword
+        body:
+          mappings:
+            properties:
+              _type: { "type": "keyword" }
+
+  - do:
+      bulk:
+        index: type-keyword
+        refresh: true
+        body:
+          - '{ "index": {"_id": "1"}}'
+          - '{ "_type": "question" }'
+          - '{ "index": {"_id": "2"}}'
+          - '{ "_type": "answer" }'
+
+  - do:
+      search:
+        index: type-keyword
+        body:
+          sort: [ "_type" ]
+          query: { match_all: { } }
+
+  - match: { hits.total.value: 2 }
+  - is_false: hits.hits.0._type
+  - match: { hits.hits.0._source._type: "answer" }
+  - is_false: hits.hits.1._type
+  - match: { hits.hits.1._source._type: "question" }
+
+  - do:
+      search:
+        index: type-keyword
+        body:
+          query: { term: { _type: "question" } }
+          fields: [ "_type" ]
+
+  - match: { hits.total.value: 1 }
+  - is_false: hits.hits.0._type
+  - match: { hits.hits.0.fields._type.0: "question" }

--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -80,6 +80,14 @@ public final class SearchFeatures implements FeatureSpecification {
         "search.aggs.date_histogram.hard_bounds_outside_data_fix"
     );
     public static final NodeFeature COUNT_STATS_PARAMETER = new NodeFeature("search.count.stats_parameter");
+    /**
+     * Test-only gate for REST tests asserting that a user-mapped field named {@code _type} is not
+     * surfaced as root-level hit metadata. Old nodes included it in the default metadata fetch
+     * regardless of whether it was a real metadata mapper.
+     */
+    public static final NodeFeature FETCH_FIELDS_EXCLUDES_NON_METADATA_TYPE = new NodeFeature(
+        "search.fetch_fields.excludes_non_metadata_type"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -112,7 +120,8 @@ public final class SearchFeatures implements FeatureSpecification {
             PROFILE_COORDINATOR_REQUEST_METADATA,
             SCROLL_EMPTY_CONTEXT_RETURNS_200,
             DATE_HISTOGRAM_HARD_BOUNDS_OUTSIDE_DATA_FIX,
-            COUNT_STATS_PARAMETER
+            COUNT_STATS_PARAMETER,
+            FETCH_FIELDS_EXCLUDES_NON_METADATA_TYPE
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,12 +39,31 @@ import java.util.Set;
  */
 public final class FetchFieldsPhase implements FetchSubPhase {
 
-    private static final List<FieldAndFormat> DEFAULT_METADATA_FIELDS = List.of(
+    // Every entry is kept only when it is a metadata mapper for the index. _ignored and _routing
+    // always are (see IndicesModule#initBuiltInMetadataMappers), so the filter is a no-op for them;
+    // _type only is on pre-6.0 archived indices, which keeps a user field of that name out of
+    // root-level hit metadata.
+    private static final Set<FieldAndFormat> DEFAULT_METADATA_FIELDS = Set.of(
         new FieldAndFormat(IgnoredFieldMapper.NAME, null),
         new FieldAndFormat(RoutingFieldMapper.NAME, null),
-        // will only be fetched when mapped (older archived indices)
         new FieldAndFormat(LegacyTypeFieldMapper.NAME, null)
     );
+
+    /**
+     * Returns a fresh mutable set of default metadata fields that are metadata mappers for
+     * {@code context}. Callers may add further fields to the result. Filtering by
+     * {@link SearchExecutionContext#isMetadataField} avoids surfacing a user-mapped field
+     * (for example a join field named {@code _type}) as root-level hit metadata.
+     */
+    private static Set<FieldAndFormat> defaultMetadataFields(SearchExecutionContext context) {
+        final Set<FieldAndFormat> metadataFields = new HashSet<>();
+        for (FieldAndFormat fieldAndFormat : DEFAULT_METADATA_FIELDS) {
+            if (context.isMetadataField(fieldAndFormat.field)) {
+                metadataFields.add(fieldAndFormat);
+            }
+        }
+        return metadataFields;
+    }
 
     @Override
     public FetchSubPhaseProcessor getProcessor(FetchContext fetchContext) {
@@ -97,7 +115,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
         if (storedFieldsContext != null
             && storedFieldsContext.fieldNames() != null
             && storedFieldsContext.fieldNames().isEmpty() == false) {
-            final Set<FieldAndFormat> metadataFields = new HashSet<>(DEFAULT_METADATA_FIELDS);
+            final Set<FieldAndFormat> metadataFields = defaultMetadataFields(searchExecutionContext);
             for (final String storedField : storedFieldsContext.fieldNames()) {
                 final Set<String> matchingFieldNames = searchExecutionContext.getMatchingFieldNames(storedField);
                 for (final String matchingFieldName : matchingFieldNames) {
@@ -122,7 +140,7 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             metadataFieldFetcher = FieldFetcher.create(searchExecutionContext, metadataFields);
         } else {
             // NOTE: Include also metadata stored fields requested via `fields`
-            final Set<FieldAndFormat> allMetadataFields = new HashSet<>(DEFAULT_METADATA_FIELDS);
+            final Set<FieldAndFormat> allMetadataFields = defaultMetadataFields(searchExecutionContext);
             allMetadataFields.addAll(fetchContextMetadataFields);
             metadataFieldFetcher = FieldFetcher.create(searchExecutionContext, allMetadataFields);
         }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
@@ -109,20 +109,48 @@ public class FetchFieldsPhaseTests extends ESTestCase {
         dir.close();
     }
 
-    public void testStoredFieldsSpec() {
-        StoredFieldsContext storedFieldsContext = StoredFieldsContext.fromList(List.of("stored", "_metadata"));
-        FetchFieldsContext ffc = new FetchFieldsContext(List.of(new FieldAndFormat("field", null)));
+    public void testStoredFieldsSpecIncludesTypeWhenMetadata() {
+        assertStoredFieldsSpec(true, StoredFieldsContext.fromList(List.of("stored", "_metadata")));
+    }
 
+    public void testStoredFieldsSpecExcludesTypeWhenNotMetadata() {
+        // Explicit stored_fields list takes the if-branch in FetchFieldsPhase#getProcessor.
+        assertStoredFieldsSpec(false, StoredFieldsContext.fromList(List.of("stored", "_metadata")));
+    }
+
+    public void testDefaultSearchExcludesTypeWhenNotMetadata() {
+        // Plain _search uses StoredFieldsContext.metadataOnly() (null fieldNames), the else-branch.
+        assertStoredFieldsSpec(false, StoredFieldsContext.metadataOnly());
+    }
+
+    public void testDefaultSearchIncludesTypeWhenMetadata() {
+        assertStoredFieldsSpec(true, StoredFieldsContext.metadataOnly());
+    }
+
+    /**
+     * Builds a FetchFieldsPhase processor and asserts which default metadata fields land in the
+     * stored-fields spec when {@code _type} is or is not a metadata mapper.
+     */
+    private static void assertStoredFieldsSpec(boolean typeIsMetadata, StoredFieldsContext storedFieldsContext) {
+        FetchFieldsContext ffc = new FetchFieldsContext(List.of(new FieldAndFormat("field", null)));
         SearchLookup searchLookup = mock(SearchLookup.class);
 
         SearchExecutionContext sec = mock(SearchExecutionContext.class);
-        when(sec.isMetadataField(any())).then(invocation -> invocation.getArguments()[0].toString().startsWith("_"));
+        // Treat underscore-prefixed names as metadata, except a user-mapped `_type` when typeIsMetadata
+        // is false. `_type` is only a real metadata mapper on pre-6.0 archived indices.
+        when(sec.isMetadataField(any())).then(invocation -> {
+            String field = invocation.getArguments()[0].toString();
+            if ("_type".equals(field)) {
+                return typeIsMetadata;
+            }
+            return field.startsWith("_");
+        });
 
         MappedFieldType routingFt = mock(MappedFieldType.class);
         when(routingFt.valueFetcher(any(), any())).thenReturn(new StoredValueFetcher(searchLookup, "_routing"));
         when(sec.getFieldType(eq("_routing"))).thenReturn(routingFt);
 
-        // this would normally not be mapped -> getMatchingFieldsNames would not resolve it (unless for older archive indices)
+        // Included in the default metadata list; kept only when isMetadataField("_type") is true.
         MappedFieldType typeFt = mock(MappedFieldType.class);
         when(typeFt.valueFetcher(any(), any())).thenReturn(new StoredValueFetcher(searchLookup, "_type"));
         when(sec.getFieldType(eq("_type"))).thenReturn(typeFt);
@@ -132,7 +160,8 @@ public class FetchFieldsPhaseTests extends ESTestCase {
         when(sec.getFieldType(eq("_ignored"))).thenReturn(ignoredFt);
 
         // Ideally we would test that explicitly requested stored fields are included in stored fields spec, but isStored is final hence it
-        // can't be mocked. In reality, _metadata would be included but stored would not.
+        // can't be mocked. In reality, _metadata would be included but stored would not. These stubs exist only so getFieldType does not
+        // return null if the if-branch resolves names from the stored_fields list.
         MappedFieldType storedFt = mock(MappedFieldType.class);
         when(sec.getFieldType(eq("stored"))).thenReturn(storedFt);
         MappedFieldType metadataFt = mock(MappedFieldType.class);
@@ -159,12 +188,19 @@ public class FetchFieldsPhaseTests extends ESTestCase {
         when(fetchContext.fetchFieldsContext()).thenReturn(ffc);
         when(fetchContext.storedFieldsContext()).thenReturn(storedFieldsContext);
         when(fetchContext.getSearchExecutionContext()).thenReturn(sec);
+
         FetchFieldsPhase fetchFieldsPhase = new FetchFieldsPhase();
         FetchSubPhaseProcessor processor = fetchFieldsPhase.getProcessor(fetchContext);
+        assertNotNull(processor);
         StoredFieldsSpec storedFieldsSpec = processor.storedFieldsSpec();
-        assertEquals(3, storedFieldsSpec.requiredStoredFields().size());
         assertTrue(storedFieldsSpec.requiredStoredFields().contains("_routing"));
         assertTrue(storedFieldsSpec.requiredStoredFields().contains("_ignored"));
-        assertTrue(storedFieldsSpec.requiredStoredFields().contains("_type"));
+        if (typeIsMetadata) {
+            assertTrue(storedFieldsSpec.requiredStoredFields().contains("_type"));
+            assertEquals(3, storedFieldsSpec.requiredStoredFields().size());
+        } else {
+            assertFalse(storedFieldsSpec.requiredStoredFields().contains("_type"));
+            assertEquals(2, storedFieldsSpec.requiredStoredFields().size());
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Exclude non-metadata `_type` from default search hit fields (#155706)
