### PR TITLE
ES|QL: Add internal histogram_fraction function

### DIFF
--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionExponentialHistogramEvaluator.java
@@ -1,0 +1,152 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.ExponentialHistogramBlock;
+import org.elasticsearch.compute.data.ExponentialHistogramScratch;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link HistogramFraction}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class HistogramFractionExponentialHistogramEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(HistogramFractionExponentialHistogramEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator histogram;
+
+  private final ExpressionEvaluator bucket;
+
+  private final Integer decimals;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public HistogramFractionExponentialHistogramEvaluator(Source source,
+      ExpressionEvaluator histogram, ExpressionEvaluator bucket, Integer decimals,
+      DriverContext driverContext) {
+    this.source = source;
+    this.histogram = histogram;
+    this.bucket = bucket;
+    this.decimals = decimals;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (ExponentialHistogramBlock histogramBlock = (ExponentialHistogramBlock) histogram.eval(page)) {
+      try (DoubleRangeBlock bucketBlock = (DoubleRangeBlock) bucket.eval(page)) {
+        return eval(page.getPositionCount(), histogramBlock, bucketBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += histogram.baseRamBytesUsed();
+    baseRamBytesUsed += bucket.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, ExponentialHistogramBlock histogramBlock,
+      DoubleRangeBlock bucketBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      ExponentialHistogramScratch histogramScratch = new ExponentialHistogramScratch();
+      DoubleRangeBlockBuilder.DoubleRange bucketScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (histogramBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (bucketBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        ExponentialHistogram histogram = histogramBlock.getExponentialHistogram(histogramBlock.getFirstValueIndex(p), histogramScratch);
+        DoubleRangeBlockBuilder.DoubleRange bucket = bucketBlock.getDoubleRange(bucketBlock.getFirstValueIndex(p), bucketScratch);
+        result.appendDouble(HistogramFraction.process(histogram, bucket, this.decimals));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "HistogramFractionExponentialHistogramEvaluator[" + "histogram=" + histogram + ", bucket=" + bucket + ", decimals=" + decimals + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(histogram, bucket);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = driverContext.createWarnings(source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory histogram;
+
+    private final ExpressionEvaluator.Factory bucket;
+
+    private final Integer decimals;
+
+    public Factory(Source source, ExpressionEvaluator.Factory histogram,
+        ExpressionEvaluator.Factory bucket, Integer decimals) {
+      this.source = source;
+      this.histogram = histogram;
+      this.bucket = bucket;
+      this.decimals = decimals;
+    }
+
+    @Override
+    public HistogramFractionExponentialHistogramEvaluator get(DriverContext context) {
+      return new HistogramFractionExponentialHistogramEvaluator(source, histogram.get(context), bucket.get(context), decimals, context);
+    }
+
+    @Override
+    public String toString() {
+      return "HistogramFractionExponentialHistogramEvaluator[" + "histogram=" + histogram + ", bucket=" + bucket + ", decimals=" + decimals + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTDigestEvaluator.java
@@ -1,0 +1,160 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.function.Function;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlock;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.TDigestBlock;
+import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.aggregations.metrics.MemoryTrackingTDigestArrays;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+/**
+ * {@link ExpressionEvaluator} implementation for {@link HistogramFraction}.
+ * This class is generated. Edit {@code EvaluatorImplementer} instead.
+ */
+public final class HistogramFractionTDigestEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(HistogramFractionTDigestEvaluator.class);
+
+  private final Source source;
+
+  private final ExpressionEvaluator histogram;
+
+  private final ExpressionEvaluator bucket;
+
+  private final Integer decimals;
+
+  private final MemoryTrackingTDigestArrays tdigestArrays;
+
+  private final DriverContext driverContext;
+
+  private Warnings warnings;
+
+  public HistogramFractionTDigestEvaluator(Source source, ExpressionEvaluator histogram,
+      ExpressionEvaluator bucket, Integer decimals, MemoryTrackingTDigestArrays tdigestArrays,
+      DriverContext driverContext) {
+    this.source = source;
+    this.histogram = histogram;
+    this.bucket = bucket;
+    this.decimals = decimals;
+    this.tdigestArrays = tdigestArrays;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (TDigestBlock histogramBlock = (TDigestBlock) histogram.eval(page)) {
+      try (DoubleRangeBlock bucketBlock = (DoubleRangeBlock) bucket.eval(page)) {
+        return eval(page.getPositionCount(), histogramBlock, bucketBlock);
+      }
+    }
+  }
+
+  @Override
+  public long baseRamBytesUsed() {
+    long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+    baseRamBytesUsed += histogram.baseRamBytesUsed();
+    baseRamBytesUsed += bucket.baseRamBytesUsed();
+    return baseRamBytesUsed;
+  }
+
+  public DoubleBlock eval(int positionCount, TDigestBlock histogramBlock,
+      DoubleRangeBlock bucketBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      TDigestHolder histogramScratch = new TDigestHolder();
+      DoubleRangeBlockBuilder.DoubleRange bucketScratch = new DoubleRangeBlockBuilder.DoubleRange();
+      position: for (int p = 0; p < positionCount; p++) {
+        switch (histogramBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        switch (bucketBlock.getValueCount(p)) {
+          case 0:
+              result.appendNull();
+              continue position;
+          case 1:
+              break;
+          default:
+              warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+              result.appendNull();
+              continue position;
+        }
+        TDigestHolder histogram = histogramBlock.getTDigestHolder(histogramBlock.getFirstValueIndex(p), histogramScratch);
+        DoubleRangeBlockBuilder.DoubleRange bucket = bucketBlock.getDoubleRange(bucketBlock.getFirstValueIndex(p), bucketScratch);
+        result.appendDouble(HistogramFraction.process(histogram, bucket, this.decimals, this.tdigestArrays));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "HistogramFractionTDigestEvaluator[" + "histogram=" + histogram + ", bucket=" + bucket + ", decimals=" + decimals + ", tdigestArrays=" + tdigestArrays + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(histogram, bucket);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = driverContext.createWarnings(source);
+    }
+    return warnings;
+  }
+
+  static class Factory implements ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final ExpressionEvaluator.Factory histogram;
+
+    private final ExpressionEvaluator.Factory bucket;
+
+    private final Integer decimals;
+
+    private final Function<DriverContext, MemoryTrackingTDigestArrays> tdigestArrays;
+
+    public Factory(Source source, ExpressionEvaluator.Factory histogram,
+        ExpressionEvaluator.Factory bucket, Integer decimals,
+        Function<DriverContext, MemoryTrackingTDigestArrays> tdigestArrays) {
+      this.source = source;
+      this.histogram = histogram;
+      this.bucket = bucket;
+      this.decimals = decimals;
+      this.tdigestArrays = tdigestArrays;
+    }
+
+    @Override
+    public HistogramFractionTDigestEvaluator get(DriverContext context) {
+      return new HistogramFractionTDigestEvaluator(source, histogram.get(context), bucket.get(context), decimals, tdigestArrays.apply(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "HistogramFractionTDigestEvaluator[" + "histogram=" + histogram + ", bucket=" + bucket + ", decimals=" + decimals + ", tdigestArrays=" + tdigestArrays + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ScalarFunctionWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ScalarFunctionWritables.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.date.RangeMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.RangeWithin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.ToRange;
 import org.elasticsearch.xpack.esql.expression.function.scalar.histogram.ExtractHistogramComponent;
+import org.elasticsearch.xpack.esql.expression.function.scalar.histogram.HistogramFraction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.histogram.HistogramPercentile;
 import org.elasticsearch.xpack.esql.expression.function.scalar.ip.CIDRMatch;
 import org.elasticsearch.xpack.esql.expression.function.scalar.ip.IpPrefix;
@@ -141,6 +142,7 @@ public class ScalarFunctionWritables {
         entries.add(Tau.ENTRY);
         entries.add(ToLower.ENTRY);
         entries.add(ToUpper.ENTRY);
+        entries.add(HistogramFraction.ENTRY);
         entries.add(HistogramPercentile.ENTRY);
         entries.add(ExtractHistogramComponent.ENTRY);
         entries.add(WindowFilter.ENTRY);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFraction.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.aggregation.TDigestStates;
+import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogramQuantile;
+import org.elasticsearch.search.aggregations.metrics.MemoryTrackingTDigestArrays;
+import org.elasticsearch.tdigest.TDigest;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.AnyNullIsNull;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.math.Maths;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.THIRD;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNotNull;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+
+/**
+ * Estimates the number of values of a histogram that fall into a given range (bucket).
+ * Because the count is estimated and might involve interpolation, the result can be fractional.
+ * The optional {@code decimals} argument defines the number of decimal places to round the result to
+ * (with the same semantics as {@code ROUND}); if it is absent, no rounding is performed.
+ * The rounding is performed in a way so that rounding errors amortize across adjacent buckets instead of accumulating.
+ * Note that this function is currently only intended for internal usage and not available as a user-facing function.
+ * Therefore, it is intentionally not registered in {@link org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry}.
+ */
+public class HistogramFraction extends EsqlScalarFunction implements OptionalArgument, AnyNullIsNull {
+
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "HistogramFraction",
+        HistogramFraction::new
+    );
+
+    private final Expression histogram;
+    private final Expression bucket;
+    private final Expression decimals;
+
+    @FunctionInfo(
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.GA) },
+        returnType = { "double" },
+        briefSummary = "Estimates the number of values of a histogram that fall into a given range."
+    )
+    public HistogramFraction(
+        Source source,
+        @Param(name = "histogram", type = { "exponential_histogram", "tdigest" }) Expression histogram,
+        @Param(name = "bucket", type = { "double_range" }) Expression bucket,
+        @Param(
+            optional = true,
+            name = "decimals",
+            type = { "integer" },
+            description = "The number of decimal places to round to, must be a non-null literal. If absent, no rounding is performed."
+        ) Expression decimals
+    ) {
+        super(source, decimals != null ? List.of(histogram, bucket, decimals) : List.of(histogram, bucket));
+        this.histogram = histogram;
+        this.bucket = bucket;
+        this.decimals = decimals;
+    }
+
+    private HistogramFraction(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(Expression.class),
+            in.readNamedWriteable(Expression.class),
+            in.readOptionalNamedWriteable(Expression.class)
+        );
+    }
+
+    Expression histogram() {
+        return histogram;
+    }
+
+    Expression bucket() {
+        return bucket;
+    }
+
+    Expression decimals() {
+        return decimals;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        TypeResolution resolution = isType(
+            histogram,
+            dt -> dt == DataType.EXPONENTIAL_HISTOGRAM || dt == DataType.TDIGEST,
+            sourceText(),
+            FIRST,
+            "exponential_histogram",
+            "tdigest"
+        ).and(isType(bucket, dt -> dt == DataType.DOUBLE_RANGE, sourceText(), SECOND, "double_range"));
+        if (decimals != null) {
+            resolution = resolution.and(isType(decimals, dt -> dt == DataType.INTEGER, sourceText(), THIRD, "integer"))
+                .and(isNotNull(decimals, sourceText(), THIRD))
+                .and(isFoldable(decimals, sourceText(), THIRD));
+        }
+        return resolution;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.DOUBLE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new HistogramFraction(source(), newChildren.get(0), newChildren.get(1), decimals == null ? null : newChildren.get(2));
+    }
+
+    @Override
+    public boolean foldable() {
+        return histogram.foldable() && bucket.foldable() && (decimals == null || decimals.foldable());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, HistogramFraction::new, histogram, bucket, decimals);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        out.writeNamedWriteable(histogram);
+        out.writeNamedWriteable(bucket);
+        out.writeOptionalNamedWriteable(decimals);
+    }
+
+    @Evaluator(extraName = "ExponentialHistogram")
+    static double process(ExponentialHistogram histogram, DoubleRangeBlockBuilder.DoubleRange bucket, @Fixed Integer decimals) {
+        if (histogram.valueCount() == 0) {
+            return 0.0;
+        }
+        double lowerCount = ExponentialHistogramQuantile.estimateRank(histogram, bucket.from(), false);
+        double upperCount = ExponentialHistogramQuantile.estimateRank(histogram, bucket.to(), false);
+        if (decimals == null) {
+            return upperCount - lowerCount;
+        } else {
+            return Maths.round(upperCount, decimals).doubleValue() - Maths.round(lowerCount, decimals).doubleValue();
+        }
+    }
+
+    @Evaluator(extraName = "TDigest")
+    static double process(
+        TDigestHolder histogram,
+        DoubleRangeBlockBuilder.DoubleRange bucket,
+        @Fixed Integer decimals,
+        @Fixed(scope = Fixed.Scope.THREAD_LOCAL) MemoryTrackingTDigestArrays tdigestArrays
+    ) {
+        try (TDigest scratch = TDigest.createMergingDigest(tdigestArrays, TDigestStates.COMPRESSION)) {
+            scratch.add(histogram);
+            long totalNumValues = scratch.size();
+            if (totalNumValues == 0) {
+                return 0.0;
+            }
+            double lowerCount = scratch.cdf(bucket.from()) * totalNumValues;
+            double upperCount = scratch.cdf(bucket.to()) * totalNumValues;
+            if (decimals == null) {
+                return upperCount - lowerCount;
+            } else {
+                return Maths.round(upperCount, decimals).doubleValue() - Maths.round(lowerCount, decimals).doubleValue();
+            }
+        }
+    }
+
+    @Override
+    public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        var histogramEvaluator = toEvaluator.apply(histogram);
+        var bucketEvaluator = toEvaluator.apply(bucket);
+        // decimals is enforced to be a literal in resolveType(), so it can be folded here and baked into the evaluator.
+        // A null value here means the optional argument was omitted.
+        Integer decimalsValue = decimals == null ? null : (Integer) decimals.fold(toEvaluator.foldCtx());
+        DataType histogramType = histogram.dataType();
+        return switch (histogramType) {
+            case EXPONENTIAL_HISTOGRAM -> new HistogramFractionExponentialHistogramEvaluator.Factory(
+                source(),
+                histogramEvaluator,
+                bucketEvaluator,
+                decimalsValue
+            );
+            case TDIGEST -> new HistogramFractionTDigestEvaluator.Factory(
+                source(),
+                histogramEvaluator,
+                bucketEvaluator,
+                decimalsValue,
+                driverContext -> new MemoryTrackingTDigestArrays(driverContext.breaker())
+            );
+            default -> throw EsqlIllegalArgumentException.illegalDataType(histogramType);
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionErrorTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HistogramFractionErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(HistogramFractionTests.parameters());
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new HistogramFraction(source, args.get(0), args.get(1), args.size() == 2 ? null : args.get(2));
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        if (signature.size() == 3
+            && signature.get(2) == DataType.NULL
+            && validPerPosition.get(0).contains(signature.get(0))
+            && validPerPosition.get(1).contains(signature.get(1))) {
+            return equalTo("third argument of [" + sourceForSignature(signature) + "] cannot be null, received []");
+        }
+        return equalTo(typeErrorMessage(true, validPerPosition, signature, (valid, position) -> switch (position) {
+            case 0 -> "exponential_histogram or tdigest";
+            case 1 -> "double_range";
+            case 2 -> "integer";
+            default -> throw new AssertionError("unexpected parameter position [" + position + "]");
+        }));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionSerializationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class HistogramFractionSerializationTests extends AbstractExpressionSerializationTests<HistogramFraction> {
+
+    @Override
+    protected HistogramFraction createTestInstance() {
+        return new HistogramFraction(randomSource(), randomChild(), randomChild(), randomOptionalChild());
+    }
+
+    @Override
+    protected HistogramFraction mutateInstance(HistogramFraction instance) throws IOException {
+        Expression histogram = instance.histogram();
+        Expression bucket = instance.bucket();
+        Expression decimals = instance.decimals();
+        switch (between(0, 2)) {
+            case 0 -> histogram = randomValueOtherThan(histogram, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> bucket = randomValueOtherThan(bucket, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> decimals = randomValueOtherThan(decimals, HistogramFractionSerializationTests::randomOptionalChild);
+            default -> throw new AssertionError("unexpected branch");
+        }
+        return new HistogramFraction(randomSource(), histogram, bucket, decimals);
+    }
+
+    private static Expression randomOptionalChild() {
+        return randomBoolean() ? null : randomChild();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTests.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.compute.aggregation.TDigestStates;
+import org.elasticsearch.compute.data.DoubleRangeBlockBuilder;
+import org.elasticsearch.compute.data.TDigestHolder;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogramQuantile;
+import org.elasticsearch.search.aggregations.metrics.MemoryTrackingTDigestArrays;
+import org.elasticsearch.tdigest.TDigest;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.math.Maths;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.startsWith;
+
+public class HistogramFractionTests extends AbstractScalarFunctionTestCase {
+
+    public HistogramFractionTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
+        this.testCase = testCaseSupplier.get();
+    }
+
+    @Override
+    protected boolean canSerialize() {
+        return DataType.DOUBLE_RANGE.supportedVersion().supportedLocally();
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        List<TestCaseSupplier> suppliers = new ArrayList<>();
+        List<TestCaseSupplier.TypedDataSupplier> histogramSuppliers = new ArrayList<>();
+        histogramSuppliers.addAll(TestCaseSupplier.exponentialHistogramCases());
+        histogramSuppliers.addAll(TestCaseSupplier.tdigestCases());
+
+        for (TestCaseSupplier.TypedDataSupplier histogramSupplier : histogramSuppliers) {
+            addCase(suppliers, histogramSupplier, null);
+            addCase(suppliers, histogramSupplier, -3);
+            addCase(suppliers, histogramSupplier, 0);
+            addCase(suppliers, histogramSupplier, 3);
+        }
+        List<TestCaseSupplier> cases = anyNullIsNull(true, suppliers).stream()
+            .filter(supplier -> supplier.types().size() < 3 || supplier.types().get(2) != DataType.NULL)
+            .toList();
+        return parameterSuppliersFromTypedData(cases);
+    }
+
+    private static void addCase(List<TestCaseSupplier> suppliers, TestCaseSupplier.TypedDataSupplier histogramSupplier, Integer decimals) {
+        List<DataType> types = decimals != null
+            ? List.of(histogramSupplier.type(), DataType.DOUBLE_RANGE, DataType.INTEGER)
+            : List.of(histogramSupplier.type(), DataType.DOUBLE_RANGE);
+        suppliers.add(new TestCaseSupplier(histogramSupplier.name() + ", decimals=" + decimals, types, () -> {
+            TestCaseSupplier.TypedData histogram = histogramSupplier.get();
+            DoubleRangeBlockBuilder.DoubleRange bucket = TestCaseSupplier.randomDoubleRange();
+            List<TestCaseSupplier.TypedData> data = new ArrayList<>();
+            data.add(histogram);
+            data.add(new TestCaseSupplier.TypedData(bucket, DataType.DOUBLE_RANGE, "bucket"));
+            if (decimals != null) {
+                data.add(new TestCaseSupplier.TypedData(decimals, DataType.INTEGER, "decimals").forceLiteral());
+            }
+            return new TestCaseSupplier.TestCase(
+                data,
+                evaluatorMatcher(histogramSupplier.type(), decimals),
+                DataType.DOUBLE,
+                expectedMatcher(histogram.data(), bucket, decimals)
+            );
+        }));
+    }
+
+    private static Matcher<String> evaluatorMatcher(DataType histogramType, Integer decimals) {
+        String prefix = "HistogramFraction"
+            + (histogramType == DataType.TDIGEST ? "TDigest" : "ExponentialHistogram")
+            + "Evaluator[histogram=Attribute[channel=0], bucket=Attribute[channel=1], decimals="
+            + decimals;
+        return histogramType == DataType.TDIGEST ? startsWith(prefix) : equalTo(prefix + "]");
+    }
+
+    private static Matcher<Double> expectedMatcher(Object histogram, DoubleRangeBlockBuilder.DoubleRange bucket, Integer decimals) {
+        RankRange lowerRank;
+        RankRange upperRank;
+        if (histogram instanceof ExponentialHistogram exponentialHistogram) {
+            if (exponentialHistogram.valueCount() == 0) {
+                return equalTo(0.0);
+            }
+            long count = exponentialHistogram.valueCount();
+            DoubleUnaryOperator quantile = q -> ExponentialHistogramQuantile.getQuantile(exponentialHistogram, q);
+            lowerRank = rankRange(count, bucket.from(), quantile);
+            upperRank = rankRange(count, bucket.to(), quantile);
+        } else if (histogram instanceof TDigestHolder tdigest) {
+            try (
+                TDigest scratch = TDigest.createMergingDigest(
+                    new MemoryTrackingTDigestArrays(new NoopCircuitBreaker("histogram-fraction-tests")),
+                    TDigestStates.COMPRESSION
+                )
+            ) {
+                scratch.add(tdigest);
+                long count = scratch.size();
+                if (count == 0) {
+                    return equalTo(0.0);
+                }
+                lowerRank = rankRange(count, bucket.from(), scratch::quantile);
+                upperRank = rankRange(count, bucket.to(), scratch::quantile);
+            }
+        } else {
+            throw new AssertionError("unexpected histogram [" + histogram + "]");
+        }
+
+        double lowerResult;
+        double upperResult;
+        if (decimals == null) {
+            lowerResult = upperRank.lower() - lowerRank.upper();
+            upperResult = upperRank.upper() - lowerRank.lower();
+        } else {
+            lowerResult = Maths.round(upperRank.lower(), decimals).doubleValue() - Maths.round(lowerRank.upper(), decimals).doubleValue();
+            upperResult = Maths.round(upperRank.upper(), decimals).doubleValue() - Maths.round(lowerRank.lower(), decimals).doubleValue();
+        }
+        lowerResult = Math.max(0.0, lowerResult);
+        upperResult = Math.max(lowerResult, upperResult);
+        return allOf(greaterThanOrEqualTo(lowerResult), lessThanOrEqualTo(upperResult));
+    }
+
+    /**
+     * Finds adjacent quantiles that bracket the rank of {@code value}.
+     */
+    private static RankRange rankRange(long count, double value, DoubleUnaryOperator quantile) {
+        if (value < quantile.applyAsDouble(0.0)) {
+            return new RankRange(0.0, 0.0);
+        }
+        if (value > quantile.applyAsDouble(1.0)) {
+            return new RankRange(count, count);
+        }
+
+        long low = 1;
+        long high = count;
+        long firstGreater = -1;
+        while (low <= high) {
+            long mid = low + (high - low) / 2;
+            if (quantile.applyAsDouble(mid / (double) count) > value) {
+                firstGreater = mid;
+                high = mid - 1;
+            } else {
+                low = mid + 1;
+            }
+        }
+        if (firstGreater == -1) {
+            return new RankRange(count, count);
+        }
+        return new RankRange(firstGreater - 1.0, firstGreater);
+    }
+
+    private record RankRange(double lower, double upper) {}
+
+    public void testDecimalsMustBeFoldable() {
+        HistogramFraction function = new HistogramFraction(
+            Source.EMPTY,
+            field("histogram", DataType.TDIGEST),
+            field("bucket", DataType.DOUBLE_RANGE),
+            field("decimals", DataType.INTEGER)
+        );
+        assertTrue(function.typeResolved().unresolved());
+        assertThat(function.typeResolved().message(), equalTo("third argument of [] must be a constant, received [decimals]"));
+    }
+
+    public void testEmptyExponentialHistogramReturnsZero() {
+        DoubleRangeBlockBuilder.DoubleRange bucket = new DoubleRangeBlockBuilder.DoubleRange(-1.0, 1.0);
+        assertEquals(0.0, HistogramFraction.process(ExponentialHistogram.empty(), bucket, null), 0.0);
+        assertEquals(0.0, HistogramFraction.process(ExponentialHistogram.empty(), bucket, 2), 0.0);
+    }
+
+    public void testWholeExponentialHistogramReturnsCount() {
+        ExponentialHistogram exponentialHistogram = randomValueOtherThanMany(
+            ExponentialHistogram::isEmpty,
+            EsqlTestUtils::randomExponentialHistogram
+        );
+        DoubleRangeBlockBuilder.DoubleRange exponentialHistogramRange = new DoubleRangeBlockBuilder.DoubleRange(
+            Math.nextDown(exponentialHistogram.min()),
+            Math.nextUp(exponentialHistogram.max())
+        );
+        assertEquals(
+            exponentialHistogram.valueCount(),
+            HistogramFraction.process(exponentialHistogram, exponentialHistogramRange, null),
+            0.0
+        );
+    }
+
+    public void testWholeTDigestReturnsCount() {
+        TDigestHolder tdigest = EsqlTestUtils.randomTDigest();
+        DoubleRangeBlockBuilder.DoubleRange tdigestRange = new DoubleRangeBlockBuilder.DoubleRange(
+            Math.nextDown(tdigest.getMin()),
+            Math.nextUp(tdigest.getMax())
+        );
+        assertEquals(tdigest.size(), HistogramFraction.process(tdigest, tdigestRange, null, newTDigestArrays()), 0.0);
+    }
+
+    public void testExponentialHistogramFractionsAreAdditive() {
+        int decimals = randomIntBetween(-5, 50);
+        ExponentialHistogram exponentialHistogram = randomValueOtherThanMany(
+            ExponentialHistogram::isEmpty,
+            EsqlTestUtils::randomExponentialHistogram
+        );
+        assertFractionsAreAdditive(
+            exponentialHistogram.min(),
+            exponentialHistogram.max(),
+            decimals,
+            bucket -> HistogramFraction.process(exponentialHistogram, bucket, decimals)
+        );
+    }
+
+    public void testTDigestFractionsAreAdditive() {
+        int decimals = randomIntBetween(-5, 50);
+        TDigestHolder tdigest = EsqlTestUtils.randomTDigest();
+        MemoryTrackingTDigestArrays tdigestArrays = newTDigestArrays();
+        assertFractionsAreAdditive(
+            tdigest.getMin(),
+            tdigest.getMax(),
+            decimals,
+            bucket -> HistogramFraction.process(tdigest, bucket, decimals, tdigestArrays)
+        );
+    }
+
+    private void assertFractionsAreAdditive(
+        double min,
+        double max,
+        int decimals,
+        Function<DoubleRangeBlockBuilder.DoubleRange, Double> fraction
+    ) {
+        double rangeMin = min - Math.abs(min) * 0.1;
+        double rangeMax = max + Math.abs(max) * 0.1;
+        double from = randomDoubleBetween(rangeMin, rangeMax, true);
+        double to = randomDoubleBetween(from, rangeMax, true);
+        double x = randomDoubleBetween(from, to, true);
+
+        double whole = fraction.apply(new DoubleRangeBlockBuilder.DoubleRange(from, to));
+        double parts = fraction.apply(new DoubleRangeBlockBuilder.DoubleRange(from, x)) + fraction.apply(
+            new DoubleRangeBlockBuilder.DoubleRange(x, to)
+        );
+        double tolerance = Math.ulp(whole) + Math.ulp(parts);
+        assertEquals("decimals=" + decimals + ", range=[" + from + ", " + to + "], x=" + x, whole, parts, tolerance);
+    }
+
+    private static MemoryTrackingTDigestArrays newTDigestArrays() {
+        return new MemoryTrackingTDigestArrays(new NoopCircuitBreaker("histogram-fraction-tests"));
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new HistogramFraction(source, args.get(0), args.get(1), args.size() == 2 ? null : args.get(2));
+    }
+}


### PR DESCRIPTION
Part of #156259

Implements an internal only `histogram_fraction` scalar function, which we in follow ups will use for
 * the implementation of `COUNT(histogram, bucket)`
 * wire it into PromQL as [histogram_fraction](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_fraction) for native histograms

Histogram fraction takes two mandatory arguments: The histogram and the bucket to compute the fraction for as `double_range`. We implement this functionatliy based on rank estimation, which can involve interpolation. Therefore results can be fractional. Because for `COUNT(histogram, bucket)` we don't want fractional results, an optional rounding can be performed by providing an optional third `decimals` parameter.

The rounding needs to be backed into `histogram_fraction` as this allows us to amortize rounding errors across buckets to provide the following guarantee:
```
histogram_fraction(_, [x , y], digits) + histogram_fraction(_, [y, z], digits) == histogram_fraction(_, [x, z], digits)
```

In other words: It doesn't matter how you split up your buckets, the total count will be preserved.
This guarantee is validated via additional unit tests.