### PR TITLE
[8.19] inject wait for LDAP server readiness to fix LDAP test flakiness (#156178)

### DIFF
--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -20,8 +20,8 @@ dockerFixtures {
   }
   openldap {
     dockerContext = file("src/main/resources/openldap")
-    version = "1.0"
-    baseImages = ["osixia/openldap:1.4.0"]
+    version = "1.1"
+    baseImages = ["osixia/openldap:1.5.0"]
   }
 }
 

--- a/x-pack/test/idp-fixture/src/main/java/org/elasticsearch/test/fixtures/idp/OpenLdapTestContainer.java
+++ b/x-pack/test/idp-fixture/src/main/java/org/elasticsearch/test/fixtures/idp/OpenLdapTestContainer.java
@@ -8,9 +8,11 @@
 package org.elasticsearch.test.fixtures.idp;
 
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
+import org.elasticsearch.test.fixtures.testcontainers.PullOrBuildImage;
 import org.junit.rules.TemporaryFolder;
 import org.testcontainers.containers.Network;
-import org.testcontainers.images.RemoteDockerImage;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -19,7 +21,14 @@ import static org.elasticsearch.test.fixtures.ResourceUtils.copyResourceToFile;
 
 public final class OpenLdapTestContainer extends DockerEnvironmentAwareTestContainer {
 
-    private static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/openldap-fixture:1.0";
+    private static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/openldap-fixture:1.1";
+    private static final String LDAP_READY_COMMAND = """
+        ldapsearch -LLL -x\
+         -H ldaps://localhost:636\
+         -D "cn=admin,$LDAP_BASE_DN"\
+         -w "$LDAP_ADMIN_PASSWORD"\
+         -b "uid=cap,ou=people,$LDAP_BASE_DN"\
+         -s base dn""";
 
     private final TemporaryFolder temporaryFolder = new TemporaryFolder();
     private Path certsPath;
@@ -29,10 +38,21 @@ public final class OpenLdapTestContainer extends DockerEnvironmentAwareTestConta
     }
 
     public OpenLdapTestContainer(Network network) {
-        super(new RemoteDockerImage(DOCKER_BASE_IMAGE));
+        super(
+            new PullOrBuildImage(
+                DOCKER_BASE_IMAGE,
+                new ImageFromDockerfile("localhost/es-openldap-fixture").withFileFromClasspath("Dockerfile", "/openldap/Dockerfile")
+                    .withFileFromClasspath("ldif/users.ldif", "/openldap/ldif/users.ldif")
+                    .withFileFromClasspath("ldif/config.ldif", "/openldap/ldif/config.ldif")
+                    .withFileFromClasspath("certs", "/openldap/certs")
+                    .withFileFromClasspath("wait-for-slapd.sh", "/openldap/wait-for-slapd.sh")
+            )
+        );
         withNetworkAliases("openldap");
         withNetwork(network);
         withExposedPorts(389, 636);
+        withCommand("--loglevel", "debug");
+        waitingFor(Wait.forSuccessfulCommand(LDAP_READY_COMMAND));
     }
 
     public String getLdapUrl() {

--- a/x-pack/test/idp-fixture/src/main/resources/openldap/Dockerfile
+++ b/x-pack/test/idp-fixture/src/main/resources/openldap/Dockerfile
@@ -1,5 +1,4 @@
-FROM osixia/openldap:1.4.0
-
+FROM osixia/openldap:1.5.0
 
 ENV LDAP_ADMIN_PASSWORD=NickFuryHeartsES
 ENV LDAP_DOMAIN=oldap.test.elasticsearch.com
@@ -10,8 +9,18 @@ ENV LDAP_TLS_CA_CRT_FILENAME=ca_server.pem
 ENV LDAP_TLS_KEY_FILENAME=ldap_server.key
 ENV LDAP_TLS_VERIFY_CLIENT=never
 ENV LDAP_TLS_CIPHER_SUITE=NORMAL
-ENV LDAP_LOG_LEVEL=256
+ENV LDAP_LOG_LEVEL=0
 
 COPY ./ldif/users.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/20-bootstrap-users.ldif
 COPY ./ldif/config.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/10-bootstrap-config.ldif
 COPY ./certs /container/service/slapd/assets/certs
+COPY wait-for-slapd.sh /usr/local/bin/wait-for-slapd
+
+# inject a patched slapd startup check, to avoid e.g. https://github.com/elastic/elasticsearch/issues/152601
+RUN chmod 0755 /usr/local/bin/wait-for-slapd \
+    && grep -Fq \
+        'while [ ! -e /run/slapd/slapd.pid ]; do sleep 0.1; done' \
+        /container/service/slapd/startup.sh \
+    && sed -i \
+        's|while \[ ! -e /run/slapd/slapd.pid \]; do sleep 0.1; done|/usr/local/bin/wait-for-slapd|' \
+        /container/service/slapd/startup.sh

--- a/x-pack/test/idp-fixture/src/main/resources/openldap/wait-for-slapd.sh
+++ b/x-pack/test/idp-fixture/src/main/resources/openldap/wait-for-slapd.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+# The readiness check in the base image only checks for a PID associated with slapd, not that slapd is actually ready to serve LDAP.
+# This causes intermittent startup errors when `ldapadd` is run before slapd is ready to accept it.
+# This script is intended to replace the faulty readiness check.
+
+set -euo pipefail
+
+last_error=""
+
+for ((attempt = 1; attempt <= 300; attempt++)); do
+    if last_error="$(
+        ldapsearch \
+            -Q \
+            -Y EXTERNAL \
+            -H ldapi:/// \
+            -s base \
+            -b cn=config \
+            dn 2>&1
+    )"; then
+        exit 0
+    fi
+
+    sleep 0.1
+done
+
+printf 'OpenLDAP did not become ready within 30 seconds. Last ldapsearch error:\n%s\n' \
+    "$last_error" >&2
+exit 1


### PR DESCRIPTION
Backports the following commits to 8.19:
 - inject wait for LDAP server readiness to fix LDAP test flakiness (#156178)