### PR TITLE
Reuse LookupJoinTypesIT indices across suite

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -13,6 +13,7 @@ import io.netty.util.ThreadDeathWatcher;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
@@ -220,6 +221,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -231,6 +234,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -3156,7 +3160,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         assert INSTANCE == null;
         if (isSuiteScopedTest(targetClass)) {
             // note we need to do this this way to make sure this is reproducible
-            INSTANCE = (ESIntegTestCase) targetClass.getConstructor().newInstance();
+            INSTANCE = newSuiteScopeTestInstance(targetClass);
             boolean success = false;
             try {
                 INSTANCE.printTestMessage("setup");
@@ -3170,6 +3174,42 @@ public abstract class ESIntegTestCase extends ESTestCase {
             }
         } else {
             INSTANCE = null;
+        }
+    }
+
+    private static ESIntegTestCase newSuiteScopeTestInstance(Class<?> targetClass) throws Exception {
+        try {
+            return (ESIntegTestCase) targetClass.getConstructor().newInstance();
+        } catch (NoSuchMethodException e) {
+            // Parameterized tests do not have a no-argument constructor. The suite fixture does not participate in the test runs, so
+            // using the first parameter set gives it the same construction semantics while setupSuiteScopeCluster initializes static
+            // state shared by all parameterized instances.
+            for (Method method : targetClass.getMethods()) {
+                if (method.getAnnotation(ParametersFactory.class) == null) {
+                    continue;
+                }
+                Object parameters = method.invoke(null);
+                if (parameters instanceof Iterable<?> iterable) {
+                    Iterator<?> iterator = iterable.iterator();
+                    if (iterator.hasNext() == false) {
+                        throw new IllegalStateException("parameter factory [" + method.getName() + "] returned no parameters", e);
+                    }
+                    Object firstParameters = iterator.next();
+                    if (firstParameters instanceof Object[] arguments) {
+                        for (Constructor<?> constructor : targetClass.getConstructors()) {
+                            if (constructor.getParameterCount() == arguments.length) {
+                                return (ESIntegTestCase) constructor.newInstance(arguments);
+                            }
+                        }
+                    }
+                    throw new IllegalStateException(
+                        "parameter factory [" + method.getName() + "] did not return arguments for a public constructor",
+                        e
+                    );
+                }
+                throw new IllegalStateException("parameter factory [" + method.getName() + "] must return an Iterable", e);
+            }
+            throw e;
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
@@ -8,11 +8,9 @@
 package org.elasticsearch.xpack.esql.action;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.lucene.queryparser.ext.Extensions.Pair;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -21,6 +19,7 @@ import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.SuiteScopeTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.VerificationException;
@@ -106,11 +105,8 @@ import static org.hamcrest.Matchers.is;
  * E.g. the field {@code main_byte} will occur another time in the index {@code main_byte_as_short} when we're testing a byte-short union
  * type.
  */
-// TODO: This suite creates a lot of indices. It should be sufficient to just create 1 main index with 1 field per relevant type and 1
-// lookup index with 1 field per relevant type; only union types require additional main indices so we can have the same field mapped to
-// different types.
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 @ClusterScope(scope = SUITE, numClientNodes = 1, numDataNodes = 1)
+@SuiteScopeTestCase
 @LuceneTestCase.SuppressFileSystems(value = "HandleLimitFS")
 public class LookupJoinTypesIT extends ESIntegTestCase {
     private static final String MAIN_INDEX_PREFIX = "main_";
@@ -147,6 +143,7 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
     }
 
     private static final Map<Pair<String, BinaryComparisonOperation>, TestConfigs> testConfigurations = new HashMap<>();
+    private static final TestConfigs suiteTestConfigurations;
     static {
         List<BinaryComparisonOperation> operations = new ArrayList<>(List.of(BinaryComparisonOperation.values()));
         operations.add(null); // null means field-based join
@@ -361,21 +358,15 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
                 }
             }
         }
-        // Make sure we have never added two configurations with the same lookup index name.
-        // This prevents accidentally adding the same test config to two different groups.
-        Set<String> knownTypes = new HashSet<>();
+        suiteTestConfigurations = new TestConfigs("all", null);
         for (TestConfigs configs : testConfigurations.values()) {
             for (TestConfig config : configs.configs.values()) {
-                if (knownTypes.contains(config.lookupIndexName())) {
-                    throw new IllegalArgumentException("Duplicate lookup index name: " + config.lookupIndexName());
+                TestConfig existing = suiteTestConfigurations.configs.putIfAbsent(config.lookupIndexName(), config);
+                if (existing != null && existing.lookupIndex().equals(config.lookupIndex()) == false) {
+                    throw new IllegalArgumentException("Conflicting lookup index mappings: " + config.lookupIndexName());
                 }
-                knownTypes.add(config.lookupIndexName());
             }
         }
-    }
-
-    static String stringForOperation(BinaryComparisonOperation operation) {
-        return operation == null ? "_field" : "_" + operation.name().toLowerCase(Locale.ROOT);
     }
 
     private static boolean existingIndex(
@@ -384,8 +375,14 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
         DataType lookupType,
         BinaryComparisonOperation operation
     ) {
-        String indexName = LOOKUP_INDEX_PREFIX + mainType.esType() + "_" + lookupType.esType() + stringForOperation(operation);
-        return existing.stream().anyMatch(c -> c.exists(indexName));
+        String indexName = LOOKUP_INDEX_PREFIX + mainType.esType() + "_" + lookupType.esType();
+        return existing.stream().filter(c -> c.operation == operation).anyMatch(c -> c.exists(indexName));
+    }
+
+    @Override
+    public void setupSuiteScopeCluster() {
+        initIndexes(suiteTestConfigurations);
+        initData(suiteTestConfigurations);
     }
 
     /** This test generates documentation for the supported output types of the lookup join. */
@@ -451,8 +448,6 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
 
     private void testLookupJoinTypes(String group, BinaryComparisonOperation operation) {
         TestConfigs configs = testConfigurations.get(new Pair<>(group, operation));
-        initIndexes(configs);
-        initData(configs);
         for (TestConfig config : configs.values()) {
             if ((isValidDataType(config.mainType()) && isValidDataType(config.lookupType())) == false) {
                 continue;
@@ -804,7 +799,7 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
         }
 
         default String lookupIndexName() {
-            return LOOKUP_INDEX_PREFIX + mainType().esType() + "_" + lookupType().esType() + stringForOperation(operation());
+            return LOOKUP_INDEX_PREFIX + mainType().esType() + "_" + lookupType().esType();
         }
 
         default TestMapping lookupIndex() {
@@ -924,17 +919,11 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
         @Override
         public String lookupIndexName() {
             // Override so it doesn't clash with other lookup indices from non-union type tests.
-            return LOOKUP_INDEX_PREFIX
-                + mainType().esType()
-                + "_union_"
-                + otherMainType().esType()
-                + "_"
-                + lookupType().esType()
-                + stringForOperation(operation());
+            return LOOKUP_INDEX_PREFIX + mainType().esType() + "_union_" + otherMainType().esType() + "_" + lookupType().esType();
         }
 
         private String additionalIndexName() {
-            return mainFieldName() + "_as_" + otherMainType().typeName() + stringForOperation(operation());
+            return mainFieldName() + "_as_" + otherMainType().typeName();
         }
 
         @Override


### PR DESCRIPTION
## Summary

- create the `LookupJoinTypesIT` indices and documents once per suite
- share lookup indices across comparison-operation parameter variants
- retain dedicated union-type main indices while creating them only once
- support suite-scoped parameterized integration tests when no public no-argument constructor exists
- remove the temporary 40-minute suite timeout

## Why

`LookupJoinTypesIT` previously initialized and wiped roughly 14 indices for every parameterized test invocation. With seven parameter variants across nine methods, this resulted in 63 create-and-wipe cycles and caused timeouts in constrained environments.

The suite now builds the combined mappings and fixtures once, then reuses them across all test methods and parameter variants.

This supersedes the temporary 40-minute `@TimeoutSuite` workaround in #155775. Suite-scoped index setup brings runtime well within the default 20-minute limit, so the override is removed intentionally.

## Validation

- `./gradlew :test:framework:test :test:framework:spotlessJavaCheck :x-pack:plugin:esql:spotlessJavaCheck`
- `./gradlew :x-pack:plugin:esql:internalClusterTest --tests org.elasticsearch.xpack.esql.action.LookupJoinTypesIT -Dtests.output=always` (68 tests, 0 failures)

## Follow-up

The muted `testOutputSupportedTypes {p0=LT}` failure (#155694) is unrelated to suite setup cost; it should be tracked and unmuted separately once that bug is fixed.

Closes #155776