### PR TITLE
Fix wrong argument in allocation top-up

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/RandomizedAssignmentRounding.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/RandomizedAssignmentRounding.java
@@ -367,7 +367,7 @@ class RandomizedAssignmentRounding {
                             resourceTracker.remainingModelAllocations.get(m),
                             m.findOptimalAllocations(
                                 resourceTracker.remainingNodeCores.get(n) / m.threadsPerAllocation(),
-                                resourceTracker.remainingModelAllocations.get(m)
+                                resourceTracker.remainingNodeMemory.get(n)
                             )
                         )
                     );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/RandomizedAssignmentRoundingTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/RandomizedAssignmentRoundingTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.assignment.planning;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class RandomizedAssignmentRoundingTests extends ESTestCase {
+
+    /**
+     * Rounding the relaxed LP solution down leaves deployments short of the allocations they asked
+     * for, which is why {@code tryAssigningRemainingCores} exists: it tops them up using whatever
+     * capacity is left on nodes that are not yet hosting the deployment.
+     *
+     * Here a deployment asks for 4 allocations and the rounded solution gives it 1 on the first
+     * node. The first node has a single core, so it is fully consumed by that one allocation and
+     * {@code assignExcessCores} - which tops up nodes the deployment already runs on - cannot place
+     * any more there. The second node is completely idle with ample memory and cores, so the only
+     * way to reach the requested 4 allocations is for {@code tryAssigningRemainingCores} to spread
+     * the remaining 3 onto it.
+     *
+     * This only exercises the interesting path for deployments that publish
+     * {@code per_deployment_memory_bytes} / {@code per_allocation_memory_bytes}; when both are 0,
+     * {@code findOptimalAllocations} returns early and the memory arithmetic is skipped entirely.
+     */
+    public void testTopUpUsesLeftoverCapacity_GivenDeploymentWithMemoryMetadata() {
+        Node node1 = new Node("n_1", ByteSizeValue.ofGb(10).getBytes(), 1);
+        Node node2 = new Node("n_2", ByteSizeValue.ofGb(10).getBytes(), 8);
+
+        Deployment deployment = new Deployment(
+            "d_1",
+            "m_1",
+            ByteSizeValue.ofMb(100).getBytes(), // model size
+            4,                                  // requested allocations
+            1,                                  // threads per allocation
+            Map.of(),                           // no pre-existing allocations
+            0,
+            null,
+            ByteSizeValue.ofMb(400).getBytes(), // per deployment memory
+            ByteSizeValue.ofMb(200).getBytes()  // per allocation memory
+        );
+
+        // Integer values mean there are no soft assignments, so randomized rounding is skipped and
+        // the outcome does not depend on the random seed.
+        Map<Tuple<Deployment, Node>, Double> allocationVars = Map.of(
+            Tuple.tuple(deployment, node1),
+            1.0,
+            Tuple.tuple(deployment, node2),
+            0.0
+        );
+        Map<Tuple<Deployment, Node>, Double> assignmentVars = Map.of(
+            Tuple.tuple(deployment, node1),
+            1.0,
+            Tuple.tuple(deployment, node2),
+            0.0
+        );
+
+        AssignmentPlan plan = new RandomizedAssignmentRounding(random(), 1, List.of(node1, node2), List.of(deployment)).computePlan(
+            allocationVars,
+            assignmentVars
+        );
+
+        Map<Node, Integer> assignments = plan.assignments(deployment).orElse(Map.of());
+        int totalAllocations = assignments.values().stream().mapToInt(Integer::intValue).sum();
+
+        assertThat(totalAllocations, equalTo(4));
+        assertThat(plan.satisfiesAllocations(deployment), is(true));
+    }
+}


### PR DESCRIPTION
Part of #156640

`tryAssigningRemainingCores` tops up deployments that came out of the rounding step short of their requested allocations, by spreading them onto nodes that are not yet hosting them. The second argument to `findOptimalAllocations` is `long availableMemoryBytes`, but the number of allocations still wanted was passed instead:

```java
m.findOptimalAllocations(
    resourceTracker.remainingNodeCores.get(n) / m.threadsPerAllocation(),
    resourceTracker.remainingModelAllocations.get(m)   // a count, not bytes
)
```

The division then asks whether a few bytes can hold a 532 MiB allocation, which is always `0`, so the surrounding `Math.min` makes the whole result `0` and the pass assigns nothing. The sibling call in `doRandomizedRounding` (line 289) already passes `remainingNodeMemory` correctly.

This only affects deployments that publish `per_deployment_memory_bytes` / `per_allocation_memory_bytes` — with both at `0`, `findOptimalAllocations` returns early and the division never runs. Every existing test in the package passes `0`, which is why no test covers the broken path.

### Verification

The added test gives a deployment 1 of 4 requested allocations on a node with no spare cores, plus a second idle node with ample memory and cores. It assigns **1 of 4** before this change and **4** after.

**The scenario needs the node the deployment already runs on to be out of cores.** `assignExcessCores` tops up nodes the deployment already occupies and passes memory correctly, so if that node still has spare cores it covers for the broken path and nothing looks wrong.