### PR TITLE
Add fetch circuit breaker category, fix wildcard case-insensitive label

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -70,6 +70,9 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     /** Per-phase retained query memory charged by {@link org.elasticsearch.index.query.AbstractQueryBuilder#toQuery}. */
     public static final String CATEGORY_QUERY = "query";
 
+    /** Fetch-phase retained memory. */
+    public static final String CATEGORY_FETCH = "fetch";
+
     /** Query-construction reservation for compiled wildcard automata. */
     public static final String CATEGORY_WILDCARD = "wildcard";
 
@@ -84,6 +87,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
 
     private static final Set<String> KNOWN_CATEGORIES = Set.of(
         CATEGORY_QUERY,
+        CATEGORY_FETCH,
         CATEGORY_WILDCARD,
         CATEGORY_REGEXP,
         CATEGORY_RANGE,

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -91,7 +91,7 @@ public class AutomatonQueries {
             nfa,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             circuitBreaker,
-            "wildcard-ci:" + wildcardquery.field()
+            ChildMemoryCircuitBreaker.CATEGORY_WILDCARD + "[ci]:" + wildcardquery.field()
         );
     }
 
@@ -105,7 +105,7 @@ public class AutomatonQueries {
             nfa,
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
             circuitBreaker,
-            "wildcard:" + wildcardquery.field()
+            ChildMemoryCircuitBreaker.CATEGORY_WILDCARD + ":" + wildcardquery.field()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -307,7 +308,8 @@ public final class FetchPhase {
             ? bytes -> memoryChecker.accept(bytes > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) bytes)
             : bytes -> {
                 if (bytes > 0) {
-                    context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, "script_field");
+                    context.circuitBreaker()
+                        .addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[script_field]");
                     scriptFieldsBreakerBytes[0] += bytes;
                 }
             };
@@ -347,7 +349,7 @@ public final class FetchPhase {
 
             IntConsumer memChecker = memoryChecker != null ? memoryChecker : bytes -> {
                 locallyAccumulatedBytes[0] += bytes;
-                if (context.checkCircuitBreaker(locallyAccumulatedBytes[0], "fetch source")) {
+                if (context.checkCircuitBreaker(locallyAccumulatedBytes[0], ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[source]")) {
                     addRequestBreakerBytes(locallyAccumulatedBytes[0]);
                     locallyAccumulatedBytes[0] = 0;
                 }
@@ -445,7 +447,7 @@ public final class FetchPhase {
                 context.addFetchThreadsMetrics(docsIterator.getFetchMetricsDelta());
                 long leakedBytes = docsIterator.getRequestBreakerBytes();
                 if (leakedBytes > 0) {
-                    context.circuitBreaker().addWithoutBreaking(-leakedBytes);
+                    context.circuitBreaker().addWithoutBreaking(-leakedBytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
                 }
                 buildListener.onFailure(e);
                 listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSearchResult.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.search.fetch;
 
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -136,7 +137,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
 
     public void releaseCircuitBreakerBytes(CircuitBreaker circuitBreaker) {
         if (searchHitsSizeBytes > 0L) {
-            circuitBreaker.addWithoutBreaking(-searchHitsSizeBytes);
+            circuitBreaker.addWithoutBreaking(-searchHitsSizeBytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
             searchHitsSizeBytes = 0L;
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.search.fetch.chunk;
 
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
@@ -43,6 +44,13 @@ import java.util.function.LongConsumer;
 class FetchPhaseResponseStream extends AbstractRefCounted {
 
     private static final Logger logger = LogManager.getLogger(FetchPhaseResponseStream.class);
+
+    /**
+     * Label used for both the per-chunk accumulation admits here and the embedded-last-chunk admit in
+     * {@link TransportFetchPhaseCoordinationAction}, so all chunked-fetch coordination memory is tracked under a
+     * single {@code fetch} sub-category.
+     */
+    static final String FETCH_CHUNK_BREAKER_LABEL = ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[chunk]";
 
     private final int shardIndex;
     private final int expectedTotalDocs;
@@ -98,7 +106,7 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
         boolean success = false;
         try {
             long estimatedRetainedBytes = chunk.estimatedRetainedBytes();
-            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, "fetch_chunk_accumulation");
+            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, FETCH_CHUNK_BREAKER_LABEL);
             totalBreakerBytes.addAndGet(estimatedRetainedBytes);
 
             chunk.consumeHits((position, hit) -> queue.add(new SequencedHit(hit, position)));
@@ -209,7 +217,7 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
 
         // Release circuit breaker bytes added during accumulation when hits are released from memory
         if (totalBreakerBytes.get() > 0) {
-            circuitBreaker.addWithoutBreaking(-totalBreakerBytes.get());
+            circuitBreaker.addWithoutBreaking(-totalBreakerBytes.get(), FETCH_CHUNK_BREAKER_LABEL);
             if (logger.isDebugEnabled()) {
                 logger.debug(
                     "Released [{}] breaker bytes for shard [{}], used breaker bytes [{}]",

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
@@ -241,7 +241,7 @@ public class TransportFetchPhaseCoordinationAction extends HandledTransportActio
                         responseStream.addHitWithSequence(hit, position);
                     }
                 }
-                circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, "fetch_chunk_accumulation");
+                circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedRetainedBytes, FetchPhaseResponseStream.FETCH_CHUNK_BREAKER_LABEL);
                 responseStream.trackBreakerBytes(estimatedRetainedBytes);
             }
 

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTests.java
@@ -27,16 +27,21 @@ public class ChildMemoryCircuitBreakerTests extends ESTestCase {
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_REGEXP, ChildMemoryCircuitBreaker.categoryFor("regexp"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_RANGE, ChildMemoryCircuitBreaker.categoryFor("range"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_PREALLOCATE, ChildMemoryCircuitBreaker.categoryFor("preallocate"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch"));
     }
 
     public void testCategoryForCompositeLabelsBracket() {
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_PREALLOCATE, ChildMemoryCircuitBreaker.categoryFor("preallocate[aggregations]"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_PREALLOCATE, ChildMemoryCircuitBreaker.categoryFor("preallocate[test]"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch[source]"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch[script_field]"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_WILDCARD, ChildMemoryCircuitBreaker.categoryFor("wildcard[ci]:my_field"));
     }
 
     public void testCategoryForCompositeLabelsColon() {
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_RANGE, ChildMemoryCircuitBreaker.categoryFor("range:my_field"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_RANGE, ChildMemoryCircuitBreaker.categoryFor("range:field.keyword"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_WILDCARD, ChildMemoryCircuitBreaker.categoryFor("wildcard:my_field"));
     }
 
     public void testCategoryForUnknownLabel() {


### PR DESCRIPTION
The request circuit breaker tracks memory usage per "category" (`query`, `wildcard`, `regexp`, range, `preallocate`), but most of the memory it actually tracks doesn't fall into any of those - it just gets lumped into `uncategorized`. That makes it hard to tell what's actually using memory when you're looking at the metrics.

There was also a small bug: case-insensitive wildcard queries (`case_insensitive: true`) used the label `wildcard-ci:<field>`, which doesn't actually match the `wildcard` category due to how the label matching works. So this memory was silently counted as "uncategorized" instead of "wildcard".

### Update
- Adds a new `fetch` category, and uses it everywhere fetch-phase memory is charged against the breaker: loading `_source`, script fields, and the chunked-fetch accumulation buffer on the coordinator.
- Fixes the case-insensitive wildcard label so it's correctly counted under `wildcard` instead of falling through to `uncategorized`.

No behavior change from a user's perspective - this only affects how memory is labeled internally for metrics