### PR TITLE
 ESQL: Optimize unmaped_fields blob away during analysis if there are unpatterned KEEPs

### DIFF
--- a/docs/changelog/156585.yaml
+++ b/docs/changelog/156585.yaml
@@ -1,0 +1,7 @@
+area: ES|QL
+issues:
+ - 156173
+pr: 156585
+summary: "ESQL: Optimize `unmaped_fields` blob away during analysis if there are unpatterned\
+  \ KEEPs"
+type: feature

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load-all.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-load-all.csv-spec
@@ -96,6 +96,25 @@ FROM partial_mapping_sample_data
 2024-10-23T13:55:01.543Z | Disconnected from 10.1.0.1
 ;
 
+keepMixtureOfPatternedAndNonPatternedUnmappedFields
+required_capability: optional_fields_load_all
+
+SET unmapped_fields="LOAD_ALL"\;
+FROM partial_mapping_sample_data
+| KEEP @timestamp, unmapped_message, unmapped_event*
+| SORT @timestamp
+;
+
+@timestamp:datetime      | unmapped_message:keyword   | unmapped_event_duration:keyword
+2024-10-23T12:15:03.360Z | Disconnected from 10.1.0.3 | 3450234
+2024-10-23T12:27:28.948Z | Disconnected from 10.1.0.2 | 2764890
+2024-10-23T13:33:34.937Z | 43                         | 1232383
+2024-10-23T13:51:54.732Z | Disconnection error        | 725449
+2024-10-23T13:52:55.015Z | Disconnection error        | 8268154
+2024-10-23T13:53:55.832Z | Disconnection error        | 5033756
+2024-10-23T13:55:01.543Z | Disconnected from 10.1.0.1 | 1756468
+;
+
 keepFieldAbsentFromSource
 required_capability: optional_fields_load_all
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/DetermineUnmappedFieldsToKeep.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/rules/DetermineUnmappedFieldsToKeep.java
@@ -27,6 +27,10 @@ import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
  * would survive to the query output. Expanding the {@code _unmapped_fields} column into per-field
  * output columns is a coordinator-level post-processing step and does not affect data-node execution.
  *
+ * <p>When the computed pattern is {@link UnmappedFieldsPattern#NONE}—e.g., a pattern-less {@code KEEP}
+ * that can never let an unmapped source field through—the rule leaves the plan untouched, so data nodes
+ * never load {@code _source} for expansion.
+ *
  * <p>The rule runs in the Finish Analysis batch <em>before</em> {@link ResolvedProjects}, so
  * {@link ResolvingProject} nodes — which carry the original wildcard patterns — are still present.
  * For any other {@link UnmappedResolution} the rule is a no-op.
@@ -39,6 +43,9 @@ public class DetermineUnmappedFieldsToKeep extends ParameterizedRule<LogicalPlan
             return plan;
         }
         UnmappedFieldsPattern pattern = computeUnmappedFieldsToKeep(plan);
+        if (pattern.isNone()) {
+            return plan;
+        }
         return plan.transformUp(EsRelation.class, esr -> {
             if (esr.indexMode() == IndexMode.LOOKUP) {
                 return esr;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnmappedFieldsPattern.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnmappedFieldsPattern.java
@@ -75,13 +75,8 @@ public final class UnmappedFieldsPattern implements NamedWriteable {
     /**
      * The pattern of a {@code KEEP} command, computed from the projection list it was written with.
      *
-     * <p>All projection terms from this single {@code KEEP} form one OR group: a source field survives if it
-     * matches any listed term. An explicitly named term is included just like a wildcard is; a name that turns
-     * out to be an already-visible column is filtered out downstream anyway, because
-     * {@code DetermineUnmappedFieldsToKeep} excludes every {@code EsRelation.output()} name — which covers both
-     * mapped columns and the fields {@code ResolveUnmapped} demand-loads for explicit references.
-     *
-     * <p>An empty include list — a {@code KEEP} listing nothing at all — keeps no unmapped source field.
+     * <p>Wildcard terms from this single {@code KEEP} form one OR group: a source field survives if it matches any listed
+     * pattern. An all-literal {@code KEEP} therefore yields {@link #NONE}.
      */
     public static UnmappedFieldsPattern forKeep(List<? extends NamedExpression> projections) {
         List<String> includes = new ArrayList<>();
@@ -91,7 +86,8 @@ public final class UnmappedFieldsPattern implements NamedWriteable {
                     return ALL;
                 }
                 case UnresolvedNamePattern unp -> includes.add(unp.pattern());
-                case UnresolvedAttribute ua -> includes.add(ua.name());
+                case UnresolvedAttribute ignored -> {
+                }
                 default -> throw new IllegalStateException("Unsupported KEEP projection [" + proj + "]");
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTestCase.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.analysis;
 
 import org.elasticsearch.common.util.ArrayUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.optimizer.GoldenTestCase;
 
 import java.util.ArrayList;
@@ -29,6 +30,11 @@ abstract class AnalyzerUnmappedGoldenTestCase extends GoldenTestCase {
 
     protected TestBuilder load(String query, String... variants) {
         return builder("SET unmapped_fields=\"load\"; " + query).nestedPath(ArrayUtils.prepend("load", variants));
+    }
+
+    protected TestBuilder loadAll(String query, String... variants) {
+        assumeTrue("Requires OPTIONAL_FIELDS_LOAD_ALL", EsqlCapabilities.Cap.OPTIONAL_FIELDS_LOAD_ALL.isEnabled());
+        return builder("SET unmapped_fields=\"LOAD_ALL\"; " + query).nestedPath(ArrayUtils.prepend("load_all", variants));
     }
 
     /** Runs the same query in the nullify and load modes. */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedGoldenTests.java
@@ -42,6 +42,35 @@ public class AnalyzerUnmappedGoldenTests extends AnalyzerUnmappedGoldenTestCase 
             """);
     }
 
+    public void testLoadAllPatternLessKeep() throws Exception {
+        loadAll("""
+            FROM employees
+            | KEEP emp_no, first_name
+            """).run();
+    }
+
+    public void testLoadAllKeepThenDrop() throws Exception {
+        loadAll("""
+            FROM employees
+            | KEEP emp_no
+            | DROP emp_no
+            """).run();
+    }
+
+    public void testLoadAllPatternLessKeepUnmappedName() throws Exception {
+        loadAll("""
+            FROM employees
+            | KEEP emp_no, does_not_exist_field
+            """).run();
+    }
+
+    public void testLoadAllKeepWildcard() throws Exception {
+        loadAll("""
+            FROM employees
+            | KEEP emp_no*
+            """).run();
+    }
+
     public void testKeepRepeated() throws Exception {
         runInNullifyAndLoadModes("""
             FROM employees

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
-import org.elasticsearch.xpack.esql.plan.logical.UnmappedFieldsAttribute;
 import org.elasticsearch.xpack.esql.plan.logical.join.AbstractSubqueryJoin;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
@@ -1504,7 +1503,7 @@ public class AnalyzerUnmappedTests extends AnalyzerUnmappedTestBase {
             | SORT name
             | LIMIT 10
             """));
-        assertThat(Expressions.names(plan.output()), equalTo(List.of("name", "x", UnmappedFieldsAttribute.ATTRIBUTE_NAME)));
+        assertThat(Expressions.names(plan.output()), equalTo(List.of("name", "x")));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/DetermineUnmappedFieldsToKeepTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/DetermineUnmappedFieldsToKeepTests.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -88,10 +89,20 @@ public class DetermineUnmappedFieldsToKeepTests extends AnalyzerUnmappedTestBase
         assertNotKept(pattern, excl());
     }
 
-    public void testKeepExactName() {
-        UnmappedFieldsPattern pattern = patternFor("FROM test | KEEP salary");
-        assertNotKept(pattern, excl());
-        assertNotKept(pattern, "unmapped_extra", "salary_bonus");
+    public void testKeepExactNameOmitsUnmappedFieldsAttribute() {
+        assertNoUnmappedFieldsAttribute("FROM test | KEEP salary");
+    }
+
+    public void testKeepExactNameBeforePatternOmitsUnmappedFieldsAttribute() {
+        assertNoUnmappedFieldsAttribute("FROM test | KEEP salary | KEEP sal*");
+    }
+
+    public void testKeepExactNameAfterPatternOmitsUnmappedFieldsAttribute() {
+        assertNoUnmappedFieldsAttribute("FROM test | KEEP first_name* | KEEP first_name");
+    }
+
+    public void testKeepThenDropOmitsUnmappedFieldsAttribute() {
+        assertNoUnmappedFieldsAttribute("FROM test | KEEP salary | DROP salary");
     }
 
     public void testKeepWildcardIgnoresMappedExactNameInSameCommand() {
@@ -174,10 +185,10 @@ public class DetermineUnmappedFieldsToKeepTests extends AnalyzerUnmappedTestBase
 
     public void testKeepThenDropRemovesAllMappedColumns() {
         // KEEP first* leaves only the mapped field "first_name"; DROP first_name* then removes it, so NO mapped
-        // column survives. This is still valid under LOAD_ALL — analysis must not fail: ResolvingProject always
-        // re-appends _unmapped_fields, so the projection is never empty, and unmapped source fields matching
-        // "first*" but not "first_name*" (e.g. "first_pet") are still kept. We cannot know at planning time
-        // whether such fields exist in _source, so erroring would be wrong.
+        // column survives. This is still valid under LOAD_ALL — analysis must not fail: the DROP wildcard still
+        // leaves unmapped source fields matching "first*" but not "first_name*" (e.g. "first_pet"), so the
+        // synthetic $$unmapped_fields column remains. We cannot know at planning time whether such fields exist
+        // in _source, so erroring would be wrong.
         UnmappedFieldsPattern pattern = patternFor("FROM test | KEEP first* | DROP first_name*");
         assertKept(pattern, "first_pet", "first_grade");
         assertNotKept(pattern, "first_name_suffix", "unmapped_extra");
@@ -243,13 +254,11 @@ public class DetermineUnmappedFieldsToKeepTests extends AnalyzerUnmappedTestBase
     /**
      * {@code _unmapped_fields} is not a reserved name: the synthetic column is called
      * {@link UnmappedFieldsAttribute#ATTRIBUTE_NAME}, which no query can spell. So a query referencing
-     * {@code _unmapped_fields} gets an ordinary source field demand-loaded as a keyword — which in turn puts
-     * the name into {@code EsRelation.output()} and therefore out of the expansion pattern.
+     * {@code _unmapped_fields} gets an ordinary source field demand-loaded as a keyword — which is an explicit
+     * column of the relation. A pattern-less KEEP of that name therefore yields no synthetic column at all.
      */
     public void testKeepUnmappedFieldsIsAnOrdinarySourceField() {
-        UnmappedFieldsPattern pattern = patternFor("FROM test | KEEP _unmapped_fields");
-        assertNotKept(pattern, "_unmapped_fields", "unmapped_extra");
-        assertNotKept(pattern, excl());
+        assertNoUnmappedFieldsAttribute("FROM test | KEEP _unmapped_fields");
     }
 
     public void testDropUnmappedFieldsIsAnOrdinarySourceField() {
@@ -273,6 +282,17 @@ public class DetermineUnmappedFieldsToKeepTests extends AnalyzerUnmappedTestBase
     private static void assertKept(UnmappedFieldsPattern pattern, String... names) {
         for (String name : names) {
             assertThat("expected [" + name + "] to be kept", pattern.matches(name), is(true));
+        }
+    }
+
+    private static void assertNoUnmappedFieldsAttribute(String query) {
+        LogicalPlan plan = test().statement(setUnmappedLoadAll(query));
+        for (EsRelation relation : plan.collect(EsRelation.class)) {
+            assertThat(
+                "expected no UnmappedFieldsAttribute on " + relation,
+                CollectionUtils.collect(relation.output(), UnmappedFieldsAttribute.class),
+                empty()
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepThenDrop/load_all/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepThenDrop/load_all/analysis.expected
@@ -1,0 +1,4 @@
+Limit[1000[INTEGER],false,false]
+\_Project[[]]
+  \_Project[[emp_no{f}#0]]
+    \_EsRelation[employees][avg_worked_seconds{f}#1, birth_date{f}#2, emp_no{f}#0, first_name{f}#3, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepThenDrop/load_all/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepThenDrop/load_all/query.esql
@@ -1,0 +1,3 @@
+SET unmapped_fields="LOAD_ALL"; FROM employees
+| KEEP emp_no
+| DROP emp_no

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepWildcard/load_all/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepWildcard/load_all/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Project[[emp_no{f}#0, $$unmapped_fields{m}#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#0, first_name{f}#4, gender{f}#5, height{f}#6, height.float{f}#7, height.half_float{f}#8, height.scaled_float{f}#9, hire_date{f}#10, is_rehired{f}#11, job_positions{f}#12, languages{f}#13, languages.byte{f}#14, languages.long{f}#15, languages.short{f}#16, last_name{f}#17, salary{f}#18, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23, $$unmapped_fields{m}#1]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepWildcard/load_all/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllKeepWildcard/load_all/query.esql
@@ -1,0 +1,2 @@
+SET unmapped_fields="LOAD_ALL"; FROM employees
+| KEEP emp_no*

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeep/load_all/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeep/load_all/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Project[[emp_no{f}#0, first_name{f}#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#0, first_name{f}#1, gender{f}#4, height{f}#5, height.float{f}#6, height.half_float{f}#7, height.scaled_float{f}#8, hire_date{f}#9, is_rehired{f}#10, job_positions{f}#11, languages{f}#12, languages.byte{f}#13, languages.long{f}#14, languages.short{f}#15, last_name{f}#16, salary{f}#17, salary_change{f}#18, salary_change.int{f}#19, salary_change.keyword{f}#20, salary_change.long{f}#21, still_hired{f}#22]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeep/load_all/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeep/load_all/query.esql
@@ -1,0 +1,2 @@
+SET unmapped_fields="LOAD_ALL"; FROM employees
+| KEEP emp_no, first_name

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeepUnmappedName/load_all/analysis.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeepUnmappedName/load_all/analysis.expected
@@ -1,0 +1,3 @@
+Limit[1000[INTEGER],false,false]
+\_Project[[emp_no{f}#0, does_not_exist_field{f(PotentiallyUnmappedKeywordEsField)}#1]]
+  \_EsRelation[employees][avg_worked_seconds{f}#2, birth_date{f}#3, emp_no{f}#0, first_name{f}#4, gender{f}#5, height{f}#6, height.float{f}#7, height.half_float{f}#8, height.scaled_float{f}#9, hire_date{f}#10, is_rehired{f}#11, job_positions{f}#12, languages{f}#13, languages.byte{f}#14, languages.long{f}#15, languages.short{f}#16, last_name{f}#17, salary{f}#18, salary_change{f}#19, salary_change.int{f}#20, salary_change.keyword{f}#21, salary_change.long{f}#22, still_hired{f}#23, does_not_exist_field{f(PotentiallyUnmappedKeywordEsField)}#1]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeepUnmappedName/load_all/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/analysis/golden_tests/AnalyzerUnmappedGoldenTests/testLoadAllPatternLessKeepUnmappedName/load_all/query.esql
@@ -1,0 +1,2 @@
+SET unmapped_fields="LOAD_ALL"; FROM employees
+| KEEP emp_no, does_not_exist_field


### PR DESCRIPTION
If we have an patterned `KEEP`, i.e., a `KEEP` without a `*`, we know for certain no unmapped and unreferenced fields should be loaded from `_source` as part of `LOAD_ALL` (although referenced one are still `LOAD`ed, of course). More generally, if the `UnmappedFieldsPattern` admits no fields (i.e., `isNone()` is `true`), we can avoid loading unreferenced fields. So this PR does two things:

- Ignore unpatterned-`KEEP`s instead of adding them to the `UnmappedFieldsPattern`; since this is only used for unmentioned fields, and `KEEP x` mentioned `x`.
- If `isNone()` is `true`, doesn't add the `$$unmapped_fields` field to the `EsRelation`, preventing the runtime from trying to expand the JSON (unless there are other `_source` readers, of course).

Resolves #156173.