### PR TITLE
Randomize fls policy in StandardVersusLogsdbFieldLevelSecurityChallengeRestIT

### DIFF
--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsdbFieldLevelSecurityChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsdbFieldLevelSecurityChallengeRestIT.java
@@ -49,11 +49,13 @@ public class StandardVersusLogsdbFieldLevelSecurityChallengeRestIT extends BulkC
         }
         indexDocuments(() -> documents, () -> documents);
 
-        // Deny one field so that, when it lands inside an _ignored_source capture on the logsdb side, FLS must drop that entry and hand
-        // back the survivors - the multi-value re-encode path the fix guards. Both indices filter identically, so the sources must match.
-        final String deniedField = randomDeniedField();
+        // Target one field so that, when it lands inside an _ignored_source capture on the logsdb side, FLS must drop entries and re-encode
+        // the survivors. Also, randomize the polarity: excluding the field exercises the exclude automaton, while granting only it
+        // exercises the include automaton. Both indices filter identically, so the sources must match either way.
+        final String targetField = randomDeniedField();
+        final boolean grantOnly = randomBoolean();
 
-        final String encoded = createFieldLevelSecurityApiKey(deniedField);
+        final String encoded = createFieldLevelSecurityApiKey(targetField, grantOnly);
 
         final SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).size(numberOfDocuments);
 
@@ -63,7 +65,8 @@ public class StandardVersusLogsdbFieldLevelSecurityChallengeRestIT extends BulkC
             .expected(querySourcesAsApiKey(getBaselineDataStreamName(), search, encoded))
             .ignoringSort(true)
             .isEqualTo(querySourcesAsApiKey(getContenderDataStreamName(), search, encoded));
-        assertTrue("denied field [" + deniedField + "]: " + matchResult.getMessage(), matchResult.isMatch());
+        final String policy = grantOnly ? "grant-only" : "except";
+        assertTrue("target field [" + targetField + "] policy [" + policy + "]: " + matchResult.getMessage(), matchResult.isMatch());
     }
 
     /**
@@ -94,7 +97,12 @@ public class StandardVersusLogsdbFieldLevelSecurityChallengeRestIT extends BulkC
         return randomFrom(fields);
     }
 
-    private String createFieldLevelSecurityApiKey(final String deniedField) throws IOException {
+    private String createFieldLevelSecurityApiKey(final String targetField, final boolean grantOnly) throws IOException {
+        // grantOnly grants just @timestamp plus the target field (an include filter that drops everything else); otherwise grant all
+        // fields except the target (an exclude filter). @timestamp is always granted so the routing/sort field survives both polarities.
+        final String fieldSecurity = grantOnly
+            ? Strings.format("{ \"grant\": [ \"@timestamp\", \"%s\" ] }", targetField)
+            : Strings.format("{ \"grant\": [ \"*\" ], \"except\": [ \"%s\" ] }", targetField);
         final Request request = new Request("POST", "/_security/api_key");
         request.setJsonEntity(Strings.format("""
             {
@@ -105,12 +113,12 @@ public class StandardVersusLogsdbFieldLevelSecurityChallengeRestIT extends BulkC
                     {
                       "names": [ "%s", "%s" ],
                       "privileges": [ "read" ],
-                      "field_security": { "grant": [ "*" ], "except": [ "%s" ] }
+                      "field_security": %s
                     }
                   ]
                 }
               }
-            }""", getBaselineDataStreamName(), getContenderDataStreamName(), deniedField));
+            }""", getBaselineDataStreamName(), getContenderDataStreamName(), fieldSecurity));
         final Response response = client.performRequest(request);
         assertOK(response);
         return (String) entityAsMap(response).get("encoded");


### PR DESCRIPTION
Adds FLS policy randomization based on the suggestion [here](https://github.com/elastic/elasticsearch/pull/156341#discussion_r3754673997).