### PR TITLE
Add Accountable heap estimates for small metadata types

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -19,7 +21,7 @@ import java.util.Objects;
 /**
  * Base class for rollover request conditions
  */
-public abstract class Condition<T> implements NamedWriteable, ToXContentFragment {
+public abstract class Condition<T> implements NamedWriteable, ToXContentFragment, Accountable {
 
     /*
      * Describes the type of condition - a min_* condition (MIN), max_* condition (MAX), or an automatic condition (automatic conditions
@@ -82,6 +84,16 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
 
     public Type type() {
         return type;
+    }
+
+    /**
+     * Estimated heap footprint of this condition. Counts the shared {@code type} enum singleton (so summing many conditions over-counts
+     * those few bytes). All concrete subclasses only set the inherited {@code value} and declare no extra fields.
+     */
+    @Override
+    public final long ramBytesUsed() {
+        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.shallowSizeOf(type) + RamUsageEstimator.sizeOf(name)
+            + RamUsageEstimator.sizeOfObject(value);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -29,7 +31,10 @@ import java.util.Objects;
 public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize averageShardSize)
     implements
         Writeable,
-        ToXContentFragment {
+        ToXContentFragment,
+        Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexMetadataStats.class);
 
     public static final ParseField WRITE_LOAD_FIELD = new ParseField("write_load");
     public static final ParseField AVERAGE_SIZE_FIELD = new ParseField("avg_size");
@@ -124,6 +129,12 @@ public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize
 
     public IndexWriteLoad writeLoad() {
         return indexWriteLoad;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // averageShardSize holds only primitives, so its shallow size is a complete accounting.
+        return BASE_RAM_BYTES_USED + indexWriteLoad.ramBytesUsed() + RamUsageEstimator.shallowSizeOf(averageShardSize);
     }
 
     public record AverageShardSize(long totalSizeInBytes, int numberOfShards) implements Writeable, ToXContentFragment {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -26,7 +28,9 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
-public class IndexWriteLoad implements Writeable, ToXContentFragment {
+public class IndexWriteLoad implements Writeable, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexWriteLoad.class);
 
     public static final ParseField SHARDS_WRITE_LOAD_FIELD = new ParseField("loads");
     public static final ParseField SHARDS_UPTIME_IN_MILLIS = new ParseField("uptimes");
@@ -212,6 +216,12 @@ public class IndexWriteLoad implements Writeable, ToXContentFragment {
 
     public int numberOfShards() {
         return shardWriteLoad.length;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(shardWriteLoad) + RamUsageEstimator.sizeOf(shardUptimeInMillis)
+            + RamUsageEstimator.sizeOf(shardRecentWriteLoad) + RamUsageEstimator.sizeOf(shardPeakWriteLoad);
     }
 
     private void assertShardInBounds(int shardId) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.node;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.regex.Regex;
@@ -21,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class DiscoveryNodeFilters {
+public class DiscoveryNodeFilters implements Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DiscoveryNodeFilters.class);
 
     public static final Set<String> SINGLE_NODE_NAMES = Set.of("_id", "_name", "name");
     static final Set<String> NON_ATTRIBUTE_NAMES = Set.of("_ip", "_host_ip", "_publish_ip", "host", "_id", "_name", "name");
@@ -252,6 +256,17 @@ public class DiscoveryNodeFilters {
 
     public boolean hasFilters() {
         return filters.isEmpty() == false;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // opType is a shared enum singleton; counting it here over-counts those few bytes when many filters are summed.
+        long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(opType) + RamUsageEstimator.sizeOfMap(filters);
+        // withoutTierPreferences may alias this instance.
+        if (withoutTierPreferences != null && withoutTierPreferences != this) {
+            size += withoutTierPreferences.ramBytesUsed();
+        }
+        return size;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexLongFieldRange.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexLongFieldRange.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.shard;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,7 +31,9 @@ import java.util.stream.IntStream;
  * information is accumulated shard-by-shard, and we keep track of which shards are represented in this value. Only once all shards are
  * represented should this information be considered accurate for the index.
  */
-public class IndexLongFieldRange implements Writeable, ToXContentFragment {
+public class IndexLongFieldRange implements Writeable, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexLongFieldRange.class);
 
     /**
      * Sentinel value indicating that no information is currently available, for instance because the index has just been created.
@@ -71,6 +75,12 @@ public class IndexLongFieldRange implements Writeable, ToXContentFragment {
      */
     public boolean containsAllShardRanges() {
         return isComplete() && this != IndexLongFieldRange.UNKNOWN;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // shards is null once the range is complete (covers all shards); when non-null it holds the tracked shard ids.
+        return BASE_RAM_BYTES_USED + (shards == null ? 0L : RamUsageEstimator.sizeOf(shards));
     }
 
     // exposed for testing

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.rollover;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return Condition.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("name", "value", "type");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return new MaxDocsCondition(1L);
+    }
+
+    /**
+     * Non-tautology check: the different value types must each contribute a boxed/value cost on top of the shallow condition size.
+     */
+    public void testRamBytesUsedCountsConditionValue() {
+        long shallow = shallowSizeOf(new MaxDocsCondition(1L));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(shallow));
+        assertThat(new MaxSizeCondition(ByteSizeValue.ofMb(1)).ramBytesUsed(), greaterThan(shallow));
+        assertThat(new MaxAgeCondition(TimeValue.timeValueDays(1)).ramBytesUsed(), greaterThan(shallow));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexMetadataStatsRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexMetadataStats.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("indexWriteLoad", "averageShardSize");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return new IndexMetadataStats(IndexWriteLoad.builder(16).build(), 100L, 16);
+    }
+
+    /**
+     * Non-tautology check: the stats estimate must include the nested {@link IndexWriteLoad}, so more shards means a larger estimate.
+     */
+    public void testRamBytesUsedIncludesWriteLoad() {
+        IndexMetadataStats few = new IndexMetadataStats(IndexWriteLoad.builder(1).build(), 100L, 1);
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexWriteLoadRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexWriteLoad.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("shardWriteLoad", "shardUptimeInMillis", "shardRecentWriteLoad", "shardPeakWriteLoad");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return IndexWriteLoad.builder(16).build();
+    }
+
+    /**
+     * Non-tautology check: more shards means larger backing arrays and therefore a larger estimate.
+     */
+    public void testRamBytesUsedGrowsWithShardCount() {
+        IndexWriteLoad few = IndexWriteLoad.builder(1).build();
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.node;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class DiscoveryNodeFiltersRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return DiscoveryNodeFilters.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("filters", "withoutTierPreferences", "opType");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return DiscoveryNodeFilters.buildFromKeyValues(
+            DiscoveryNodeFilters.OpType.AND,
+            Map.of("_id", List.of("n1", "n2"), "rack", List.of("r1"))
+        );
+    }
+
+    /**
+     * Non-tautology check: more filter attributes must increase the reported size.
+     */
+    public void testRamBytesUsedGrowsWithFilters() {
+        DiscoveryNodeFilters one = DiscoveryNodeFilters.buildFromKeyValues(DiscoveryNodeFilters.OpType.AND, Map.of("_id", List.of("n1")));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexLongFieldRangeRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexLongFieldRange.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("shards");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        // NO_SHARDS still holds a non-null shards array, so the estimate covers array overhead rather than a null leaf.
+        return IndexLongFieldRange.NO_SHARDS;
+    }
+
+    /**
+     * Non-tautology check: a range still tracking shards (holding a non-null {@code shards} array, e.g. {@code NO_SHARDS}) must be larger
+     * than a complete range whose array is {@code null} (e.g. {@code UNKNOWN}).
+     */
+    public void testRamBytesUsedCountsTrackedShardsArray() {
+        assertThat(IndexLongFieldRange.NO_SHARDS.isComplete(), org.hamcrest.Matchers.is(false));
+        assertThat(IndexLongFieldRange.UNKNOWN.isComplete(), org.hamcrest.Matchers.is(true));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(IndexLongFieldRange.UNKNOWN.ramBytesUsed()));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test;
+
+import org.apache.lucene.tests.util.RamUsageTester;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Base class for tests of {@link Accountable#ramBytesUsed()} implementations that estimate an object's heap footprint field-by-field.
+ * <p>
+ * The core check is a structural tripwire: every non-static, non-primitive field declared on the class under test must be classified as
+ * either <em>accounted for</em> (its heap cost is added explicitly in {@code ramBytesUsed()}) or <em>excluded</em> (deliberately not
+ * counted, e.g. a derived cache or a documented gap). Primitive fields are ignored automatically because they are already covered by the
+ * shallow instance size that every {@code ramBytesUsed()} implementation is expected to include. When someone adds or removes a reference
+ * field without updating the estimate, this test fails, forcing them to decide how the new field should be accounted for.
+ * <p>
+ * When {@link #assertsAgainstRamUsageTester()} is true, a value check also asserts that {@code ramBytesUsed()} never under-counts the
+ * retained heap measured by Lucene's {@link RamUsageTester}. Subclasses that deliberately omit shared/interned state (e.g. interned
+ * {@code Settings} strings, shared enum singletons, or cross-index deduplicated mappings) should override that hook to {@code false} and
+ * document why a full-graph comparison would fail by design; those classes still get the structural tripwire and should keep their own
+ * behavioural assertions.
+ */
+public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
+
+    /**
+     * @return the concrete {@link Accountable} class whose fields are checked. Only fields declared directly on this class are inspected;
+     * fields inherited from a superclass are the superclass's own responsibility to account for and test.
+     */
+    protected abstract Class<? extends Accountable> classUnderTest();
+
+    /**
+     * @return names of reference fields whose heap cost is added explicitly in {@code ramBytesUsed()}.
+     */
+    protected abstract Set<String> fieldsAccountedForInRamBytesUsed();
+
+    /**
+     * @return names of reference fields deliberately not counted in {@code ramBytesUsed()}, each of which should have a comment (in the
+     * subclass or the production code) explaining why it needs no accounting.
+     */
+    protected abstract Set<String> fieldsExcludedFromRamBytesUsed();
+
+    /**
+     * A populated instance of {@link #classUnderTest()} for {@link #testRamBytesUsedNeverUnderCountsActualHeap()}. Subclasses that opt out
+     * via {@link #assertsAgainstRamUsageTester()} need not override this.
+     */
+    protected Accountable createTestInstance() {
+        throw new UnsupportedOperationException(
+            classUnderTest().getSimpleName() + " must implement createTestInstance() when assertsAgainstRamUsageTester() is true"
+        );
+    }
+
+    /**
+     * Whether to assert {@code ramBytesUsed() >= RamUsageTester.ramUsed(...)}. Defaults to {@code true}. Override to {@code false} when the
+     * estimate deliberately under-counts shared or interned state that a full object-graph walk would include.
+     */
+    protected boolean assertsAgainstRamUsageTester() {
+        return true;
+    }
+
+    @SuppressForbidden(reason = "need the names of all declared fields, most of which are private")
+    public void testRamBytesUsedAccountsForAllReferenceFields() {
+        final Class<? extends Accountable> clazz = classUnderTest();
+        final Set<String> accounted = fieldsAccountedForInRamBytesUsed();
+        final Set<String> excluded = fieldsExcludedFromRamBytesUsed();
+
+        assertThat(
+            "a field cannot be both accounted for and excluded in [" + clazz.getSimpleName() + "]",
+            Sets.intersection(accounted, excluded),
+            empty()
+        );
+
+        // Primitive fields are already covered by RamUsageEstimator.shallowSizeOf(...); only reference fields must be classified.
+        final Set<String> referenceFields = Arrays.stream(clazz.getDeclaredFields())
+            .filter(f -> Modifier.isStatic(f.getModifiers()) == false)
+            .filter(f -> f.getType().isPrimitive() == false)
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+
+        assertThat(
+            "reference field(s) on ["
+                + clazz.getSimpleName()
+                + "] are not classified for heap accounting - add each new field to the accounted-for set (and add its cost to "
+                + "ramBytesUsed()) or to the excluded set (with a comment explaining why it needs no accounting)",
+            referenceFields,
+            equalTo(Sets.union(accounted, excluded))
+        );
+    }
+
+    /**
+     * Value check against a real object-graph measurement. Catches systematic under-counting that the structural tripwire cannot.
+     */
+    public void testRamBytesUsedNeverUnderCountsActualHeap() {
+        assumeTrue(
+            classUnderTest().getSimpleName() + " deliberately under-counts shared/interned state vs a full-graph RamUsageTester walk",
+            assertsAgainstRamUsageTester()
+        );
+        Accountable instance = createTestInstance();
+        long estimate = instance.ramBytesUsed();
+        long actual = RamUsageTester.ramUsed(instance);
+        assertThat(
+            "estimate under-counts retained heap: estimate=" + estimate + " actual=" + actual + " for " + classUnderTest().getSimpleName(),
+            estimate,
+            greaterThanOrEqualTo(actual)
+        );
+    }
+
+    /**
+     * Convenience for subclasses: the shallow size of the given instance, i.e. the lower bound that any correct {@code ramBytesUsed()}
+     * must not go below.
+     */
+    protected static long shallowSizeOf(Accountable instance) {
+        return RamUsageEstimator.shallowSizeOf(instance);
+    }
+}


### PR DESCRIPTION
## Summary
First PR in a 4-PR stack for index metadata heap accounting.

- Adds `AbstractAccountableFieldsTestCase` test infrastructure
- Implements `Accountable.ramBytesUsed()` on small metadata types: `Condition`, `DiscoveryNodeFilters`, `IndexWriteLoad`, `IndexMetadataStats`, `IndexLongFieldRange`
- Adds field tripwire tests for each

## Stack
1. **This PR** → `accountable-small-sample`
2. `accountable-metadata-leaves` (draft, pending)
3. `accountable-index-metadata` (draft, pending)
4. `index-metadata-heap-calculation` (draft, pending — replaces #154764)


Made with [Cursor](https://cursor.com)