### PR TITLE
Migrate more xpack:qa:rolling-upgrade-legacy tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -18,12 +19,18 @@ smartRetry.pruneIndividualTests.set(false)
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(project(':x-pack:qa'))
+  javaRestTestImplementation(testArtifact(project(':server')))
+  javaRestTestImplementation(testArtifact(project(xpackModule('inference'))))
 }
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      systemProperty 'tests.ml.skip', 'true'
+    }
   }
 }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.upgrades;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
@@ -39,5 +40,9 @@ public abstract class AbstractXpackRollingUpgradeTestCase extends ParameterizedR
         }
 
         return customizer.apply(builder).build();
+    }
+
+    protected static boolean isOriginalClusterCurrent() {
+        return getOldClusterVersion().equals(Build.current().version());
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -6,9 +6,10 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Build;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -16,14 +17,15 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.Strings;
+import org.elasticsearch.features.InfrastructureFeatures;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matchers;
 
@@ -37,13 +39,16 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.upgrades.IndexingIT.assertCount;
 import static org.hamcrest.Matchers.equalTo;
 
-public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
+public class DataStreamsUpgradeIT extends AbstractXpackRollingUpgradeWithSecurityTestCase {
+
+    public DataStreamsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
 
     public void testDataStreams() throws IOException {
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             String requestBody = """
                 {
                   "index_patterns": [ "logs-*" ],
@@ -76,7 +81,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             bulk.setJsonEntity(b.toString());
             Response response = client().performRequest(bulk);
             assertEquals("{\"errors\":false}", EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
-        } else if (CLUSTER_TYPE == ClusterType.MIXED) {
+        } else if (isMixedCluster()) {
             long nowMillis = System.currentTimeMillis();
             Request rolloverRequest = new Request("POST", "/logs-foobar/_rollover");
             client().performRequest(rolloverRequest);
@@ -84,7 +89,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             Request index = new Request("POST", "/logs-foobar/_doc");
             index.addParameter("refresh", "true");
             index.addParameter("filter_path", "_index");
-            if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
+            if (isFirstMixedCluster()) {
                 // include legacy name and date-named indices with today +/-1 in case of clock skew
                 var expectedIndices = List.of(
                     "{\"_index\":\"" + DataStreamTestHelper.getLegacyDefaultBackingIndexName("logs-foobar", 2) + "\"}",
@@ -110,15 +115,15 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         }
 
         final int expectedCount;
-        if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
+        if (isOldCluster()) {
             expectedCount = 1000;
-        } else if (CLUSTER_TYPE.equals(ClusterType.MIXED)) {
-            if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
+        } else if (isMixedCluster()) {
+            if (isFirstMixedCluster()) {
                 expectedCount = 1001;
             } else {
                 expectedCount = 1002;
             }
-        } else if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+        } else if (isUpgradedCluster()) {
             expectedCount = 1002;
         } else {
             throw new AssertionError("unexpected cluster type");
@@ -127,7 +132,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     public void testDataStreamValidationDoesNotBreakUpgrade() throws Exception {
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             String requestBody = """
                 {
                   "index_patterns": [ "logs-*" ],
@@ -164,13 +169,13 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             Request rolloverRequest = new Request("POST", "/logs-barbaz-2021.01.13/_rollover");
             client().performRequest(rolloverRequest);
         } else {
-            if (CLUSTER_TYPE == ClusterType.MIXED) {
+            if (isMixedCluster()) {
                 ensureHealth((request -> {
                     request.addParameter("timeout", "70s");
                     request.addParameter("wait_for_nodes", "3");
                     request.addParameter("wait_for_status", "yellow");
                 }));
-            } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+            } else if (isUpgradedCluster()) {
                 // Wait for the cluster to recover to yellow at least before checking index status
                 ensureHealth((request -> {
                     request.addParameter("timeout", "30s");
@@ -205,10 +210,10 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             stopILM();
         }
 
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             createAndRolloverDataStream(dataStreamName, numRollovers, hasILMPolicy, ilmEnabled);
             createDataStreamFromNonDataStreamIndices(dataStreamFromNonDataStreamIndices);
-        } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+        } else if (isUpgradedCluster()) {
             Map<String, Map<String, Object>> oldIndicesMetadata = getIndicesMetadata(dataStreamName);
             String oldWriteIndex = getDataStreamBackingIndexNames(dataStreamName).getLast();
             upgradeDataStream(dataStreamName, numRollovers, numRollovers + 1, 0, ilmEnabled);
@@ -238,10 +243,10 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         int numRollovers = randomIntBetween(0, 5);
         boolean hasILMPolicy = randomBoolean();
         boolean ilmEnabled = hasILMPolicy && randomBoolean();
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             createAndRolloverDataStream(dataStreamName, numRollovers, hasILMPolicy, ilmEnabled);
             upgradeDataStream(dataStreamName, numRollovers, numRollovers + 1, 0, ilmEnabled);
-        } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+        } else if (isUpgradedCluster()) {
             makeSureNoUpgrade(dataStreamName);
             cancelReindexTask(dataStreamName);
             // Delete the data streams to avoid ILM continuously running cluster state tasks, see
@@ -358,7 +363,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void compareMappings(Map<?, ?> oldMappings, Map<?, ?> upgradedMappings) {
-        boolean ignoreSource = Version.fromString(UPGRADE_FROM_VERSION).before(Version.V_9_0_0);
+        boolean ignoreSource = clusterHasFeature(InfrastructureFeatures.CURRENT_VERSION) == false;
         if (ignoreSource) {
             Map<?, ?> doc = (Map<?, ?>) oldMappings.get("_doc");
             if (doc != null) {
@@ -669,7 +674,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
                 assertOK(statusResponse);
                 assertThat(statusResponseString, statusResponseMap.get("complete"), equalTo(true));
                 final int originalWriteIndex = 1;
-                if (isOriginalClusterSameMajorVersionAsCurrent() || CLUSTER_TYPE == ClusterType.OLD) {
+                if (isOriginalClusterSameMajorVersionAsCurrent() || isOldCluster()) {
                     assertThat(
                         statusResponseString,
                         statusResponseMap.get("total_indices_in_data_stream"),
@@ -753,11 +758,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
      * for 8.6 and 8.17, but false for 7.17 and 8.18.
      */
     private boolean isOriginalClusterSameMajorVersionAsCurrent() {
-        /*
-         * Since data stream reindex is specifically about upgrading a data stream from one major version to the next, it's ok to use the
-         * deprecated Version.fromString here
-         */
-        return Version.fromString(UPGRADE_FROM_VERSION).major == Version.fromString(Build.current().version()).major;
+        return Version.fromString(getOldClusterVersion()).getMajor() == Version.fromString(Build.current().version()).getMajor();
     }
 
     private static void bulkLoadData(String dataStreamName) throws IOException {
@@ -839,5 +840,15 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         configureClient(builder, Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build());
         builder.setStrictDeprecationMode(true);
         return builder.build();
+    }
+
+    private static void assertCount(String index, int count) throws IOException {
+        Request searchTestIndexRequest = new Request("POST", "/" + index + "/_search");
+        searchTestIndexRequest.addParameter("rest_total_hits_as_int", "true");
+        searchTestIndexRequest.addParameter("filter_path", "hits.total");
+        Response searchTestIndexResponse = client().performRequest(searchTestIndexRequest);
+        assertEquals(Strings.format("""
+            {"hits":{"total":%s}}\
+            """, count), EntityUtils.toString(searchTestIndexResponse.getEntity(), StandardCharsets.UTF_8));
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -6,11 +6,13 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,37 +21,38 @@ import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_A
 
 /**
  * Basic test that indexed documents survive the rolling restart.
- * <p>
- * This test is an almost exact copy of <code>IndexingIT</code> in the
- * oss rolling restart tests. We should work on a way to remove this
- * duplication but for now we have no real way to share code.
  */
-public class IndexingIT extends AbstractUpgradeTestCase {
+public class IndexingIT extends AbstractXpackRollingUpgradeTestCase {
+
+    @org.junit.ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public IndexingIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     public void testIndexing() throws IOException {
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                break;
-            case MIXED:
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                break;
-            case UPGRADED:
-                ensureHealth("test_index,index_with_replicas,empty_index", (request -> {
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "green");
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("level", "shards");
-                }));
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isMixedCluster()) {
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+        } else if (isUpgradedCluster()) {
+            ensureHealth("test_index,index_with_replicas,empty_index", (request -> {
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "green");
+                request.addParameter("timeout", "70s");
+                request.addParameter("level", "shards");
+            }));
         }
 
-        if (CLUSTER_TYPE == ClusterType.OLD) {
-
+        if (isOldCluster()) {
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("""
                 {"settings": {"index.number_of_replicas": 0}}""");
@@ -70,31 +73,23 @@ public class IndexingIT extends AbstractUpgradeTestCase {
             bulk("index_with_replicas", "_OLD", 5);
         }
 
-        int expectedCount;
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                expectedCount = 5;
-                break;
-            case MIXED:
-                if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
-                    expectedCount = 5;
-                } else {
-                    expectedCount = 10;
-                }
-                break;
-            case UPGRADED:
-                expectedCount = 15;
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        final int expectedCount;
+        if (isOldCluster()) {
+            expectedCount = 5;
+        } else if (isMixedCluster()) {
+            expectedCount = isFirstMixedCluster() ? 5 : 10;
+        } else {
+            assert isUpgradedCluster();
+            expectedCount = 15;
         }
 
         assertCount("test_index", expectedCount);
         assertCount("index_with_replicas", 5);
         assertCount("empty_index", 0);
 
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            bulk("test_index", "_" + CLUSTER_TYPE, 5);
+        if (isOldCluster() == false) {
+            String suffix = isMixedCluster() ? "_MIXED" : "_UPGRADED";
+            bulk("test_index", suffix, 5);
             Request toBeDeleted = new Request("PUT", "/test_index/_doc/to_be_deleted");
             toBeDeleted.addParameter("refresh", "true");
             toBeDeleted.setJsonEntity("{\"f1\": \"delete-me\"}");

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -7,16 +7,21 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,7 +36,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
+public class MLModelDeploymentsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     // See PyTorchModelIT for how this model was created
     static final String BASE_64_ENCODED_MODEL =
@@ -60,6 +67,18 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     static final long RAW_MODEL_SIZE; // size of the model before base64 encoding
     static {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MLModelDeploymentsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @BeforeClass
@@ -110,47 +129,41 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     public void testTrainedModelDeployment() throws Exception {
         final String modelId = "upgrade-deployment-test";
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                setupDeployment(modelId);
+        if (isOldCluster()) {
+            setupDeployment(modelId);
+            assertInfer(modelId);
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted(modelId);
+            // attempt inference on new and old nodes multiple times
+            for (int i = 0; i < 10; i++) {
                 assertInfer(modelId);
             }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted(modelId);
-                // attempt inference on new and old nodes multiple times
-                for (int i = 0; i < 10; i++) {
-                    assertInfer(modelId);
-                }
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
 
-                waitForDeploymentStarted(modelId);
-                assertInfer(modelId);
-                stopDeployment(modelId);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+            waitForDeploymentStarted(modelId);
+            assertInfer(modelId);
+            stopDeployment(modelId);
         }
     }
 
     public void testTrainedModelDeploymentStopOnMixedCluster() throws Exception {
         final String modelId = "upgrade-deployment-test-stop-mixed-cluster";
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                setupDeployment(modelId);
-                assertInfer(modelId);
-            }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                stopDeployment(modelId);
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                assertThatTrainedModelAssignmentMetadataIsEmpty(modelId);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            setupDeployment(modelId);
+            assertInfer(modelId);
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            stopDeployment(modelId);
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            assertThatTrainedModelAssignmentMetadataIsEmpty(modelId);
         }
     }
 
@@ -226,7 +239,7 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
         String inferenceThreadParamName = "threads_per_allocation";
         String modelThreadParamName = "number_of_allocations";
         String compatibleHeader = null;
-        if (CLUSTER_TYPE.equals(ClusterType.OLD) || CLUSTER_TYPE.equals(ClusterType.MIXED)) {
+        if (isOldCluster() || isMixedCluster()) {
             compatibleHeader = compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_8);
             inferenceThreadParamName = "inference_threads";
             modelThreadParamName = "model_threads";

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -16,7 +18,9 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,7 +34,7 @@ import static org.elasticsearch.client.WarningsHandler.PERMISSIVE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
+public class MlAssignmentPlannerUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
     private static final boolean IS_SINGLE_PROCESSOR_TEST = Booleans.parseBoolean(
         System.getProperty("tests.configure_test_clusters_with_one_processor", "false")
@@ -67,43 +71,52 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlAssignmentPlannerUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     public void testMlAssignmentPlannerUpgrade() throws Exception {
         assumeFalse("This test deploys multiple models which cannot be accommodated on a single processor", IS_SINGLE_PROCESSOR_TEST);
 
         logger.info("Starting testMlAssignmentPlannerUpgrade, model size {}", RAW_MODEL_SIZE);
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                // setup deployments using old and new memory format
-                setupDeployments();
+        if (isOldCluster()) {
+            // setup deployments using old and new memory format
+            setupDeployments();
 
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
 
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
-                assertNewMemoryFormat("new_memory_format");
-            }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
+            // assert correct memory format is used
+            assertOldMemoryFormat("old_memory_format");
+            assertNewMemoryFormat("new_memory_format");
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
 
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
-                assertNewMemoryFormat("new_memory_format");
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
+            // assert correct memory format is used
+            assertOldMemoryFormat("old_memory_format");
+            assertNewMemoryFormat("new_memory_format");
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
 
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
-                assertNewMemoryFormat("new_memory_format");
+            assertNewMemoryFormat("old_memory_format");
+            assertNewMemoryFormat("new_memory_format");
 
-                cleanupDeployments();
-            }
+            cleanupDeployments();
         }
     }
 
@@ -121,30 +134,50 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void assertOldMemoryFormat(String modelId) throws Exception {
-        var response = getTrainedModelStats(modelId);
-        Map<String, Object> map = entityAsMap(response);
-        List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
-        assertThat(stats, hasSize(1));
-        var stat = stats.get(0);
-        Long expectedMemoryUsage = ByteSizeValue.ofMb(240).getBytes() + RAW_MODEL_SIZE * 2;
-        Integer actualMemoryUsage = (Integer) XContentMapValues.extractValue("model_size_stats.required_native_memory_bytes", stat);
-        assertThat(
-            Strings.format("Memory usage mismatch for the model %s in cluster state %s", modelId, CLUSTER_TYPE.toString()),
-            actualMemoryUsage,
-            equalTo(expectedMemoryUsage.intValue())
-        );
+        assertBusy(() -> {
+            Response response = getTrainedModelStats(modelId);
+            Map<String, Object> map = entityAsMap(response);
+            List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
+            assertThat(stats, hasSize(1));
+            var stat = stats.get(0);
+            assertThat(
+                stat.toString(),
+                XContentMapValues.extractValue("deployment_stats.adaptive_allocations.enabled", stat),
+                equalTo(false)
+            );
+            var assignments = (List<Map<String, Object>>) XContentMapValues.extractValue("deployment_stats.nodes", stat);
+            assertThat(assignments, hasSize(1));
+            var assignment = assignments.get(0);
+            assertThat(assignment.toString(), XContentMapValues.extractValue("per_deployment_memory_bytes", assignment), equalTo(0));
+            assertThat(assignment.toString(), XContentMapValues.extractValue("per_allocation_memory_bytes", assignment), equalTo(0));
+        }, 30, TimeUnit.SECONDS);
     }
 
     @SuppressWarnings("unchecked")
     private void assertNewMemoryFormat(String modelId) throws Exception {
-        var response = getTrainedModelStats(modelId);
-        Map<String, Object> map = entityAsMap(response);
-        List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
-        assertThat(stats, hasSize(1));
-        var stat = stats.get(0);
-        Long expectedMemoryUsage = ByteSizeValue.ofMb(300).getBytes() + RAW_MODEL_SIZE + ByteSizeValue.ofMb(10).getBytes();
-        Integer actualMemoryUsage = (Integer) XContentMapValues.extractValue("model_size_stats.required_native_memory_bytes", stat);
-        assertThat(stat.toString(), actualMemoryUsage.toString(), equalTo(expectedMemoryUsage.toString()));
+        long expectedPerDeploymentMemoryBytes = ByteSizeValue.ofMb(300).getBytes();
+        long expectedPerAllocationMemoryBytes = ByteSizeValue.ofMb(10).getBytes();
+
+        assertBusy(() -> {
+            Response response = getTrainedModelStats(modelId);
+            Map<String, Object> map = entityAsMap(response);
+            List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
+            assertThat(stats, hasSize(1));
+            var stat = stats.get(0);
+            var assignments = (List<Map<String, Object>>) XContentMapValues.extractValue("deployment_stats.nodes", stat);
+            assertThat(assignments, hasSize(1));
+            var assignment = assignments.get(0);
+            assertThat(
+                assignment.toString(),
+                ((Number) XContentMapValues.extractValue("per_deployment_memory_bytes", assignment)).longValue(),
+                equalTo(expectedPerDeploymentMemoryBytes)
+            );
+            assertThat(
+                assignment.toString(),
+                ((Number) XContentMapValues.extractValue("per_allocation_memory_bytes", assignment)).longValue(),
+                equalTo(expectedPerAllocationMemoryBytes)
+            );
+        }, 30, TimeUnit.SECONDS);
     }
 
     private Response getTrainedModelStats(String modelId) throws IOException {
@@ -252,7 +285,7 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         String inferenceThreadParamName = "threads_per_allocation";
         String modelThreadParamName = "number_of_allocations";
         String compatibleHeader = null;
-        if (CLUSTER_TYPE.equals(ClusterType.OLD) || CLUSTER_TYPE.equals(ClusterType.MIXED)) {
+        if (isOldCluster() || isMixedCluster()) {
             compatibleHeader = compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_8);
             inferenceThreadParamName = "inference_threads";
             modelThreadParamName = "model_threads";

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -6,31 +6,34 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -39,23 +42,41 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
+public class MlJobSnapshotUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     private static final String JOB_ID = "ml-snapshots-upgrade-job";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlJobSnapshotUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
 
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     protected static void waitForPendingUpgraderTasks() throws Exception {
@@ -71,32 +92,32 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         adjustLoggingLevels.setJsonEntity("""
             {"persistent": {"logger.org.elasticsearch.xpack.ml": "trace"}}""");
         client().performRequest(adjustLoggingLevels);
-        switch (CLUSTER_TYPE) {
-            case OLD -> createJobAndSnapshots();
-            case MIXED -> {
-                assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
-                assumeTrue(
-                    "Older versions could not always reliably determine if we were in a mixed cluster state",
-                    Version.fromString(UPGRADE_FROM_VERSION).onOrAfter(Version.V_9_3_0)
-                );
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                testSnapshotUpgradeFailsOnMixedCluster();
-            }
-            case UPGRADED -> {
-                assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                testSnapshotUpgrade();
-                waitForPendingUpgraderTasks();
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+
+        if (isOldCluster()) {
+            createJobAndSnapshots();
+        }
+        if (isMixedCluster()) {
+            assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
+            assumeTrue(
+                "Older versions could not always reliably determine if we were in a mixed cluster state",
+                Version.fromString(getOldClusterVersion()).onOrAfter("9.3.0")
+            );
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+            testSnapshotUpgradeFailsOnMixedCluster();
+        }
+        if (isUpgradedCluster()) {
+            assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+            testSnapshotUpgrade();
+            waitForPendingUpgraderTasks();
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -6,9 +6,13 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.core.Booleans;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
@@ -17,15 +21,14 @@ import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.test.rest.IndexMappingTemplateAsserter;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
 import static org.hamcrest.Matchers.anyOf;
@@ -35,7 +38,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
+public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
 
@@ -47,19 +52,35 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
         + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlMappingsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     /**
@@ -68,40 +89,37 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
      */
     public void testMappingsUpgrade() throws Exception {
 
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                createAndOpenTestJob();
-                break;
-            case MIXED:
-                // We don't know whether the job is on an old or upgraded node, so cannot assert that the mappings have been upgraded
-                break;
-            case UPGRADED:
-                assertUpgradedResultsMappings();
-                assertUpgradedAnnotationsMappings();
-                closeAndReopenTestJob();
-                assertUpgradedConfigMappings();
-                assertMlLegacyTemplatesDeleted();
-                IndexMappingTemplateAsserter.assertMlMappingsMatchTemplates(client());
-                assertNotificationsIndexAliasCreated();
-                assertBusy(
-                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
-                        client(),
-                        ".ml-anomalies-",
-                        ML_INDEX_TEMPLATE_VERSION,
-                        List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*", ".reindexed-v8-ml-anomalies-*")
-                    )
-                );
-                assertBusy(
-                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
-                        client(),
-                        ".ml-state",
-                        ML_INDEX_TEMPLATE_VERSION,
-                        Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns())
-                    )
-                );
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            createAndOpenTestJob();
+        }
+
+        // On mixed clusters, we don't know whether the job is on an old or upgraded node, so cannot assert that the mappings have been
+        // upgraded
+
+        if (isUpgradedCluster()) {
+            assertUpgradedResultsMappings();
+            assertUpgradedAnnotationsMappings();
+            closeAndReopenTestJob();
+            assertUpgradedConfigMappings();
+            assertMlLegacyTemplatesDeleted();
+            IndexMappingTemplateAsserter.assertMlMappingsMatchTemplates(client());
+            assertNotificationsIndexAliasCreated();
+            assertBusy(
+                () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                    client(),
+                    ".ml-anomalies-",
+                    ML_INDEX_TEMPLATE_VERSION,
+                    List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*", ".reindexed-v8-ml-anomalies-*")
+                )
+            );
+            assertBusy(
+                () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                    client(),
+                    ".ml-state",
+                    ML_INDEX_TEMPLATE_VERSION,
+                    Arrays.asList(AnomalyDetectorsIndex.jobStateIndexPatterns())
+                )
+            );
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -7,28 +7,34 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
+public class MlTrainedModelsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     static final String BOOLEAN_FIELD = "boolean-field";
     static final String NUMERICAL_FIELD = "numerical-field";
@@ -40,41 +46,54 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
     static final List<String> KEYWORD_FIELD_VALUES = List.of("cat", "dog");
     static final String INDEX_NAME = "created_index";
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlTrainedModelsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     public void testTrainedModelInference() throws Exception {
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                createIndexWithName(INDEX_NAME);
-                indexData(INDEX_NAME, 1000);
-                createAndRunClassificationJob("classification-upgrade-job");
-                createAndRunRegressionJob();
-                List<String> oldModels = getTrainedModels();
-                createPipelines(oldModels);
-                testInfer(oldModels);
-            }
-            case MIXED, UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                List<String> modelIds = getTrainedModels();
-                // Test that stats are serializable and can be gathered
-                getTrainedModelStats();
-                // Verify that the pipelines still work and inference is possible
-                testInfer(modelIds);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            createIndexWithName(INDEX_NAME);
+            indexData(INDEX_NAME, 1000);
+            createAndRunClassificationJob("classification-upgrade-job");
+            createAndRunRegressionJob();
+            List<String> oldModels = getTrainedModels();
+            createPipelines(oldModels);
+            testInfer(oldModels);
+        }
+        if (isMixedCluster() || isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            List<String> modelIds = getTrainedModels();
+            // Test that stats are serializable and can be gathered
+            getTrainedModelStats();
+            // Verify that the pipelines still work and inference is possible
+            testInfer(modelIds);
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.search.join.ScoreMode;
@@ -28,6 +29,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -36,6 +38,7 @@ import org.elasticsearch.xpack.core.ml.search.SparseVectorQueryBuilder;
 import org.elasticsearch.xpack.inference.mapper.SemanticTextField;
 import org.elasticsearch.xpack.inference.model.TestModel;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,6 +46,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests.addSemanticTextInferenceResults;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.randomSemanticText;
@@ -50,7 +55,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
+public class SemanticTextUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
     private static final String INDEX_BASE_NAME = "semantic_text_test_index";
     private static final String SPARSE_FIELD = "sparse_field";
     private static final String DENSE_FIELD = "dense_field";
@@ -69,6 +75,9 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
 
     private final boolean useLegacyFormat;
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
     @BeforeClass
     public static void beforeClass() {
         SPARSE_MODEL = TestModel.createRandomInstance(TaskType.SPARSE_EMBEDDING);
@@ -76,31 +85,36 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         DENSE_MODEL = TestModel.createRandomInstance(TaskType.TEXT_EMBEDDING, List.of(SimilarityMeasure.DOT_PRODUCT));
     }
 
-    public SemanticTextUpgradeIT(boolean useLegacyFormat) {
+    public SemanticTextUpgradeIT(@Name("upgradedNodes") int upgradedNodes, @Name("useLegacyFormat") boolean useLegacyFormat) {
+        super(upgradedNodes);
         this.useLegacyFormat = useLegacyFormat;
     }
 
-    @ParametersFactory
+    @ParametersFactory(shuffle = false)
     public static Iterable<Object[]> parameters() {
-        return List.of(new Object[] { true }, new Object[] { false });
+        return IntStream.rangeClosed(0, NODE_NUM)
+            .boxed()
+            .flatMap(n -> Stream.of(new Object[] { n, false }, new Object[] { n, true }))
+            .toList();
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     public void testSemanticTextOperations() throws Exception {
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                assumeFalse(
-                    "Legacy format index creation is not supported on clusters with index version ["
-                        + IndexVersions.SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN
-                        + "] or later",
-                    useLegacyFormat && minimumIndexVersion().onOrAfter(IndexVersions.SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN)
-                );
-                createAndPopulateIndex();
-            }
-            case MIXED, UPGRADED -> {
-                assumeTrue("Skipping because index was not created in the old cluster phase", indexExists(getIndexName()));
-                performIndexQueryHighlightOps();
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            assumeFalse(
+                "Legacy format index creation is not supported on clusters with index version ["
+                    + IndexVersions.SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN
+                    + "] or later",
+                useLegacyFormat && minimumIndexVersion().onOrAfter(IndexVersions.SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN)
+            );
+            createAndPopulateIndex();
+        } else {
+            assumeTrue("Skipping because index was not created in the old cluster phase", indexExists(getIndexName()));
+            performIndexQueryHighlightOps();
         }
     }
 
@@ -198,8 +212,8 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
                     fieldModel.getServiceSettings().dimensions()
                 );
 
-                // Create a query vector with a value of 1 for each dimension, which will effectively act as a pass-through for the document
-                // vector
+                // Create a query vector with a value of 1 for each dimension, which will effectively act as a pass-through for the
+                // document vector
                 float[] queryVector = new float[embeddingLength];
                 if (elementType == DenseVectorFieldMapper.ElementType.BIT) {
                     Arrays.fill(queryVector, -128.0f);

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
@@ -4,12 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 package org.elasticsearch.upgrades;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -17,10 +19,12 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -43,7 +47,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
+public class TransformSurvivesUpgradeIT extends AbstractXpackRollingUpgradeWithSecurityTestCase {
 
     private static final String TRANSFORM_ENDPOINT = "/_transform/";
     private static final String CONTINUOUS_TRANSFORM_ID = "continuous-transform-upgrade-job";
@@ -54,8 +58,16 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         .map(TimeValue::timeValueMinutes)
         .collect(Collectors.toList());
 
-    protected static void waitForPendingTransformTasks() throws Exception {
-        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TRANSFORM_TASK_NAME) == false);
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public TransformSurvivesUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @Override
@@ -64,6 +76,10 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         configureClient(builder, settings);
         builder.setStrictDeprecationMode(false);
         return builder.build();
+    }
+
+    protected static void waitForPendingTransformTasks() throws Exception {
+        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TRANSFORM_TASK_NAME) == false);
     }
 
     /**
@@ -84,27 +100,19 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         Request waitForYellow = new Request("GET", "/_cluster/health");
         waitForYellow.addParameter("wait_for_nodes", "3");
         waitForYellow.addParameter("wait_for_status", "yellow");
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                client().performRequest(waitForYellow);
-                createAndStartContinuousTransform();
-            }
-            case MIXED -> {
-                client().performRequest(waitForYellow);
-                long lastCheckpoint = 1;
-                if (Booleans.parseBoolean(System.getProperty("tests.first_round")) == false) {
-                    lastCheckpoint = 2;
-                }
-                verifyContinuousTransformHandlesData(lastCheckpoint);
-                verifyUpgradeFailsIfMixedCluster();
-            }
-            case UPGRADED -> {
-                client().performRequest(waitForYellow);
-                verifyContinuousTransformHandlesData(3);
-                verifyUpgrade();
-                cleanUpTransforms();
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            client().performRequest(waitForYellow);
+            createAndStartContinuousTransform();
+        } else if (isMixedCluster()) {
+            client().performRequest(waitForYellow);
+            long lastCheckpoint = isFirstMixedCluster() ? 1 : 2;
+            verifyContinuousTransformHandlesData(lastCheckpoint);
+            verifyUpgradeFailsIfMixedCluster();
+        } else if (isUpgradedCluster()) {
+            client().performRequest(waitForYellow);
+            verifyContinuousTransformHandlesData(3);
+            verifyUpgrade();
+            cleanUpTransforms();
         }
     }
 
@@ -237,8 +245,8 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         if (isOriginalClusterCurrent()) {
             return;
         }
-        var oldestVersion = Version.fromString(UPGRADE_FROM_VERSION);
-        if (oldestVersion.onOrAfter(Version.V_9_3_0)) {
+        var oldestVersion = Version.fromString(getOldClusterVersion());
+        if (oldestVersion.onOrAfter("9.3.0")) {
             final Request upgradeTransformRequest = new Request("POST", getTransformEndpoint() + "_upgrade");
             Exception ex = expectThrows(Exception.class, () -> client().performRequest(upgradeTransformRequest));
             assertThat(ex.getMessage(), containsString("Cannot upgrade transforms while cluster upgrade is in progress"));


### PR DESCRIPTION
Continuation of #155762

Migrates some more of the `:x-pack:qa:rolling-upgrade-legacy` tests to the new JUnit-based rolling upgrade framework.
