### PR TITLE
[Docs] Document Jira Data Center PAT authentication

### DIFF
--- a/docs/reference/search-connectors/es-connectors-jira.md
+++ b/docs/reference/search-connectors/es-connectors-jira.md
@@ -120,16 +120,16 @@ The following configuration fields are required to set up the connector:
 `data_source`
 :   Dropdown to determine the Jira platform type: `Jira Cloud`, `Jira Server`, or `Jira Data Center`. Default value is `Jira Cloud`.
 
-`data_center_auth_method`
+`data_center_auth_method` {applies_to}`stack: ga 9.6`
 :   The authentication method for Jira Data Center: `Basic authentication` or `Personal access token`. Default value is `Basic authentication`.
 
 `data_center_username`
-:   The username of the account for Jira Data Center. This field is only available for `Basic authentication`.
+:   The username of the account for Jira Data Center. {applies_to}`stack: ga 9.6` This field is only available for `Basic authentication`.
 
 `data_center_password`
-:   The password of the account to be used for Jira Data Center. This field is only available for `Basic authentication`.
+:   The password of the account to be used for Jira Data Center. {applies_to}`stack: ga 9.6` This field is only available for `Basic authentication`.
 
-`data_center_personal_access_token`
+`data_center_personal_access_token` {applies_to}`stack: ga 9.6`
 :   The personal access token for Jira Data Center. This field is only available for `Personal access token`.
 
 `username`

--- a/docs/reference/search-connectors/es-connectors-jira.md
+++ b/docs/reference/search-connectors/es-connectors-jira.md
@@ -120,11 +120,17 @@ The following configuration fields are required to set up the connector:
 `data_source`
 :   Dropdown to determine the Jira platform type: `Jira Cloud`, `Jira Server`, or `Jira Data Center`. Default value is `Jira Cloud`.
 
+`data_center_auth_method`
+:   The authentication method for Jira Data Center: `Basic authentication` or `Personal access token`. Default value is `Basic authentication`.
+
 `data_center_username`
-:   The username of the account for Jira Data Center.
+:   The username of the account for Jira Data Center. This field is only available for `Basic authentication`.
 
 `data_center_password`
-:   The password of the account to be used for Jira Data Center.
+:   The password of the account to be used for Jira Data Center. This field is only available for `Basic authentication`.
+
+`data_center_personal_access_token`
+:   The personal access token for Jira Data Center. This field is only available for `Personal access token`.
 
 `username`
 :   The username of the account for Jira Server.


### PR DESCRIPTION
Documents the new Data Center authentication fields for the Jira connector from [elastic/connectors#4338](https://github.com/elastic/connectors/pull/4338) ([elastic/connectors#3253](https://github.com/elastic/connectors/issues/3253)).

Changes:
- `es-connectors-jira.md`: add `data_center_auth_method` and `data_center_personal_access_token`; note that username/password apply only for basic authentication.

Docs-only change; no code or console snippets affected.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`?
- [x] If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [ ] If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.