### PR TITLE
Disallow lookup index mode in data streams

### DIFF
--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -71,7 +71,7 @@ $$$index-mode-setting$$$ `index.mode` {applies_to}`serverless: all`
     The `index.mode` setting supports the following values:
        - `null`:   Default value (same as `standard`).
        -  `standard`:   Standard indexing with default settings.
-       -  `lookup`: Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join.md) in ES|QL. Limited to 1 shard.
+       -  `lookup`: *(standalone indices only)* Index that can be used for [LOOKUP JOIN](/reference/query-languages/esql/esql-lookup-join.md) in ES|QL. Limited to 1 shard. Cannot be used for data streams.
        - `time_series`:   *(data streams only)* Index mode optimized for storage of metrics. For more information, see [Time series index settings](time-series.md).
        - `logsdb`: Index mode optimized for [logs](docs-content://manage-data/data-store/data-streams/logs-data-stream.md).
        - `vectordb_document` {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`: Index mode optimized for vector search use cases. Applies settings and defaults tuned for indexing, merging, and searching dense vector data. For details, see [Index modes for vector search](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-index-modes).

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
@@ -38,6 +38,11 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     public static final NodeFeature DATA_STREAMS_MODIFY_DELETE_INDEX = new NodeFeature("data_stream.modify.delete_index", true);
 
+    /**
+     * Feature flag indicating that the {@code lookup} index mode is no longer allowed in data streams.
+     */
+    public static final NodeFeature LOOKUP_MODE_NOT_ALLOWED_IN_DATA_STREAMS = new NodeFeature("data_stream.lookup_mode_not_allowed");
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(
@@ -55,7 +60,8 @@ public class DataStreamFeatures implements FeatureSpecification {
             LOGS_STREAM_FEATURE,
             FAILURE_STORE_IN_LOG_DATA_STREAMS,
             DOWNSAMPLE_MULTI_VALUE_DIMENSIONS,
-            DATA_STREAMS_MAPPINGS_API
+            DATA_STREAMS_MAPPINGS_API,
+            LOOKUP_MODE_NOT_ALLOWED_IN_DATA_STREAMS
         );
     }
 }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/310_lookup_mode_not_allowed.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/310_lookup_mode_not_allowed.yml
@@ -1,0 +1,84 @@
+---
+setup:
+  - requires:
+      cluster_features: [ "data_stream.lookup_mode_not_allowed" ]
+      reason: "lookup index mode is not allowed in data streams"
+
+---
+"lookup mode in index template directly is rejected":
+  - do:
+      catch: '/specifies \[index\.mode=lookup\], which is not supported for data streams/'
+      indices.put_index_template:
+        name: lookup-ds-template
+        body:
+          index_patterns: [ lookup-ds-* ]
+          data_stream: {}
+          template:
+            settings:
+              index:
+                mode: lookup
+
+---
+"lookup mode via composed_of component template is rejected":
+  - do:
+      cluster.put_component_template:
+        name: lookup-mode-settings
+        body:
+          template:
+            settings:
+              index:
+                mode: lookup
+  - is_true: acknowledged
+
+  - do:
+      catch: '/specifies \[index\.mode=lookup\], which is not supported for data streams/'
+      indices.put_index_template:
+        name: lookup-ds-composed-template
+        body:
+          index_patterns: [ lookup-ds-composed-* ]
+          data_stream: {}
+          composed_of: [ lookup-mode-settings ]
+
+---
+"standalone lookup index is still allowed":
+  - do:
+      indices.create:
+        index: standalone-lookup-index
+        body:
+          settings:
+            index:
+              mode: lookup
+  - is_true: acknowledged
+
+---
+"lookup index cannot be added as a backing index via modify_data_stream":
+  - do:
+      indices.put_index_template:
+        name: modify-ds-template
+        body:
+          index_patterns: [ modify-ds-* ]
+          data_stream: {}
+  - is_true: acknowledged
+
+  - do:
+      indices.create_data_stream:
+        name: modify-ds-1
+  - is_true: acknowledged
+
+  - do:
+      indices.create:
+        index: standalone-lookup-for-modify
+        body:
+          settings:
+            index:
+              mode: lookup
+  - is_true: acknowledged
+
+  - do:
+      catch: '/specifies \[index\.mode=lookup\], which is not supported for data streams/'
+      indices.modify_data_stream:
+        body:
+          actions:
+            - add_backing_index:
+                data_stream: modify-ds-1
+                index: standalone-lookup-for-modify

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -291,6 +291,10 @@ public class MetadataCreateDataStreamService {
         final ComposableIndexTemplate template = isSystem
             ? systemDataStreamDescriptor.getComposableIndexTemplate()
             : lookupTemplateForDataStream(dataStreamName, currentProject);
+        IndexMode.validateSupportsDataStreams(
+            currentProject.retrieveIndexModeFromTemplate(template),
+            "data stream [" + dataStreamName + "]"
+        );
         // The initial backing index and the initial failure store index will have the same initial generation.
         // This is not a problem as both have different prefixes (`.ds-` vs `.fs-`) and both will be using the same `generation` field
         // when rolling over in the future.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
@@ -674,11 +674,13 @@ public class MetadataDataStreamsService {
     ) {
         var dataStream = validateDataStream(project, dataStreamName);
         var index = validateIndex(project, indexName);
+        var indexMetadata = project.index(index.getWriteIndex());
+        IndexMode.validateSupportsDataStreams(indexMetadata.getIndexMode(), "index [" + indexName + "]");
 
         try {
             MetadataMigrateToDataStreamService.prepareBackingIndex(
                 builder,
-                project.index(index.getWriteIndex()),
+                indexMetadata,
                 dataStreamName,
                 mapperSupplier,
                 false,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettingProvider;
 import org.elasticsearch.index.IndexSettingProviders;
@@ -800,13 +801,14 @@ public class MetadataIndexTemplateService {
         final var componentTemplates = projectMetadata.componentTemplates();
         final var combinedMappings = collectMappings(indexTemplate, componentTemplates, "tmp_idx");
         final var combinedSettings = resolveSettings(indexTemplate, componentTemplates);
+        final IndexMode templateIndexMode = projectMetadata.retrieveIndexModeFromTemplate(indexTemplate);
         var additionalSettingsBuilder = Settings.builder();
         for (var provider : indexSettingProviders) {
             Settings.Builder builder = Settings.builder();
             provider.provideAdditionalSettings(
                 VALIDATE_INDEX_NAME,
                 indexTemplate.getDataStreamTemplate() != null ? VALIDATE_DATA_STREAM_NAME : null,
-                projectMetadata.retrieveIndexModeFromTemplate(indexTemplate),
+                templateIndexMode,
                 projectMetadata,
                 now,
                 combinedSettings,
@@ -835,6 +837,7 @@ public class MetadataIndexTemplateService {
         maybeValidateDataStreamsStillReferenced(projectMetadata, name, templateToValidate);
         validateLifecycle(componentTemplates, name, templateToValidate, globalRetentionSettings.get(false));
         validateDataStreamOptions(componentTemplates, name, templateToValidate, globalRetentionSettings.get(true));
+        validateIndexMode(name, indexTemplate, templateIndexMode);
 
         if (templateToValidate.isDeprecated() == false) {
             validateUseOfDeprecatedComponentTemplates(name, templateToValidate, componentTemplates);
@@ -955,6 +958,13 @@ public class MetadataIndexTemplateService {
                         .addWarningHeaderIfDataRetentionNotEffective(globalRetention, isInternalDataStream);
                 }
             }
+        }
+    }
+
+    // Visible for testing
+    static void validateIndexMode(String indexTemplateName, ComposableIndexTemplate template, @Nullable IndexMode resolvedIndexMode) {
+        if (template.getDataStreamTemplate() != null) {
+            IndexMode.validateSupportsDataStreams(resolvedIndexMode, "index template [" + indexTemplateName + "]");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -457,6 +457,13 @@ public enum IndexMode {
         public SourceFieldMapper.Mode defaultSourceMode() {
             return SourceFieldMapper.Mode.STORED;
         }
+
+        @Override
+        public boolean supportsDataStreams() {
+            // Lookup mode is single-shard, cannot roll over, and is not auto-sharded.
+            // It is only supported for standalone indices, not data streams.
+            return false;
+        }
     },
     COLUMNAR("columnar") {
         @Override
@@ -985,6 +992,29 @@ public enum IndexMode {
      */
     public static boolean isTsdbName(@Nullable String name) {
         return name != null && TIME_SERIES.getName().equalsIgnoreCase(name);
+    }
+
+    /**
+     * Whether indices in this mode may be part of a data stream. Data streams are append-only, rolled over, and
+     * auto-sharded. Modes that return {@code false} are only supported for standalone indices.
+     */
+    public boolean supportsDataStreams() {
+        return true;
+    }
+
+    /**
+     * Validates that {@code mode} supports data streams and throws {@link IllegalArgumentException} if it does not.
+     * {@code subject} describes the entity being validated and is included in the error message,
+     * e.g. {@code "index template [my-template]"} or {@code "data stream [my-ds]"}.
+     * A {@code null} mode means {@code index.mode} was not set explicitly, which defaults to {@link #STANDARD}
+     * and is always allowed.
+     */
+    public static void validateSupportsDataStreams(@Nullable IndexMode mode, String subject) {
+        if (mode != null && mode.supportsDataStreams() == false) {
+            throw new IllegalArgumentException(
+                subject + " specifies [" + IndexSettings.MODE.getKey() + "=" + mode.getName() + "], which is not supported for data streams"
+            );
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -619,6 +619,42 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         );
     }
 
+    public void testCreateDataStreamWithLookupIndexModeFails() throws Exception {
+        final MetadataCreateIndexService metadataCreateIndexService = getMetadataCreateIndexService();
+        final String dataStreamName = "my-data-stream";
+        ComposableIndexTemplate template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(dataStreamName + "*"))
+            .template(new Template(Settings.builder().put("index.mode", "lookup").build(), null, null))
+            .dataStreamTemplate(new DataStreamTemplate())
+            .build();
+        final var projectId = randomProjectIdOrDefault();
+        // Insert directly into project metadata, bypassing template validation (simulating an upgraded cluster
+        // with a pre-existing lookup-mode data stream template).
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .putProjectMetadata(ProjectMetadata.builder(projectId).put("template", template).build())
+            .build();
+        CreateDataStreamClusterStateUpdateRequest req = new CreateDataStreamClusterStateUpdateRequest(projectId, dataStreamName);
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MetadataCreateDataStreamService.createDataStream(
+                metadataCreateIndexService,
+                Settings.EMPTY,
+                cs,
+                randomBoolean(),
+                req,
+                RerouteBehavior.PERFORM_REROUTE,
+                ActionListener.noop(),
+                false
+            )
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("data stream [my-data-stream] specifies [index.mode=lookup], which is not supported for data streams")
+        );
+        // No backing index must have been created before the check fires
+        assertThat(cs.metadata().getProject(projectId).indices().size(), equalTo(0));
+    }
+
     public void testCreateDataStreamMatchingSystemIndexDescriptorFails() throws Exception {
         final String dataStreamName = ".my-system-idx";
         SystemIndices systemIndices = new SystemIndices(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
@@ -436,6 +436,49 @@ public class MetadataDataStreamsServiceTests extends MapperServiceTestCase {
         assertThat(e.getMessage(), equalTo("index [" + missingIndex + "] not found"));
     }
 
+    public void testAddLookupIndexAsBackingIndexFails() {
+        final long epochMillis = System.currentTimeMillis();
+        final int numBackingIndices = randomIntBetween(1, 4);
+        final String dataStreamName = randomAlphaOfLength(5);
+        IndexMetadata[] backingIndices = new IndexMetadata[numBackingIndices];
+        ProjectMetadata.Builder mb = ProjectMetadata.builder(randomProjectIdOrDefault());
+        for (int k = 0; k < numBackingIndices; k++) {
+            backingIndices[k] = IndexMetadata.builder(DataStream.getDefaultBackingIndexName(dataStreamName, k + 1, epochMillis))
+                .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putMapping(generateMapping("@timestamp"))
+                .build();
+            mb.put(backingIndices[k], false);
+        }
+        mb.put(DataStreamTestHelper.newInstance(dataStreamName, Arrays.stream(backingIndices).map(IndexMetadata::getIndex).toList()));
+
+        final String lookupIndexName = randomAlphaOfLength(5);
+        IndexMetadata lookupIndex = IndexMetadata.builder(lookupIndexName)
+            .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).put("index.mode", "lookup"))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .putMapping(generateMapping("@timestamp"))
+            .build();
+        mb.put(lookupIndex, false);
+
+        ProjectMetadata originalProject = mb.build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).putProjectMetadata(originalProject).build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MetadataDataStreamsService.modifyDataStream(
+                clusterState.projectState(originalProject.id()),
+                List.of(DataStreamAction.addBackingIndex(dataStreamName, lookupIndexName)),
+                this::getMapperService,
+                Settings.EMPTY
+            )
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("index [" + lookupIndexName + "] specifies [index.mode=lookup], which is not supported for data streams")
+        );
+    }
+
     public void testRemoveBrokenBackingIndexReference() {
         var dataStreamName = "my-logs";
         var project = DataStreamTestHelper.getProjectWithDataStreams(List.of(new Tuple<>(dataStreamName, 2)), List.of());

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -1459,6 +1459,60 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         );
     }
 
+    public void testInvalidDataStreamTemplateWithLookupIndexMode() throws Exception {
+        MetadataIndexTemplateService metadataIndexTemplateService = getMetadataIndexTemplateService();
+        ComposableIndexTemplate template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("my-ds-*"))
+            .template(Template.builder().settings(Settings.builder().put("index.mode", "lookup").build()).build())
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .build();
+        ProjectMetadata project = ProjectMetadata.builder(randomProjectIdOrDefault()).build();
+        Exception exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> metadataIndexTemplateService.validateIndexTemplateV2(project, "my-template", template)
+        );
+        assertThat(
+            exception.getMessage(),
+            containsString("index template [my-template] specifies [index.mode=lookup], which is not supported for data streams")
+        );
+    }
+
+    public void testInvalidDataStreamTemplateWithLookupIndexModeViaComponentTemplate() throws Exception {
+        // index.mode=lookup set in a component template must also be rejected when the composable template is a data stream template
+        MetadataIndexTemplateService metadataIndexTemplateService = getMetadataIndexTemplateService();
+        ComponentTemplate ct = new ComponentTemplate(
+            Template.builder().settings(Settings.builder().put("index.mode", "lookup").build()).build(),
+            1L,
+            new HashMap<>()
+        );
+        ComposableIndexTemplate composable = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("my-ds-composed-*"))
+            .componentTemplates(List.of("ct-lookup"))
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .build();
+        ProjectMetadata project = ProjectMetadata.builder(randomProjectIdOrDefault()).componentTemplates(Map.of("ct-lookup", ct)).build();
+        Exception exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> metadataIndexTemplateService.validateIndexTemplateV2(project, "my-composed-template", composable)
+        );
+        assertThat(
+            exception.getMessage(),
+            containsString("index template [my-composed-template] specifies [index.mode=lookup], which is not supported for data streams")
+        );
+    }
+
+    public void testNonDataStreamTemplateWithLookupIndexModeIsAllowed() throws Exception {
+        // A non-data-stream template with index.mode=lookup must not be rejected
+        MetadataIndexTemplateService metadataIndexTemplateService = getMetadataIndexTemplateService();
+        ComposableIndexTemplate template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of("my-lookup-*"))
+            .template(Template.builder().settings(Settings.builder().put("index.mode", "lookup").build()).build())
+            .build(); // no dataStreamTemplate
+        ProjectMetadata project = ProjectMetadata.builder(randomProjectIdOrDefault()).build();
+        // Must not throw
+        metadataIndexTemplateService.validateIndexTemplateV2(project, "my-lookup-template", template);
+    }
+
     public void testSystemDataStreamsIgnoredByValidateIndexTemplateV2() throws Exception {
         /*
          * This test makes sure that system data streams (which do not have named templates) do not appear in the list of data streams

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -127,6 +127,7 @@ tasks.named("yamlRestCompatTestTransform").configure(
     task.skipTest("esql/190_lookup_join/alias-pattern-multiple", "LOOKUP JOIN does not support index aliases for now")
     task.skipTest("esql/190_lookup_join/alias-pattern-single", "LOOKUP JOIN does not support index aliases for now")
     task.skipTest("esql/180_match_operator/match with disjunctions", "Disjunctions in full text functions work now")
+    task.skipTest("esql/191_lookup_join_on_datastreams/data streams supported in LOOKUP JOIN", "lookup index mode is no longer allowed in data streams")
     task.skipTest("esql/130_spatial/values unsupported for geo_point", "Spatial types are now supported in VALUES aggregation")
     task.skipTest("esql/130_spatial/values unsupported for geo_point status code", "Spatial types are now supported in VALUES aggregation")
     // Expected deprecation warning to compat yaml tests:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/191_lookup_join_on_datastreams.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/191_lookup_join_on_datastreams.yml
@@ -1,13 +1,8 @@
 ---
-setup:
+"data streams cannot use the lookup index mode":
   - requires:
-      test_runner_features: [capabilities, contains]
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: []
-          capabilities: [enable_lookup_join_on_aliases]
-      reason: "uses LOOKUP JOIN"
+      cluster_features: [ "data_stream.lookup_mode_not_allowed" ]
+      reason: "lookup index mode is no longer allowed in data streams"
 
   - do:
       cluster.put_component_template:
@@ -17,58 +12,14 @@ setup:
             settings:
               index:
                 mode: lookup
-
-
-  - do:
-      cluster.put_component_template:
-        name: my_mappings
-        body:
-          template:
-            mappings:
-              properties:
-                "@timestamp":
-                   type: date
-                x:
-                  type: keyword
-                y:
-                  type: keyword
+  - is_true: acknowledged
 
   - do:
+      catch: '/specifies \[index\.mode=lookup\], which is not supported for data streams/'
       indices.put_index_template:
         name: my_index_template
         body:
           index_patterns: my_data_stream*
           data_stream: {}
-          composed_of: [ "my_mappings", "my_settings" ]
+          composed_of: [ "my_settings" ]
           priority: 500
-
-  - do:
-      indices.create_data_stream:
-        name: my_data_stream
-
-  - do:
-      index:
-        index:  my_data_stream
-        body:
-          '@timestamp': '2020-12-12'
-          'x': 'foo'
-          'y': 'y1'
-
-  - do:
-      indices.refresh:
-        index: my_data_stream
----
-"data streams supported in LOOKUP JOIN":
-  - do:
-      esql.query:
-        body:
-          query: 'ROW x = "foo" | LOOKUP JOIN my_data_stream ON x | KEEP x, y | LIMIT 1'
-
-  - match: {columns.0.name: "x"}
-  - match: {columns.0.type: "keyword"}
-  - match: {columns.1.name: "y"}
-  - match: {columns.1.type: "keyword"}
-  - match: {values.0: ["foo", "y1"]}
-
-
-


### PR DESCRIPTION
## Summary

The `lookup` index mode is single-shard, cannot roll over, and is skipped by auto-sharding — fundamentally incompatible with data streams, which are append-only, rolled-over, and auto-sharded. Previously nothing prevented creating a lookup-mode data stream, resulting in a half-broken object patched by three ad-hoc guards in `DataStream.unsafeRollover`, `DataStreamAutoShardingService`, and `IndexModeSettingsProvider`.

This change rejects the combination at the source, at every entry point where a lookup-mode index can enter a data stream:

- **`PUT _index_template`** — `MetadataIndexTemplateService.validateIndexTemplateV2` rejects a data stream template (or composed component template) that resolves to `index.mode=lookup`. Also fires on component template updates that cause a dependent data stream template to resolve to lookup mode (same BWC behaviour as all other template validations).
- **`PUT _data_stream` / auto-create** — `MetadataCreateDataStreamService.createDataStream` backstop for pre-existing templates in upgraded clusters; fires before any backing index is created.
- **`POST _data_stream/_modify` (add_backing_index / add_failure_store_index)** — `MetadataDataStreamsService.addBackingIndex` rejects lookup-mode concrete indices.

The existing guards in `DataStream.unsafeRollover` and `DataStreamAutoShardingService` are kept as defence-in-depth for any lookup data streams that already exist in upgraded clusters.

### Backwards compatibility

No wire-format change; no new `TransportVersion` needed.

**One accepted behaviour change:** `addComponentTemplate` re-validates all dependent composable templates. In an upgraded cluster that holds a lookup-mode data stream template, updating any unrelated component template it composes will now fail until the offending template is fixed or removed. This is consistent with how every other template validation has been introduced in Elasticsearch.

## Changes

- `IndexMode.supportsDataStreams()` — new overridable predicate, defaults to `true`; `LOOKUP` overrides to `false`.
- `IndexMode.validateSupportsDataStreams(@Nullable IndexMode, String)` — null-safe throwing helper called at all three enforcement sites.
- `MetadataIndexTemplateService` — new `static validateIndexMode(...)` method; called from `validateIndexTemplateV2`.
- `MetadataCreateDataStreamService` — backstop check after template resolution, before index creation.
- `MetadataDataStreamsService` — check on `indexMetadata.getIndexMode()` in `addBackingIndex`.
- `DataStreamFeatures.LOOKUP_MODE_NOT_ALLOWED_IN_DATA_STREAMS` — test-only `NodeFeature` gating the YAML tests.
- `esql/191_lookup_join_on_datastreams.yml` — inverted: now asserts the template PUT is rejected. `192_lookup_join_on_aliases.yml` keeps alias-over-lookup coverage intact.
- New YAML file `data_stream/310_lookup_mode_not_allowed.yml` — 4 cases covering all enforcement points plus the standalone-index control.
- `docs/reference/elasticsearch/index-settings/index-modules.md` — added `*(standalone indices only)*` to the `lookup` bullet.

## Test plan

- [x] `MetadataIndexTemplateServiceTests` — 3 new unit tests (direct mode, via component template, non-data-stream template allowed)
- [x] `MetadataCreateDataStreamServiceTests` — `testCreateDataStreamWithLookupIndexModeFails`
- [x] `MetadataDataStreamsServiceTests` — `testAddLookupIndexAsBackingIndexFails`
- [x] `data_stream/310_lookup_mode_not_allowed.yml` — 4 YAML REST cases (all passed)
- [x] `esql/191_lookup_join_on_datastreams.yml` — inverted test passed
- [x] Existing data stream and auto-sharding tests pass unmodified