### PR TITLE
[Security] Grant viewer/editor access to neutral Entity Store v2 indices

### DIFF
--- a/docs/changelog/156478.yaml
+++ b/docs/changelog/156478.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 156478
+summary: Grant built-in viewer/editor access to solution-neutral Entity Store v2 indices
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -83,9 +83,21 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
 
     /** "Security Solutions" Entity Store and Asset Criticality indices for Asset Inventory and Entity Analytics */
     public static final String ENTITY_STORE_V1_LATEST_INDEX = ".entities.v1.latest.security_*";
-    public static final String ENTITY_STORE_V2_LATEST_INDEX = ".entities.v2.latest.security_*";
-    public static final String ENTITY_STORE_V2_UPDATES_INDEX = ".entities.v2.updates.security_*";
-    public static final String ENTITY_STORE_V2_METADATA_INDEX = ".entities.v2.metadata.security_*";
+    /**
+     * Entity Store v2 latest indices. Solution-neutral {@code .entities.v2.latest.{namespace}-*} names,
+     * including legacy {@code .entities.v2.latest.security_*} compatibility aliases.
+     */
+    public static final String ENTITY_STORE_V2_LATEST_INDEX = ".entities.v2.latest.*";
+    /**
+     * Entity Store v2 updates data streams. Solution-neutral {@code .entities.v2.updates.{namespace}} names,
+     * including legacy {@code .entities.v2.updates.security_*} names during migration.
+     */
+    public static final String ENTITY_STORE_V2_UPDATES_INDEX = ".entities.v2.updates.*";
+    /**
+     * Entity Store v2 metadata data streams. Solution-neutral {@code .entities.v2.metadata.{namespace}} names,
+     * including legacy {@code .entities.v2.metadata.security_*} compatibility aliases.
+     */
+    public static final String ENTITY_STORE_V2_METADATA_INDEX = ".entities.v2.metadata.*";
     public static final String ENTITY_STORE_HISTORY_INDEX = ".entities.*.history.*";
     public static final String ASSET_CRITICALITY_INDEX = ".asset-criticality.asset-criticality-*";
     public static final String PRIVILEGED_USER_MONITORING_INDEX = ".entity_analytics.monitoring*";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -2075,7 +2075,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertViewIndexMetadata(kibanaRole, indexName);
         });
 
-        Arrays.asList(".entities.v2.metadata.security_" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach(indexName -> {
+        Arrays.asList(
+            ".entities.v2.metadata." + randomAlphaOfLength(randomIntBetween(1, 13)),
+            ".entities.v2.metadata.security_" + randomAlphaOfLength(randomIntBetween(0, 13))
+        ).forEach(indexName -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
             assertThat(kibanaRole.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportCreateIndexAction.TYPE.name()).test(indexAbstraction), is(true));
@@ -4006,8 +4009,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, randomAlphaOfLength(5));
 
         assertOnlyReadAllowed(role, ".entities.v1.latest.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.latest." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.latest.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.updates." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.updates.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.metadata." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.metadata.security_" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".asset-criticality.asset-criticality-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".entity_analytics.monitoring" + randomIntBetween(0, 5));
@@ -4090,8 +4096,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, "profiling-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".profiling-" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".entities.v1.latest.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.latest." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.latest.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.updates." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.updates.security_" + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, ".entities.v2.metadata." + randomAlphaOfLengthBetween(1, 8));
         assertOnlyReadAllowed(role, ".entities.v2.metadata.security_" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".entity_analytics.monitoring" + randomIntBetween(0, 5));
         assertOnlyReadAllowed(role, ".entity_analytics.entity-leads" + randomIntBetween(0, 5));


### PR DESCRIPTION
## Summary
- Update built-in `viewer` / `editor` reserved-role Entity Store v2 index patterns from Security-scoped `.entities.v2.*.security_*` to solution-neutral `.entities.v2.*.*` so privileges continue to match after the Entity Store platform shared migration ([elastic/kibana#282130](https://github.com/elastic/kibana/pull/282130)).
- Broader neutral patterns also match legacy `.entities.v2.*.security_*` compatibility aliases created during migration, so this can land in coordinated order with the Kibana change.
- Leave Entity Store v1 (`security_*`) patterns and history (already `.entities.*.history.*`) unchanged.
- `kibana_system` already grants `.entities.*`, so no role descriptor change was required there; tests now cover neutral metadata names too.

### Pattern mapping
| Before | After |
| --- | --- |
| `.entities.v2.latest.security_*` | `.entities.v2.latest.*` |
| `.entities.v2.updates.security_*` | `.entities.v2.updates.*` |
| `.entities.v2.metadata.security_*` | `.entities.v2.metadata.*` |

### Coordination
- Kibana migration PR: [elastic/kibana#282130](https://github.com/elastic/kibana/pull/282130)
- Serverless counterpart: [elastic/elasticsearch-controller#1992](https://github.com/elastic/elasticsearch-controller/pull/1992)

## Test plan
- [x] `./gradlew :x-pack:plugin:core:test --tests ...ReservedRolesStoreTests.testPredefinedViewerRole --tests ...testPredefinedEditorRole --tests ...testKibanaSystemRole*`
- [ ] Confirm `viewer`/`editor` can read `.entities.v2.latest.{space}` / `.entities.v2.metadata.{space}` after upgrade
- [ ] Confirm legacy compatibility aliases `.entities.v2.*.security_{space}` remain readable during the migration window