### PR TITLE
[9.5] Fix nested integer sort returning LONG sentinel on pre-8.19/9.0.x indices (#155580)

### DIFF
--- a/docs/changelog/155580.yaml
+++ b/docs/changelog/155580.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 155243
+pr: 155580
+summary: Fix nested integer sort returning LONG sentinel and descending or "mode"-based sorts on multi-valued fields returned the wrong value  on pre-8.19/9.0.x indices 
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -27,6 +27,8 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
@@ -40,6 +42,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -124,6 +127,11 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected boolean forbidPrivateIndexSettings() {
         return false;
     }
 
@@ -1643,7 +1651,7 @@ public class FieldSortIT extends ESIntegTestCase {
     /**
      * Test case for issue 6150: https://github.com/elastic/elasticsearch/issues/6150
      */
-    public void testNestedSort() throws IOException, InterruptedException, ExecutionException {
+    public void testNestedSort() throws IOException {
         assertAcked(
             prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
@@ -1782,7 +1790,74 @@ public class FieldSortIT extends ESIntegTestCase {
         assertThat(exc.toString(), containsString("it is mandatory to set the [nested] context"));
     }
 
-    public void testSortDuelBetweenSingleShardAndMultiShardIndex() throws Exception {
+    public void testNestedIntegerSortOnOldIndex() throws Exception {
+        IndexVersion oldVersion = randomBoolean()
+            ? IndexVersionUtils.randomVersionBetween(
+                IndexVersions.MINIMUM_COMPATIBLE,
+                IndexVersionUtils.getPreviousVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19)
+            )
+            : IndexVersionUtils.randomVersionBetween(
+                IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
+                IndexVersionUtils.getPreviousVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE)
+            );
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, oldVersion).build();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("""
+            {
+                "properties": {
+                    "obj": {
+                        "type": "nested",
+                        "properties": {
+                            "value": { "type": "integer" }
+                        }
+                    },
+                    "values": { "type": "integer" }
+                }
+            }
+            """));
+        indexRandom(
+            true,
+            prepareIndex("test").setSource(
+                jsonBuilder().startObject().startObject("obj").field("value", 30).endObject().array("values", 1, 100).endObject()
+            ),
+            prepareIndex("test").setSource(
+                jsonBuilder().startObject().startObject("obj").field("value", 10).endObject().array("values", 20, 30).endObject()
+            ),
+            prepareIndex("test").setSource(
+                jsonBuilder().startObject().startObject("obj").field("value", 20).endObject().array("values", 40, 50).endObject()
+            )
+        );
+
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchAllQuery())
+                .addSort(SortBuilders.fieldSort("obj.value").setNestedSort(new NestedSortBuilder("obj")).order(SortOrder.ASC)),
+            response -> assertSortValues(response, 10L, 20L, 30L)
+        );
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchAllQuery())
+                .addSort(SortBuilders.fieldSort("obj.value").setNestedSort(new NestedSortBuilder("obj")).order(SortOrder.DESC)),
+            response -> assertSortValues(response, 30L, 20L, 10L)
+        );
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchAllQuery())
+                .addSort(SortBuilders.fieldSort("values").sortMode(SortMode.MAX).order(SortOrder.DESC)),
+            response -> assertSortValues(response, 100L, 50L, 30L)
+        );
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchAllQuery())
+                .addSort(SortBuilders.fieldSort("values").sortMode(SortMode.SUM).order(SortOrder.DESC)),
+            response -> assertSortValues(response, 101L, 90L, 50L)
+        );
+    }
+
+    private static void assertSortValues(SearchResponse response, long... expectedValues) {
+        SearchHit[] hits = response.getHits().getHits();
+        assertThat(hits.length, is(expectedValues.length));
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertThat(((Number) hits[i].getSortValues()[0]).longValue(), equalTo(expectedValues[i]));
+        }
+    }
+
+    public void testSortDuelBetweenSingleShardAndMultiShardIndex() {
         String sortField = "sortField";
         assertAcked(
             prepareCreate("test1").setSettings(
@@ -1828,7 +1903,7 @@ public class FieldSortIT extends ESIntegTestCase {
         );
     }
 
-    public void testCustomFormat() throws Exception {
+    public void testCustomFormat() {
         // Use an ip field, which uses different internal/external
         // representations of values, to make sure values are both correctly
         // rendered and parsed (search_after)
@@ -1930,7 +2005,7 @@ public class FieldSortIT extends ESIntegTestCase {
         );
     }
 
-    public void testFieldAliasesWithMissingValues() throws Exception {
+    public void testFieldAliasesWithMissingValues() {
         // Create two indices and add the field 'route_length_miles' as an alias in
         // one, and a concrete field in the other.
         assertAcked(prepareCreate("old_index").setMapping("distance", "type=double", "route_length_miles", "type=alias,path=distance"));

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -86,15 +86,12 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
      * match the field's <code>numericType</code>.
      */
     public final SortField sortField(
-        boolean indexSort,
         NumericType targetNumericType,
         Object missingValue,
         MultiValueMode sortMode,
         Nested nested,
         boolean reverse
     ) {
-        XFieldComparatorSource source = comparatorSource(targetNumericType, missingValue, sortMode, nested);
-
         /*
          * Use a SortField with the custom comparator logic if required because
          * 1. The underlying data source needs it.
@@ -105,18 +102,33 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         boolean requiresCustomComparator = nested != null
             || (sortMode != MultiValueMode.MAX && sortMode != MultiValueMode.MIN)
             || targetNumericType != getNumericType();
-        if (indexSort == false || sortRequiresCustomComparator()) {
+        return buildSortField(targetNumericType, missingValue, sortMode, nested, reverse, false, requiresCustomComparator == false);
+    }
+
+    private SortField buildSortField(
+        NumericType targetNumericType,
+        Object missingValue,
+        MultiValueMode sortMode,
+        Nested nested,
+        boolean reverse,
+        boolean useNativeSortField,
+        boolean optimizeSortWithPoints
+    ) {
+        XFieldComparatorSource source = comparatorSource(targetNumericType, missingValue, sortMode, nested);
+        if (useNativeSortField == false || sortRequiresCustomComparator()) {
             SortField sortField = new SortField(getFieldName(), source, reverse);
-            sortField.setOptimizeSortWithPoints(requiresCustomComparator == false && canUseOptimizedSort(indexType()));
+            sortField.setOptimizeSortWithPoints(optimizeSortWithPoints && canUseOptimizedSort(indexType()));
             return sortField;
         }
 
+        assert nested == null;
+        assert sortMode == MultiValueMode.MIN || sortMode == MultiValueMode.MAX;
         SortedNumericSelector.Type selectorType = sortMode == MultiValueMode.MAX
             ? SortedNumericSelector.Type.MAX
             : SortedNumericSelector.Type.MIN;
-        SortField sortField = new SortedNumericSortField(getFieldName(), getNumericType().sortFieldType, reverse, selectorType);
+        SortField sortField = new SortedNumericSortField(getFieldName(), targetNumericType.sortFieldType, reverse, selectorType);
         sortField.setMissingValue(source.missingObject(missingValue, reverse));
-        sortField.setOptimizeSortWithPoints(canUseOptimizedSort(indexType()));
+        sortField.setOptimizeSortWithPoints(optimizeSortWithPoints && canUseOptimizedSort(indexType()));
         return sortField;
     }
 
@@ -139,7 +151,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
 
     @Override
     public final SortField sortField(Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
-        return sortField(false, getNumericType(), missingValue, sortMode, nested, reverse);
+        return sortField(getNumericType(), missingValue, sortMode, nested, reverse);
     }
 
     @Override
@@ -156,7 +168,25 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
         Nested nested,
         boolean reverse
     ) {
-        SortField sortField = sortField(indexSort, getNumericType(), missingValue, sortMode, nested, reverse);
+        // Integer sorts used LONG before 8.19 and in 9.0. Use that historical type directly because an index sort's type is persisted
+        // in the index writer configuration, and search sorts must use the same representation for compatibility.
+        boolean useBwcLongSort = getNumericType().sortFieldType == SortField.Type.INT
+            // we introduced INT sort type in 8.19 and from 9.1
+            && indexCreatedVersion.before(IndexVersions.INDEX_INT_SORT_INT_TYPE)
+            && indexCreatedVersion.between(IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19, UPGRADE_TO_LUCENE_10_0_0) == false;
+
+        NumericType targetNumericType = useBwcLongSort ? NumericType.LONG : getNumericType();
+        boolean hasNativeSelector = nested == null && (sortMode == MultiValueMode.MIN || sortMode == MultiValueMode.MAX);
+        boolean useNativeSortField = hasNativeSelector && (indexSort || useBwcLongSort);
+        SortField sortField = buildSortField(
+            targetNumericType,
+            missingValue,
+            sortMode,
+            nested,
+            reverse,
+            useNativeSortField,
+            useBwcLongSort == false && hasNativeSelector
+        );
 
         if (getNumericType() == NumericType.DATE_NANOSECONDS
             && indexCreatedVersion.before(IndexVersions.V_7_14_0)
@@ -166,43 +196,8 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
             // to 0L - for compatibility we require to a missing value of MIN_VALUE to allow to
             // open the index.
             sortField.setMissingValue(Long.MIN_VALUE);
-            return sortField;
         }
-
-        if (getNumericType().sortFieldType != SortField.Type.INT
-            // we introduced INT sort type in 8.19 and from 9.1
-            || indexCreatedVersion.onOrAfter(IndexVersions.INDEX_INT_SORT_INT_TYPE)
-            || indexCreatedVersion.between(IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19, UPGRADE_TO_LUCENE_10_0_0)) {
-            return sortField;
-        }
-
-        // if the index was created before 8.19, or in 9.0
-        // we need to rewrite the sort field to use LONG sort type
-        // Before indices used TYPE.LONG for index sorting on integer field,
-        // and this is stored in their index writer config on disk and can't be modified.
-        // Now sortField() returns TYPE.INT when sorting on integer field,
-        // but to support sorting on old indices, we need to rewrite this sort to TYPE.LONG.
-
-        XFieldComparatorSource longSource = comparatorSource(NumericType.LONG, missingValue, sortMode, nested);
-        if (sortField instanceof SortedNumericSortField snsf) {
-            SortedNumericSortField rewrittenSortField = new SortedNumericSortField(
-                snsf.getField(),
-                SortField.Type.LONG,
-                snsf.getReverse(),
-                snsf.getSelector()
-            );
-            rewrittenSortField.setMissingValue(longSource.missingObject(missingValue, reverse));
-            // we don't optimize sorting on int field for old indices
-            rewrittenSortField.setOptimizeSortWithPoints(false);
-            return rewrittenSortField;
-        }
-
-        SortField rewrittenSortField = new SortedNumericSortField(sortField.getField(), SortField.Type.LONG, reverse);
-        rewrittenSortField.setMissingValue(longSource.missingObject(missingValue, reverse));
-        // we don't optimize sorting on int field for old indices
-        rewrittenSortField.setOptimizeSortWithPoints(false);
-        return rewrittenSortField;
-
+        return sortField;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -357,7 +357,7 @@ public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
             }
             IndexNumericFieldData numericFieldData = (IndexNumericFieldData) fieldData;
             NumericType resolvedType = resolveNumericType(numericType);
-            field = numericFieldData.sortField(false, resolvedType, missing, localSortMode(), nested, reverse);
+            field = numericFieldData.sortField(resolvedType, missing, localSortMode(), nested, reverse);
             isNanosecond = resolvedType == NumericType.DATE_NANOSECONDS;
         } else {
             field = fieldData.sortField(false, context.indexVersionCreated(), missing, localSortMode(), nested, reverse);

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
@@ -36,6 +37,8 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.fieldcomparator.LongValuesComparatorSource;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -68,6 +71,7 @@ import static org.elasticsearch.search.sort.FieldSortBuilder.getPrimaryFieldSort
 import static org.elasticsearch.search.sort.NestedSortBuilderTests.createRandomNestedSort;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder> {
 
@@ -81,7 +85,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         return randomFieldSortBuilder();
     }
 
-    private List<Object> missingContent = Arrays.asList("_last", "_first", Integer.toString(randomInt()), randomInt());
+    private final List<Object> missingContent = Arrays.asList("_last", "_first", Integer.toString(randomInt()), randomInt());
 
     public FieldSortBuilder randomFieldSortBuilder() {
         String fieldName = rarely() ? FieldSortBuilder.DOC_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
@@ -860,6 +864,73 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
             SortField.Type.INT
         );
         assertIntegerSortRewrite(IndexVersion.current(), SortField.Type.INT);
+    }
+
+    /**
+     * Nested sorts on integer fields in old (pre-8.19 / 9.0.x) indices must keep the nested-aware
+     * {@link LongValuesComparatorSource} after the BWC int-to-long rewrite. A plain
+     * {@code SortedNumericSortField(LONG)} only reads the parent doc's own values; since the integer
+     * lives only in the nested children the parent appears "missing" and sorts by {@code Long.MAX_VALUE}.
+     */
+    public void testNestedIntegerSortOnOldIndexKeepsNestedComparator() throws IOException {
+        // versions subject to the int->long BWC rewrite: pre-8.19, or the 9.0.x range
+        IndexVersion oldVersion = randomBoolean()
+            ? IndexVersionUtils.randomPreviousCompatibleVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19)
+            : IndexVersionUtils.randomVersionBetween(
+                IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
+                IndexVersionUtils.getPreviousVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE)
+            );
+        SearchExecutionContext context = createMockSearchExecutionContext(oldVersion);
+        FieldSortBuilder builder = new FieldSortBuilder("custom-integer").setNestedSort(new NestedSortBuilder("path"));
+        SortField sortField = builder.build(context).field();
+        // Must NOT be a SortedNumericSortField: that construction discards the nested-aware
+        // comparator source and returns Long.MAX_VALUE (the LONG missing sentinel) for every parent.
+        assertThat(sortField, not(instanceOf(SortedNumericSortField.class)));
+
+        XFieldComparatorSource source = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertThat(source, instanceOf(LongValuesComparatorSource.class));
+        assertThat(source.reducedType(), equalTo(SortField.Type.LONG));  // INT source would fail here
+        assertNotNull(source.nested());
+    }
+
+    public void testIntegerSortOnOldIndexPreservesSortMode() throws IOException {
+        IndexVersion oldVersion = randomBoolean()
+            ? IndexVersionUtils.randomPreviousCompatibleVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19)
+            : IndexVersionUtils.randomVersionBetween(
+                IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
+                IndexVersionUtils.getPreviousVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE)
+            );
+        SearchExecutionContext context = createMockSearchExecutionContext(oldVersion);
+
+        for (SortMode sortMode : SortMode.values()) {
+            SortField sortField = new FieldSortBuilder("custom-integer").sortMode(sortMode).build(context).field();
+            assertFalse(sortField.getOptimizeSortWithPoints());
+            if (sortMode == SortMode.MIN || sortMode == SortMode.MAX) {
+                assertThat(sortField, instanceOf(SortedNumericSortField.class));
+                SortedNumericSortField numericSortField = (SortedNumericSortField) sortField;
+                assertThat(numericSortField.getNumericType(), equalTo(SortField.Type.LONG));
+                assertThat(
+                    numericSortField.getSelector(),
+                    equalTo(sortMode == SortMode.MAX ? SortedNumericSelector.Type.MAX : SortedNumericSelector.Type.MIN)
+                );
+            } else {
+                assertThat(sortField.getComparatorSource(), instanceOf(LongValuesComparatorSource.class));
+                XFieldComparatorSource source = (XFieldComparatorSource) sortField.getComparatorSource();
+                assertThat(source.reducedType(), equalTo(SortField.Type.LONG));
+                assertThat(source.sortMode(), equalTo(MultiValueMode.fromString(sortMode.toString())));
+            }
+        }
+
+        IndexNumericFieldData fieldData = (IndexNumericFieldData) context.getForField(
+            context.getFieldType("custom-integer"),
+            MappedFieldType.FielddataOperation.SEARCH
+        );
+        SortField indexSort = fieldData.indexSort(oldVersion, null, MultiValueMode.MAX, true);
+        assertFalse(indexSort.getOptimizeSortWithPoints());
+        assertThat(indexSort, instanceOf(SortedNumericSortField.class));
+        SortedNumericSortField numericIndexSort = (SortedNumericSortField) indexSort;
+        assertThat(numericIndexSort.getNumericType(), equalTo(SortField.Type.LONG));
+        assertThat(numericIndexSort.getSelector(), equalTo(SortedNumericSelector.Type.MAX));
     }
 
     private void assertIntegerSortRewrite(IndexVersion version, SortField.Type expectedType) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix nested integer sort returning LONG sentinel on pre-8.19/9.0.x indices (#155580)