### PR TITLE
[8.19] Keep scroll contexts on transient search queue rejection (#155697)

### DIFF
--- a/docs/changelog/155697.yaml
+++ b/docs/changelog/155697.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 90912
+pr: 155697
+summary: Keep scroll contexts on transient search queue rejection
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -145,36 +145,34 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         final CountDownLatch block = new CountDownLatch(1);
         final int threads = threadPool.info(ThreadPool.Names.SEARCH).getMax();
         final CountDownLatch started = new CountDownLatch(threads);
-        // Stoppable wrapper lets try-with-resources own the ExecutorService without shutting down the
-        // node-owned SEARCH pool (shutdown/close are no-ops). Tasks keep running on the real executor
-        // until the returned releasable counts down {@code block}.
-        try (ExecutorService searchExecutor = new StoppableExecutorServiceWrapper(threadPool.executor(ThreadPool.Names.SEARCH))) {
-            try {
-                for (int i = 0; i < threads; i++) {
-                    searchExecutor.execute(() -> {
-                        started.countDown();
-                        awaitQuietly(block);
-                    });
-                }
-                safeAwait(started);
-                // Fill the queue slot (queue_size=1). With all workers blocked, the next submit rejects.
-                try {
-                    searchExecutor.execute(() -> awaitQuietly(block));
-                } catch (EsRejectedExecutionException e) {
-                    // already full
-                }
-                expectThrows(EsRejectedExecutionException.class, () -> searchExecutor.execute(() -> {}));
-            } catch (Throwable t) {
-                // The cluster is shared by the whole suite, so never leave SEARCH threads blocked on a setup failure.
-                block.countDown();
-                throw new AssertionError("failed to saturate SEARCH pool", t);
+        // Stoppable wrapper: shutdown() is a no-op so we cannot tear down the node-owned SEARCH pool.
+        // Not try-with-resources: on this branch ExecutorService is not AutoCloseable.
+        final ExecutorService searchExecutor = new StoppableExecutorServiceWrapper(threadPool.executor(ThreadPool.Names.SEARCH));
+        try {
+            for (int i = 0; i < threads; i++) {
+                searchExecutor.execute(() -> {
+                    started.countDown();
+                    awaitQuietly(block);
+                });
             }
-            return () -> {
-                if (block.getCount() > 0) {
-                    block.countDown();
-                }
-            };
+            safeAwait(started);
+            // Fill the queue slot (queue_size=1). With all workers blocked, the next submit rejects.
+            try {
+                searchExecutor.execute(() -> awaitQuietly(block));
+            } catch (EsRejectedExecutionException e) {
+                // already full
+            }
+            expectThrows(EsRejectedExecutionException.class, () -> searchExecutor.execute(() -> {}));
+        } catch (Throwable t) {
+            // The cluster is shared by the whole suite, so never leave SEARCH threads blocked on a setup failure.
+            block.countDown();
+            throw new AssertionError("failed to saturate SEARCH pool", t);
         }
+        return () -> {
+            if (block.getCount() > 0) {
+                block.countDown();
+            }
+        };
     }
 
     private void assertBusyOpenContexts(String index, long expected) throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -9,17 +9,27 @@
 
 package org.elasticsearch.search;
 
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.StoppableExecutorServiceWrapper;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class SearchWithRejectionsIT extends ESIntegTestCase {
@@ -39,8 +49,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         for (int i = 0; i < docs; i++) {
             prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
-        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().get();
-        assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
+        assertThat(indicesAdmin().prepareStats("test").get().getTotal().getSearch().getOpenContexts(), equalTo(0L));
         refresh();
 
         int numSearches = 10;
@@ -56,10 +65,137 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
                 responses[i].get().decRef();
             } catch (Exception t) {}
         }
+        assertBusyOpenContexts("test", 0L);
+    }
+
+    public void testScrollContextSurvivesQueueRejection() throws Exception {
+        createIndex("test-scroll", 1, 0);
+        ensureGreen("test-scroll");
+        final int numDocs = 10;
+        Set<String> expectedIds = new HashSet<>();
+        for (int i = 0; i < numDocs; i++) {
+            String id = Integer.toString(i);
+            expectedIds.add(id);
+            prepareIndex("test-scroll").setId(id).setSource("field", "value").get();
+        }
+        refresh();
+
+        SearchResponse openResponse = prepareSearch("test-scroll").setQuery(matchAllQuery())
+            .setSize(1)
+            .setScroll(TimeValue.timeValueMinutes(5))
+            .get();
+        String scrollId = openResponse.getScrollId();
+        Set<String> seenIds = new HashSet<>();
+        try {
+            collectIds(openResponse, seenIds);
+            assertBusyOpenContexts("test-scroll", 1L);
+
+            String primaryNodeId = clusterService().state().routingTable().index("test-scroll").shard(0).primaryShard().currentNodeId();
+            String primaryNodeName = clusterService().state().nodes().get(primaryNodeId).getName();
+            ThreadPool primaryThreadPool = internalCluster().getInstance(ThreadPool.class, primaryNodeName);
+
+            // Closing unblockSearchPool releases the blocked SEARCH threads so later scrolls can run.
+            try (Releasable unblockSearchPool = blockSearchThreadPool(primaryThreadPool)) {
+                // Bounded wait: if rejection fails to surface, do not deadlock the suite.
+                Exception e = expectThrows(Exception.class, () -> {
+                    SearchResponse response = client().prepareSearchScroll(scrollId)
+                        .setScroll(TimeValue.timeValueMinutes(5))
+                        .get(SAFE_AWAIT_TIMEOUT);
+                    response.decRef();
+                });
+                assertThat(ExceptionsHelper.unwrap(e, EsRejectedExecutionException.class), notNullValue());
+            }
+
+            assertBusyOpenContexts("test-scroll", 1L);
+
+            assertBusy(() -> {
+                try {
+                    while (seenIds.size() < numDocs) {
+                        SearchResponse scrollResponse = client().prepareSearchScroll(scrollId)
+                            .setScroll(TimeValue.timeValueMinutes(5))
+                            .get();
+                        try {
+                            if (scrollResponse.getHits().getHits().length == 0) {
+                                break;
+                            }
+                            collectIds(scrollResponse, seenIds);
+                        } finally {
+                            scrollResponse.decRef();
+                        }
+                    }
+                } catch (Exception e) {
+                    if (ExceptionsHelper.unwrap(e, EsRejectedExecutionException.class) != null) {
+                        throw new AssertionError("retry scroll after rejection", e);
+                    }
+                    throw new AssertionError(e);
+                }
+                assertThat(seenIds, equalTo(expectedIds));
+            }, 10, TimeUnit.SECONDS);
+        } finally {
+            openResponse.decRef();
+            client().prepareClearScroll().addScrollId(scrollId).get();
+        }
+    }
+
+    /**
+     * Blocks all SEARCH threads and fills the queue on {@code threadPool} so the next submission is rejected.
+     * Caller must close the returned releasable to unblock those threads.
+     */
+    private Releasable blockSearchThreadPool(ThreadPool threadPool) {
+        final CountDownLatch block = new CountDownLatch(1);
+        final int threads = threadPool.info(ThreadPool.Names.SEARCH).getMax();
+        final CountDownLatch started = new CountDownLatch(threads);
+        // Stoppable wrapper lets try-with-resources own the ExecutorService without shutting down the
+        // node-owned SEARCH pool (shutdown/close are no-ops). Tasks keep running on the real executor
+        // until the returned releasable counts down {@code block}.
+        try (ExecutorService searchExecutor = new StoppableExecutorServiceWrapper(threadPool.executor(ThreadPool.Names.SEARCH))) {
+            try {
+                for (int i = 0; i < threads; i++) {
+                    searchExecutor.execute(() -> {
+                        started.countDown();
+                        awaitQuietly(block);
+                    });
+                }
+                safeAwait(started);
+                // Fill the queue slot (queue_size=1). With all workers blocked, the next submit rejects.
+                try {
+                    searchExecutor.execute(() -> awaitQuietly(block));
+                } catch (EsRejectedExecutionException e) {
+                    // already full
+                }
+                expectThrows(EsRejectedExecutionException.class, () -> searchExecutor.execute(() -> {}));
+            } catch (Throwable t) {
+                // The cluster is shared by the whole suite, so never leave SEARCH threads blocked on a setup failure.
+                block.countDown();
+                throw new AssertionError("failed to saturate SEARCH pool", t);
+            }
+            return () -> {
+                if (block.getCount() > 0) {
+                    block.countDown();
+                }
+            };
+        }
+    }
+
+    private void assertBusyOpenContexts(String index, long expected) throws Exception {
         assertBusy(
-            () -> assertThat(indicesAdmin().prepareStats().get().getTotal().getSearch().getOpenContexts(), equalTo(0L)),
-            1,
+            () -> assertThat(indicesAdmin().prepareStats(index).get().getTotal().getSearch().getOpenContexts(), equalTo(expected)),
+            2,
             TimeUnit.SECONDS
         );
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void collectIds(SearchResponse response, Set<String> seenIds) {
+        for (SearchHit hit : response.getHits()) {
+            assertTrue("duplicate hit id " + hit.getId(), seenIds.add(hit.getId()));
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -997,7 +997,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 // we handle the failure in the failure listener below
                 throw e;
             }
-        }, wrapFailureListener(listener, readerContext, markAsUsed));
+        }, wrapFailureListener(listener, markAsUsed, e -> processScrollContinuationFailure(readerContext, e)));
     }
 
     /**
@@ -1121,7 +1121,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 // we handle the failure in the failure listener below
                 throw e;
             }
-        }, wrapFailureListener(releaseCircuitBreakerOnResponse(listener, result -> result.fetchResult()), readerContext, markAsUsed));
+        },
+            wrapFailureListener(
+                releaseCircuitBreakerOnResponse(listener, result -> result.fetchResult()),
+                markAsUsed,
+                e -> processScrollContinuationFailure(readerContext, e)
+            )
+        );
     }
 
     public void executeFetchPhase(ShardFetchRequest request, CancellableTask task, ActionListener<FetchSearchResult> listener) {
@@ -1480,6 +1486,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     private <T> ActionListener<T> wrapFailureListener(ActionListener<T> listener, ReaderContext context, Releasable releasable) {
+        return wrapFailureListener(listener, releasable, e -> processFailure(context, e));
+    }
+
+    private static <T> ActionListener<T> wrapFailureListener(
+        ActionListener<T> listener,
+        Releasable releasable,
+        Consumer<Exception> onFailureCleanup
+    ) {
         return new ActionListener<>() {
             @Override
             public void onResponse(T resp) {
@@ -1489,15 +1503,46 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
             @Override
             public void onFailure(Exception exc) {
-                processFailure(context, exc);
-                Releasables.close(releasable);
-                listener.onFailure(exc);
+                try {
+                    onFailureCleanup.accept(exc);
+                } finally {
+                    try {
+                        Releasables.close(releasable);
+                    } finally {
+                        listener.onFailure(exc);
+                    }
+                }
             }
         };
     }
 
     private static boolean isScrollContext(ReaderContext context) {
         return context instanceof LegacyReaderContext && context.singleSession() == false;
+    }
+
+    /**
+     * Whether the failure is a transient search-thread-pool rejection (queue full) rather than
+     * a rejection caused by executor shutdown.
+     * Visible for testing.
+     */
+    static boolean isTransientRejection(Exception exc) {
+        Throwable rejected = ExceptionsHelper.unwrap(exc, EsRejectedExecutionException.class);
+        return rejected instanceof EsRejectedExecutionException esre && esre.isExecutorShutdown() == false;
+    }
+
+    /**
+     * Failure handler for scroll continuation ({@link InternalScrollSearchRequest}) query/fetch paths.
+     * Keeps the reader context on transient search-thread-pool rejection so the client can retry with
+     * the same {@code scroll_id}; otherwise delegates to {@link #processFailure}.
+     */
+    private void processScrollContinuationFailure(ReaderContext context, Exception exc) {
+        if (isTransientRejection(exc)) {
+            // Rejection is raised at executor submission, before the task body runs, so
+            // ScrollContext.lastEmittedDoc is unchanged and a client retry is safe.
+            logger.trace(() -> format("keeping scroll context [%s] after transient rejected execution", context.id()));
+            return;
+        }
+        processFailure(context, exc);
     }
 
     private void processFailure(ReaderContext context, Exception exc) {

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
@@ -71,6 +72,7 @@ import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.common.Strings.format;
+import static org.elasticsearch.search.SearchService.isTransientRejection;
 import static org.elasticsearch.search.SearchService.wrapListenerForErrorHandling;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
@@ -237,6 +239,20 @@ public class SearchServiceTests extends IndexShardTestCase {
             listener = wrapListenerForErrorHandling(listener, TransportVersion.current(), nodeId, shardId, taskId, threadPool);
             listener.onFailure(e);
         }
+    }
+
+    public void testIsTransientRejection() {
+        assertTrue(isTransientRejection(new EsRejectedExecutionException("rejected", false)));
+        assertFalse(isTransientRejection(new EsRejectedExecutionException("shutdown", true)));
+        assertFalse(isTransientRejection(new RuntimeException("other")));
+
+        Exception wrapped = new RuntimeException(new EsRejectedExecutionException("rejected", false));
+        assertTrue(isTransientRejection(wrapped));
+
+        // suppressed-only rejection must not retain (cause-chain unwrap only)
+        RuntimeException primary = new RuntimeException("primary");
+        primary.addSuppressed(new EsRejectedExecutionException("rejected", false));
+        assertFalse(isTransientRejection(primary));
     }
 
     public void testBuildQueryWithCircuitBreakerAccountsMemory() throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Keep scroll contexts on transient search queue rejection (#155697)
