### PR TITLE
[9.4] Fix flaky IndexStatsIT#testFilterCacheStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -116,9 +116,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/154877
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/155421
 - class: org.elasticsearch.packaging.test.KeystoreManagementTests
   method: test50CreateKeystoreManually
   issue: https://github.com/elastic/elasticsearch/issues/155335

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -48,7 +48,6 @@ import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.engine.SegmentsStats;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.IndicesRequestCache;
@@ -59,7 +58,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -71,7 +69,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -84,6 +81,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.index.seqno.SequenceNumbersTestUtils.persistGlobalCheckpointOnPrimaryShards;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -1106,7 +1104,6 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertEquals(total, shardTotal);
     }
 
-    @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "https://github.com/elastic/elasticsearch/issues/124447")
     public void testFilterCacheStats() throws Exception {
         Settings settings = Settings.builder()
             .put(indexSettings())
@@ -1120,7 +1117,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             prepareIndex("index").setId("1").setSource("foo", "bar"),
             prepareIndex("index").setId("2").setSource("foo", "baz")
         );
-        persistGlobalCheckpoint("index"); // Need to persist the global checkpoint for the soft-deletes retention MP.
+        persistGlobalCheckpointOnPrimaryShards("index"); // Need to persist the global checkpoint for the soft-deletes retention MP.
         refresh();
         ensureGreen();
 
@@ -1153,7 +1150,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         // Here we are testing that a fully deleted segment should be dropped and its cached is evicted.
         // In order to instruct the merge policy not to keep a fully deleted segment,
         // we need to flush and make that commit safe so that the SoftDeletesPolicy can drop everything.
-        persistGlobalCheckpoint("index");
+        persistGlobalCheckpointOnPrimaryShards("index");
         assertBusy(() -> {
             for (final ShardStats shardStats : indicesAdmin().prepareStats("index").get().getIndex("index").getShards()) {
                 final long maxSeqNo = shardStats.getSeqNoStats().getMaxSeqNo();
@@ -1368,26 +1365,5 @@ public class IndexStatsIT extends ESIntegTestCase {
             assertThat(indexStatsAfterIndexing, is(notNullValue()));
             assertThat(indexStatsAfterIndexing.getPrimaries().getIndexing().getTotal().getWriteLoad(), is(greaterThan(0.0)));
         });
-    }
-
-    /**
-     * Persist the global checkpoint on all shards of the given index into disk.
-     * This makes sure that the persisted global checkpoint on those shards will equal to the in-memory value.
-     */
-    private void persistGlobalCheckpoint(String index) throws Exception {
-        final Set<String> nodes = internalCluster().nodesInclude(index);
-        for (String node : nodes) {
-            final IndicesService indexServices = internalCluster().getInstance(IndicesService.class, node);
-            for (IndexService indexService : indexServices) {
-                for (IndexShard indexShard : indexService) {
-                    indexShard.sync();
-                    assertThat(
-                        "Routing entry for shard " + indexShard.routingEntry().toString(),
-                        indexShard.getLastSyncedGlobalCheckpoint(),
-                        equalTo(indexShard.getLastKnownGlobalCheckpoint())
-                    );
-                }
-            }
-        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
@@ -208,7 +209,7 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws Exception {
         persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
     }
 
@@ -218,40 +219,50 @@ public final class SequenceNumbersTestUtils {
      *
      * This helper method is useful if you do not use replicas in your test setup.
      *
-     * @param cluster the cluster containing the index
-     * @param index   the name of the index
+     * @param cluster   the cluster containing the index
+     * @param indexName the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String indexName) throws Exception {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
-            for (String node : cluster.nodesInclude(index)) {
-                for (IndexService indexService : cluster.getInstance(IndicesService.class, node)) {
-                    for (IndexShard indexShard : indexService) {
-                        if (indexShard.routingEntry().primary() == false) {
-                            continue;
-                        }
-                        assertThat(
-                            "Shard " + indexShard.getShardUuid() + " should be active",
-                            indexShard.routingEntry().active(),
-                            equalTo(true)
-                        );
-
-                        final var globalCheckpoint = indexShard.withEngine(Engine::getMaxSeqNo);
-                        final var listener = listeners.acquire(
-                            ignored -> assertThat(
-                                "Global checkpoint not synced for shard: " + indexShard.routingEntry(),
-                                indexShard.getLastSyncedGlobalCheckpoint(),
-                                equalTo(globalCheckpoint)
-                            )
-                        );
-                        indexShard.syncGlobalCheckpoint(globalCheckpoint, e -> {
-                            if (e == null) {
-                                listener.onResponse(null);
-                            } else {
-                                listener.onFailure(e);
-                            }
-                        });
+            final var index = cluster.clusterService().state().metadata().getProject().index(indexName).getIndex();
+            for (String node : cluster.nodesInclude(indexName)) {
+                IndexService indexService = cluster.getInstance(IndicesService.class, node).indexServiceSafe(index);
+                for (IndexShard indexShard : indexService) {
+                    if (indexShard.routingEntry().primary() == false) {
+                        continue;
                     }
+                    assertThat(
+                        "Shard " + indexShard.getShardUuid() + " should be active",
+                        indexShard.routingEntry().active(),
+                        equalTo(true)
+                    );
+
+                    final var maxSeqNo = indexShard.withEngine(Engine::getMaxSeqNo);
+
+                    indexShard.sync(); // sync to ensure local checkpoint is processed
+
+                    if (indexShard.getTranslogDurability() == Translog.Durability.ASYNC) {
+                        // in the async case, there is a background process that updates the global checkpoint.
+                        // We need to wait for that process to run. Alternatively, we could use indexShard.updateLocalCheckpointForShard
+                        // to enforce a sync but this would be a bit hacky.
+                        ESIntegTestCase.assertBusy(() -> assertThat(indexShard.getLastKnownGlobalCheckpoint(), equalTo(maxSeqNo)));
+                    }
+
+                    final var listener = listeners.acquire(
+                        ignored -> assertThat(
+                            "Global checkpoint not synced for shard: " + indexShard.routingEntry(),
+                            indexShard.getLastSyncedGlobalCheckpoint(),
+                            equalTo(maxSeqNo)
+                        )
+                    );
+                    indexShard.syncGlobalCheckpoint(maxSeqNo, e -> {
+                        if (e == null) {
+                            listener.onResponse(null);
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
Backport of #146133 and #146507, neither of which was applied to 9.4.

testFilterCacheStats still used its own persistGlobalCheckpoint helper, which fsyncs the translog and then asserts that the persisted global checkpoint equals the in-memory one. Translog#sync is a no-op when no operations are pending, so a global checkpoint that advanced after the last fsync is never persisted and the assertion fails:

```
  AssertionError: Routing entry for shard [index][5], [P], s[STARTED]
  Expected: <1L> but: was <0L>
```

Use SequenceNumbersTestUtils#persistGlobalCheckpointOnPrimaryShards instead, which persists the checkpoint explicitly through IndexShard#syncGlobalCheckpoint, and bring the 9.4 copy of that helper in line with main: sync the shard first and, when translog durability is async, wait for the background global checkpoint update before asserting.

Unmutes the test.

Closes #155421
