### PR TITLE
[9.5] Fix BroadcastMessageAction request serialization (#156603)

### DIFF
--- a/docs/changelog/156603.yaml
+++ b/docs/changelog/156603.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 156603
+summary: Fix `BroadcastMessageAction` request serialization
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/BroadcastMessageAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/BroadcastMessageAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Broadcasts a {@link Writeable} to all nodes and responds with an empty object.
@@ -56,7 +57,7 @@ public abstract class BroadcastMessageAction<Message extends Writeable> extends 
             clusterService,
             transportService,
             actionFilters,
-            in -> new NodeRequest<>(messageReader.read(in)),
+            in -> new NodeRequest<>(in, messageReader),
             clusterService.threadPool().executor(ThreadPool.Names.MANAGEMENT)
         );
     }
@@ -122,13 +123,45 @@ public abstract class BroadcastMessageAction<Message extends Writeable> extends 
     public static class NodeRequest<Message extends Writeable> extends AbstractTransportRequest {
         private final Message message;
 
-        private NodeRequest(Message message) {
+        NodeRequest(Message message) {
             this.message = message;
+        }
+
+        NodeRequest(StreamInput in, Writeable.Reader<Message> messageReader) throws IOException {
+            super(in);
+            this.message = messageReader.read(in);
+        }
+
+        Message message() {
+            return message;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            message.writeTo(out);
         }
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
             return new CancellableTask(id, type, action, "broadcasted message to an individual node", parentTaskId, headers);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NodeRequest<?> other = (NodeRequest<?>) o;
+            return Objects.equals(message, other.message) && Objects.equals(getParentTask(), other.getParentTask());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(message, getParentTask());
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/BroadcastMessageActionNodeRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/BroadcastMessageActionNodeRequestTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+import org.elasticsearch.xpack.inference.common.BroadcastMessageAction.NodeRequest;
+
+import java.io.IOException;
+
+/**
+ * Guards the symmetry of {@link BroadcastMessageAction.NodeRequest}'s wire format. An earlier version
+ * wrote the parent task id (inherited {@code writeTo}) without ever reading it back, and never wrote
+ * the message at all: remote nodes were left with unread bytes, which the transport layer escalates to
+ * a fatal error when assertions are enabled, killing the receiving node. A non-empty test message
+ * proves the payload itself crosses the wire.
+ */
+public class BroadcastMessageActionNodeRequestTests extends AbstractBWCWireSerializationTestCase<
+    NodeRequest<BroadcastMessageActionNodeRequestTests.TestMessage>> {
+
+    record TestMessage(String value) implements Writeable {
+        TestMessage(StreamInput in) throws IOException {
+            this(in.readString());
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(value);
+        }
+    }
+
+    @Override
+    protected Writeable.Reader<NodeRequest<TestMessage>> instanceReader() {
+        return in -> new NodeRequest<>(in, TestMessage::new);
+    }
+
+    @Override
+    protected NodeRequest<TestMessage> createTestInstance() {
+        var request = new NodeRequest<>(new TestMessage(randomAlphaOfLengthBetween(1, 20)));
+        if (randomBoolean()) {
+            // Node-level requests carry the parent (coordinating) task id; it must round-trip too.
+            request.setParentTask(new TaskId(randomAlphaOfLength(22), randomNonNegativeLong()));
+        }
+        return request;
+    }
+
+    @Override
+    protected NodeRequest<TestMessage> mutateInstance(NodeRequest<TestMessage> instance) {
+        var mutated = new NodeRequest<>(new TestMessage(randomValueOtherThan(instance.message().value(), () -> randomAlphaOfLength(21))));
+        mutated.setParentTask(instance.getParentTask());
+        return mutated;
+    }
+
+    @Override
+    protected NodeRequest<TestMessage> mutateInstanceForVersion(NodeRequest<TestMessage> instance, TransportVersion version) {
+        // The wire format has no version-dependent fields.
+        return instance;
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix BroadcastMessageAction request serialization (#156603)](https://github.com/elastic/elasticsearch/pull/156603)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)