### PR TITLE
Replace setUp/tearDown overrides with @Before/@After in remaining tests

### DIFF
--- a/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
+++ b/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cli.CommandTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -42,8 +43,8 @@ public class GeoIpCliTests extends CommandTestCase {
     private Path source;
     private Path target;
 
-    public void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void initTestDirs() throws Exception {
         source = createTempDir();
         target = createTempDir();
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -147,10 +147,8 @@ public class InstallPluginActionTests extends ESTestCase {
         System.setProperty("java.io.tmpdir", temp.apply("tmpdir").toString());
     }
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initPluginInstallEnvironment() throws Exception {
         pluginDir = createPluginDir(temp);
         terminal = MockTerminal.create();
         env = createEnv(temp);
@@ -164,15 +162,13 @@ public class InstallPluginActionTests extends ESTestCase {
         defaultAction = new InstallPluginAction(terminal, env.v2(), false);
     }
 
-    @Override
     @After
     @SuppressForbidden(reason = "resets java.io.tmpdir")
-    public void tearDown() throws Exception {
+    public void closePluginInstallActions() throws Exception {
         defaultAction.close();
         skipJarHellAction.close();
         System.setProperty("java.io.tmpdir", javaIoTmpdir);
         PathUtilsForTesting.teardown();
-        super.tearDown();
     }
 
     @ParametersFactory

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -45,10 +45,8 @@ public class RemovePluginActionTests extends ESTestCase {
     private Path home;
     private Environment env;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initTestEnvironment() throws Exception {
         home = createTempDir();
         Files.createDirectories(home.resolve("bin"));
         Files.createFile(home.resolve("bin").resolve("elasticsearch"));

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
@@ -48,10 +48,8 @@ public class SyncPluginsActionTests extends ESTestCase {
     private PluginsConfig config;
     private MockTerminal terminal;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initPluginsEnvironment() throws Exception {
         Path home = createTempDir();
         Settings settings = Settings.builder().put("path.home", home).build();
         env = TestEnvironment.newEnvironment(settings);

--- a/distribution/tools/server-launcher/src/test/java/org/elasticsearch/server/launcher/ServerLauncherTests.java
+++ b/distribution/tools/server-launcher/src/test/java/org/elasticsearch/server/launcher/ServerLauncherTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.server.launcher;
 import org.elasticsearch.server.launcher.common.LaunchDescriptor;
 import org.elasticsearch.server.launcher.common.ProcessUtil;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 
@@ -171,8 +172,8 @@ public class ServerLauncherTests extends ESTestCase {
         System.setErr(new PrintStream(capturedStderr, true, StandardCharsets.UTF_8));
     }
 
-    @Override
-    public void tearDown() throws Exception {
+    @After
+    public void stopActiveServerAndRestoreErr() throws Exception {
         try {
             ServerProcess server = activeServer;
             if (server != null) {
@@ -180,11 +181,7 @@ public class ServerLauncherTests extends ESTestCase {
                 server.stop();
             }
         } finally {
-            try {
-                System.setErr(originalErr);
-            } finally {
-                super.tearDown();
-            }
+            System.setErr(originalErr);
         }
     }
 

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AbstractEC2MockAPITestCase.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AbstractEC2MockAPITestCase.java
@@ -52,12 +52,11 @@ public abstract class AbstractEC2MockAPITestCase extends ESTestCase {
     protected NetworkService networkService = new NetworkService(Collections.emptyList());
 
     @Before
-    public void setUp() throws Exception {
+    public void startHttpServerAndThreadPool() throws Exception {
         httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.start();
         threadPool = new TestThreadPool(EC2RetriesTests.class.getName());
         transportService = createTransportService();
-        super.setUp();
     }
 
     protected abstract MockTransportService createTransportService();
@@ -72,12 +71,8 @@ public abstract class AbstractEC2MockAPITestCase extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
-        try {
-            IOUtils.close(transportService, () -> terminate(threadPool), () -> httpServer.stop(0));
-        } finally {
-            super.tearDown();
-        }
+    public void stopHttpServerAndThreadPool() throws Exception {
+        IOUtils.close(transportService, () -> terminate(threadPool), () -> httpServer.stop(0));
     }
 
     /**

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.hamcrest.Matcher;
 import org.junit.After;
-import org.junit.Before;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,17 +33,9 @@ public class EvilBootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
 
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
     @After
-    public void tearDown() throws Exception {
+    public void restoreEnforceBootstrapChecksSysprop() throws Exception {
         setEsEnforceBootstrapChecks(esEnforceBootstrapChecks);
-        super.tearDown();
     }
 
     public void testEnforceBootstrapChecks() throws NodeValidationException {

--- a/qa/serverless-system-properties/src/test/java/org/elasticsearch/transport/ServerlessTransportHandshakeTests.java
+++ b/qa/serverless-system-properties/src/test/java/org/elasticsearch/transport/ServerlessTransportHandshakeTests.java
@@ -82,11 +82,10 @@ public class ServerlessTransportHandshakeTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeTransportServices() throws Exception {
         for (TransportService transportService : transportServices) {
             transportService.close();
         }
-        super.tearDown();
     }
 
     @AfterClass

--- a/x-pack/extras/plugins/microsoft-graph-authz/src/test/java/org/elasticsearch/xpack/security/authz/microsoft/MicrosoftGraphAuthzRealmTests.java
+++ b/x-pack/extras/plugins/microsoft-graph-authz/src/test/java/org/elasticsearch/xpack/security/authz/microsoft/MicrosoftGraphAuthzRealmTests.java
@@ -101,16 +101,13 @@ public class MicrosoftGraphAuthzRealmTests extends ESTestCase {
     };
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setTraceLogging() throws Exception {
         final var logger = LogManager.getLogger(MicrosoftGraphAuthzRealm.class);
         Loggers.setLevel(logger, Level.TRACE);
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void terminateThreadPool() throws Exception {
         terminate(threadPool);
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/FollowStatsMonitoringDocTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/FollowStatsMonitoringDocTests.java
@@ -44,10 +44,8 @@ public class FollowStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Fol
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time").withZone(ZoneOffset.UTC);
     private ShardFollowNodeTaskStatus status;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initStatusMock() throws Exception {
         status = mock(ShardFollowNodeTaskStatus.class);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractClusterStateLicenseServiceTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractClusterStateLicenseServiceTestCase.java
@@ -94,8 +94,7 @@ public abstract class AbstractClusterStateLicenseServiceTestCase extends ESTestC
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void stopLicenseService() throws Exception {
         licenseService.stop();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmConfigTests.java
@@ -32,12 +32,11 @@ public class RealmConfigTests extends ESTestCase {
     private ThreadContext threadContext;
 
     @Before
-    public void setUp() throws Exception {
+    public void initRealmConfig() throws Exception {
         realmIdentifier = new RealmConfig.RealmIdentifier(randomAlphaOfLengthBetween(4, 12), randomAlphaOfLengthBetween(4, 12));
         environment = Mockito.mock(Environment.class);
         globalSettings = Settings.builder().put("path.home", createTempDir()).build();
         threadContext = new ThreadContext(globalSettings);
-        super.setUp();
     }
 
     public void testWillPassWhenOrderSettingIsConfigured() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
@@ -84,8 +84,7 @@ public class SecurityIndexReaderWrapperUnitTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void closeDirectoryReader() throws Exception {
         esIn.close();
     }
 

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionPluginTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionPluginTests.java
@@ -71,10 +71,9 @@ public class DLMFrozenTransitionPluginTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeClusterServiceAndThreadPool() throws Exception {
         clusterService.close();
         terminate(threadPool);
-        super.tearDown();
     }
 
     /**

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionServiceTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionServiceTests.java
@@ -124,10 +124,9 @@ public class DLMFrozenTransitionServiceTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeClusterServiceAndThreadPool() throws Exception {
         clusterService.close();
         terminate(threadPool);
-        super.tearDown();
     }
 
     private static DLMFrozenTransitionExecutor newTransitionExecutor(

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -139,8 +139,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
     private IndicesAdminClient indicesAdminClient;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initMocks() throws Exception {
         mocks = MockitoAnnotations.openMocks(this);
         action = new TransportDownsampleAction(
             client,
@@ -211,8 +210,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void closeMocks() throws Exception {
         mocks.close();
     }
 

--- a/x-pack/plugin/geoip-enterprise-downloader/src/test/java/org/elasticsearch/xpack/geoip/EnterpriseGeoIpDownloaderLicenseListenerTests.java
+++ b/x-pack/plugin/geoip-enterprise-downloader/src/test/java/org/elasticsearch/xpack/geoip/EnterpriseGeoIpDownloaderLicenseListenerTests.java
@@ -65,8 +65,7 @@ public class EnterpriseGeoIpDownloaderLicenseListenerTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void shutdownThreadPool() throws Exception {
         threadPool.shutdownNow();
     }
 

--- a/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportActionTests.java
+++ b/x-pack/plugin/migrate/src/test/java/org/elasticsearch/xpack/migrate/action/ReindexDataStreamIndexTransportActionTests.java
@@ -65,14 +65,12 @@ public class ReindexDataStreamIndexTransportActionTests extends ESTestCase {
     private AutoCloseable mocks;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void openMocks() throws Exception {
         mocks = MockitoAnnotations.openMocks(this);
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void closeMocks() throws Exception {
         mocks.close();
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMetricsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMetricsTests.java
@@ -61,10 +61,8 @@ public class MlConfigMetricsTests extends ESTestCase {
     private Supplier<Collection<LongWithAttributes>> authTypeObserver;
     private Supplier<Collection<LongWithAttributes>> projectRoutingObserver;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initMlConfigMetricsTestDeps() throws Exception {
         threadPool = createThreadPool(
             new ScalingExecutorBuilder(MachineLearning.UTILITY_THREAD_POOL_NAME, 0, 1, TimeValue.timeValueMinutes(10), false)
         );
@@ -76,11 +74,9 @@ public class MlConfigMetricsTests extends ESTestCase {
         projectRoutingObserver = captureLongsGauge(meterRegistry, "es.ml.datafeeds.cps.project_routing.current");
     }
 
-    @Override
     @After
-    public void tearDown() throws Exception {
+    public void closeThreadPool() throws Exception {
         threadPool.close();
-        super.tearDown();
     }
 
     public void testComputeCountsShouldBucketMixedConfigs() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
@@ -70,10 +70,8 @@ public class AdaptiveAllocationsScalerServiceTests extends ESTestCase {
     private InferenceAuditor inferenceAuditor;
     private MeterRegistry meterRegistry;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initAdaptiveAllocationsTestDeps() throws Exception {
         threadPool = createThreadPool(
             new ScalingExecutorBuilder(MachineLearning.UTILITY_THREAD_POOL_NAME, 0, 1, TimeValue.timeValueMinutes(10), false)
         );
@@ -85,11 +83,9 @@ public class AdaptiveAllocationsScalerServiceTests extends ESTestCase {
         meterRegistry = mock(MeterRegistry.class);
     }
 
-    @Override
     @After
-    public void tearDown() throws Exception {
+    public void closeThreadPool() throws Exception {
         this.threadPool.close();
-        super.tearDown();
     }
 
     private ClusterState getClusterState(int numAllocations, AssignmentState assignmentState) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/VoidChainTaskExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/VoidChainTaskExecutorTests.java
@@ -25,14 +25,9 @@ public class VoidChainTaskExecutorTests extends ESTestCase {
     private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
     private final CountDownLatch latch = new CountDownLatch(1);
 
-    @Override
     @After
-    public void tearDown() throws Exception {
-        try {
-            terminate(threadPool);
-        } finally {
-            super.tearDown();
-        }
+    public void terminateThreadPool() throws Exception {
+        terminate(threadPool);
     }
 
     public void testExecute() throws InterruptedException {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -44,8 +44,7 @@ public class MonitoringServiceTests extends ESTestCase {
     private SSLService sslService;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initMonitoringServiceTestDeps() throws Exception {
         threadPool = new TestThreadPool(getTestName());
         clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put("path.home", createTempDir()).build();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
@@ -38,10 +38,8 @@ public class MonitoringBulkDocTests extends ESTestCase {
     private BytesReference source;
     private XContentType xContentType;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initMonitoringBulkDocFields() throws Exception {
         system = randomFrom(MonitoredSystem.values());
         type = randomAlphaOfLength(5);
         id = randomBoolean() ? randomAlphaOfLength(10) : null;

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -98,10 +98,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
     private final boolean needToEnableTLS = randomBoolean();
     private final boolean apmIndicesExist = randomBoolean();
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initClusterStatsFields() throws Exception {
         clusterName = randomAlphaOfLength(5);
         version = randomAlphaOfLengthBetween(6, 32);
         clusterStatus = randomFrom(ClusterHealthStatus.values());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
@@ -49,10 +49,8 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
 
     private RecoveryResponse mockRecoveryResponse;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initRecoveryResponseMock() throws Exception {
         mockRecoveryResponse = mock(RecoveryResponse.class);
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -77,10 +77,8 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
     private IndexRoutingTable routingTable;
     private ClusterIndexHealth indexHealth;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initIndexStatsFields() throws Exception {
         indexStats = mock(IndexStats.class);
         metadata = mockIndexMetadata(index, primaries, replicas);
         routingTable = mockIndexRoutingTable(index, primaries, replicas, activePrimaries, activeReplicas, initializing, relocating);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -43,10 +43,8 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
 
     private List<IndexStats> indicesStats;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initIndicesStats() throws Exception {
         indicesStats = Collections.singletonList(
             new IndexStats(
                 "index-0",

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
@@ -45,10 +45,8 @@ public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobSta
 
     private JobStats mockJobStats;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initJobStatsMock() throws Exception {
         mockJobStats = mock(JobStats.class);
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -61,10 +61,8 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
     private NodeStats nodeStats;
     private boolean mlockall;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initNodeStatsFields() throws Exception {
         nodeId = randomAlphaOfLength(5);
         isMaster = randomBoolean();
         nodeStats = mock(NodeStats.class);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsMonitoringDocTests.java
@@ -32,10 +32,8 @@ public class ShardsMonitoringDocTests extends BaseFilteredMonitoringDocTestCase<
     private boolean assignedToNode;
     private ShardRouting shardRouting;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initShardRoutingFields() throws Exception {
         stateUuid = randomAlphaOfLength(5);
         assignedToNode = randomBoolean();
         node = assignedToNode ? MonitoringTestUtils.randomMonitoringNode(random()) : null;

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BaseMonitoringDocTestCase.java
@@ -53,10 +53,8 @@ public abstract class BaseMonitoringDocTestCase<T extends MonitoringDoc> extends
     protected String type;
     protected String id;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initMonitoringDocFields() throws Exception {
         cluster = UUIDs.randomBase64UUID();
         timestamp = frequently() ? randomLongBetween(1, DateUtils.MAX_MILLIS_BEFORE_9999) : 0L;
         interval = randomNonNegativeLong();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BytesReferenceMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BytesReferenceMonitoringDocTests.java
@@ -35,10 +35,8 @@ public class BytesReferenceMonitoringDocTests extends BaseMonitoringDocTestCase<
     private XContentType xContentType;
     private BytesReference source;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initBytesReferenceFields() throws Exception {
         xContentType = randomFrom(XContentType.values());
         source = RandomObjects.randomSource(random(), xContentType);
     }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupRequestTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupRequestTranslationTests.java
@@ -45,10 +45,8 @@ public class RollupRequestTranslationTests extends ESTestCase {
 
     private NamedWriteableRegistry namedWriteableRegistry;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initNamedWriteableRegistry() throws Exception {
         SearchModule searchModule = new SearchModule(Settings.EMPTY, emptyList());
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.addAll(searchModule.getNamedWriteables());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -83,10 +83,8 @@ public class SearchActionTests extends ESTestCase {
 
     private NamedWriteableRegistry namedWriteableRegistry;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initNamedWriteableRegistry() throws Exception {
         SearchModule searchModule = new SearchModule(Settings.EMPTY, emptyList());
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.addAll(IndicesModule.getNamedWriteables());

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
@@ -107,9 +107,8 @@ public class CertificateGenerateToolTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeJimfs() throws Exception {
         IOUtils.close(jimfs);
-        super.tearDown();
     }
 
     public void testOutputDirectory() throws Exception {

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -140,9 +140,8 @@ public class CertificateToolTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeJimfs() throws Exception {
         IOUtils.close(jimfs);
-        super.tearDown();
     }
 
     public void testOutputDirectory() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -256,8 +256,7 @@ public class TokenServiceTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void closeClusterServiceAndRecycler() throws Exception {
         clusterService.close();
         // wait for any async threads to release their recycler pages
         assertBusy(() -> assertEquals(0, bytesRefRecycler.activePageCount()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -84,10 +84,8 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
     private MockTransportService remoteTransportService;
 
     @SuppressWarnings("unchecked")
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initTransportServices() throws Exception {
         threadPool = new TestThreadPool(getClass().getName());
         authenticationException = new AtomicReference<>();
         remoteClusterName = "test-remote_cluster_service_" + randomAlphaOfLength(8);
@@ -166,11 +164,9 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
         remoteTransportService.acceptIncomingRequests();
     }
 
-    @Override
     @After
-    public void tearDown() throws Exception {
+    public void closeTransportServicesAndThreadPool() throws Exception {
         logger.info("tearDown");
-        super.tearDown();
         IOUtils.close(
             remoteTransportService,
             remoteSecurityNetty4ServerTransport,

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/action/NewCommitNotificationRequestTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/action/NewCommitNotificationRequestTests.java
@@ -35,10 +35,8 @@ public class NewCommitNotificationRequestTests extends AbstractWireSerializingTe
 
     private IndexShardRoutingTable indexShardRoutingTable;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initIndexShardRoutingTable() throws Exception {
         indexShardRoutingTable = randomIndexShardRoutingTable();
     }
 

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/PinnedWindowEvictionPolicyTests.java
@@ -62,8 +62,7 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
     private ClusterSettings clusterSettings;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initTaskQueueAndClusterService() throws Exception {
         taskQueue = new DeterministicTaskQueue();
         taskQueue.runTasksUpToTimeInOrder(System.currentTimeMillis());
         clusterSettings = createClusterSettings(Settings.EMPTY);
@@ -71,9 +70,8 @@ public class PinnedWindowEvictionPolicyTests extends ESTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeClusterService() throws Exception {
         clusterService.close();
-        super.tearDown();
     }
 
     public void testDurationBelowMinimumRejected() {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotShardContextFactoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/StatelessSnapshotShardContextFactoryTests.java
@@ -84,8 +84,7 @@ public class StatelessSnapshotShardContextFactoryTests extends ESTestCase {
     private TestHarness testHarness;
 
     @After
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void closeTestHarness() throws Exception {
         if (testHarness != null) {
             testHarness.close();
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigrationTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformConfigAutoMigrationTests.java
@@ -53,8 +53,7 @@ public class TransformConfigAutoMigrationTests extends ESTestCase {
     private TransformConfigAutoMigration autoMigration;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initAutoMigration() throws Exception {
         transformConfigManager = mock();
         auditor = mock();
         ThreadPool threadPool = mock();

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointNodeActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointNodeActionTests.java
@@ -62,8 +62,7 @@ public class TransportGetCheckpointNodeActionTests extends ESTestCase {
     private Set<ShardId> shards;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initCheckpointNodeActionTestDeps() throws Exception {
         ClusterService clusterService = new ClusterService(
             Settings.builder().put("node.name", NODE_NAME).build(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportSetTransformUpgradeModeActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportSetTransformUpgradeModeActionTests.java
@@ -55,8 +55,7 @@ public class TransportSetTransformUpgradeModeActionTests extends ESTestCase {
     private TransportSetTransformUpgradeModeAction action;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initUpgradeModeActionTestDeps() throws Exception {
         clusterService = clusterService();
         doAnswer(ans -> {
             ClusterStateUpdateTask task = ans.getArgument(1);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/telemetry/TransformCrossProjectMetricsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/telemetry/TransformCrossProjectMetricsTests.java
@@ -45,11 +45,8 @@ public class TransformCrossProjectMetricsTests extends ESTestCase {
 
     private TransformCrossProjectMetrics component;
 
-    @Override
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void initTransformCrossProjectMetrics() throws Exception {
         var meterRegistry = mock(MeterRegistry.class);
         when(meterRegistry.registerLongsGauge(anyString(), anyString(), anyString(), any())).thenAnswer(inv -> {
             observersByMetricName.put(inv.getArgument(0), inv.getArgument(3));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -132,8 +132,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
     }
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initAutoMigrationMock() throws Exception {
         autoMigration = mock();
         doAnswer(ans -> {
             ActionListener<?> listener = ans.getArgument(1);

--- a/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/crypto/tool/SystemKeyToolTests.java
+++ b/x-pack/qa/security-tools-tests/src/test/java/org/elasticsearch/xpack/security/crypto/tool/SystemKeyToolTests.java
@@ -41,9 +41,8 @@ public class SystemKeyToolTests extends CommandTestCase {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void closeJimfs() throws Exception {
         IOUtils.close(jimfs);
-        super.tearDown();
     }
 
     @Override


### PR DESCRIPTION
Continues the migration away from `setUp()`/`tearDown()` overrides toward
`@Before`/`@After` methods, so the framework handles lifecycle ordering and a
forgotten `super` call can't silently skip setup or cleanup.

Converts the remaining overrides across distribution tools (geoip-cli,
plugin-cli, server-launcher), discovery-ec2, qa (evil-tests,
serverless-system-properties), and x-pack plugins (ccr, core,
dlm-frozen-transition, downsample, geoip-enterprise-downloader, migrate, ml,
monitoring, rollup, security, stateless, transform, microsoft-graph-authz).
Each override is renamed to a descriptive `@Before`/`@After` method and its
`super.setUp()`/`super.tearDown()` call dropped.

This clears the way for making `setUp`/`tearDown` final in `ESTestCase`.
