### PR TITLE
ES|QL: add field_extract fusion audit harness

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
+import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
+import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression.PushedBlockLoaderExpression;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.IndexResolution;
+import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
+import org.elasticsearch.xpack.esql.session.Versioned;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_CFG;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_SEARCH_STATS;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.classpathResources;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.testAnalyzerContext;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Corpus-driven dry run of {@code field_extract} block-loader <em>fusion</em>, the whole-corpus sibling of the
+ * offline shape matrix in {@code FieldExtractFusionInventoryTests} (unit tests). Instead of a handful of hand-written
+ * shapes it feeds the real csv-spec corpus through the same rewrite + plan + walk pipeline that
+ * {@link CsvFlattenedKeywordIT} exercises on a cluster, but stops short of executing anything: each query is
+ * <ol>
+ *     <li>restricted to the <b>single-dataset</b> {@code FROM &lt;index&gt;} subset (no {@code JOIN}/{@code ENRICH}/{@code FORK}
+ *     /multi-index/subquery), so an offline analyzer over exactly one flattened mapping is enough &mdash; everything
+ *     else is tallied under a skip bucket so the coverage is explicit;</li>
+ *     <li>rewritten with the production {@link AstKeywordFieldRewriter} so every keyword reference becomes
+ *     {@code field_extract(&lt;field&gt;, "&lt;subkey&gt;")}, using the same {@link KeywordToFlattenedTransformer}
+ *     keyword&rarr;flattened mapping transform the IT uses to build its indices;</li>
+ *     <li>planned through the local physical optimizer, then split at the coordinator/data-node exchange; only the
+ *     <b>data-node fragment</b> is walked, because {@code PushExpressionsToFieldLoad} is a data-node-local rule and a
+ *     coordinator-side {@code EVAL} is never a fusion candidate.</li>
+ * </ol>
+ * <p>
+ *     The walk counts fused loads (synthetic {@link FieldAttribute}s backed by a {@link FunctionEsField} for the
+ *     keyed sub-field) versus surviving {@link FieldExtract} fallbacks, bucketing each fallback by the gate in
+ *     {@code PushExpressionsToFieldLoad#transformExpression} that rejected it. Stats are the all-supporting
+ *     {@link EsqlTestUtils#TEST_SEARCH_STATS}, so this measures the <em>best case</em>: of the extracts that could
+ *     fuse, how many the optimizer actually fuses across real query shapes, and where the residue lands.
+ * </p>
+ * <p>
+ *     This lives in {@code internalClusterTest} only because {@link AstKeywordFieldRewriter} and the flattened mapping
+ *     transform do; the test itself needs no cluster and extends {@link ESTestCase}. It is a reporting/audit harness:
+ *     the aggregate histogram is logged at {@code INFO}, and the assertions stay loose (the corpus grows over time) so
+ *     it does not turn into a brittle golden-count test.
+ * </p>
+ */
+public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
+
+    private static final Logger logger = LogManager.getLogger(FieldExtractFusionCorpusInventoryTests.class);
+
+    /** Leading {@code FROM <index>} of a query; the capture group is the first index token. */
+    private static final Pattern LEADING_FROM = Pattern.compile("^\\s*FROM\\s+([A-Za-z0-9_.\\-]+)", Pattern.CASE_INSENSITIVE);
+
+    /** Commands that introduce a second source or need extra resolution the single-dataset analyzer does not carry. */
+    private static final Pattern MULTI_SOURCE = Pattern.compile("\\b(JOIN|ENRICH|FORK)\\b", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Why a {@code field_extract} did not fuse. Each non-{@link #FUSED} value corresponds to one gate in
+     * {@code PushExpressionsToFieldLoad#transformExpression}, in the order they are checked. Mirrors the enum in
+     * {@code FieldExtractFusionInventoryTests}.
+     */
+    enum Fusion {
+        FUSED,
+        DYNAMIC_KEY,
+        NON_FLATTENED_INPUT,
+        UNION_TYPE,
+        ABOVE_JOIN_OR_MULTISOURCE,
+        UNSUPPORTED_LOADER_CONFIG
+    }
+
+    /** Why a corpus query was not measured (i.e. contributed no fused/fallback counts). */
+    enum Skip {
+        /** Carries a {@code skip_flattened_rewrite:} directive: a documented field_extract limitation. */
+        SILENCED,
+        /** Not a clean single-dataset {@code FROM <known index>} query (multi-source, subquery, unknown index, ...). */
+        NOT_SINGLE_DATASET,
+        /** The dataset mapping could not be parsed / transformed into an offline analyzer. */
+        DATASET_UNAVAILABLE,
+        /** The rewrite touched no in-scope keyword reference, so no {@code field_extract} was introduced. */
+        NO_KEYWORD_REFS,
+        /** Analysis or planning threw (unsupported command, mapping mismatch, ...). */
+        UNPLANNABLE,
+        /** Planned, but the query produced no data-node fragment to inspect. */
+        NO_DATA_NODE_FRAGMENT
+    }
+
+    /** Per-dataset offline analyzer plus the keyword paths the rewriter should wrap. {@code null} analyzer means unusable. */
+    private record DatasetPlan(Analyzer analyzer, Set<String> keywordPaths) {}
+
+    private final Map<String, DatasetPlan> datasetPlans = new HashMap<>();
+
+    /**
+     * The dry run analyzes and plans the whole corpus, so the analyzer legitimately emits planner warnings
+     * ("No limit defined ...", "Field 'x' shadowed by field ...") for many queries. Those are irrelevant to the
+     * fusion audit and there is no fixed set to assert, so opt out of the end-of-test warning-header check rather
+     * than enumerate thousands of expected warnings.
+     */
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
+    public void testCorpusFusionInventory() {
+        assumeTrue("field_extract must be part of this build for the plans to analyze", FieldExtract.isFnFieldExtractCapabilityMet());
+
+        int fused = 0;
+        Map<Fusion, Integer> fallbackByReason = new EnumMap<>(Fusion.class);
+        Map<Skip, Integer> skipByReason = new EnumMap<>(Skip.class);
+        int measuredQueries = 0;
+
+        for (CsvSpecReader.CsvTestCase testCase : loadAllCsvSpecTestCases()) {
+            Skip skip = trySkip(testCase);
+            if (skip != null) {
+                skipByReason.merge(skip, 1, Integer::sum);
+                continue;
+            }
+            DatasetPlan datasetPlan = datasetPlan(singleSourceDataset(testCase.query));
+            if (datasetPlan == null || datasetPlan.analyzer() == null) {
+                skipByReason.merge(Skip.DATASET_UNAVAILABLE, 1, Integer::sum);
+                continue;
+            }
+
+            AstKeywordFieldRewriter.RewriteResult rewrite = AstKeywordFieldRewriter.rewrite(
+                testCase.query,
+                q -> datasetPlan.keywordPaths(),
+                KeywordToFlattenedTransformer.WRAPPER_SUBKEY,
+                List.of()
+            );
+            if (rewrite.modified() == false) {
+                skipByReason.merge(Skip.NO_KEYWORD_REFS, 1, Integer::sum);
+                continue;
+            }
+
+            PhysicalPlan dataNode;
+            try {
+                dataNode = dataNodeFragment(datasetPlan.analyzer(), rewrite.rewrittenQuery());
+            } catch (Exception e) {
+                skipByReason.merge(Skip.UNPLANNABLE, 1, Integer::sum);
+                logger.debug(() -> "keyword\u2192flattened dry run: unplannable [" + rewrite.rewrittenQuery() + "]", e);
+                continue;
+            }
+            if (dataNode == null) {
+                skipByReason.merge(Skip.NO_DATA_NODE_FRAGMENT, 1, Integer::sum);
+                continue;
+            }
+
+            Inventory inv = walk(dataNode, TEST_SEARCH_STATS);
+            fused += inv.fused();
+            inv.fallbackByReason().forEach((reason, count) -> fallbackByReason.merge(reason, count, Integer::sum));
+            measuredQueries++;
+        }
+
+        logReport(measuredQueries, fused, fallbackByReason, skipByReason);
+
+        assertThat("corpus dry run must plan at least some single-dataset queries", measuredQueries, greaterThan(0));
+        assertThat("field_extract must fuse for at least some real corpus shapes", fused, greaterThan(0));
+    }
+
+    // ---- per test-case gating --------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link Skip} reason if the test case is out of scope for the offline single-dataset dry run, or
+     * {@code null} if it should be measured. Kept before the (more expensive) analyzer/rewrite steps.
+     */
+    private static Skip trySkip(CsvSpecReader.CsvTestCase testCase) {
+        if (testCase.skipFlattenedRewrite != null && testCase.skipFlattenedRewrite.isBlank() == false) {
+            return Skip.SILENCED;
+        }
+        if (singleSourceDataset(testCase.query) == null) {
+            return Skip.NOT_SINGLE_DATASET;
+        }
+        return null;
+    }
+
+    /**
+     * The single {@link CsvTestsDataLoader.TestDataset} a query reads, or {@code null} when the query is not a clean
+     * single-dataset {@code FROM <known index>} (multi-index, cross-cluster, wildcard, subquery, or a command that
+     * adds a second source). The offline analyzer only carries one index resolution, so anything else is skipped.
+     */
+    private static CsvTestsDataLoader.TestDataset singleSourceDataset(String query) {
+        Matcher matcher = LEADING_FROM.matcher(query);
+        if (matcher.find() == false) {
+            return null;
+        }
+        String token = matcher.group(1);
+        if (token.indexOf('*') >= 0 || token.indexOf(':') >= 0) {
+            return null; // wildcard or cross-cluster pattern
+        }
+        // Reject multi-index FROM (a comma anywhere in the source list before the first pipe).
+        int firstPipe = query.indexOf('|');
+        String fromClause = firstPipe < 0 ? query : query.substring(0, firstPipe);
+        if (fromClause.indexOf(',') >= 0 || fromClause.indexOf('(') >= 0) {
+            return null;
+        }
+        if (MULTI_SOURCE.matcher(query).find()) {
+            return null;
+        }
+        CsvTestsDataLoader.TestDataset dataset = CsvTestsDataLoader.CSV_DATASET.get(token);
+        if (dataset == null || dataset.mappingFileName() == null) {
+            return null;
+        }
+        return dataset;
+    }
+
+    // ---- offline analyzer construction -----------------------------------------------------------------
+
+    /** Builds (and caches) the offline analyzer + keyword-path set for a dataset; caches unusable datasets as {@code null} analyzer. */
+    private DatasetPlan datasetPlan(CsvTestsDataLoader.TestDataset dataset) {
+        if (dataset == null) {
+            return null;
+        }
+        return datasetPlans.computeIfAbsent(dataset.indexName(), name -> {
+            try {
+                String originalMapping = CsvTestsDataLoader.readMappingFile(dataset);
+                Set<String> keywordPaths = new HashSet<>();
+                collectKeywordPaths("", LoadMapping.loadMapping(stream(originalMapping)), keywordPaths);
+
+                String flattened = KeywordToFlattenedTransformer.transformMapping(originalMapping, Set.of()).transformedMapping();
+                Map<String, EsField> flattenedFields = LoadMapping.loadMapping(stream(flattened));
+                EsIndex index = new EsIndex(name, flattenedFields, Map.of(name, IndexMode.STANDARD), Map.of(), Map.of());
+                Map<IndexPattern, IndexResolution> resolutions = Map.of(new IndexPattern(Source.EMPTY, name), IndexResolution.valid(index));
+                Analyzer analyzer = new Analyzer(
+                    testAnalyzerContext(TEST_CFG, TEST_FUNCTION_REGISTRY, resolutions, new EnrichResolution(), emptyInferenceResolution()),
+                    TEST_VERIFIER
+                );
+                return new DatasetPlan(analyzer, keywordPaths);
+            } catch (Exception e) {
+                logger.debug(() -> "keyword\u2192flattened dry run: cannot build analyzer for [" + name + "]", e);
+                return new DatasetPlan(null, Set.of());
+            }
+        });
+    }
+
+    private static ByteArrayInputStream stream(String json) {
+        return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Recursively collects the dotted paths of every {@code KEYWORD}-typed field, matching what the transform flattens. */
+    private static void collectKeywordPaths(String prefix, Map<String, EsField> fields, Set<String> out) {
+        for (Map.Entry<String, EsField> entry : fields.entrySet()) {
+            EsField field = entry.getValue();
+            String path = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+            if (field.getDataType() == DataType.KEYWORD) {
+                out.add(path);
+            }
+            if (field.getProperties().isEmpty() == false) {
+                collectKeywordPaths(path, field.getProperties(), out);
+            }
+        }
+    }
+
+    // ---- planning --------------------------------------------------------------------------------------
+
+    /**
+     * Analyzes, optimizes and localizes a query, then returns just the data-node fragment (below the exchange), which
+     * is where {@code PushExpressionsToFieldLoad} runs. Returns {@code null} when there is no data-node fragment.
+     * Mirrors the pipeline in {@code TestPlannerOptimizer} (which lives in the unit-test source set and is not visible
+     * here), minus the local-reduction alignment that does not affect field-load fusion.
+     */
+    private PhysicalPlan dataNodeFragment(Analyzer analyzer, String query) {
+        var minVersion = analyzer.context().minimumVersion();
+        var logicalOptimizer = new LogicalPlanOptimizer(new LogicalOptimizerContext(TEST_CFG, FoldContext.small(), minVersion));
+        var physicalOptimizer = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(TEST_CFG, minVersion));
+        var localLogical = new LocalLogicalPlanOptimizer(
+            new LocalLogicalOptimizerContext(TEST_CFG, FoldContext.small(), TEST_SEARCH_STATS)
+        );
+        var localPhysical = new LocalPhysicalPlanOptimizer(
+            new LocalPhysicalOptimizerContext(
+                PlannerSettings.DEFAULTS,
+                new EsqlFlags(true),
+                TEST_CFG,
+                FoldContext.small(),
+                TEST_SEARCH_STATS
+            )
+        );
+
+        LogicalPlan logical = logicalOptimizer.optimize(analyzer.analyze(EsqlTestUtils.TEST_PARSER.parseQuery(query)));
+        PhysicalPlan physical = new Mapper().map(new Versioned<>(logical, minVersion));
+        physical = EstimatesRowSize.estimateRowSize(0, physicalOptimizer.optimize(physical));
+        PhysicalPlan localized = PlannerUtils.localPlan(physical, localLogical, localPhysical, null);
+
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(localized, TEST_CFG);
+        return split.v2();
+    }
+
+    // ---- walker (ported from FieldExtractFusionInventoryTests) -----------------------------------------
+
+    /** Outcome of walking one data-node fragment: how many loads fused, and the fallback bucket histogram. */
+    record Inventory(int fused, Map<Fusion, Integer> fallbackByReason) {}
+
+    private Inventory walk(PhysicalPlan plan, SearchStats stats) {
+        Set<String> fused = new HashSet<>();
+        Map<Fusion, Integer> fallbackByReason = new EnumMap<>(Fusion.class);
+        Set<FieldExtract> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        plan.forEachDown(PhysicalPlan.class, node -> {
+            node.forEachExpressionDown(FieldAttribute.class, fa -> {
+                if (fa.field() instanceof FunctionEsField fe
+                    && fe.functionConfig() != null
+                    && fe.functionConfig().function() == BlockLoaderFunctionConfig.Function.EXTRACT_FLATTENED_SUBFIELD) {
+                    fused.add(fa.name());
+                }
+            });
+            node.forEachExpressionDown(FieldExtract.class, fx -> {
+                if (seen.add(fx)) {
+                    fallbackByReason.merge(classify(fx, stats), 1, Integer::sum);
+                }
+            });
+        });
+        return new Inventory(fused.size(), fallbackByReason);
+    }
+
+    /**
+     * Re-derives the fusion decision for a residual {@link FieldExtract}, mirroring the gate order in
+     * {@code PushExpressionsToFieldLoad#transformExpression}. Identical to the classifier in
+     * {@code FieldExtractFusionInventoryTests}.
+     */
+    private Fusion classify(FieldExtract fx, SearchStats stats) {
+        PushedBlockLoaderExpression fuse = fx.tryPushToFieldLoading(stats);
+        if (fuse == null) {
+            Expression pathArg = fx.children().get(1);
+            return pathArg.foldable() ? Fusion.NON_FLATTENED_INPUT : Fusion.DYNAMIC_KEY;
+        }
+        if (fuse.field().field() instanceof UnionTypeEsField) {
+            return Fusion.UNION_TYPE;
+        }
+        if (stats.supportsLoaderConfig(fuse.field().fieldName(), fuse.config(), MappedFieldType.FieldExtractPreference.NONE) == false) {
+            return Fusion.UNSUPPORTED_LOADER_CONFIG;
+        }
+        return Fusion.ABOVE_JOIN_OR_MULTISOURCE;
+    }
+
+    // ---- corpus enumeration + reporting ----------------------------------------------------------------
+
+    /** Loads every csv-spec test case on the classpath, the same way {@link CsvFlattenedKeywordIT} does. */
+    private static List<CsvSpecReader.CsvTestCase> loadAllCsvSpecTestCases() {
+        try {
+            List<URL> urls = classpathResources("/*.csv-spec");
+            List<Object[]> rows = SpecReader.readScriptSpec(urls, CsvSpecReader::specParser);
+            List<CsvSpecReader.CsvTestCase> cases = new ArrayList<>(rows.size());
+            for (Object[] row : rows) {
+                if (row[4] instanceof CsvSpecReader.CsvTestCase tc) {
+                    cases.add(tc);
+                }
+            }
+            return cases;
+        } catch (Exception e) {
+            throw new AssertionError("failed to enumerate csv-spec resources", e);
+        }
+    }
+
+    private static void logReport(int measured, int fused, Map<Fusion, Integer> fallbackByReason, Map<Skip, Integer> skipByReason) {
+        int fallback = fallbackByReason.values().stream().mapToInt(Integer::intValue).sum();
+        StringBuilder report = new StringBuilder("field_extract corpus fusion inventory: ").append(measured)
+            .append(" measured queries, ")
+            .append(fused)
+            .append(" fused, ")
+            .append(fallback)
+            .append(" fallback");
+        fallbackByReason.forEach((reason, count) -> report.append(", ").append(reason).append('=').append(count));
+        logger.info(report.toString());
+
+        StringBuilder skips = new StringBuilder("field_extract corpus fusion inventory (skipped)");
+        // EnumMap iterates in declaration order; copy into a TreeMap keyed by name only to keep the log stable if reordered.
+        Map<String, Integer> stable = new TreeMap<>();
+        skipByReason.forEach((reason, count) -> stable.put(reason.name(), count));
+        stable.forEach((reason, count) -> skips.append(": ").append(reason).append('=').append(count));
+        logger.info(skips.toString());
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -109,6 +110,12 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     /** Leading {@code FROM <index>} of a query; the capture group is the first index token. */
     private static final Pattern LEADING_FROM = Pattern.compile("^\\s*FROM\\s+([A-Za-z0-9_.\\-]+)", Pattern.CASE_INSENSITIVE);
 
+    /** Leading source command keyword of a query (e.g. {@code FROM}, {@code TS}, {@code ROW}, {@code SHOW}). */
+    private static final Pattern LEADING_COMMAND = Pattern.compile("^\\s*([A-Za-z]+)");
+
+    /** One or more leading {@code SET <name> = <value>;} pragmas, stripped before the real source is classified. */
+    private static final Pattern SET_PREAMBLE = Pattern.compile("^(?:\\s*SET\\b[^;]*;)+", Pattern.CASE_INSENSITIVE);
+
     /**
      * Commands that introduce a second source the offline analyzer cannot resolve. {@code LOOKUP JOIN} is deliberately
      * absent: every {@code lookup-settings.json} dataset is pre-resolved into the shared lookup map (see
@@ -151,6 +158,32 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         NO_DATA_NODE_FRAGMENT
     }
 
+    /**
+     * Sub-reason for a {@link Skip#NOT_SINGLE_DATASET} query, so the (large) catch-all bucket can be prioritised for
+     * further widening. Exactly one applies per rejected query, tested in the same order as {@link #classifySource}.
+     */
+    enum NotSingle {
+        /** Query does not start with {@code FROM} (e.g. {@code ROW}, {@code SHOW}, {@code TS}, {@code EXPLAIN}). */
+        NON_FROM_START,
+        /** Leading source token is a wildcard ({@code *}) or cross-cluster ({@code remote:index}) pattern. */
+        WILDCARD_OR_REMOTE,
+        /** Multi-index {@code FROM a, b} or a sub-query source (comma/paren before the first pipe). */
+        MULTI_INDEX_FROM,
+        /** Contains an {@code ENRICH} the offline harness cannot resolve (no enrich policy resolution built). */
+        ENRICH,
+        /** Contains a {@code FORK}, which fans out into multiple sub-plans. */
+        FORK,
+        /** Leading {@code FROM <token>} names an index with no known/loadable dataset mapping. */
+        UNKNOWN_INDEX
+    }
+
+    /**
+     * Result of classifying a query's source: exactly one of {@code dataset} (measurable) or {@code reason} is non-null.
+     * {@code mode} is the {@link IndexMode} the source reads with ({@link IndexMode#STANDARD} for {@code FROM},
+     * {@link IndexMode#TIME_SERIES} for {@code TS}); it is only meaningful when {@code dataset} is non-null.
+     */
+    private record SourceClass(CsvTestsDataLoader.TestDataset dataset, IndexMode mode, NotSingle reason) {}
+
     /** Per-dataset offline analyzer plus the keyword paths the rewriter should wrap. {@code null} analyzer means unusable. */
     private record DatasetPlan(Analyzer analyzer, Set<String> keywordPaths) {}
 
@@ -176,24 +209,39 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         int fused = 0;
         Map<Fusion, Integer> fallbackByReason = new EnumMap<>(Fusion.class);
         Map<Skip, Integer> skipByReason = new EnumMap<>(Skip.class);
+        // Breakdown of the (large) NOT_SINGLE_DATASET bucket, to prioritise which shape to widen coverage to next.
+        Map<NotSingle, Integer> notSingleByReason = new EnumMap<>(NotSingle.class);
+        // Further split of NON_FROM_START by leading command (TS/ROW/SHOW/...), since only index-reading sources fuse.
+        Map<String, Integer> nonFromLeadingCommand = new TreeMap<>();
         // A few representative rewritten queries per fallback bucket, so each residual is directly inspectable.
         Map<Fusion, List<String>> fallbackSamples = new EnumMap<>(Fusion.class);
         int measuredQueries = 0;
 
         for (CsvSpecReader.CsvTestCase testCase : loadAllCsvSpecTestCases()) {
-            Skip skip = trySkip(testCase);
-            if (skip != null) {
-                skipByReason.merge(skip, 1, Integer::sum);
+            if (testCase.skipFlattenedRewrite != null && testCase.skipFlattenedRewrite.isBlank() == false) {
+                skipByReason.merge(Skip.SILENCED, 1, Integer::sum);
                 continue;
             }
-            DatasetPlan datasetPlan = datasetPlan(singleSourceDataset(testCase.query));
+            // Drop any leading SET pragmas (e.g. SET unmapped_fields="nullify";) so the real FROM/TS source is classified
+            // and planned; the dropped pragma is orthogonal to field_extract fusion on mapped keyword fields.
+            String query = stripSetPreamble(testCase.query);
+            SourceClass source = classifySource(query);
+            if (source.dataset() == null) {
+                skipByReason.merge(Skip.NOT_SINGLE_DATASET, 1, Integer::sum);
+                notSingleByReason.merge(source.reason(), 1, Integer::sum);
+                if (source.reason() == NotSingle.NON_FROM_START) {
+                    nonFromLeadingCommand.merge(leadingCommand(query), 1, Integer::sum);
+                }
+                continue;
+            }
+            DatasetPlan datasetPlan = datasetPlan(source.dataset(), source.mode());
             if (datasetPlan == null || datasetPlan.analyzer() == null) {
                 skipByReason.merge(Skip.DATASET_UNAVAILABLE, 1, Integer::sum);
                 continue;
             }
 
             AstKeywordFieldRewriter.RewriteResult rewrite = AstKeywordFieldRewriter.rewrite(
-                testCase.query,
+                query,
                 q -> datasetPlan.keywordPaths(),
                 KeywordToFlattenedTransformer.WRAPPER_SUBKEY,
                 List.of()
@@ -228,7 +276,7 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
             measuredQueries++;
         }
 
-        logReport(measuredQueries, fused, fallbackByReason, skipByReason, fallbackSamples);
+        logReport(measuredQueries, fused, fallbackByReason, skipByReason, notSingleByReason, nonFromLeadingCommand, fallbackSamples);
 
         assertThat("corpus dry run must plan at least some single-dataset queries", measuredQueries, greaterThan(0));
         assertThat("field_extract must fuse for at least some real corpus shapes", fused, greaterThan(0));
@@ -237,58 +285,92 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     // ---- per test-case gating --------------------------------------------------------------------------
 
     /**
-     * Returns a {@link Skip} reason if the test case is out of scope for the offline single-dataset dry run, or
-     * {@code null} if it should be measured. Kept before the (more expensive) analyzer/rewrite steps.
+     * Classifies a query's source into either the single {@link CsvTestsDataLoader.TestDataset} it reads (measurable),
+     * or a {@link NotSingle} reason it is out of scope. Kept in one place so the reject reasons stay mutually exclusive
+     * and the {@link Skip#NOT_SINGLE_DATASET} bucket can be broken down for prioritising further widening. Both
+     * {@code FROM <index>} and {@code TS <index>} (time-series) are treated as single-source reads; the index name may
+     * be quoted or backtick-quoted. A trailing {@code LOOKUP JOIN} stays in scope (resolved from {@link #lookupResolutions()}).
      */
-    private static Skip trySkip(CsvSpecReader.CsvTestCase testCase) {
-        if (testCase.skipFlattenedRewrite != null && testCase.skipFlattenedRewrite.isBlank() == false) {
-            return Skip.SILENCED;
+    private static SourceClass classifySource(String query) {
+        Matcher command = LEADING_COMMAND.matcher(query);
+        if (command.find() == false) {
+            return new SourceClass(null, null, NotSingle.NON_FROM_START);
         }
-        if (singleSourceDataset(testCase.query) == null) {
-            return Skip.NOT_SINGLE_DATASET;
+        IndexMode mode = switch (command.group(1).toUpperCase(Locale.ROOT)) {
+            case "FROM" -> IndexMode.STANDARD;
+            case "TS" -> IndexMode.TIME_SERIES;
+            default -> null;
+        };
+        if (mode == null) {
+            return new SourceClass(null, null, NotSingle.NON_FROM_START);
         }
-        return null;
-    }
-
-    /**
-     * The single {@link CsvTestsDataLoader.TestDataset} a query reads from its leading {@code FROM}, or {@code null}
-     * when that source is not a clean single {@code FROM <known index>} (multi-index, cross-cluster, wildcard, subquery,
-     * or an {@code ENRICH}/{@code FORK} that the offline analyzer cannot resolve). A trailing {@code LOOKUP JOIN} is
-     * allowed: its target is resolved from the shared lookup map ({@link #lookupResolutions()}), not the main source.
-     */
-    private static CsvTestsDataLoader.TestDataset singleSourceDataset(String query) {
-        Matcher matcher = LEADING_FROM.matcher(query);
-        if (matcher.find() == false) {
-            return null;
-        }
-        String token = matcher.group(1);
-        if (token.indexOf('*') >= 0 || token.indexOf(':') >= 0) {
-            return null; // wildcard or cross-cluster pattern
-        }
-        // Reject multi-index FROM (a comma anywhere in the source list before the first pipe).
+        // The source list runs from the end of the command keyword to the first pipe (or end of query).
         int firstPipe = query.indexOf('|');
-        String fromClause = firstPipe < 0 ? query : query.substring(0, firstPipe);
-        if (fromClause.indexOf(',') >= 0 || fromClause.indexOf('(') >= 0) {
-            return null;
+        String sourceList = (firstPipe < 0 ? query.substring(command.end()) : query.substring(command.end(), firstPipe)).trim();
+        // Reject multi-index sources and sub-query sources (a comma or open paren in the source list).
+        if (sourceList.indexOf(',') >= 0 || sourceList.indexOf('(') >= 0) {
+            return new SourceClass(null, null, NotSingle.MULTI_INDEX_FROM);
         }
-        if (MULTI_SOURCE.matcher(query).find()) {
-            return null;
+        String token = unquoteIndexToken(sourceList);
+        if (token.indexOf('*') >= 0 || token.indexOf(':') >= 0) {
+            return new SourceClass(null, null, NotSingle.WILDCARD_OR_REMOTE);
+        }
+        Matcher multiSource = MULTI_SOURCE.matcher(query);
+        if (multiSource.find()) {
+            boolean fork = multiSource.group(1).equalsIgnoreCase("FORK");
+            return new SourceClass(null, null, fork ? NotSingle.FORK : NotSingle.ENRICH);
         }
         CsvTestsDataLoader.TestDataset dataset = CsvTestsDataLoader.CSV_DATASET.get(token);
         if (dataset == null || dataset.mappingFileName() == null) {
-            return null;
+            return new SourceClass(null, null, NotSingle.UNKNOWN_INDEX);
         }
-        return dataset;
+        return new SourceClass(dataset, mode, null);
+    }
+
+    /**
+     * Extracts the single index name from a source list: strips surrounding quotes/backticks and any trailing options
+     * (e.g. {@code METADATA _id}). Returns the bare token, which the caller matches against known datasets.
+     */
+    private static String unquoteIndexToken(String sourceList) {
+        String token = sourceList;
+        if (token.isEmpty() == false) {
+            char first = token.charAt(0);
+            if (first == '"' || first == '\'' || first == '`') {
+                int close = token.indexOf(first, 1);
+                token = close > 0 ? token.substring(1, close) : token.substring(1);
+                return token;
+            }
+        }
+        int space = token.indexOf(' ');
+        return space >= 0 ? token.substring(0, space) : token;
+    }
+
+    /** The leading command keyword of a query, upper-cased (e.g. {@code TS}, {@code ROW}); {@code "?"} if none matches. */
+    private static String leadingCommand(String query) {
+        Matcher matcher = LEADING_COMMAND.matcher(query);
+        return matcher.find() ? matcher.group(1).toUpperCase(Locale.ROOT) : "?";
+    }
+
+    /** Removes any leading {@code SET ...;} pragmas so the real {@code FROM}/{@code TS} source can be classified/planned. */
+    private static String stripSetPreamble(String query) {
+        return SET_PREAMBLE.matcher(query).replaceFirst("").stripLeading();
     }
 
     // ---- offline analyzer construction -----------------------------------------------------------------
 
-    /** Builds (and caches) the offline analyzer + keyword-path set for a dataset; caches unusable datasets as {@code null} analyzer. */
-    private DatasetPlan datasetPlan(CsvTestsDataLoader.TestDataset dataset) {
+    /**
+     * Builds (and caches) the offline analyzer + keyword-path set for a dataset read in the given {@link IndexMode}
+     * ({@link IndexMode#STANDARD} for {@code FROM}, {@link IndexMode#TIME_SERIES} for {@code TS}). The cache key includes
+     * the mode, since the same dataset planned as time-series needs a different index resolution. Unusable datasets are
+     * cached with a {@code null} analyzer.
+     */
+    private DatasetPlan datasetPlan(CsvTestsDataLoader.TestDataset dataset, IndexMode mode) {
         if (dataset == null) {
             return null;
         }
-        return datasetPlans.computeIfAbsent(dataset.indexName(), name -> {
+        String cacheKey = dataset.indexName() + '|' + mode;
+        return datasetPlans.computeIfAbsent(cacheKey, key -> {
+            String name = dataset.indexName();
             try {
                 String originalMapping = CsvTestsDataLoader.readMappingFile(dataset);
                 Set<String> keywordPaths = new HashSet<>();
@@ -296,7 +378,7 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
 
                 String flattened = KeywordToFlattenedTransformer.transformMapping(originalMapping, Set.of()).transformedMapping();
                 Map<String, EsField> flattenedFields = LoadMapping.loadMapping(stream(flattened));
-                EsIndex index = new EsIndex(name, flattenedFields, Map.of(name, IndexMode.STANDARD), Map.of(), Map.of());
+                EsIndex index = new EsIndex(name, flattenedFields, Map.of(name, mode), Map.of(), Map.of());
                 Map<IndexPattern, IndexResolution> resolutions = Map.of(new IndexPattern(Source.EMPTY, name), IndexResolution.valid(index));
                 Analyzer analyzer = new Analyzer(
                     testAnalyzerContext(
@@ -475,6 +557,8 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         int fused,
         Map<Fusion, Integer> fallbackByReason,
         Map<Skip, Integer> skipByReason,
+        Map<NotSingle, Integer> notSingleByReason,
+        Map<String, Integer> nonFromLeadingCommand,
         Map<Fusion, List<String>> fallbackSamples
     ) {
         int fallback = fallbackByReason.values().stream().mapToInt(Integer::intValue).sum();
@@ -493,6 +577,14 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         skipByReason.forEach((reason, count) -> stable.put(reason.name(), count));
         stable.forEach((reason, count) -> skips.append(": ").append(reason).append('=').append(count));
         logger.info(skips.toString());
+
+        StringBuilder notSingle = new StringBuilder("field_extract corpus fusion inventory (not-single-dataset breakdown)");
+        notSingleByReason.forEach((reason, count) -> notSingle.append(": ").append(reason).append('=').append(count));
+        logger.info(notSingle.toString());
+
+        StringBuilder nonFrom = new StringBuilder("field_extract corpus fusion inventory (non-FROM leading command)");
+        nonFromLeadingCommand.forEach((cmd, count) -> nonFrom.append(": ").append(cmd).append('=').append(count));
+        logger.info(nonFrom.toString());
 
         // One log line per sampled fallback query, so each residual bucket is directly inspectable.
         fallbackSamples.forEach((reason, samples) -> {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -14,12 +14,13 @@ import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
-import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
-import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
@@ -37,7 +38,7 @@ import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
-import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
@@ -71,8 +72,6 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_SEARCH_STATS;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.classpathResources;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.testAnalyzerContext;
 import static org.hamcrest.Matchers.greaterThan;
 
 /**
@@ -119,13 +118,13 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     private static final Pattern SET_PREAMBLE = Pattern.compile("^(?:\\s*SET\\b[^;]*;)+", Pattern.CASE_INSENSITIVE);
 
     /**
-     * Commands that introduce a second source the offline analyzer cannot resolve. {@code LOOKUP JOIN} is deliberately
-     * absent: every {@code lookup-settings.json} dataset is pre-resolved into the shared lookup map (see
-     * {@link #lookupResolutions()}), so join shapes are measured (and are where the real {@code ABOVE_JOIN_OR_MULTISOURCE}
-     * fallbacks surface). {@code ENRICH} still needs an enrich policy resolution the harness does not build, and
-     * {@code FORK} fans out into multiple sub-plans, so both remain out of scope.
+     * Commands that introduce a second source the offline analyzer cannot resolve. Both {@code LOOKUP JOIN} and
+     * {@code ENRICH} are deliberately absent: every {@code lookup-settings.json} dataset is pre-resolved into the shared
+     * lookup map ({@link #lookupResolutions()}) and every corpus enrich policy into the analyzer's enrich resolution
+     * ({@link #registerCorpusEnrichPolicies}), so both shapes are measured. Only {@code FORK}, which fans out into
+     * multiple sub-plans, remains out of scope here.
      */
-    private static final Pattern MULTI_SOURCE = Pattern.compile("\\b(ENRICH|FORK)\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern MULTI_SOURCE = Pattern.compile("\\bFORK\\b", Pattern.CASE_INSENSITIVE);
 
     /** How many representative rewritten queries to log per fallback bucket. */
     private static final int MAX_SAMPLES_PER_REASON = 5;
@@ -171,8 +170,6 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         WILDCARD_OR_REMOTE,
         /** Multi-index {@code FROM a, b} or a sub-query source (comma/paren before the first pipe). */
         MULTI_INDEX_FROM,
-        /** Contains an {@code ENRICH} the offline harness cannot resolve (no enrich policy resolution built). */
-        ENRICH,
         /** Contains a {@code FORK}, which fans out into multiple sub-plans. */
         FORK,
         /** Leading {@code FROM <token>} names an index with no known/loadable dataset mapping. */
@@ -262,7 +259,9 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
             PhysicalPlan dataNode;
             try {
                 dataNode = dataNodeFragment(datasetPlan.analyzer(), rewrite.rewrittenQuery());
-            } catch (Exception e) {
+            } catch (Exception | AssertionError e) {
+                // Analysis/planning of an arbitrary corpus query can throw either (e.g. the analyzer asserts on an
+                // unresolved enrich mode); treat any such failure as unplannable rather than a harness error.
                 skipByReason.merge(Skip.UNPLANNABLE, 1, Integer::sum);
                 logger.debug(() -> "keyword\u2192flattened dry run: unplannable [" + rewrite.rewrittenQuery() + "]", e);
                 continue;
@@ -297,8 +296,9 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
      * {@link NotSingle} reason it is out of scope. Kept in one place so the reject reasons stay mutually exclusive and
      * the {@link Skip#NOT_SINGLE_DATASET} bucket can be broken down for prioritising further widening. {@code FROM} and
      * {@code TS} (time-series) sources are in scope, including multi-index {@code FROM a, b} (merged into one resolution
-     * with union types for conflicting fields); index names may be quoted. A trailing {@code LOOKUP JOIN} stays in scope
-     * (resolved from {@link #lookupResolutions()}); {@code ENRICH}/{@code FORK} and cross-cluster/wildcard remain out.
+     * with union types for conflicting fields); index names may be quoted. Trailing {@code LOOKUP JOIN} and {@code ENRICH}
+     * stay in scope (resolved from {@link #lookupResolutions()} / the analyzer's enrich resolution); only {@code FORK} and
+     * cross-cluster/wildcard sources remain out.
      */
     private static SourceClass classifySource(String query) {
         Matcher command = LEADING_COMMAND.matcher(query);
@@ -320,10 +320,9 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         if (sourceList.indexOf('(') >= 0) {
             return SourceClass.rejected(NotSingle.MULTI_INDEX_FROM);
         }
-        // ENRICH/FORK anywhere in the query need resolution the harness does not build, regardless of the source shape.
-        Matcher multiSource = MULTI_SOURCE.matcher(query);
-        if (multiSource.find()) {
-            return SourceClass.rejected(multiSource.group(1).equalsIgnoreCase("FORK") ? NotSingle.FORK : NotSingle.ENRICH);
+        // FORK fans out into multiple sub-plans the harness does not model, regardless of the source shape.
+        if (MULTI_SOURCE.matcher(query).find()) {
+            return SourceClass.rejected(NotSingle.FORK);
         }
         List<CsvTestsDataLoader.TestDataset> datasets = new ArrayList<>();
         List<String> names = new ArrayList<>();
@@ -398,22 +397,14 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
                 }
                 Map<String, EsField> fields = mergeFields(perIndexFields);
                 EsIndex index = new EsIndex(source.indexPattern(), fields, concreteIndices, Map.of(), Map.of());
-                Map<IndexPattern, IndexResolution> resolutions = Map.of(
-                    new IndexPattern(Source.EMPTY, source.indexPattern()),
-                    IndexResolution.valid(index)
-                );
-                Analyzer analyzer = new Analyzer(
-                    testAnalyzerContext(
-                        TEST_CFG,
-                        TEST_FUNCTION_REGISTRY,
-                        resolutions,
-                        lookupResolutions(),
-                        new EnrichResolution(),
-                        emptyInferenceResolution()
-                    ),
-                    TEST_VERIFIER
-                );
-                return new DatasetPlan(analyzer, keywordPaths);
+
+                // TestAnalyzer defers enrich resolution until analyze(), keying each ENRICH occurrence by its Source the way
+                // production does, so registering every corpus policy up front resolves whichever ones a query uses.
+                TestAnalyzer builder = EsqlTestUtils.analyzer().configuration(TEST_CFG).functionRegistry(TEST_FUNCTION_REGISTRY);
+                builder.addIndex(source.indexPattern(), IndexResolution.valid(index));
+                lookupResolutions().values().forEach(builder::addLookupIndex);
+                registerCorpusEnrichPolicies(builder);
+                return new DatasetPlan(builder.buildAnalyzer(TEST_VERIFIER), keywordPaths);
             } catch (Exception e) {
                 logger.debug(() -> "keyword\u2192flattened dry run: cannot build analyzer for [" + key + "]", e);
                 return new DatasetPlan(null, Set.of());
@@ -449,6 +440,45 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
             }
         });
         return merged;
+    }
+
+    /**
+     * Registers every corpus enrich policy ({@link CsvTestsDataLoader#ENRICH_POLICIES}) into the analyzer builder, so
+     * queries containing {@code ENRICH <policy>} resolve offline. The match type and field come from the policy JSON;
+     * the enrich-field types come from the source index mapping ({@link TestAnalyzer#addEnrichPolicy} derives the enrich
+     * fields as every mapped field except the match field). Each policy is registered under all {@link Enrich.Mode}s, so
+     * bare {@code ENRICH policy} as well as {@code _coordinator:}/{@code _remote:} pinned occurrences resolve (an
+     * unregistered mode would make the analyzer assert on an unresolved policy rather than fail softly). Registration is
+     * best-effort per policy: one whose JSON or mapping cannot be read is skipped rather than breaking the whole analyzer.
+     */
+    private static void registerCorpusEnrichPolicies(TestAnalyzer builder) {
+        for (CsvTestsDataLoader.EnrichConfig policy : CsvTestsDataLoader.ENRICH_POLICIES.values()) {
+            try {
+                String matchType;
+                String matchField;
+                try (
+                    XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, policy.loadPolicy())
+                ) {
+                    parser.nextToken(); // START_OBJECT
+                    parser.nextToken(); // FIELD_NAME: the match type (match / range / geo_match)
+                    matchType = parser.currentName();
+                    parser.nextToken(); // START_OBJECT: the policy body
+                    matchField = (String) parser.map().get("match_field");
+                }
+                for (Enrich.Mode mode : Enrich.Mode.values()) {
+                    builder.addEnrichPolicy(
+                        mode,
+                        matchType,
+                        policy.policyName(),
+                        matchField,
+                        policy.index(),
+                        "mapping-" + policy.index() + ".json"
+                    );
+                }
+            } catch (Exception e) {
+                logger.debug(() -> "keyword\u2192flattened dry run: cannot register enrich policy [" + policy.policyName() + "]", e);
+            }
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -112,6 +112,9 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     /** Commands that introduce a second source or need extra resolution the single-dataset analyzer does not carry. */
     private static final Pattern MULTI_SOURCE = Pattern.compile("\\b(JOIN|ENRICH|FORK)\\b", Pattern.CASE_INSENSITIVE);
 
+    /** How many representative rewritten queries to log per fallback bucket. */
+    private static final int MAX_SAMPLES_PER_REASON = 5;
+
     /**
      * Why a {@code field_extract} did not fuse. Each non-{@link #FUSED} value corresponds to one gate in
      * {@code PushExpressionsToFieldLoad#transformExpression}, in the order they are checked. Mirrors the enum in
@@ -164,6 +167,8 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         int fused = 0;
         Map<Fusion, Integer> fallbackByReason = new EnumMap<>(Fusion.class);
         Map<Skip, Integer> skipByReason = new EnumMap<>(Skip.class);
+        // A few representative rewritten queries per fallback bucket, so each residual is directly inspectable.
+        Map<Fusion, List<String>> fallbackSamples = new EnumMap<>(Fusion.class);
         int measuredQueries = 0;
 
         for (CsvSpecReader.CsvTestCase testCase : loadAllCsvSpecTestCases()) {
@@ -204,11 +209,17 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
 
             Inventory inv = walk(dataNode, TEST_SEARCH_STATS);
             fused += inv.fused();
-            inv.fallbackByReason().forEach((reason, count) -> fallbackByReason.merge(reason, count, Integer::sum));
+            inv.fallbackByReason().forEach((reason, count) -> {
+                fallbackByReason.merge(reason, count, Integer::sum);
+                List<String> samples = fallbackSamples.computeIfAbsent(reason, k -> new ArrayList<>());
+                if (samples.size() < MAX_SAMPLES_PER_REASON) {
+                    samples.add(collapseWhitespace(rewrite.rewrittenQuery()));
+                }
+            });
             measuredQueries++;
         }
 
-        logReport(measuredQueries, fused, fallbackByReason, skipByReason);
+        logReport(measuredQueries, fused, fallbackByReason, skipByReason, fallbackSamples);
 
         assertThat("corpus dry run must plan at least some single-dataset queries", measuredQueries, greaterThan(0));
         assertThat("field_extract must fuse for at least some real corpus shapes", fused, greaterThan(0));
@@ -407,7 +418,13 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         }
     }
 
-    private static void logReport(int measured, int fused, Map<Fusion, Integer> fallbackByReason, Map<Skip, Integer> skipByReason) {
+    private static void logReport(
+        int measured,
+        int fused,
+        Map<Fusion, Integer> fallbackByReason,
+        Map<Skip, Integer> skipByReason,
+        Map<Fusion, List<String>> fallbackSamples
+    ) {
         int fallback = fallbackByReason.values().stream().mapToInt(Integer::intValue).sum();
         StringBuilder report = new StringBuilder("field_extract corpus fusion inventory: ").append(measured)
             .append(" measured queries, ")
@@ -424,5 +441,16 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
         skipByReason.forEach((reason, count) -> stable.put(reason.name(), count));
         stable.forEach((reason, count) -> skips.append(": ").append(reason).append('=').append(count));
         logger.info(skips.toString());
+
+        // One log line per sampled fallback query, so each residual bucket is directly inspectable.
+        fallbackSamples.forEach((reason, samples) -> {
+            for (String sample : samples) {
+                logger.info("field_extract fallback sample [{}]: {}", reason, sample);
+            }
+        });
+    }
+
+    private static String collapseWhitespace(String query) {
+        return query.replaceAll("\\s+", " ").trim();
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
+import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
 import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression.PushedBlockLoaderExpression;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
@@ -56,6 +57,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -178,11 +180,17 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     }
 
     /**
-     * Result of classifying a query's source: exactly one of {@code dataset} (measurable) or {@code reason} is non-null.
-     * {@code mode} is the {@link IndexMode} the source reads with ({@link IndexMode#STANDARD} for {@code FROM},
-     * {@link IndexMode#TIME_SERIES} for {@code TS}); it is only meaningful when {@code dataset} is non-null.
+     * Result of classifying a query's source: either {@code datasets} (measurable, one entry for a single
+     * {@code FROM}/{@code TS}, several for a multi-index {@code FROM a, b}) or {@code reason} is non-null. {@code mode}
+     * is the {@link IndexMode} the source reads with ({@code STANDARD} for {@code FROM}, {@code TIME_SERIES} for
+     * {@code TS}); {@code indexPattern} is the comma-joined pattern the parser produces, used to key the resolution.
+     * Only meaningful when {@code datasets} is non-null.
      */
-    private record SourceClass(CsvTestsDataLoader.TestDataset dataset, IndexMode mode, NotSingle reason) {}
+    private record SourceClass(List<CsvTestsDataLoader.TestDataset> datasets, IndexMode mode, String indexPattern, NotSingle reason) {
+        static SourceClass rejected(NotSingle reason) {
+            return new SourceClass(null, null, null, reason);
+        }
+    }
 
     /** Per-dataset offline analyzer plus the keyword paths the rewriter should wrap. {@code null} analyzer means unusable. */
     private record DatasetPlan(Analyzer analyzer, Set<String> keywordPaths) {}
@@ -226,7 +234,7 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
             // and planned; the dropped pragma is orthogonal to field_extract fusion on mapped keyword fields.
             String query = stripSetPreamble(testCase.query);
             SourceClass source = classifySource(query);
-            if (source.dataset() == null) {
+            if (source.datasets() == null) {
                 skipByReason.merge(Skip.NOT_SINGLE_DATASET, 1, Integer::sum);
                 notSingleByReason.merge(source.reason(), 1, Integer::sum);
                 if (source.reason() == NotSingle.NON_FROM_START) {
@@ -234,7 +242,7 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
                 }
                 continue;
             }
-            DatasetPlan datasetPlan = datasetPlan(source.dataset(), source.mode());
+            DatasetPlan datasetPlan = datasetPlan(source);
             if (datasetPlan == null || datasetPlan.analyzer() == null) {
                 skipByReason.merge(Skip.DATASET_UNAVAILABLE, 1, Integer::sum);
                 continue;
@@ -285,16 +293,17 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     // ---- per test-case gating --------------------------------------------------------------------------
 
     /**
-     * Classifies a query's source into either the single {@link CsvTestsDataLoader.TestDataset} it reads (measurable),
-     * or a {@link NotSingle} reason it is out of scope. Kept in one place so the reject reasons stay mutually exclusive
-     * and the {@link Skip#NOT_SINGLE_DATASET} bucket can be broken down for prioritising further widening. Both
-     * {@code FROM <index>} and {@code TS <index>} (time-series) are treated as single-source reads; the index name may
-     * be quoted or backtick-quoted. A trailing {@code LOOKUP JOIN} stays in scope (resolved from {@link #lookupResolutions()}).
+     * Classifies a query's source into either the {@link CsvTestsDataLoader.TestDataset}(s) it reads (measurable), or a
+     * {@link NotSingle} reason it is out of scope. Kept in one place so the reject reasons stay mutually exclusive and
+     * the {@link Skip#NOT_SINGLE_DATASET} bucket can be broken down for prioritising further widening. {@code FROM} and
+     * {@code TS} (time-series) sources are in scope, including multi-index {@code FROM a, b} (merged into one resolution
+     * with union types for conflicting fields); index names may be quoted. A trailing {@code LOOKUP JOIN} stays in scope
+     * (resolved from {@link #lookupResolutions()}); {@code ENRICH}/{@code FORK} and cross-cluster/wildcard remain out.
      */
     private static SourceClass classifySource(String query) {
         Matcher command = LEADING_COMMAND.matcher(query);
         if (command.find() == false) {
-            return new SourceClass(null, null, NotSingle.NON_FROM_START);
+            return SourceClass.rejected(NotSingle.NON_FROM_START);
         }
         IndexMode mode = switch (command.group(1).toUpperCase(Locale.ROOT)) {
             case "FROM" -> IndexMode.STANDARD;
@@ -302,29 +311,37 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
             default -> null;
         };
         if (mode == null) {
-            return new SourceClass(null, null, NotSingle.NON_FROM_START);
+            return SourceClass.rejected(NotSingle.NON_FROM_START);
         }
         // The source list runs from the end of the command keyword to the first pipe (or end of query).
         int firstPipe = query.indexOf('|');
         String sourceList = (firstPipe < 0 ? query.substring(command.end()) : query.substring(command.end(), firstPipe)).trim();
-        // Reject multi-index sources and sub-query sources (a comma or open paren in the source list).
-        if (sourceList.indexOf(',') >= 0 || sourceList.indexOf('(') >= 0) {
-            return new SourceClass(null, null, NotSingle.MULTI_INDEX_FROM);
+        // A sub-query source (open paren in the source list) is out of scope; a comma is a multi-index list, handled below.
+        if (sourceList.indexOf('(') >= 0) {
+            return SourceClass.rejected(NotSingle.MULTI_INDEX_FROM);
         }
-        String token = unquoteIndexToken(sourceList);
-        if (token.indexOf('*') >= 0 || token.indexOf(':') >= 0) {
-            return new SourceClass(null, null, NotSingle.WILDCARD_OR_REMOTE);
-        }
+        // ENRICH/FORK anywhere in the query need resolution the harness does not build, regardless of the source shape.
         Matcher multiSource = MULTI_SOURCE.matcher(query);
         if (multiSource.find()) {
-            boolean fork = multiSource.group(1).equalsIgnoreCase("FORK");
-            return new SourceClass(null, null, fork ? NotSingle.FORK : NotSingle.ENRICH);
+            return SourceClass.rejected(multiSource.group(1).equalsIgnoreCase("FORK") ? NotSingle.FORK : NotSingle.ENRICH);
         }
-        CsvTestsDataLoader.TestDataset dataset = CsvTestsDataLoader.CSV_DATASET.get(token);
-        if (dataset == null || dataset.mappingFileName() == null) {
-            return new SourceClass(null, null, NotSingle.UNKNOWN_INDEX);
+        List<CsvTestsDataLoader.TestDataset> datasets = new ArrayList<>();
+        List<String> names = new ArrayList<>();
+        for (String raw : sourceList.split(",")) {
+            String token = unquoteIndexToken(raw.trim());
+            if (token.indexOf('*') >= 0 || token.indexOf(':') >= 0) {
+                return SourceClass.rejected(NotSingle.WILDCARD_OR_REMOTE);
+            }
+            CsvTestsDataLoader.TestDataset dataset = CsvTestsDataLoader.CSV_DATASET.get(token);
+            if (dataset == null || dataset.mappingFileName() == null) {
+                return SourceClass.rejected(NotSingle.UNKNOWN_INDEX);
+            }
+            datasets.add(dataset);
+            names.add(token);
         }
-        return new SourceClass(dataset, mode, null);
+        // The parser joins multi-index patterns with a bare comma (IdentifierBuilder), and IndexPattern equality is on
+        // that exact string, so reconstruct it the same way to key the resolution.
+        return new SourceClass(datasets, mode, String.join(",", names), null);
     }
 
     /**
@@ -359,27 +376,32 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     // ---- offline analyzer construction -----------------------------------------------------------------
 
     /**
-     * Builds (and caches) the offline analyzer + keyword-path set for a dataset read in the given {@link IndexMode}
-     * ({@link IndexMode#STANDARD} for {@code FROM}, {@link IndexMode#TIME_SERIES} for {@code TS}). The cache key includes
-     * the mode, since the same dataset planned as time-series needs a different index resolution. Unusable datasets are
-     * cached with a {@code null} analyzer.
+     * Builds (and caches) the offline analyzer + keyword-path set for a classified source: one dataset for a single
+     * {@code FROM}/{@code TS}, or several merged into one resolution (with {@link InvalidMappedField} union types for
+     * cross-index type conflicts) for a multi-index {@code FROM a, b}. The cache key is the index pattern plus the mode,
+     * since the same dataset planned as time-series needs a different resolution. Unusable sources cache a {@code null}
+     * analyzer.
      */
-    private DatasetPlan datasetPlan(CsvTestsDataLoader.TestDataset dataset, IndexMode mode) {
-        if (dataset == null) {
-            return null;
-        }
-        String cacheKey = dataset.indexName() + '|' + mode;
+    private DatasetPlan datasetPlan(SourceClass source) {
+        String cacheKey = source.indexPattern() + '|' + source.mode();
         return datasetPlans.computeIfAbsent(cacheKey, key -> {
-            String name = dataset.indexName();
             try {
-                String originalMapping = CsvTestsDataLoader.readMappingFile(dataset);
                 Set<String> keywordPaths = new HashSet<>();
-                collectKeywordPaths("", LoadMapping.loadMapping(stream(originalMapping)), keywordPaths);
-
-                String flattened = KeywordToFlattenedTransformer.transformMapping(originalMapping, Set.of()).transformedMapping();
-                Map<String, EsField> flattenedFields = LoadMapping.loadMapping(stream(flattened));
-                EsIndex index = new EsIndex(name, flattenedFields, Map.of(name, mode), Map.of(), Map.of());
-                Map<IndexPattern, IndexResolution> resolutions = Map.of(new IndexPattern(Source.EMPTY, name), IndexResolution.valid(index));
+                Map<String, Map<String, EsField>> perIndexFields = new LinkedHashMap<>();
+                Map<String, IndexMode> concreteIndices = new LinkedHashMap<>();
+                for (CsvTestsDataLoader.TestDataset dataset : source.datasets()) {
+                    String originalMapping = CsvTestsDataLoader.readMappingFile(dataset);
+                    collectKeywordPaths("", LoadMapping.loadMapping(stream(originalMapping)), keywordPaths);
+                    String flattened = KeywordToFlattenedTransformer.transformMapping(originalMapping, Set.of()).transformedMapping();
+                    perIndexFields.put(dataset.indexName(), LoadMapping.loadMapping(stream(flattened)));
+                    concreteIndices.put(dataset.indexName(), source.mode());
+                }
+                Map<String, EsField> fields = mergeFields(perIndexFields);
+                EsIndex index = new EsIndex(source.indexPattern(), fields, concreteIndices, Map.of(), Map.of());
+                Map<IndexPattern, IndexResolution> resolutions = Map.of(
+                    new IndexPattern(Source.EMPTY, source.indexPattern()),
+                    IndexResolution.valid(index)
+                );
                 Analyzer analyzer = new Analyzer(
                     testAnalyzerContext(
                         TEST_CFG,
@@ -393,10 +415,40 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
                 );
                 return new DatasetPlan(analyzer, keywordPaths);
             } catch (Exception e) {
-                logger.debug(() -> "keyword\u2192flattened dry run: cannot build analyzer for [" + name + "]", e);
+                logger.debug(() -> "keyword\u2192flattened dry run: cannot build analyzer for [" + key + "]", e);
                 return new DatasetPlan(null, Set.of());
             }
         });
+    }
+
+    /**
+     * Merges the per-index (already flattened) top-level field maps into one, mirroring the field-caps merge closely
+     * enough for the fusion audit: a field with a single data type across every index that has it keeps its
+     * {@link EsField}; a field with more than one data type becomes an {@link InvalidMappedField} (the union-type shape
+     * {@code field_extract} must reject). Only top-level fields are merged (nested-object merges across indices are rare
+     * in the corpus and, when mismatched, surface as {@code UNPLANNABLE} rather than a wrong fusion verdict).
+     */
+    private static Map<String, EsField> mergeFields(Map<String, Map<String, EsField>> perIndexFields) {
+        if (perIndexFields.size() == 1) {
+            return perIndexFields.values().iterator().next();
+        }
+        Map<String, EsField> firstSeen = new LinkedHashMap<>();
+        Map<String, LinkedHashMap<String, Set<String>>> typesToIndices = new LinkedHashMap<>();
+        perIndexFields.forEach((indexName, fields) -> fields.forEach((fieldName, field) -> {
+            firstSeen.putIfAbsent(fieldName, field);
+            typesToIndices.computeIfAbsent(fieldName, k -> new LinkedHashMap<>())
+                .computeIfAbsent(field.getDataType().typeName(), k -> new HashSet<>())
+                .add(indexName);
+        }));
+        Map<String, EsField> merged = new LinkedHashMap<>();
+        typesToIndices.forEach((fieldName, byType) -> {
+            if (byType.size() == 1) {
+                merged.put(fieldName, firstSeen.get(fieldName));
+            } else {
+                merged.put(fieldName, new InvalidMappedField(fieldName, byType));
+            }
+        });
+        return merged;
     }
 
     /**

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/FieldExtractFusionCorpusInventoryTests.java
@@ -109,8 +109,14 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     /** Leading {@code FROM <index>} of a query; the capture group is the first index token. */
     private static final Pattern LEADING_FROM = Pattern.compile("^\\s*FROM\\s+([A-Za-z0-9_.\\-]+)", Pattern.CASE_INSENSITIVE);
 
-    /** Commands that introduce a second source or need extra resolution the single-dataset analyzer does not carry. */
-    private static final Pattern MULTI_SOURCE = Pattern.compile("\\b(JOIN|ENRICH|FORK)\\b", Pattern.CASE_INSENSITIVE);
+    /**
+     * Commands that introduce a second source the offline analyzer cannot resolve. {@code LOOKUP JOIN} is deliberately
+     * absent: every {@code lookup-settings.json} dataset is pre-resolved into the shared lookup map (see
+     * {@link #lookupResolutions()}), so join shapes are measured (and are where the real {@code ABOVE_JOIN_OR_MULTISOURCE}
+     * fallbacks surface). {@code ENRICH} still needs an enrich policy resolution the harness does not build, and
+     * {@code FORK} fans out into multiple sub-plans, so both remain out of scope.
+     */
+    private static final Pattern MULTI_SOURCE = Pattern.compile("\\b(ENRICH|FORK)\\b", Pattern.CASE_INSENSITIVE);
 
     /** How many representative rewritten queries to log per fallback bucket. */
     private static final int MAX_SAMPLES_PER_REASON = 5;
@@ -149,6 +155,9 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     private record DatasetPlan(Analyzer analyzer, Set<String> keywordPaths) {}
 
     private final Map<String, DatasetPlan> datasetPlans = new HashMap<>();
+
+    /** Shared {@link IndexMode#LOOKUP} resolutions for {@code LOOKUP JOIN} targets, built once on first use. */
+    private Map<String, IndexResolution> lookupResolutions;
 
     /**
      * The dry run analyzes and plans the whole corpus, so the analyzer legitimately emits planner warnings
@@ -242,9 +251,10 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
     }
 
     /**
-     * The single {@link CsvTestsDataLoader.TestDataset} a query reads, or {@code null} when the query is not a clean
-     * single-dataset {@code FROM <known index>} (multi-index, cross-cluster, wildcard, subquery, or a command that
-     * adds a second source). The offline analyzer only carries one index resolution, so anything else is skipped.
+     * The single {@link CsvTestsDataLoader.TestDataset} a query reads from its leading {@code FROM}, or {@code null}
+     * when that source is not a clean single {@code FROM <known index>} (multi-index, cross-cluster, wildcard, subquery,
+     * or an {@code ENRICH}/{@code FORK} that the offline analyzer cannot resolve). A trailing {@code LOOKUP JOIN} is
+     * allowed: its target is resolved from the shared lookup map ({@link #lookupResolutions()}), not the main source.
      */
     private static CsvTestsDataLoader.TestDataset singleSourceDataset(String query) {
         Matcher matcher = LEADING_FROM.matcher(query);
@@ -289,7 +299,14 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
                 EsIndex index = new EsIndex(name, flattenedFields, Map.of(name, IndexMode.STANDARD), Map.of(), Map.of());
                 Map<IndexPattern, IndexResolution> resolutions = Map.of(new IndexPattern(Source.EMPTY, name), IndexResolution.valid(index));
                 Analyzer analyzer = new Analyzer(
-                    testAnalyzerContext(TEST_CFG, TEST_FUNCTION_REGISTRY, resolutions, new EnrichResolution(), emptyInferenceResolution()),
+                    testAnalyzerContext(
+                        TEST_CFG,
+                        TEST_FUNCTION_REGISTRY,
+                        resolutions,
+                        lookupResolutions(),
+                        new EnrichResolution(),
+                        emptyInferenceResolution()
+                    ),
                     TEST_VERIFIER
                 );
                 return new DatasetPlan(analyzer, keywordPaths);
@@ -298,6 +315,41 @@ public class FieldExtractFusionCorpusInventoryTests extends ESTestCase {
                 return new DatasetPlan(null, Set.of());
             }
         });
+    }
+
+    /**
+     * Shared {@code LOOKUP JOIN} target resolutions (keyed by index name, {@link IndexMode#LOOKUP}), built once from
+     * every {@code lookup-settings.json} dataset with the same keyword&#8594;flattened mapping remap applied. Attaching
+     * these to every per-dataset analyzer lets {@code FROM <main> | ... | LOOKUP JOIN <lookup> ON <key>} shapes plan
+     * offline. The join key is never a keyword the rewriter wraps (see the {@code LOOKUP_JOIN_ON} skip site in
+     * {@code CsvFlattenedKeywordIT}), so it stays intact across the flatten and the join still type-checks. Datasets
+     * whose mapping cannot be parsed are simply omitted; queries that reference them fall to {@code UNPLANNABLE}.
+     */
+    private Map<String, IndexResolution> lookupResolutions() {
+        if (lookupResolutions == null) {
+            Map<String, IndexResolution> resolutions = new HashMap<>();
+            for (CsvTestsDataLoader.TestDataset dataset : CsvTestsDataLoader.CSV_DATASET.values()) {
+                if ("lookup-settings.json".equals(dataset.settingFileName()) == false || dataset.mappingFileName() == null) {
+                    continue;
+                }
+                resolutions.computeIfAbsent(dataset.indexName(), name -> {
+                    try {
+                        String flattened = KeywordToFlattenedTransformer.transformMapping(
+                            CsvTestsDataLoader.readMappingFile(dataset),
+                            Set.of()
+                        ).transformedMapping();
+                        Map<String, EsField> fields = LoadMapping.loadMapping(stream(flattened));
+                        EsIndex index = new EsIndex(name, fields, Map.of(name, IndexMode.LOOKUP), Map.of(), Map.of());
+                        return IndexResolution.valid(index);
+                    } catch (Exception e) {
+                        logger.debug(() -> "keyword\u2192flattened dry run: cannot build lookup resolution for [" + name + "]", e);
+                        return null;
+                    }
+                });
+            }
+            lookupResolutions = Collections.unmodifiableMap(resolutions);
+        }
+        return lookupResolutions;
     }
 
     private static ByteArrayInputStream stream(String json) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/FieldExtractFusionInventoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/FieldExtractFusionInventoryTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer;
+
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
+import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
+import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression.PushedBlockLoaderExpression;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Inventory / audit harness for {@code field_extract} block-loader <em>fusion</em>.
+ * <p>
+ *     "Fusion" is the fast path for {@code field_extract(<flattened root>, "<key>")}: instead of
+ *     materializing the whole flattened JSON blob per row and re-parsing it in a compute-engine
+ *     evaluator, the call is folded into the field load so the keyed sub-field's doc values are read
+ *     directly. The decision is made during local physical planning by
+ *     {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushExpressionsToFieldLoad},
+ *     which replaces a pushable {@link FieldExtract} with a synthetic {@link FieldAttribute} backed by
+ *     a {@link FunctionEsField} carrying an {@code ExtractFlattenedSubfieldConfig}.
+ * </p>
+ * <p>
+ *     This test plans representative query shapes offline (no cluster) with
+ *     {@link TestPlannerOptimizer} over a flattened mapping, then walks the optimized physical plan to
+ *     count two things:
+ * </p>
+ * <p>
+ *     The {@code EVAL} shapes carry a trailing {@code | SORT id | LIMIT 10}. Fusion is a local
+ *     (data-node) physical optimization, so an {@code EVAL} must sit <em>below</em> the exchange boundary
+ *     to be eligible; a bare {@code FROM ... | EVAL ... | KEEP} leaves the {@code EVAL} on the coordinator
+ *     side where the rule never runs. The {@code SORT}/{@code LIMIT} pushes it into the data-node fragment,
+ *     mirroring {@code PushExpressionsToFieldLoadTests}. A {@code WHERE} predicate is already data-node local.
+ * </p>
+ * <ul>
+ *     <li><b>fused</b> loads: {@link FieldAttribute}s whose {@link FieldAttribute#field()} is a
+ *     {@link FunctionEsField} with function {@link BlockLoaderFunctionConfig.Function#EXTRACT_FLATTENED_SUBFIELD};</li>
+ *     <li><b>fallback</b> loads: {@link FieldExtract} expressions that survived the rule (i.e. still run
+ *     the per-row evaluator), each bucketed by <em>why</em> it did not fuse.</li>
+ * </ul>
+ * <p>
+ *     The {@link #classify} reasons mirror the gates in {@code PushExpressionsToFieldLoad#transformExpression}
+ *     one-for-one, so a residual {@code field_extract} is attributed to the exact gate that rejected it.
+ *     This is the offline sibling of the corpus-driven {@code CsvFlattenedKeywordIT}: it answers "which
+ *     query shapes still fall back, and why" without needing to run the whole CSV corpus on a cluster, and
+ *     gives a place to add regression coverage as more shapes become fusible on the road to GA.
+ * </p>
+ * <p>
+ *     The two hardest-to-reach gates in isolation are documented but not asserted here:
+ *     {@link Fusion#UNION_TYPE} (needs a union-typed field mapping) and
+ *     {@link Fusion#ABOVE_JOIN_OR_MULTISOURCE} (needs a {@code LOOKUP JOIN} so the field's lineage traces
+ *     to more than one source). They are exercised by the corpus-driven pass instead.
+ * </p>
+ */
+public class FieldExtractFusionInventoryTests extends AbstractLocalPhysicalPlanOptimizerTests {
+
+    /**
+     * Plain flattened root ({@code data}) plus two keyword fields ({@code id}, {@code key}). {@code data}
+     * has no mapped sub-fields, so every literal key is an unmapped keyed sub-field and is fusible; {@code key}
+     * gives us a non-foldable (column) path to exercise the dynamic-key fallback.
+     */
+    private static final String FLATTENED_MAPPING = "mapping-flattened_keyed.json";
+
+    /**
+     * Why a {@code field_extract} did not fuse. Each non-{@link #FUSED} value corresponds to one gate in
+     * {@code PushExpressionsToFieldLoad#transformExpression}, in the order they are checked.
+     */
+    enum Fusion {
+        /** Fused into the keyed sub-field doc-values loader (the fast path). */
+        FUSED,
+        /** Path is not a foldable literal, so no keyed loader can be built at plan time. */
+        DYNAMIC_KEY,
+        /** First argument is not a real {@code FLATTENED} {@link FieldAttribute} (e.g. an alias/expression). */
+        NON_FLATTENED_INPUT,
+        /** The flattened root is a {@link UnionTypeEsField} (conflicting mappings across indices). */
+        UNION_TYPE,
+        /** Field lineage does not trace to exactly one non-LOOKUP source (e.g. above a {@code LOOKUP JOIN}). */
+        ABOVE_JOIN_OR_MULTISOURCE,
+        /**
+         * The field type rejected the loader config for this key (a mapped sub-field, or no doc values),
+         * so reading it via the keyed channel would diverge from the keyword evaluator.
+         */
+        UNSUPPORTED_LOADER_CONFIG
+    }
+
+    /** Outcome of walking one optimized plan: how many loads fused, and the fallback bucket histogram. */
+    record Inventory(int fused, Map<Fusion, Integer> fallbackByReason) {
+        int fallback() {
+            return fallbackByReason.values().stream().mapToInt(Integer::intValue).sum();
+        }
+    }
+
+    private TestPlannerOptimizer flattenedPlanner;
+
+    public FieldExtractFusionInventoryTests(String name, Configuration config) {
+        super(name, config);
+    }
+
+    @Before
+    public void setUpFlattenedPlanner() {
+        assumeTrue("field_extract must be part of this build for the plans to analyze", FieldExtract.isFnFieldExtractCapabilityMet());
+        flattenedPlanner = new TestPlannerOptimizer(config, makeAnalyzer(FLATTENED_MAPPING));
+    }
+
+    // ---- shape matrix -------------------------------------------------------------------------------
+
+    public void testConstantKeyFusesOnFlattenedRoot() {
+        Inventory inv = inventory(
+            "FROM test | EVAL x = field_extract(data, \"host.name\") | SORT id | LIMIT 10 | KEEP x",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals("a literal key on a plain flattened root must fuse", 1, inv.fused());
+        assertEquals("nothing should fall back", 0, inv.fallback());
+    }
+
+    public void testConsumingFunctionDoesNotBlockFusion() {
+        // The field_extract fuses even though its result is immediately consumed by another scalar function;
+        // fusion is about how the value is loaded, not what happens to it afterwards.
+        Inventory inv = inventory(
+            "FROM test | EVAL x = TO_UPPER(field_extract(data, \"host.name\")) | SORT id | LIMIT 10 | KEEP x",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals(1, inv.fused());
+        assertEquals(0, inv.fallback());
+    }
+
+    public void testMultipleDistinctKeysEachFuse() {
+        Inventory inv = inventory(
+            "FROM test | EVAL a = field_extract(data, \"k1\"), b = field_extract(data, \"k2\") | SORT id | LIMIT 10 | KEEP a, b",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals("each distinct key becomes its own fused keyed load", 2, inv.fused());
+        assertEquals(0, inv.fallback());
+    }
+
+    public void testFilterPredicateFuses() {
+        // field_extract in a WHERE predicate still needs the extracted keyword column (the pushed Lucene
+        // query is a RECHECK candidate), so the load fuses rather than falling back to the per-row evaluator.
+        Inventory inv = inventory(
+            "FROM test | WHERE field_extract(data, \"host.name\") == \"v\" | KEEP id",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals(1, inv.fused());
+        assertEquals(0, inv.fallback());
+    }
+
+    public void testDynamicKeyFallsBack() {
+        // A column path (the keyword field `key`) is not foldable, so no keyed loader can be built.
+        Inventory inv = inventory(
+            "FROM test | EVAL x = field_extract(data, key) | SORT id | LIMIT 10 | KEEP x",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals("a dynamic key cannot fuse", 0, inv.fused());
+        assertEquals(Map.of(Fusion.DYNAMIC_KEY, 1), inv.fallbackByReason());
+    }
+
+    public void testUnsupportedLoaderConfigFallsBack() {
+        // Stats that reject every loader config stand in for a mapped sub-field / a field without doc values:
+        // the key is foldable and the root is flattened, but the field type declines the keyed load.
+        Inventory inv = inventory(
+            "FROM test | EVAL x = field_extract(data, \"host.name\") | SORT id | LIMIT 10 | KEEP x",
+            new EsqlTestUtils.TestSearchStats(false)
+        );
+        assertEquals(0, inv.fused());
+        assertEquals(Map.of(Fusion.UNSUPPORTED_LOADER_CONFIG, 1), inv.fallbackByReason());
+    }
+
+    // ---- walker -------------------------------------------------------------------------------------
+
+    private Inventory inventory(String esql, SearchStats stats) {
+        PhysicalPlan plan = flattenedPlanner.plan(esql, stats);
+
+        // A node's forEachExpressionDown only walks that node's own expressions, so descend the physical
+        // tree first and inspect each node's expressions (the same idiom PushExpressionsToFieldLoadTests uses).
+        Set<String> fused = new HashSet<>();
+        Map<Fusion, Integer> fallbackByReason = new EnumMap<>(Fusion.class);
+        Set<FieldExtract> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        plan.forEachDown(PhysicalPlan.class, node -> {
+            // Fused loads are synthetic FieldAttributes backed by a FunctionEsField for the flattened
+            // sub-field extraction. The same attribute is referenced from several nodes (Eval,
+            // FieldExtractExec, Project), so dedup by the synthetic name, which is unique per (root, key).
+            node.forEachExpressionDown(FieldAttribute.class, fa -> {
+                if (fa.field() instanceof FunctionEsField fe
+                    && fe.functionConfig() != null
+                    && fe.functionConfig().function() == BlockLoaderFunctionConfig.Function.EXTRACT_FLATTENED_SUBFIELD) {
+                    fused.add(fa.name());
+                }
+            });
+            // Fallback loads are surviving FieldExtract expressions. Dedup by node identity so a call is
+            // counted once, then attribute each to the gate that rejected it.
+            node.forEachExpressionDown(FieldExtract.class, fx -> {
+                if (seen.add(fx)) {
+                    fallbackByReason.merge(classify(fx, stats), 1, Integer::sum);
+                }
+            });
+        });
+
+        return new Inventory(fused.size(), fallbackByReason);
+    }
+
+    /**
+     * Re-derives the fusion decision for a residual {@link FieldExtract}, mirroring the gate order in
+     * {@code PushExpressionsToFieldLoad#transformExpression}. If the call is pushable in isolation yet still
+     * survived in the plan, the only remaining reason is lineage (it sits above a join / multi-source), which
+     * is the {@link Fusion#ABOVE_JOIN_OR_MULTISOURCE} fall-through.
+     */
+    private Fusion classify(FieldExtract fx, SearchStats stats) {
+        PushedBlockLoaderExpression fuse = fx.tryPushToFieldLoading(stats);
+        if (fuse == null) {
+            // tryPushToFieldLoading returns null either because the path is not foldable, or because the
+            // field is not a real FLATTENED FieldAttribute. The path argument is the second child.
+            Expression pathArg = fx.children().get(1);
+            return pathArg.foldable() ? Fusion.NON_FLATTENED_INPUT : Fusion.DYNAMIC_KEY;
+        }
+        if (fuse.field().field() instanceof UnionTypeEsField) {
+            return Fusion.UNION_TYPE;
+        }
+        if (stats.supportsLoaderConfig(fuse.field().fieldName(), fuse.config(), MappedFieldType.FieldExtractPreference.NONE) == false) {
+            return Fusion.UNSUPPORTED_LOADER_CONFIG;
+        }
+        return Fusion.ABOVE_JOIN_OR_MULTISOURCE;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/FieldExtractFusionInventoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/FieldExtractFusionInventoryTests.java
@@ -7,26 +7,46 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
+import org.elasticsearch.xpack.esql.analysis.Verifier;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
 import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression.PushedBlockLoaderExpression;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.FieldExtract;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.EsIndexGenerator;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
+import org.elasticsearch.xpack.esql.telemetry.Metrics;
 import org.junit.Before;
 
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.testAnalyzerContext;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.indexResolutions;
 
 /**
  * Inventory / audit harness for {@code field_extract} block-loader <em>fusion</em>.
@@ -44,6 +64,12 @@ import java.util.Set;
  *     {@link TestPlannerOptimizer} over a flattened mapping, then walks the optimized physical plan to
  *     count two things:
  * </p>
+ * <ul>
+ *     <li><b>fused</b> loads: {@link FieldAttribute}s whose {@link FieldAttribute#field()} is a
+ *     {@link FunctionEsField} with function {@link BlockLoaderFunctionConfig.Function#EXTRACT_FLATTENED_SUBFIELD};</li>
+ *     <li><b>fallback</b> loads: {@link FieldExtract} expressions that survived the rule (i.e. still run
+ *     the per-row evaluator), each bucketed by <em>why</em> it did not fuse.</li>
+ * </ul>
  * <p>
  *     The {@code EVAL} shapes carry a trailing {@code | SORT id | LIMIT 10}. Fusion is a local
  *     (data-node) physical optimization, so an {@code EVAL} must sit <em>below</em> the exchange boundary
@@ -51,12 +77,6 @@ import java.util.Set;
  *     side where the rule never runs. The {@code SORT}/{@code LIMIT} pushes it into the data-node fragment,
  *     mirroring {@code PushExpressionsToFieldLoadTests}. A {@code WHERE} predicate is already data-node local.
  * </p>
- * <ul>
- *     <li><b>fused</b> loads: {@link FieldAttribute}s whose {@link FieldAttribute#field()} is a
- *     {@link FunctionEsField} with function {@link BlockLoaderFunctionConfig.Function#EXTRACT_FLATTENED_SUBFIELD};</li>
- *     <li><b>fallback</b> loads: {@link FieldExtract} expressions that survived the rule (i.e. still run
- *     the per-row evaluator), each bucketed by <em>why</em> it did not fuse.</li>
- * </ul>
  * <p>
  *     The {@link #classify} reasons mirror the gates in {@code PushExpressionsToFieldLoad#transformExpression}
  *     one-for-one, so a residual {@code field_extract} is attributed to the exact gate that rejected it.
@@ -65,10 +85,10 @@ import java.util.Set;
  *     gives a place to add regression coverage as more shapes become fusible on the road to GA.
  * </p>
  * <p>
- *     The two hardest-to-reach gates in isolation are documented but not asserted here:
- *     {@link Fusion#UNION_TYPE} (needs a union-typed field mapping) and
- *     {@link Fusion#ABOVE_JOIN_OR_MULTISOURCE} (needs a {@code LOOKUP JOIN} so the field's lineage traces
- *     to more than one source). They are exercised by the corpus-driven pass instead.
+ *     {@link Fusion#UNION_TYPE} is defined for completeness but is not reachable through {@code field_extract}:
+ *     the function requires its first argument to resolve to a {@code FLATTENED} {@link FieldAttribute}, and a
+ *     field with conflicting mappings across indices resolves to a union type instead, so the call never
+ *     analyzes. The gate still exists in the rule because it guards <em>all</em> block-loader expressions.
  * </p>
  */
 public class FieldExtractFusionInventoryTests extends AbstractLocalPhysicalPlanOptimizerTests {
@@ -173,6 +193,38 @@ public class FieldExtractFusionInventoryTests extends AbstractLocalPhysicalPlanO
         assertEquals(Map.of(Fusion.DYNAMIC_KEY, 1), inv.fallbackByReason());
     }
 
+    public void testAboveUnionDegradesToNonFieldAttribute() {
+        assumeTrue("subqueries must be enabled", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());
+        assumeTrue("subqueries must be enabled", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_WITHOUT_IMPLICIT_LIMIT.isEnabled());
+        // Above a two-source union the flattened root is no longer a direct FieldAttribute (it is the union's
+        // merged reference), so field_extract cannot fuse. This is the union-shaped face of "multi-source":
+        // the attribute degrades before the Primaries lineage check even applies.
+        Inventory inv = inventory(
+            "FROM test, (FROM test | KEEP data, id) | EVAL x = field_extract(data, \"host.name\") | KEEP x",
+            EsqlTestUtils.TEST_SEARCH_STATS
+        );
+        assertEquals(0, inv.fused());
+        assertEquals(Map.of(Fusion.NON_FLATTENED_INPUT, 1), inv.fallbackByReason());
+    }
+
+    public void testAboveLookupJoinFallsBack() {
+        // field_extract sits above a LOOKUP JOIN, referencing the flattened root from the left (main) side.
+        // The root stays a real FieldAttribute, so the call is pushable in isolation, but its lineage now
+        // traces to two sources (main + lookup). The Primaries check forbids the push: the ABOVE_JOIN gate.
+        TestPlannerOptimizer joinPlanner = new TestPlannerOptimizer(config, joinAnalyzer());
+        Inventory inv = inventory(joinPlanner, """
+            FROM test
+            | RENAME languages AS language_code
+            | LOOKUP JOIN languages_lookup ON language_code
+            | EVAL x = field_extract(data, "host.name")
+            | SORT language_code
+            | LIMIT 10
+            | KEEP x
+            """, EsqlTestUtils.TEST_SEARCH_STATS);
+        assertEquals(0, inv.fused());
+        assertEquals(Map.of(Fusion.ABOVE_JOIN_OR_MULTISOURCE, 1), inv.fallbackByReason());
+    }
+
     public void testUnsupportedLoaderConfigFallsBack() {
         // Stats that reject every loader config stand in for a mapped sub-field / a field without doc values:
         // the key is foldable and the root is flattened, but the field type declines the keyed load.
@@ -184,10 +236,79 @@ public class FieldExtractFusionInventoryTests extends AbstractLocalPhysicalPlanO
         assertEquals(Map.of(Fusion.UNSUPPORTED_LOADER_CONFIG, 1), inv.fallbackByReason());
     }
 
+    // ---- corpus-style summary ------------------------------------------------------------------------
+
+    /**
+     * Aggregates a spread of shapes into one fused-vs-fallback-by-reason report and logs it. This is the
+     * offline shape of the summary a corpus-wide dry run produces: a single-glance tally of how many loads
+     * fuse and, for those that don't, which gate stopped them. Extend {@link #corpus()} as shapes are added.
+     * <p>
+     *     A faithful whole-corpus version belongs in the {@code internalClusterTest} module, where
+     *     {@code CsvFlattenedKeywordIT}'s {@code AstKeywordFieldRewriter} and per-dataset flattened mappings
+     *     already exist: feed each rewritten CSV query through the same {@link #inventory} walk instead of
+     *     executing it on a cluster, and aggregate identically.
+     * </p>
+     */
+    public void testFusionInventorySummary() {
+        Inventory total = aggregate(corpus());
+
+        StringBuilder report = new StringBuilder("field_extract fusion inventory: ").append(total.fused()).append(" fused");
+        total.fallbackByReason().forEach((reason, count) -> report.append(", ").append(reason).append('=').append(count));
+        logger.info(report.toString());
+
+        // Sanity checks on the aggregate: the fusible shapes fused, and every non-fusible shape landed in a bucket.
+        assertEquals("constant + two-key fusions", 3, total.fused());
+        assertEquals(
+            Map.of(Fusion.DYNAMIC_KEY, 1, Fusion.UNSUPPORTED_LOADER_CONFIG, 1, Fusion.ABOVE_JOIN_OR_MULTISOURCE, 1),
+            total.fallbackByReason()
+        );
+    }
+
+    /** The curated mini-corpus behind {@link #testFusionInventorySummary}; capability-gated shapes are excluded. */
+    private Inventory aggregate(List<Inventory> runs) {
+        int fused = 0;
+        Map<Fusion, Integer> byReason = new EnumMap<>(Fusion.class);
+        for (Inventory run : runs) {
+            fused += run.fused();
+            run.fallbackByReason().forEach((reason, count) -> byReason.merge(reason, count, Integer::sum));
+        }
+        return new Inventory(fused, byReason);
+    }
+
+    private List<Inventory> corpus() {
+        SearchStats supported = EsqlTestUtils.TEST_SEARCH_STATS;
+        TestPlannerOptimizer joinPlanner = new TestPlannerOptimizer(config, joinAnalyzer());
+        return List.of(
+            inventory("FROM test | EVAL x = field_extract(data, \"host.name\") | SORT id | LIMIT 10 | KEEP x", supported),
+            inventory(
+                "FROM test | EVAL a = field_extract(data, \"k1\"), b = field_extract(data, \"k2\") | SORT id | LIMIT 10 | KEEP a, b",
+                supported
+            ),
+            inventory("FROM test | EVAL x = field_extract(data, key) | SORT id | LIMIT 10 | KEEP x", supported),
+            inventory(
+                "FROM test | EVAL x = field_extract(data, \"host.name\") | SORT id | LIMIT 10 | KEEP x",
+                new EsqlTestUtils.TestSearchStats(false)
+            ),
+            inventory(joinPlanner, """
+                FROM test
+                | RENAME languages AS language_code
+                | LOOKUP JOIN languages_lookup ON language_code
+                | EVAL x = field_extract(data, "host.name")
+                | SORT language_code
+                | LIMIT 10
+                | KEEP x
+                """, supported)
+        );
+    }
+
     // ---- walker -------------------------------------------------------------------------------------
 
     private Inventory inventory(String esql, SearchStats stats) {
-        PhysicalPlan plan = flattenedPlanner.plan(esql, stats);
+        return inventory(flattenedPlanner, esql, stats);
+    }
+
+    private Inventory inventory(TestPlannerOptimizer planner, String esql, SearchStats stats) {
+        PhysicalPlan plan = planner.plan(esql, stats);
 
         // A node's forEachExpressionDown only walks that node's own expressions, so descend the physical
         // tree first and inspect each node's expressions (the same idiom PushExpressionsToFieldLoadTests uses).
@@ -239,5 +360,27 @@ public class FieldExtractFusionInventoryTests extends AbstractLocalPhysicalPlanO
             return Fusion.UNSUPPORTED_LOADER_CONFIG;
         }
         return Fusion.ABOVE_JOIN_OR_MULTISOURCE;
+    }
+
+    /**
+     * Analyzer over {@code mapping-basic.json} plus a synthetic flattened {@code data} field and the shared
+     * lookup resolution, so a {@code LOOKUP JOIN} shape can put a fusible {@code field_extract(data, ...)}
+     * above the join.
+     */
+    private Analyzer joinAnalyzer() {
+        Map<String, EsField> mapping = new LinkedHashMap<>(loadMapping("mapping-basic.json"));
+        mapping.put("data", new EsField("data", DataType.FLATTENED, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+        EsIndex test = EsIndexGenerator.esIndex("test", mapping, Map.of("test", IndexMode.STANDARD));
+        return new Analyzer(
+            testAnalyzerContext(
+                config,
+                TEST_FUNCTION_REGISTRY,
+                indexResolutions(test),
+                defaultLookupResolution(),
+                new EnrichResolution(),
+                emptyInferenceResolution()
+            ),
+            new Verifier(new Metrics(TEST_FUNCTION_REGISTRY, true, true), new XPackLicenseState(() -> 0L))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds an offline, tests-only audit harness for `field_extract` block-loader
fusion on `flattened` fields. It has no production impact; it exists to quantify
where `field_extract(<flattened>, "<key>")` does and does not fuse into the
keyed sub-field load, and to guard against regressions as coverage widens.

Two complementary views:

- **`FieldExtractFusionInventoryTests`** (unit, `src/test`) — a shape matrix that
  drives each fusion gate in `PushExpressionsToFieldLoad` (dynamic key,
  non-flattened input, union type, above-join/multi-source, unsupported loader
  config) and asserts the resulting fusion category per shape.
- **`FieldExtractFusionCorpusInventoryTests`** (`internalClusterTest`) — a
  corpus dry run that replays the whole CSV-spec suite through the same
  keyword&#8594;flattened remap the `CsvFlattenedKeywordIT` uses, plans each
  rewritten query offline, walks the data-node fragment, and reports a histogram
  of fused vs. fallback counts (with a few representative sample queries per
  fallback bucket). Assertions stay loose (the corpus grows over time) so it is
  a reporting harness, not a brittle golden-count test.

The corpus dry run now also covers **`LOOKUP JOIN`** shapes: every
`lookup-settings.json` dataset is pre-resolved into a shared LOOKUP-mode
resolution attached to each per-dataset analyzer, so `FROM <main> | ... |
LOOKUP JOIN <lookup> ON <key>` queries plan offline. This surfaces the genuine
`ABOVE_JOIN_OR_MULTISOURCE` fallbacks (field_extract sitting above a join, which
the conservative `Primaries` lineage check blocks) that the earlier
single-source scope hid.

## Test plan

- [x] `FieldExtractFusionInventoryTests` passes.
- [x] `FieldExtractFusionCorpusInventoryTests` passes; logged inventory shows
      1625 measured queries, 1149 fused, residual fallbacks limited to a
      non-foldable dynamic key and 57 above-join cases.

Made with [Cursor](https://cursor.com)