### PR TITLE
[9.4] Simplify field matching in exclude source vectors (#156466)

### DIFF
--- a/docs/changelog/156466.yaml
+++ b/docs/changelog/156466.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues: []
+pr: 156466
+summary: Fix search failures on indices without vector fields when many field patterns
+  are requested
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -12,7 +12,6 @@ package org.elasticsearch.index.get;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.replication.StaleRequestException;
 import org.elasticsearch.cluster.routing.IndexRouting;
@@ -542,33 +541,40 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         if (shouldExcludeVectorsFromSource(indexSettings, fetchSourceContext) == false) {
             return Tuple.tuple(fetchSourceContext, null);
         }
-        var fetchFieldsAut = fetchFieldsContext != null && fetchFieldsContext.fields().size() > 0
-            ? new CharacterRunAutomaton(
-                Regex.simpleMatchToAutomaton(fetchFieldsContext.fields().stream().map(f -> f.field).toArray(String[]::new))
-            )
-            : null;
-        var inferenceFieldsAut = mappingLookup.inferenceFields().size() > 0
-            ? new CharacterRunAutomaton(
-                Regex.simpleMatchToAutomaton(mappingLookup.inferenceFields().keySet().stream().map(f -> f + "*").toArray(String[]::new))
-            )
+        // Quick check first whether the mapping contains a vector field at all, since there is otherwise nothing to exclude.
+        final Set<String> vectorFields = mappingLookup.vectorEmbeddingFields();
+        if (vectorFields.isEmpty()) {
+            return Tuple.tuple(fetchSourceContext, null);
+        }
+        // The requested patterns are matched one at a time rather than compiled into a single automaton. Compiling only pays off when
+        // many strings are tested against it, and the strings tested here are just the vector fields, of which there are few. The
+        // request, on the other hand, can carry thousands of patterns, which is expensive to compile and can exceed the
+        // determinization limit outright.
+        final String[] fetchFieldsPatterns = fetchFieldsContext == null
+            ? null
+            : fetchFieldsContext.fields().stream().map(f -> f.field).toArray(String[]::new);
+        // The inference field patterns are derived from the mapping rather than the request, so their number is bounded by the number
+        // of semantic text fields. Regex#simpleMatcher picks the cheapest strategy for them.
+        var inferenceFieldsMatcher = mappingLookup.inferenceFields().size() > 0
+            ? Regex.simpleMatcher(mappingLookup.inferenceFields().keySet().stream().map(f -> f + "*").toArray(String[]::new))
             : null;
 
         SourceFilter filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
 
         List<String> lateExcludes = new ArrayList<>();
-        var excludes = mappingLookup.getFullNameToFieldType().values().stream().filter(MappedFieldType::isVectorEmbedding).filter(f -> {
+        var excludes = vectorFields.stream().filter(f -> {
             // Keep the vector fields that are explicitly included and not explicitly excluded
-            if (filter != null && filter.isExplicitlyIncluded(f.name())) {
-                return filter.isPathFiltered(f.name(), false);
+            if (filter != null && filter.isExplicitlyIncluded(f)) {
+                return filter.isPathFiltered(f, false);
             }
             // Exclude the field specified by the `fields` option
-            if (fetchFieldsAut != null && fetchFieldsAut.run(f.name())) {
-                lateExcludes.add(f.name());
+            if (Regex.simpleMatch(fetchFieldsPatterns, f)) {
+                lateExcludes.add(f);
                 return false;
             }
             // Exclude vectors from semantic text fields, as they are processed separately
-            return inferenceFieldsAut == null || inferenceFieldsAut.run(f.name()) == false;
-        }).map(MappedFieldType::name).toList();
+            return inferenceFieldsMatcher == null || inferenceFieldsMatcher.test(f) == false;
+        }).toList();
 
         var sourceFilter = excludes.isEmpty() ? null : new SourceFilter(new String[] {}, excludes.toArray(String[]::new));
         if (lateExcludes.size() > 0) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -56,6 +56,7 @@ public final class MappingLookup {
     private final Map<String, ObjectMapper> objectMappers;
     private final Map<String, InferenceFieldMetadata> inferenceFields;
     private final Set<String> syntheticVectorFields;
+    private final Set<String> vectorEmbeddingFields;
     private final int runtimeFieldMappersCount;
     private final NestedLookup nestedLookup;
     private final FieldTypeLookup fieldTypeLookup;
@@ -211,6 +212,7 @@ public final class MappingLookup {
 
         Map<String, InferenceFieldMetadata> inferenceFields = new HashMap<>();
         List<String> syntheticVectorFields = new ArrayList<>();
+        Set<String> vectorEmbeddingFields = new HashSet<>();
         for (FieldMapper mapper : mappers) {
             if (mapper instanceof InferenceFieldMapper inferenceFieldMapper) {
                 inferenceFields.put(mapper.fullPath(), inferenceFieldMapper.getMetadata(fieldTypeLookup.sourcePaths(mapper.fullPath())));
@@ -218,9 +220,13 @@ public final class MappingLookup {
             if (mapper.syntheticVectorsLoader() != null) {
                 syntheticVectorFields.add(mapper.fullPath());
             }
+            if (mapper.fieldType().isVectorEmbedding()) {
+                vectorEmbeddingFields.add(mapper.fullPath());
+            }
         }
         this.inferenceFields = Map.copyOf(inferenceFields);
         this.syntheticVectorFields = Set.copyOf(syntheticVectorFields);
+        this.vectorEmbeddingFields = Set.copyOf(vectorEmbeddingFields);
 
         if (runtimeFields.isEmpty()) {
             // without runtime fields this is the same as the field type lookup
@@ -422,6 +428,17 @@ public final class MappingLookup {
 
     public Set<String> syntheticVectorFields() {
         return syntheticVectorFields;
+    }
+
+    /**
+     * Returns the paths of every field holding a vector embedding, which are the candidates for being stripped from {@code _source}.
+     * <p>
+     * This is deliberately not the same as {@link #syntheticVectorFields()}, which only holds the fields whose mapper offers a synthetic
+     * vectors loader and is therefore empty unless {@code index.mapping.exclude_source_vectors} is enabled. Vectors can also be excluded
+     * per request, so the set of candidates has to be established independently of that index setting.
+     */
+    public Set<String> vectorEmbeddingFields() {
+        return vectorEmbeddingFields;
     }
 
     public NestedLookup nestedLookup() {

--- a/server/src/test/java/org/elasticsearch/index/get/ExcludeVectorFieldsFromSourceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/get/ExcludeVectorFieldsFromSourceTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.get;
+
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
+import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/** Tests {@link ShardGetService#maybeExcludeVectorFields}, which strips vector fields from {@code _source} during get and fetch. */
+public class ExcludeVectorFieldsFromSourceTests extends MapperServiceTestCase {
+
+    /** Padding, so that fewer patterns are needed to reach the limit than short names would require. */
+    private static final String FILLER = "_filler_to_pad_the_name_";
+
+    /**
+     * Builds a {@code fields} request that {@link Regex#simpleMatchToAutomaton} cannot compile, which is what a client sends when it asks
+     * for a long list of fields next to a `*`. Compiling the requested patterns is exactly what the code under test must not do.
+     * <p>
+     * Concrete names alone never exceed the limit, at any count: {@code Automata#makeStringUnion} returns a minimal DFA and
+     * {@code Operations#determinize} short circuits on it. It is the match-all pattern that forces the subset construction, where every
+     * state of the union pairs with the always accepting state of the wildcard, which puts the ceiling at around 50000 states. Each name
+     * carries a unique head and a unique tail so that neither prefix nor suffix minimization collapses it, and is padded so that fewer
+     * of them are needed to reach that ceiling.
+     */
+    private static List<FieldAndFormat> fieldPatternsOverDeterminizeLimit() {
+        List<FieldAndFormat> fields = new ArrayList<>();
+        for (int i = 0; i < 2000; i++) {
+            String index = Strings.format("%05d", i);
+            fields.add(new FieldAndFormat("f" + index + FILLER + new StringBuilder(index).reverse(), null));
+        }
+        fields.add(new FieldAndFormat("*", null));
+        return fields;
+    }
+
+    /**
+     * Guards the fixture above: it only covers anything as long as the patterns it builds really are too many to compile. Without this the
+     * tests below keep passing if that limit ever moves, while no longer exercising the case they were written for.
+     */
+    public void testFieldPatternsCannotBeCompiledIntoAnAutomaton() {
+        String[] patterns = fieldPatternsOverDeterminizeLimit().stream().map(f -> f.field).toArray(String[]::new);
+        expectThrows(TooComplexToDeterminizeException.class, () -> Regex.simpleMatchToAutomaton(patterns));
+    }
+
+    private MapperService mapperServiceWithVectorField() throws IOException {
+        return createMapperService(mapping(b -> {
+            b.startObject("title").field("type", "keyword").endObject();
+            b.startObject("embedding").field("type", "dense_vector").field("dims", 3).field("index", false).endObject();
+        }));
+    }
+
+    /**
+     * A mapping without vector embeddings has nothing to exclude from {@code _source}, so the requested field patterns must never be
+     * compiled. Otherwise a request asking for a large number of fields fails with a shard error even though the filtering step would
+     * have been a no-op.
+     */
+    public void testFieldPatternsAreNotCompiledWhenMappingHasNoVectors() throws IOException {
+        MapperService mapperService = createMapperService(mapping(b -> { b.startObject("title").field("type", "keyword").endObject(); }));
+
+        List<FieldAndFormat> fields = fieldPatternsOverDeterminizeLimit();
+        var result = ShardGetService.maybeExcludeVectorFields(
+            mapperService.mappingLookup(),
+            mapperService.getIndexSettings(),
+            null,
+            new FetchFieldsContext(fields)
+        );
+        assertThat(result.v1(), nullValue());
+        assertThat(result.v2(), nullValue());
+    }
+
+    /**
+     * The requested field patterns are matched against the vector fields one at a time, so a request carrying more patterns than can be
+     * compiled into a single automaton is still served. The match-all among them counts as asking for the vector field, which is
+     * therefore excluded late, exactly as it is when it is the only pattern.
+     */
+    public void testManyRequestedFieldsWithVectorFieldInMapping() throws IOException {
+        MapperService mapperService = mapperServiceWithVectorField();
+
+        List<FieldAndFormat> fields = fieldPatternsOverDeterminizeLimit();
+        var result = ShardGetService.maybeExcludeVectorFields(
+            mapperService.mappingLookup(),
+            mapperService.getIndexSettings(),
+            null,
+            new FetchFieldsContext(fields)
+        );
+        assertThat(result.v1(), notNullValue());
+        assertThat(result.v1().excludes(), arrayContaining("embedding"));
+        assertThat(result.v2(), nullValue());
+    }
+
+    /**
+     * A match-all pattern counts as asking for the vector field, so it must be excluded late rather than up front: the value stays
+     * loadable for the sub-fetch phases that return it, and is dropped only when {@code _source} itself is rendered.
+     */
+    public void testMatchAllRequestedFieldPatternExcludesVectorsLate() throws IOException {
+        MapperService mapperService = mapperServiceWithVectorField();
+
+        var result = ShardGetService.maybeExcludeVectorFields(
+            mapperService.mappingLookup(),
+            mapperService.getIndexSettings(),
+            null,
+            new FetchFieldsContext(List.of(new FieldAndFormat("*", null)))
+        );
+        assertThat(result.v1(), notNullValue());
+        assertThat(result.v1().excludes(), arrayContaining("embedding"));
+        assertThat(result.v2(), nullValue());
+    }
+
+    /**
+     * The mapping holds a vector field but the request carries no {@code fields} option, which is how ES|QL and the get API call this.
+     * There is nothing to match the vector field against, so it is excluded up front rather than late.
+     */
+    public void testVectorFieldInMappingIsExcludedWhenNoFieldsRequested() throws IOException {
+        MapperService mapperService = mapperServiceWithVectorField();
+
+        var result = ShardGetService.maybeExcludeVectorFields(mapperService.mappingLookup(), mapperService.getIndexSettings(), null, null);
+        assertThat(result.v2(), notNullValue());
+        assertThat(result.v2().getExcludes(), arrayContaining("embedding"));
+    }
+
+    /**
+     * A vector field requested through the {@code fields} option is excluded late, so it stays available to sub-fetch phases. A plain
+     * list of field names needs no automaton, so this path must work regardless of how many fields are requested.
+     */
+    public void testRequestedVectorFieldIsExcludedLate() throws IOException {
+        MapperService mapperService = mapperServiceWithVectorField();
+
+        List<FieldAndFormat> fields = new ArrayList<>();
+        fields.add(new FieldAndFormat("title", null));
+        fields.add(new FieldAndFormat("embedding", null));
+
+        var result = ShardGetService.maybeExcludeVectorFields(
+            mapperService.mappingLookup(),
+            mapperService.getIndexSettings(),
+            null,
+            new FetchFieldsContext(fields)
+        );
+        assertThat(result.v1(), notNullValue());
+        assertThat(result.v1().excludes(), arrayContaining("embedding"));
+        assertThat(result.v2(), nullValue());
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Simplify field matching in exclude source vectors (#156466)

The automatic backport hit a cherry-pick conflict in `MappingLookup.java`, resolved manually against 9.4's collection idioms: kept `List<String> syntheticVectorFields` / `Set.copyOf` rather than main's `LinkedHashSet` / `Collections.unmodifiableSet`, and did not pull in `dimensionFieldMappers` / `metricFieldMappers`, which are main-only and appeared only as diff context. Exclude ordering is not significant (`SourceFilter` compiles excludes into automata), so `Set.copyOf` is equivalent.

Verified on 9.4: `ExcludeVectorFieldsFromSourceTests`, `MappingLookupTests` and `:server:spotlessJavaCheck` all pass.