### PR TITLE
Add Accountable heap estimates for metadata leaf types

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.Strings;
@@ -28,7 +30,9 @@ import java.util.Objects;
 /**
  * Class for holding Rollover related information within an index
  */
-public class RolloverInfo implements SimpleDiffable<RolloverInfo>, Writeable, ToXContentFragment {
+public class RolloverInfo implements SimpleDiffable<RolloverInfo>, Writeable, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(RolloverInfo.class);
 
     public static final ParseField CONDITION_FIELD = new ParseField("met_conditions");
     public static final ParseField TIME_FIELD = new ParseField("time");
@@ -79,6 +83,12 @@ public class RolloverInfo implements SimpleDiffable<RolloverInfo>, Writeable, To
 
     public long getTime() {
         return time;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // metConditions elements are Accountable, so sizeOfCollection recurses into each condition's ramBytesUsed.
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(alias) + RamUsageEstimator.sizeOfCollection(metConditions);
     }
 
     public static Diff<RolloverInfo> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
@@ -27,13 +29,17 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Collections.emptySet;
 
-public class AliasMetadata implements SimpleDiffable<AliasMetadata>, ToXContentFragment, AliasInfo {
+public class AliasMetadata implements SimpleDiffable<AliasMetadata>, ToXContentFragment, AliasInfo, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(AliasMetadata.class);
 
     private final String alias;
 
@@ -121,6 +127,36 @@ public class AliasMetadata implements SimpleDiffable<AliasMetadata>, ToXContentF
 
     public Set<String> searchRoutingValues() {
         return searchRoutingValues;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        size += RamUsageEstimator.sizeOf(alias);
+        if (filter != null) {
+            size += filter.ramBytesUsed();
+        }
+        size += RamUsageEstimator.sizeOf(indexRouting);
+        size += RamUsageEstimator.sizeOf(searchRouting);
+        size += ramBytesUsedBySearchRoutingValues(searchRoutingValues);
+        // writeIndex and isHidden are boxed Booleans referenced from the shallow size; count the boxed instances when present.
+        size += RamUsageEstimator.shallowSizeOf(writeIndex);
+        size += RamUsageEstimator.shallowSizeOf(isHidden);
+        return size;
+    }
+
+    /**
+     * {@code searchRoutingValues} is either the shared empty-set singleton or an unmodifiable wrapper around a {@link HashSet}.
+     * {@link RamUsageEstimator#sizeOfCollection} assumes array-backed List storage and under-counts the HashMap node/table graph, so
+     * non-empty sets also add the backing {@link HashSet}/{@link HashMap} shallow sizes. String payloads in the set are distinct from
+     * {@code searchRouting} (comma-split copies) and are counted via {@code sizeOfCollection}.
+     */
+    private static long ramBytesUsedBySearchRoutingValues(Set<String> values) {
+        if (values.isEmpty()) {
+            return 0L;
+        }
+        return RamUsageEstimator.sizeOfCollection(values) + RamUsageEstimator.shallowSizeOfInstance(HashSet.class) + RamUsageEstimator
+            .shallowSizeOfInstance(HashMap.class);
     }
 
     public Boolean writeIndex() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetadata.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
@@ -29,8 +30,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -133,30 +132,29 @@ public class AliasMetadata implements SimpleDiffable<AliasMetadata>, ToXContentF
     public long ramBytesUsed() {
         long size = BASE_RAM_BYTES_USED;
         size += RamUsageEstimator.sizeOf(alias);
-        if (filter != null) {
-            size += filter.ramBytesUsed();
-        }
+        size += RamUsageEstimator.sizeOfObject(filter);
         size += RamUsageEstimator.sizeOf(indexRouting);
         size += RamUsageEstimator.sizeOf(searchRouting);
         size += ramBytesUsedBySearchRoutingValues(searchRoutingValues);
-        // writeIndex and isHidden are boxed Booleans referenced from the shallow size; count the boxed instances when present.
-        size += RamUsageEstimator.shallowSizeOf(writeIndex);
-        size += RamUsageEstimator.shallowSizeOf(isHidden);
+        // writeIndex and isHidden are boxed Boolean singletons and the references are already in BASE_RAM_BYTES_USED
         return size;
     }
 
     /**
-     * {@code searchRoutingValues} is either the shared empty-set singleton or an unmodifiable wrapper around a {@link HashSet}.
+     * {@code searchRoutingValues} is either the shared empty-set singleton or an unmodifiable wrapper around a {@link java.util.HashSet}.
      * {@link RamUsageEstimator#sizeOfCollection} assumes array-backed List storage and under-counts the HashMap node/table graph, so
-     * non-empty sets also add the backing {@link HashSet}/{@link HashMap} shallow sizes. String payloads in the set are distinct from
+     * non-empty sets also add the backing {@link java.util.HashSet}/{@link java.util.HashMap} shallow sizes. String payloads in the
+     * set are distinct from
      * {@code searchRouting} (comma-split copies) and are counted via {@code sizeOfCollection}.
      */
     private static long ramBytesUsedBySearchRoutingValues(Set<String> values) {
         if (values.isEmpty()) {
             return 0L;
         }
-        return RamUsageEstimator.sizeOfCollection(values) + RamUsageEstimator.shallowSizeOfInstance(HashSet.class) + RamUsageEstimator
-            .shallowSizeOfInstance(HashMap.class);
+
+        // Need the shallow sizes here due to the unmodifiable wrappers adding overhead.
+        return RamUsageEstimator.sizeOfCollection(values) + RamUsageEstimates.HASH_SET_SHALLOW_SIZE
+            + RamUsageEstimates.HASH_MAP_SHALLOW_SIZE;
     }
 
     public Boolean writeIndex() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadata.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -88,7 +90,9 @@ import java.util.Objects;
  * We only allow at most a single resharding operation to be in flight for an index, so removing this metadata is a prerequisite
  * to beginning another resharding operation.
  */
-public class IndexReshardingMetadata implements ToXContentFragment, Writeable {
+public class IndexReshardingMetadata implements ToXContentFragment, Writeable, Accountable {
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexReshardingMetadata.class);
+
     private static final String SPLIT_FIELD_NAME = "split";
     private static final ParseField SPLIT_FIELD = new ParseField(SPLIT_FIELD_NAME);
 
@@ -199,6 +203,11 @@ public class IndexReshardingMetadata implements ToXContentFragment, Writeable {
 
     public String toString() {
         return "IndexReshardingMetadata [state=" + state + "]";
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + state.ramBytesUsed();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,7 +31,7 @@ import java.util.stream.Stream;
  * IndexReshardingState is an abstract class holding the persistent state of a generic resharding operation. It contains
  * concrete subclasses for the operations that are currently defined (which is only split for now).
  */
-public abstract sealed class IndexReshardingState implements Writeable, ToXContentFragment {
+public abstract sealed class IndexReshardingState implements Writeable, ToXContentFragment, Accountable {
     /**
      * @return the number of shards the index has at the start of this operation
      */
@@ -43,6 +45,8 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
     // This class exists only so that tests can check that IndexReshardingMetadata can support more than one kind of operation.
     // When we have another real operation such as Shrink this can be removed.
     public static final class Noop extends IndexReshardingState {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Noop.class);
+
         private static final ObjectParser<Noop, Void> NOOP_PARSER = new ObjectParser<>("noop", Noop::new);
 
         Noop() {}
@@ -85,9 +89,16 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
         public int shardCountAfter() {
             return 1;
         }
+
+        @Override
+        public long ramBytesUsed() {
+            return BASE_RAM_BYTES_USED;
+        }
     }
 
     public static final class Split extends IndexReshardingState {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Split.class);
+
         /// States of split source shards:
         ///
         /// [SourceShardState#SOURCE] - split is in progress, source shard is expecting start_split requests from target shards.
@@ -269,6 +280,20 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
         @Override
         public int shardCountAfter() {
             return newShardCount;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            // Array elements are shared enum singletons; counting each slot over-counts when the same enum appears repeatedly or when
+            // many Splits are summed, which keeps the estimate a safe upper bound vs RamUsageTester.
+            long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(sourceShards) + RamUsageEstimator.shallowSizeOf(targetShards);
+            for (SourceShardState state : sourceShards) {
+                size += RamUsageEstimator.shallowSizeOf(state);
+            }
+            for (TargetShardState state : targetShards) {
+                size += RamUsageEstimator.shallowSizeOf(state);
+            }
+            return size;
         }
 
         // visible for testing

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexReshardingState.java
@@ -284,16 +284,8 @@ public abstract sealed class IndexReshardingState implements Writeable, ToXConte
 
         @Override
         public long ramBytesUsed() {
-            // Array elements are shared enum singletons; counting each slot over-counts when the same enum appears repeatedly or when
-            // many Splits are summed, which keeps the estimate a safe upper bound vs RamUsageTester.
-            long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(sourceShards) + RamUsageEstimator.shallowSizeOf(targetShards);
-            for (SourceShardState state : sourceShards) {
-                size += RamUsageEstimator.shallowSizeOf(state);
-            }
-            for (TargetShardState state : targetShards) {
-                size += RamUsageEstimator.shallowSizeOf(state);
-            }
-            return size;
+            // sourceShards/targetShards hold shared enum singletons; only the arrays (and their references) are counted.
+            return BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(sourceShards) + RamUsageEstimator.shallowSizeOf(targetShards);
         }
 
         // visible for testing

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
@@ -33,7 +35,10 @@ import java.util.Objects;
  * Given that the coordinator node does not necessarily have mapping information for all indices (only for those that have shards
  * in the node), the field inference information must be stored in the IndexMetadata and broadcasted to all nodes.
  */
-public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFieldMetadata>, ToXContentFragment {
+public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFieldMetadata>, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(InferenceFieldMetadata.class);
+
     private static final String INFERENCE_ID_FIELD = "inference_id";
     private static final String SEARCH_INFERENCE_ID_FIELD = "search_inference_id";
     private static final String SOURCE_FIELDS_FIELD = "source_fields";
@@ -75,6 +80,17 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
         } else {
             this.chunkingSettings = null;
         }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        size += RamUsageEstimator.sizeOf(name);
+        size += RamUsageEstimator.sizeOf(inferenceId);
+        size += RamUsageEstimator.sizeOf(searchInferenceId);
+        size += RamUsageEstimator.sizeOf(sourceFields);
+        size += RamUsageEstimator.sizeOfMap(chunkingSettings);
+        return size;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationCategory;
@@ -43,7 +45,9 @@ public record LifecycleExecutionState(
     String snapshotIndexName,
     String downsampleIndexName,
     String forceMergeCloneIndexName
-) {
+) implements Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LifecycleExecutionState.class);
 
     public static final String ILM_CUSTOM_METADATA_KEY = "ilm";
     public static final int MAXIMUM_STEP_INFO_STRING_LENGTH = 1024;
@@ -211,6 +215,31 @@ public record LifecycleExecutionState(
             builder.setForceMergeCloneIndexName(forceMergeCloneIndexName);
         }
         return builder.build();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        size += RamUsageEstimator.sizeOf(phase);
+        size += RamUsageEstimator.sizeOf(action);
+        size += RamUsageEstimator.sizeOf(step);
+        size += RamUsageEstimator.sizeOf(failedStep);
+        size += RamUsageEstimator.shallowSizeOf(isAutoRetryableError);
+        size += RamUsageEstimator.shallowSizeOf(failedStepRetryCount);
+        size += RamUsageEstimator.sizeOf(stepInfo);
+        size += RamUsageEstimator.sizeOf(previousStepInfo);
+        size += RamUsageEstimator.sizeOf(phaseDefinition);
+        size += RamUsageEstimator.shallowSizeOf(lifecycleDate);
+        size += RamUsageEstimator.shallowSizeOf(phaseTime);
+        size += RamUsageEstimator.shallowSizeOf(actionTime);
+        size += RamUsageEstimator.shallowSizeOf(stepTime);
+        size += RamUsageEstimator.sizeOf(snapshotRepository);
+        size += RamUsageEstimator.sizeOf(snapshotName);
+        size += RamUsageEstimator.sizeOf(shrinkIndexName);
+        size += RamUsageEstimator.sizeOf(snapshotIndexName);
+        size += RamUsageEstimator.sizeOf(downsampleIndexName);
+        size += RamUsageEstimator.sizeOf(forceMergeCloneIndexName);
+        return size;
     }
 
     private static boolean parseIsAutoRetryableError(String isAutoRetryableError) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
@@ -224,7 +224,7 @@ public record LifecycleExecutionState(
         size += RamUsageEstimator.sizeOf(action);
         size += RamUsageEstimator.sizeOf(step);
         size += RamUsageEstimator.sizeOf(failedStep);
-        size += RamUsageEstimator.shallowSizeOf(isAutoRetryableError);
+        // isAutoRetryableError is a boxed Boolean singleton; the reference is already in BASE_RAM_BYTES_USED
         size += RamUsageEstimator.shallowSizeOf(failedStepRetryCount);
         size += RamUsageEstimator.sizeOf(stepInfo);
         size += RamUsageEstimator.sizeOf(previousStepInfo);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
@@ -29,7 +31,9 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
 /**
  * Mapping configuration for a type.
  */
-public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
+public class MappingMetadata implements SimpleDiffable<MappingMetadata>, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(MappingMetadata.class);
 
     public static final MappingMetadata EMPTY_MAPPINGS = new MappingMetadata(
         MapperService.SINGLE_MAPPING_NAME,
@@ -112,6 +116,11 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
 
     public CompressedXContent source() {
         return this.source;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(type) + source.ramBytesUsed();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.common.compress;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -47,7 +49,9 @@ import java.util.zip.Inflater;
  * memory. Note that the compressed string might still sometimes need to be
  * decompressed in order to perform equality checks or to compute hash codes.
  */
-public final class CompressedXContent implements Writeable {
+public final class CompressedXContent implements Writeable, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(CompressedXContent.class);
 
     private static final ThreadLocal<InflaterAndBuffer> inflater = ThreadLocal.withInitial(InflaterAndBuffer::new);
 
@@ -198,6 +202,11 @@ public final class CompressedXContent implements Writeable {
 
     public String getSha256() {
         return sha256;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(bytes) + RamUsageEstimator.sizeOf(sha256);
     }
 
     public static CompressedXContent readCompressedString(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -53,6 +53,9 @@ public final class CompressedXContent implements Writeable, Accountable {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(CompressedXContent.class);
 
+    /** Base64 encoding of a 256-bit SHA-256 digest is always 44 characters. */
+    private static final long SHA256_RAM_BYTES_USED = RamUsageEstimator.sizeOf(Base64.getEncoder().encodeToString(new byte[32]));
+
     private static final ThreadLocal<InflaterAndBuffer> inflater = ThreadLocal.withInitial(InflaterAndBuffer::new);
 
     private static final ThreadLocal<BytesStreamOutput> baos = ThreadLocal.withInitial(BytesStreamOutput::new);
@@ -206,7 +209,7 @@ public final class CompressedXContent implements Writeable, Accountable {
 
     @Override
     public long ramBytesUsed() {
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(bytes) + RamUsageEstimator.sizeOf(sha256);
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(bytes) + SHA256_RAM_BYTES_USED;
     }
 
     public static CompressedXContent readCompressedString(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentFieldRamUsageEstimator.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentFieldRamUsageEstimator.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.common.document;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -157,11 +158,13 @@ public final class DocumentFieldRamUsageEstimator {
             long capacity = Math.max(16L, Long.highestOneBit((long) n * 2L - 1L) << 1);
             size += ARRAY_HEADER_BYTES + capacity * REF_BYTES;
         } else if (collection instanceof HashSet<?> || collection instanceof LinkedHashSet<?>) {
-            size += RamUsageEstimator.shallowSizeOfInstance(collection instanceof LinkedHashSet<?> ? LinkedHashMap.class : HashMap.class);
+            size += collection instanceof LinkedHashSet<?>
+                ? RamUsageEstimates.LINKED_HASH_MAP_SHALLOW_SIZE
+                : RamUsageEstimates.HASH_MAP_SHALLOW_SIZE;
             size += ARRAY_HEADER_BYTES + hashTableCapacity(n) * (long) REF_BYTES;
             size += n * (collection instanceof LinkedHashSet<?> ? LINKED_HASH_MAP_ENTRY_BYTES : HASH_MAP_ENTRY_BYTES);
         } else if (collection instanceof TreeSet<?>) {
-            size += RamUsageEstimator.shallowSizeOfInstance(TreeMap.class);
+            size += RamUsageEstimates.TREE_MAP_SHALLOW_SIZE;
             size += n * TREE_MAP_ENTRY_BYTES;
         } else if (n > 0) {
             long capacity = Math.max(10L, (long) Math.ceil(n * 1.5));

--- a/server/src/main/java/org/elasticsearch/common/lucene/RamUsageEstimates.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/RamUsageEstimates.java
@@ -15,9 +15,14 @@ import org.elasticsearch.core.SuppressForbidden;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -25,6 +30,21 @@ import java.util.stream.Collectors;
  * shallow instance size is a complete accounting of retained heap. Assertions fire only when assertions are enabled.
  */
 public final class RamUsageEstimates {
+
+    /** Shallow instance size of an empty {@link HashMap}. */
+    public static final long HASH_MAP_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(HashMap.class);
+
+    /** Shallow instance size of an empty {@link HashSet} (includes its backing {@link HashMap}). */
+    public static final long HASH_SET_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(HashSet.class);
+
+    /** Shallow instance size of an empty {@link LinkedHashMap}. */
+    public static final long LINKED_HASH_MAP_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(LinkedHashMap.class);
+
+    /** Shallow instance size of an empty {@link ArrayList}. */
+    public static final long ARRAY_LIST_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ArrayList.class);
+
+    /** Shallow instance size of an empty {@link TreeMap}. */
+    public static final long TREE_MAP_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TreeMap.class);
 
     private RamUsageEstimates() {}
 

--- a/server/src/main/java/org/elasticsearch/search/SearchHitRamUsageEstimator.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHitRamUsageEstimator.java
@@ -11,8 +11,8 @@ package org.elasticsearch.search;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -21,7 +21,6 @@ import java.util.Map;
 public final class SearchHitRamUsageEstimator {
 
     private static final long SEARCH_HIT_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SearchHit.class);
-    private static final long HASH_MAP_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(HashMap.class);
     private static final long SEARCH_HITS_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(SearchHits.class);
     private static final long HASH_MAP_NODE_SIZE = RamUsageEstimator.alignObjectSize(
         RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + 3L * RamUsageEstimator.NUM_BYTES_OBJECT_REF
@@ -37,8 +36,8 @@ public final class SearchHitRamUsageEstimator {
         size += estimateFields(hit.getMetadataFields());
         Map<String, SearchHits> innerHits = hit.getInnerHits();
         if (innerHits != null) {
-            size += HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) innerHits.size() * (HASH_MAP_NODE_SIZE
-                + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+            size += RamUsageEstimates.HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) innerHits.size()
+                * (HASH_MAP_NODE_SIZE + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
             for (Map.Entry<String, SearchHits> entry : innerHits.entrySet()) {
                 size += RamUsageEstimator.sizeOf(entry.getKey());
                 SearchHit[] innerHitsArray = entry.getValue().getHits();
@@ -56,8 +55,8 @@ public final class SearchHitRamUsageEstimator {
         if (fields == null || fields.isEmpty()) {
             return 0L;
         }
-        long size = HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) fields.size() * (HASH_MAP_NODE_SIZE
-            + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+        long size = RamUsageEstimates.HASH_MAP_SHALLOW_SIZE + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) fields.size()
+            * (HASH_MAP_NODE_SIZE + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
         for (DocumentField field : fields.values()) {
             size += field.ramBytesUsedEstimate();
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfoRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfoRamBytesUsedTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.rollover;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class RolloverInfoRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return RolloverInfo.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("alias", "metConditions");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return new RolloverInfo(
+            "alias",
+            List.of(new MaxDocsCondition(1L), new MaxAgeCondition(TimeValue.timeValueDays(1)), new MaxDocsCondition(2L)),
+            1L
+        );
+    }
+
+    /**
+     * Non-tautology check: adding more met conditions must increase the reported size.
+     */
+    public void testRamBytesUsedGrowsWithConditions() {
+        RolloverInfo one = new RolloverInfo("alias", List.of(new MaxDocsCondition(1L)), 1L);
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfoRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfoRamBytesUsedTests.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.action.admin.indices.rollover;
 
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -31,17 +31,19 @@ public class RolloverInfoRamBytesUsedTests extends AbstractAccountableFieldsTest
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+    protected boolean assertsAgainstRamUsageTester() {
+        // Nested Condition instances omit shared Type enum singletons that RamUsageTester includes.
+        return false;
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return new RolloverInfo(
-            "alias",
-            List.of(new MaxDocsCondition(1L), new MaxAgeCondition(TimeValue.timeValueDays(1)), new MaxDocsCondition(2L)),
-            1L
-        );
+    protected Accountable createRandomTestInstance() {
+        int n = randomIntBetween(1, 4);
+        List<Condition<?>> conditions = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            conditions.add(new MaxDocsCondition(randomNonNegativeLong()));
+        }
+        return new RolloverInfo(randomAlphaOfLengthBetween(1, 12), conditions, randomNonNegativeLong());
     }
 
     /**
@@ -49,6 +51,11 @@ public class RolloverInfoRamBytesUsedTests extends AbstractAccountableFieldsTest
      */
     public void testRamBytesUsedGrowsWithConditions() {
         RolloverInfo one = new RolloverInfo("alias", List.of(new MaxDocsCondition(1L)), 1L);
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+        RolloverInfo many = new RolloverInfo(
+            "alias",
+            List.of(new MaxDocsCondition(1L), new MaxDocsCondition(2L), new MaxDocsCondition(3L)),
+            1L
+        );
+        assertThat(many.ramBytesUsed(), greaterThan(one.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AliasMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AliasMetadataRamBytesUsedTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class AliasMetadataRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return AliasMetadata.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("alias", "filter", "indexRouting", "searchRouting", "searchRoutingValues", "writeIndex", "isHidden");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return AliasMetadata.builder("alias")
+            .filter("{\"term\":{\"field\":\"value\"}}")
+            .indexRouting("routing")
+            .searchRouting("sr1,sr2")
+            .writeIndex(true)
+            .build();
+    }
+
+    /**
+     * Non-tautology check: attaching a filter and routing must increase the estimate over a bare alias.
+     */
+    public void testRamBytesUsedGrowsWithOptionalFields() {
+        AliasMetadata bare = AliasMetadata.builder("alias").build();
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(bare.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AliasMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AliasMetadataRamBytesUsedTests.java
@@ -29,18 +29,30 @@ public class AliasMetadataRamBytesUsedTests extends AbstractAccountableFieldsTes
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+    protected boolean assertsAgainstRamUsageTester() {
+        // searchRoutingValues is a HashSet whose table/node graph RamUsageTester walks more completely than sizeOfCollection.
+        return false;
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return AliasMetadata.builder("alias")
-            .filter("{\"term\":{\"field\":\"value\"}}")
-            .indexRouting("routing")
-            .searchRouting("sr1,sr2")
-            .writeIndex(true)
-            .build();
+    protected Accountable createRandomTestInstance() {
+        AliasMetadata.Builder builder = AliasMetadata.builder(randomAlphaOfLengthBetween(1, 12));
+        if (randomBoolean()) {
+            builder.filter("{\"term\":{\"" + randomAlphaOfLength(5) + "\":\"" + randomAlphaOfLength(8) + "\"}}");
+        }
+        if (randomBoolean()) {
+            builder.indexRouting(randomAlphaOfLengthBetween(1, 8));
+        }
+        if (randomBoolean()) {
+            builder.searchRouting(randomAlphaOfLengthBetween(1, 8));
+        }
+        if (randomBoolean()) {
+            builder.writeIndex(randomBoolean());
+        }
+        if (randomBoolean()) {
+            builder.isHidden(randomBoolean());
+        }
+        return builder.build();
     }
 
     /**
@@ -48,6 +60,12 @@ public class AliasMetadataRamBytesUsedTests extends AbstractAccountableFieldsTes
      */
     public void testRamBytesUsedGrowsWithOptionalFields() {
         AliasMetadata bare = AliasMetadata.builder("alias").build();
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(bare.ramBytesUsed()));
+        AliasMetadata populated = AliasMetadata.builder("alias")
+            .filter("{\"term\":{\"field\":\"value\"}}")
+            .indexRouting("routing")
+            .searchRouting("sr1,sr2")
+            .writeIndex(true)
+            .build();
+        assertThat(populated.ramBytesUsed(), greaterThan(bare.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataRamBytesUsedTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexReshardingMetadataRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexReshardingMetadata.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("state");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return IndexReshardingMetadata.newSplitByMultiple(8, 2);
+    }
+
+    /**
+     * Non-tautology check: a split into more shards holds larger source/target arrays and so reports a larger estimate.
+     */
+    public void testRamBytesUsedGrowsWithShardCount() {
+        IndexReshardingMetadata small = IndexReshardingMetadata.newSplitByMultiple(1, 2);
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingMetadataRamBytesUsedTests.java
@@ -29,13 +29,14 @@ public class IndexReshardingMetadataRamBytesUsedTests extends AbstractAccountabl
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+    protected boolean assertsAgainstRamUsageTester() {
+        // Nested Split arrays hold shared enum singletons that RamUsageTester includes and ramBytesUsed() does not.
+        return false;
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return IndexReshardingMetadata.newSplitByMultiple(8, 2);
+    protected Accountable createRandomTestInstance() {
+        return IndexReshardingMetadata.newSplitByMultiple(randomIntBetween(1, 16), 2);
     }
 
     /**
@@ -43,6 +44,7 @@ public class IndexReshardingMetadataRamBytesUsedTests extends AbstractAccountabl
      */
     public void testRamBytesUsedGrowsWithShardCount() {
         IndexReshardingMetadata small = IndexReshardingMetadata.newSplitByMultiple(1, 2);
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+        IndexReshardingMetadata large = IndexReshardingMetadata.newSplitByMultiple(8, 2);
+        assertThat(large.ramBytesUsed(), greaterThan(small.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateNoopRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateNoopRamBytesUsedTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexReshardingStateNoopRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexReshardingState.Noop.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createRandomTestInstance() {
+        return new IndexReshardingState.Noop();
+    }
+
+    /**
+     * Non-tautology check: {@link IndexReshardingState.Noop} has no reference fields; the estimate is the shallow instance size.
+     */
+    public void testRamBytesUsedIsShallowSize() {
+        IndexReshardingState.Noop noop = new IndexReshardingState.Noop();
+        assertThat(noop.ramBytesUsed(), equalTo(RamUsageEstimator.shallowSizeOfInstance(IndexReshardingState.Noop.class)));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateSplitRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateSplitRamBytesUsedTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+public class IndexReshardingStateSplitRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexReshardingState.Split.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("sourceShards", "targetShards");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return IndexReshardingState.Split.newSplitByMultiple(8, 2);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateSplitRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexReshardingStateSplitRamBytesUsedTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
 
 import java.util.Set;
 
+import static org.hamcrest.Matchers.greaterThan;
+
 public class IndexReshardingStateSplitRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
 
     @Override
@@ -27,12 +29,22 @@ public class IndexReshardingStateSplitRamBytesUsedTests extends AbstractAccounta
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+    protected boolean assertsAgainstRamUsageTester() {
+        // Array elements are shared enum singletons; RamUsageTester includes them and ramBytesUsed() does not.
+        return false;
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return IndexReshardingState.Split.newSplitByMultiple(8, 2);
+    protected Accountable createRandomTestInstance() {
+        return IndexReshardingState.Split.newSplitByMultiple(randomIntBetween(1, 16), 2);
+    }
+
+    /**
+     * Non-tautology check: more source shards means larger arrays and a larger estimate.
+     */
+    public void testRamBytesUsedGrowsWithShardCount() {
+        IndexReshardingState.Split small = IndexReshardingState.Split.newSplitByMultiple(1, 2);
+        IndexReshardingState.Split large = IndexReshardingState.Split.newSplitByMultiple(8, 2);
+        assertThat(large.ramBytesUsed(), greaterThan(small.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataRamBytesUsedTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class InferenceFieldMetadataRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return InferenceFieldMetadata.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("name", "inferenceId", "searchInferenceId", "sourceFields", "chunkingSettings");
+    }
+
+    @Override
+    protected Accountable createRandomTestInstance() {
+        String name = randomAlphaOfLengthBetween(3, 10);
+        String inferenceId = randomIdentifier();
+        String searchInferenceId = randomIdentifier();
+        String[] sourceFields = generateRandomStringArray(randomIntBetween(1, 5), 10, false, false);
+        Map<String, Object> chunkingSettings = InferenceFieldMetadataTests.generateRandomChunkingSettings();
+        return new InferenceFieldMetadata(name, inferenceId, searchInferenceId, sourceFields, chunkingSettings);
+    }
+
+    /**
+     * Non-tautology check: more source fields and chunking settings must increase the estimate.
+     */
+    public void testRamBytesUsedGrowsWithSourceFieldsAndChunkingSettings() {
+        InferenceFieldMetadata minimal = new InferenceFieldMetadata("field", "inference", "inference", new String[0], null);
+        InferenceFieldMetadata populated = new InferenceFieldMetadata(
+            "field",
+            "inference-id-with-more-chars",
+            "search-inference-id-with-more-chars",
+            new String[] { "source1", "source2", "source3" },
+            Map.of("strategy", "word_boundary", "max_chunk_size", 100, "overlap", 10)
+        );
+        assertThat(populated.ramBytesUsed(), greaterThan(minimal.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class LifecycleExecutionStateRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return LifecycleExecutionState.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of(
+            "phase",
+            "action",
+            "step",
+            "failedStep",
+            "isAutoRetryableError",
+            "failedStepRetryCount",
+            "stepInfo",
+            "previousStepInfo",
+            "phaseDefinition",
+            "lifecycleDate",
+            "phaseTime",
+            "actionTime",
+            "stepTime",
+            "snapshotRepository",
+            "snapshotName",
+            "shrinkIndexName",
+            "snapshotIndexName",
+            "downsampleIndexName",
+            "forceMergeCloneIndexName"
+        );
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep("check-rollover-ready")
+            .setStepInfo("{\"some\":\"info\"}")
+            .build();
+    }
+
+    /**
+     * Non-tautology check: populating string fields must increase the estimate over the empty state.
+     */
+    public void testRamBytesUsedGrowsWhenPopulated() {
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(LifecycleExecutionState.EMPTY_STATE.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
@@ -49,24 +49,36 @@ public class LifecycleExecutionStateRamBytesUsedTests extends AbstractAccountabl
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
-        return LifecycleExecutionState.builder()
-            .setPhase("hot")
-            .setAction("rollover")
-            .setStep("check-rollover-ready")
-            .setStepInfo("{\"some\":\"info\"}")
-            .build();
+    protected Accountable createRandomTestInstance() {
+        LifecycleExecutionState.Builder builder = LifecycleExecutionState.builder();
+        if (randomBoolean()) {
+            builder.setPhase(randomAlphaOfLengthBetween(3, 8));
+        }
+        if (randomBoolean()) {
+            builder.setAction(randomAlphaOfLengthBetween(3, 12));
+        }
+        if (randomBoolean()) {
+            builder.setStep(randomAlphaOfLengthBetween(3, 16));
+        }
+        if (randomBoolean()) {
+            builder.setStepInfo("{\"info\":\"" + randomAlphaOfLengthBetween(4, 24) + "\"}");
+        }
+        if (randomBoolean()) {
+            builder.setPhaseTime(randomNonNegativeLong());
+        }
+        return builder.build();
     }
 
     /**
      * Non-tautology check: populating string fields must increase the estimate over the empty state.
      */
     public void testRamBytesUsedGrowsWhenPopulated() {
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(LifecycleExecutionState.EMPTY_STATE.ramBytesUsed()));
+        LifecycleExecutionState populated = LifecycleExecutionState.builder()
+            .setPhase("hot")
+            .setAction("rollover")
+            .setStep("check-rollover-ready")
+            .setStepInfo("{\"some\":\"info\"}")
+            .build();
+        assertThat(populated.ramBytesUsed(), greaterThan(LifecycleExecutionState.EMPTY_STATE.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/LifecycleExecutionStateRamBytesUsedTests.java
@@ -30,7 +30,6 @@ public class LifecycleExecutionStateRamBytesUsedTests extends AbstractAccountabl
             "action",
             "step",
             "failedStep",
-            "isAutoRetryableError",
             "failedStepRetryCount",
             "stepInfo",
             "previousStepInfo",
@@ -46,6 +45,12 @@ public class LifecycleExecutionStateRamBytesUsedTests extends AbstractAccountabl
             "downsampleIndexName",
             "forceMergeCloneIndexName"
         );
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        // Boxed Boolean singleton; only the field reference is counted in BASE_RAM_BYTES_USED.
+        return Set.of("isAutoRetryableError");
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MappingMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MappingMetadataRamBytesUsedTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class MappingMetadataRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return MappingMetadata.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("type", "source");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        try {
+            return new MappingMetadata(CompressedXContent.fromJSON("""
+                { "_doc": { "properties": {
+                  "a": { "type": "keyword" }, "b": { "type": "keyword" }, "c": { "type": "text" }, "d": { "type": "long" }
+                } } }
+                """));
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Non-tautology check: the estimate must include the compressed mapping source, so a larger mapping is larger on heap.
+     */
+    public void testRamBytesUsedIncludesSource() throws IOException {
+        MappingMetadata small = new MappingMetadata(CompressedXContent.fromJSON("""
+            { "_doc": { "properties": { "a": { "type": "keyword" } } } }
+            """));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MappingMetadataRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MappingMetadataRamBytesUsedTests.java
@@ -31,18 +31,9 @@ public class MappingMetadataRamBytesUsedTests extends AbstractAccountableFieldsT
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
+    protected Accountable createRandomTestInstance() {
         try {
-            return new MappingMetadata(CompressedXContent.fromJSON("""
-                { "_doc": { "properties": {
-                  "a": { "type": "keyword" }, "b": { "type": "keyword" }, "c": { "type": "text" }, "d": { "type": "long" }
-                } } }
-                """));
+            return new MappingMetadata(CompressedXContent.fromJSON(randomMappingJson(randomIntBetween(1, 16))));
         } catch (IOException e) {
             throw new AssertionError(e);
         }
@@ -52,9 +43,20 @@ public class MappingMetadataRamBytesUsedTests extends AbstractAccountableFieldsT
      * Non-tautology check: the estimate must include the compressed mapping source, so a larger mapping is larger on heap.
      */
     public void testRamBytesUsedIncludesSource() throws IOException {
-        MappingMetadata small = new MappingMetadata(CompressedXContent.fromJSON("""
-            { "_doc": { "properties": { "a": { "type": "keyword" } } } }
-            """));
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+        MappingMetadata small = new MappingMetadata(CompressedXContent.fromJSON(randomMappingJson(1)));
+        MappingMetadata large = new MappingMetadata(CompressedXContent.fromJSON(randomMappingJson(16)));
+        assertThat(large.ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+    }
+
+    private static String randomMappingJson(int fieldCount) {
+        StringBuilder json = new StringBuilder("{ \"_doc\": { \"properties\": {");
+        for (int i = 0; i < fieldCount; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\"field").append(i).append("\": { \"type\": \"keyword\" }");
+        }
+        json.append("} } }");
+        return json.toString();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/compress/CompressedXContentRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/CompressedXContentRamBytesUsedTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.compress;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class CompressedXContentRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return CompressedXContent.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("bytes", "sha256");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        try {
+            return CompressedXContent.fromJSON("""
+                { "_doc": { "properties": { "field": { "type": "keyword" } } } }
+                """);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Non-tautology check: the estimate must cover at least the raw compressed payload plus the sha256 string content. These lower bounds
+     * are derived independently of {@code ramBytesUsed()}'s own formula, so a systematically under-counting implementation would fail here.
+     */
+    public void testRamBytesUsedCoversRawPayload() {
+        CompressedXContent content = (CompressedXContent) createTestInstance();
+        long rawLowerBound = (long) content.compressed().length + content.getSha256().length();
+        assertThat(content.ramBytesUsed(), greaterThan(rawLowerBound));
+    }
+
+    public void testRamBytesUsedGrowsWithPayload() throws IOException {
+        CompressedXContent small = CompressedXContent.fromJSON("""
+            { "_doc": { "properties": { "a": { "type": "keyword" } } } }
+            """);
+        StringBuilder manyFields = new StringBuilder("{ \"_doc\": { \"properties\": {");
+        for (int i = 0; i < 200; i++) {
+            manyFields.append(i == 0 ? "" : ",").append("\"field").append(i).append("\": { \"type\": \"keyword\" }");
+        }
+        manyFields.append("} } }");
+        CompressedXContent large = CompressedXContent.fromJSON(manyFields.toString());
+        assertThat(large.ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/compress/CompressedXContentRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/CompressedXContentRamBytesUsedTests.java
@@ -30,16 +30,9 @@ public class CompressedXContentRamBytesUsedTests extends AbstractAccountableFiel
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
+    protected Accountable createRandomTestInstance() {
         try {
-            return CompressedXContent.fromJSON("""
-                { "_doc": { "properties": { "field": { "type": "keyword" } } } }
-                """);
+            return CompressedXContent.fromJSON(randomMappingJson(randomIntBetween(1, 32)));
         } catch (IOException e) {
             throw new AssertionError(e);
         }
@@ -50,21 +43,26 @@ public class CompressedXContentRamBytesUsedTests extends AbstractAccountableFiel
      * are derived independently of {@code ramBytesUsed()}'s own formula, so a systematically under-counting implementation would fail here.
      */
     public void testRamBytesUsedCoversRawPayload() {
-        CompressedXContent content = (CompressedXContent) createTestInstance();
+        CompressedXContent content = (CompressedXContent) createRandomTestInstance();
         long rawLowerBound = (long) content.compressed().length + content.getSha256().length();
         assertThat(content.ramBytesUsed(), greaterThan(rawLowerBound));
     }
 
     public void testRamBytesUsedGrowsWithPayload() throws IOException {
-        CompressedXContent small = CompressedXContent.fromJSON("""
-            { "_doc": { "properties": { "a": { "type": "keyword" } } } }
-            """);
-        StringBuilder manyFields = new StringBuilder("{ \"_doc\": { \"properties\": {");
-        for (int i = 0; i < 200; i++) {
-            manyFields.append(i == 0 ? "" : ",").append("\"field").append(i).append("\": { \"type\": \"keyword\" }");
-        }
-        manyFields.append("} } }");
-        CompressedXContent large = CompressedXContent.fromJSON(manyFields.toString());
+        CompressedXContent small = CompressedXContent.fromJSON(randomMappingJson(1));
+        CompressedXContent large = CompressedXContent.fromJSON(randomMappingJson(200));
         assertThat(large.ramBytesUsed(), greaterThan(small.ramBytesUsed()));
+    }
+
+    private static String randomMappingJson(int fieldCount) {
+        StringBuilder json = new StringBuilder("{ \"_doc\": { \"properties\": {");
+        for (int i = 0; i < fieldCount; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\"field").append(i).append("\": { \"type\": \"keyword\" }");
+        }
+        json.append("} } }");
+        return json.toString();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/RamUsageEstimatesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/RamUsageEstimatesTests.java
@@ -15,6 +15,11 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -73,5 +78,13 @@ public class RamUsageEstimatesTests extends ESTestCase {
     public void testShallowSizeOfShallowCompleteIsAtLeastReferenceOverhead() {
         long shallow = RamUsageEstimates.shallowSizeOfShallowComplete(ByteSizeValue.ofMb(1));
         assertThat(shallow, greaterThan(0L));
+    }
+
+    public void testCollectionShallowSizesMatchRamUsageEstimator() {
+        assertThat(RamUsageEstimates.HASH_MAP_SHALLOW_SIZE, equalTo(RamUsageEstimator.shallowSizeOfInstance(HashMap.class)));
+        assertThat(RamUsageEstimates.HASH_SET_SHALLOW_SIZE, equalTo(RamUsageEstimator.shallowSizeOfInstance(HashSet.class)));
+        assertThat(RamUsageEstimates.LINKED_HASH_MAP_SHALLOW_SIZE, equalTo(RamUsageEstimator.shallowSizeOfInstance(LinkedHashMap.class)));
+        assertThat(RamUsageEstimates.ARRAY_LIST_SHALLOW_SIZE, equalTo(RamUsageEstimator.shallowSizeOfInstance(ArrayList.class)));
+        assertThat(RamUsageEstimates.TREE_MAP_SHALLOW_SIZE, equalTo(RamUsageEstimator.shallowSizeOfInstance(TreeMap.class)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/test/AccountableFieldsTestCoverageTests.java
+++ b/server/src/test/java/org/elasticsearch/test/AccountableFieldsTestCoverageTests.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test;
+
+public class AccountableFieldsTestCoverageTests extends ESTestCase {
+
+    public void testMetadataLeafAccountablesHaveFieldsTests() throws Exception {
+        AccountableFieldsTestCoverage.assertMetadataLeafCoverage();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/AccountableFieldsTestCoverage.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AccountableFieldsTestCoverage.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+/**
+ * Verifies that in-scope {@link Accountable} implementations have a matching {@link AbstractAccountableFieldsTestCase} subclass.
+ */
+public final class AccountableFieldsTestCoverage {
+
+    public static final Set<String> METADATA_LEAF_PACKAGES = Set.of(
+        "org.elasticsearch.cluster.metadata",
+        "org.elasticsearch.action.admin.indices.rollover",
+        "org.elasticsearch.cluster.node",
+        "org.elasticsearch.index.shard",
+        "org.elasticsearch.common.compress"
+    );
+
+    private AccountableFieldsTestCoverage() {}
+
+    public static void assertMetadataLeafCoverage() throws Exception {
+        assertCoverage(METADATA_LEAF_PACKAGES);
+    }
+
+    public static void assertCoverage(Set<String> packages) throws Exception {
+        Set<Class<?>> required = findRequiredAccountables(packages);
+        Set<Class<?>> covered = findCoveredAccountables(packages);
+        Set<Class<?>> missing = Sets.difference(required, covered);
+        assertThat(
+            "Accountable class(es) missing "
+                + AbstractAccountableFieldsTestCase.class.getSimpleName()
+                + ": "
+                + missing.stream().map(Class::getName).sorted().collect(Collectors.joining(", ")),
+            missing,
+            empty()
+        );
+    }
+
+    static Set<Class<?>> findRequiredAccountables(Set<String> packages) throws Exception {
+        Set<Class<?>> required = new LinkedHashSet<>();
+        for (String pkg : packages) {
+            for (Class<?> clazz : loadClassesInPackage(pkg)) {
+                if (requiresAccountableFieldsTest(clazz)) {
+                    required.add(clazz);
+                }
+            }
+        }
+        return required;
+    }
+
+    static Set<Class<?>> findCoveredAccountables(Set<String> packages) throws Exception {
+        Set<Class<?>> covered = new LinkedHashSet<>();
+        for (String pkg : packages) {
+            for (Class<?> clazz : loadClassesInPackage(pkg)) {
+                if (isConcreteAccountableFieldsTestClass(clazz)) {
+                    covered.add(readClassUnderTest(clazz));
+                }
+            }
+        }
+        return covered;
+    }
+
+    private static boolean requiresAccountableFieldsTest(Class<?> clazz) {
+        if (clazz.isInterface() || clazz.isEnum() || clazz.isSynthetic()) {
+            return false;
+        }
+        if (Accountable.class.isAssignableFrom(clazz) == false) {
+            return false;
+        }
+        if (Modifier.isAbstract(clazz.getModifiers())) {
+            // Sealed bases (e.g. IndexReshardingState) are covered by tests on each permitted subtype.
+            return clazz.isSealed() == false;
+        }
+        // Concrete leaves of abstract non-sealed bases (e.g. MaxDocsCondition) are covered by a test on the base.
+        return hasAbstractNonSealedAccountableSuperclass(clazz) == false;
+    }
+
+    private static boolean hasAbstractNonSealedAccountableSuperclass(Class<?> clazz) {
+        for (Class<?> superClass = clazz.getSuperclass(); superClass != null && superClass != Object.class; superClass = superClass
+            .getSuperclass()) {
+            if (Accountable.class.isAssignableFrom(superClass)
+                && Modifier.isAbstract(superClass.getModifiers())
+                && superClass.isSealed() == false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isConcreteAccountableFieldsTestClass(Class<?> clazz) {
+        return AbstractAccountableFieldsTestCase.class.isAssignableFrom(clazz)
+            && Modifier.isAbstract(clazz.getModifiers()) == false
+            && clazz != AbstractAccountableFieldsTestCase.class;
+    }
+
+    @SuppressForbidden(reason = "test-only reflection to read classUnderTest() from convention tests")
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Accountable> readClassUnderTest(Class<?> testClass) throws ReflectiveOperationException {
+        AbstractAccountableFieldsTestCase test = (AbstractAccountableFieldsTestCase) testClass.getDeclaredConstructor().newInstance();
+        Method method = AbstractAccountableFieldsTestCase.class.getDeclaredMethod("classUnderTest");
+        method.setAccessible(true);
+        return (Class<? extends Accountable>) method.invoke(test);
+    }
+
+    @SuppressForbidden(reason = "test-only classpath scan for accountable coverage conventions")
+    private static List<Class<?>> loadClassesInPackage(String packageName) throws Exception {
+        Set<String> classNames = new LinkedHashSet<>();
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        String path = packageName.replace('.', '/');
+        Enumeration<URL> resources = loader.getResources(path);
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            if ("file".equals(resource.getProtocol()) == false) {
+                continue;
+            }
+            Path directory = PathUtils.get(resource.toURI());
+            if (Files.isDirectory(directory)) {
+                collectClassNames(directory, packageName, classNames);
+            }
+        }
+        List<Class<?>> classes = new ArrayList<>(classNames.size());
+        for (String className : classNames.stream().sorted(Comparator.naturalOrder()).toList()) {
+            classes.add(Class.forName(className, false, loader));
+        }
+        return classes;
+    }
+
+    private static void collectClassNames(Path directory, String pkg, Set<String> classNames) throws Exception {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
+            for (Path entry : stream) {
+                if (Files.isDirectory(entry)) {
+                    collectClassNames(entry, pkg + "." + entry.getFileName(), classNames);
+                } else if (entry.getFileName().toString().endsWith(".class")) {
+                    String simpleName = entry.getFileName().toString().replace(".class", "");
+                    classNames.add(pkg + "." + simpleName);
+                }
+            }
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/TokenListCategorizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/TokenListCategorizer.java
@@ -13,6 +13,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -64,7 +65,6 @@ public class TokenListCategorizer implements Accountable {
 
     public static final int MAX_TOKENS = 100;
     private static final long SHALLOW_SIZE = shallowSizeOfInstance(TokenListCategorizer.class);
-    private static final long SHALLOW_SIZE_OF_ARRAY_LIST = shallowSizeOfInstance(ArrayList.class);
     private static final float EPSILON = 0.000001f;
     private static final Logger logger = LogManager.getLogger(TokenListCategorizer.class);
 
@@ -340,7 +340,7 @@ public class TokenListCategorizer implements Accountable {
             // method called for categoriesByNumMatches, getting the size of the contained objects from a different
             // variable.
             + alignObjectSize(
-                SHALLOW_SIZE_OF_ARRAY_LIST + NUM_BYTES_ARRAY_HEADER + categoriesByNumMatches.size() * NUM_BYTES_OBJECT_REF
+                RamUsageEstimates.ARRAY_LIST_SHALLOW_SIZE + NUM_BYTES_ARRAY_HEADER + categoriesByNumMatches.size() * NUM_BYTES_OBJECT_REF
                     + categoriesByNumMatchesContentsSize
             );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/TokenListCategory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/TokenListCategory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.aggs.categorization;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 
@@ -31,7 +32,6 @@ import static org.apache.lucene.util.RamUsageEstimator.sizeOfCollection;
 public class TokenListCategory implements Accountable {
 
     private static final long SHALLOW_SIZE = shallowSizeOfInstance(TokenListCategory.class);
-    private static final long SHALLOW_SIZE_OF_ARRAY_LIST = shallowSizeOfInstance(ArrayList.class);
 
     /**
      * ID that's locally unique for a given {@link TokenListCategorizer}.
@@ -613,11 +613,11 @@ public class TokenListCategory implements Accountable {
             // method called for baseWeightedTokenIds and commonUniqueTokenIds, but taking advantage of the fact
             // that TokenAndWeight objects have fixed size.
             + alignObjectSize(
-                SHALLOW_SIZE_OF_ARRAY_LIST + NUM_BYTES_ARRAY_HEADER + baseWeightedTokenIds.size() * (TokenAndWeight.SHALLOW_SIZE
-                    + NUM_BYTES_OBJECT_REF)
+                RamUsageEstimates.ARRAY_LIST_SHALLOW_SIZE + NUM_BYTES_ARRAY_HEADER + baseWeightedTokenIds.size()
+                    * (TokenAndWeight.SHALLOW_SIZE + NUM_BYTES_OBJECT_REF)
             ) + alignObjectSize(
-                SHALLOW_SIZE_OF_ARRAY_LIST + NUM_BYTES_ARRAY_HEADER + commonUniqueTokenIds.size() * (TokenAndWeight.SHALLOW_SIZE
-                    + NUM_BYTES_OBJECT_REF)
+                RamUsageEstimates.ARRAY_LIST_SHALLOW_SIZE + NUM_BYTES_ARRAY_HEADER + commonUniqueTokenIds.size()
+                    * (TokenAndWeight.SHALLOW_SIZE + NUM_BYTES_OBJECT_REF)
             );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/modelsize/SizeEstimatorHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/modelsize/SizeEstimatorHelper.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.ml.inference.modelsize;
 
+import org.elasticsearch.common.lucene.RamUsageEstimates;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +41,7 @@ final class SizeEstimatorHelper {
 
     static long sizeOfHashMap(List<Long> sizeOfKeys, List<Long> sizeOfValues) {
         assert sizeOfKeys.size() == sizeOfValues.size();
-        long mapsize = shallowSizeOfInstance(HashMap.class);
+        long mapsize = RamUsageEstimates.HASH_MAP_SHALLOW_SIZE;
         final long mapEntrySize = shallowSizeOfInstance(HashMap.Entry.class);
         mapsize += Stream.concat(sizeOfKeys.stream(), sizeOfValues.stream()).mapToLong(Long::longValue).sum();
         mapsize += mapEntrySize * sizeOfKeys.size();

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/BytesStore.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/BytesStore.java
@@ -23,6 +23,7 @@ import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,8 +34,8 @@ import java.util.List;
 
 class BytesStore extends DataOutput implements Accountable {
 
-    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesStore.class) + RamUsageEstimator
-        .shallowSizeOfInstance(ArrayList.class);
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesStore.class)
+        + RamUsageEstimates.ARRAY_LIST_SHALLOW_SIZE;
 
     private final List<byte[]> blocks = new ArrayList<>();
 


### PR DESCRIPTION
## End goal of this stack

Stateless nodes today charge a **fixed per-index heap overhead** (`INDEX_MEMORY_OVERHEAD`, 350 KB × index count) when estimating node base memory. That constant is easy to reason about, but it does not reflect how much heap index metadata objects actually retain — a cluster with lightweight indices is over-estimated, and the number never adapts as metadata grows or shrinks.

This stack replaces that blunt estimate with an **object-size walk of cluster-state index metadata**:

1. **Make metadata types accountable** — implement Lucene `Accountable#ramBytesUsed()` on index metadata classes, with field tripwire tests so new fields force an explicit accounting decision.
2. **Aggregate accurately at project/cluster scope** — sum per-index estimates from `IndexMetadata` / `ProjectMetadata`, deduplicating shared objects (e.g. shared `MappingMetadata`) where it matters.
3. **Wire it into stateless memory metrics** — on each master cluster-state change, `StatelessMemoryMetricsService` computes `getIndexMetadataEstimatedHeapBytes()` from that walk instead of relying solely on the fixed per-index constant.

The intended outcome is **more accurate, size-aware index metadata heap accounting** on stateless indexing nodes — better input for heap-usage-aware allocation and node memory reporting, with typical clusters seeing **lower** metadata overhead than the legacy flat rate while still guarding against under-counting via tests.

> **Note:** The walk is an approximate retained-heap estimate, not measured RSS. Interned settings strings are not double-counted across indices; some shared leaf types are sized shallowly by design.

## This PR

Stack PR 2/4. Adds `Accountable` to the remaining leaf metadata types that `IndexMetadata` composes:

`CompressedXContent`, `MappingMetadata`, `IndexReshardingMetadata`, `IndexReshardingState`, `RolloverInfo`, `AliasMetadata`, `LifecycleExecutionState`, and `InferenceFieldMetadata`, each with field tripwire tests.

Depends on #156429.

## Stack (review in order)

1. #156429 → `accountable-small-sample`
2. **This PR** → `accountable-metadata-leaves`
3. #156428 → `accountable-index-metadata` (draft)
4. #154764 → `index-metadata-heap-calculation` (draft)