### PR TITLE
Remove the experimental flag for the auto_calibrate configuration

### DIFF
--- a/docs/changelog/156623.yaml
+++ b/docs/changelog/156623.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 156623
+summary: Remove the experimental flag for the `auto_calibrate` configuration
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2190,11 +2190,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 }
 
                 boolean doPrecondition = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("precondition"), false);
-
-                boolean autoCalibrate = false;
-                if (experimentalFeaturesEnabled) {
-                    autoCalibrate = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("auto_calibrate"), false);
-                }
+                boolean autoCalibrate = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("auto_calibrate"), false);
 
                 MappingParser.checkNoRemainingFields(fieldName, indexOptionsMap);
                 return new BBQIVFIndexOptions(


### PR DESCRIPTION
We missed removing the experimental flag for auto_calibrate in 9.5 so currently setting auto_calibrate in the index options fails; this fixes that.  