### PR TITLE
Unmute RemoteClustersIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -55,10 +55,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.integration.continuous.TransformContinuousIT
   method: testContinuousEvents
   issue: https://github.com/elastic/elasticsearch/issues/153782
-- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
-  issue: https://github.com/elastic/elasticsearch/issues/156233
-- class: org.elasticsearch.docker.test.DockerYmlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/156234
 - class: org.elasticsearch.search.SearchWithRejectionsIT
   method: testOpenContextsAfterRejections
   issue: https://github.com/elastic/elasticsearch/issues/156244


### PR DESCRIPTION

The test needs a local Elasticsearch Docker image tagged `elasticsearch:test`, built by Gradle before the test runs. When that build step didn't run first, Testcontainers tried to pull `elasticsearch:test` from a public registry instead of using the local image, and that pull always failed since the tag only exists locally. 

This PR removes it from the muted tests list and turns it back on.


Closes #156233
Closes #156234