### PR TITLE
Handle threadpool rejection in inference tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,4 +1,4 @@
-#tests:
+tests:
 - class: org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointAggregatorTests
   method: testSlopeUp
   issue: https://github.com/elastic/elasticsearch/issues/156237

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,4 +1,4 @@
-tests:
+#tests:
 - class: org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointAggregatorTests
   method: testSlopeUp
   issue: https://github.com/elastic/elasticsearch/issues/156237
@@ -753,9 +753,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIpIT
   method: test {csv-spec:ip.pushDownIPWithIn}
   issue: https://github.com/elastic/elasticsearch/issues/156501
-- class: org.elasticsearch.xpack.esql.inference.textembedding.TextEmbeddingOperatorTests
-  method: testInferenceFailure
-  issue: https://github.com/elastic/elasticsearch/issues/156502
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFoldingIT
   method: test {csv-spec:folding.mvDouble_IN_MultiValueConstant}
   issue: https://github.com/elastic/elasticsearch/issues/156503

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceOperatorTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceOperatorTestCase.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -141,40 +142,44 @@ public abstract class InferenceOperatorTestCase<InferenceResultsType extends Inf
                 Request request,
                 ActionListener<Response> listener
             ) {
-                runWithRandomDelay(() -> {
-                    if (shouldFail.get()) {
-                        listener.onFailure(failureException);
-                        return;
-                    }
-                    if (action instanceof InferenceAction && request instanceof InferenceAction.Request inferenceRequest) {
-                        listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(inferenceRequest)));
-                        return;
-                    }
-                    if (action instanceof EmbeddingAction && request instanceof EmbeddingAction.Request embeddingRequest) {
-                        List<String> inputs = embeddingRequest.getEmbeddingRequest()
-                            .inputs()
-                            .stream()
-                            .map(group -> group.value().value())
-                            .toList();
-                        InferenceAction.Request syntheticRequest = InferenceAction.Request.builder(
-                            embeddingRequest.getInferenceEntityId(),
-                            embeddingRequest.getTaskType()
-                        ).setInput(inputs).build();
-                        listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(syntheticRequest)));
-                        return;
-                    }
-                    if (action instanceof RerankAction && request instanceof RerankAction.Request rerankRequest) {
-                        List<String> inputs = rerankRequest.getRerankRequest().inputs().stream().map(InferenceString::value).toList();
-                        InferenceAction.Request syntheticRequest = InferenceAction.Request.builder(
-                            rerankRequest.getInferenceEntityId(),
-                            rerankRequest.getTaskType()
-                        ).setInput(inputs).build();
-                        listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(syntheticRequest)));
-                        return;
-                    }
+                try {
+                    runWithRandomDelay(() -> {
+                        if (shouldFail.get()) {
+                            listener.onFailure(failureException);
+                            return;
+                        }
+                        if (action instanceof InferenceAction && request instanceof InferenceAction.Request inferenceRequest) {
+                            listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(inferenceRequest)));
+                            return;
+                        }
+                        if (action instanceof EmbeddingAction && request instanceof EmbeddingAction.Request embeddingRequest) {
+                            List<String> inputs = embeddingRequest.getEmbeddingRequest()
+                                .inputs()
+                                .stream()
+                                .map(group -> group.value().value())
+                                .toList();
+                            InferenceAction.Request syntheticRequest = InferenceAction.Request.builder(
+                                embeddingRequest.getInferenceEntityId(),
+                                embeddingRequest.getTaskType()
+                            ).setInput(inputs).build();
+                            listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(syntheticRequest)));
+                            return;
+                        }
+                        if (action instanceof RerankAction && request instanceof RerankAction.Request rerankRequest) {
+                            List<String> inputs = rerankRequest.getRerankRequest().inputs().stream().map(InferenceString::value).toList();
+                            InferenceAction.Request syntheticRequest = InferenceAction.Request.builder(
+                                rerankRequest.getInferenceEntityId(),
+                                rerankRequest.getTaskType()
+                            ).setInput(inputs).build();
+                            listener.onResponse((Response) new InferenceAction.Response(mockInferenceResult(syntheticRequest)));
+                            return;
+                        }
 
-                    listener.onFailure(new UnsupportedOperationException("Unexpected action: " + action));
-                });
+                        listener.onFailure(new UnsupportedOperationException("Unexpected action: " + action));
+                    });
+                } catch (EsRejectedExecutionException e) {
+                    listener.onFailure(e);
+                }
             }
 
             private void runWithRandomDelay(Runnable runnable) {


### PR DESCRIPTION
Fixes #156502

The NoopClient wasn't handling threadpool rejection, just letting the exception propagate, eventually hitting an assertion failure when something threw that shouldn't have. Instead handle it via the listener, as it should