### PR TITLE
[9.5] Fail request instead of node on deep aggregations (#155745)

### DIFF
--- a/docs/changelog/155745.yaml
+++ b/docs/changelog/155745.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 155745
+summary: Fail request instead of node on deep aggregations
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/AggregationsIntegrationIT.java
@@ -9,9 +9,13 @@
 
 package org.elasticsearch.search.aggregations;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.ArrayList;
@@ -21,6 +25,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertScrollResponsesAndHitCount;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.SuiteScopeTestCase
 public class AggregationsIntegrationIT extends ESIntegTestCase {
@@ -58,5 +64,57 @@ public class AggregationsIntegrationIT extends ESIntegTestCase {
                 }
             }
         );
+    }
+
+    public void testDeeplyNestedAggregationIsRejectedWithoutKillingTheNode() {
+        TermsAggregationBuilder agg = terms("a0").field("f");
+        for (int i = 1; i < 2000; i++) {
+            agg = terms("a" + i).field("f").subAggregation(agg);
+        }
+        final TermsAggregationBuilder deepAgg = agg;
+        ActionRequestValidationException e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> prepareSearch("index").addAggregation(deepAgg).get()
+        );
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "The nested depth of the aggregations exceeds the maximum nested depth for aggregations of ["
+                    + AggregatorFactories.MAX_NESTED_DEPTH
+                    + "]"
+            )
+        );
+        assertThat(ExceptionsHelper.status(e), equalTo(RestStatus.BAD_REQUEST));
+
+        ensureGreen("index");
+        assertNoFailures(prepareSearch("index").addAggregation(terms("f").field("f")));
+    }
+
+    public void testDeeplyNestedAggregationIsRejectedAsAWholeRequestWithPartialResultsAllowed() {
+        assertAcked(
+            prepareCreate("deeply-nested-multi-shard").setSettings(indexSettings(between(2, 5), 0)).setMapping("f", "type=keyword")
+        );
+        indexRandom(true, prepareIndex("deeply-nested-multi-shard").setSource("f", "0"));
+
+        TermsAggregationBuilder agg = terms("a0").field("f");
+        for (int i = 1; i < 2000; i++) {
+            agg = terms("a" + i).field("f").subAggregation(agg);
+        }
+        final TermsAggregationBuilder deepAgg = agg;
+        ActionRequestValidationException e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> prepareSearch("deeply-nested-multi-shard").setAllowPartialSearchResults(true).addAggregation(deepAgg).get()
+        );
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "The nested depth of the aggregations exceeds the maximum nested depth for aggregations of ["
+                    + AggregatorFactories.MAX_NESTED_DEPTH
+                    + "]"
+            )
+        );
+
+        ensureGreen("deeply-nested-multi-shard");
+        assertNoFailures(prepareSearch("deeply-nested-multi-shard").addAggregation(terms("f").field("f")));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
+++ b/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
@@ -10,6 +10,9 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +24,8 @@ import java.util.concurrent.Executor;
  * A basic interface for rewriteable classes.
  */
 public interface Rewriteable<T> {
+
+    Logger logger = LogManager.getLogger(Rewriteable.class);
 
     int MAX_REWRITE_ROUNDS = 16;
 
@@ -118,6 +123,7 @@ public interface Rewriteable<T> {
         int iteration
     ) {
         T builder = original;
+        final T rewritten;
         try {
             for (T rewrittenBuilder = builder.rewrite(context); rewrittenBuilder != builder; rewrittenBuilder = builder.rewrite(context)) {
                 builder = rewrittenBuilder;
@@ -137,10 +143,16 @@ public interface Rewriteable<T> {
                     return;
                 }
             }
-            rewriteResponse.onResponse(builder);
+            rewritten = builder;
         } catch (Exception ex) {
             rewriteResponse.onFailure(ex);
+            return;
+        } catch (StackOverflowError ex) {
+            logger.warn(() -> Strings.format("stack overflow while rewriting [%s]", original.getClass().getName()), ex);
+            rewriteResponse.onFailure(new IllegalArgumentException("The request is too deeply nested to rewrite"));
+            return;
         }
+        rewriteResponse.onResponse(rewritten);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -2169,6 +2169,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 );
             } catch (IOException e) {
                 throw new AggregationInitializationException("Failed to create aggregators", e);
+            } catch (StackOverflowError e) {
+                throw new IllegalArgumentException("The aggregations are too deeply nested to build");
             }
         }
         if (source.suggest() != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -62,6 +62,8 @@ public class AggregationPhase {
             return new AggregatorCollector(aggregators, bucketCollector);
         } catch (IOException e) {
             throw new AggregationInitializationException("Could not initialize aggregators", e);
+        } catch (StackOverflowError e) {
+            throw new IllegalArgumentException("The aggregations are too deeply nested to build");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -424,6 +425,9 @@ public class AggregatorFactories {
          * Validate the root of the aggregation tree.
          */
         public ActionRequestValidationException validate(ActionRequestValidationException e) {
+            if (exceedsMaxNestedDepth()) {
+                return ValidateActions.addValidationError(maxNestedDepthExceededMessage(), e);
+            }
             PipelineAggregationBuilder.ValidationContext context = PipelineAggregationBuilder.ValidationContext.forTreeRoot(
                 aggregationBuilders,
                 e
@@ -461,6 +465,12 @@ public class AggregatorFactories {
         }
 
         private void checkMaxNestedDepth() {
+            if (exceedsMaxNestedDepth()) {
+                throw new IllegalArgumentException(maxNestedDepthExceededMessage());
+            }
+        }
+
+        private boolean exceedsMaxNestedDepth() {
             final Deque<Builder> builders = new ArrayDeque<>();
             final Deque<Integer> levels = new ArrayDeque<>();
             builders.push(this);
@@ -470,13 +480,14 @@ public class AggregatorFactories {
                 final int level = levels.pop();
                 if (level >= MAX_NESTED_DEPTH
                     && (current.aggregationBuilders.isEmpty() == false || current.pipelineAggregatorBuilders.isEmpty() == false)) {
-                    throw new IllegalArgumentException(maxNestedDepthExceededMessage());
+                    return true;
                 }
                 for (AggregationBuilder aggBuilder : current.aggregationBuilders) {
                     builders.push(aggBuilder.factoriesBuilder);
                     levels.push(level + 1);
                 }
             }
+            return false;
         }
 
         public AggregatorFactories build(AggregationContext context, AggregatorFactory parent) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RewriteableTests.java
@@ -8,10 +8,14 @@
  */
 package org.elasticsearch.index.query;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -23,10 +27,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 public class RewriteableTests extends ESTestCase {
@@ -67,6 +73,60 @@ public class RewriteableTests extends ESTestCase {
             }
         });
         assertEquals("too many rewrite rounds, rewriteable might return new objects even if they are not rewritten", ise.getMessage());
+    }
+
+    public void testRewriteAndFetchStackOverflow() {
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<TestRewriteable> future = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(new StackOverflowingTestRewriteable(), context, future);
+
+        Throwable failure = expectThrows(ExecutionException.class, future::get).getCause();
+        assertThat(failure, instanceOf(IllegalArgumentException.class));
+        assertEquals("The request is too deeply nested to rewrite", failure.getMessage());
+        assertTrue("no Error may be reachable from the failure", ExceptionsHelper.maybeError(failure).isEmpty());
+    }
+
+    public void testRewriteAndFetchLogsTheStackOverflowBeforeDiscardingIt() {
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<TestRewriteable> future = new PlainActionFuture<>();
+
+        MockLog.assertThatLogger(
+            () -> Rewriteable.rewriteAndFetch(new StackOverflowingTestRewriteable(), context, future),
+            Rewriteable.class,
+            new MockLog.SeenEventExpectation(
+                "stack overflow warning",
+                Rewriteable.class.getCanonicalName(),
+                Level.WARN,
+                "stack overflow while rewriting [" + StackOverflowingTestRewriteable.class.getName() + "]"
+            ) {
+                @Override
+                public boolean innerMatch(LogEvent event) {
+                    return event.getThrown() instanceof StackOverflowError;
+                }
+            }
+        );
+
+        expectThrows(ExecutionException.class, future::get);
+    }
+
+    public void testRewriteAndFetchDoesNotConvertFailuresRaisedByTheListener() {
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        AtomicBoolean failureNotified = new AtomicBoolean();
+        ActionListener<TestRewriteable> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(TestRewriteable rewritten) {
+                throw new StackOverflowError();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failureNotified.set(true);
+            }
+        };
+
+        TestRewriteable rewriteable = new TestRewriteable(randomIntBetween(0, Rewriteable.MAX_REWRITE_ROUNDS));
+        expectThrows(StackOverflowError.class, () -> Rewriteable.rewriteAndFetch(rewriteable, context, listener));
+        assertFalse("the listener must not be completed a second time", failureNotified.get());
     }
 
     public void testRewriteList() throws IOException {
@@ -290,6 +350,18 @@ public class RewriteableTests extends ESTestCase {
                 new Thread(() -> { l.onFailure(new RuntimeException("Simulated async failure")); }).start();
             });
             return new FailingTestRewriteable(numRewrites - 1);
+        }
+    }
+
+    private static class StackOverflowingTestRewriteable extends TestRewriteable {
+
+        StackOverflowingTestRewriteable() {
+            super(1);
+        }
+
+        @Override
+        public TestRewriteable rewrite(QueryRewriteContext ctx) {
+            throw new StackOverflowError();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -11,6 +11,8 @@ package org.elasticsearch.search.aggregations;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -37,6 +39,7 @@ import org.elasticsearch.search.aggregations.pipeline.AbstractPipelineAggregatio
 import org.elasticsearch.search.aggregations.pipeline.BucketScriptPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -259,6 +262,41 @@ public class AggregatorFactoriesTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("exceeds the maximum nested depth for aggregations of [" + maxDepth + "]"));
     }
 
+    public void testMaxNestedDepthEnforcedAtValidationTime() {
+        int maxDepth = defaultMaxNestedDepth();
+        ActionRequestValidationException e = nestedTermsBuilder(maxDepth + 1).validate(null);
+        assertNotNull(e);
+        assertThat(e.getMessage(), containsString("exceeds the maximum nested depth for aggregations of [" + maxDepth + "]"));
+    }
+
+    public void testValidationOfVeryDeepTreeDoesNotOverflowTheStack() {
+        int maxDepth = defaultMaxNestedDepth();
+        ActionRequestValidationException e = veryDeeplyNestedTermsBuilder().validate(null);
+        assertNotNull(e);
+        assertThat(e.getMessage(), containsString(maxNestedDepthExceededMessage(maxDepth)));
+    }
+
+    public void testValidationOfVeryDeepTreeInSearchRequestDoesNotOverflowTheStack() {
+        int maxDepth = defaultMaxNestedDepth();
+        SearchRequest request = new SearchRequest().source(new SearchSourceBuilder().aggregationsBuilder(veryDeeplyNestedTermsBuilder()));
+        ActionRequestValidationException e = request.validate();
+        assertNotNull(e);
+        assertThat(e.getMessage(), containsString(maxNestedDepthExceededMessage(maxDepth)));
+    }
+
+    public void testMaxNestedDepthEnforcedAtValidationTimeRegardlessOfAllowPartialSearchResults() {
+        int maxDepth = defaultMaxNestedDepth();
+        SearchRequest request = new SearchRequest().source(new SearchSourceBuilder().aggregationsBuilder(nestedTermsBuilder(maxDepth + 1)))
+            .allowPartialSearchResults(true);
+        ActionRequestValidationException e = request.validate();
+        assertNotNull(e);
+        assertThat(e.getMessage(), containsString("exceeds the maximum nested depth for aggregations of [" + maxDepth + "]"));
+    }
+
+    public void testMaxNestedDepthBoundaryAcceptedAtValidationTime() {
+        assertNull(nestedTermsBuilder(defaultMaxNestedDepth()).validate(null));
+    }
+
     public void testMaxNestedDepthBoundaryAcceptedAtBuildTime() {
         AggregatorFactories.Builder atLimit = nestedTermsBuilder(AggregatorFactories.MAX_NESTED_DEPTH);
         try {
@@ -272,6 +310,17 @@ public class AggregatorFactoriesTests extends ESTestCase {
         }
     }
 
+    private static AggregatorFactories.Builder veryDeeplyNestedTermsBuilder() {
+        TermsAggregationBuilder leaf = new TermsAggregationBuilder("a0").field("f");
+        AggregatorFactories.Builder builder = new AggregatorFactories.Builder().addAggregator(leaf);
+        for (int i = 1; i < 20_000; i++) {
+            TermsAggregationBuilder child = new TermsAggregationBuilder("a" + i).field("f");
+            leaf.subAggregation(child);
+            leaf = child;
+        }
+        return builder;
+    }
+
     private static AggregatorFactories.Builder nestedTermsBuilder(int depth) {
         TermsAggregationBuilder root = new TermsAggregationBuilder("a0").field("f");
         TermsAggregationBuilder parent = root;
@@ -281,6 +330,18 @@ public class AggregatorFactoriesTests extends ESTestCase {
             parent = child;
         }
         return new AggregatorFactories.Builder().addAggregator(root);
+    }
+
+    private static int defaultMaxNestedDepth() {
+        return AggregatorFactories.MAX_NESTED_DEPTH;
+    }
+
+    /**
+     * Mirrors {@code AggregatorFactories.maxNestedDepthExceededMessage()} so tests can assert against the full
+     * expected message rather than a hand-typed partial substring.
+     */
+    private static String maxNestedDepthExceededMessage(int maxDepth) {
+        return "The nested depth of the aggregations exceeds the maximum nested depth for aggregations of [" + maxDepth + "]";
     }
 
     private void assertNestedDepthAccepted(int depth) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fail request instead of node on deep aggregations (#155745)](https://github.com/elastic/elasticsearch/pull/155745)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)