### PR TITLE
Add Accountable heap estimates for small metadata types

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -19,7 +21,7 @@ import java.util.Objects;
 /**
  * Base class for rollover request conditions
  */
-public abstract class Condition<T> implements NamedWriteable, ToXContentFragment {
+public abstract class Condition<T> implements NamedWriteable, ToXContentFragment, Accountable {
 
     /*
      * Describes the type of condition - a min_* condition (MIN), max_* condition (MAX), or an automatic condition (automatic conditions
@@ -82,6 +84,16 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
 
     public Type type() {
         return type;
+    }
+
+    /**
+     * Estimated heap footprint of this condition. Counts the shared {@code type} enum singleton (so summing many conditions over-counts
+     * those few bytes). All concrete subclasses only set the inherited {@code value} and declare no extra fields.
+     */
+    @Override
+    public final long ramBytesUsed() {
+        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.shallowSizeOf(type) + RamUsageEstimator.sizeOf(name)
+            + RamUsageEstimator.sizeOfObject(value);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -87,13 +87,13 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
     }
 
     /**
-     * Estimated heap footprint of this condition. Counts the shared {@code type} enum singleton (so summing many conditions over-counts
-     * those few bytes). All concrete subclasses only set the inherited {@code value} and declare no extra fields.
+     * Estimated heap footprint of this condition. The {@code type} enum is a shared singleton, so only the field reference is counted
+     * (already included in {@link RamUsageEstimator#shallowSizeOf(Object)}). All concrete subclasses only set the inherited {@code value}
+     * and declare no extra fields.
      */
     @Override
     public final long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.shallowSizeOf(type) + RamUsageEstimator.sizeOf(name)
-            + RamUsageEstimator.sizeOfObject(value);
+        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + RamUsageEstimator.sizeOfObject(value);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xcontent.ToXContentFragment;
 
@@ -93,19 +94,7 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
      */
     @Override
     public final long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + sizeOfValue(value);
-    }
-
-    private static long sizeOfValue(Object value) {
-        if (value == null) {
-            return 0;
-        }
-        return switch (value) {
-            case Long l -> RamUsageEstimator.sizeOf(l);
-            case Integer i -> RamUsageEstimator.sizeOf(i);
-            case Accountable a -> a.ramBytesUsed();
-            default -> RamUsageEstimator.shallowSizeOf(value);
-        };
+        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + RamUsageEstimates.sizeOfShallowCompleteValue(value);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -93,7 +93,19 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
      */
     @Override
     public final long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + RamUsageEstimator.sizeOfObject(value);
+        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + sizeOfValue(value);
+    }
+
+    private static long sizeOfValue(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        return switch (value) {
+            case Long l -> RamUsageEstimator.sizeOf(l);
+            case Integer i -> RamUsageEstimator.sizeOf(i);
+            case Accountable a -> a.ramBytesUsed();
+            default -> RamUsageEstimator.shallowSizeOf(value);
+        };
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/Condition.java
@@ -24,6 +24,8 @@ import java.util.Objects;
  */
 public abstract class Condition<T> implements NamedWriteable, ToXContentFragment, Accountable {
 
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Condition.class);
+
     /*
      * Describes the type of condition - a min_* condition (MIN), max_* condition (MAX), or an automatic condition (automatic conditions
      * are something that the platform configures and manages)
@@ -89,12 +91,12 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
 
     /**
      * Estimated heap footprint of this condition. The {@code type} enum is a shared singleton, so only the field reference is counted
-     * (already included in {@link RamUsageEstimator#shallowSizeOf(Object)}). All concrete subclasses only set the inherited {@code value}
-     * and declare no extra fields.
+     * (already included in {@link #SHALLOW_SIZE}). Concrete subclasses must only set the inherited {@code value} and declare no extra
+     * fields.
      */
     @Override
     public final long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOf(this) + RamUsageEstimator.sizeOf(name) + RamUsageEstimates.sizeOfShallowCompleteValue(value);
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(name) + RamUsageEstimates.sizeOfShallowCompleteValue(value);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -29,7 +31,10 @@ import java.util.Objects;
 public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize averageShardSize)
     implements
         Writeable,
-        ToXContentFragment {
+        ToXContentFragment,
+        Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexMetadataStats.class);
 
     public static final ParseField WRITE_LOAD_FIELD = new ParseField("write_load");
     public static final ParseField AVERAGE_SIZE_FIELD = new ParseField("avg_size");
@@ -124,6 +129,12 @@ public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize
 
     public IndexWriteLoad writeLoad() {
         return indexWriteLoad;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // averageShardSize holds only primitives, so its shallow size is a complete accounting.
+        return BASE_RAM_BYTES_USED + indexWriteLoad.ramBytesUsed() + RamUsageEstimator.shallowSizeOf(averageShardSize);
     }
 
     public record AverageShardSize(long totalSizeInBytes, int numberOfShards) implements Writeable, ToXContentFragment {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataStats.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -133,8 +134,7 @@ public record IndexMetadataStats(IndexWriteLoad indexWriteLoad, AverageShardSize
 
     @Override
     public long ramBytesUsed() {
-        // averageShardSize holds only primitives, so its shallow size is a complete accounting.
-        return BASE_RAM_BYTES_USED + indexWriteLoad.ramBytesUsed() + RamUsageEstimator.shallowSizeOf(averageShardSize);
+        return BASE_RAM_BYTES_USED + indexWriteLoad.ramBytesUsed() + RamUsageEstimates.shallowSizeOfPrimitiveOnly(averageShardSize);
     }
 
     public record AverageShardSize(long totalSizeInBytes, int numberOfShards) implements Writeable, ToXContentFragment {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexWriteLoad.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -26,7 +28,9 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
-public class IndexWriteLoad implements Writeable, ToXContentFragment {
+public class IndexWriteLoad implements Writeable, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexWriteLoad.class);
 
     public static final ParseField SHARDS_WRITE_LOAD_FIELD = new ParseField("loads");
     public static final ParseField SHARDS_UPTIME_IN_MILLIS = new ParseField("uptimes");
@@ -212,6 +216,12 @@ public class IndexWriteLoad implements Writeable, ToXContentFragment {
 
     public int numberOfShards() {
         return shardWriteLoad.length;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(shardWriteLoad) + RamUsageEstimator.sizeOf(shardUptimeInMillis)
+            + RamUsageEstimator.sizeOf(shardRecentWriteLoad) + RamUsageEstimator.sizeOf(shardPeakWriteLoad);
     }
 
     private void assertShardInBounds(int shardId) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.node;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.regex.Regex;
@@ -21,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class DiscoveryNodeFilters {
+public class DiscoveryNodeFilters implements Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DiscoveryNodeFilters.class);
 
     public static final Set<String> SINGLE_NODE_NAMES = Set.of("_id", "_name", "name");
     static final Set<String> NON_ATTRIBUTE_NAMES = Set.of("_ip", "_host_ip", "_publish_ip", "host", "_id", "_name", "name");
@@ -252,6 +256,17 @@ public class DiscoveryNodeFilters {
 
     public boolean hasFilters() {
         return filters.isEmpty() == false;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // opType is a shared enum singleton; counting it here over-counts those few bytes when many filters are summed.
+        long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(opType) + RamUsageEstimator.sizeOfMap(filters);
+        // withoutTierPreferences may alias this instance.
+        if (withoutTierPreferences != null && withoutTierPreferences != this) {
+            size += withoutTierPreferences.ramBytesUsed();
+        }
+        return size;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -260,8 +260,8 @@ public class DiscoveryNodeFilters implements Accountable {
 
     @Override
     public long ramBytesUsed() {
-        // opType is a shared enum singleton; counting it here over-counts those few bytes when many filters are summed.
-        long size = BASE_RAM_BYTES_USED + RamUsageEstimator.shallowSizeOf(opType) + RamUsageEstimator.sizeOfMap(filters);
+        // opType is a shared enum singleton; its cost is only the field reference already included in BASE_RAM_BYTES_USED.
+        long size = BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOfMap(filters);
         // withoutTierPreferences may alias this instance.
         if (withoutTierPreferences != null && withoutTierPreferences != this) {
             size += withoutTierPreferences.ramBytesUsed();

--- a/server/src/main/java/org/elasticsearch/common/lucene/RamUsageEstimates.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/RamUsageEstimates.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.lucene;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Assert-guarded helpers for {@link RamUsageEstimator#shallowSizeOf(Object)} at {@link Accountable#ramBytesUsed()} call sites where the
+ * shallow instance size is a complete accounting of retained heap. Assertions fire only when assertions are enabled.
+ */
+public final class RamUsageEstimates {
+
+    private RamUsageEstimates() {}
+
+    /**
+     * Returns {@link RamUsageEstimator#shallowSizeOf(Object)} after asserting that every non-static instance field on {@code o}'s class
+     * hierarchy is primitive.
+     */
+    public static long shallowSizeOfPrimitiveOnly(Object o) {
+        assert o != null;
+        assert objectHasOnlyPrimitiveFields(o.getClass())
+            : shallowCompleteAssertionMessage(o.getClass(), ReferenceFieldPolicy.PRIMITIVE_ONLY);
+        return RamUsageEstimator.shallowSizeOf(o);
+    }
+
+    /**
+     * Returns {@link RamUsageEstimator#shallowSizeOf(Object)} after asserting that every non-static instance field is either primitive or
+     * an enum. Enum constants are shared singletons, so only the reference slot is retained per instance.
+     */
+    public static long shallowSizeOfShallowComplete(Object o) {
+        assert o != null;
+        assert objectHasOnlyShallowCompleteFields(o.getClass())
+            : shallowCompleteAssertionMessage(o.getClass(), ReferenceFieldPolicy.SHALLOW_COMPLETE);
+        return RamUsageEstimator.shallowSizeOf(o);
+    }
+
+    /**
+     * Size of a loosely typed value field: boxed primitives, {@link String}, and {@link Accountable} values use dedicated estimators;
+     * all other types must be shallow-complete (primitives and enums only).
+     */
+    public static long sizeOfShallowCompleteValue(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        return switch (value) {
+            case Long l -> RamUsageEstimator.sizeOf(l);
+            case Integer i -> RamUsageEstimator.sizeOf(i);
+            case String s -> RamUsageEstimator.sizeOf(s);
+            case Accountable a -> a.ramBytesUsed();
+            default -> shallowSizeOfShallowComplete(value);
+        };
+    }
+
+    /** Returns true if every non-static instance field on {@code clazz}'s hierarchy is primitive. */
+    public static boolean objectHasOnlyPrimitiveFields(Class<?> clazz) {
+        return unaccountedReferenceFields(clazz, ReferenceFieldPolicy.PRIMITIVE_ONLY).isEmpty();
+    }
+
+    /** Returns true if every non-static instance field is primitive or enum. */
+    public static boolean objectHasOnlyShallowCompleteFields(Class<?> clazz) {
+        return unaccountedReferenceFields(clazz, ReferenceFieldPolicy.SHALLOW_COMPLETE).isEmpty();
+    }
+
+    /**
+     * Names of non-static, non-primitive fields declared directly on {@code clazz}. Inherited fields are the declaring class's
+     * responsibility. Used by accountable field tests to ensure every reference field is explicitly classified.
+     */
+    @SuppressForbidden(reason = "test-only field introspection for accountable field tripwires")
+    public static Set<String> referenceFieldNamesDeclaredOn(Class<?> clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+            .filter(f -> Modifier.isStatic(f.getModifiers()) == false)
+            .filter(f -> f.getType().isPrimitive() == false)
+            .map(Field::getName)
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private enum ReferenceFieldPolicy {
+        PRIMITIVE_ONLY,
+        SHALLOW_COMPLETE
+    }
+
+    @SuppressForbidden(reason = "assert-only field introspection for ramBytesUsed() tripwires")
+    private static Set<Field> unaccountedReferenceFields(Class<?> clazz, ReferenceFieldPolicy policy) {
+        Set<Field> refs = new LinkedHashSet<>();
+        for (Class<?> c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Field field : c.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                if (field.getType().isPrimitive()) {
+                    continue;
+                }
+                if (policy == ReferenceFieldPolicy.SHALLOW_COMPLETE && field.getType().isEnum()) {
+                    continue;
+                }
+                refs.add(field);
+            }
+        }
+        return refs;
+    }
+
+    private static String shallowCompleteAssertionMessage(Class<?> clazz, ReferenceFieldPolicy policy) {
+        String fields = unaccountedReferenceFields(clazz, policy).stream()
+            .map(f -> f.getName() + ":" + f.getType().getSimpleName())
+            .collect(Collectors.joining(", "));
+        return switch (policy) {
+            case PRIMITIVE_ONLY -> clazz.getName()
+                + " has non-primitive fields ["
+                + fields
+                + "]; use shallowSizeOfShallowComplete or account explicitly";
+            case SHALLOW_COMPLETE -> clazz.getName()
+                + " has reference fields beyond enums ["
+                + fields
+                + "]; implement Accountable or account explicitly";
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexLongFieldRange.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexLongFieldRange.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.shard;
 
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,7 +31,9 @@ import java.util.stream.IntStream;
  * information is accumulated shard-by-shard, and we keep track of which shards are represented in this value. Only once all shards are
  * represented should this information be considered accurate for the index.
  */
-public class IndexLongFieldRange implements Writeable, ToXContentFragment {
+public class IndexLongFieldRange implements Writeable, ToXContentFragment, Accountable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexLongFieldRange.class);
 
     /**
      * Sentinel value indicating that no information is currently available, for instance because the index has just been created.
@@ -71,6 +75,12 @@ public class IndexLongFieldRange implements Writeable, ToXContentFragment {
      */
     public boolean containsAllShardRanges() {
         return isComplete() && this != IndexLongFieldRange.UNKNOWN;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // shards is null once the range is complete (covers all shards); when non-null it holds the tracked shard ids.
+        return BASE_RAM_BYTES_USED + (shards == null ? 0L : RamUsageEstimator.sizeOf(shards));
     }
 
     // exposed for testing

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.rollover;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return Condition.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("name", "value", "type");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return new MaxDocsCondition(1L);
+    }
+
+    /**
+     * Non-tautology check: the different value types must each contribute a boxed/value cost on top of the shallow condition size.
+     */
+    public void testRamBytesUsedCountsConditionValue() {
+        long shallow = shallowSizeOf(new MaxDocsCondition(1L));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(shallow));
+        assertThat(new MaxSizeCondition(ByteSizeValue.ofMb(1)).ramBytesUsed(), greaterThan(shallow));
+        assertThat(new MaxAgeCondition(TimeValue.timeValueDays(1)).ramBytesUsed(), greaterThan(shallow));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
@@ -10,8 +10,6 @@
 package org.elasticsearch.action.admin.indices.rollover;
 
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
 
 import java.util.Set;
@@ -27,26 +25,47 @@ public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCas
 
     @Override
     protected Set<String> fieldsAccountedForInRamBytesUsed() {
-        return Set.of("name", "value", "type");
+        return Set.of("name", "value");
     }
 
     @Override
     protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+        // Shared enum singleton; only the field reference is counted in shallowSizeOf(this).
+        return Set.of("type");
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return new MaxDocsCondition(1L);
+    protected boolean assertsAgainstRamUsageTester() {
+        // RamUsageTester includes the Type enum instance; ramBytesUsed() does not, by design.
+        return false;
+    }
+
+    @Override
+    protected Accountable createRandomTestInstance() {
+        return switch (randomIntBetween(0, 10)) {
+            case 0 -> new MaxDocsCondition(randomNonNegativeLong());
+            case 1 -> new MinDocsCondition(randomNonNegativeLong());
+            case 2 -> new MaxPrimaryShardDocsCondition(randomNonNegativeLong());
+            case 3 -> new MinPrimaryShardDocsCondition(randomNonNegativeLong());
+            case 4 -> new MaxSizeCondition(randomByteSizeValue());
+            case 5 -> new MinSizeCondition(randomByteSizeValue());
+            case 6 -> new MaxPrimaryShardSizeCondition(randomByteSizeValue());
+            case 7 -> new MinPrimaryShardSizeCondition(randomByteSizeValue());
+            case 8 -> new MaxAgeCondition(randomTimeValue());
+            case 9 -> new MinAgeCondition(randomTimeValue());
+            case 10 -> new OptimalShardCountCondition(randomIntBetween(1, 100));
+            default -> throw new AssertionError("unexpected condition branch");
+        };
     }
 
     /**
-     * Non-tautology check: the different value types must each contribute a boxed/value cost on top of the shallow condition size.
+     * Non-tautology check: the condition value (Long, ByteSizeValue, TimeValue, or Integer) must contribute a cost on top of the shallow
+     * instance size.
      */
     public void testRamBytesUsedCountsConditionValue() {
-        long shallow = shallowSizeOf(new MaxDocsCondition(1L));
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(shallow));
-        assertThat(new MaxSizeCondition(ByteSizeValue.ofMb(1)).ramBytesUsed(), greaterThan(shallow));
-        assertThat(new MaxAgeCondition(TimeValue.timeValueDays(1)).ramBytesUsed(), greaterThan(shallow));
+        for (int i = 0; i < 10; i++) {
+            Condition<?> instance = (Condition<?>) createRandomTestInstance();
+            assertThat(instance.ramBytesUsed(), greaterThan(shallowSizeOf(instance)));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
@@ -10,10 +10,21 @@
 package org.elasticsearch.action.admin.indices.rollover;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+import org.elasticsearch.test.ClasspathUtils;
 
+import java.lang.reflect.Modifier;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
@@ -30,7 +41,7 @@ public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCas
 
     @Override
     protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        // Shared enum singleton; only the field reference is counted in shallowSizeOf(this).
+        // Shared enum singleton; only the field reference is counted in SHALLOW_SIZE.
         return Set.of("type");
     }
 
@@ -66,6 +77,61 @@ public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCas
         for (int i = 0; i < 10; i++) {
             Condition<?> instance = (Condition<?>) createRandomTestInstance();
             assertThat(instance.ramBytesUsed(), greaterThan(shallowSizeOf(instance)));
+        }
+    }
+
+    /**
+     * {@link Condition#ramBytesUsed()} uses {@code Condition}'s shallow size. A subclass that adds instance fields would be under-counted.
+     */
+    public void testConditionSubclassesDeclareNoFields() throws Exception {
+        Set<Class<?>> leaves = discoverConcreteConditionSubclasses();
+
+        Set<String> registeredNames = IndicesModule.getNamedWriteables()
+            .stream()
+            .filter(entry -> entry.categoryClass == Condition.class)
+            .map(entry -> entry.name)
+            .collect(Collectors.toUnmodifiableSet());
+        Set<String> discoveredNames = leaves.stream()
+            .map(ConditionRamBytesUsedTests::writeableName)
+            .collect(Collectors.toUnmodifiableSet());
+        assertThat(discoveredNames, equalTo(registeredNames));
+
+        for (Class<?> leaf : leaves) {
+            assertThat(
+                leaf.getSimpleName() + " must not declare instance fields; Condition.ramBytesUsed() uses Condition's shallow size",
+                Arrays.stream(leaf.getDeclaredFields()).filter(field -> Modifier.isStatic(field.getModifiers()) == false).toList(),
+                empty()
+            );
+        }
+    }
+
+    private static Set<Class<?>> discoverConcreteConditionSubclasses() throws Exception {
+        String pkg = Condition.class.getPackageName();
+        Path[] roots = ClasspathUtils.findFilePaths(ConditionRamBytesUsedTests.class.getClassLoader(), pkg.replace('.', '/'));
+        Set<Class<?>> leaves = new HashSet<>();
+        for (Path root : roots) {
+            if (Files.isDirectory(root) == false) {
+                continue;
+            }
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(root, "*.class")) {
+                for (Path entry : stream) {
+                    Class<?> clazz = Class.forName(pkg + "." + entry.getFileName().toString().replace(".class", ""));
+                    if (clazz != Condition.class
+                        && Condition.class.isAssignableFrom(clazz)
+                        && Modifier.isAbstract(clazz.getModifiers()) == false) {
+                        leaves.add(clazz);
+                    }
+                }
+            }
+        }
+        return leaves;
+    }
+
+    private static String writeableName(Class<?> clazz) {
+        try {
+            return (String) clazz.getField("NAME").get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(clazz.getName() + " must declare a public static NAME field", e);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionRamBytesUsedTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.action.admin.indices.rollover;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
 import org.elasticsearch.test.ClasspathUtils;
@@ -83,6 +84,7 @@ public class ConditionRamBytesUsedTests extends AbstractAccountableFieldsTestCas
     /**
      * {@link Condition#ramBytesUsed()} uses {@code Condition}'s shallow size. A subclass that adds instance fields would be under-counted.
      */
+    @SuppressForbidden(reason = "need access to all fields, including private instance fields")
     public void testConditionSubclassesDeclareNoFields() throws Exception {
         Set<Class<?>> leaves = discoverConcreteConditionSubclasses();
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexMetadataStatsRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexMetadataStats.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("indexWriteLoad", "averageShardSize");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return new IndexMetadataStats(IndexWriteLoad.builder(16).build(), 100L, 16);
+    }
+
+    /**
+     * Non-tautology check: the stats estimate must include the nested {@link IndexWriteLoad}, so more shards means a larger estimate.
+     */
+    public void testRamBytesUsedIncludesWriteLoad() {
+        IndexMetadataStats few = new IndexMetadataStats(IndexWriteLoad.builder(1).build(), 100L, 1);
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsRamBytesUsedTests.java
@@ -29,13 +29,9 @@ public class IndexMetadataStatsRamBytesUsedTests extends AbstractAccountableFiel
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
-        return new IndexMetadataStats(IndexWriteLoad.builder(16).build(), 100L, 16);
+    protected Accountable createRandomTestInstance() {
+        int shards = randomIntBetween(1, 32);
+        return new IndexMetadataStats(IndexWriteLoad.builder(shards).build(), randomNonNegativeLong(), shards);
     }
 
     /**
@@ -43,6 +39,7 @@ public class IndexMetadataStatsRamBytesUsedTests extends AbstractAccountableFiel
      */
     public void testRamBytesUsedIncludesWriteLoad() {
         IndexMetadataStats few = new IndexMetadataStats(IndexWriteLoad.builder(1).build(), 100L, 1);
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+        IndexMetadataStats many = new IndexMetadataStats(IndexWriteLoad.builder(16).build(), 100L, 16);
+        assertThat(many.ramBytesUsed(), greaterThan(few.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexWriteLoadRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexWriteLoad.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("shardWriteLoad", "shardUptimeInMillis", "shardRecentWriteLoad", "shardPeakWriteLoad");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return IndexWriteLoad.builder(16).build();
+    }
+
+    /**
+     * Non-tautology check: more shards means larger backing arrays and therefore a larger estimate.
+     */
+    public void testRamBytesUsedGrowsWithShardCount() {
+        IndexWriteLoad few = IndexWriteLoad.builder(1).build();
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexWriteLoadRamBytesUsedTests.java
@@ -29,13 +29,8 @@ public class IndexWriteLoadRamBytesUsedTests extends AbstractAccountableFieldsTe
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
-        return IndexWriteLoad.builder(16).build();
+    protected Accountable createRandomTestInstance() {
+        return IndexWriteLoad.builder(randomIntBetween(1, 32)).build();
     }
 
     /**
@@ -43,6 +38,7 @@ public class IndexWriteLoadRamBytesUsedTests extends AbstractAccountableFieldsTe
      */
     public void testRamBytesUsedGrowsWithShardCount() {
         IndexWriteLoad few = IndexWriteLoad.builder(1).build();
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(few.ramBytesUsed()));
+        IndexWriteLoad many = IndexWriteLoad.builder(16).build();
+        assertThat(many.ramBytesUsed(), greaterThan(few.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.node;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class DiscoveryNodeFiltersRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return DiscoveryNodeFilters.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("filters", "withoutTierPreferences", "opType");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        return DiscoveryNodeFilters.buildFromKeyValues(
+            DiscoveryNodeFilters.OpType.AND,
+            Map.of("_id", List.of("n1", "n2"), "rack", List.of("r1"))
+        );
+    }
+
+    /**
+     * Non-tautology check: more filter attributes must increase the reported size.
+     */
+    public void testRamBytesUsedGrowsWithFilters() {
+        DiscoveryNodeFilters one = DiscoveryNodeFilters.buildFromKeyValues(DiscoveryNodeFilters.OpType.AND, Map.of("_id", List.of("n1")));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersRamBytesUsedTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.cluster.node;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,20 +28,34 @@ public class DiscoveryNodeFiltersRamBytesUsedTests extends AbstractAccountableFi
 
     @Override
     protected Set<String> fieldsAccountedForInRamBytesUsed() {
-        return Set.of("filters", "withoutTierPreferences", "opType");
+        return Set.of("filters", "withoutTierPreferences");
     }
 
     @Override
     protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
+        // Shared enum singleton; only the field reference is counted in BASE_RAM_BYTES_USED.
+        return Set.of("opType");
     }
 
     @Override
-    protected Accountable createTestInstance() {
-        return DiscoveryNodeFilters.buildFromKeyValues(
-            DiscoveryNodeFilters.OpType.AND,
-            Map.of("_id", List.of("n1", "n2"), "rack", List.of("r1"))
-        );
+    protected boolean assertsAgainstRamUsageTester() {
+        // RamUsageTester includes the OpType enum instance; ramBytesUsed() does not, by design.
+        return false;
+    }
+
+    @Override
+    protected Accountable createRandomTestInstance() {
+        Map<String, List<String>> filters = new HashMap<>();
+        if (randomBoolean()) {
+            int attrs = randomIntBetween(1, 4);
+            for (int i = 0; i < attrs; i++) {
+                filters.put("attr" + i, randomList(1, 3, () -> randomAlphaOfLengthBetween(1, 8)));
+            }
+        }
+        if (filters.isEmpty() || randomBoolean()) {
+            filters.put("_tier_preference", List.of(randomFrom("data_hot", "data_warm", "data_cold")));
+        }
+        return DiscoveryNodeFilters.buildFromKeyValues(randomFrom(DiscoveryNodeFilters.OpType.values()), filters);
     }
 
     /**
@@ -48,6 +63,25 @@ public class DiscoveryNodeFiltersRamBytesUsedTests extends AbstractAccountableFi
      */
     public void testRamBytesUsedGrowsWithFilters() {
         DiscoveryNodeFilters one = DiscoveryNodeFilters.buildFromKeyValues(DiscoveryNodeFilters.OpType.AND, Map.of("_id", List.of("n1")));
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+        DiscoveryNodeFilters many = DiscoveryNodeFilters.buildFromKeyValues(
+            DiscoveryNodeFilters.OpType.AND,
+            Map.of("_id", List.of("n1", "n2"), "rack", List.of("r1"))
+        );
+        assertThat(many.ramBytesUsed(), greaterThan(one.ramBytesUsed()));
+    }
+
+    /**
+     * A {@code _tier_preference} filter materializes a distinct {@code withoutTierPreferences} instance whose heap is added on top.
+     */
+    public void testRamBytesUsedCountsWithoutTierPreferences() {
+        DiscoveryNodeFilters withoutTier = DiscoveryNodeFilters.buildFromKeyValues(
+            DiscoveryNodeFilters.OpType.AND,
+            Map.of("_id", List.of("n1"))
+        );
+        DiscoveryNodeFilters withTier = DiscoveryNodeFilters.buildFromKeyValues(
+            DiscoveryNodeFilters.OpType.AND,
+            Map.of("_id", List.of("n1"), "_tier_preference", List.of("data_hot"))
+        );
+        assertThat(withTier.ramBytesUsed(), greaterThan(withoutTier.ramBytesUsed()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/RamUsageEstimatesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/RamUsageEstimatesTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.lucene;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.cluster.metadata.IndexMetadataStats;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+public class RamUsageEstimatesTests extends ESTestCase {
+
+    public void testObjectHasOnlyPrimitiveFields() {
+        assertTrue(RamUsageEstimates.objectHasOnlyPrimitiveFields(IndexMetadataStats.AverageShardSize.class));
+        assertFalse(RamUsageEstimates.objectHasOnlyPrimitiveFields(ByteSizeValue.class));
+    }
+
+    public void testObjectHasOnlyShallowCompleteFields() {
+        assertTrue(RamUsageEstimates.objectHasOnlyShallowCompleteFields(IndexMetadataStats.AverageShardSize.class));
+        assertTrue(RamUsageEstimates.objectHasOnlyShallowCompleteFields(ByteSizeValue.class));
+        assertTrue(RamUsageEstimates.objectHasOnlyShallowCompleteFields(TimeValue.class));
+        assertFalse(RamUsageEstimates.objectHasOnlyShallowCompleteFields(String.class));
+    }
+
+    public void testShallowSizeOfPrimitiveOnlyMatchesRamUsageEstimator() {
+        var averageShardSize = new IndexMetadataStats.AverageShardSize(1024L, 4);
+        assertThat(
+            RamUsageEstimates.shallowSizeOfPrimitiveOnly(averageShardSize),
+            equalTo(RamUsageEstimator.shallowSizeOf(averageShardSize))
+        );
+    }
+
+    public void testShallowSizeOfShallowCompleteMatchesRamUsageEstimator() {
+        ByteSizeValue byteSizeValue = ByteSizeValue.ofMb(1);
+        TimeValue timeValue = new TimeValue(1, TimeUnit.DAYS);
+        assertThat(RamUsageEstimates.shallowSizeOfShallowComplete(byteSizeValue), equalTo(RamUsageEstimator.shallowSizeOf(byteSizeValue)));
+        assertThat(RamUsageEstimates.shallowSizeOfShallowComplete(timeValue), equalTo(RamUsageEstimator.shallowSizeOf(timeValue)));
+    }
+
+    public void testSizeOfShallowCompleteValue() {
+        assertThat(RamUsageEstimates.sizeOfShallowCompleteValue(null), is(0L));
+        assertThat(RamUsageEstimates.sizeOfShallowCompleteValue(1L), equalTo(RamUsageEstimator.sizeOf(1L)));
+        assertThat(
+            RamUsageEstimates.sizeOfShallowCompleteValue(TimeValue.timeValueDays(1)),
+            equalTo(RamUsageEstimator.shallowSizeOf(TimeValue.timeValueDays(1)))
+        );
+        assertThat(
+            RamUsageEstimates.sizeOfShallowCompleteValue("unknown-condition-value"),
+            equalTo(RamUsageEstimator.sizeOf("unknown-condition-value"))
+        );
+    }
+
+    public void testReferenceFieldNamesDeclaredOn() {
+        assertThat(
+            RamUsageEstimates.referenceFieldNamesDeclaredOn(IndexMetadataStats.class),
+            equalTo(java.util.Set.of("indexWriteLoad", "averageShardSize"))
+        );
+    }
+
+    public void testShallowSizeOfShallowCompleteIsAtLeastReferenceOverhead() {
+        long shallow = RamUsageEstimates.shallowSizeOfShallowComplete(ByteSizeValue.ofMb(1));
+        assertThat(shallow, greaterThan(0L));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.test.AbstractAccountableFieldsTestCase;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class IndexLongFieldRangeRamBytesUsedTests extends AbstractAccountableFieldsTestCase {
+
+    @Override
+    protected Class<? extends Accountable> classUnderTest() {
+        return IndexLongFieldRange.class;
+    }
+
+    @Override
+    protected Set<String> fieldsAccountedForInRamBytesUsed() {
+        return Set.of("shards");
+    }
+
+    @Override
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
+
+    @Override
+    protected Accountable createTestInstance() {
+        // NO_SHARDS still holds a non-null shards array, so the estimate covers array overhead rather than a null leaf.
+        return IndexLongFieldRange.NO_SHARDS;
+    }
+
+    /**
+     * Non-tautology check: a range still tracking shards (holding a non-null {@code shards} array, e.g. {@code NO_SHARDS}) must be larger
+     * than a complete range whose array is {@code null} (e.g. {@code UNKNOWN}).
+     */
+    public void testRamBytesUsedCountsTrackedShardsArray() {
+        assertThat(IndexLongFieldRange.NO_SHARDS.isComplete(), org.hamcrest.Matchers.is(false));
+        assertThat(IndexLongFieldRange.UNKNOWN.isComplete(), org.hamcrest.Matchers.is(true));
+        assertThat(createTestInstance().ramBytesUsed(), greaterThan(IndexLongFieldRange.UNKNOWN.ramBytesUsed()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexLongFieldRangeRamBytesUsedTests.java
@@ -29,14 +29,9 @@ public class IndexLongFieldRangeRamBytesUsedTests extends AbstractAccountableFie
     }
 
     @Override
-    protected Set<String> fieldsExcludedFromRamBytesUsed() {
-        return Set.of();
-    }
-
-    @Override
-    protected Accountable createTestInstance() {
-        // NO_SHARDS still holds a non-null shards array, so the estimate covers array overhead rather than a null leaf.
-        return IndexLongFieldRange.NO_SHARDS;
+    protected Accountable createRandomTestInstance() {
+        // Mix of null shards (complete/empty) and non-null arrays of varying length, so a missed array-length term fails.
+        return IndexLongFieldRangeTestUtils.randomSpecificRange();
     }
 
     /**
@@ -46,6 +41,6 @@ public class IndexLongFieldRangeRamBytesUsedTests extends AbstractAccountableFie
     public void testRamBytesUsedCountsTrackedShardsArray() {
         assertThat(IndexLongFieldRange.NO_SHARDS.isComplete(), org.hamcrest.Matchers.is(false));
         assertThat(IndexLongFieldRange.UNKNOWN.isComplete(), org.hamcrest.Matchers.is(true));
-        assertThat(createTestInstance().ramBytesUsed(), greaterThan(IndexLongFieldRange.UNKNOWN.ramBytesUsed()));
+        assertThat(IndexLongFieldRange.NO_SHARDS.ramBytesUsed(), greaterThan(IndexLongFieldRange.UNKNOWN.ramBytesUsed()));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test;
+
+import org.apache.lucene.tests.util.RamUsageTester;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Base class for tests of {@link Accountable#ramBytesUsed()} implementations that estimate an object's heap footprint field-by-field.
+ * <p>
+ * The core check is a structural tripwire: every non-static, non-primitive field declared on the class under test must be classified as
+ * either <em>accounted for</em> (its heap cost is added explicitly in {@code ramBytesUsed()}) or <em>excluded</em> (deliberately not
+ * counted, e.g. a derived cache or a documented gap). Primitive fields are ignored automatically because they are already covered by the
+ * shallow instance size that every {@code ramBytesUsed()} implementation is expected to include. When someone adds or removes a reference
+ * field without updating the estimate, this test fails, forcing them to decide how the new field should be accounted for.
+ * <p>
+ * When {@link #assertsAgainstRamUsageTester()} is true, a value check also asserts that {@code ramBytesUsed()} never under-counts the
+ * retained heap measured by Lucene's {@link RamUsageTester}. Subclasses that deliberately omit shared/interned state (e.g. interned
+ * {@code Settings} strings, shared enum singletons, or cross-index deduplicated mappings) should override that hook to {@code false} and
+ * document why a full-graph comparison would fail by design; those classes still get the structural tripwire and should keep their own
+ * behavioural assertions.
+ */
+public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
+
+    /**
+     * @return the concrete {@link Accountable} class whose fields are checked. Only fields declared directly on this class are inspected;
+     * fields inherited from a superclass are the superclass's own responsibility to account for and test.
+     */
+    protected abstract Class<? extends Accountable> classUnderTest();
+
+    /**
+     * @return names of reference fields whose heap cost is added explicitly in {@code ramBytesUsed()}.
+     */
+    protected abstract Set<String> fieldsAccountedForInRamBytesUsed();
+
+    /**
+     * @return names of reference fields deliberately not counted in {@code ramBytesUsed()}, each of which should have a comment (in the
+     * subclass or the production code) explaining why it needs no accounting.
+     */
+    protected abstract Set<String> fieldsExcludedFromRamBytesUsed();
+
+    /**
+     * A populated instance of {@link #classUnderTest()} for {@link #testRamBytesUsedNeverUnderCountsActualHeap()}. Subclasses that opt out
+     * via {@link #assertsAgainstRamUsageTester()} need not override this.
+     */
+    protected Accountable createTestInstance() {
+        throw new UnsupportedOperationException(
+            classUnderTest().getSimpleName() + " must implement createTestInstance() when assertsAgainstRamUsageTester() is true"
+        );
+    }
+
+    /**
+     * Whether to assert {@code ramBytesUsed() >= RamUsageTester.ramUsed(...)}. Defaults to {@code true}. Override to {@code false} when the
+     * estimate deliberately under-counts shared or interned state that a full object-graph walk would include.
+     */
+    protected boolean assertsAgainstRamUsageTester() {
+        return true;
+    }
+
+    @SuppressForbidden(reason = "need the names of all declared fields, most of which are private")
+    public void testRamBytesUsedAccountsForAllReferenceFields() {
+        final Class<? extends Accountable> clazz = classUnderTest();
+        final Set<String> accounted = fieldsAccountedForInRamBytesUsed();
+        final Set<String> excluded = fieldsExcludedFromRamBytesUsed();
+
+        assertThat(
+            "a field cannot be both accounted for and excluded in [" + clazz.getSimpleName() + "]",
+            Sets.intersection(accounted, excluded),
+            empty()
+        );
+
+        // Primitive fields are already covered by RamUsageEstimator.shallowSizeOf(...); only reference fields must be classified.
+        final Set<String> referenceFields = Arrays.stream(clazz.getDeclaredFields())
+            .filter(f -> Modifier.isStatic(f.getModifiers()) == false)
+            .filter(f -> f.getType().isPrimitive() == false)
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+
+        assertThat(
+            "reference field(s) on ["
+                + clazz.getSimpleName()
+                + "] are not classified for heap accounting - add each new field to the accounted-for set (and add its cost to "
+                + "ramBytesUsed()) or to the excluded set (with a comment explaining why it needs no accounting)",
+            referenceFields,
+            equalTo(Sets.union(accounted, excluded))
+        );
+    }
+
+    /**
+     * Value check against a real object-graph measurement. Catches systematic under-counting that the structural tripwire cannot.
+     */
+    public void testRamBytesUsedNeverUnderCountsActualHeap() {
+        assumeTrue(
+            classUnderTest().getSimpleName() + " deliberately under-counts shared/interned state vs a full-graph RamUsageTester walk",
+            assertsAgainstRamUsageTester()
+        );
+        Accountable instance = createTestInstance();
+        long estimate = instance.ramBytesUsed();
+        long actual = RamUsageTester.ramUsed(instance);
+        assertThat(
+            "estimate under-counts retained heap: estimate=" + estimate + " actual=" + actual + " for " + classUnderTest().getSimpleName(),
+            estimate,
+            greaterThanOrEqualTo(actual)
+        );
+    }
+
+    /**
+     * Convenience for subclasses: the shallow size of the given instance, i.e. the lower bound that any correct {@code ramBytesUsed()}
+     * must not go below.
+     */
+    protected static long shallowSizeOf(Accountable instance) {
+        return RamUsageEstimator.shallowSizeOf(instance);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
@@ -55,17 +55,21 @@ public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
 
     /**
      * @return names of reference fields deliberately not counted in {@code ramBytesUsed()}, each of which should have a comment (in the
-     * subclass or the production code) explaining why it needs no accounting.
+     * subclass or the production code) explaining why it needs no accounting. Defaults to none; override when a field is intentionally
+     * omitted (e.g. a shared enum singleton).
      */
-    protected abstract Set<String> fieldsExcludedFromRamBytesUsed();
+    protected Set<String> fieldsExcludedFromRamBytesUsed() {
+        return Set.of();
+    }
 
     /**
-     * A populated instance of {@link #classUnderTest()} for {@link #testRamBytesUsedNeverUnderCountsActualHeap()}. Subclasses that opt out
-     * via {@link #assertsAgainstRamUsageTester()} need not override this.
+     * A randomly populated instance of {@link #classUnderTest()} for {@link #testRamBytesUsedNeverUnderCountsActualHeap()}. Varying sizes
+     * (array lengths, map entries, string lengths) catch estimates that miss a length-dependent cost. Subclasses that opt out via
+     * {@link #assertsAgainstRamUsageTester()} need not override this.
      */
-    protected Accountable createTestInstance() {
+    protected Accountable createRandomTestInstance() {
         throw new UnsupportedOperationException(
-            classUnderTest().getSimpleName() + " must implement createTestInstance() when assertsAgainstRamUsageTester() is true"
+            classUnderTest().getSimpleName() + " must implement createRandomTestInstance() when assertsAgainstRamUsageTester() is true"
         );
     }
 
@@ -114,14 +118,22 @@ public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
             classUnderTest().getSimpleName() + " deliberately under-counts shared/interned state vs a full-graph RamUsageTester walk",
             assertsAgainstRamUsageTester()
         );
-        Accountable instance = createTestInstance();
-        long estimate = instance.ramBytesUsed();
-        long actual = RamUsageTester.ramUsed(instance);
-        assertThat(
-            "estimate under-counts retained heap: estimate=" + estimate + " actual=" + actual + " for " + classUnderTest().getSimpleName(),
-            estimate,
-            greaterThanOrEqualTo(actual)
-        );
+        final int iterations = scaledRandomIntBetween(5, 20);
+        for (int i = 0; i < iterations; i++) {
+            Accountable instance = createRandomTestInstance();
+            long estimate = instance.ramBytesUsed();
+            long actual = RamUsageTester.ramUsed(instance);
+            assertThat(
+                "estimate under-counts retained heap: estimate="
+                    + estimate
+                    + " actual="
+                    + actual
+                    + " for "
+                    + classUnderTest().getSimpleName(),
+                estimate,
+                greaterThanOrEqualTo(actual)
+            );
+        }
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractAccountableFieldsTestCase.java
@@ -12,14 +12,10 @@ package org.elasticsearch.test;
 import org.apache.lucene.tests.util.RamUsageTester;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.lucene.RamUsageEstimates;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.SuppressForbidden;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -81,7 +77,6 @@ public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
         return true;
     }
 
-    @SuppressForbidden(reason = "need the names of all declared fields, most of which are private")
     public void testRamBytesUsedAccountsForAllReferenceFields() {
         final Class<? extends Accountable> clazz = classUnderTest();
         final Set<String> accounted = fieldsAccountedForInRamBytesUsed();
@@ -94,11 +89,7 @@ public abstract class AbstractAccountableFieldsTestCase extends ESTestCase {
         );
 
         // Primitive fields are already covered by RamUsageEstimator.shallowSizeOf(...); only reference fields must be classified.
-        final Set<String> referenceFields = Arrays.stream(clazz.getDeclaredFields())
-            .filter(f -> Modifier.isStatic(f.getModifiers()) == false)
-            .filter(f -> f.getType().isPrimitive() == false)
-            .map(Field::getName)
-            .collect(Collectors.toSet());
+        final Set<String> referenceFields = RamUsageEstimates.referenceFieldNamesDeclaredOn(clazz);
 
         assertThat(
             "reference field(s) on ["


### PR DESCRIPTION
## End goal of this stack

Stateless nodes today charge a **fixed per-index heap overhead** (`INDEX_MEMORY_OVERHEAD`, 350 KB × index count) when estimating node base memory. That constant is easy to reason about, but it does not reflect how much heap index metadata objects actually retain — a cluster with lightweight indices is over-estimated, and the number never adapts as metadata grows or shrinks.

This stack replaces that blunt estimate with an **object-size walk of cluster-state index metadata**:

1. **Make metadata types accountable** — implement Lucene `Accountable#ramBytesUsed()` on index metadata classes, with field tripwire tests so new fields force an explicit accounting decision.
2. **Aggregate accurately at project/cluster scope** — sum per-index estimates from `IndexMetadata` / `ProjectMetadata`, deduplicating shared objects (e.g. shared `MappingMetadata`) where it matters.
3. **Wire it into stateless memory metrics** — on each master cluster-state change, `StatelessMemoryMetricsService` computes `getIndexMetadataEstimatedHeapBytes()` from that walk instead of relying solely on the fixed per-index constant.

The intended outcome is **more accurate, size-aware index metadata heap accounting** on stateless indexing nodes — better input for heap-usage-aware allocation and node memory reporting, with typical clusters seeing **lower** metadata overhead than the legacy flat rate while still guarding against under-counting via tests.

> **Note:** The walk is an approximate retained-heap estimate, not measured RSS. Interned settings strings are not double-counted across indices; some shared leaf types are sized shallowly by design.

## This PR

Stack PR 1/4. Introduces `AbstractAccountableFieldsTestCase` and the first sample of small `Accountable` metadata types + tests:

- Adds `AbstractAccountableFieldsTestCase` test infrastructure
- Implements `Accountable.ramBytesUsed()` on `Condition`, `DiscoveryNodeFilters`, `IndexWriteLoad`, `IndexMetadataStats`, `IndexLongFieldRange`
- Adds field tripwire tests for each

## Stack (review in order)

1. **This PR** → `accountable-small-sample`
2. #156427 → `accountable-metadata-leaves` (draft)
3. #156428 → `accountable-index-metadata` (draft)
4. #154764 → `index-metadata-heap-calculation` (draft)