### PR TITLE
[8.19] Fix truncating JSON objects mid-object (#156382)

### DIFF
--- a/docs/changelog/156382.yaml
+++ b/docs/changelog/156382.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues:
+ - 156289
+pr: 156382
+summary: Fix truncating JSON objects mid-object
+type: bug

--- a/libs/x-content/impl/src/main/java/module-info.java
+++ b/libs/x-content/impl/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module org.elasticsearch.xcontent.impl {
     requires com.fasterxml.jackson.dataformat.yaml;
     requires org.elasticsearch.base;
     requires org.elasticsearch.xcontent;
+    requires org.yaml.snakeyaml;
 
     provides org.elasticsearch.xcontent.spi.XContentProvider with org.elasticsearch.xcontent.provider.XContentProviderImpl;
 }

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.provider.filtering.FilterPathBasedFilter;
+import org.yaml.snakeyaml.error.YAMLException;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -592,19 +593,54 @@ public class JsonXContentGenerator implements XContentGenerator {
 
     @Override
     public void close() throws IOException {
+        close(false);
+    }
+
+    @Override
+    public void closeAllowIllFormed() throws IOException {
+        close(true);
+    }
+
+    private void close(boolean allowIllFormed) throws IOException {
         if (generator.isClosed()) {
             return;
         }
-        JsonStreamContext context = generator.getOutputContext();
-        if ((context != null) && (context.inRoot() == false)) {
-            throw new IOException("Unclosed object or array found");
+
+        boolean failsStructuralCheck = false;
+        IOException exception = null;
+        try {
+            if (allowIllFormed == false) {
+                JsonStreamContext context = generator.getOutputContext();
+                failsStructuralCheck = (context != null) && (context.inRoot() == false);
+            }
+            if (writeLineFeedAtEnd) {
+                flush();
+                // Bypass generator to always write the line feed
+                getLowLevelGenerator().writeRaw(LF);
+            }
+        } catch (IOException e) {
+            exception = e;
         }
-        if (writeLineFeedAtEnd) {
-            flush();
-            // Bypass generator to always write the line feed
-            getLowLevelGenerator().writeRaw(LF);
+
+        try {
+            generator.close();
+        } catch (YAMLException e) {
+            // ignore the SnakeYAML exception, our own structural check handles the same case
+            assert failsStructuralCheck : "Should fail the structural check, but didn't: " + e.getMessage();
+        } catch (IOException e) {
+            if (exception == null) {
+                exception = e;
+            } else {
+                exception.addSuppressed(e);
+            }
         }
-        generator.close();
+
+        if (failsStructuralCheck) {
+            assert false : "Unclosed object or array found";
+            throw new IOException("Unclosed object or array found", exception);
+        } else if (exception != null) {
+            throw exception;
+        }
     }
 
     @Override

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentGenerator.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.provider.json.JsonXContentGenerator;
+import org.yaml.snakeyaml.error.YAMLException;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Set;
 
@@ -36,5 +38,13 @@ public class YamlXContentGenerator extends JsonXContentGenerator {
     @Override
     protected boolean supportsRawWrites() {
         return false;
+    }
+
+    @Override
+    public void closeAllowIllFormed() throws IOException {
+        // SnakeYAML fails with an exception when trying to close a generator that is in the middle of object/array
+        try {
+            super.closeAllowIllFormed();
+        } catch (YAMLException ignored) {}
     }
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilder.java
@@ -1292,6 +1292,18 @@ public final class XContentBuilder implements Closeable, Flushable {
         }
     }
 
+    /**
+     * Closes this {@linkplain XContentBuilder builder}, but skips checks validating the correctness of the XContent structure (e.g.
+     * unclosed object or array).
+     */
+    public void closeAllowIllFormed() {
+        try {
+            generator.closeAllowIllFormed();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to close the XContentBuilder", e);
+        }
+    }
+
     public XContentGenerator generator() {
         return this.generator;
     }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentGenerator.java
@@ -176,4 +176,9 @@ public interface XContentGenerator extends Closeable, Flushable {
      */
     boolean isClosed();
 
+    /**
+     * Closes this {@linkplain XContentGenerator generator}, but skips checks validating the correctness of the XContent structure (e.g.
+     * unclosed object or array).
+     */
+    void closeAllowIllFormed() throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -824,11 +824,14 @@ public class Strings {
                     break;
                 }
             }
-            if (chunkedToXContent.isFragment()) {
+            if (truncatedStream.isTruncated() == false && chunkedToXContent.isFragment()) {
                 builder.endObject();
             }
 
-            return new TruncatedString(toString(builder), truncatedStream.isTruncated());
+            return new TruncatedString(
+                toString(builder, /* allowIllFormed = */ truncatedStream.isTruncated()),
+                truncatedStream.isTruncated()
+            );
         } catch (IOException e) {
             return new TruncatedString(exceptionToJsonString(e, pretty, human), false);
         }
@@ -888,7 +891,15 @@ public class Strings {
      * @param xContentBuilder builder containing an object to converted to a string
      */
     public static String toString(XContentBuilder xContentBuilder) {
-        xContentBuilder.close();
+        return toString(xContentBuilder, /* allowIllFormed = */ false);
+    }
+
+    private static String toString(XContentBuilder xContentBuilder, boolean allowIllFormed) {
+        if (allowIllFormed) {
+            xContentBuilder.closeAllowIllFormed();
+        } else {
+            xContentBuilder.close();
+        }
         OutputStream stream = xContentBuilder.getOutputStream();
         if (stream instanceof ByteArrayOutputStream baos) {
             return baos.toString(StandardCharsets.UTF_8);

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.common;
 
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
@@ -40,6 +41,8 @@ import static org.elasticsearch.common.Strings.substring;
 import static org.elasticsearch.common.Strings.toLowercaseAscii;
 import static org.elasticsearch.common.Strings.tokenizeByCommaToSet;
 import static org.elasticsearch.common.Strings.trimLeadingCharacter;
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.startArray;
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.startObject;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
@@ -47,6 +50,8 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 public class StringsTests extends ESTestCase {
 
@@ -369,6 +374,62 @@ public class StringsTests extends ESTestCase {
 
         assertFalse(result.truncated());
         assertThat(result.string(), containsString("error building toString out of XContent:"));
+    }
+
+    public void testTruncatesSuccessfullyEvenIfStoppedMidObject() {
+        ChunkedToXContent chunkedToXContent = __ -> Iterators.concat(
+            startObject("nested"),
+            IntStream.iterate(0, i -> i + 1)
+                .<ToXContent>mapToObj(i -> (b, p) -> b.field("field" + i, randomAlphaOfLengthBetween(0, 50)))
+                .iterator()
+        );
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024 * 1024);
+
+        assertTrue(result.truncated());
+        assertThat(result.string(), startsWith("{"));
+        assertThat(result.string(), not(endsWith("}")));
+    }
+
+    public void testTruncatesSuccessfullyEvenIfStoppedMidObject_ChunkedToXContentObject() {
+        ChunkedToXContentObject chunkedToXContent = __ -> Iterators.concat(
+            startObject(),
+            IntStream.iterate(0, i -> i + 1)
+                .<ToXContent>mapToObj(i -> (b, p) -> b.field("field" + i, randomAlphaOfLengthBetween(0, 50)))
+                .iterator()
+        );
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024 * 1024);
+
+        assertTrue(result.truncated());
+        assertThat(result.string(), startsWith("{"));
+        assertThat(result.string(), not(endsWith("}")));
+    }
+
+    public void testTruncatesSuccessfullyEvenIfStoppedMidArray() {
+        ChunkedToXContent chunkedToXContent = __ -> Iterators.concat(
+            startArray("array"),
+            IntStream.iterate(0, i -> i + 1).<ToXContent>mapToObj(i -> (b, p) -> b.value(randomAlphaOfLengthBetween(0, 50))).iterator()
+        );
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024 * 1024);
+
+        assertTrue(result.truncated());
+        assertThat(result.string(), startsWith("{"));
+        assertThat(result.string(), not(endsWith("}")));
+    }
+
+    public void testTruncatesSuccessfullyEvenIfStoppedMidArray_ChunkedToXContentObject() {
+        ChunkedToXContentObject chunkedToXContent = __ -> Iterators.concat(
+            startArray(),
+            IntStream.iterate(0, i -> i + 1).<ToXContent>mapToObj(i -> (b, p) -> b.value(randomAlphaOfLengthBetween(0, 50))).iterator()
+        );
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024 * 1024);
+
+        assertTrue(result.truncated());
+        assertThat(result.string(), startsWith("["));
+        assertThat(result.string(), not(endsWith("]")));
     }
 
     private static String lowercaseAsciiOnly(String s) {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -75,13 +75,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
 
 public abstract class BaseXContentTestCase extends ESTestCase {
 
@@ -96,9 +93,9 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testStartEndObject() throws IOException {
-        expectUnclosedException(() -> BytesReference.bytes(builder().startObject()));
-        expectUnclosedException(() -> builder().startObject().close());
-        expectUnclosedException(() -> Strings.toString(builder().startObject()));
+        expectUnclosedAssertionError(() -> BytesReference.bytes(builder().startObject()));
+        expectUnclosedAssertionError(() -> builder().startObject().close());
+        expectUnclosedAssertionError(() -> Strings.toString(builder().startObject()));
 
         expectObjectException(() -> BytesReference.bytes(builder().endObject()));
         expectObjectException(() -> builder().endObject().close());
@@ -117,9 +114,9 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testStartEndArray() throws IOException {
-        expectUnclosedException(() -> BytesReference.bytes(builder().startArray()));
-        expectUnclosedException(() -> builder().startArray().close());
-        expectUnclosedException(() -> Strings.toString(builder().startArray()));
+        expectUnclosedAssertionError(() -> BytesReference.bytes(builder().startArray()));
+        expectUnclosedAssertionError(() -> builder().startArray().close());
+        expectUnclosedAssertionError(() -> Strings.toString(builder().startArray()));
 
         expectArrayException(() -> BytesReference.bytes(builder().endArray()));
         expectArrayException(() -> builder().endArray().close());
@@ -136,7 +133,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     public void testField() throws IOException {
         expectValueException(() -> BytesReference.bytes(builder().field("foo")));
         expectNonNullFieldException(() -> BytesReference.bytes(builder().field(null)));
-        expectUnclosedException(() -> BytesReference.bytes(builder().startObject().field("foo")));
+        expectUnclosedAssertionError(() -> BytesReference.bytes(builder().startObject().field("foo")));
 
         assertResult("{'foo':'bar'}", () -> builder().startObject().field("foo").value("bar").endObject());
     }
@@ -144,7 +141,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     public void testNullField() throws IOException {
         expectValueException(() -> BytesReference.bytes(builder().nullField("foo")));
         expectNonNullFieldException(() -> BytesReference.bytes(builder().nullField(null)));
-        expectUnclosedException(() -> BytesReference.bytes(builder().startObject().nullField("foo")));
+        expectUnclosedAssertionError(() -> BytesReference.bytes(builder().startObject().nullField("foo")));
 
         assertResult("{'foo':null}", () -> builder().startObject().nullField("foo").endObject());
     }
@@ -822,8 +819,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         assertEquals(xcontentType(), XContentFactory.xContentType(data));
     }
 
-    public void testMissingEndObject() throws IOException {
-        IOException e = expectThrows(IOException.class, () -> {
+    public void testMissingEndObject() {
+        AssertionError e = expectThrows(AssertionError.class, () -> {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             try (XContentGenerator generator = xcontentType().xContent().createGenerator(os)) {
                 generator.writeStartObject();
@@ -834,8 +831,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         assertEquals(e.getMessage(), "Unclosed object or array found");
     }
 
-    public void testMissingEndArray() throws IOException {
-        IOException e = expectThrows(IOException.class, () -> {
+    public void testMissingEndArray() {
+        AssertionError e = expectThrows(AssertionError.class, () -> {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             try (XContentGenerator generator = xcontentType().xContent().createGenerator(os)) {
                 generator.writeStartArray();
@@ -1175,11 +1172,9 @@ public abstract class BaseXContentTestCase extends ESTestCase {
 
     }
 
-    private static void expectUnclosedException(ThrowingRunnable runnable) {
-        IllegalStateException e = expectThrows(IllegalStateException.class, runnable);
-        assertThat(e.getMessage(), containsString("Failed to close the XContentBuilder"));
-        assertThat(e.getCause(), allOf(notNullValue(), instanceOf(IOException.class)));
-        assertThat(e.getCause().getMessage(), containsString("Unclosed object or array found"));
+    private static void expectUnclosedAssertionError(ThrowingRunnable runnable) {
+        AssertionError e = expectThrows(AssertionError.class, runnable);
+        assertThat(e.getMessage(), containsString("Unclosed object or array found"));
     }
 
     private static void expectValueException(ThrowingRunnable runnable) {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -378,19 +378,18 @@ public class XContentBuilderTests extends ESTestCase {
         }
     }
 
-    public void testMissingEndObject() throws IOException {
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+    public void testMissingEndObject() {
+        var e = expectThrows(AssertionError.class, () -> {
             try (XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()))) {
                 builder.startObject();
                 builder.field("foo", true);
             }
         });
-        assertThat(e.getMessage(), equalTo("Failed to close the XContentBuilder"));
-        assertThat(e.getCause().getMessage(), equalTo("Unclosed object or array found"));
+        assertThat(e.getMessage(), equalTo("Unclosed object or array found"));
     }
 
-    public void testMissingEndArray() throws IOException {
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+    public void testMissingEndArray() {
+        var e = expectThrows(AssertionError.class, () -> {
             try (XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()))) {
                 builder.startObject();
                 builder.startArray("foo");
@@ -398,8 +397,7 @@ public class XContentBuilderTests extends ESTestCase {
                 builder.value(1);
             }
         });
-        assertThat(e.getMessage(), equalTo("Failed to close the XContentBuilder"));
-        assertThat(e.getCause().getMessage(), equalTo("Unclosed object or array found"));
+        assertThat(e.getMessage(), equalTo("Unclosed object or array found"));
     }
 
     private static class TestWritableValue {
@@ -544,5 +542,37 @@ public class XContentBuilderTests extends ESTestCase {
 
     public void testEnumIsXContentable() {
         XContentBuilder.ensureToXContentable(XContentableEnum.A);
+    }
+
+    public void testCloseAlwaysClosesUnderlyingJacksonGenerator() throws IOException {
+        var type = randomFrom(XContentType.values()).canonical();
+        XContentBuilder builder = XContentFactory.contentBuilder(type);
+
+        var e = expectThrows(AssertionError.class, () -> {
+            builder.startObject();
+            builder.field("foo", true);
+            builder.close();
+        });
+        assertThat(e.getMessage(), equalTo("Unclosed object or array found"));
+
+        if (type != XContentType.YAML) {
+            assertTrue(builder.generator().isClosed());
+        }
+    }
+
+    public void testCloseAllowIllFormedDoesNotValidateStructuralCorrectness() throws IOException {
+        var type = randomFrom(XContentType.values()).canonical();
+
+        XContentBuilder builder = XContentFactory.contentBuilder(type);
+        builder.startObject();
+        builder.field("foo", true);
+        builder.closeAllowIllFormed();
+
+        // SnakeYAML fails with an exception when trying to close a generator that is in the middle of object/array
+        // which is why the generator will not be marked as closed in that case: the important thing is that the XContentGenerator does not
+        // throw
+        if (type != XContentType.YAML) {
+            assertTrue(builder.generator().isClosed());
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix truncating JSON objects mid-object (#156382)