### PR TITLE
[ESQL] Honor error_mode for oversized NDJSON numbers

### DIFF
--- a/docs/changelog/156667.yaml
+++ b/docs/changelog/156667.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 156667
+summary: Honor `error_mode` for oversized NDJSON numbers
+type: bug

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.esql.datasource.ndjson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.io.JsonEOFException;
 
 import org.apache.lucene.document.InetAddressPoint;
@@ -749,21 +751,30 @@ public class NdJsonPageDecoder implements Closeable {
     /**
      * Whole-line JSON failures always drop the line. {@link ErrorPolicy.Mode#NULL_FIELD} is treated
      * like {@link ErrorPolicy.Mode#SKIP_ROW} here; per-field null-fill would require partial decode support.
+     * <p>
+     * A {@code StreamReadConstraints} violation lands here rather than on the per-cell
+     * {@link BlockDecoder#coercionFailure} path because Jackson enforces those limits while scanning a token,
+     * before the value is ever read: the parser cannot be resumed mid-record afterwards, so there is no
+     * partially decoded row left whose cell could be nulled.
      */
-    private void onNdjsonLineParseError(JsonParseException e, long logicalRowIndex, String phaseLabel) {
+    private void onNdjsonLineParseError(JsonProcessingException e, long logicalRowIndex, String phaseLabel) {
+        String kind = switch (e) {
+            case JsonEOFException ignored -> "Truncated";
+            case StreamConstraintsException ignored -> "Oversized";
+            case JsonParseException ignored -> "Malformed";
+            default -> throw new AssertionError("unexpected NDJSON line failure [" + e.getClass().getName() + "]");
+        };
         if (errorPolicy.isStrict()) {
-            throw new EsqlIllegalArgumentException(e, "Malformed NDJSON [{}]: {}", phaseLabel, e.getOriginalMessage());
+            throw new EsqlIllegalArgumentException(
+                e,
+                "{} NDJSON [{}]: {}; set error_mode=skip_row (or null_field) to drop the record and warn instead of failing",
+                kind,
+                phaseLabel,
+                e.getOriginalMessage()
+            );
         }
         errorCount++;
-        skipWarnings.add(
-            (e instanceof JsonEOFException ? "Truncated" : "Malformed")
-                + " NDJSON at logical row ["
-                + logicalRowIndex
-                + "] ("
-                + phaseLabel
-                + "): "
-                + e.getOriginalMessage()
-        );
+        skipWarnings.add(kind + " NDJSON at logical row [" + logicalRowIndex + "] (" + phaseLabel + "): " + e.getOriginalMessage());
         checkErrorBudgetOrThrow();
         logger.log(
             errorPolicy.logErrors() ? Level.INFO : Level.DEBUG,
@@ -774,7 +785,7 @@ public class NdJsonPageDecoder implements Closeable {
             // existing assertion since this is a log-only message).
             LoggerMessageFormat.format(
                 "{} NDJSON at logical row [{}] ({}): {}",
-                (Object) (e instanceof JsonEOFException ? "Truncated" : "Malformed"),
+                (Object) kind,
                 logicalRowIndex,
                 phaseLabel,
                 e.getOriginalMessage()
@@ -936,8 +947,7 @@ public class NdJsonPageDecoder implements Closeable {
     }
 
     /**
-     * {@link ErrorPolicy.Mode#FAIL_FAST}: abort on the first {@link JsonParseException} on a line
-     * (no recovery, no scratch-row path).
+     * {@link ErrorPolicy.Mode#FAIL_FAST}: abort on the first unparseable line (no recovery, no scratch-row path).
      */
     private Page decodePageFailFast(Block.Builder[] blockBuilders) throws IOException {
         int lineCount = 0;
@@ -946,7 +956,7 @@ public class NdJsonPageDecoder implements Closeable {
                 if (parser.nextToken() == null) {
                     break; // End of stream
                 }
-            } catch (JsonParseException e) {
+            } catch (JsonParseException | StreamConstraintsException e) {
                 totalRowCount++;
                 onNdjsonLineParseError(e, totalRowCount, "nextToken"); // FAIL_FAST: throws
             }
@@ -965,7 +975,7 @@ public class NdJsonPageDecoder implements Closeable {
 
             try {
                 decoder.decodeObject(parser, false);
-            } catch (JsonParseException e) {
+            } catch (JsonParseException | StreamConstraintsException e) {
                 onNdjsonLineParseError(e, totalRowCount, "decodeObject");
             }
 
@@ -1024,7 +1034,7 @@ public class NdJsonPageDecoder implements Closeable {
                 if (parser.nextToken() == null) {
                     break; // End of stream
                 }
-            } catch (JsonParseException e) {
+            } catch (JsonParseException | StreamConstraintsException e) {
                 totalRowCount++;
                 onNdjsonLineParseError(e, totalRowCount, "nextToken");
                 recoverFromParseException(parser);
@@ -1051,7 +1061,7 @@ public class NdJsonPageDecoder implements Closeable {
                 decoder.setupBuilders(rowScratch, 1);
                 try {
                     decoder.decodeObject(parser, false);
-                } catch (JsonParseException e) {
+                } catch (JsonParseException | StreamConstraintsException e) {
                     onNdjsonLineParseError(e, totalRowCount, "decodeObject");
                     recoverFromParseException(parser);
                     continue;

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.ndjson;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.logging.LogManager;
@@ -84,13 +85,13 @@ public class NdJsonSchemaInferrer {
                     if (parser.nextToken() == null) {
                         break; // End of stream
                     }
-                } catch (JsonParseException e) {
+                } catch (JsonParseException | StreamConstraintsException e) {
                     // Schema inference is a best-effort sampling pass: malformed lines here are
                     // safe to skip because every such line will be re-encountered during the
                     // actual slice read (see NdJsonPageIterator), where the configured
                     // ErrorPolicy decides whether to log/fail. Logging at debug avoids noisy
                     // duplicate reports of the same issue.
-                    logger.debug("Malformed NDJSON at line {}: {}", lineCount, e);
+                    logger.debug("Unparseable NDJSON at line {}: {}", lineCount, e);
                     inputStream = NdJsonUtils.moveToNextLine(parser, inputStream);
                     parser = NdJsonUtils.JSON_FACTORY.createParser(inputStream);
                     continue;
@@ -99,9 +100,9 @@ public class NdJsonSchemaInferrer {
                 try {
                     inferObjectSchema(parser, root);
                     lineCount++;
-                } catch (JsonParseException e) {
+                } catch (JsonParseException | StreamConstraintsException e) {
                     // See comment above: deferred to the slice read for policy-driven handling.
-                    logger.debug("Malformed NDJSON at line {}: {}", lineCount, e);
+                    logger.debug("Unparseable NDJSON at line {}: {}", lineCount, e);
                     inputStream = NdJsonUtils.moveToNextLine(parser, inputStream);
                     parser = NdJsonUtils.JSON_FACTORY.createParser(inputStream);
                 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoderTests.java
@@ -752,11 +752,15 @@ public class NdJsonPageDecoderTests extends ESTestCase {
     }
 
     private Page decodeOneColumn(String ndjson, DataType type, ErrorPolicy policy) throws IOException {
+        return decodeColumns(ndjson, policy, attribute("v", type));
+    }
+
+    private Page decodeColumns(String ndjson, ErrorPolicy policy, Attribute... attributes) throws IOException {
         try (
             NdJsonPageDecoder decoder = new NdJsonPageDecoder(
                 new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8)),
                 null,
-                List.of(attribute("v", type)),
+                List.of(attributes),
                 null,
                 10,
                 blockFactory,
@@ -1283,4 +1287,77 @@ public class NdJsonPageDecoderTests extends ESTestCase {
         assertFalse("expected skip_row warnings for the poisoned record", warnings.isEmpty());
         assertScratchIsRecordSized(breaker, 2);
     }
+
+    // --- oversized number tokens (Jackson's StreamReadConstraints number-length limit) ---
+
+    private static final int MAX_NUMBER_LENGTH = NdJsonUtils.JSON_FACTORY.streamReadConstraints().getMaxNumberLength();
+
+    private static final String OVERSIZED_NUMBER = "1".repeat(MAX_NUMBER_LENGTH + 1);
+
+    private record OversizedFixture(String description, String ndjson) {}
+
+    /** Reproducer for https://github.com/elastic/esql-planning/issues/1159. */
+    public void testOversizedNumberFailsFast() {
+        EsqlIllegalArgumentException e = expectThrows(
+            EsqlIllegalArgumentException.class,
+            () -> decodeOneColumn("{\"v\":1}\n{\"v\":" + OVERSIZED_NUMBER + "}\n{\"v\":2}\n", DataType.LONG, ErrorPolicy.STRICT)
+        );
+        assertThat(e.getMessage(), Matchers.startsWith("Oversized NDJSON [decodeObject]: "));
+        assertThat(e.getMessage(), Matchers.containsString("StreamReadConstraints.getMaxNumberLength()"));
+        assertThat(
+            e.getMessage(),
+            Matchers.endsWith("; set error_mode=skip_row (or null_field) to drop the record and warn instead of failing")
+        );
+    }
+
+    public void testOversizedNumberDropsRecord() throws IOException {
+        var oversizedFixtures = List.of(
+            new OversizedFixture("a projected field's value", "{\"v\":9,\"w\":" + OVERSIZED_NUMBER + "}"),
+            new OversizedFixture("an unprojected field's value", "{\"v\":9,\"w\":9,\"other\":" + OVERSIZED_NUMBER + "}"),
+            new OversizedFixture("an element inside an array", "{\"v\":9,\"w\":[9," + OVERSIZED_NUMBER + "]}")
+        );
+        for (OversizedFixture fixture : oversizedFixtures) {
+            for (ErrorPolicy policy : List.of(ErrorPolicy.LENIENT, ErrorPolicy.PERMISSIVE)) {
+                String context = fixture.description() + " under " + policy.modeName();
+                String ndjson = "{\"v\":1,\"w\":1}\n" + fixture.ndjson() + "\n{\"v\":2,\"w\":2}\n";
+                try (Page page = decodeColumns(ndjson, policy, attribute("v", DataType.LONG), attribute("w", DataType.LONG))) {
+                    assertGoodRowsSurvived(context + ", column v", page.getBlock(0));
+                    assertGoodRowsSurvived(context + ", column w", page.getBlock(1));
+                }
+                assertThat(context, drainWarnings(), Matchers.hasItem(Matchers.containsString(OVERSIZED_ROW_2_WARNING)));
+            }
+        }
+    }
+
+    public void testOversizedNumberDropsRecordForAKeywordColumn() throws IOException {
+        String ndjson = "{\"v\":\"a\"}\n{\"v\":" + OVERSIZED_NUMBER + "}\n{\"v\":\"b\"}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.KEYWORD, ErrorPolicy.LENIENT)) {
+            BytesRefBlock block = page.getBlock(0);
+            assertEquals(2, block.getPositionCount());
+            BytesRef scratch = new BytesRef();
+            assertEquals(new BytesRef("a"), BytesRef.deepCopyOf(block.getBytesRef(0, scratch)));
+            assertEquals(new BytesRef("b"), BytesRef.deepCopyOf(block.getBytesRef(1, scratch)));
+        }
+        assertThat(drainWarnings(), Matchers.hasItem(Matchers.containsString(OVERSIZED_ROW_2_WARNING)));
+    }
+
+    public void testLargestTokenizableNumberIsStillAPerCellFailure() throws IOException {
+        String ndjson = "{\"v\":1}\n{\"v\":" + "1".repeat(MAX_NUMBER_LENGTH) + "}\n{\"v\":2}\n";
+        try (Page page = decodeOneColumn(ndjson, DataType.LONG, ErrorPolicy.PERMISSIVE)) {
+            LongBlock block = page.getBlock(0);
+            assertEquals("the record is kept, not dropped", 3, block.getPositionCount());
+            assertEquals(1L, block.getLong(block.getFirstValueIndex(0)));
+            assertTrue("the out-of-range value nulls its own cell", block.isNull(1));
+            assertEquals(2L, block.getLong(block.getFirstValueIndex(2)));
+        }
+        drainWarnings();
+    }
+
+    private static void assertGoodRowsSurvived(String context, LongBlock block) {
+        assertThat(context, block.getPositionCount(), Matchers.equalTo(2));
+        assertThat(context, block.getLong(block.getFirstValueIndex(0)), Matchers.equalTo(1L));
+        assertThat(context, block.getLong(block.getFirstValueIndex(1)), Matchers.equalTo(2L));
+    }
+
+    private static final String OVERSIZED_ROW_2_WARNING = "Oversized NDJSON at logical row [2] (decodeObject): ";
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrerTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrerTests.java
@@ -62,6 +62,18 @@ public class NdJsonSchemaInferrerTests extends ESTestCase {
     }
 
     /**
+     * A number token past the reader's number-length limit is rejected while the token is scanned, one step
+     * earlier than any value read, so it used to escape inference's malformed-line handling and fail the query
+     * during sampling — before decoding, regardless of error_mode (elastic/esql-planning#1159). The line must be
+     * skipped like any other unusable one, leaving the type to the records that can be read. {@code age} comes
+     * back nullable because the skipped line still counts as a round in which the field was absent.
+     */
+    public void testIgnoreOversizedNumberToken() throws IOException {
+        String oversized = "1".repeat(NdJsonUtils.JSON_FACTORY.streamReadConstraints().getMaxNumberLength() + 1);
+        check("{\"age\": 30}\n{\"age\": " + oversized + "}\n{\"age\": 25}\n", field("age", DataType.INTEGER, true));
+    }
+
+    /**
      * Test case: check line ending variations
      */
     public void testLineEndingVariations() throws IOException {


### PR DESCRIPTION
## Summary

Oversized numeric tokens in NDJSON used to fail the whole `FROM` read with a raw Jackson `StreamConstraintsException` (HTTP 400), even when `error_mode` was `skip_row` or `null_field`.

The failure is a **whole-line** error, not a per-cell coercion. Jackson enforces `StreamReadConstraints.maxNumberLength` while *scanning* the token (`nextToken` / `nextFieldName`), before any column is resolved. `StreamConstraintsException` is a sibling of `JsonParseException` under `JsonProcessingException`, so the existing `catch (JsonParseException)` sites missed it.

This change:

- Widens the record-level catches in `NdJsonPageDecoder` and `NdJsonSchemaInferrer` to `JsonParseException | StreamConstraintsException`.
- Routes the failure through the existing line-level handler. `fail_fast` throws an `EsqlIllegalArgumentException` that names the constraint and hints at `error_mode`; `skip_row` and `null_field` drop just that record and keep decoding.
- Classifies the line as `Truncated` / `Oversized` / `Malformed` so the exception, warning, and log stay consistent.

`null_field` still drops the record rather than nulling a single cell. After the throw the parser is unusable (it impersonates a clean EOF), so there is no partial row left to `null`. That is the same documented degradation as for malformed JSON.