### PR TITLE
Rework netty http flow control

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpFlowControlHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpFlowControlHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.util.ReferenceCountUtil;
+
+import java.util.ArrayDeque;
+
+/**
+ * Forwards one inbound HTTP message at a time. Handlers above emit one-to-many: the HTTP decoder splits a socket read
+ * into several messages, and the content decompressor expands any one of those into several more. Handlers below accept
+ * a single message at a time.
+ * <p>
+ * Serves the purpose of netty's {@link io.netty.handler.flow.FlowControlHandler}, and differs from it deliberately in
+ * two ways. It forwards from {@code read()} and {@code channelReadComplete} rather than as a message arrives, so a
+ * message leaves on a later stack than the one that delivered it. And it keeps at most one read outstanding, so
+ * repeated reads collapse into a single read upstream rather than accumulating.
+ */
+class Netty4HttpFlowControlHandler extends ChannelDuplexHandler {
+
+    private final ArrayDeque<HttpObject> queue = new ArrayDeque<>(4);
+
+    private boolean readPending;
+
+    @Override
+    public void read(ChannelHandlerContext ctx) {
+        if (readPending) {
+            return;
+        }
+        readPending = true;
+        if (emit(ctx) == false) {
+            ctx.read();
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        assert msg instanceof HttpObject : "unexpected inbound message [" + msg.getClass() + "]";
+        queue.addLast((HttpObject) msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        if (readPending && emit(ctx) == false) {
+            ctx.read();
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        releaseQueued();
+        ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) {
+        releaseQueued();
+    }
+
+    private boolean emit(ChannelHandlerContext ctx) {
+        final HttpObject msg = queue.pollFirst();
+        if (msg == null) {
+            return false;
+        }
+        readPending = false;
+        ctx.fireChannelRead(msg);
+        ctx.fireChannelReadComplete();
+        return true;
+    }
+
+    private void releaseQueued() {
+        HttpObject queued;
+        while ((queued = queue.pollFirst()) != null) {
+            ReferenceCountUtil.release(queued);
+        }
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -31,7 +31,6 @@ import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.flow.FlowControlHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutHandler;
@@ -410,6 +409,9 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             if (httpValidator != null) {
                 // runs a validation function on the first HTTP message piece which contains all the headers
                 // if validation passes, the pieces of that particular request are forwarded, otherwise they are discarded
+                // withholds the request while validation runs, so it does its own flow control for that window: it
+                // queues the rest of the read and releases one message per read
+                // TODO: drop that buffering and move flow control above the validator, leaving one place that does it
                 ch.pipeline()
                     .addLast(
                         "header_validator",
@@ -419,6 +421,9 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                         )
                     );
             }
+
+            // the HTTP decoder above reads socket bytes and emits multiple HttpObjects per read, content still compressed
+            ch.pipeline().addLast("decoder_flow_control", new Netty4HttpFlowControlHandler());
 
             ch.pipeline().addLast("decoder_compress", new HttpContentDecompressor() { // this handles request body decompression
                 private String currentUri;
@@ -470,10 +475,9 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 ch.pipeline().addLast(new Netty4LeakDetectionHandler());
             }
             ch.pipeline().addLast(new Netty4EmptyChunkHandler());
-            // See https://github.com/netty/netty/issues/15053: the combination of FlowControlHandler and HttpContentDecompressor above
-            // can emit multiple chunks per read, but HttpBody.Stream requires chunks to arrive one-at-a-time so until that issue is
-            // resolved we must add another flow controller here:
-            ch.pipeline().addLast(new FlowControlHandler());
+            // the decompressor above turns a single compressed HttpContent into multiple decompressed ones: at the default
+            // 8KB http.max_chunk_size and a worst case 1:1000 ratio, one chunk expands to 8MB, emitted as 128 x 64KB
+            ch.pipeline().addLast("decoder_compress_flow_control", new Netty4HttpFlowControlHandler());
             ch.pipeline()
                 .addLast(
                     "pipelining",

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpFlowControlHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpFlowControlHandlerTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Netty4HttpFlowControlHandlerTests extends ESTestCase {
+
+    private EmbeddedChannel channel;
+    private ReadSniffer readSniffer;
+    private ReadCompleteCounter readCompletes;
+
+    @Before
+    public void initChannel() {
+        channel = new EmbeddedChannel();
+        channel.config().setAutoRead(false);
+        readSniffer = new ReadSniffer();
+        readCompletes = new ReadCompleteCounter();
+        // readSniffer sits upstream so it counts the reads this handler forwards towards the network
+        channel.pipeline().addLast(readSniffer, new Netty4HttpFlowControlHandler(), readCompletes);
+    }
+
+    @After
+    public void closeChannel() {
+        channel.close();
+        channel.checkException();
+    }
+
+    /**
+     * The invariant, over a random interleaving of socket reads and downstream reads: however many messages arrive
+     * together, at most one is released per read, in arrival order, and none are lost.
+     */
+    public void testReleasesOneMessagePerReadInOrder() {
+        var arrived = new ArrayList<HttpObject>();
+        var released = new ArrayList<HttpObject>();
+
+        for (int step = 0; step < between(50, 200); step++) {
+            if (randomBoolean()) {
+                var batch = randomBatch();
+                arrived.addAll(batch);
+                channel.writeInbound(batch.toArray());
+            } else {
+                channel.read();
+            }
+            collectOne(released);
+        }
+
+        while (released.size() < arrived.size()) {
+            int before = released.size();
+            channel.read();
+            collectOne(released);
+            assertEquals("a read with messages queued must release exactly one", before + 1, released.size());
+        }
+
+        assertEquals("no message may be lost", arrived.size(), released.size());
+        for (int i = 0; i < arrived.size(); i++) {
+            assertSame("messages must be released in arrival order", arrived.get(i), released.get(i));
+        }
+        releaseAll(arrived);
+    }
+
+    public void testDoesNotCombineContentRuns() {
+        var first = randomContent(between(1, 64));
+        var second = randomContent(between(1, 64));
+        var last = randomLastContent(between(1, 64));
+
+        channel.writeInbound(first, second, last);
+        assertSame(first, readOne());
+        assertSame(second, readOne());
+        assertSame(last, readOne());
+        releaseAll(List.of(first, second, last));
+    }
+
+    public void testSatisfiesReadArmedBeforeMessageArrives() {
+        channel.read(); // the transport arms a read when it sets the channel up, before any message exists
+        assertEquals(1, readSniffer.readCount);
+
+        var content = randomContent(between(1, 64));
+        channel.writeInbound(content);
+        assertSame("an armed read must be satisfied as soon as a message arrives", content, channel.readInbound());
+        assertNull("an armed read must be satisfied only once", channel.readInbound());
+        content.release();
+    }
+
+    public void testRepeatedReadsAreDeduplicated() {
+        for (int i = 0; i < between(2, 5); i++) {
+            channel.read();
+        }
+        assertEquals("repeated reads with nothing to release must issue a single upstream read", 1, readSniffer.readCount);
+
+        var first = randomContent(between(1, 64));
+        var second = randomContent(between(1, 64));
+        channel.writeInbound(first, second);
+        assertSame(first, channel.readInbound());
+        assertNull("repeated reads must not release more than one message", channel.readInbound());
+        first.release(); // second is still queued, and closing the channel releases it
+    }
+
+    public void testFiresOneReadCompletePerReleasedMessage() {
+        var content = randomContent(between(1, 64));
+        var last = randomLastContent(between(1, 64));
+        channel.writeInbound(content, last); // EmbeddedChannel fires channelReadComplete once the batch is written
+
+        assertEquals("upstream read-completes must not reach handlers below", 0, readCompletes.count);
+        readOne();
+        assertEquals(1, readCompletes.count);
+        readOne();
+        assertEquals(2, readCompletes.count);
+        releaseAll(List.of(content, last));
+    }
+
+    /**
+     * A read cycle that produced nothing must be retried, or a wire chunk that decompressed to no output at all would
+     * stall the stream.
+     */
+    public void testEmptyReadCycleReadsUpstreamAgain() {
+        channel.read();
+        assertEquals(1, readSniffer.readCount);
+
+        channel.pipeline().fireChannelReadComplete();
+        assertEquals("a read cycle that produced nothing must be retried", 2, readSniffer.readCount);
+        assertEquals("nothing was released, so nothing may be signalled downstream", 0, readCompletes.count);
+    }
+
+    /**
+     * A handler below may call {@code read()} from inside {@code channelRead}, as Netty4HttpContentSizeHandler does for
+     * content it is dropping. That read must be honoured rather than swallowed by the flag the release just cleared.
+     */
+    public void testSynchronousDownstreamReadIsHonoured() {
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                ctx.fireChannelRead(msg);
+                ctx.read();
+            }
+        });
+
+        var batch = randomBatch();
+        channel.writeInbound(batch.toArray());
+        channel.read();
+
+        for (HttpObject expected : batch) {
+            assertSame("a read from within channelRead must release the next message", expected, channel.readInbound());
+        }
+        releaseAll(batch);
+    }
+
+    public void testReleasesQueuedContentOnClose() {
+        var content = randomContent(between(1, 64));
+        channel.writeInbound(content);
+        assertEquals(1, content.refCnt());
+        channel.close();
+        assertEquals("queued content must be released when the channel closes", 0, content.refCnt());
+    }
+
+    private <T> T readOne() {
+        T msg = channel.readInbound();
+        if (msg == null) {
+            channel.read();
+            msg = channel.readInbound();
+        }
+        assertNull("must release at most one message per read", channel.readInbound());
+        return msg;
+    }
+
+    private void collectOne(List<HttpObject> released) {
+        HttpObject msg = channel.readInbound();
+        if (msg != null) {
+            released.add(msg);
+        }
+        assertNull("must release at most one message per read", channel.readInbound());
+    }
+
+    /**
+     * One socket read's worth of decoded messages: a request followed by the chunks the decoder split its body into,
+     * possibly for several pipelined requests.
+     */
+    private List<HttpObject> randomBatch() {
+        var batch = new ArrayList<HttpObject>();
+        for (int i = 0; i < between(1, 3); i++) {
+            batch.add(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/" + i));
+            int chunkCount = between(1, 5);
+            for (int c = 0; c < chunkCount; c++) {
+                batch.add(c == chunkCount - 1 ? randomLastContent(between(0, 64)) : randomContent(between(0, 64)));
+            }
+        }
+        return batch;
+    }
+
+    private static void releaseAll(List<? extends HttpObject> msgs) {
+        msgs.forEach(ReferenceCountUtil::release);
+    }
+
+    private HttpContent randomContent(int size) {
+        return new DefaultHttpContent(Unpooled.wrappedBuffer(randomByteArrayOfLength(size)));
+    }
+
+    private LastHttpContent randomLastContent(int size) {
+        return new DefaultLastHttpContent(Unpooled.wrappedBuffer(randomByteArrayOfLength(size)));
+    }
+
+    private static class ReadCompleteCounter extends ChannelInboundHandlerAdapter {
+        int count;
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) {
+            count++;
+            ctx.fireChannelReadComplete();
+        }
+    }
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderThreadContextTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpHeaderThreadContextTests.java
@@ -19,7 +19,6 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.flow.FlowControlHandler;
 
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -53,7 +52,7 @@ public class Netty4HttpHeaderThreadContextTests extends ESTestCase {
 
     @Before
     public void initChannel() throws Exception {
-        channel = new EmbeddedChannel(new FlowControlHandler());
+        channel = new EmbeddedChannel();
         channel.config().setAutoRead(false);
         threadPool = new TestThreadPool(TEST_MOCK_TRANSPORT_THREAD_PREFIX);
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
@@ -18,7 +18,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.flow.FlowControlHandler;
 
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -50,9 +49,9 @@ public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
     @Before
     public void initStream() throws Exception {
         channel = new EmbeddedChannel();
-        readSniffer = new ReadSniffer();
-        channel.pipeline().addLast(new FlowControlHandler(), readSniffer);
         channel.config().setAutoRead(false);
+        readSniffer = new ReadSniffer();
+        channel.pipeline().addLast(new Netty4HttpFlowControlHandler(), readSniffer);
         channel.pipeline().addLast(new SimpleChannelInboundHandler<HttpContent>(false) {
             @Override
             public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
@@ -122,8 +121,9 @@ public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
         try {
             // activity tracker requires stream execution in the same thread, setting up stream inside event-loop
             eventLoop.submit(() -> {
-                channel = new EmbeddedChannel(new FlowControlHandler());
+                channel = new EmbeddedChannel();
                 channel.config().setAutoRead(false);
+                channel.pipeline().addLast(new Netty4HttpFlowControlHandler());
                 channel.pipeline().addLast(new SimpleChannelInboundHandler<HttpContent>(false) {
                     @Override
                     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
@@ -149,23 +149,20 @@ public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
                         headers.set(threadContext.getHeaders());
                     }
                 });
-                channel.pipeline().addFirst(new FlowControlHandler()); // block all incoming messages, need explicit channel.read()
             }).await();
 
-            channel.writeInbound(randomContent(chunkSize));
-            channel.writeInbound(randomLastContent(chunkSize));
-
+            // one chunk is requested and delivered at a time, so that each next() gets the context captured when it was called
             threadContext.putHeader("header2", "value2");
             stream.next();
 
-            eventLoop.submit(() -> channel.runPendingTasks()).await();
+            eventLoop.submit(() -> channel.writeInbound(randomContent(chunkSize))).await();
             assertThat(headers.get(), hasEntry("header1", "value1"));
             assertThat(headers.get(), hasEntry("header2", "value2"));
 
             threadContext.putHeader("header3", "value3");
             stream.next();
 
-            eventLoop.submit(() -> channel.runPendingTasks()).await();
+            eventLoop.submit(() -> channel.writeInbound(randomLastContent(chunkSize))).await();
             assertThat(headers.get(), hasEntry("header1", "value1"));
             assertThat(headers.get(), hasEntry("header2", "value2"));
             assertThat(headers.get(), hasEntry("header3", "value3"));


### PR DESCRIPTION
This PR reworks flow control in HTTP pipeline. It solves few existing problems: breaking change in the `FlowControlControl` in Netty 4.1.136 and have finer memory control for compressed data.

I add a simpler version of the Netty's `FlowControlHander`, a channel handler that enqueues upstream messages and emits only one per read on it's own event-loop invocation. Handlers such as `HttpRequestDecoder` and `HttpContentDecompressor` emit 1-to-many messages downstream. Forwarding messages from new stack on event-loop prevents re-entrancy issues and stack overflow on pathological cases with thousands of small chunked encoded parts.

The new `Netty4HttpFlowControlHandler` is plugged in two different places - after `HttpRequestDecoder` and after `HttpContentDecompressor`. And both have different purposes:

- `HttpRequestDecoder` flow control bounds memory before decompression. Decoder reads 64kb chunks from the socket and emits 8kb compressed HttpContent chunks (default settings). In worst compression ratio case 1:1000 a single compressed  8kb chunk would produce 128x64kb=8Mb decompressed chunks. So this flow-control ensures that no more than one compressed chunk flows into decompressor and we control memory by `http.max_chunk_size` setting.
- `HttpContentDecompressor` flow control bounds memory for the REST handler and ensures single message per-read - `HttpBody.Stream` interface contract. In worst case it still holds all 128x64kb=8Mb decompressed chunks, but emits only one 64kb to the REST handler.