### PR TITLE
Improve `dense_vector` query docs and bump page to version 9.6

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-dense-vector-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-dense-vector-query.md
@@ -12,7 +12,7 @@ applies_to:
 Performs exact, brute-force scoring of a query vector against every document that has a value for a
 [`dense_vector`](/reference/elasticsearch/mapping-reference/dense-vector.md) field. Unlike the approximate
 [`knn` query](/reference/query-languages/query-dsl/query-dsl-knn-query.md), it does not use an index
-structure or a `k`/`num_candidates` cutoff: every matching document is scored. This is useful when you need
+structure or an exploration cutoff based on `k` or `num_candidates`: every matching document is scored. This is useful when you need
 exact scores, want to combine exact vector scoring with other queries, or want to score a `dense_vector`
 field that is not indexed for approximate search (`index: false`).
 
@@ -83,7 +83,7 @@ both. See [`query_vector_builder`](/reference/query-languages/query-dsl/query-ds
 
 `similarity_function`
 :   (Optional, string) The similarity metric used for scoring, overriding the field's mapped similarity for
-this query. One of `l2_norm`, `dot_product`, `cosine`, or `max_inner_product`. Defaults to the field's
+this query. One of `l2_norm`, `dot_product`, `cosine`, or `max_inner_product` (see [valid similarity values](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-similarity) for definitions). Defaults to the field's
 configured similarity, or to `cosine` for a non-indexed (`index: false`) field, which has no configured
 similarity. For `bit` fields, only `l2_norm` is supported. Cannot be combined with `quantized: true`.
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-dense-vector-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-dense-vector-query.md
@@ -3,7 +3,7 @@ navigation_title: "Dense vector"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dense-vector-query.html
 applies_to:
-  stack: ga 9.5
+  stack: ga 9.6
   serverless: all
 ---
 
@@ -17,7 +17,7 @@ exact scores, want to combine exact vector scoring with other queries, or want t
 field that is not indexed for approximate search (`index: false`).
 
 By default, scoring uses the original, full-precision vectors, so a [quantized](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization)
-index still produces full-precision scores. See [`quantized`](#dense-vector-query-params) to score against
+index still produces full-precision scores. See [`quantized`](#dense-vector-query-quantized) to score against
 the quantized representation instead.
 
 ## Example request [dense-vector-query-ex-request]
@@ -87,7 +87,9 @@ this query. One of `l2_norm`, `dot_product`, `cosine`, or `max_inner_product`. D
 configured similarity, or to `cosine` for a non-indexed (`index: false`) field, which has no configured
 similarity. For `bit` fields, only `l2_norm` is supported. Cannot be combined with `quantized: true`.
 
-`quantized` [dense-vector-query-quantized]
+$$$dense-vector-query-quantized$$$
+
+`quantized`
 :   (Optional, Boolean) Defaults to `false`.
 
     When `false` (the default), scoring iterates the preserved full-precision vectors, producing raw scores
@@ -98,9 +100,11 @@ similarity. For `bit` fields, only `l2_norm` is supported. Cannot be combined wi
     with `similarity_function`.
 
     ::::{note}
-    `quantized: true` only makes sense for [quantized](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization)
-    fields. For non-quantized `dense_vector` fields, the setting is ignored and the original vectors are used
-    for scoring.
+    `quantized: true` is a best-effort option: it uses quantized vectors when the field is
+    [quantized](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization), and
+    falls back to full-precision scoring for non-quantized `dense_vector` fields. During an index type
+    transition (for example, `hnsw` to `int8_hnsw`), older segments retain their original codec until merged
+    away, so scores within a single query may mix quantized and full-precision semantics.
     ::::
 
 `boost`


### PR DESCRIPTION
- Bump from 9.5 to 9.6 since it missed 9.5 window
- Fix anchor rendering: definition list terms require the $$$id$$$ syntax, not [id]; the old form leaked as visible text on the page
- Fix cross-reference to link directly to #dense-vector-query-quantized rather than the top of the params section
- Reframe the note from "setting is ignored" to a best-effort "when available" description, per reviewer feedback
- Document that scores may mix quantized and full-precision semantics during an index type transition (e.g. hnsw → int8_hnsw), because older segments retain their original codec until merged away
- Improves wording for exploration cut off when describing approximate vs exact search