### PR TITLE
Charge/refund request breaker for highlight automata

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -88,6 +88,9 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     /** Coordinating-node buffer for multi-search sub-responses (label is {@code msearch[<detail>]}). */
     public static final String CATEGORY_MSEARCH = "msearch";
 
+    /** Reservation for automata rebuilt by Lucene's {@code UnifiedHighlighter} during highlighting. */
+    public static final String CATEGORY_HIGHLIGHT = "highlight";
+
     private static final Set<String> KNOWN_CATEGORIES = Set.of(
         CATEGORY_QUERY,
         CATEGORY_FETCH,
@@ -95,7 +98,8 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
         CATEGORY_REGEXP,
         CATEGORY_RANGE,
         CATEGORY_PREALLOCATE,
-        CATEGORY_MSEARCH
+        CATEGORY_MSEARCH,
+        CATEGORY_HIGHLIGHT
     );
 
     /**

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -133,10 +133,18 @@ public final class CustomUnifiedHighlighter extends UnifiedHighlighter {
         this.noMatchSize = noMatchSize;
         this.maxAnalyzedOffset = maxAnalyzedOffset;
         this.queryMaxAnalyzedOffset = queryMaxAnalyzedOffset;
-        if (weightMatchesEnabled == false || requireFieldMatch == false || weightMatchesUnsupported(query)) {
+        if (isWeightMatchesEffective(weightMatchesEnabled, requireFieldMatch, query) == false) {
             getFlags(field).remove(HighlightFlag.WEIGHT_MATCHES);
         }
         fieldHighlighter = (CustomFieldHighlighter) getFieldHighlighter(field, query, extractTerms(query), maxPassages);
+    }
+
+    /**
+     * Whether this highlighter will run {@code query} with {@link HighlightFlag#WEIGHT_MATCHES} enabled.
+     * Exposed so callers can predict this before building the highlighter.
+     */
+    public static boolean isWeightMatchesEffective(boolean weightMatchesEnabled, boolean requireFieldMatch, Query query) {
+        return weightMatchesEnabled && requireFieldMatch && weightMatchesUnsupported(query) == false;
     }
 
     /**
@@ -289,7 +297,7 @@ public final class CustomUnifiedHighlighter extends UnifiedHighlighter {
      *
      * @param query The query to highlight
      */
-    private boolean weightMatchesUnsupported(Query query) {
+    private static boolean weightMatchesUnsupported(Query query) {
         boolean[] hasUnknownLeaf = new boolean[1];
         query.visit(new QueryVisitor() {
             @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/DefaultHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/DefaultHighlighter.java
@@ -20,12 +20,15 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.search.cost.HighlightAutomatonCostEstimator;
 import org.elasticsearch.lucene.search.uhighlight.BoundedBreakIteratorScanner;
 import org.elasticsearch.lucene.search.uhighlight.CustomPassageFormatter;
 import org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighter;
@@ -44,6 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighter.MULTIVAL_SEP_CHAR;
@@ -51,6 +55,30 @@ import static org.elasticsearch.lucene.search.uhighlight.CustomUnifiedHighlighte
 public class DefaultHighlighter implements Highlighter {
 
     public static final String NAME = "unified";
+
+    /**
+     * Key into {@link FieldHighlightContext#cache} for the {@link AtomicLong} that accumulates the
+     * bytes charged to the circuit breaker for automata rebuilt by the {@code UnifiedHighlighter}
+     * (see {@link #buildHighlighter}). {@link HighlightPhase} drains this holder and refunds the
+     * breaker when the fetch-phase processor closes.
+     */
+    static final String BREAKER_BYTES_CACHE_KEY = DefaultHighlighter.class.getName() + "#breakerBytes";
+
+    /**
+     * Returns the {@link AtomicLong} holder tracking accumulated highlight breaker charges for this
+     * search, creating it on first access.
+     */
+    static AtomicLong breakerBytesHolder(Map<String, Object> cache) {
+        return (AtomicLong) cache.computeIfAbsent(BREAKER_BYTES_CACHE_KEY, k -> new AtomicLong());
+    }
+
+    private static long saturatingAdd(long a, long b) {
+        try {
+            return Math.addExact(a, b);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
 
     @Override
     public boolean canHighlight(MappedFieldType fieldType) {
@@ -155,15 +183,46 @@ public class DefaultHighlighter implements Highlighter {
         builder.withFormatter(passageFormatter);
 
         Set<String> matchedFields = fieldContext.field.fieldOptions().matchedFields();
+        List<Predicate<String>> extractionPasses;
         if (matchedFields != null && matchedFields.isEmpty() == false) {
             // Masked fields require that the default field matcher is used
             if (fieldContext.field.fieldOptions().requireFieldMatch() == false) {
                 throw new IllegalArgumentException("Matched fields are not supported when [require_field_match] is set to [false]");
             }
             builder.withMaskedFieldsFunc((fieldName) -> fieldName.equals(fieldContext.fieldName) ? matchedFields : Collections.emptySet());
+
+            // Mirror UnifiedHighlighter's one-pass-per-masked-field-plus-original-field extraction.
+            extractionPasses = new ArrayList<>(matchedFields.size() + 1);
+            for (String maskedField : matchedFields) {
+                extractionPasses.add(maskedField::equals);
+            }
+            extractionPasses.add(fieldContext.fieldName::equals);
         } else {
-            builder.withFieldMatcher(fieldMatcher(fieldContext));
+            Predicate<String> fieldMatcher = fieldMatcher(fieldContext);
+            builder.withFieldMatcher(fieldMatcher);
+            extractionPasses = List.of(fieldMatcher);
         }
+
+        CircuitBreaker breaker = fieldContext.context.getSearchExecutionContext().getCircuitBreaker();
+        if (breaker != null) {
+            boolean weightMatchesEffective = CustomUnifiedHighlighter.isWeightMatchesEffective(
+                weightMatchesEnabled,
+                fieldContext.field.fieldOptions().requireFieldMatch(),
+                fieldContext.query
+            );
+            long bytes = 0L;
+            for (Predicate<String> passFieldMatcher : extractionPasses) {
+                bytes = saturatingAdd(
+                    bytes,
+                    new HighlightAutomatonCostEstimator(fieldContext.query, passFieldMatcher, weightMatchesEffective).estimate()
+                );
+            }
+            if (bytes > 0) {
+                breaker.addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_HIGHLIGHT);
+                breakerBytesHolder(fieldContext.cache).accumulateAndGet(bytes, DefaultHighlighter::saturatingAdd);
+            }
+        }
+
         return new CustomUnifiedHighlighter(
             builder,
             offsetSource,

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -11,6 +11,8 @@ package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -26,6 +28,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 public class HighlightPhase implements FetchSubPhase {
@@ -76,6 +79,20 @@ public class HighlightPhase implements FetchSubPhase {
                     }
                 }
                 hitContext.hit().highlightFields(highlightFields);
+            }
+
+            @Override
+            public void close() {
+                Object holder = sharedCache.get(DefaultHighlighter.BREAKER_BYTES_CACHE_KEY);
+                if (holder instanceof AtomicLong breakerBytes) {
+                    long total = breakerBytes.getAndSet(0);
+                    if (total > 0) {
+                        CircuitBreaker breaker = context.getSearchExecutionContext().getCircuitBreaker();
+                        if (breaker != null) {
+                            breaker.addWithoutBreaking(-total, ChildMemoryCircuitBreaker.CATEGORY_HIGHLIGHT);
+                        }
+                    }
+                }
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreakerTests.java
@@ -29,6 +29,7 @@ public class ChildMemoryCircuitBreakerTests extends ESTestCase {
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_PREALLOCATE, ChildMemoryCircuitBreaker.categoryFor("preallocate"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_MSEARCH, ChildMemoryCircuitBreaker.categoryFor("msearch"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_HIGHLIGHT, ChildMemoryCircuitBreaker.categoryFor("highlight"));
     }
 
     public void testCategoryForCompositeLabelsBracket() {
@@ -39,6 +40,7 @@ public class ChildMemoryCircuitBreakerTests extends ESTestCase {
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch[source]"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_FETCH, ChildMemoryCircuitBreaker.categoryFor("fetch[script_field]"));
         assertEquals(ChildMemoryCircuitBreaker.CATEGORY_WILDCARD, ChildMemoryCircuitBreaker.categoryFor("wildcard[ci]:my_field"));
+        assertEquals(ChildMemoryCircuitBreaker.CATEGORY_HIGHLIGHT, ChildMemoryCircuitBreaker.categoryFor("highlight[field1]"));
     }
 
     public void testCategoryForCompositeLabelsColon() {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhaseCircuitBreakerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhaseCircuitBreakerTests.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.fetch.subphase.highlight;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.HighlighterTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class HighlightPhaseCircuitBreakerTests extends HighlighterTestCase {
+
+    public void testFuzzyQueryChargesAndCloseRefundsBreaker() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+            .highlighter(new HighlightBuilder().field("field"));
+
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(100));
+        runHighlightProcessor(mapperService, doc, search, breaker, processorAndHit -> {
+            long baseline = breaker.getUsed();
+            processorAndHit.process();
+            assertThat("highlighting a fuzzy query must charge the breaker", breaker.getUsed() - baseline, greaterThan(0L));
+            processorAndHit.processor().close();
+            assertEquals("close() must refund exactly what highlighting charged", baseline, breaker.getUsed());
+        });
+    }
+
+    public void testTermQueryChargesNothing() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some text" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "some"))
+            .highlighter(new HighlightBuilder().field("field"));
+
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(100));
+        runHighlightProcessor(mapperService, doc, search, breaker, processorAndHit -> {
+            long baseline = breaker.getUsed();
+            processorAndHit.process();
+            assertEquals("a term query rebuilds no automata, so highlighting should add no charge", baseline, breaker.getUsed());
+            processorAndHit.processor().close();
+            assertEquals(baseline, breaker.getUsed());
+        });
+    }
+
+    public void testTwoHighlightedFieldsAccumulateAndSingleCloseRefundsAll() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field1" : { "type" : "text" },
+                "field2" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field1" : "some fuzzy text", "field2" : "other fuzzy content" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field1", "fuzzz").fuzziness(Fuzziness.TWO))
+            .highlighter(new HighlightBuilder().field("field1").field("field2"));
+
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(100));
+        runHighlightProcessor(mapperService, doc, search, breaker, processorAndHit -> {
+            long baseline = breaker.getUsed();
+            processorAndHit.process();
+            long chargedForBothFields = breaker.getUsed() - baseline;
+            assertThat(chargedForBothFields, greaterThan(0L));
+
+            processorAndHit.processor().close();
+            assertEquals("closing once must refund the accumulated charge for every field", baseline, breaker.getUsed());
+        });
+    }
+
+    public void testCrossFieldQueryDoesNotChargeForUnhighlightedField() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field_a" : { "type" : "text" },
+                "field_b" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field_a" : "some fuzzy text", "field_b" : "other fuzzy content" }
+            """));
+
+        long chargeHighlightingOnlyFieldA = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(
+                QueryBuilders.boolQuery()
+                    .should(QueryBuilders.fuzzyQuery("field_a", "fuzzz").fuzziness(Fuzziness.TWO))
+                    .should(QueryBuilders.fuzzyQuery("field_b", "fuzzz").fuzziness(Fuzziness.TWO))
+            ).highlighter(new HighlightBuilder().field("field_a"))
+        );
+        long chargeHighlightingFieldAAlone = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field_a", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field("field_a"))
+        );
+
+        assertThat(chargeHighlightingFieldAAlone, greaterThan(0L));
+        assertEquals(
+            "field_b's fuzzy clause must not be charged when only field_a is highlighted",
+            chargeHighlightingFieldAAlone,
+            chargeHighlightingOnlyFieldA
+        );
+    }
+
+    public void testDoubleCloseIsIdempotent() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+            .highlighter(new HighlightBuilder().field("field"));
+
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(100));
+        runHighlightProcessor(mapperService, doc, search, breaker, processorAndHit -> {
+            long baseline = breaker.getUsed();
+            processorAndHit.process();
+            assertThat(breaker.getUsed() - baseline, greaterThan(0L));
+
+            processorAndHit.processor().close();
+            assertEquals(baseline, breaker.getUsed());
+
+            processorAndHit.processor().close();
+            assertEquals(baseline, breaker.getUsed());
+        });
+    }
+
+    public void testMatchedFieldsDoNotInflateChargeWhenQueryDoesNotTargetThem() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text", "fields" : { "exact" : { "type" : "text" } } }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+
+        long unmatchedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field("field"))
+        );
+        long matchedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field("field").matchedFields("field.exact")))
+        );
+
+        assertThat(unmatchedCharge, greaterThan(0L));
+        assertEquals(
+            "matched_fields must not inflate the charge when the query has no clause on the matched field",
+            unmatchedCharge,
+            matchedCharge
+        );
+    }
+
+    public void testMustNotFuzzyClauseChargesNothing() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.matchAllQuery())
+                .mustNot(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+        ).highlighter(new HighlightBuilder().field("field"));
+
+        long charged = chargeFor(mapperService, doc, search);
+        assertEquals("a fuzzy clause under must_not is never visited by UnifiedHighlighter, so it must not be charged", 0L, charged);
+    }
+
+    public void testExistsFilterOnHighlightedFieldSuppressesFuzzyCharge() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text" }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+        SearchSourceBuilder search = new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .filter(QueryBuilders.existsQuery("field"))
+        ).highlighter(new HighlightBuilder().field("field"));
+
+        long charged = chargeFor(mapperService, doc, search);
+        assertEquals("an exists clause on the highlighted field makes UnifiedHighlighter skip automata extraction entirely", 0L, charged);
+    }
+
+    public void testMatchedFieldsChargeSumsClausesActuallyTargetingEachField() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text", "fields" : { "exact" : { "type" : "text" } } }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+
+        long unmatchedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field("field"))
+        );
+
+        long combinedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(
+                QueryBuilders.boolQuery()
+                    .should(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                    .should(QueryBuilders.fuzzyQuery("field.exact", "fuzzz").fuzziness(Fuzziness.TWO))
+            ).highlighter(new HighlightBuilder().field(new HighlightBuilder.Field("field").matchedFields("field.exact")))
+        );
+
+        assertThat(unmatchedCharge, greaterThan(0L));
+        assertThat(combinedCharge, equalTo(unmatchedCharge * 2));
+    }
+
+    public void testMatchedFieldsChargeDoublesWhenHighlightedFieldListsItself() throws IOException {
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "field" : { "type" : "text", "fields" : { "exact" : { "type" : "text" } } }
+            }}}
+            """);
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            { "field" : "this is some fuzzy text content" }
+            """));
+
+        long unmatchedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field("field"))
+        );
+
+        long selfMatchedCharge = chargeFor(
+            mapperService,
+            doc,
+            new SearchSourceBuilder().query(QueryBuilders.fuzzyQuery("field", "fuzzz").fuzziness(Fuzziness.TWO))
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field("field").matchedFields("field", "field.exact")))
+        );
+
+        assertThat(unmatchedCharge, greaterThan(0L));
+        assertThat(selfMatchedCharge, equalTo(unmatchedCharge * 2));
+    }
+
+    private long chargeFor(MapperService mapperService, ParsedDocument doc, SearchSourceBuilder search) throws IOException {
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(100));
+        long[] charged = new long[1];
+        runHighlightProcessor(mapperService, doc, search, breaker, processorAndHit -> {
+            long baseline = breaker.getUsed();
+            processorAndHit.process();
+            charged[0] = breaker.getUsed() - baseline;
+            processorAndHit.processor().close();
+        });
+        return charged[0];
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
@@ -15,6 +15,9 @@ import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.StoredFields;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -64,11 +67,29 @@ public class HighlighterTestCase extends MapperServiceTestCase {
     protected final Map<String, HighlightField> highlight(MapperService mapperService, ParsedDocument doc, SearchSourceBuilder search)
         throws IOException {
         Map<String, HighlightField> highlights = new HashMap<>();
+        runHighlightProcessor(mapperService, doc, search, null, processorAndHit -> {
+            processorAndHit.process();
+            highlights.putAll(processorAndHit.hitContext().hit().getHighlightFields());
+            processorAndHit.processor().close();
+        });
+        return highlights;
+    }
+
+    protected final void runHighlightProcessor(
+        MapperService mapperService,
+        ParsedDocument doc,
+        SearchSourceBuilder search,
+        @Nullable CircuitBreaker circuitBreaker,
+        CheckedConsumer<HighlightProcessorAndHit, IOException> body
+    ) throws IOException {
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), ir -> {
             SearchExecutionContext context = createSearchExecutionContext(
                 mapperService,
                 newSearcher(new NoStoredFieldsFilterDirectoryReader(ir))
             );
+            if (circuitBreaker != null) {
+                context = new SearchExecutionContext(context, circuitBreaker);
+            }
             HighlightPhase highlightPhase = new HighlightPhase(getHighlighters());
             FetchSubPhaseProcessor processor = highlightPhase.getProcessor(fetchContext(context, search));
             Map<String, List<Object>> storedFields = storedFields(processor.storedFieldsSpec(), doc);
@@ -76,13 +97,17 @@ public class HighlighterTestCase extends MapperServiceTestCase {
             SearchHit hit = new SearchHit(0, "id");
             try {
                 FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext(hit, ir.leaves().get(0), 0, storedFields, source, null);
-                processor.process(hitContext);
-                highlights.putAll(hitContext.hit().getHighlightFields());
+                body.accept(new HighlightProcessorAndHit(processor, hitContext));
             } finally {
                 hit.decRef();
             }
         });
-        return highlights;
+    }
+
+    protected record HighlightProcessorAndHit(FetchSubPhaseProcessor processor, FetchSubPhase.HitContext hitContext) {
+        public void process() throws IOException {
+            processor.process(hitContext);
+        }
     }
 
     private static Map<String, List<Object>> storedFields(StoredFieldsSpec spec, ParsedDocument doc) {


### PR DESCRIPTION
## End goal of this stack

Highlighting a query with automata-driven clauses (`fuzzy`, `wildcard`, `regexp`, etc.) makes Lucene's `UnifiedHighlighter` rebuild compiled automata on the fly, per field, per hit — separately from and in addition to the automata built during query execution. 

Query-time automata are already charged against the request circuit breaker (`MaxClauseCountQueryVisitor`), but this highlight-time reconstruction currently escapes accounting entirely, so a search that highlights fuzzy/wildcard/regexp matches can retain significant untracked heap regardless of the breaker limit.

This stack closes that gap across four PRs: a release hook for fetch sub-phases, an automaton cost estimator, breaker charge/refund wiring built on both, and end-to-end verification. See "This PR" below for what each one adds.

The outcome: highlighting `fuzzy/multi-term` queries can no longer allocate unbounded, untracked heap — it's bounded by and accounted against the same request circuit breaker as the rest of the search.

###  This PR
Stack **PR 3/4**. Wires PR2's estimator into live request-breaker accounting, using the release hook from PR1 to refund it.
- Adds a `highlight` category to `ChildMemoryCircuitBreaker` for automata reservations made during highlighting
- `DefaultHighlighter` computes the highlight-automaton charge per `UnifiedHighlighter` extraction pass (correctly handling `matched_fields`' one-pass-per-masked-field-plus-original-field semantics) and reserves it against the request breaker when the highlighter is built
- `HighlightPhase` accumulates that charge per search and refunds it via the `close()` hook added in PR1 once the fetch phase finishes
- Exposes `CustomUnifiedHighlighter.isWeightMatchesEffective` as a static, reusable predicate so the cost estimator can predict `WEIGHT_MATCHES` behavior before the highlighter is actually built


### Stack (review in order)
1. [PR1](https://github.com/elastic/elasticsearch/pull/156529) #156529 → `pr1-fetch-processor-close`
2. [PR2](https://github.com/elastic/elasticsearch/pull/156531) #156531 → `pr2-highlight-cost-estimator`
3. **This PR3** → `pr3-breaker-wiring`
4. [PR4](https://github.com/elastic/elasticsearch/pull/156533) #156533 → `pr4-breaker-release-its` (draft)
