### PR TITLE
ESQL: Corrects bug handling warnings when mixing old ES versions

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -140,7 +140,11 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                         clusterRequest,
                         groupTask,
                         TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(clusterListener, ComputeResponse::new, searchExecutor)
+                        new ActionListenerResponseHandler<>(
+                            clusterListener,
+                            in -> new ComputeResponse(in, transportService.getThreadPool().getThreadContext()),
+                            searchExecutor
+                        )
                     );
                     var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, cluster.connection);
                     exchangeSource.addRemoteSink(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
@@ -11,12 +11,15 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -63,11 +66,16 @@ final class ComputeResponse extends TransportResponse {
     }
 
     ComputeResponse(StreamInput in) throws IOException {
+        this(in, null);
+    }
+
+    ComputeResponse(StreamInput in, ThreadContext threadContext) throws IOException {
+        DriverCompletionInfo info;
         if (supportsCompletionInfo(in.getTransportVersion())) {
-            completionInfo = DriverCompletionInfo.readFrom(in);
+            info = DriverCompletionInfo.readFrom(in);
         } else {
             if (in.readBoolean()) {
-                completionInfo = new DriverCompletionInfo(
+                info = new DriverCompletionInfo(
                     0,
                     0,
                     0,
@@ -81,9 +89,13 @@ final class ComputeResponse extends TransportResponse {
                     Set.of()
                 );
             } else {
-                completionInfo = DriverCompletionInfo.EMPTY;
+                info = DriverCompletionInfo.EMPTY;
             }
         }
+        if (in.getTransportVersion().supports(DriverCompletionInfo.ESQL_DRIVER_WARNINGS) == false && threadContext != null) {
+            info = recoverWarningsFromThreadContext(info, threadContext);
+        }
+        this.completionInfo = info;
         this.took = in.readOptionalTimeValue();
         this.totalShards = in.readVInt();
         this.successfulShards = in.readVInt();
@@ -144,5 +156,35 @@ final class ComputeResponse extends TransportResponse {
 
     public List<ShardSearchFailure> getFailures() {
         return failures;
+    }
+
+    /**
+     * Recovers warnings from ThreadContext response headers when deserializing from an old node
+     * that doesn't support the {@code esql_driver_warnings} wire field. Old nodes send warnings
+     * as transport response headers; the transport layer deposits them into the current thread's
+     * context before the response constructor is called.
+     */
+    static DriverCompletionInfo recoverWarningsFromThreadContext(DriverCompletionInfo info, ThreadContext threadContext) {
+        Set<String> recoveredWarnings = threadContext.getResponseHeaders()
+            .getOrDefault("Warning", List.of())
+            .stream()
+            .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false))
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        if (recoveredWarnings.isEmpty()) {
+            return info;
+        }
+        return new DriverCompletionInfo(
+            info.documentsFound(),
+            info.valuesLoaded(),
+            info.rowsEmitted(),
+            info.bytesRead(),
+            info.readNanos(),
+            info.cpuNanos(),
+            info.driverProfiles(),
+            info.planProfiles(),
+            info.capturedSourceMetadata(),
+            info.partial(),
+            recoveredWarnings
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
@@ -65,10 +65,6 @@ final class ComputeResponse extends TransportResponse {
         this.failures = failures;
     }
 
-    ComputeResponse(StreamInput in) throws IOException {
-        this(in, null);
-    }
-
     ComputeResponse(StreamInput in, ThreadContext threadContext) throws IOException {
         DriverCompletionInfo info;
         if (supportsCompletionInfo(in.getTransportVersion())) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeResponse.java
@@ -164,7 +164,7 @@ final class ComputeResponse extends TransportResponse {
         Set<String> recoveredWarnings = threadContext.getResponseHeaders()
             .getOrDefault("Warning", List.of())
             .stream()
-            .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false))
+            .map(ComputeResponse::extractPlainWarningText)
             .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
         if (recoveredWarnings.isEmpty()) {
             return info;
@@ -182,5 +182,28 @@ final class ComputeResponse extends TransportResponse {
             info.partial(),
             recoveredWarnings
         );
+    }
+
+    /**
+     * Extracts the plain warning text from an RFC 7234 warning header value.
+     * {@link HeaderWarning#extractWarningValueFromWarningHeader} returns the escaped form
+     * (matching {@code escapeAndEncode(original)}), so we must reverse the backslash escaping
+     * to recover the original text that {@link HeaderWarning#addWarning} expects.
+     */
+    static String extractPlainWarningText(String warningHeader) {
+        String escaped = HeaderWarning.extractWarningValueFromWarningHeader(warningHeader, false);
+        if (escaped.indexOf('\\') < 0) {
+            return escaped;
+        }
+        StringBuilder sb = new StringBuilder(escaped.length());
+        for (int i = 0; i < escaped.length(); i++) {
+            char c = escaped.charAt(i);
+            if (c == '\\' && i + 1 < escaped.length()) {
+                sb.append(escaped.charAt(++i));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -229,7 +229,10 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 new ActionListenerResponseHandler<>(computeListener.acquireCompute().map(r -> {
                                     nodeResponseRef.set(r);
                                     return r.completionInfo();
-                                }), DataNodeComputeResponse::new, searchExecutor)
+                                }),
+                                    in -> new DataNodeComputeResponse(in, transportService.getThreadPool().getThreadContext()),
+                                    searchExecutor
+                                )
                             );
                             final var remoteSink = exchangeService.newRemoteSink(groupTask, childSessionId, transportService, connection);
                             exchangeSource.addRemoteSink(
@@ -397,7 +400,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                             TransportRequestOptions.EMPTY,
                             new ActionListenerResponseHandler<>(
                                 computeListener.acquireCompute().map(DataNodeComputeResponse::completionInfo),
-                                DataNodeComputeResponse::new,
+                                in -> new DataNodeComputeResponse(in, transportService.getThreadPool().getThreadContext()),
                                 searchExecutor
                             )
                         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponse.java
@@ -38,10 +38,6 @@ final class DataNodeComputeResponse extends TransportResponse {
         this.shardLevelFailures = shardLevelFailures;
     }
 
-    DataNodeComputeResponse(StreamInput in) throws IOException {
-        this(in, null);
-    }
-
     DataNodeComputeResponse(StreamInput in, ThreadContext threadContext) throws IOException {
         DriverCompletionInfo info;
         if (supportsCompletionInfo(in.getTransportVersion())) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponse.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.plugin;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.operator.DriverCompletionInfo;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.index.shard.ShardId;
@@ -38,13 +39,16 @@ final class DataNodeComputeResponse extends TransportResponse {
     }
 
     DataNodeComputeResponse(StreamInput in) throws IOException {
+        this(in, null);
+    }
+
+    DataNodeComputeResponse(StreamInput in, ThreadContext threadContext) throws IOException {
+        DriverCompletionInfo info;
         if (supportsCompletionInfo(in.getTransportVersion())) {
-            this.completionInfo = DriverCompletionInfo.readFrom(in);
+            info = DriverCompletionInfo.readFrom(in);
             this.shardLevelFailures = in.readMap(ShardId::new, StreamInput::readException);
-            return;
-        }
-        if (DataNodeComputeHandler.supportShardLevelRetryFailure(in.getTransportVersion())) {
-            this.completionInfo = new DriverCompletionInfo(
+        } else if (DataNodeComputeHandler.supportShardLevelRetryFailure(in.getTransportVersion())) {
+            info = new DriverCompletionInfo(
                 0,
                 0,
                 0,
@@ -58,10 +62,14 @@ final class DataNodeComputeResponse extends TransportResponse {
                 Set.of()
             );
             this.shardLevelFailures = in.readMap(ShardId::new, StreamInput::readException);
-            return;
+        } else {
+            info = new ComputeResponse(in, threadContext).getCompletionInfo();
+            this.shardLevelFailures = Map.of();
         }
-        this.completionInfo = new ComputeResponse(in).getCompletionInfo();
-        this.shardLevelFailures = Map.of();
+        if (in.getTransportVersion().supports(DriverCompletionInfo.ESQL_DRIVER_WARNINGS) == false && threadContext != null) {
+            info = ComputeResponse.recoverWarningsFromThreadContext(info, threadContext);
+        }
+        this.completionInfo = info;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -87,10 +87,13 @@ import java.io.IOException;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
@@ -578,9 +581,22 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         /*
          * Shift all of ESQL's carefully maintained Warnings onto the spooky ThreadLocal
          * for render.
+         *
+         * In mixed-cluster BWC scenarios, old data nodes send warnings as transport response headers
+         * which the transport layer deposits into ThreadContext. Those same warnings are also recovered
+         * into DriverCompletionInfo by the response constructors. To avoid duplicates, skip any warning
+         * whose plain text already appears in the current ThreadContext response headers.
          */
+        Set<String> existingWarnings = threadPool.getThreadContext()
+            .getResponseHeaders()
+            .getOrDefault("Warning", List.of())
+            .stream()
+            .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false))
+            .collect(Collectors.toCollection(HashSet::new));
         for (String warning : result.completionInfo().warnings()) {
-            HeaderWarning.addWarning(warning);
+            if (existingWarnings.contains(warning) == false) {
+                HeaderWarning.addWarning(warning);
+            }
         }
         List<ColumnInfoImpl> columns = result.schema().stream().map(c -> {
             List<String> originalTypes;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -591,7 +591,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             .getResponseHeaders()
             .getOrDefault("Warning", List.of())
             .stream()
-            .map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false))
+            .map(ComputeResponse::extractPlainWarningText)
             .collect(Collectors.toCollection(HashSet::new));
         for (String warning : result.completionInfo().warnings()) {
             if (existingWarnings.contains(warning) == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.HeaderWarning;
@@ -29,12 +28,14 @@ import static org.hamcrest.Matchers.empty;
 public class ComputeResponseTests extends ESTestCase {
 
     /**
-     * Reproduces the BWC warning loss in {@link ComputeResponse} after PR #155976.
+     * Verifies that warnings are recovered from {@link ThreadContext} response headers when
+     * deserializing a {@link ComputeResponse} from an old remote cluster node that does not
+     * support the {@code esql_driver_warnings} wire field.
      * <p>
-     * When a new coordinator deserializes a {@code ComputeResponse} from an old remote cluster
-     * node that does not support the {@code esql_driver_warnings} wire field, warnings that the
-     * old node sent as transport response headers are silently discarded. This is the CCS
-     * counterpart of the same gap in {@code DataNodeComputeResponse}.
+     * Old nodes send warnings as transport response headers; the transport layer deposits them
+     * into the current thread's context before the response constructor is called. The
+     * {@link ThreadContext}-aware constructor recovers them, matching the pattern used by
+     * {@code BatchExchangeStatusResponse}.
      */
     public void testWarningsRecoveredFromThreadContextWhenOldVersion() throws IOException {
         var warningTexts = List.of(
@@ -73,17 +74,17 @@ public class ComputeResponseTests extends ESTestCase {
 
         StreamInput in = out.bytes().streamInput();
         in.setTransportVersion(oldVersion);
-        var deserialized = new ComputeResponse(in);
+        var deserialized = new ComputeResponse(in, threadContext);
 
-        // The deserialized response should have recovered the warnings from the ThreadContext.
         assertThat(deserialized.getCompletionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
     }
 
     /**
-     * Confirms that the current code drops warnings from an old node: the round-trip produces an
-     * empty warnings set even though the warnings are present in the ThreadContext.
+     * Verifies that warnings are empty when deserializing from an old node without a
+     * {@link ThreadContext} (i.e. using the single-arg constructor). This is the expected
+     * behavior: without ThreadContext, there is no way to recover the response headers.
      */
-    public void testWarningsLostFromOldVersion() throws IOException {
+    public void testWarningsEmptyWithoutThreadContext() throws IOException {
         var warningTexts = List.of(
             "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
             "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
@@ -113,7 +114,6 @@ public class ComputeResponseTests extends ESTestCase {
         in.setTransportVersion(oldVersion);
         var deserialized = new ComputeResponse(in);
 
-        // Confirms the current broken behavior: warnings are empty.
         assertThat(deserialized.getCompletionInfo().warnings(), empty());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 
 public class ComputeResponseTests extends ESTestCase {
 
@@ -77,43 +76,5 @@ public class ComputeResponseTests extends ESTestCase {
         var deserialized = new ComputeResponse(in, threadContext);
 
         assertThat(deserialized.getCompletionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
-    }
-
-    /**
-     * Verifies that warnings are empty when deserializing from an old node without a
-     * {@link ThreadContext} (i.e. using the single-arg constructor). This is the expected
-     * behavior: without ThreadContext, there is no way to recover the response headers.
-     */
-    public void testWarningsEmptyWithoutThreadContext() throws IOException {
-        var warningTexts = List.of(
-            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
-            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
-        );
-        var completionInfoWithWarnings = new DriverCompletionInfo(
-            10,
-            10,
-            5,
-            0,
-            0,
-            0,
-            List.of(),
-            List.of(),
-            Map.of(),
-            false,
-            new LinkedHashSet<>(warningTexts)
-        );
-        var response = new ComputeResponse(completionInfoWithWarnings, TimeValue.timeValueMillis(100), 5, 5, 0, 0, List.of());
-
-        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
-
-        BytesStreamOutput out = new BytesStreamOutput();
-        out.setTransportVersion(oldVersion);
-        response.writeTo(out);
-
-        StreamInput in = out.bytes().streamInput();
-        in.setTransportVersion(oldVersion);
-        var deserialized = new ComputeResponse(in);
-
-        assertThat(deserialized.getCompletionInfo().warnings(), empty());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeResponseTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.operator.DriverCompletionInfo;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+public class ComputeResponseTests extends ESTestCase {
+
+    /**
+     * Reproduces the BWC warning loss in {@link ComputeResponse} after PR #155976.
+     * <p>
+     * When a new coordinator deserializes a {@code ComputeResponse} from an old remote cluster
+     * node that does not support the {@code esql_driver_warnings} wire field, warnings that the
+     * old node sent as transport response headers are silently discarded. This is the CCS
+     * counterpart of the same gap in {@code DataNodeComputeResponse}.
+     */
+    public void testWarningsRecoveredFromThreadContextWhenOldVersion() throws IOException {
+        var warningTexts = List.of(
+            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
+        );
+        var completionInfoWithWarnings = new DriverCompletionInfo(
+            10,
+            10,
+            5,
+            0,
+            0,
+            0,
+            List.of(),
+            List.of(),
+            Map.of(),
+            false,
+            new LinkedHashSet<>(warningTexts)
+        );
+        var response = new ComputeResponse(completionInfoWithWarnings, TimeValue.timeValueMillis(100), 5, 5, 0, 0, List.of());
+
+        // Use a transport version just before esql_driver_warnings.
+        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
+
+        // Serialize with the old version: warnings are NOT written to the wire.
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(oldVersion);
+        response.writeTo(out);
+
+        // Set up ThreadContext with Warning response headers — simulating what the transport
+        // framework does when receiving a response from an old remote cluster node.
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        for (String warning : warningTexts) {
+            threadContext.addResponseHeader("Warning", HeaderWarning.formatWarning(warning));
+        }
+
+        StreamInput in = out.bytes().streamInput();
+        in.setTransportVersion(oldVersion);
+        var deserialized = new ComputeResponse(in);
+
+        // The deserialized response should have recovered the warnings from the ThreadContext.
+        assertThat(deserialized.getCompletionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
+    }
+
+    /**
+     * Confirms that the current code drops warnings from an old node: the round-trip produces an
+     * empty warnings set even though the warnings are present in the ThreadContext.
+     */
+    public void testWarningsLostFromOldVersion() throws IOException {
+        var warningTexts = List.of(
+            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
+        );
+        var completionInfoWithWarnings = new DriverCompletionInfo(
+            10,
+            10,
+            5,
+            0,
+            0,
+            0,
+            List.of(),
+            List.of(),
+            Map.of(),
+            false,
+            new LinkedHashSet<>(warningTexts)
+        );
+        var response = new ComputeResponse(completionInfoWithWarnings, TimeValue.timeValueMillis(100), 5, 5, 0, 0, List.of());
+
+        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(oldVersion);
+        response.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setTransportVersion(oldVersion);
+        var deserialized = new ComputeResponse(in);
+
+        // Confirms the current broken behavior: warnings are empty.
+        assertThat(deserialized.getCompletionInfo().warnings(), empty());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.HeaderWarning;
@@ -28,18 +27,14 @@ import static org.hamcrest.Matchers.empty;
 public class DataNodeComputeResponseTests extends ESTestCase {
 
     /**
-     * Reproduces the BWC warning loss in {@link DataNodeComputeResponse} after PR #155976.
+     * Verifies that warnings are recovered from {@link ThreadContext} response headers when
+     * deserializing a {@link DataNodeComputeResponse} from an old data node that does not
+     * support the {@code esql_driver_warnings} wire field.
      * <p>
-     * When a new coordinator deserializes a {@code DataNodeComputeResponse} from an old data node
-     * that does not support the {@code esql_driver_warnings} wire field, warnings that the old
-     * node sent as transport response headers (the pre-PR mechanism) are silently discarded.
-     * {@link DriverCompletionInfo#readFrom} sets {@code warnings = Set.of()} for old versions,
-     * and there is no fallback to read them from the {@link ThreadContext} — unlike
-     * {@code BatchExchangeStatusResponse} which correctly recovers them.
-     * <p>
-     * This causes intermittent failures in mixed-cluster BWC tests (e.g.
-     * {@code MixedClusterEsqlSpec*IT}) whenever a query that generates warnings is routed to an
-     * old data node.
+     * Old nodes send warnings as transport response headers; the transport layer deposits them
+     * into the current thread's context before the response constructor is called. The
+     * {@link ThreadContext}-aware constructor recovers them, matching the pattern used by
+     * {@code BatchExchangeStatusResponse}.
      */
     public void testWarningsRecoveredFromThreadContextWhenOldVersion() throws IOException {
         var warningTexts = List.of(
@@ -61,18 +56,12 @@ public class DataNodeComputeResponseTests extends ESTestCase {
         );
         var response = new DataNodeComputeResponse(completionInfoWithWarnings, Map.of());
 
-        // Use a transport version just before esql_driver_warnings — supports the full
-        // DriverCompletionInfo wire format but not the warnings field.
         var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
 
-        // Serialize with the old version: warnings are NOT written to the wire.
         BytesStreamOutput out = new BytesStreamOutput();
         out.setTransportVersion(oldVersion);
         response.writeTo(out);
 
-        // Before deserializing, set up ThreadContext with Warning response headers — this is
-        // exactly what the transport framework does when receiving a response from an old node
-        // that emitted warnings via HeaderWarning.addWarning (the pre-PR mechanism).
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         for (String warning : warningTexts) {
             threadContext.addResponseHeader("Warning", HeaderWarning.formatWarning(warning));
@@ -80,19 +69,17 @@ public class DataNodeComputeResponseTests extends ESTestCase {
 
         StreamInput in = out.bytes().streamInput();
         in.setTransportVersion(oldVersion);
-        var deserialized = new DataNodeComputeResponse(in);
+        var deserialized = new DataNodeComputeResponse(in, threadContext);
 
-        // The deserialized response should have recovered the warnings from the ThreadContext,
-        // just as BatchExchangeStatusResponse does.
         assertThat(deserialized.completionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
     }
 
     /**
-     * Confirms that the current code drops warnings from an old node: the round-trip produces an
-     * empty warnings set even though the warnings are present in the ThreadContext.
-     * This is the symptom that the fix must eliminate.
+     * Verifies that warnings are empty when deserializing from an old node without a
+     * {@link ThreadContext} (i.e. using the single-arg constructor). This is the expected
+     * behavior: without ThreadContext, there is no way to recover the response headers.
      */
-    public void testWarningsLostFromOldVersion() throws IOException {
+    public void testWarningsEmptyWithoutThreadContext() throws IOException {
         var warningTexts = List.of(
             "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
             "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
@@ -122,7 +109,6 @@ public class DataNodeComputeResponseTests extends ESTestCase {
         in.setTransportVersion(oldVersion);
         var deserialized = new DataNodeComputeResponse(in);
 
-        // Confirms the current broken behavior: warnings are empty.
         assertThat(deserialized.completionInfo().warnings(), empty());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.operator.DriverCompletionInfo;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+public class DataNodeComputeResponseTests extends ESTestCase {
+
+    /**
+     * Reproduces the BWC warning loss in {@link DataNodeComputeResponse} after PR #155976.
+     * <p>
+     * When a new coordinator deserializes a {@code DataNodeComputeResponse} from an old data node
+     * that does not support the {@code esql_driver_warnings} wire field, warnings that the old
+     * node sent as transport response headers (the pre-PR mechanism) are silently discarded.
+     * {@link DriverCompletionInfo#readFrom} sets {@code warnings = Set.of()} for old versions,
+     * and there is no fallback to read them from the {@link ThreadContext} — unlike
+     * {@code BatchExchangeStatusResponse} which correctly recovers them.
+     * <p>
+     * This causes intermittent failures in mixed-cluster BWC tests (e.g.
+     * {@code MixedClusterEsqlSpec*IT}) whenever a query that generates warnings is routed to an
+     * old data node.
+     */
+    public void testWarningsRecoveredFromThreadContextWhenOldVersion() throws IOException {
+        var warningTexts = List.of(
+            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
+        );
+        var completionInfoWithWarnings = new DriverCompletionInfo(
+            10,
+            10,
+            5,
+            0,
+            0,
+            0,
+            List.of(),
+            List.of(),
+            Map.of(),
+            false,
+            new LinkedHashSet<>(warningTexts)
+        );
+        var response = new DataNodeComputeResponse(completionInfoWithWarnings, Map.of());
+
+        // Use a transport version just before esql_driver_warnings — supports the full
+        // DriverCompletionInfo wire format but not the warnings field.
+        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
+
+        // Serialize with the old version: warnings are NOT written to the wire.
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(oldVersion);
+        response.writeTo(out);
+
+        // Before deserializing, set up ThreadContext with Warning response headers — this is
+        // exactly what the transport framework does when receiving a response from an old node
+        // that emitted warnings via HeaderWarning.addWarning (the pre-PR mechanism).
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        for (String warning : warningTexts) {
+            threadContext.addResponseHeader("Warning", HeaderWarning.formatWarning(warning));
+        }
+
+        StreamInput in = out.bytes().streamInput();
+        in.setTransportVersion(oldVersion);
+        var deserialized = new DataNodeComputeResponse(in);
+
+        // The deserialized response should have recovered the warnings from the ThreadContext,
+        // just as BatchExchangeStatusResponse does.
+        assertThat(deserialized.completionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
+    }
+
+    /**
+     * Confirms that the current code drops warnings from an old node: the round-trip produces an
+     * empty warnings set even though the warnings are present in the ThreadContext.
+     * This is the symptom that the fix must eliminate.
+     */
+    public void testWarningsLostFromOldVersion() throws IOException {
+        var warningTexts = List.of(
+            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
+            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
+        );
+        var completionInfoWithWarnings = new DriverCompletionInfo(
+            10,
+            10,
+            5,
+            0,
+            0,
+            0,
+            List.of(),
+            List.of(),
+            Map.of(),
+            false,
+            new LinkedHashSet<>(warningTexts)
+        );
+        var response = new DataNodeComputeResponse(completionInfoWithWarnings, Map.of());
+
+        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(oldVersion);
+        response.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setTransportVersion(oldVersion);
+        var deserialized = new DataNodeComputeResponse(in);
+
+        // Confirms the current broken behavior: warnings are empty.
+        assertThat(deserialized.completionInfo().warnings(), empty());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeResponseTests.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 
 public class DataNodeComputeResponseTests extends ESTestCase {
 
@@ -72,43 +71,5 @@ public class DataNodeComputeResponseTests extends ESTestCase {
         var deserialized = new DataNodeComputeResponse(in, threadContext);
 
         assertThat(deserialized.completionInfo().warnings(), containsInAnyOrder(warningTexts.toArray()));
-    }
-
-    /**
-     * Verifies that warnings are empty when deserializing from an old node without a
-     * {@link ThreadContext} (i.e. using the single-arg constructor). This is the expected
-     * behavior: without ThreadContext, there is no way to recover the response headers.
-     */
-    public void testWarningsEmptyWithoutThreadContext() throws IOException {
-        var warningTexts = List.of(
-            "Line 1:9: evaluation of [x] failed, treating result as null. Only first 20 failures recorded.",
-            "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"
-        );
-        var completionInfoWithWarnings = new DriverCompletionInfo(
-            10,
-            10,
-            5,
-            0,
-            0,
-            0,
-            List.of(),
-            List.of(),
-            Map.of(),
-            false,
-            new LinkedHashSet<>(warningTexts)
-        );
-        var response = new DataNodeComputeResponse(completionInfoWithWarnings, Map.of());
-
-        var oldVersion = TransportVersionUtils.getPreviousVersion(DriverCompletionInfo.ESQL_DRIVER_WARNINGS);
-
-        BytesStreamOutput out = new BytesStreamOutput();
-        out.setTransportVersion(oldVersion);
-        response.writeTo(out);
-
-        StreamInput in = out.bytes().streamInput();
-        in.setTransportVersion(oldVersion);
-        var deserialized = new DataNodeComputeResponse(in);
-
-        assertThat(deserialized.completionInfo().warnings(), empty());
     }
 }


### PR DESCRIPTION
Following #155976, we got another batch of warnings failures, specifically for mixed version clusters.

I think the problem is we were handling the case where the coordinator is old, data nodes are new correctly in [DataNodeComputeHandler#messageReceived](https://github.com/elastic/elasticsearch/blob/c29ae7c9646133321db19759c75f75d01257ba0f/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java#L793). But not the case where the coordinator is new, data nodes are old.

This pr changes `DataNodeComputeResponse` and `ComputeResponse` to inspect the thread context and copy the warnings into driver info.