### PR TITLE
Backport of #127799 (commit 89efe2c) to 8.19.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -13,9 +13,6 @@ tests:
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
   method: testTracingCrossCluster
   issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
-  method: testDeprecatedSettingsReturnWarnings
-  issue: https://github.com/elastic/elasticsearch/issues/108628
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -910,7 +910,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
         @Override
         public Releasable captureResponseHeaders() {
-            final var storedContext = threadContext.newStoredContext();
+            final var storedContext = threadContextSupplier.get();
             return Releasables.wrap(() -> {
                 final var newResponseHeaders = threadContext.getResponseHeaders();
                 if (newResponseHeaders.isEmpty()) {

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -298,7 +298,6 @@ public class MasterServiceTests extends ESTestCase {
             }
 
             try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
-
                 final var expectedHeaders = new HashMap<String, String>();
                 expectedHeaders.put(randomIdentifier(), randomIdentifier());
                 for (final var copiedHeader : Task.HEADERS_TO_COPY) {
@@ -318,8 +317,10 @@ public class MasterServiceTests extends ESTestCase {
                     new AckedClusterStateUpdateTask(ackedRequest(ackTimeout, masterTimeout), null) {
                         @Override
                         public ClusterState execute(ClusterState currentState) {
-                            assertTrue(threadPool.getThreadContext().isSystemContext());
-                            assertEquals(Collections.emptyMap(), threadPool.getThreadContext().getHeaders());
+                            // the task is executed in the context in which the task was originally created.
+                            // note: this is typically not a system context.
+                            assertExpectedThreadContext(Map.of());
+
                             expectedResponseHeaders.forEach(
                                 (name, values) -> values.forEach(v -> threadPool.getThreadContext().addResponseHeader(name, v))
                             );

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -1,10 +1,14 @@
 ---
 setup:
   - requires:
+      test_runner_features: [ "allowed_warnings_regex" ]
       cluster_features: ["gte_v8.13.0"]
       reason: "Universal Profiling test infrastructure is available in 8.12+"
 
   - do:
+      allowed_warnings_regex:
+        # https://github.com/elastic/elasticsearch/issues/127911
+        - "Index \\[\\.profiling-.*\\] name begins with a dot .* and will not be allowed in a future Elasticsearch version."
       cluster.put_settings:
         body:
           persistent:


### PR DESCRIPTION
MasterService.ExecutionResult#captureResponseHeaders was creating a new empty stored context instead of restoring the context captured at task submission. This caused the x-opaque-id to be dropped before deprecation warnings were logged, making them invisible to tests that filter by opaque-id.

Unmutes DeprecationHttpIT#testDeprecatedSettingsReturnWarnings on 8.19.

Relates to #127799
Closes #108628