### PR TITLE
[9.5] Fix smart-retry gap in rolling-upgrade-legacy (#156078)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -577,15 +577,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.ndjson.NdJsonCompressedFormatSpecIT
   method: test {csv-spec:external-basic.fileMetadataFilterModifiedInExcludesAll [ndjson.zst/HTTP]}
   issue: https://github.com/elastic/elasticsearch/issues/153610
-- class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
-  method: testDataStreams
-  issue: https://github.com/elastic/elasticsearch/issues/153414
-- class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
-  method: testMigrateDoesNotRestartOnUpgrade
-  issue: https://github.com/elastic/elasticsearch/issues/153415
-- class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
-  method: testDataStreamValidationDoesNotBreakUpgrade
-  issue: https://github.com/elastic/elasticsearch/issues/153413
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecStatsFirstLastIT
   method: test {csv-spec:stats_first_last.Test aggregating on integers from row}
   issue: https://github.com/elastic/elasticsearch/issues/153700


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix smart-retry gap in rolling-upgrade-legacy (#156078)](https://github.com/elastic/elasticsearch/pull/156078)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)