### PR TITLE
Add close() lifecycle to FetchSubPhaseProcessor

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -90,47 +90,51 @@ final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
 
                         SearchHighlightContext highlight = new SearchHighlightContext(fetchContext.highlight().fields());
                         FetchSubPhaseProcessor processor = highlightPhase.getProcessor(fetchContext, highlight, query);
-                        StoredFieldLoader storedFields = StoredFieldLoader.fromSpec(processor.storedFieldsSpec());
-                        LeafStoredFieldLoader leafStoredFields = storedFields.getLoader(percolatorLeafReaderContext, null);
+                        try {
+                            StoredFieldLoader storedFields = StoredFieldLoader.fromSpec(processor.storedFieldsSpec());
+                            LeafStoredFieldLoader leafStoredFields = storedFields.getLoader(percolatorLeafReaderContext, null);
 
-                        for (Object matchedSlot : field.getValues()) {
-                            int slot = (int) matchedSlot;
-                            BytesReference document = percolateQuery.getDocuments().get(slot);
-                            leafStoredFields.advanceTo(slot);
-                            HitContext subContext = new HitContext(
-                                SearchHit.unpooled(slot, "unknown"),
-                                percolatorLeafReaderContext,
-                                slot,
-                                leafStoredFields.storedFields(),
-                                Source.fromBytes(document),
-                                null
-                            );
-                            processor.process(subContext);
-                            for (Map.Entry<String, HighlightField> entry : subContext.hit().getHighlightFields().entrySet()) {
-                                if (percolateQuery.getDocuments().size() == 1) {
-                                    String hlFieldName;
-                                    if (singlePercolateQuery) {
-                                        hlFieldName = entry.getKey();
+                            for (Object matchedSlot : field.getValues()) {
+                                int slot = (int) matchedSlot;
+                                BytesReference document = percolateQuery.getDocuments().get(slot);
+                                leafStoredFields.advanceTo(slot);
+                                HitContext subContext = new HitContext(
+                                    SearchHit.unpooled(slot, "unknown"),
+                                    percolatorLeafReaderContext,
+                                    slot,
+                                    leafStoredFields.storedFields(),
+                                    Source.fromBytes(document),
+                                    null
+                                );
+                                processor.process(subContext);
+                                for (Map.Entry<String, HighlightField> entry : subContext.hit().getHighlightFields().entrySet()) {
+                                    if (percolateQuery.getDocuments().size() == 1) {
+                                        String hlFieldName;
+                                        if (singlePercolateQuery) {
+                                            hlFieldName = entry.getKey();
+                                        } else {
+                                            hlFieldName = percolateQuery.getName() + "_" + entry.getKey();
+                                        }
+                                        hit.hit()
+                                            .getHighlightFields()
+                                            .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                     } else {
-                                        hlFieldName = percolateQuery.getName() + "_" + entry.getKey();
+                                        // In case multiple documents are being percolated we need to identify to which document
+                                        // a highlight belongs to.
+                                        String hlFieldName;
+                                        if (singlePercolateQuery) {
+                                            hlFieldName = slot + "_" + entry.getKey();
+                                        } else {
+                                            hlFieldName = percolateQuery.getName() + "_" + slot + "_" + entry.getKey();
+                                        }
+                                        hit.hit()
+                                            .getHighlightFields()
+                                            .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                     }
-                                    hit.hit()
-                                        .getHighlightFields()
-                                        .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
-                                } else {
-                                    // In case multiple documents are being percolated we need to identify to which document
-                                    // a highlight belongs to.
-                                    String hlFieldName;
-                                    if (singlePercolateQuery) {
-                                        hlFieldName = slot + "_" + entry.getKey();
-                                    } else {
-                                        hlFieldName = percolateQuery.getName() + "_" + slot + "_" + entry.getKey();
-                                    }
-                                    hit.hit()
-                                        .getHighlightFields()
-                                        .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                 }
                             }
+                        } finally {
+                            processor.close();
                         }
                     }
                 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhaseProcessorCloseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhaseProcessorCloseIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.fetch;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1, numClientNodes = 0)
+public class FetchSubPhaseProcessorCloseIT extends ESIntegTestCase {
+
+    private static final String INDEX_NAME = "close-tracking-test";
+
+    @Before
+    public void resetCounters() {
+        ClosableFetchSubPhasePlugin.PROCESS_COUNT.set(0);
+        ClosableFetchSubPhasePlugin.CLOSE_COUNT.set(0);
+        ClosableFetchSubPhasePlugin.FAIL_ON_PROCESS.set(false);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(ClosableFetchSubPhasePlugin.class);
+    }
+
+    public void testProcessorClosedOnSuccessfulFetch() {
+        createAndPopulateIndex();
+
+        assertNoFailuresAndResponse(prepareSearch(INDEX_NAME), response -> assertEquals(1L, response.getHits().getTotalHits().value()));
+
+        assertThat(ClosableFetchSubPhasePlugin.PROCESS_COUNT.get(), equalTo(1));
+        assertThat(
+            "close() must be called once the fetch phase completes successfully",
+            ClosableFetchSubPhasePlugin.CLOSE_COUNT.get(),
+            equalTo(1)
+        );
+    }
+
+    public void testProcessorClosedWhenFetchFails() {
+        createAndPopulateIndex();
+        ClosableFetchSubPhasePlugin.FAIL_ON_PROCESS.set(true);
+
+        expectThrows(SearchPhaseExecutionException.class, () -> prepareSearch(INDEX_NAME).get());
+
+        assertThat(ClosableFetchSubPhasePlugin.PROCESS_COUNT.get(), equalTo(1));
+        assertThat(
+            "close() must still be called when the fetch phase fails, not just on success",
+            ClosableFetchSubPhasePlugin.CLOSE_COUNT.get(),
+            equalTo(1)
+        );
+    }
+
+    private void createAndPopulateIndex() {
+        assertAcked(
+            prepareCreate(INDEX_NAME).setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        );
+        prepareIndex(INDEX_NAME).setId("1").setSource("field", "value").get();
+        refresh(INDEX_NAME);
+    }
+
+    public static class ClosableFetchSubPhasePlugin extends Plugin implements SearchPlugin {
+        static final AtomicInteger PROCESS_COUNT = new AtomicInteger();
+        static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+        static final AtomicBoolean FAIL_ON_PROCESS = new AtomicBoolean(false);
+
+        @Override
+        public List<FetchSubPhase> getFetchSubPhases(FetchPhaseConstructionContext context) {
+            return Collections.singletonList(fetchContext -> new FetchSubPhaseProcessor() {
+                @Override
+                public void setNextReader(LeafReaderContext readerContext) {}
+
+                @Override
+                public StoredFieldsSpec storedFieldsSpec() {
+                    return StoredFieldsSpec.NO_REQUIREMENTS;
+                }
+
+                @Override
+                public void process(FetchSubPhase.HitContext hitContext) throws IOException {
+                    PROCESS_COUNT.incrementAndGet();
+                    if (FAIL_ON_PROCESS.get()) {
+                        throw new IOException("simulated fetch sub-phase failure");
+                    }
+                }
+
+                @Override
+                public void close() {
+                    CLOSE_COUNT.incrementAndGet();
+                }
+            });
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -193,7 +193,12 @@ public final class FetchPhase {
                 ? Profiler.NOOP
                 : Profilers.startProfilingFetchPhase();
 
-        var docsIterator = createDocsIterator(context, profiler, rankDocs, writer != null ? bytes -> {} : memoryChecker);
+        var docsIteratorAndProcessors = createDocsIterator(context, profiler, rankDocs, writer != null ? bytes -> {} : memoryChecker);
+        var docsIterator = docsIteratorAndProcessors.docsIterator();
+        ActionListener<Void> releasingBuildListener = ActionListener.releaseAfter(
+            resolvedBuildListener,
+            Releasables.wrap(docsIteratorAndProcessors.processors())
+        );
 
         // Common completion handler for both sync and streaming modes
         // finalizes profiling, stores the shard result, and signals the outer listener.
@@ -217,7 +222,7 @@ public final class FetchPhase {
         });
 
         if (writer == null) {
-            buildSearchHits(context, docIdsToLoad, docsIterator, resolvedBuildListener, hitsListener);
+            buildSearchHits(context, docIdsToLoad, docsIterator, releasingBuildListener, hitsListener);
         } else {
             assert continuationExecutor != null : "continuationExecutor is required in streaming mode";
             var settings = context.getSearchExecutionContext().getIndexSettings().getSettings();
@@ -229,7 +234,7 @@ public final class FetchPhase {
                 resolveMaxInFlightChunks(maxInFlightChunks, settings),
                 resolveTargetChunkBytes(targetChunkBytes, settings),
                 continuationExecutor,
-                resolvedBuildListener,
+                releasingBuildListener,
                 hitsListener
             );
         }
@@ -266,7 +271,7 @@ public final class FetchPhase {
      * Creates the docs iterator that handles per-document fetching and sub-phase processing.
      * Shared between sync and streaming modes; the memoryChecker parameter controls per-hit memory accounting.
      */
-    private StreamingFetchPhaseDocsIterator createDocsIterator(
+    private DocsIteratorAndProcessors createDocsIterator(
         SearchContext context,
         Profiler profiler,
         RankDocShardInfo rankDocs,
@@ -421,8 +426,15 @@ public final class FetchPhase {
                 }
             }
         };
-        return docsIterator;
+        return new DocsIteratorAndProcessors(docsIterator, processors);
     }
+
+    /**
+     * Pairs the per-search {@link StreamingFetchPhaseDocsIterator} with the {@link FetchSubPhaseProcessor}s
+     * it drives, so callers can release processor resources (e.g. circuit breaker reservations held by
+     * {@link org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase}) once fetching completes.
+     */
+    private record DocsIteratorAndProcessors(StreamingFetchPhaseDocsIterator docsIterator, List<FetchSubPhaseProcessor> processors) {}
 
     /**
      * Synchronous fetch: iterates all documents, collects hits in memory, and returns them at once.

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchProfiler.java
@@ -139,6 +139,11 @@ public class FetchProfiler implements FetchPhase.Profiler {
                     timer.stop();
                 }
             }
+
+            @Override
+            public void close() {
+                delegate.close();
+            }
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseProcessor.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchSubPhaseProcessor.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.search.fetch;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
 
 import java.io.IOException;
@@ -18,7 +19,7 @@ import java.util.Map;
 /**
  * Executes the logic for a {@link FetchSubPhase} against a particular leaf reader and hit
  */
-public interface FetchSubPhaseProcessor {
+public interface FetchSubPhaseProcessor extends Releasable {
 
     /**
      * Called when moving to the next {@link LeafReaderContext} for a set of hits
@@ -42,4 +43,11 @@ public interface FetchSubPhaseProcessor {
      * The stored fields or source required by this sub phase
      */
     StoredFieldsSpec storedFieldsSpec();
+
+    /**
+     * Called once, after all hits have been processed (on success or failure), to release any
+     * resources held for the duration of the fetch phase.
+     */
+    @Override
+    default void close() {}
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/FetchProfilerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/FetchProfilerTests.java
@@ -9,14 +9,17 @@
 
 package org.elasticsearch.search.fetch;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.search.fetch.FetchSubPhase.HitContext;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
@@ -39,5 +42,45 @@ public class FetchProfilerTests extends ESTestCase {
         // Make sure that serialization preserves the order
         ProfileResult copy = copyWriteable(result, new NamedWriteableRegistry(List.of()), ProfileResult::new);
         assertMap(copy.getDebugInfo(), matchesMap().entry("stored_fields", List.of("_id", "_routing", "_source")));
+    }
+
+    public void testProfileWrapperDelegatesClose() throws IOException {
+        FetchProfiler profiler = new FetchProfiler();
+        CountingProcessor delegate = new CountingProcessor();
+
+        FetchSubPhaseProcessor wrapped = profiler.profile("test", "", delegate);
+        wrapped.setNextReader(null);
+        wrapped.process(null);
+        wrapped.close();
+
+        assertEquals(1, delegate.nextReaderCount.get());
+        assertEquals(1, delegate.processCount.get());
+        assertEquals(1, delegate.closeCount.get());
+    }
+
+    private static class CountingProcessor implements FetchSubPhaseProcessor {
+        final AtomicInteger nextReaderCount = new AtomicInteger();
+        final AtomicInteger processCount = new AtomicInteger();
+        final AtomicInteger closeCount = new AtomicInteger();
+
+        @Override
+        public void setNextReader(LeafReaderContext readerContext) {
+            nextReaderCount.incrementAndGet();
+        }
+
+        @Override
+        public void process(HitContext hitContext) {
+            processCount.incrementAndGet();
+        }
+
+        @Override
+        public StoredFieldsSpec storedFieldsSpec() {
+            return StoredFieldsSpec.NO_REQUIREMENTS;
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+        }
     }
 }


### PR DESCRIPTION
## End goal of this stack

Highlighting a query with automata-driven clauses (`fuzzy`, `wildcard`, `regexp`, etc.) makes Lucene's `UnifiedHighlighter` rebuild compiled automata on the fly, per field, per hit — separately from and in addition to the automata built during query execution. 

Query-time automata are already charged against the request circuit breaker (`MaxClauseCountQueryVisitor`), but this highlight-time reconstruction currently escapes accounting entirely, so a search that highlights fuzzy/wildcard/regexp matches can retain significant untracked heap regardless of the breaker limit.

This stack closes that gap across four PRs: a release hook for fetch sub-phases, an automaton cost estimator, breaker charge/refund wiring built on both, and end-to-end verification. See "This PR" below for what each one adds.

The outcome: highlighting `fuzzy/multi-term` queries can no longer allocate unbounded, untracked heap — it's bounded by and accounted against the same request circuit breaker as the rest of the search.

###  This PR
Stack **PR 1/4**. Adds the resource-release lifecycle that later PRs in this stack rely on to refund circuit-breaker charges  — no charging happens yet in this PR.
- Extends `FetchSubPhaseProcessor` with a `close()` method (default no-op, via `Releasable`)
- Wires `FetchPhase` to close every processor once the fetch phase completes, on success or failure (`ActionListener.releaseAfter` + `Releasables.wrap`)
- Makes `FetchProfiler`'s profiling wrapper delegate `close()` to the wrapped processor
- Updates `PercolatorHighlightSubFetchPhase` to close its per-hit highlighter processor in a `try`/`finally`

### Stack (review in order)
1. **This PR1** → `pr1-fetch-processor-close`
2. [PR2](https://github.com/elastic/elasticsearch/pull/156531) #156531 → `pr2-highlight-cost-estimator` (draft)
3. [PR3](https://github.com/elastic/elasticsearch/pull/156532) #156532 → `pr3-breaker-wiring` (draft)
4. [PR4](https://github.com/elastic/elasticsearch/pull/156533) #156533 → `pr4-breaker-release-its` (draft)

