### PR TITLE
[8.19] Expand retries for Windows FS operations. (#156286)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -13,12 +13,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.packaging.test.PackagingTestCase.getRootTempDir;
 import static org.elasticsearch.packaging.util.FileUtils.lsGlob;

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -75,11 +75,9 @@ public class Cleanup {
         // when we run es as a role user on windows, add the equivalent here
         // delete files that may still exist
 
-        lsGlob(getRootTempDir(), "elasticsearch*").forEach(Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm);
+        lsGlob(getRootTempDir(), "elasticsearch*").forEach(FileUtils::rm);
         final List<String> filesToDelete = Platforms.WINDOWS ? ELASTICSEARCH_FILES_WINDOWS : ELASTICSEARCH_FILES_LINUX;
-        // windows needs leniency due to asinine releasing of file locking async from a process exiting
-        Consumer<? super Path> rm = Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm;
-        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(rm);
+        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(FileUtils::rm);
     }
 
     private static void purgePackagesLinux() {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.packaging.util;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -75,19 +76,24 @@ public class FileUtils {
     }
 
     public static void rm(Path... paths) {
-        try {
-            IOUtils.rm(paths);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (Platforms.WINDOWS) {
+            runWithRetries(() -> IOUtils.rm(paths));
+        } else {
+            try {
+                IOUtils.rm(paths);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
-    public static void rmWithRetries(Path... paths) {
+    // windows needs leniency due to asinine releasing of file locking async from a process exiting
+    private static void runWithRetries(CheckedRunnable<IOException> runnable) {
         int tries = 10;
-        Exception exception = null;
+        IOException exception = null;
         while (tries-- > 0) {
             try {
-                IOUtils.rm(paths);
+                runnable.run();
                 return;
             } catch (IOException e) {
                 if (exception == null) {
@@ -103,7 +109,7 @@ public class FileUtils {
                 return;
             }
         }
-        throw new RuntimeException(exception);
+        throw new UncheckedIOException(exception);
     }
 
     public static Path mktempDir(Path path) {
@@ -131,6 +137,10 @@ public class FileUtils {
     }
 
     public static Path mv(Path source, Path target) {
+        if (Platforms.WINDOWS) {
+            runWithRetries(() -> Files.move(source, target));
+            return target;
+        }
         try {
             return Files.move(source, target);
         } catch (IOException e) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Expand retries for Windows FS operations. (#156286)](https://github.com/elastic/elasticsearch/pull/156286)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)