### PR TITLE
Fix ReindexRelocationOnShutdownIT again

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -769,11 +769,8 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
             mockLog.awaitAllExpectationsMatched();
 
             // Release the transport block. With the fix the task was NOT cancelled, so the destination
-            // handler runs and the relocation completes normally.
+            // handler runs, and the relocation completes normally.
             resumeBlocked.countDown();
-
-            // We've seen everything we need to see, rethrottle to allow the task to finish
-            rethrottleRunningRootReindex(numDocs);
 
             // The source task should complete via TaskRelocatedException (relocated, not cancelled).
             safeAwait(listenerDone);
@@ -782,6 +779,9 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
 
             // Wait for prepareForShutdown to return (it will see the task is gone and exit its inner loop).
             safeGet(shutdownFuture);
+
+            // We've seen everything we need to see, rethrottle to allow the task to finish
+            rethrottleRunningRootReindex(numDocs);
 
             // The relocated task should complete successfully on the data node.
             final GetTaskResponse relocatedResult = clusterAdmin().prepareGetTask(new TaskId(relocatedTaskIdString))

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -774,9 +774,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecFoldingIT
   method: test {csv-spec:folding.mvBoolean_Equals_MultiValueConstant}
   issue: https://github.com/elastic/elasticsearch/issues/156530
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testRelocatingTaskIsNotCancelledOnShutdownTimeout
-  issue: https://github.com/elastic/elasticsearch/issues/155593
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecUnmappedTypeConflictsIT
   method: test {csv-spec:unmapped-type-conflicts.typeConflictLongDateUnmappedNonExistentCastToDouble}
   issue: https://github.com/elastic/elasticsearch/issues/156542


### PR DESCRIPTION
This is the third and hopefully final time I've had to fix this test.

There was a race where we'd sometimes call re-throttle before the relocation was complete. You can't call re-throttle while the relocation is in progress, but fortunately we already have a future we can use to know when the relocation is complete.

I've run this one on loop for a while and it seems OK, will check the flakiness report before I merge as well.

Fixes #155593