### PR TITLE
Fix MlAssignmentPlannerUpgradeIT failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -619,18 +619,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/156415
-- class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT
-  method: testMlAssignmentPlannerUpgrade {upgradedNodes=0}
-  issue: https://github.com/elastic/elasticsearch/issues/156418
-- class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT
-  method: testMlAssignmentPlannerUpgrade {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/156419
-- class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT
-  method: testMlAssignmentPlannerUpgrade {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/156420
-- class: org.elasticsearch.upgrades.MlAssignmentPlannerUpgradeIT
-  method: testMlAssignmentPlannerUpgrade {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/156421
 - class: org.elasticsearch.xpack.inference.external.http.HttpClientTests
   method: testStream_CancelAfterPauseReleasesConnection
   issue: https://github.com/elastic/elasticsearch/issues/156431

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -113,7 +113,7 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractXpackRollingUpgradeTes
             waitForDeploymentStarted("old_memory_format");
             waitForDeploymentStarted("new_memory_format");
 
-            assertNewMemoryFormat("old_memory_format");
+            assertOldMemoryFormat("old_memory_format");
             assertNewMemoryFormat("new_memory_format");
 
             cleanupDeployments();
@@ -134,50 +134,30 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractXpackRollingUpgradeTes
 
     @SuppressWarnings("unchecked")
     private void assertOldMemoryFormat(String modelId) throws Exception {
-        assertBusy(() -> {
-            Response response = getTrainedModelStats(modelId);
-            Map<String, Object> map = entityAsMap(response);
-            List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
-            assertThat(stats, hasSize(1));
-            var stat = stats.get(0);
-            assertThat(
-                stat.toString(),
-                XContentMapValues.extractValue("deployment_stats.adaptive_allocations.enabled", stat),
-                equalTo(false)
-            );
-            var assignments = (List<Map<String, Object>>) XContentMapValues.extractValue("deployment_stats.nodes", stat);
-            assertThat(assignments, hasSize(1));
-            var assignment = assignments.get(0);
-            assertThat(assignment.toString(), XContentMapValues.extractValue("per_deployment_memory_bytes", assignment), equalTo(0));
-            assertThat(assignment.toString(), XContentMapValues.extractValue("per_allocation_memory_bytes", assignment), equalTo(0));
-        }, 30, TimeUnit.SECONDS);
+        Response response = getTrainedModelStats(modelId);
+        Map<String, Object> map = entityAsMap(response);
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
+        assertThat(stats, hasSize(1));
+        var stat = stats.get(0);
+        Long expectedMemoryUsage = ByteSizeValue.ofMb(240).getBytes() + RAW_MODEL_SIZE * 2;
+        Integer actualMemoryUsage = (Integer) XContentMapValues.extractValue("model_size_stats.required_native_memory_bytes", stat);
+        assertThat(
+            Strings.format("Memory usage mismatch for model %s", modelId),
+            actualMemoryUsage,
+            equalTo(expectedMemoryUsage.intValue())
+        );
     }
 
     @SuppressWarnings("unchecked")
     private void assertNewMemoryFormat(String modelId) throws Exception {
-        long expectedPerDeploymentMemoryBytes = ByteSizeValue.ofMb(300).getBytes();
-        long expectedPerAllocationMemoryBytes = ByteSizeValue.ofMb(10).getBytes();
-
-        assertBusy(() -> {
-            Response response = getTrainedModelStats(modelId);
-            Map<String, Object> map = entityAsMap(response);
-            List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
-            assertThat(stats, hasSize(1));
-            var stat = stats.get(0);
-            var assignments = (List<Map<String, Object>>) XContentMapValues.extractValue("deployment_stats.nodes", stat);
-            assertThat(assignments, hasSize(1));
-            var assignment = assignments.get(0);
-            assertThat(
-                assignment.toString(),
-                ((Number) XContentMapValues.extractValue("per_deployment_memory_bytes", assignment)).longValue(),
-                equalTo(expectedPerDeploymentMemoryBytes)
-            );
-            assertThat(
-                assignment.toString(),
-                ((Number) XContentMapValues.extractValue("per_allocation_memory_bytes", assignment)).longValue(),
-                equalTo(expectedPerAllocationMemoryBytes)
-            );
-        }, 30, TimeUnit.SECONDS);
+        Response response = getTrainedModelStats(modelId);
+        Map<String, Object> map = entityAsMap(response);
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) map.get("trained_model_stats");
+        assertThat(stats, hasSize(1));
+        var stat = stats.get(0);
+        Long expectedMemoryUsage = ByteSizeValue.ofMb(300).getBytes() + RAW_MODEL_SIZE + ByteSizeValue.ofMb(10).getBytes();
+        Integer actualMemoryUsage = (Integer) XContentMapValues.extractValue("model_size_stats.required_native_memory_bytes", stat);
+        assertThat(stat.toString(), actualMemoryUsage.toString(), equalTo(expectedMemoryUsage.toString()));
     }
 
     private Response getTrainedModelStats(String modelId) throws IOException {


### PR DESCRIPTION
This PR reverts the memory format assertions in the MlAssignmentPlannerUpgradeIT test back to their previous versions, before it was migrated to the new rolling upgrade framework.

Cause: when converting the tests Claude must have hallucinated the memory format checks, and while for some reason they passed the CI checks, they failed later on. I've made sure locally that these tests now pass for 8.19.21, 9.4.6, 9.5.2 and 9.6.0 BWC checks.

Closes #156418
Closes #156419
Closes #156420
Closes #156421
