### PR TITLE
[9.5] Flakiness: correct precompile gate metric docs (#156297)

### DIFF
--- a/.buildkite/scripts/flakiness-detection/README.md
+++ b/.buildkite/scripts/flakiness-detection/README.md
@@ -178,7 +178,7 @@ Derived in priority order by `analyzer/outcome.ts` (`deriveOutcome`):
 | `hang`          | `rc == 0` but zero recorded test cases                                          |
 | `clean_pass`    | `rc == 0` with recorded cases and no real failures                              |
 | `not_applicable`| assigned upstream (not by `deriveOutcome`) for a test that could not be re-run at all, e.g. a BWC qa project whose bare task is disabled - "nothing to re-run", excluded from the false-failure metric |
-| `build_failed`  | assigned upstream when the pre-flight compile gate fails: the PR did not compile, so the re-run batches were skipped. One record stands in for the skipped batches; excluded from the false-failure metric (the PR is already red from its main build) |
+| `build_failed`  | assigned upstream when the pre-flight compile gate fails: the PR did not compile, so the re-run batches were skipped. `analyze` emits one `build_failed`, excluded from the false-failure metric (the PR is already red from its main build). The skipped batch jobs write no status file, so - like any pre-wrapper failure (see the note below) - the external pipeline currently still records each as `infra_fail` from job state; suppressing that is an external-pipeline concern, not something this repo can control. |
 
 `timedOut` is reported alongside `outcome` so the two timeout shapes stay
 distinguishable: a job that times out **with** a real failure is
@@ -193,7 +193,13 @@ the job log). Finer infra subtypes (disk-full, etc.) would require the job log,
 which we currently choose not to read, so they are left unset. Jobs that fail
 *before* the wrapper runs (e.g. a pre-command hook failure) write no status file
 and so produce no payload; the external pipeline records those as `infra_fail`
-from job state.
+from job state. The same is true of batch jobs **skipped** by a failed
+`depends_on` (e.g. when the pre-flight compile gate fails): they never run the
+wrapper, so the external pipeline currently records each skipped job as
+`infra_fail` from its `waiting_failed` state - even though `analyze` already
+reports the gate failure as a single `build_failed`. Filtering those skipped
+jobs out (and skipping the fallback for the `flakiness-detection:precompile`
+step) is an external-pipeline concern.
 
 ## File layout
 

--- a/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
+++ b/.buildkite/scripts/flakiness-detection/runners/buildkite.ts
@@ -154,14 +154,21 @@ const FLAKINESS_SKIPPED_ARTIFACT = "flakiness-skipped.json";
 // batches (which are skipped) producing none. Keep in sync with entrypoints/analyze.ts.
 const FLAKINESS_PRECOMPILE_ARTIFACT = "flakiness-precompile.json";
 
-// Pre-flight compile gate. A PR that does not compile otherwise fails every
-// re-run batch identically (up to 100x fan-out), which wastes CI and floods the
-// metric with `infra_fail`. This step compiles the affected source sets once;
-// batch steps hard-depend on it (allow_failure: false) so Buildkite skips them
-// when it fails. It is intentionally NOT never-fail wrapped: it must exit
-// non-zero to make Buildkite skip the batches. That turns the step red, but only
-// ever on a PR that genuinely does not compile - which is already red from its
-// main build - so it never introduces a false failure on an otherwise-green PR.
+// Pre-flight compile gate. A PR that does not compile otherwise runs every
+// re-run batch to a doomed failure (up to 100x fan-out), wasting CI. This step
+// compiles the affected source sets once; batch steps hard-depend on it
+// (allow_failure: false) so Buildkite skips them when it fails, saving that
+// compute. It is intentionally NOT never-fail wrapped: it must exit non-zero to
+// make Buildkite skip the batches. That turns the step red, but only ever on a
+// PR that genuinely does not compile - which is already red from its main build -
+// so it never introduces a false failure on an otherwise-green PR.
+//
+// Note on the metric: skipping the batches saves CI, but does not by itself
+// reduce the `infra_fail` count. A skipped job writes no status file, so the
+// external pipeline still records each skipped batch (and this gate job) as
+// `infra_fail` from job state. The analyze step folds the gate failure into a
+// single `build_failed`; suppressing the skipped-job fallback is an
+// external-pipeline concern (see README).
 const PRECOMPILE_KEY = "flakiness-detection:precompile";
 const PRECOMPILE_TIMEOUT_MINUTES = 30;
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Flakiness: correct precompile gate metric docs (#156297)