### PR TITLE
Fixed flaky LongBlockLoader tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -328,15 +328,6 @@ tests:
 - class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
   method: testDuel
   issue: https://github.com/elastic/elasticsearch/issues/154243
-- class: org.elasticsearch.index.mapper.blockloader.LongFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=NONE]}
-  issue: https://github.com/elastic/elasticsearch/issues/154912
-- class: org.elasticsearch.index.mapper.blockloader.LongFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=DOC_VALUES]}
-  issue: https://github.com/elastic/elasticsearch/issues/154913
-- class: org.elasticsearch.index.mapper.blockloader.LongFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=STORED]}
-  issue: https://github.com/elastic/elasticsearch/issues/154914
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/154916

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/LongFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/LongFieldBlockLoaderTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper.blockloader;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.datageneration.FieldType;
 import org.elasticsearch.index.mapper.NumberFieldBlockLoaderTestCase;
 
@@ -22,5 +23,31 @@ public class LongFieldBlockLoaderTests extends NumberFieldBlockLoaderTestCase<Lo
     @Override
     protected Long convert(Number value, Map<String, Object> fieldMapping) {
         return value.longValue();
+    }
+
+    /**
+     * Overrides the default {@link Double#parseDouble}-based implementation to match the long mapper's actual indexing behavior.
+     */
+    @Override
+    protected Number tryParseString(String s) {
+        try {
+            return Numbers.toLong(s, true);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Overrides the default {@link #tryParseString(String)}-based implementation because the stored-source re-parsing path goes through
+     * {@code objectToLong -> objectToDouble -> Double.parseDouble}, which rejects some Unicode digits that are accepted by
+     * {@link Numbers#toLong}.
+     */
+    @Override
+    protected Number tryParseStringFromSource(String s) {
+        try {
+            return Double.parseDouble(s);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldBlockLoaderTestCase.java
@@ -25,18 +25,28 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
     protected Object expected(Map<String, Object> fieldMapping, Object value, TestContext testContext) {
         var nullValue = fieldMapping.get("null_value") != null ? convert((Number) fieldMapping.get("null_value"), fieldMapping) : null;
 
-        if (value instanceof List<?> == false) {
-            return convert(value, nullValue, fieldMapping);
-        }
-
         boolean hasDocValues = hasDocValues(fieldMapping, true);
         boolean useDocValues = params.preference() == MappedFieldType.FieldExtractPreference.NONE
             || params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES
             || params.syntheticSource();
+
+        ValueSource source;
         if (hasDocValues && useDocValues) {
+            source = ValueSource.DOC_VALUES;
+        } else if (params.syntheticSource()) {
+            source = ValueSource.IGNORED_SOURCE;
+        } else {
+            source = ValueSource.STORED_SOURCE;
+        }
+
+        if (value instanceof List<?> == false) {
+            return convert(value, nullValue, fieldMapping, source);
+        }
+
+        if (source == ValueSource.DOC_VALUES) {
             // Sorted
             var resultList = ((List<Object>) value).stream()
-                .map(v -> convert(v, nullValue, fieldMapping))
+                .map(v -> convert(v, nullValue, fieldMapping, source))
                 .filter(Objects::nonNull)
                 .sorted()
                 .toList();
@@ -44,25 +54,103 @@ public abstract class NumberFieldBlockLoaderTestCase<T extends Number> extends B
         }
 
         // parsing from source
-        var resultList = ((List<Object>) value).stream().map(v -> convert(v, nullValue, fieldMapping)).filter(Objects::nonNull).toList();
+        var resultList = ((List<Object>) value).stream()
+            .map(v -> convert(v, nullValue, fieldMapping, source))
+            .filter(Objects::nonNull)
+            .toList();
         return maybeFoldList(resultList);
     }
 
-    @SuppressWarnings("unchecked")
-    private T convert(Object value, T nullValue, Map<String, Object> fieldMapping) {
-        if (value == null) {
-            return nullValue;
-        }
-        // String coercion is true by default
-        if (value instanceof String s && s.isEmpty()) {
-            return nullValue;
-        }
-        if (value instanceof Number n) {
-            return convert(n, fieldMapping);
-        }
+    /**
+     * Identifies which code path the block loader uses to retrieve a value. The distinction matters
+     * because {@code NumberType.parse(XContentParser, boolean)} and
+     * {@code NumberType.parse(Object, boolean)} can differ in how they handle non-latin Unicode digits.
+     *
+     * <p>{@link #DOC_VALUES} and {@link #IGNORED_SOURCE} both use the {@code XContentParser}
+     * overload, so they share the same string-parsing behavior. {@link #STORED_SOURCE} uses the
+     * {@code Object} overload and may therefore produce different results for the same input.
+     */
+    private enum ValueSource {
+        /** Values indexed into doc values via the {@code XContentParser} overload. */
+        DOC_VALUES,
+        /**
+         * Synthetic source without doc values: values stored in {@code _ignored_source} and
+         * re-parsed by {@code NumberFallbackSyntheticSourceReader} using the {@code XContentParser}
+         * overload.
+         */
+        IGNORED_SOURCE,
+        /**
+         * Non-synthetic source without doc values: values re-parsed from stored {@code _source} by
+         * the {@code SourceValueFetcher} returned from {@code NumberFieldType#sourceValueFetcher},
+         * using the {@code Object} overload.
+         */
+        STORED_SOURCE
+    }
 
-        // Malformed values are excluded
-        return null;
+    private T convert(Object value, T nullValue, Map<String, Object> fieldMapping, ValueSource valueSource) {
+        switch (value) {
+            case null -> {
+                return nullValue;
+            }
+
+            // String coercion is true by default
+            case String s -> {
+                if (s.isEmpty()) {
+                    return nullValue;
+                }
+                // Attempt to parse the string as a number. If that fails, the string is malformed, so return null.
+                // The block loader paths use different parsers, so we delegate to the appropriate method.
+                Number parsed = switch (valueSource) {
+                    case DOC_VALUES, IGNORED_SOURCE -> tryParseString(s);
+                    case STORED_SOURCE -> tryParseStringFromSource(s);
+                };
+                if (parsed != null) {
+                    return convert(parsed, fieldMapping);
+                }
+                return null;
+            }
+
+            case Number n -> {
+                return convert(n, fieldMapping);
+            }
+
+            default -> {
+                // Malformed values are excluded
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Tries to parse a string as a number, matching the behavior used during indexing (doc values)
+     * and when reading from {@code _ignored_source} via {@code NumberFallbackSyntheticSourceReader}.
+     * Returns null if the string cannot be parsed as a valid number.
+     *
+     * <p>Both paths use {@code NumberType.parse(XContentParser, boolean)}. The default implementation
+     * uses {@link Double#parseDouble(String)}, which matches the coercion behavior of most numeric
+     * field mappers.
+     */
+    protected Number tryParseString(String s) {
+        try {
+            return Double.parseDouble(s);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Tries to parse a string as a number, matching the behavior used when re-parsing from the
+     * original stored {@code _source} (via the {@code SourceValueFetcher} returned from
+     * {@code NumberFieldType#sourceValueFetcher}). Returns null if the string cannot be parsed as a
+     * valid number.
+     *
+     * <p>The stored-source path uses {@code NumberType.parse(Object, boolean)}.
+     *
+     * <p>This is intentionally separate from {@link #tryParseString(String)} because the two paths can
+     * differ (see {@code LongFieldBlockLoaderTests}).
+     */
+    protected Number tryParseStringFromSource(String s) {
+        return tryParseString(s);
     }
 
     protected abstract T convert(Number value, Map<String, Object> fieldMapping);

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldBlockLoaderTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldBlockLoaderTests.java
@@ -7,16 +7,19 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.datageneration.FieldType;
 import org.elasticsearch.index.mapper.NumberFieldBlockLoaderTestCase;
 import org.elasticsearch.plugins.Plugin;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public class UnsignedLongFieldBlockLoaderTests extends NumberFieldBlockLoaderTestCase<Long> {
     private static final long MASK_2_63 = 0x8000000000000000L;
+    private static final BigInteger BIGINTEGER_2_64_MINUS_ONE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
 
     public UnsignedLongFieldBlockLoaderTests(Params params) {
         super(FieldType.UNSIGNED_LONG, params);
@@ -28,6 +31,23 @@ public class UnsignedLongFieldBlockLoaderTests extends NumberFieldBlockLoaderTes
         // See mapper implementation.
         var unsigned = value.longValue();
         return unsigned ^ MASK_2_63;
+    }
+
+    @Override
+    protected Number tryParseString(String s) {
+        try {
+            return Long.parseUnsignedLong(s);
+        } catch (NumberFormatException ignored) {
+            try {
+                var bigInteger = Numbers.newBigDecimal(s).toBigIntegerExact();
+                if (bigInteger.signum() < 0 || bigInteger.compareTo(BIGINTEGER_2_64_MINUS_ONE) > 0) {
+                    return null;
+                }
+                return bigInteger.longValue();
+            } catch (ArithmeticException | NumberFormatException e) {
+                return null;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This mirrors what we already do in main.

Closes https://github.com/elastic/elasticsearch/issues/154912
Closes https://github.com/elastic/elasticsearch/issues/154913
Closes https://github.com/elastic/elasticsearch/issues/154914
Closes https://github.com/elastic/elasticsearch/issues/154915

These have already been fixed in [9.4](https://github.com/elastic/elasticsearch/pull/141559) and [9.5](https://github.com/elastic/elasticsearch/pull/150035).