### PR TITLE
Add end-to-end highlight breaker-release ITs

### DIFF
--- a/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorHighlightCircuitBreakerIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorHighlightCircuitBreakerIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.percolator;
+
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.fuzzyQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numClientNodes = 0, maxNumDataNodes = 1)
+public class PercolatorHighlightCircuitBreakerIT extends ESIntegTestCase {
+
+    private static final String INDEX_NAME = "percolator-highlight-cb-test";
+    private static final String FIELD = "field1";
+    private static final String TERM = "abcdefghij";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(PercolatorPlugin.class);
+    }
+
+    @Before
+    public void checkBreakerType() {
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
+    }
+
+    public void testPercolateFuzzyHighlightingReleasesBreakerMemory() throws Exception {
+        assertAcked(
+            indicesAdmin().prepareCreate(INDEX_NAME).setMapping("id", "type=keyword", FIELD, "type=text", "query", "type=percolator")
+        );
+        prepareIndex(INDEX_NAME).setId("1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("id", "1")
+                    .field("query", fuzzyQuery(FIELD, TERM).fuzziness(Fuzziness.TWO).prefixLength(0))
+                    .endObject()
+            )
+            .get();
+        refresh(INDEX_NAME);
+
+        assertBusy(() -> assertEquals("Request breaker should be empty before search", 0L, getRequestBreakerEstimated()));
+
+        BytesReference document = BytesReference.bytes(jsonBuilder().startObject().field(FIELD, "some " + TERM + " content").endObject());
+        assertResponse(
+            prepareSearch(INDEX_NAME).setQuery(new PercolateQueryBuilder("query", document, XContentType.JSON))
+                .highlighter(new HighlightBuilder().field(FIELD)),
+            response -> assertEquals(1L, response.getHits().getTotalHits().value())
+        );
+
+        assertBusy(
+            () -> assertEquals("Request breaker memory should be released after search completes", 0L, getRequestBreakerEstimated())
+        );
+    }
+
+    public void testMultiplePercolateQueriesPerHitReleaseBreakerMemory() throws Exception {
+        assertAcked(
+            indicesAdmin().prepareCreate(INDEX_NAME).setMapping("id", "type=keyword", FIELD, "type=text", "query", "type=percolator")
+        );
+        prepareIndex(INDEX_NAME).setId("1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("id", "1")
+                    .field("query", fuzzyQuery(FIELD, TERM).fuzziness(Fuzziness.TWO).prefixLength(0))
+                    .endObject()
+            )
+            .get();
+        refresh(INDEX_NAME);
+
+        assertBusy(() -> assertEquals("Request breaker should be empty before search", 0L, getRequestBreakerEstimated()));
+
+        BytesReference document1 = BytesReference.bytes(jsonBuilder().startObject().field(FIELD, "some " + TERM + " content").endObject());
+        BytesReference document2 = BytesReference.bytes(jsonBuilder().startObject().field(FIELD, "other " + TERM + " stuff").endObject());
+        assertResponse(
+            prepareSearch(INDEX_NAME).setQuery(
+                boolQuery().should(new PercolateQueryBuilder("query", document1, XContentType.JSON).setName("query1"))
+                    .should(new PercolateQueryBuilder("query", document2, XContentType.JSON).setName("query2"))
+            ).highlighter(new HighlightBuilder().field(FIELD)),
+            response -> {
+                assertEquals(1L, response.getHits().getTotalHits().value());
+                assertEquals(2, response.getHits().getAt(0).getHighlightFields().size());
+            }
+        );
+
+        assertBusy(
+            () -> assertEquals("Request breaker memory should be released after search completes", 0L, getRequestBreakerEstimated())
+        );
+    }
+
+    private boolean noopBreakerUsed() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        for (NodeStats nodeStats : stats.getNodes()) {
+            if (nodeStats.getBreaker().getStats(CircuitBreaker.REQUEST).getLimit() == NoopCircuitBreaker.LIMIT) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private long getRequestBreakerEstimated() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        long estimated = 0;
+        for (NodeStats stat : stats.getNodes()) {
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.REQUEST);
+            if (breakerStats != null) {
+                estimated += breakerStats.getEstimated();
+            }
+        }
+        return estimated;
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightAutomatonCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightAutomatonCircuitBreakerIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.fetch.subphase.highlight;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.query.FuzzyQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.lucene.search.FuzzyQueries;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.CoreMatchers.containsString;
+
+@ESIntegTestCase.ClusterScope(scope = TEST, numClientNodes = 0, maxNumDataNodes = 1)
+public class HighlightAutomatonCircuitBreakerIT extends ESIntegTestCase {
+
+    private static final String INDEX_NAME = "highlight-cb-test";
+    private static final String KEYWORD_FIELD = "kw_field";
+    private static final String TERM = "abcdefghij";
+
+    @Before
+    public void checkBreakerType() {
+        assumeFalse("--> noop breakers used, skipping test", noopBreakerUsed());
+    }
+
+    @After
+    public void resetBreakerSettings() {
+        updateClusterSettings(
+            Settings.builder()
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
+                .putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey())
+        );
+    }
+
+    public void testHighlightedFuzzyQueryReleasesBreakerMemory() throws Exception {
+        createAndPopulateIndex();
+        assertBusy(() -> assertEquals("Request breaker should be empty before search", 0L, getRequestBreakerEstimated()));
+
+        assertResponse(
+            prepareSearch(INDEX_NAME).setQuery(fuzzyQuery())
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field(KEYWORD_FIELD))),
+            response -> assertEquals(1L, response.getHits().getTotalHits().value())
+        );
+
+        assertBusy(
+            () -> assertEquals("Request breaker memory should be released after search completes", 0L, getRequestBreakerEstimated())
+        );
+    }
+
+    public void testHighlightingTripsCircuitBreakerWhileQueryAloneSucceeds() {
+        createAndPopulateIndex();
+
+        FuzzyQuery fuzzyQuery = new FuzzyQuery(new Term(KEYWORD_FIELD, TERM), Fuzziness.TWO.asDistance(TERM), 0);
+        long automataBytes = FuzzyQueries.estimateAutomataBytes(fuzzyQuery);
+        long limitBytes = automataBytes + automataBytes / 2;
+
+        updateClusterSettings(
+            Settings.builder()
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), limitBytes + "b")
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 1.0)
+        );
+
+        assertResponse(
+            prepareSearch(INDEX_NAME).setQuery(fuzzyQuery()),
+            response -> assertEquals(1L, response.getHits().getTotalHits().value())
+        );
+
+        assertFailures(
+            prepareSearch(INDEX_NAME).setQuery(fuzzyQuery())
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field(KEYWORD_FIELD))),
+            RestStatus.TOO_MANY_REQUESTS,
+            containsString("Data too large")
+        );
+    }
+
+    public void testMatchedFieldsScalesHighlightCharge() {
+        createAndPopulateIndex();
+
+        FuzzyQuery fuzzyQuery = new FuzzyQuery(new Term(KEYWORD_FIELD, TERM), Fuzziness.TWO.asDistance(TERM), 0);
+        long queryBytes = FuzzyQueries.estimateBytes(fuzzyQuery);
+        long automataBytes = FuzzyQueries.estimateAutomataBytes(fuzzyQuery);
+        long limitBytes = queryBytes + automataBytes + automataBytes / 2;
+
+        updateClusterSettings(
+            Settings.builder()
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), limitBytes + "b")
+                .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_OVERHEAD_SETTING.getKey(), 1.0)
+        );
+
+        assertResponse(
+            prepareSearch(INDEX_NAME).setQuery(fuzzyQuery())
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field(KEYWORD_FIELD))),
+            response -> assertEquals(1L, response.getHits().getTotalHits().value())
+        );
+
+        assertFailures(
+            prepareSearch(INDEX_NAME).setQuery(fuzzyQuery())
+                .highlighter(new HighlightBuilder().field(new HighlightBuilder.Field(KEYWORD_FIELD).matchedFields(KEYWORD_FIELD))),
+            RestStatus.TOO_MANY_REQUESTS,
+            containsString("Data too large")
+        );
+    }
+
+    private FuzzyQueryBuilder fuzzyQuery() {
+        return QueryBuilders.fuzzyQuery(KEYWORD_FIELD, TERM).fuzziness(Fuzziness.TWO).prefixLength(0);
+    }
+
+    private boolean noopBreakerUsed() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        for (NodeStats nodeStats : stats.getNodes()) {
+            if (nodeStats.getBreaker().getStats(CircuitBreaker.REQUEST).getLimit() == NoopCircuitBreaker.LIMIT) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private long getRequestBreakerEstimated() {
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
+        long estimated = 0;
+        for (NodeStats stat : stats.getNodes()) {
+            CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.REQUEST);
+            if (breakerStats != null) {
+                estimated += breakerStats.getEstimated();
+            }
+        }
+        return estimated;
+    }
+
+    private void createAndPopulateIndex() {
+        assertAcked(
+            prepareCreate(INDEX_NAME).setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+                .setMapping(KEYWORD_FIELD, "type=keyword")
+        );
+        prepareIndex(INDEX_NAME).setId("1").setSource(KEYWORD_FIELD, TERM).get();
+        for (int i = 0; i < 20; i++) {
+            prepareIndex(INDEX_NAME).setId("other-" + i).setSource(KEYWORD_FIELD, "unrelated" + i).get();
+        }
+        refresh(INDEX_NAME);
+    }
+}


### PR DESCRIPTION
## End goal of this stack

Highlighting a query with automata-driven clauses (`fuzzy`, `wildcard`, `regexp`, etc.) makes Lucene's `UnifiedHighlighter` rebuild compiled automata on the fly, per field, per hit — separately from and in addition to the automata built during query execution. 

Query-time automata are already charged against the request circuit breaker (`MaxClauseCountQueryVisitor`), but this highlight-time reconstruction currently escapes accounting entirely, so a search that highlights fuzzy/wildcard/regexp matches can retain significant untracked heap regardless of the breaker limit.

This stack closes that gap across four PRs: a release hook for fetch sub-phases, an automaton cost estimator, breaker charge/refund wiring built on both, and end-to-end verification. See "This PR" below for what each one adds.

The outcome: highlighting `fuzzy/multi-term` queries can no longer allocate unbounded, untracked heap — it's bounded by and accounted against the same request circuit breaker as the rest of the search.

###  This PR
Stack **PR 4/4.** End-to-end proof that the full stack behaves correctly on a real cluster — no new production logic, just integration coverage.
- `HighlightAutomatonCircuitBreakerIT`: highlighting a fuzzy query charges the request breaker and fully releases it once the search completes; a highlighter that would push past the breaker limit trips it (`TOO_MANY_REQUESTS`) even though the underlying query alone succeeds; `matched_fields` scales the charge as expected
- `PercolatorHighlightCircuitBreakerIT`: the same charge/release guarantees hold for percolator highlighting, including when multiple percolator queries match and highlight the same hit

### Stack (review in order)
1. [PR1](https://github.com/elastic/elasticsearch/pull/156529) #156529 → `pr1-fetch-processor-close`
2. [PR2](https://github.com/elastic/elasticsearch/pull/156531) #156531 → `pr2-highlight-cost-estimator`
3. [PR3](https://github.com/elastic/elasticsearch/pull/156532) #156532 → `pr3-breaker-wiring` (draft)
4. **This PR** → `pr4-breaker-release-its`