### PR TITLE
[9.5] Fix flaky byte-count assertion in SearchCoordinatorPhaseShardBytesMetricsIT (#153241)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -445,9 +445,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:BASELINE}
   issue: https://github.com/elastic/elasticsearch/issues/154058
-- class: org.elasticsearch.search.telemetry.SearchCoordinatorPhaseShardBytesMetricsIT
-  method: testBatchedQueryPhaseShardErrorRecordsBothRequestAndResultBytes
-  issue: https://github.com/elastic/elasticsearch/issues/156627
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/156415

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/telemetry/SearchCoordinatorPhaseShardBytesMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/telemetry/SearchCoordinatorPhaseShardBytesMetricsIT.java
@@ -549,10 +549,10 @@ public class SearchCoordinatorPhaseShardBytesMetricsIT extends ESIntegTestCase {
 
             assertThat("query request bytes are fetch-method independent", chunkedQueryRequestBytes, equalTo(nonChunkedQueryRequestBytes));
 
-            // The query result (NodeQueryResponse) includes a per-shard serviceTimeEWMA that is
-            // updated between runs and may shift by 1-2 bytes per shard when VLong encoding width
-            // changes. 16 bytes covers two shards with a 2-byte shift each, with room to spare.
-            long queryResultTolerance = 16L;
+            // The query result (NodeQueryResponse) includes a per-shard serviceTimeEWMA whose VLong
+            // encoding width can shift between runs; empirically this is usually 0 but occasionally a
+            // few bytes per shard. Scale with numShards, plus a flat margin for that jitter.
+            long queryResultTolerance = numShards * 2L + 24L;
             assertThat(
                 "chunked and non-chunked query result bytes are within encoding tolerance",
                 chunkedQueryResultBytes,
@@ -653,6 +653,10 @@ public class SearchCoordinatorPhaseShardBytesMetricsIT extends ESIntegTestCase {
     public void testBatchedQueryPhaseShardErrorRecordsBothRequestAndResultBytes() {
         // we use this local index to ensure that we go past the query phase
         final String localIndex = "local-shards-error-test";
+        // At least 2 shards per data node so both searches below are always batched.
+        int localIndexShards = between(2 * internalCluster().numDataNodes(), maximumNumberOfShards());
+        prepareCreate(localIndex).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, localIndexShards)).get();
+        ensureGreen(localIndex);
         prepareIndex(localIndex).setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         try {
@@ -691,9 +695,9 @@ public class SearchCoordinatorPhaseShardBytesMetricsIT extends ESIntegTestCase {
             assertThat(queryRequestBytes, hasSize(1));
             assertThat(queryRequestBytes.get(0).getLong(), greaterThan(queryRequestBytesLocalIndex));
 
-            // NodeQueryResponse is always deserialised via handler.read() — per-shard exceptions
-            // are payload, not transport-level errors — so result bytes are non-zero even though
-            // every shard in the batch failed.
+            // Both searches are batched, so their result bytes are comparable: batched failures are folded
+            // into the merged NodeQueryResponse as compact exception stamps, not full QuerySearchResult
+            // objects, so batched and non-batched byte counts sit on different scales.
             queryResultBytes = plugin.getLongHistogramMeasurement(QUERY_SHARD_RESULT_BYTES_HISTOGRAM_NAME);
             assertThat(queryResultBytes, hasSize(1));
             assertThat(queryResultBytes.get(0).getLong(), greaterThan(queryResultBytesLocalIndex));


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix flaky byte-count assertion in SearchCoordinatorPhaseShardBytesMetricsIT (#153241)
