### PR TITLE
Add API reference links to ES|QL data federation docs

### DIFF
--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -84,16 +84,12 @@ To customize the inferred schema, rename columns, or override field types, use t
 
 Datasets are managed under the `/_query/dataset` endpoint. All dataset operations require the index `manage` privilege on the dataset name, or a fine-grained dataset privilege. Refer to [manage credentials and privileges](esql-data-federation-security.md) for details.
 
-| Operation | Endpoint |
-|---|---|
-| [Create or update](#create-or-update-a-dataset) | `PUT /_query/dataset/{name}` |
-| [Get](#get-a-dataset) | `GET /_query/dataset/{name}` |
-| [List all](#list-all-datasets) | `GET /_query/dataset` |
-| [Delete](#delete-a-dataset) | `DELETE /_query/dataset/{name}` |
-
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-put-dataset -->
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-dataset -->
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-delete-dataset -->
+| Operation | Endpoint | API reference |
+|---|---|---|
+| [Create or update](#create-or-update-a-dataset) | `PUT /_query/dataset/{name}` | [Create or update an ES\|QL dataset](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-put-dataset) |
+| [Get](#get-a-dataset) | `GET /_query/dataset/{name}` | [Get ES\|QL datasets](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-dataset) |
+| [List all](#list-all-datasets) | `GET /_query/dataset` | [Get ES\|QL datasets](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-dataset) |
+| [Delete](#delete-a-dataset) | `DELETE /_query/dataset/{name}` | [Delete ES\|QL datasets](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-delete-dataset) |
 
 ### Create or update a dataset
 

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -93,7 +93,7 @@ Datasets are managed under the `/_query/dataset` endpoint. All dataset operation
 
 ### Create or update a dataset
 
-`PUT` creates a new dataset or replaces an existing one entirely.
+[`PUT /_query/dataset/{name}`](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-put-dataset) creates a new dataset or replaces an existing one entirely.
 
 :::{important}
 A dataset cannot have the same name as an existing index, data stream, alias, or view, because dataset names share the same namespace. Dataset names must be lowercase and cannot begin with `-`, `_`, or `+`.
@@ -186,7 +186,7 @@ For self-describing columnar formats such as Parquet, names bind to the file sch
 
 ### Get a dataset
 
-Retrieves a dataset by name.
+[`GET /_query/dataset/{name}`](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-dataset) retrieves a dataset by name.
 
 ::::{tab-set}
 :group: api-ref
@@ -210,7 +210,7 @@ curl -X GET "${ELASTICSEARCH_URL}/_query/dataset/access_logs" \
 
 ### List all datasets
 
-Returns all registered datasets.
+[`GET /_query/dataset`](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-dataset) returns all registered datasets.
 
 ::::{tab-set}
 :group: api-ref
@@ -234,7 +234,7 @@ curl -X GET "${ELASTICSEARCH_URL}/_query/dataset" \
 
 ### Delete a dataset
 
-Deletes a dataset by name.
+[`DELETE /_query/dataset/{name}`](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-delete-dataset) deletes a dataset by name.
 
 ::::{tab-set}
 :group: api-ref

--- a/docs/reference/query-languages/esql/esql-data-federation-sources.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-sources.md
@@ -64,19 +64,14 @@ For the full set of authentication methods and what each one requires, refer to 
 
 ## Manage data sources using the API
 
-<!-- TODO: link to API reference once https://github.com/elastic/elasticsearch-specification/pull/6503 is published -->
 Data sources are managed under the `/_query/data_source` endpoint. All data source operations require the cluster `manage` privilege or a `global.data_source` privilege. Refer to [manage credentials and privileges](esql-data-federation-security.md) for details.
 
-| Operation | Endpoint |
-|---|---|
-| [Create or update](#create-or-update-a-data-source) | `PUT /_query/data_source/{name}` |
-| [Get](#get-a-data-source) | `GET /_query/data_source/{name}` |
-| [List all](#list-all-data-sources) | `GET /_query/data_source` |
-| [Delete](#delete-a-data-source) | `DELETE /_query/data_source/{name}` |
-
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-put-data-source -->
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-data-source -->
-<!-- # https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-delete-data-source -->
+| Operation | Endpoint | API reference |
+|---|---|---|
+| [Create or update](#create-or-update-a-data-source) | `PUT /_query/data_source/{name}` | [Create or update an ES\|QL data source](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-put-data-source) |
+| [Get](#get-a-data-source) | `GET /_query/data_source/{name}` | [Get ES\|QL data sources](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-data-source) |
+| [List all](#list-all-data-sources) | `GET /_query/data_source` | [Get ES\|QL data sources](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-get-data-source) |
+| [Delete](#delete-a-data-source) | `DELETE /_query/data_source/{name}` | [Delete ES\|QL data sources](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-esql-delete-data-source) |
 
 ### Create or update a data source
 


### PR DESCRIPTION
Now that the ES|QL data federation API specs are publicly visible (see [elasticsearch-specification#6566](https://github.com/elastic/elasticsearch-specification/pull/6566), which reverses [elasticsearch-specification#6510](https://github.com/elastic/elasticsearch-specification/pull/6510)), this PR links the published API reference pages from the data source and dataset documentation.

**Changes:**

- **`esql-data-federation-sources.md`**: Added an "API reference" column to the operations table linking to the put, get, and delete data source API docs. Removed the TODO comment and commented-out placeholder URLs.
- **`esql-data-federation-datasets.md`**: Same treatment for the dataset operations table.

Contributes to https://github.com/elastic/docs-content-internal/issues/1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)