### PR TITLE
[9.5] Fix histogram min/max not being fully respected in rank estimation (#156268)

### DIFF
--- a/docs/changelog/156268.yaml
+++ b/docs/changelog/156268.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 156057
+pr: 156268
+summary: Fix exponential histogram min/max not being fully respected in rank estimation
+type: bug

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramQuantile.java
@@ -98,19 +98,27 @@ public class ExponentialHistogramQuantile {
             if (value > 0 || inclusive) {
                 rank += histo.zeroBucket().count();
             }
-            rank += estimateRank(histo.positiveBuckets().iterator(), value, inclusive, histo.max());
+            rank += estimateRank(histo.positiveBuckets().iterator(), value, inclusive, histo.min(), histo.max());
             return rank;
         } else {
-            long numValuesGreater = estimateRank(histo.negativeBuckets().iterator(), -value, inclusive == false, -histo.min());
+            long numValuesGreater = estimateRank(
+                histo.negativeBuckets().iterator(),
+                -value,
+                inclusive == false,
+                -histo.max(),
+                -histo.min()
+            );
             return histo.negativeBuckets().valueCount() - numValuesGreater;
         }
     }
 
-    private static long estimateRank(BucketIterator buckets, double value, boolean inclusive, double maxValue) {
+    private static long estimateRank(BucketIterator buckets, double value, boolean inclusive, double minValue, double maxValue) {
         long rank = 0;
         while (buckets.hasNext()) {
             double bucketMidpoint = ExponentialScaleUtils.getPointOfLeastRelativeError(buckets.peekIndex(), buckets.scale());
-            bucketMidpoint = Math.min(bucketMidpoint, maxValue);
+            // no values outside of [minValue, maxValue] exist in the histogram, so clamp the midpoint accordingly.
+            // This e.g. matters when querying the rank of exactly the minimum or maximum with a midpoint slightly off
+            bucketMidpoint = Math.clamp(bucketMidpoint, minValue, maxValue);
             if (bucketMidpoint < value || (inclusive && bucketMidpoint == value)) {
                 rank += buckets.peekCount();
                 buckets.advance();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix histogram min/max not being fully respected in rank estimation (#156268)](https://github.com/elastic/elasticsearch/pull/156268)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)