### PR TITLE
Fix histogram min/max not being fully respected in rank estimation

### DIFF
--- a/docs/changelog/156268.yaml
+++ b/docs/changelog/156268.yaml
@@ -1,6 +1,6 @@
-area: Mapping
+area: Aggregations
 issues:
  - 156057
 pr: 156268
-summary: Fix histogram min/max not being fully respected in rank estimation
+summary: Fix exponential histogram min/max not being fully respected in rank estimation
 type: bug

--- a/docs/changelog/156268.yaml
+++ b/docs/changelog/156268.yaml
@@ -1,0 +1,6 @@
+area: Mapping
+issues:
+ - 156057
+pr: 156268
+summary: Fix histogram min/max not being fully respected in rank estimation
+type: bug

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
@@ -98,19 +98,27 @@ public class ExponentialHistogramQuantile {
             if (value > 0 || inclusive) {
                 rank += histo.zeroBucket().count();
             }
-            rank += estimateRank(histo.positiveBuckets().iterator(), value, inclusive, histo.max());
+            rank += estimateRank(histo.positiveBuckets().iterator(), value, inclusive, histo.min(), histo.max());
             return rank;
         } else {
-            long numValuesGreater = estimateRank(histo.negativeBuckets().iterator(), -value, inclusive == false, -histo.min());
+            long numValuesGreater = estimateRank(
+                histo.negativeBuckets().iterator(),
+                -value,
+                inclusive == false,
+                -histo.max(),
+                -histo.min()
+            );
             return histo.negativeBuckets().valueCount() - numValuesGreater;
         }
     }
 
-    private static long estimateRank(BucketIterator buckets, double value, boolean inclusive, double maxValue) {
+    private static long estimateRank(BucketIterator buckets, double value, boolean inclusive, double minValue, double maxValue) {
         long rank = 0;
         while (buckets.hasNext()) {
             double bucketMidpoint = ExponentialScaleUtils.getPointOfLeastRelativeError(buckets.peekIndex(), buckets.scale());
-            bucketMidpoint = Math.min(bucketMidpoint, maxValue);
+            // no values outside of [minValue, maxValue] exist in the histogram, so clamp the midpoint accordingly.
+            // This e.g. matters when querying the rank of exactly the minimum or maximum with a midpoint slightly off
+            bucketMidpoint = Math.clamp(bucketMidpoint, minValue, maxValue);
             if (bucketMidpoint < value || (inclusive && bucketMidpoint == value)) {
                 rank += buckets.peekCount();
                 buckets.advance();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -583,9 +583,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecUnmappedNullifyIT
   method: test {csv-spec:unmapped-nullify.statsNullifiedLast}
   issue: https://github.com/elastic/elasticsearch/issues/156027
-- class: org.elasticsearch.exponentialhistogram.RankAccuracyTests
-  method: testRandomDistribution
-  issue: https://github.com/elastic/elasticsearch/issues/156057
 - class: org.elasticsearch.xpack.esql.action.ExternalCsvHivePartitionedIT
   method: testHivePartitionShadowWarningReachesClient
   issue: https://github.com/elastic/elasticsearch/issues/153780


### PR DESCRIPTION
Fixes #156057

`ExponentialHistogramQuantile.estimateRank` clamped bucket midpoints only on one side (towards the histogram maximum for positive buckets, towards the minimum for negative buckets). When all values in the histogram share one sign, the bucket containing the other boundary (e.g. the max of an all-negative histogram) can have a midpoint lying outside the histogram's actual `[min, max]` range. Querying the rank of a value between that midpoint and the true min/max then returned a wrong result, since the histogram guarantees no values exist outside `[min, max]`.

This change clamps bucket midpoints to both bounds and unmutes `RankAccuracyTests.testRandomDistribution`, which reproduced the problem deterministically with the seed from #156057 (an all-negative histogram queried at exactly its max). For histograms containing both signs the additional bound is a no-op.

Verified by running the previously failing seed and 200 random iterations of `RankAccuracyTests`.