### PR TITLE
[9.5] docs: behavior when both `pipeline` query is passed in bulk request and (#151096)

### DIFF
--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -260,12 +260,22 @@ $$$index-routing-allocation-enable-setting$$$
 $$$index-default-pipeline$$$
 
 `index.default_pipeline` {applies_to}`serverless: all`
-:   Default ingest pipeline for the index. Index requests will fail if the default pipeline is set and the pipeline does not exist. The default may be overridden using the `pipeline` parameter. The special pipeline name `_none` indicates no default ingest pipeline will run.
+:   Default ingest pipeline for the index. Index requests will fail if the default pipeline is set and the pipeline does not exist.
+
+    The default pipeline is used only if no request-specific pipeline is specified. The pipeline to execute is resolved using the following order of precedence, from highest to lowest:
+
+    1. The `pipeline` parameter specified in the individual document's action/metadata line of a bulk request.
+    2. The `pipeline` query parameter passed in the bulk or index request URL.
+    3. The `index.default_pipeline` index setting.
+
+    For example, a `pipeline` query parameter overrides `index.default_pipeline`, and a `pipeline` parameter in a bulk action/metadata line overrides both.
+
+    The special pipeline name `_none` indicates no ingest pipeline will run. This can be used at any of the above levels to disable pipeline execution and override lower-precedence settings.
 
 $$$index-final-pipeline$$$
 
 `index.final_pipeline` {applies_to}`serverless: all`
-:   Final ingest pipeline for the index. Indexing requests will fail if the final pipeline is set and the pipeline does not exist. The final pipeline always runs after the request pipeline (if specified) and the default pipeline (if it exists). The special pipeline name `_none` indicates no final ingest pipeline will run.
+:   Final ingest pipeline for the index. Indexing requests will fail if the final pipeline is set and the pipeline does not exist. The final pipeline always runs after the request pipeline (if specified via query parameter or bulk action/metadata line) and the default pipeline (if it exists). The special pipeline name `_none` indicates no final ingest pipeline will run.
 
     ::::{note}
     You can’t use a final pipeline to change the `_index` field. If the pipeline attempts to change the `_index` field, the indexing request will fail.


### PR DESCRIPTION
Backports the following commits to 9.5:
 - docs: behavior when both `pipeline` query is passed in bulk request and (#151096)