### PR TITLE
Tighten SimdVecLibraryTests

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/SimdVecLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/SimdVecLibrary.java
@@ -122,6 +122,10 @@ public abstract class SimdVecLibrary {
         }
     }
 
+    /**
+     * Loads the native vector library, or returns an empty {@code Optional} if this host CPU/OS does not
+     * support vector functions. Callers have already established that the library is supported here.
+     */
     static Optional<SimdVecLibrary> tryLoad() {
         int capability = VecCaps.caps();
         if (capability < 0) {
@@ -135,6 +139,8 @@ public abstract class SimdVecLibrary {
             return Optional.empty();
         }
         var lib = LibraryProvider.lookupLibrary(SimdVecLibrary.class);
+        // lookupLibrary must succeed here, we already checked requirements
+        // (and loaded the native library to call vec_caps)
         assert lib != null;
         return Optional.of(lib);
     }

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
@@ -14,17 +14,15 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.NodeNamePatternConverter;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT_UNALIGNED;
-import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
-import static org.hamcrest.Matchers.not;
 
 public abstract class SimdVecLibraryTests extends ESTestCase {
 
@@ -40,7 +38,7 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
 
     protected final SimdVecLibrary.SimilarityFunction function;
     protected final int size;
-    protected final Optional<SimdVecLibrary> vectorSimilarityFunctions;
+    protected final SimdVecLibrary vectorSimilarityFunctions;
 
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() {
@@ -55,9 +53,18 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
     protected SimdVecLibraryTests(SimdVecLibrary.SimilarityFunction function, int size) {
         this.function = function;
         this.size = size;
-        vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions();
+        vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions().orElse(null);
 
         logger.info(platformMsg());
+    }
+
+    @Before
+    public void ensureSimilarityFunctionResolved() {
+        if (supported()) {
+            assertNotNull(vectorSimilarityFunctions);
+        } else {
+            assertNull(vectorSimilarityFunctions);
+        }
     }
 
     public static void setup() {
@@ -71,28 +78,12 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
         arena.close();
     }
 
-    public void testSupported() {
-        supported();
-    }
-
     protected SimdVecLibrary getVectorDistance() {
-        return vectorSimilarityFunctions.get();
+        return vectorSimilarityFunctions;
     }
 
-    public boolean supported() {
-        var jdkVersion = Runtime.version().feature();
-        var arch = System.getProperty("os.arch");
-        var osName = System.getProperty("os.name");
-
-        if (jdkVersion >= 21
-            && ((arch.equals("aarch64") && (osName.startsWith("Mac") || osName.equals("Linux")))
-                || (arch.equals("amd64") && osName.equals("Linux")))) {
-            assertThat(vectorSimilarityFunctions, isPresent());
-            return true;
-        } else {
-            assertThat(vectorSimilarityFunctions, not(isPresent()));
-            return false;
-        }
+    public static boolean supported() {
+        return PosixNativeAccess.isNativeVectorLibSupported() && VecCaps.caps() > 0;
     }
 
     public static String notSupportedMsg() {
@@ -106,11 +97,6 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
         return "JDK=" + jdkVersion + ", os=" + osName + ", arch=" + arch;
     }
 
-    // Support for passing on-heap arrays/segments to native
-    protected static boolean supportsHeapSegments() {
-        return Runtime.version().feature() >= 22;
-    }
-
     protected static RuntimeException rethrow(Throwable t) {
         if (t instanceof Error err) {
             throw err;
@@ -118,7 +104,7 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
         return t instanceof RuntimeException re ? re : new RuntimeException(t);
     }
 
-    protected static float[] randomFloatArray(int length) {
+    public static float[] randomFloatArray(int length) {
         float[] fa = new float[length];
         for (int i = 0; i < length; i++) {
             fa[i] = randomFloat();

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
@@ -57,12 +57,12 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
     }
 
     public static void setup() {
-        var supported = supported();
-        if (supported) {
+        var simdVecSupported = supported();
+        if (simdVecSupported) {
             vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions().orElse(null);
             assertNotNull("native vector library must be available on [" + platformMsg() + "]", vectorSimilarityFunctions);
         }
-        assumeTrue(notSupportedMsg(), supported);
+        assumeTrue(notSupportedMsg(), simdVecSupported);
 
         // Occasionally back every segment of this suite with a guard page, so that a native over-read faults
         // instead of silently returning a wrong score.

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/SimdVecLibraryTests.java
@@ -14,7 +14,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.NodeNamePatternConverter;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Before;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -34,11 +33,11 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
     public static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
     public static final Class<IndexOutOfBoundsException> IOOBE = IndexOutOfBoundsException.class;
 
+    protected static SimdVecLibrary vectorSimilarityFunctions;
     protected static Arena arena;
 
     protected final SimdVecLibrary.SimilarityFunction function;
     protected final int size;
-    protected final SimdVecLibrary vectorSimilarityFunctions;
 
     @ParametersFactory
     public static Iterable<Object[]> parametersFactory() {
@@ -53,21 +52,18 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
     protected SimdVecLibraryTests(SimdVecLibrary.SimilarityFunction function, int size) {
         this.function = function;
         this.size = size;
-        vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions().orElse(null);
 
         logger.info(platformMsg());
     }
 
-    @Before
-    public void ensureSimilarityFunctionResolved() {
-        if (supported()) {
-            assertNotNull(vectorSimilarityFunctions);
-        } else {
-            assertNull(vectorSimilarityFunctions);
-        }
-    }
-
     public static void setup() {
+        var supported = supported();
+        if (supported) {
+            vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions().orElse(null);
+            assertNotNull("native vector library must be available on [" + platformMsg() + "]", vectorSimilarityFunctions);
+        }
+        assumeTrue(notSupportedMsg(), supported);
+
         // Occasionally back every segment of this suite with a guard page, so that a native over-read faults
         // instead of silently returning a wrong score.
         var useGuardPageAllocator = randomBoolean();
@@ -75,7 +71,10 @@ public abstract class SimdVecLibraryTests extends ESTestCase {
     }
 
     public static void cleanup() {
-        arena.close();
+        if (arena != null) {
+            arena.close();
+            arena = null;
+        }
     }
 
     protected SimdVecLibrary getVectorDistance() {

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQGuardPageTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQGuardPageTests.java
@@ -27,6 +27,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.nativeaccess.SimdVecLibrary.SimilarityFunction.DOT_PRODUCT;
+import static org.elasticsearch.nativeaccess.SimdVecLibraryTests.notSupportedMsg;
+import static org.elasticsearch.nativeaccess.SimdVecLibraryTests.platformMsg;
+import static org.elasticsearch.nativeaccess.SimdVecLibraryTests.supported;
 
 /**
  * Tests that the native BBQ vector kernels do not read past the end of their input buffers.
@@ -80,9 +83,14 @@ public class JDKVectorLibraryBBQGuardPageTests extends ESTestCase {
     public static void beforeClass() {
         // a pass here must mean the guard page was real, so skip rather than run unguarded
         assumeTrue("guard pages are not supported on this platform", GuardPageAllocator.isSupported());
-        var vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions();
-        assumeTrue("native vector library is not available on this platform", vectorSimilarityFunctions.isPresent());
-        library = vectorSimilarityFunctions.get();
+
+        var simdVecSupported = supported();
+        if (simdVecSupported) {
+            var vectorSimilarityFunctions = NativeAccess.instance().getVectorSimilarityFunctions();
+            assertTrue("native vector library must be available on [" + platformMsg() + "]", vectorSimilarityFunctions.isPresent());
+            library = vectorSimilarityFunctions.get();
+        }
+        assumeTrue(notSupportedMsg(), simdVecSupported);
     }
 
     @AfterClass

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQTests.java
@@ -105,18 +105,16 @@ public class JDKVectorLibraryBBQTests extends SimdVecLibraryTests {
             float expected = ScalarOperations.similarity(function, unpackedQueryVectors[queryIndex], unpackedIndexVectors[indexIndex]);
             assertEquals(expected, nativeSimilarity(indexSlice, querySlice, indexVectorBytes), 0f);
 
-            if (supportsHeapSegments()) {
-                var queryHeapSegment = MemorySegment.ofArray(queryVectors[queryIndex]);
-                var indexHeapSegment = MemorySegment.ofArray(indexVectors[indexIndex]);
-                assertEquals(expected, nativeSimilarity(indexHeapSegment, queryHeapSegment, indexVectorBytes), 0f);
-                assertEquals(expected, nativeSimilarity(indexHeapSegment, querySlice, indexVectorBytes), 0f);
-                assertEquals(expected, nativeSimilarity(indexSlice, queryHeapSegment, indexVectorBytes), 0f);
+            var queryHeapSegment = MemorySegment.ofArray(queryVectors[queryIndex]);
+            var indexHeapSegment = MemorySegment.ofArray(indexVectors[indexIndex]);
+            assertEquals(expected, nativeSimilarity(indexHeapSegment, queryHeapSegment, indexVectorBytes), 0f);
+            assertEquals(expected, nativeSimilarity(indexHeapSegment, querySlice, indexVectorBytes), 0f);
+            assertEquals(expected, nativeSimilarity(indexSlice, queryHeapSegment, indexVectorBytes), 0f);
 
-                // trivial bulk with a single vector
-                float[] bulkScore = new float[1];
-                nativeSimilarityBulk(indexSlice, querySlice, indexVectorBytes, 1, MemorySegment.ofArray(bulkScore));
-                assertEquals(expected, bulkScore[0], 0f);
-            }
+            // trivial bulk with a single vector
+            float[] bulkScore = new float[1];
+            nativeSimilarityBulk(indexSlice, querySlice, indexVectorBytes, 1, MemorySegment.ofArray(bulkScore));
+            assertEquals(expected, bulkScore[0], 0f);
         }
     }
 
@@ -199,17 +197,15 @@ public class JDKVectorLibraryBBQTests extends SimdVecLibraryTests {
         nativeSimilarityBulk(testData.indexSegment, testData.querySegment, testData.indexVectorBytes, numVecs, bulkScoresSeg);
         assertScoresEquals(expectedScores, bulkScoresSeg);
 
-        if (supportsHeapSegments()) {
-            float[] bulkScores = new float[numVecs];
-            nativeSimilarityBulk(
-                testData.indexSegment,
-                testData.querySegment,
-                testData.indexVectorBytes,
-                numVecs,
-                MemorySegment.ofArray(bulkScores)
-            );
-            assertArrayEquals(expectedScores, bulkScores, 0f);
-        }
+        float[] bulkScores = new float[numVecs];
+        nativeSimilarityBulk(
+            testData.indexSegment,
+            testData.querySegment,
+            testData.indexVectorBytes,
+            numVecs,
+            MemorySegment.ofArray(bulkScores)
+        );
+        assertArrayEquals(expectedScores, bulkScores, 0f);
     }
 
     public void testInt4BulkWithOffsets() {
@@ -274,8 +270,6 @@ public class JDKVectorLibraryBBQTests extends SimdVecLibraryTests {
     }
 
     public void testInt4BulkWithOffsetsHeapSegments() {
-        assumeTrue(notSupportedMsg(), supported());
-        assumeTrue("Requires support for heap MemorySegments", supportsHeapSegments());
         assumeTrue(notSupportedMsg(), supported());
 
         final int numVecs = randomIntBetween(2, 101);

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryFloat32Tests.java
@@ -84,13 +84,11 @@ public class JDKVectorLibraryFloat32Tests extends SimdVecLibraryTests {
 
             float expected = ScalarOperations.similarity(function, values[first], values[second]);
             assertEquals(expected, similarity(nativeSeg1, nativeSeg2, dims), delta);
-            if (supportsHeapSegments()) {
-                var heapSeg1 = MemorySegment.ofArray(values[first]);
-                var heapSeg2 = MemorySegment.ofArray(values[second]);
-                assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), delta);
-                assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), delta);
-                assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), delta);
-            }
+            var heapSeg1 = MemorySegment.ofArray(values[first]);
+            var heapSeg2 = MemorySegment.ofArray(values[second]);
+            assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), delta);
+            assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), delta);
+            assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), delta);
         }
     }
 
@@ -114,11 +112,9 @@ public class JDKVectorLibraryFloat32Tests extends SimdVecLibraryTests {
         similarityBulk(segment, nativeQuerySeg, dims, numVecs, bulkScoresSeg);
         assertScoresEquals(expectedScores, bulkScoresSeg, delta);
 
-        if (supportsHeapSegments()) {
-            float[] bulkScores = new float[numVecs];
-            similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
-            assertArrayEquals(expectedScores, bulkScores, delta);
-        }
+        float[] bulkScores = new float[numVecs];
+        similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
+        assertArrayEquals(expectedScores, bulkScores, delta);
     }
 
     public void testFloat32BulkWithOffsets() {
@@ -178,7 +174,6 @@ public class JDKVectorLibraryFloat32Tests extends SimdVecLibraryTests {
 
     public void testFloat32BulkWithOffsetsHeapSegments() {
         assumeTrue(notSupportedMsg(), supported());
-        assumeTrue("Requires support for heap MemorySegments", supportsHeapSegments());
         final int dims = size;
         final int numVecs = randomIntBetween(2, 101);
         var offsets = new int[numVecs];

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt4Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt4Tests.java
@@ -90,18 +90,16 @@ public class JDKVectorLibraryInt4Tests extends SimdVecLibraryTests {
             int expected = dotProductI4SinglePacked(unpackedValues[first], packedValues[second]);
             assertEquals(expected, similarity(nativeUnpacked, nativePacked, packedLen));
 
-            if (supportsHeapSegments()) {
-                var heapUnpacked = MemorySegment.ofArray(unpackedValues[first]);
-                var heapPacked = MemorySegment.ofArray(packedValues[second]);
-                assertEquals(expected, similarity(heapUnpacked, heapPacked, packedLen));
-                assertEquals(expected, similarity(nativeUnpacked, heapPacked, packedLen));
-                assertEquals(expected, similarity(heapUnpacked, nativePacked, packedLen));
+            var heapUnpacked = MemorySegment.ofArray(unpackedValues[first]);
+            var heapPacked = MemorySegment.ofArray(packedValues[second]);
+            assertEquals(expected, similarity(heapUnpacked, heapPacked, packedLen));
+            assertEquals(expected, similarity(nativeUnpacked, heapPacked, packedLen));
+            assertEquals(expected, similarity(heapUnpacked, nativePacked, packedLen));
 
-                // trivial bulk with a single vector
-                float[] bulkScore = new float[1];
-                similarityBulk(nativePacked, nativeUnpacked, packedLen, 1, MemorySegment.ofArray(bulkScore));
-                assertEquals(expected, bulkScore[0], 0f);
-            }
+            // trivial bulk with a single vector
+            float[] bulkScore = new float[1];
+            similarityBulk(nativePacked, nativeUnpacked, packedLen, 1, MemorySegment.ofArray(bulkScore));
+            assertEquals(expected, bulkScore[0], 0f);
         }
     }
 
@@ -131,11 +129,9 @@ public class JDKVectorLibraryInt4Tests extends SimdVecLibraryTests {
         similarityBulk(packedSegment, nativeQuerySeg, packedLen, numVecs, bulkScoresSeg);
         assertScoresEquals(expectedScores, bulkScoresSeg);
 
-        if (supportsHeapSegments()) {
-            float[] bulkScores = new float[numVecs];
-            similarityBulk(packedSegment, nativeQuerySeg, packedLen, numVecs, MemorySegment.ofArray(bulkScores));
-            assertArrayEquals(expectedScores, bulkScores, 0f);
-        }
+        float[] bulkScores = new float[numVecs];
+        similarityBulk(packedSegment, nativeQuerySeg, packedLen, numVecs, MemorySegment.ofArray(bulkScores));
+        assertArrayEquals(expectedScores, bulkScores, 0f);
     }
 
     public void testInt4BulkWithOffsets() {
@@ -206,7 +202,6 @@ public class JDKVectorLibraryInt4Tests extends SimdVecLibraryTests {
 
     public void testInt4BulkWithOffsetsHeapSegments() {
         assumeTrue(notSupportedMsg(), supported());
-        assumeTrue("Requires support for heap MemorySegments", supportsHeapSegments());
         final int dims = size;
         final int packedLen = dims / 2;
         final int numVecs = randomIntBetween(2, 101);

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt7uTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt7uTests.java
@@ -72,18 +72,16 @@ public class JDKVectorLibraryInt7uTests extends SimdVecLibraryTests {
 
             float expected = ScalarOperations.similarity(function, values[first], values[second]);
             assertEquals(expected, similarity(nativeSeg1, nativeSeg2, dims), 0f);
-            if (supportsHeapSegments()) {
-                var heapSeg1 = MemorySegment.ofArray(values[first]);
-                var heapSeg2 = MemorySegment.ofArray(values[second]);
-                assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), 0f);
-                assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), 0f);
-                assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), 0f);
+            var heapSeg1 = MemorySegment.ofArray(values[first]);
+            var heapSeg2 = MemorySegment.ofArray(values[second]);
+            assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), 0f);
+            assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), 0f);
+            assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), 0f);
 
-                // trivial bulk with a single vector
-                float[] bulkScore = new float[1];
-                similarityBulk(nativeSeg1, nativeSeg2, dims, 1, MemorySegment.ofArray(bulkScore));
-                assertEquals(expected, bulkScore[0], 0f);
-            }
+            // trivial bulk with a single vector
+            float[] bulkScore = new float[1];
+            similarityBulk(nativeSeg1, nativeSeg2, dims, 1, MemorySegment.ofArray(bulkScore));
+            assertEquals(expected, bulkScore[0], 0f);
         }
     }
 
@@ -106,11 +104,9 @@ public class JDKVectorLibraryInt7uTests extends SimdVecLibraryTests {
         similarityBulk(segment, nativeQuerySeg, dims, numVecs, bulkScoresSeg);
         assertScoresEquals(expectedScores, bulkScoresSeg);
 
-        if (supportsHeapSegments()) {
-            float[] bulkScores = new float[numVecs];
-            similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
-            assertArrayEquals(expectedScores, bulkScores, 0f);
-        }
+        float[] bulkScores = new float[numVecs];
+        similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
+        assertArrayEquals(expectedScores, bulkScores, 0f);
     }
 
     public void testInt7uBulkWithOffsets() {
@@ -284,7 +280,6 @@ public class JDKVectorLibraryInt7uTests extends SimdVecLibraryTests {
 
     public void testInt7uBulkWithOffsetsHeapSegments() {
         assumeTrue(notSupportedMsg(), supported());
-        assumeTrue("Requires support for heap MemorySegments", supportsHeapSegments());
         final int dims = size;
         final int numVecs = randomIntBetween(2, 101);
         var offsets = new int[numVecs];

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryInt8Tests.java
@@ -71,13 +71,11 @@ public class JDKVectorLibraryInt8Tests extends SimdVecLibraryTests {
 
             float expected = ScalarOperations.similarity(function, values[first], values[second]);
             assertEquals(expected, similarity(nativeSeg1, nativeSeg2, dims), delta);
-            if (supportsHeapSegments()) {
-                var heapSeg1 = MemorySegment.ofArray(values[first]);
-                var heapSeg2 = MemorySegment.ofArray(values[second]);
-                assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), delta);
-                assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), delta);
-                assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), delta);
-            }
+            var heapSeg1 = MemorySegment.ofArray(values[first]);
+            var heapSeg2 = MemorySegment.ofArray(values[second]);
+            assertEquals(expected, similarity(heapSeg1, heapSeg2, dims), delta);
+            assertEquals(expected, similarity(nativeSeg1, heapSeg2, dims), delta);
+            assertEquals(expected, similarity(heapSeg1, nativeSeg2, dims), delta);
         }
     }
 
@@ -101,11 +99,9 @@ public class JDKVectorLibraryInt8Tests extends SimdVecLibraryTests {
         similarityBulk(segment, nativeQuerySeg, dims, numVecs, bulkScoresSeg);
         assertScoresEquals(expectedScores, bulkScoresSeg, delta);
 
-        if (supportsHeapSegments()) {
-            float[] bulkScores = new float[numVecs];
-            similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
-            assertArrayEquals(expectedScores, bulkScores, delta);
-        }
+        float[] bulkScores = new float[numVecs];
+        similarityBulk(segment, nativeQuerySeg, dims, numVecs, MemorySegment.ofArray(bulkScores));
+        assertArrayEquals(expectedScores, bulkScores, delta);
     }
 
     public void testByteBulkWithOffsets() {
@@ -227,7 +223,6 @@ public class JDKVectorLibraryInt8Tests extends SimdVecLibraryTests {
 
     public void testByteBulkWithOffsetsHeapSegments() {
         assumeTrue(notSupportedMsg(), supported());
-        assumeTrue("Requires support for heap MemorySegments", supportsHeapSegments());
         final int dims = size;
         final int numVecs = randomIntBetween(2, 101);
         var offsets = new int[numVecs];

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryLargeSegmentTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryLargeSegmentTests.java
@@ -22,6 +22,8 @@ import java.lang.foreign.ValueLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT_UNALIGNED;
+import static org.elasticsearch.nativeaccess.SimdVecLibraryTests.randomFloatArray;
+import static org.elasticsearch.nativeaccess.SimdVecLibraryTests.supported;
 
 /**
  * Tests that bulk-with-offsets scoring works correctly when the vectors
@@ -40,22 +42,13 @@ public class JDKVectorLibraryLargeSegmentTests extends ESTestCase {
         LogConfigurator.configureESLogging();
     }
 
-    static boolean supported() {
-        var jdkVersion = Runtime.version().feature();
-        var arch = System.getProperty("os.arch");
-        var osName = System.getProperty("os.name");
-        return jdkVersion >= 21
-            && ((arch.equals("aarch64") && (osName.startsWith("Mac") || osName.equals("Linux")))
-                || (arch.equals("amd64") && osName.equals("Linux")));
-    }
-
     static SimdVecLibrary functions;
 
     @BeforeClass
     public static void setup() {
         assumeTrue("Native vector functions not supported on this platform", supported());
         functions = NativeAccess.instance().getVectorSimilarityFunctions().orElse(null);
-        assumeTrue("Vector similarity functions not available", functions != null);
+        assertNotNull("SimdVecLibrary was not able to load on a supported platform", functions);
     }
 
     private static MemorySegment tryAllocate(Arena arena, long size) {
@@ -174,13 +167,5 @@ public class JDKVectorLibraryLargeSegmentTests extends ESTestCase {
             float expected = ScalarOperations.dotProduct(vectors[0], vectors[1]);
             assertEquals(expected, actual, 1e-5f * dims);
         }
-    }
-
-    static float[] randomFloatArray(int length) {
-        float[] fa = new float[length];
-        for (int i = 0; i < length; i++) {
-            fa[i] = randomFloat();
-        }
-        return fa;
     }
 }


### PR DESCRIPTION
Following comments on https://github.com/elastic/elasticsearch/issues/153224, this PR tightens some SimdVecLibrary tests to closely match the current library requirements/availability.

Relates to https://github.com/elastic/elasticsearch/issues/153228