### PR TITLE
Add highlight automaton cost estimator

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/search/FuzzyQueries.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/FuzzyQueries.java
@@ -84,6 +84,21 @@ public final class FuzzyQueries {
     }
 
     /**
+     * Bytes the request circuit breaker should be charged for the compiled automata
+     * {@code query} builds; excludes the retained {@link FuzzyQuery} object itself and the
+     * segment/expansion-scaled rewrite RAM that {@link #estimateBytes(FuzzyQuery, int)} charges
+     * for search-time term expansion. {@code UnifiedHighlighter} rebuilds a single automaton
+     * directly from the query's parameters, without rewriting it into per-segment expanded terms,
+     * so this passes the floor values ({@code maxExpansions=1}, {@code segmentCount=0}) to
+     * {@link FuzzyQueryCostEstimator} to exclude that inapplicable expansion cost.
+     */
+    public static long estimateAutomataBytes(FuzzyQuery query) {
+        BytesRef bytes = query.getTerm().bytes();
+        return new FuzzyQueryCostEstimator(bytes.length, countDistinctUtf8Bytes(bytes), query.getMaxEdits(), query.getPrefixLength(), 1, 0)
+            .estimate();
+    }
+
+    /**
      * Effective expansion count for the breaker charge: a {@link TopTermsRewrite}'s configured size,
      * {@link FuzzyQueryCostEstimator#MAX_CHARGED_EXPANSIONS} for the boolean-producing rewrites that
      * can expand up to {@code IndexSearcher.getMaxClauseCount()} (which is never lower, since

--- a/server/src/main/java/org/elasticsearch/lucene/search/cost/HighlightAutomatonCostEstimator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/cost/HighlightAutomatonCostEstimator.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search.cost;
+
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.search.AutomatonQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.search.runtime.AbstractStringScriptFieldAutomatonQuery;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * {@link QueryCostEstimator} for the automata Lucene's {@code UnifiedHighlighter} rebuilds while
+ * highlighting a query, without materializing the automaton itself. {@code FuzzyQuery} is charged
+ * via {@link FuzzyQueries#estimateAutomataBytes}; leaves with an already-built cached automaton
+ * (see {@link #hasCachedAutomaton}) are charged {@link #MATCHER_WRAPPER_BYTES}; everything else is
+ * charged the {@link #REBUILT_AUTOMATON_FLOOR_BYTES} floor.
+ * <p>
+ * {@code fieldMatcher} must match the predicate for a single {@code UnifiedHighlighter} extraction
+ * pass. With {@code matched_fields}, {@code UnifiedHighlighter} runs one pass per masked field plus
+ * one for the original field; callers must invoke this estimator once per pass and sum the
+ * results, rather than passing one matcher for the field union.
+ */
+public final class HighlightAutomatonCostEstimator implements QueryCostEstimator {
+
+    /** Floor charged per rebuilt-automaton leaf that isn't a {@link FuzzyQuery}. */
+    public static final long REBUILT_AUTOMATON_FLOOR_BYTES = AutomatonQueryCostEstimator.COMPILED_AUTOMATON_RESERVATION_FLOOR_BYTES;
+
+    /** Bytes charged per cached-automaton leaf for the retained wrapper and its label. */
+    public static final long MATCHER_WRAPPER_BYTES = QueryCostEstimator.LEAF_FLOOR_BYTES;
+
+    private final Query query;
+    private final Predicate<String> fieldMatcher;
+    private final boolean weightMatchesEffective;
+
+    /**
+     * @param query the highlight query, pre-rewrite (the same query passed to {@code CustomUnifiedHighlighter}).
+     * @param fieldMatcher the field matcher for a single extraction pass; see the class javadoc.
+     * @param weightMatchesEffective whether the highlighter runs with {@code HighlightFlag#WEIGHT_MATCHES}
+     *                      enabled for {@code query}; see {@code CustomUnifiedHighlighter#isWeightMatchesEffective}.
+     */
+    public HighlightAutomatonCostEstimator(Query query, Predicate<String> fieldMatcher, boolean weightMatchesEffective) {
+        this.query = Objects.requireNonNull(query, "query");
+        this.fieldMatcher = Objects.requireNonNull(fieldMatcher, "fieldMatcher");
+        this.weightMatchesEffective = weightMatchesEffective;
+    }
+
+    /**
+     * Returns a ceiling on the bytes the highlighter's automata extraction will retain for the
+     * fields accepted by {@code fieldMatcher}, with saturation on overflow.
+     */
+    @Override
+    public long estimate() {
+        if (weightMatchesEffective && hasUnrecognizedLeaf(query, fieldMatcher)) {
+            return 0L;
+        }
+        long[] bytes = new long[1];
+        query.visit(new QueryVisitor() {
+            @Override
+            public boolean acceptField(String field) {
+                return fieldMatcher.test(field);
+            }
+
+            @Override
+            public void consumeTermsMatching(Query leaf, String field, Supplier<ByteRunAutomaton> automaton) {
+                if (bytes[0] == Long.MAX_VALUE) {
+                    return;
+                }
+                long addition = leaf instanceof FuzzyQuery fuzzyQuery ? FuzzyQueries.estimateAutomataBytes(fuzzyQuery)
+                    : hasCachedAutomaton(leaf) ? MATCHER_WRAPPER_BYTES
+                    : REBUILT_AUTOMATON_FLOOR_BYTES;
+                try {
+                    bytes[0] = Math.addExact(bytes[0], addition);
+                } catch (ArithmeticException e) {
+                    bytes[0] = Long.MAX_VALUE;
+                }
+            }
+
+            @Override
+            public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
+                if (weightMatchesEffective == false && parent instanceof SpanQuery) {
+                    return QueryVisitor.EMPTY_VISITOR;
+                }
+                return super.getSubVisitor(occur, parent);
+            }
+        });
+        return bytes[0];
+    }
+
+    /** {@code true} if {@code leaf} supplies an automaton already built and cached in a field, rather than rebuilt per call. */
+    private static boolean hasCachedAutomaton(Query leaf) {
+        return leaf instanceof Accountable
+            || leaf instanceof AbstractStringScriptFieldAutomatonQuery
+            || leaf instanceof ScanningBinaryDocValuesWildcardQuery
+            || leaf instanceof ScanningBinaryDocValuesRegexpQuery;
+    }
+
+    /**
+     * Mirrors {@code UnifiedHighlighter#hasUnrecognizedQuery}: {@code true} if {@code query} has a
+     * leaf, on a field {@code fieldMatcher} accepts, that {@code MultiTermHighlighting} can't build
+     * an automaton from.
+     */
+    private static boolean hasUnrecognizedLeaf(Query query, Predicate<String> fieldMatcher) {
+        boolean[] hasUnrecognized = new boolean[1];
+        query.visit(new QueryVisitor() {
+            @Override
+            public boolean acceptField(String field) {
+                return hasUnrecognized[0] == false && fieldMatcher.test(field);
+            }
+
+            @Override
+            public void visitLeaf(Query leaf) {
+                boolean recognized = leaf instanceof FuzzyQuery
+                    || leaf instanceof AutomatonQuery
+                    || leaf instanceof MatchAllDocsQuery
+                    || leaf instanceof MatchNoDocsQuery;
+                if (recognized == false) {
+                    hasUnrecognized[0] = true;
+                }
+            }
+        });
+        return hasUnrecognized[0];
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/search/cost/QueryCostEstimator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/cost/QueryCostEstimator.java
@@ -17,6 +17,9 @@ import org.elasticsearch.index.query.SearchExecutionContext;
  */
 public interface QueryCostEstimator {
 
+    /** Shared floor for a small retained leaf object when no more precise measurement is available. */
+    long LEAF_FLOOR_BYTES = 1024L;
+
     long estimate();
 
     /** Charge {@link #estimate()} to the breaker on {@code ctx}. No-op if unavailable or non-positive. */

--- a/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/MaxClauseCountQueryVisitor.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.lucene.search.cost.PointRangeQueryCostEstimator;
+import org.elasticsearch.lucene.search.cost.QueryCostEstimator;
 
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -48,10 +49,8 @@ import java.util.function.Supplier;
  */
 public final class MaxClauseCountQueryVisitor extends QueryVisitor {
 
-    /**
-     * Per-clause floor charged for visited queries that don't implement {@link Accountable}.
-     */
-    static final long LEAF_BASE_BYTES = 1024L;
+    /** Per-clause floor charged for visited queries that don't implement {@link Accountable}. */
+    static final long LEAF_BASE_BYTES = QueryCostEstimator.LEAF_FLOOR_BYTES;
 
     private int numClauses;
     private long estimatedBytes;

--- a/server/src/test/java/org/elasticsearch/lucene/search/cost/HighlightAutomatonCostEstimatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/cost/HighlightAutomatonCostEstimatorTests.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search.cost;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.queries.spans.SpanNearQuery;
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+
+public class HighlightAutomatonCostEstimatorTests extends ESTestCase {
+
+    private static final Predicate<String> ACCEPT_ALL_FIELDS = field -> true;
+
+    public void testConstructorRejectsNullArguments() {
+        Query query = new TermQuery(new Term("field", "value"));
+        expectThrows(NullPointerException.class, () -> new HighlightAutomatonCostEstimator(null, ACCEPT_ALL_FIELDS, true));
+        expectThrows(NullPointerException.class, () -> new HighlightAutomatonCostEstimator(query, null, true));
+    }
+
+    public void testTermQueryChargesNothing() {
+        Query query = new TermQuery(new Term("field", "value"));
+        assertEquals(0L, new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, true).estimate());
+    }
+
+    public void testAutomatonQueryChargesOnlyMatcherWrapper() {
+        WildcardQuery query = new WildcardQuery(new Term("field", "foo*bar"));
+        long estimate = new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, true).estimate();
+        assertEquals(HighlightAutomatonCostEstimator.MATCHER_WRAPPER_BYTES, estimate);
+        assertThat(
+            "must not charge the cached automaton's retained RAM, only the retained matcher wrapper",
+            estimate,
+            lessThan(query.ramBytesUsed())
+        );
+    }
+
+    public void testScriptFieldAutomatonQueryChargesOnlyMatcherWrapper() {
+        StringScriptFieldWildcardQuery query = new StringScriptFieldWildcardQuery(
+            new Script("dummy"),
+            ctx -> null,
+            "field",
+            "foo*bar",
+            randomBoolean()
+        );
+        assertEquals(
+            "the automaton is built once in the constructor and stored in a field, so the "
+                + "highlighter only retains a small wrapper on top of it, not a rebuilt automaton",
+            HighlightAutomatonCostEstimator.MATCHER_WRAPPER_BYTES,
+            new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, false).estimate()
+        );
+    }
+
+    public void testBinaryDocValuesAutomatonQueryChargesOnlyMatcherWrapper() {
+        ScanningBinaryDocValuesWildcardQuery query = new ScanningBinaryDocValuesWildcardQuery(
+            "field",
+            "foo*bar",
+            randomBoolean(),
+            randomBoolean()
+        );
+        assertEquals(
+            "the automaton is built once in the constructor and stored in a field, so the "
+                + "highlighter only retains a small wrapper on top of it, not a rebuilt automaton",
+            HighlightAutomatonCostEstimator.MATCHER_WRAPPER_BYTES,
+            new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, false).estimate()
+        );
+    }
+
+    public void testFuzzyQueryDelegatesToFuzzyQueryCostEstimator() {
+        FuzzyQuery query = new FuzzyQuery(new Term("field", "captain"), 2);
+        assertEquals(
+            FuzzyQueries.estimateAutomataBytes(query),
+            new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, true).estimate()
+        );
+    }
+
+    public void testFieldMatcherExcludesNonMatchingFields() {
+        FuzzyQuery onFieldA = new FuzzyQuery(new Term("field_a", "captain"), 2);
+        FuzzyQuery onFieldB = new FuzzyQuery(new Term("field_b", "corsair"), 2);
+        Query bq = new BooleanQuery.Builder().add(onFieldA, BooleanClause.Occur.SHOULD).add(onFieldB, BooleanClause.Occur.SHOULD).build();
+
+        long scoped = new HighlightAutomatonCostEstimator(bq, "field_a"::equals, true).estimate();
+        assertEquals(
+            "must charge only the highlighted field's clause, matching what UnifiedHighlighter actually extracts",
+            FuzzyQueries.estimateAutomataBytes(onFieldA),
+            scoped
+        );
+
+        long unscoped = new HighlightAutomatonCostEstimator(bq, ACCEPT_ALL_FIELDS, true).estimate();
+        assertThat("an unscoped matcher must charge both fields' clauses, more than the field-scoped estimate", scoped, lessThan(unscoped));
+    }
+
+    public void testFieldMatcherUnionForMatchedFields() {
+        FuzzyQuery onHighlighted = new FuzzyQuery(new Term("title", "captain"), 2);
+        FuzzyQuery onMatched = new FuzzyQuery(new Term("title.plain", "corsair"), 2);
+        FuzzyQuery onUnrelated = new FuzzyQuery(new Term("other_field", "unrelated"), 2);
+        Query bq = new BooleanQuery.Builder().add(onHighlighted, BooleanClause.Occur.SHOULD)
+            .add(onMatched, BooleanClause.Occur.SHOULD)
+            .add(onUnrelated, BooleanClause.Occur.SHOULD)
+            .build();
+
+        Set<String> extractionFields = Set.of("title", "title.plain");
+        long combined = new HighlightAutomatonCostEstimator(bq, extractionFields::contains, true).estimate();
+        long expected = FuzzyQueries.estimateAutomataBytes(onHighlighted) + FuzzyQueries.estimateAutomataBytes(onMatched);
+        assertEquals(expected, combined);
+    }
+
+    public void testBooleanQueryChargesEachRebuiltLeafOnce() {
+        FuzzyQuery f1 = new FuzzyQuery(new Term("field", "aaa"), 1);
+        FuzzyQuery f2 = new FuzzyQuery(new Term("field", "bbb"), 2);
+        Query bq = new BooleanQuery.Builder().add(f1, BooleanClause.Occur.SHOULD).add(f2, BooleanClause.Occur.SHOULD).build();
+        long combined = new HighlightAutomatonCostEstimator(bq, ACCEPT_ALL_FIELDS, true).estimate();
+        long expected = FuzzyQueries.estimateAutomataBytes(f1) + FuzzyQueries.estimateAutomataBytes(f2);
+        assertEquals(expected, combined);
+    }
+
+    public void testMustNotClauseChargesNothing() {
+        FuzzyQuery fuzzy = new FuzzyQuery(new Term("field", "captain"), 2);
+        Query bq = new BooleanQuery.Builder().add(new TermQuery(new Term("field", "other")), BooleanClause.Occur.MUST)
+            .add(fuzzy, BooleanClause.Occur.MUST_NOT)
+            .build();
+        assertEquals(
+            "a fuzzy clause under must_not is never visited by UnifiedHighlighter, so it must not be charged",
+            0L,
+            new HighlightAutomatonCostEstimator(bq, ACCEPT_ALL_FIELDS, true).estimate()
+        );
+    }
+
+    public void testSpanQueryChargesNothingWhenLookInSpanIsFalse() {
+        SpanQuery span = new SpanMultiTermQueryWrapper<>(new FuzzyQuery(new Term("field", "captain"), 2));
+        Query near = new SpanNearQuery(new SpanQuery[] { span, new SpanTermQuery(new Term("field", "corsair")) }, 2, true);
+        assertEquals(
+            "when weight-matches is not effective, UnifiedHighlighter defers span contents to PhraseHelper "
+                + "instead of extracting automata, so the estimate must be 0",
+            0L,
+            new HighlightAutomatonCostEstimator(near, ACCEPT_ALL_FIELDS, false).estimate()
+        );
+    }
+
+    public void testSpanQueryChargesWhenLookInSpanIsTrue() {
+        SpanQuery span = new SpanMultiTermQueryWrapper<>(new FuzzyQuery(new Term("field", "captain"), 2));
+        Query near = new SpanNearQuery(new SpanQuery[] { span, new SpanTermQuery(new Term("field", "corsair")) }, 2, true);
+        assertThat(new HighlightAutomatonCostEstimator(near, ACCEPT_ALL_FIELDS, true).estimate(), greaterThanOrEqualTo(1L));
+    }
+
+    public void testUnrecognizedLeafOnHighlightedFieldSkipsExtractionWhenWeightMatchesEffective() {
+        FuzzyQuery fuzzy = new FuzzyQuery(new Term("field", "captain"), 2);
+        Query bq = new BooleanQuery.Builder().add(fuzzy, BooleanClause.Occur.SHOULD)
+            .add(new FieldExistsQuery("field"), BooleanClause.Occur.FILTER)
+            .build();
+        assertEquals(
+            "an exists clause on the highlighted field makes UnifiedHighlighter skip automata "
+                + "extraction entirely once weight-matches is effective",
+            0L,
+            new HighlightAutomatonCostEstimator(bq, ACCEPT_ALL_FIELDS, true).estimate()
+        );
+    }
+
+    public void testUnrecognizedLeafStillChargedWhenWeightMatchesNotEffective() {
+        FuzzyQuery fuzzy = new FuzzyQuery(new Term("field", "captain"), 2);
+        Query bq = new BooleanQuery.Builder().add(fuzzy, BooleanClause.Occur.SHOULD)
+            .add(new FieldExistsQuery("field"), BooleanClause.Occur.FILTER)
+            .build();
+        assertEquals(
+            "without weight-matches, UnifiedHighlighter always extracts automata regardless of unrecognized leaves",
+            FuzzyQueries.estimateAutomataBytes(fuzzy),
+            new HighlightAutomatonCostEstimator(bq, ACCEPT_ALL_FIELDS, false).estimate()
+        );
+    }
+
+    public void testUnrecognizedLeafOnUnrelatedFieldDoesNotSuppressExtraction() {
+        FuzzyQuery fuzzy = new FuzzyQuery(new Term("field", "captain"), 2);
+        Query bq = new BooleanQuery.Builder().add(fuzzy, BooleanClause.Occur.SHOULD)
+            .add(new FieldExistsQuery("other_field"), BooleanClause.Occur.FILTER)
+            .build();
+        assertEquals(
+            "an exists clause on a field the fieldMatcher doesn't accept must not suppress extraction",
+            FuzzyQueries.estimateAutomataBytes(fuzzy),
+            new HighlightAutomatonCostEstimator(bq, "field"::equals, true).estimate()
+        );
+    }
+
+    /** Checks the estimate never falls below the RAM the automaton {@code FuzzyQuery} actually builds. */
+    public void testEstimateIsCeilingOnMeasuredAutomataRam() {
+        int[] termLengths = { 5, 20, 50, 200 };
+        int[] maxEditsValues = { 1, 2 };
+        int[] prefixLengths = { 0, 3 };
+        Alphabet[] alphabets = Alphabet.values();
+
+        long worstRatioMicros = 0;
+
+        for (int termLength : termLengths) {
+            for (int maxEdits : maxEditsValues) {
+                for (int prefix : prefixLengths) {
+                    for (Alphabet alphabet : alphabets) {
+                        Random rnd = new Random(0xC0FFEEL ^ termLength ^ alphabet.ordinal());
+                        String term = alphabet.generate(termLength, rnd);
+                        FuzzyQuery query = new FuzzyQuery(new Term("field", term), maxEdits, prefix);
+
+                        long estimated = new HighlightAutomatonCostEstimator(query, ACCEPT_ALL_FIELDS, true).estimate();
+                        long measured = measureConsumeTermsMatchingBytes(query);
+
+                        double ratio = measured == 0L ? Double.POSITIVE_INFINITY : (double) estimated / (double) measured;
+                        long ratioMicros = measured == 0L ? Long.MAX_VALUE : Math.round(ratio * 1_000_000.0);
+                        worstRatioMicros = Math.max(worstRatioMicros, ratioMicros);
+
+                        assertThat(
+                            String.format(
+                                Locale.ROOT,
+                                "estimate must be a ceiling on the measured highlighter automaton RAM "
+                                    + "[termLen=%d, maxEdits=%d, prefix=%d, alphabet=%s, estimated=%d, measured=%d, ratio=%.3f]",
+                                termLength,
+                                maxEdits,
+                                prefix,
+                                alphabet,
+                                estimated,
+                                measured,
+                                ratio
+                            ),
+                            estimated,
+                            greaterThanOrEqualTo(measured)
+                        );
+                    }
+                }
+            }
+        }
+        logger.info("HighlightAutomatonCostEstimator worst reservation/actual ratio: {}", worstRatioMicros / 1_000_000.0);
+    }
+
+    private static long measureConsumeTermsMatchingBytes(Query query) {
+        long[] bytes = new long[1];
+        query.visit(new QueryVisitor() {
+            @Override
+            public void consumeTermsMatching(Query leaf, String field, Supplier<ByteRunAutomaton> automaton) {
+                bytes[0] += automaton.get().ramBytesUsed();
+            }
+
+            @Override
+            public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
+                return this;
+            }
+        });
+        return bytes[0];
+    }
+
+    private enum Alphabet {
+        SINGLE_CHAR {
+            @Override
+            String generate(int n, Random r) {
+                return "a".repeat(n);
+            }
+        },
+        ASCII_LETTERS {
+            @Override
+            String generate(int n, Random r) {
+                StringBuilder sb = new StringBuilder(n);
+                for (int i = 0; i < n; i++) {
+                    sb.append((char) ('a' + r.nextInt(26)));
+                }
+                return sb.toString();
+            }
+        },
+        UNICODE_BMP {
+            @Override
+            String generate(int n, Random r) {
+                StringBuilder sb = new StringBuilder(n);
+                for (int i = 0; i < n; i++) {
+                    int cp;
+                    do {
+                        cp = r.nextInt(0xD800);
+                    } while (Character.isISOControl(cp) || Character.isWhitespace(cp));
+                    sb.appendCodePoint(cp);
+                }
+                return sb.toString();
+            }
+        };
+
+        abstract String generate(int n, Random r);
+    }
+}


### PR DESCRIPTION
## End goal of this stack

Highlighting a query with automata-driven clauses (`fuzzy`, `wildcard`, `regexp`, etc.) makes Lucene's `UnifiedHighlighter` rebuild compiled automata on the fly, per field, per hit — separately from and in addition to the automata built during query execution. 

Query-time automata are already charged against the request circuit breaker (`MaxClauseCountQueryVisitor`), but this highlight-time reconstruction currently escapes accounting entirely, so a search that highlights fuzzy/wildcard/regexp matches can retain significant untracked heap regardless of the breaker limit.

This stack closes that gap across four PRs: a release hook for fetch sub-phases, an automaton cost estimator, breaker charge/refund wiring built on both, and end-to-end verification. See "This PR" below for what each one adds.

The outcome: highlighting `fuzzy/multi-term` queries can no longer allocate unbounded, untracked heap — it's bounded by and accounted against the same request circuit breaker as the rest of the search.

###  This PR

Stack **PR 2/4**. Introduces the cost-estimation logic this stack needs, with no wiring into the breaker yet — pure, unit-testable math.
- Adds `HighlightAutomatonCostEstimator`, a `QueryCostEstimator` that walks a query the same way `UnifiedHighlighter` does (field matching, `WEIGHT_MATCHES` effectiveness, span sub-visitor skipping, `hasUnrecognizedQuery` bail-out) to bound the bytes its automata extraction will retain for a single extraction pass
- Adds `FuzzyQueries.estimateAutomataBytes`, isolating just the automaton-cost share of the existing fuzzy-query formula — excluding the retained `FuzzyQuery` object and the segment/expansion-scaled rewrite RAM that only applies to search-time term expansion, not highlight-time automaton rebuilding


### Stack (review in order)
1. [PR1r](https://github.com/elastic/elasticsearch/pull/156529) #156529 → `pr1-fetch-processor-close`
2. **This PR2** → `pr2-highlight-cost-estimator`
3. [PR3a](https://github.com/elastic/elasticsearch/pull/156532) #156532 → `pr3-breaker-wiring` (draft)
4. [PR4](https://github.com/elastic/elasticsearch/pull/156533) #156533 → `pr4-breaker-release-its` (draft)

