### PR TITLE
Use linearCombination and dotProduct where applicable

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -992,6 +992,32 @@ public class ESVectorUtil {
     }
 
     /**
+     * Computes {@code dest[destOffset..destOffset+length) = scaleOther * other[otherOffset..otherOffset+length)
+     *          + scaleDest * dest[destOffset..destOffset+length)}.
+     *
+     * @param scaleOther a multiplicative factor for other
+     * @param other the other vector
+     * @param otherOffset starting index into other
+     * @param scaleDest a multiplicative factor for dest
+     * @param dest the destination vector
+     * @param destOffset starting index into dest
+     * @param length number of elements to process
+     */
+    public static void linearCombination(
+        float scaleOther,
+        float[] other,
+        int otherOffset,
+        float scaleDest,
+        float[] dest,
+        int destOffset,
+        int length
+    ) {
+        Objects.checkFromIndexSize(otherOffset, length, other.length);
+        Objects.checkFromIndexSize(destOffset, length, dest.length);
+        IMPL.linearCombination(scaleOther, other, otherOffset, scaleDest, dest, destOffset, length);
+    }
+
+    /**
      * Computes dest = scale * other + scaledDes * dest
      *
      * @param scaleOther a multiplicative factor for other
@@ -1003,7 +1029,23 @@ public class ESVectorUtil {
         if (other.length != dest.length) {
             throw new IllegalArgumentException("vector dimensions differ: " + other.length + "!=" + dest.length);
         }
-        IMPL.linearCombination(scaleOther, other, scaleDest, dest);
+        IMPL.linearCombination(scaleOther, other, 0, scaleDest, dest, 0, dest.length);
+    }
+
+    /**
+     * Computes {@code dest[destOffset..destOffset+length) += scaleOther * other[otherOffset..otherOffset+length)}.
+     *
+     * @param scaleOther a multiplicative factor for other
+     * @param other the other vector
+     * @param otherOffset starting index into other
+     * @param dest the destination vector
+     * @param destOffset starting index into dest
+     * @param length number of elements to process
+     */
+    public static void linearCombination(float scaleOther, float[] other, int otherOffset, float[] dest, int destOffset, int length) {
+        Objects.checkFromIndexSize(otherOffset, length, other.length);
+        Objects.checkFromIndexSize(destOffset, length, dest.length);
+        IMPL.linearCombination(scaleOther, other, otherOffset, dest, destOffset, length);
     }
 
     /**
@@ -1017,7 +1059,7 @@ public class ESVectorUtil {
         if (other.length != dest.length) {
             throw new IllegalArgumentException("vector dimensions differ: " + other.length + "!=" + dest.length);
         }
-        IMPL.linearCombination(scaleOther, other, dest);
+        IMPL.linearCombination(scaleOther, other, 0, dest, 0, dest.length);
     }
 
     /**

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -855,16 +855,24 @@ public final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
     }
 
     @Override
-    public void linearCombination(float scaleOther, float[] other, float scaleDest, float[] dest) {
-        for (int d = 0; d < dest.length; d++) {
-            dest[d] = scaleOther * other[d] + scaleDest * dest[d];
+    public void linearCombination(
+        float scaleOther,
+        float[] other,
+        int otherOffset,
+        float scaleDest,
+        float[] dest,
+        int destOffset,
+        int length
+    ) {
+        for (int d = 0; d < length; d++) {
+            dest[destOffset + d] = fma(scaleOther, other[otherOffset + d], scaleDest * dest[destOffset + d]);
         }
     }
 
     @Override
-    public void linearCombination(float scaleOther, float[] other, float[] dest) {
-        for (int d = 0; d < dest.length; d++) {
-            dest[d] += scaleOther * other[d];
+    public void linearCombination(float scaleOther, float[] other, int otherOffset, float[] dest, int destOffset, int length) {
+        for (int d = 0; d < length; d++) {
+            dest[destOffset + d] = fma(scaleOther, other[otherOffset + d], dest[destOffset + d]);
         }
     }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -184,9 +184,9 @@ public interface ESVectorUtilSupport {
 
     void inRangeBitmask(long[] values, long lowerValue, long upperValue, long[] matches);
 
-    void linearCombination(float scaleOther, float[] other, float scaleDest, float[] dest);
+    void linearCombination(float scaleOther, float[] other, int otherOffset, float scaleDest, float[] dest, int destOffset, int length);
 
-    void linearCombination(float scaleOther, float[] other, float[] dest);
+    void linearCombination(float scaleOther, float[] other, int otherOffset, float[] dest, int destOffset, int length);
 
     void linearCombination(float scaleOther, byte[] other, float scaleDest, float[] dest);
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -2649,42 +2649,46 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
     }
 
     @Override
-    public void linearCombination(float scaleOther, float[] other, float scaleDest, float[] dest) {
-        assert other.length == dest.length;
-
+    public void linearCombination(
+        float scaleOther,
+        float[] other,
+        int otherOffset,
+        float scaleDest,
+        float[] dest,
+        int destOffset,
+        int length
+    ) {
         final FloatVector scaleDestVec = FloatVector.broadcast(FLOAT_SPECIES, scaleDest);
-        final int limit = FLOAT_SPECIES.loopBound(dest.length);
+        final int limit = FLOAT_SPECIES.loopBound(length);
         int i = 0;
         for (; i < limit; i += FLOAT_SPECIES.length()) {
-            FloatVector destVec = FloatVector.fromArray(FLOAT_SPECIES, dest, i);
-            FloatVector otherVec = FloatVector.fromArray(FLOAT_SPECIES, other, i);
+            FloatVector destVec = FloatVector.fromArray(FLOAT_SPECIES, dest, destOffset + i);
+            FloatVector otherVec = FloatVector.fromArray(FLOAT_SPECIES, other, otherOffset + i);
             destVec = fma(destVec, scaleDestVec, otherVec.mul(scaleOther));
-            destVec.intoArray(dest, i);
+            destVec.intoArray(dest, destOffset + i);
         }
 
         // tail
-        for (; i < dest.length; i++) {
-            dest[i] = fma(scaleOther, other[i], scaleDest * dest[i]);
+        for (; i < length; i++) {
+            dest[destOffset + i] = fma(scaleOther, other[otherOffset + i], scaleDest * dest[destOffset + i]);
         }
     }
 
     @Override
-    public void linearCombination(float scaleOther, float[] other, float[] dest) {
-        assert other.length == dest.length;
-
+    public void linearCombination(float scaleOther, float[] other, int otherOffset, float[] dest, int destOffset, int length) {
         final FloatVector scaleOtherVec = FloatVector.broadcast(FLOAT_SPECIES, scaleOther);
-        final int limit = FLOAT_SPECIES.loopBound(dest.length);
+        final int limit = FLOAT_SPECIES.loopBound(length);
         int i = 0;
         for (; i < limit; i += FLOAT_SPECIES.length()) {
-            FloatVector destVec = FloatVector.fromArray(FLOAT_SPECIES, dest, i);
-            FloatVector otherVec = FloatVector.fromArray(FLOAT_SPECIES, other, i);
+            FloatVector destVec = FloatVector.fromArray(FLOAT_SPECIES, dest, destOffset + i);
+            FloatVector otherVec = FloatVector.fromArray(FLOAT_SPECIES, other, otherOffset + i);
             destVec = fma(otherVec, scaleOtherVec, destVec);
-            destVec.intoArray(dest, i);
+            destVec.intoArray(dest, destOffset + i);
         }
 
         // tail
-        for (; i < dest.length; i++) {
-            dest[i] = fma(other[i], scaleOther, dest[i]);
+        for (; i < length; i++) {
+            dest[destOffset + i] = fma(other[otherOffset + i], scaleOther, dest[destOffset + i]);
         }
     }
 

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -1424,41 +1424,40 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
     }
 
     public void testLinearCombination() {
-        float[] x = new float[19];
-        float[] y1 = new float[19];
+        int xLength = randomIntBetween(10, 50);
+        int yLength = randomIntBetween(10, 50);
+        float[] x = VectorTestUtils.randomFloatVector(xLength);
+        float[] y1 = VectorTestUtils.randomFloatVector(yLength);
+        float[] y2 = y1.clone();
 
-        for (int i = 0; i < x.length; i++) {
-            x[i] = randomFloat();
-            y1[i] = randomFloat();
-        }
-        float[] y2 = new float[19];
-        System.arraycopy(y1, 0, y2, 0, 19);
+        int xOffset = randomIntBetween(0, xLength - 5);
+        int yOffset = randomIntBetween(0, yLength - 5);
+        int length = Math.min(xLength - xOffset, yLength - yOffset);
 
         float scaleX = randomFloat();
         float scaleY = randomFloat();
 
-        defaultedProvider.getVectorUtilSupport().linearCombination(scaleX, x, scaleY, y1);
-        panamaProvider.getVectorUtilSupport().linearCombination(scaleX, x, scaleY, y2);
+        defaultedProvider.getVectorUtilSupport().linearCombination(scaleX, x, xOffset, scaleY, y1, yOffset, length);
+        panamaProvider.getVectorUtilSupport().linearCombination(scaleX, x, xOffset, scaleY, y2, yOffset, length);
 
         assertArrayEquals(y1, y2, 1e-5f);
     }
 
     public void testLinearCombinationNoScaleDest() {
-        // Choosing 19 dimensions so that it is a rugged number that does not align with any SIMD length
-        float[] x = new float[19];
-        float[] y1 = new float[19];
+        int xLength = randomIntBetween(10, 50);
+        int yLength = randomIntBetween(10, 50);
+        float[] x = VectorTestUtils.randomFloatVector(xLength);
+        float[] y1 = VectorTestUtils.randomFloatVector(yLength);
+        float[] y2 = y1.clone();
 
-        for (int i = 0; i < x.length; i++) {
-            x[i] = randomFloat();
-            y1[i] = randomFloat();
-        }
-        float[] y2 = new float[19];
-        System.arraycopy(y1, 0, y2, 0, 19);
+        int xOffset = randomIntBetween(0, xLength - 5);
+        int yOffset = randomIntBetween(0, yLength - 5);
+        int length = Math.min(xLength - xOffset, yLength - yOffset);
 
         float scaleX = randomFloat();
 
-        defaultedProvider.getVectorUtilSupport().linearCombination(scaleX, x, y1);
-        panamaProvider.getVectorUtilSupport().linearCombination(scaleX, x, y2);
+        defaultedProvider.getVectorUtilSupport().linearCombination(scaleX, x, xOffset, y1, yOffset, length);
+        panamaProvider.getVectorUtilSupport().linearCombination(scaleX, x, xOffset, y2, yOffset, length);
 
         assertArrayEquals(y1, y2, 1e-5f);
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizer.java
@@ -225,11 +225,8 @@ public final class AsymmetricHashingQuantizer {
         float dotVecCent = ESVectorUtil.dotProduct(vector, centroid);
         float offset = dotVecCent - precomputed.centroidNormSq();
         float[] centroidProjected = precomputed.centroidProjected();
-        double correction = 0;
-        for (int j = 0; j < nDims; j++) {
-            correction = Math.fma(centroidProjected[j], xEnc[j], correction);
-        }
-        offset -= (float) (scale * correction);
+        float correction = ESVectorUtil.dotProduct(centroidProjected, xEnc);
+        offset -= scale * correction;
 
         return new EncodedVector(xEnc, scale, offset);
     }
@@ -340,25 +337,21 @@ public final class AsymmetricHashingQuantizer {
     }
 
     /** C = A @ B where A is flat (m x k), B is flat (k x n).
-     *  Uses row-broadcast accumulation for JIT auto-vectorization of the inner loop. */
+     *  Uses row-broadcast accumulation; each inner loop is a contiguous SIMD axpy. */
     private static float[] matMul(float[] a, float[] b, int m, int k, int n) {
         float[] c = new float[m * n];
         for (int i = 0; i < m; i++) {
             int aBase = i * k;
             int cBase = i * n;
             for (int l = 0; l < k; l++) {
-                float aVal = a[aBase + l];
-                int bBase = l * n;
-                for (int j = 0; j < n; j++) {
-                    c[cBase + j] = Math.fma(aVal, b[bBase + j], c[cBase + j]);
-                }
+                ESVectorUtil.linearCombination(a[aBase + l], b, l * n, c, cBase, n);
             }
         }
         return c;
     }
 
     /** C = A.T @ B where A is flat (m x k), B is flat (m x n), result is flat (k x n).
-     *  Uses row-broadcast accumulation for cache-friendly access patterns. */
+     *  Uses row-broadcast accumulation; each inner loop is a contiguous SIMD axpy. */
     private static float[] matMulTransposeA(float[] a, float[] b, int m, int k, int n) {
         float[] c = new float[k * n];
         // Accumulate by iterating over shared dimension (rows of A and B) in the outer loop.
@@ -367,11 +360,7 @@ public final class AsymmetricHashingQuantizer {
             int aBase = l * k;
             int bBase = l * n;
             for (int i = 0; i < k; i++) {
-                float aVal = a[aBase + i];
-                int cBase = i * n;
-                for (int j = 0; j < n; j++) {
-                    c[cBase + j] = Math.fma(aVal, b[bBase + j], c[cBase + j]);
-                }
+                ESVectorUtil.linearCombination(a[aBase + i], b, bBase, c, i * n, n);
             }
         }
         return c;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/SvdUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/SvdUtil.java
@@ -253,17 +253,13 @@ final class SvdUtil {
             for (int i = 0; i < k; i++) {
                 mv[i] = ESVectorUtil.dotProduct(m, i * k, v, 0, k);
             }
-            // mtmv = M^T @ mv
-            double normSq = 0;
-            for (int j = 0; j < k; j++) {
-                double sum = 0;
-                for (int i = 0; i < k; i++) {
-                    sum = Math.fma(m[i * k + j], mv[i], sum);
-                }
-                mtmv[j] = (float) sum;
-                normSq += sum * sum;
+            // mtmv = M^T @ mv: row-broadcast so M is read contiguously
+            Arrays.fill(mtmv, 0f);
+            for (int i = 0; i < k; i++) {
+                ESVectorUtil.linearCombination(mv[i], m, i * k, mtmv, 0, k);
             }
             // Normalize
+            double normSq = ESVectorUtil.dotProduct(mtmv, 0, mtmv, 0, k);
             double norm = Math.sqrt(normSq);
             if (norm < 1e-30) return 0f;
             for (int j = 0; j < k; j++) {
@@ -370,11 +366,7 @@ final class SvdUtil {
                 int aBase = i * n;
                 int wBase = i * k;
                 for (int d = 0; d < n; d++) {
-                    float aVal = a[aBase + d];
-                    int vNewBase = d * k;
-                    for (int j = 0; j < k; j++) {
-                        vNew[vNewBase + j] = Math.fma(aVal, w[wBase + j], vNew[vNewBase + j]);
-                    }
+                    ESVectorUtil.linearCombination(a[aBase + d], w, wBase, vNew, d * k, k);
                 }
             }
             qrOrthogonalize(vNew, n, k);
@@ -432,14 +424,10 @@ final class SvdUtil {
 
             // Power iteration on A A^T: u <- A (A^T u) / ||...||
             for (int iter = 0; iter < 100; iter++) {
-                // w = A^T u (n-dimensional)
+                // w = A^T u (n-dimensional): row-broadcast so A is read contiguously
                 float[] w = new float[n];
-                for (int j = 0; j < n; j++) {
-                    double sum = 0;
-                    for (int i = 0; i < m; i++) {
-                        sum = Math.fma(a[i * n + j], u[i], sum);
-                    }
-                    w[j] = (float) sum;
+                for (int i = 0; i < m; i++) {
+                    ESVectorUtil.linearCombination(u[i], a, i * n, w, 0, n);
                 }
                 // u_new = A w (m-dimensional)
                 float[] uNew = new float[m];
@@ -448,10 +436,8 @@ final class SvdUtil {
                 }
                 // Deflate
                 for (int d = 0; d < found; d++) {
-                    double dot = ESVectorUtil.dotProduct(uNew, deflated[d]);
-                    for (int i = 0; i < m; i++) {
-                        uNew[i] = (float) Math.fma(-dot, deflated[d][i], uNew[i]);
-                    }
+                    float dot = ESVectorUtil.dotProduct(uNew, deflated[d]);
+                    ESVectorUtil.linearCombination(-dot, deflated[d], uNew);
                 }
                 ESVectorUtil.l2Normalize(uNew);
                 u = uNew;
@@ -459,14 +445,10 @@ final class SvdUtil {
             deflated[found] = u;
             found++;
 
-            // Recover right singular vector: v = A^T u, then normalize
+            // Recover right singular vector: v = A^T u, then normalize; row-broadcast so A is read contiguously
             float[] sv = new float[n];
-            for (int j = 0; j < n; j++) {
-                double sum = 0;
-                for (int i = 0; i < m; i++) {
-                    sum = Math.fma(a[i * n + j], u[i], sum);
-                }
-                sv[j] = (float) sum;
+            for (int i = 0; i < m; i++) {
+                ESVectorUtil.linearCombination(u[i], a, i * n, sv, 0, n);
             }
             ESVectorUtil.l2Normalize(sv);
             System.arraycopy(sv, 0, result, vec * n, n);


### PR DESCRIPTION
Update `linearCombination` with array offset variants, and use this (and `dotProduct`) in applicable places in ASH