### PR TITLE
[9.5] Downsample: fix duplicate field in cumulative histogram reset doc (#156287)

### DIFF
--- a/docs/changelog/156287.yaml
+++ b/docs/changelog/156287.yaml
@@ -1,0 +1,6 @@
+area: Downsampling
+issues:
+ - 156276
+pr: 156287
+summary: "Downsample: fix duplicate field in cumulative histogram reset doc"
+type: bug

--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/110_downsample_temporality.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/110_downsample_temporality.yml
@@ -569,3 +569,116 @@
   - match: { hits.hits.0._source.latency.min: 1.0 }
   - match: { hits.hits.0._source.latency.max: 5.0 }
   - match: { hits.hits.0._source._doc_count: 3 }
+
+---
+"Downsample cumulative histogram with consecutive resets in same bucket":
+  # Regression test: two consecutive resets within a single downsample bucket previously caused a
+  # duplicate field name in the reset boundary document, producing an
+  # XContentParseException: Duplicate field '...' that permanently failed the shard downsample task.
+  #
+  # Scenario (values received in descending timestamp order within the tsid):
+  #   t=18:20  h1 = {1.0}       count=1  max=1  — latest; received first
+  #   t=18:10  h2 = {1.0, 2.0}  count=2  max=2  — count-based reset (2 > 1)
+  #   t=18:00  h3 = {5.0}       count=1  max=5  — structural reset: setToDifference(h2, h3) is false
+  #                                                because h2.max=2 < h3.max=5
+  #
+  # The second reset previously re-pushed h2 at t=18:10 onto the stack a second time, producing two
+  # entries for (latency, 18:10) in ResetDataPoints, which caused a Duplicate field error.
+
+  - requires:
+      cluster_features: ["downsample.cumulative_histogram_consecutive_resets_fix"]
+      reason: "fix for duplicate field in reset document when two consecutive structural resets occur"
+
+  - do:
+      indices.create:
+        index: test-consec-resets-histogram
+        body:
+          settings:
+            number_of_shards: 1
+            index:
+              mode: time_series
+              routing_path: [metricset, temporality]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+                temporality_field: temporality
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              temporality:
+                type: keyword
+                time_series_dimension: true
+              latency:
+                type: exponential_histogram
+                time_series_metric: histogram
+
+  - do:
+      bulk:
+        refresh: true
+        index: test-consec-resets-histogram
+        body:
+          # Three documents in the same 1-hour bucket (18:00–19:00) and the same tsid.
+          # Processed in descending timestamp order: 18:20, 18:10, 18:00.
+          #
+          # h1 at t=18:20: {1.0} — count=1, max=1 (after first reset)
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:20:00.000Z", "metricset": "pod", "temporality": "cumulative", "latency": {"scale":0,"sum":1.0,"min":1.0,"max":1.0,"positive":{"indices":[0],"counts":[1]}}}'
+          # h2 at t=18:10: {1.0, 2.0} — count=2, max=2 (count-based reset vs h1)
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:10:00.000Z", "metricset": "pod", "temporality": "cumulative", "latency": {"scale":0,"sum":3.0,"min":1.0,"max":2.0,"positive":{"indices":[0,1],"counts":[1,1]}}}'
+          # h3 at t=18:00: {5.0} — count=1, max=5 (structural reset: h2.max=2 < h3.max=5 makes
+          # setToDifference(h2, h3) return false, triggering the second reset)
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:00:00.000Z", "metricset": "pod", "temporality": "cumulative", "latency": {"scale":0,"sum":5.0,"min":5.0,"max":5.0,"positive":{"indices":[2],"counts":[1]}}}'
+
+  - do:
+      indices.put_settings:
+        index: test-consec-resets-histogram
+        body:
+          index.blocks.write: true
+
+  # Without the fix this call fails: the bulk indexer receives an XContentParseException for a
+  # duplicate "latency" field in the reset boundary document, sets abort=true, and the downsample
+  # task throws DownsampleShardIndexerException instead of returning acknowledged:true.
+  - do:
+      indices.downsample:
+        index: test-consec-resets-histogram
+        target_index: test-consec-resets-histogram-downsample
+        body: >
+          {
+            "fixed_interval": "1h"
+          }
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: test-consec-resets-histogram-downsample
+        body:
+          sort: [ "@timestamp" ]
+
+  # 1 main downsampled doc + 2 reset boundary docs
+  - length: { hits.hits: 3 }
+
+  # Main doc: bucket start 18:00, holds the oldest value h3 = {5.0}
+  - match: { hits.hits.0._source.@timestamp: "2021-04-28T18:00:00.000Z" }
+  - match: { hits.hits.0._source.latency.sum: 5.0 }
+  - match: { hits.hits.0._source.latency.min: 5.0 }
+  - match: { hits.hits.0._source.latency.max: 5.0 }
+  # _doc_count = total docs (3) minus reset-boundary docs (2)
+  - match: { hits.hits.0._source._doc_count: 1 }
+
+  # Reset boundary doc at 18:10: pre-reset value h2 = {1.0, 2.0}
+  - match: { hits.hits.1._source.@timestamp: "2021-04-28T18:10:00.000Z" }
+  - match: { hits.hits.1._source.latency.sum: 3.0 }
+  - match: { hits.hits.1._source.latency.min: 1.0 }
+  - match: { hits.hits.1._source.latency.max: 2.0 }
+
+  # Reset boundary doc at 18:20: pre-reset value h1 = {1.0}
+  - match: { hits.hits.2._source.@timestamp: "2021-04-28T18:20:00.000Z" }
+  - match: { hits.hits.2._source.latency.sum: 1.0 }
+  - match: { hits.hits.2._source.latency.min: 1.0 }
+  - match: { hits.hits.2._source.latency.max: 1.0 }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleFeatures.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleFeatures.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.downsample;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class DownsampleFeatures implements FeatureSpecification {
+
+    /**
+     * Marks the fix for a bug where two consecutive structural resets within the same downsample bucket
+     * caused the same (field, timestamp) pair to be emitted twice in the reset boundary document,
+     * producing an {@code XContentParseException: Duplicate field} and permanently failing the shard
+     * downsample task.
+     */
+    public static final NodeFeature CUMULATIVE_HISTOGRAM_CONSECUTIVE_RESETS_FIX = new NodeFeature(
+        "downsample.cumulative_histogram_consecutive_resets_fix"
+    );
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(CUMULATIVE_HISTOGRAM_CONSECUTIVE_RESETS_FIX);
+    }
+}

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/ExponentialHistogramFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/ExponentialHistogramFieldDownsampler.java
@@ -282,18 +282,26 @@ abstract class ExponentialHistogramFieldDownsampler extends AbstractFieldDownsam
                     // lastTimestamp == -1 means that the previous value is already persisted by a previous bucket, nothing extra to
                     // persist.
                     if (lastTimestamp > 0) {
-                        // If we have a previous value in this bucket, we need to see if the last persisted value is enough to capture
-                        // the reset or not.
-                        ExponentialHistogram lastPersisted = null;
-                        if (resetStack.isEmpty() == false) {
-                            lastPersisted = ((ResetDataPoints.HistogramResetValue) resetStack.peek().value()).value();
-                        } else if (previousBucketValueHolder != null) {
-                            lastPersisted = previousBucketValueHolder.accessor();
-                        }
-                        // If there is no known last persisted value or the last persisted has a larger value count than the
-                        // current value, we need to store the previous document to capture the reset.
-                        if (lastPersisted == null || value.valueCount() < lastPersisted.valueCount()) {
-                            resetStack.push(new ResetDataPoints.ResetPoint(lastTimestamp, copyHistogram(previousValueHolder.accessor())));
+                        // The previous data point is already on the top of the stack when the previous iteration also detected a reset
+                        // (its timestamp matches lastTimestamp). Re-pushing it would produce two entries for the same
+                        // (field, timestamp) pair, which causes a duplicate field error in the reset document.
+                        boolean previousAlreadyPersisted = resetStack.isEmpty() == false && resetStack.peek().timestamp() == lastTimestamp;
+                        if (previousAlreadyPersisted == false) {
+                            // If we have a previous value in this bucket, we need to see if the last persisted value is enough to
+                            // capture the reset or not.
+                            ExponentialHistogram lastPersisted = null;
+                            if (resetStack.isEmpty() == false) {
+                                lastPersisted = ((ResetDataPoints.HistogramResetValue) resetStack.peek().value()).value();
+                            } else if (previousBucketValueHolder != null) {
+                                lastPersisted = previousBucketValueHolder.accessor();
+                            }
+                            // If there is no known last persisted value or the last persisted has a larger value count than the
+                            // current value, we need to store the previous document to capture the reset.
+                            if (lastPersisted == null || value.valueCount() < lastPersisted.valueCount()) {
+                                resetStack.push(
+                                    new ResetDataPoints.ResetPoint(lastTimestamp, copyHistogram(previousValueHolder.accessor()))
+                                );
+                            }
                         }
                     }
                     // This is the last value before reset, which we always need to persist

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/NumericMetricFieldDownsampler.java
@@ -486,19 +486,25 @@ abstract sealed class NumericMetricFieldDownsampler extends AbstractFieldDownsam
                     // We check if we need to persist the previous value too
                     // If timestamp -1 means that the previous value is already persisted by a previous bucket, nothing extra to persist
                     if (lastTimestamp > 0) {
-                        // If we have a previous value in this bucket, we need to see if the last persisted value is enough to capture
-                        // the
-                        // reset or not.
-                        double lastPersisted = Double.NaN;
-                        if (resetStack.isEmpty() == false) {
-                            lastPersisted = ((ResetDataPoints.CounterResetValue) resetStack.peek().value()).value();
-                        } else if (Double.isNaN(previousBucketValue) == false) {
-                            lastPersisted = previousBucketValue;
-                        }
-                        // If there is no known last persisted value or the last persisted is larger than the current value,
-                        // we need to store the previous document to capture the reset.
-                        if (Double.isNaN(lastPersisted) || Double.compare(counterValue, lastPersisted) < 0) {
-                            resetStack.push(new ResetDataPoints.ResetPoint(lastTimestamp, previousValue));
+                        // The previous data point is already on the top of the stack when the previous iteration also detected a reset
+                        // (its timestamp matches lastTimestamp). Re-pushing it would produce two entries for the same
+                        // (field, timestamp) pair, which causes a duplicate field error in the reset document.
+                        boolean previousAlreadyPersisted = resetStack.isEmpty() == false && resetStack.peek().timestamp() == lastTimestamp;
+                        if (previousAlreadyPersisted == false) {
+                            // If we have a previous value in this bucket, we need to see if the last persisted value is enough to capture
+                            // the
+                            // reset or not.
+                            double lastPersisted = Double.NaN;
+                            if (resetStack.isEmpty() == false) {
+                                lastPersisted = ((ResetDataPoints.CounterResetValue) resetStack.peek().value()).value();
+                            } else if (Double.isNaN(previousBucketValue) == false) {
+                                lastPersisted = previousBucketValue;
+                            }
+                            // If there is no known last persisted value or the last persisted is larger than the current value,
+                            // we need to store the previous document to capture the reset.
+                            if (Double.isNaN(lastPersisted) || Double.compare(counterValue, lastPersisted) < 0) {
+                                resetStack.push(new ResetDataPoints.ResetPoint(lastTimestamp, previousValue));
+                            }
                         }
                     }
                     // This is the last value before reset, which we always need to persist

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/ResetDataPoints.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/ResetDataPoints.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.downsample;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogramXContent;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,13 +25,26 @@ import java.util.Map;
  * reconstruct counter resets when querying the downsampled index.
  * <p>
  * Supports both numeric counters and exponential histograms via the sealed {@link ResetValue} hierarchy.
+ * <p>
+ * Invariant: at most one reset value per (fieldName, timestamp) pair. Callers must not add the same
+ * field name twice for the same timestamp; {@link #addDataPoint} enforces this defensively.
  */
 class ResetDataPoints {
+
+    private static final Logger logger = LogManager.getLogger(ResetDataPoints.class);
 
     private final Map<Long, List<Tuple<String, ResetValue>>> dataPoints = new HashMap<>();
 
     void addDataPoint(String fieldName, ResetPoint resetPoint) {
-        dataPoints.computeIfAbsent(resetPoint.timestamp(), k -> new ArrayList<>()).add(Tuple.tuple(fieldName, resetPoint.value()));
+        var values = dataPoints.computeIfAbsent(resetPoint.timestamp(), k -> new ArrayList<>());
+        for (var existing : values) {
+            if (existing.v1().equals(fieldName)) {
+                assert false : "duplicate reset data point for field [" + fieldName + "] at timestamp [" + resetPoint.timestamp() + "]";
+                logger.warn("Skipping duplicate reset data point for field [{}] at timestamp [{}]", fieldName, resetPoint.timestamp());
+                return;
+            }
+        }
+        values.add(Tuple.tuple(fieldName, resetPoint.value()));
     }
 
     public boolean isEmpty() {

--- a/x-pack/plugin/downsample/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/downsample/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,5 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+org.elasticsearch.xpack.downsample.DownsampleFeatures

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
@@ -232,6 +232,46 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
     }
 
     /**
+     * Two consecutive resets within a single bucket. Each of the three values triggers the
+     * reset criterion ({@code counterValue > previousValue}) in back-to-back iterations,
+     * exercising the {@code previousAlreadyPersisted} guard added to mirror the analogous fix
+     * in the exponential-histogram path.
+     * <p>
+     * Values (descending time order, i.e. the order in which the collector receives them):
+     * <ol>
+     *   <li>t=40: 5  — first collected; initialises state</li>
+     *   <li>t=30: 10 — reset 1: 10 &gt; 5; the guard pushes (t=40, 5) then line 567 pushes (t=30, 10)</li>
+     *   <li>t=20: 15 — reset 2: 15 &gt; 10; {@code previousAlreadyPersisted} is true because the stack
+     *       top already carries t=30, so the guard skips the redundant push of (t=30, 10)</li>
+     * </ol>
+     * Downsampled doc: 15 (oldest value)
+     * Reset docs: 10 at t=30, 5 at t=40
+     */
+    public void testConsecutiveResetsDoNotDuplicateDataPoint() throws IOException {
+        ResetDataPoints resetDataPoints = new ResetDataPoints();
+        NumericMetricFieldDownsampler.AggregateCounter producer = new NumericMetricFieldDownsampler.AggregateCounter("my-counter", null);
+        IntArrayList docIdBuffer = IntArrayList.from(0, 1, 2);
+        LongArrayList timeValues = LongArrayList.from(40, 30, 20);
+        SortedNumericDoubleValues counterValues = getIterator(docIdBuffer, 5.0, 10.0, 15.0);
+        producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
+        producer.updateResetDataPoints(resetDataPoints);
+
+        assertThat(producer.downsampledValue(), equalTo(15.0));
+        assertThat(resetDataPoints.countResetDocuments(), equalTo(2));
+        resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
+            // Each timestamp must have exactly one entry — a duplicate would indicate the guard misfired
+            assertThat("timestamp " + timestamp + " must have exactly one reset value", dataPoints.size(), equalTo(1));
+            assertThat(timestamp, anyOf(equalTo(30L), equalTo(40L)));
+            if (timestamp == 30L) {
+                assertThat(dataPoints, equalTo(List.of(Tuple.tuple("my-counter", new ResetDataPoints.CounterResetValue(10.0)))));
+            }
+            if (timestamp == 40L) {
+                assertThat(dataPoints, equalTo(List.of(Tuple.tuple("my-counter", new ResetDataPoints.CounterResetValue(5.0)))));
+            }
+        });
+    }
+
+    /**
      * Two buckets processed in reverse time order. Bucket #2 (t=50-70) has monotonically
      * increasing values 4, 5, 6 with no resets. Bucket #1 (t=10-40) has values 7, 8, 0, 2
      * with a reset at t=30. Both the last-before-reset value (8 at t=20) and the after-reset

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldDownsamplerTests.java
@@ -251,7 +251,7 @@ public class AggregateCounterFieldDownsamplerTests extends ESTestCase {
         ResetDataPoints resetDataPoints = new ResetDataPoints();
         NumericMetricFieldDownsampler.AggregateCounter producer = new NumericMetricFieldDownsampler.AggregateCounter("my-counter", null);
         IntArrayList docIdBuffer = IntArrayList.from(0, 1, 2);
-        LongArrayList timeValues = LongArrayList.from(40, 30, 20);
+        long[] timeValues = new long[] { 40, 30, 20 };
         SortedNumericDoubleValues counterValues = getIterator(docIdBuffer, 5.0, 10.0, 15.0);
         producer.collect(counterValues, timeValues, docIdBuffer, randomFrom(Temporality.DEFAULT, Temporality.CUMULATIVE));
         producer.updateResetDataPoints(resetDataPoints);

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateHistogramFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateHistogramFieldDownsamplerTests.java
@@ -334,7 +334,7 @@ public class AggregateHistogramFieldDownsamplerTests extends ESTestCase {
         ExponentialHistogram h20 = ExponentialHistogram.create(320, ExponentialHistogramCircuitBreaker.noop(), 5.0);
 
         IntArrayList docIdBuffer = IntArrayList.from(2, 1, 0);
-        LongArrayList timeValues = LongArrayList.from(40, 30, 20);
+        long[] timeValues = new long[] { 40, 30, 20 };
         ExponentialHistogramValuesReader values = createHistogramValues(docIdBuffer, h40, h30, h20);
         producer.collect(values, timeValues, docIdBuffer, Temporality.CUMULATIVE);
 

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateHistogramFieldDownsamplerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateHistogramFieldDownsamplerTests.java
@@ -306,6 +306,54 @@ public class AggregateHistogramFieldDownsamplerTests extends ESTestCase {
         assertThat(producer.downsampledValue().valueCount(), equalTo(2L));
     }
 
+    /**
+     * Regression test for a bug where two consecutive resets within the same bucket could cause the same
+     * (field, timestamp) pair to be pushed onto the reset stack twice:
+     * <ol>
+     *   <li>A count-based reset (detected while processing {@code t=30}) pushes the previous data point
+     *       at {@code t=40} via the guard, then pushes the reset boundary at {@code t=30} unconditionally.</li>
+     *   <li>A structural reset (setToDifference returns false while count still fits) incorrectly
+     *       re-pushes the same {@code t=30} entry (= {@code lastTimestamp}), producing a duplicate field
+     *       in the reset document and an {@code XContentParseException: Duplicate field '...'} at index time.</li>
+     * </ol>
+     * <p>
+     * The bug is triggered when h20.max &gt; h30.max (making setToDifference(h30, h20) return false)
+     * while h20.count &lt; h30.count (so the count criterion alone does not fire).
+     */
+    public void testConsecutiveResetsDoNotDuplicateDataPoint() throws IOException {
+        var producer = new ExponentialHistogramFieldDownsampler.AggregateHistogram("my-histogram", null);
+
+        // Values received in descending time order:
+        // t=40: count=1, values={1.0} — after the first reset (between t=30 and t=40)
+        // t=30: count=2, values={1.0, 2.0} — before the first reset; count-based reset vs h40
+        // t=20: count=1, values={5.0} — after a second reset; max=5 > h30.max=2,
+        // so setToDifference(h30, h20) returns false,
+        // triggering a structural-reset detection
+        ExponentialHistogram h40 = ExponentialHistogram.create(320, ExponentialHistogramCircuitBreaker.noop(), 1.0);
+        ExponentialHistogram h30 = ExponentialHistogram.create(320, ExponentialHistogramCircuitBreaker.noop(), 1.0, 2.0);
+        ExponentialHistogram h20 = ExponentialHistogram.create(320, ExponentialHistogramCircuitBreaker.noop(), 5.0);
+
+        IntArrayList docIdBuffer = IntArrayList.from(2, 1, 0);
+        LongArrayList timeValues = LongArrayList.from(40, 30, 20);
+        ExponentialHistogramValuesReader values = createHistogramValues(docIdBuffer, h40, h30, h20);
+        producer.collect(values, timeValues, docIdBuffer, Temporality.CUMULATIVE);
+
+        // Downsampled value is the oldest (h20)
+        ExponentialHistogram result = producer.downsampledValue();
+        assertThat(result.valueCount(), equalTo(h20.valueCount()));
+
+        ResetDataPoints resetDataPoints = new ResetDataPoints();
+        producer.updateResetDataPoints(resetDataPoints);
+
+        // Two reset documents: one for t=30 (count-based reset boundary) and one for t=40 (count-based reset)
+        assertThat(resetDataPoints.countResetDocuments(), equalTo(2));
+        resetDataPoints.processDataPoints((timestamp, dataPoints) -> {
+            // Each timestamp must have exactly one entry — the bug produced two entries at t=30
+            assertThat("timestamp " + timestamp + " must have exactly one reset value", dataPoints.size(), equalTo(1));
+            assertThat(timestamp, anyOf(equalTo(30L), equalTo(40L)));
+        });
+    }
+
     public void testIsAggregateDownsamplerConsistentWithCreate() {
         assertThat(ExponentialHistogramFieldDownsampler.isAggregateDownsampler(DownsampleConfig.SamplingMethod.AGGREGATE), equalTo(true));
         assertThat(

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/ResetDataPointsTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/ResetDataPointsTests.java
@@ -201,6 +201,31 @@ public class ResetDataPointsTests extends ESTestCase {
         });
     }
 
+    /**
+     * Adding the same field name at the same timestamp twice must be ignored (defensive guard).
+     * In test builds with assertions enabled, this also fires an AssertionError so callers notice
+     * the violation immediately; the second add is still silently dropped so production keeps running.
+     */
+    public void testDuplicateDataPointIsIgnored() throws IOException {
+        ResetDataPoints dataPoints = new ResetDataPoints();
+        ExponentialHistogram h = histogram(1.0, 2.0);
+        long timestamp = randomLongBetween(100, 10000);
+
+        dataPoints.addDataPoint("latency", new ResetDataPoints.ResetPoint(timestamp, h));
+
+        // A second add for the same (field, timestamp) pair should be rejected with an AssertionError
+        // (assertions are always enabled in the test JVM) but must not corrupt the stored state.
+        expectThrows(AssertionError.class, () -> dataPoints.addDataPoint("latency", new ResetDataPoints.ResetPoint(timestamp, h)));
+
+        // Exactly one document and one entry for "latency"
+        assertThat(dataPoints.countResetDocuments(), equalTo(1));
+        dataPoints.processDataPoints((ts, values) -> {
+            assertThat(ts, equalTo(timestamp));
+            assertThat(values, hasSize(1));
+            assertThat(values.get(0).v1(), equalTo("latency"));
+        });
+    }
+
     public void testResetPointConvenienceConstructors() {
         var counterPoint = new ResetDataPoints.ResetPoint(100L, 42.0);
         assertThat(counterPoint.value(), equalTo(new ResetDataPoints.CounterResetValue(42.0)));


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Downsample: fix duplicate field in cumulative histogram reset doc (#156287)