### PR TITLE
[9.5] [Inference API] Translate unified tool-calling message blocks to Anthropic format (#154607)

### DIFF
--- a/docs/changelog/154607.yaml
+++ b/docs/changelog/154607.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 154607
+summary: "[Inference API] Translate unified tool-calling message blocks to Anthropic format"
+type: bug

--- a/server/src/main/java/org/elasticsearch/inference/InferenceString.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceString.java
@@ -44,6 +44,8 @@ public record InferenceString(DataType dataType, DataFormat dataFormat, String v
     // Character classes stop at literal delimiters so matching is linear. RFC 2397 ";param=value" pairs get absorbed into the {subtype}
     // class.
     private static final Pattern DATA_URI_PATTERN = Pattern.compile("^data:[^/]+/[^,]+;base64,");
+    private static final String DATA_URI_PREFIX = "data:";
+    private static final String BASE64_MARKER = ";base64";
 
     public static final String TYPE_FIELD = "type";
     public static final String FORMAT_FIELD = "format";
@@ -106,18 +108,39 @@ public record InferenceString(DataType dataType, DataFormat dataFormat, String v
     }
 
     private void validateDataURIFormat() {
-        if (dataFormat == DataFormat.BASE64) {
-            var endOfURIPart = value.indexOf(',');
-            // Fast-fail on missing or oversized URI part before the regex.
-            if (endOfURIPart < 0
-                || endOfURIPart >= MAX_DATA_URI_PREFIX_LENGTH
-                || DATA_URI_PATTERN.matcher(value).region(0, endOfURIPart + 1).matches() == false) {
-                throw new IllegalArgumentException(
-                    "base64 inputs must be specified as data URIs with the format [data:{MIME-type};base64,...]"
-                );
-            }
+        if (dataFormat == DataFormat.BASE64 && tryParseDataUri(value) == null) {
+            throw new IllegalArgumentException(
+                "base64 inputs must be specified as data URIs with the format [data:{MIME-type};base64,...]"
+            );
         }
     }
+
+    /**
+     * Parses {@code value} as a base64 data URI ({@code data:<media-type>;base64,<data>}) — the format every
+     * {@link DataFormat#BASE64} input is required to use, since consumers need the declared media type. Returns the media type
+     * exactly as declared (including any RFC 2397 parameters, e.g. {@code text/plain;charset=utf-8}) together with the base64
+     * payload, or {@code null} when the value is not a valid base64 data URI, leaving it to callers to decide whether that is
+     * an error.
+     */
+    @Nullable
+    public static DataUri tryParseDataUri(String value) {
+        var endOfURIPart = value.indexOf(',');
+        // Fast-fail on missing or oversized URI part before the regex.
+        if (endOfURIPart < 0
+            || endOfURIPart >= MAX_DATA_URI_PREFIX_LENGTH
+            || DATA_URI_PATTERN.matcher(value).region(0, endOfURIPart + 1).matches() == false) {
+            return null;
+        }
+        return new DataUri(
+            value.substring(DATA_URI_PREFIX.length(), endOfURIPart - BASE64_MARKER.length()),
+            value.substring(endOfURIPart + 1)
+        );
+    }
+
+    /**
+     * The declared media type and base64 payload of a base64 data URI, as returned by {@link #tryParseDataUri(String)}.
+     */
+    public record DataUri(String mediaType, String base64Data) {}
 
     public InferenceString(StreamInput in) throws IOException {
         this(in.readEnum(DataType.class), in.readEnum(DataFormat.class), in.readString());

--- a/server/src/test/java/org/elasticsearch/inference/InferenceStringTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/InferenceStringTests.java
@@ -36,6 +36,7 @@ import static org.elasticsearch.inference.InferenceString.fromStringList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class InferenceStringTests extends AbstractBWCSerializationTestCase<InferenceString> {
     public static final String TEST_DATA_URI = "data:mime/type;base64,abcd";
@@ -95,6 +96,28 @@ public class InferenceStringTests extends AbstractBWCSerializationTestCase<Infer
         new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/png;charset=utf-8;base64,abcd");
         new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/png;p1=v1;p2=v2;base64,abcd");
         new InferenceString(DataType.IMAGE, DataFormat.BASE64, "data:image/svg+xml;base64,abcd");
+    }
+
+    public void testTryParseDataUri_extractsMediaTypeAndPayload() {
+        assertThat(InferenceString.tryParseDataUri("data:image/png;base64,abcd"), is(new InferenceString.DataUri("image/png", "abcd")));
+        // RFC 2397 parameters are preserved as declared; interpreting them is up to the caller.
+        assertThat(
+            InferenceString.tryParseDataUri("data:text/plain;charset=utf-8;base64,abcd"),
+            is(new InferenceString.DataUri("text/plain;charset=utf-8", "abcd"))
+        );
+    }
+
+    public void testTryParseDataUri_returnsNullForInvalidValues() {
+        var invalidValues = List.of(
+            "",
+            "notADataURI",
+            "abcd", // bare base64 without a data URI prefix
+            "https://example.com/image.png", // plain URL
+            "data:image/jpeg;base64abcd", // missing final ","
+            "data:;base64,abcd", // missing MIME type
+            "data:image/" + "a".repeat(InferenceString.MAX_DATA_URI_PREFIX_LENGTH) + ";base64,abcd" // oversized prefix
+        );
+        invalidValues.forEach(value -> assertThat(value, InferenceString.tryParseDataUri(value), nullValue()));
     }
 
     /** URI prefixes exceeding {@link InferenceString#MAX_DATA_URI_PREFIX_LENGTH} are rejected before the regex runs. */

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessor.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentE
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -29,7 +30,12 @@ import static org.elasticsearch.common.Strings.format;
 import static org.elasticsearch.xpack.inference.external.response.XContentUtils.parseObjects;
 
 /**
- * Chat Completions Streaming Processor for Anthropic provider
+ * Chat Completions Streaming Processor for Anthropic provider.
+ *
+ * <p>Stateful: one instance handles exactly one response stream. Anthropic identifies streamed tool calls by their content
+ * block index, whereas the unified format expects each tool call to carry a monotonically increasing index of its own (the
+ * content block index also counts text blocks, so the two numberings diverge); the mapping between them is tracked across
+ * events.
  */
 public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcessor<
     Deque<ServerSentEvent>,
@@ -52,7 +58,6 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
     private static final String OUTPUT_TOKENS_FIELD = "output_tokens";
     private static final String STOP_REASON_FIELD = "stop_reason";
     private static final String TEXT_FIELD = "text";
-    private static final String INPUT_FIELD = "input";
     private static final String PARTIAL_JSON_FIELD = "partial_json";
     private static final String USAGE_FIELD = "usage";
     private static final String MESSAGE_FIELD = "message";
@@ -76,7 +81,24 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
     private static final String TOOL_USE_TYPE = "tool_use";
     private static final String TEXT_TYPE = "text";
 
+    // Anthropic stop reasons
+    private static final String END_TURN_STOP_REASON = "end_turn";
+    private static final String STOP_SEQUENCE_STOP_REASON = "stop_sequence";
+    private static final String PAUSE_TURN_STOP_REASON = "pause_turn";
+    private static final String MAX_TOKENS_STOP_REASON = "max_tokens";
+    private static final String TOOL_USE_STOP_REASON = "tool_use";
+    private static final String REFUSAL_STOP_REASON = "refusal";
+
+    // OpenAI finish reasons
+    private static final String STOP_FINISH_REASON = "stop";
+    private static final String LENGTH_FINISH_REASON = "length";
+    private static final String TOOL_CALLS_FINISH_REASON = "tool_calls";
+    private static final String CONTENT_FILTER_FINISH_REASON = "content_filter";
+
     private final BiFunction<String, Exception, Exception> errorParser;
+
+    private int toolCallCount = 0;
+    private final Map<Integer, Integer> contentBlockIndexToToolCallIndex = new HashMap<>();
 
     public AnthropicChatCompletionStreamingProcessor(BiFunction<String, Exception, Exception> errorParser) {
         this.errorParser = errorParser;
@@ -115,7 +137,7 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      * @return a stream of ChatCompletionChunk
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parse(
+    private Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parse(
         XContentParserConfiguration parserConfig,
         ServerSentEvent event
     ) throws IOException {
@@ -126,13 +148,13 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
                 logger.debug("Skipping event type [{}] for line [{}].", event.type(), event.data());
                 return Stream.empty();
             case MESSAGE_START_EVENT_TYPE:
-                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseMessageStart);
+                return parseObjects(parserConfig, event.data(), this::parseMessageStart);
             case CONTENT_BLOCK_START_EVENT_TYPE:
-                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseContentBlockStart);
+                return parseObjects(parserConfig, event.data(), this::parseContentBlockStart);
             case CONTENT_BLOCK_DELTA_EVENT_TYPE:
-                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseContentBlockDelta);
+                return parseObjects(parserConfig, event.data(), this::parseContentBlockDelta);
             case MESSAGE_DELTA_EVENT_TYPE:
-                return parseObjects(parserConfig, event.data(), AnthropicChatCompletionStreamingProcessor::parseMessageDelta);
+                return parseObjects(parserConfig, event.data(), this::parseMessageDelta);
             case MESSAGE_STOP_EVENT_TYPE:
                 return Stream.empty();
             case null, default:
@@ -167,13 +189,12 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageStart(XContentParser parser)
-        throws IOException {
+    private Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageStart(XContentParser parser) throws IOException {
         var messageMap = extractInnerStringObjectMap(parser.map(), MESSAGE_FIELD);
         var model = extractMandatoryString(messageMap, MODEL_FIELD);
         var id = extractMandatoryString(messageMap, ID_FIELD);
         var role = extractMandatoryString(messageMap, ROLE_FIELD);
-        var finishReason = extractOptionalString(messageMap, STOP_REASON_FIELD);
+        var finishReason = convertStopReason(extractOptionalString(messageMap, STOP_REASON_FIELD));
         var usageMap = extractInnerStringObjectMap(messageMap, USAGE_FIELD);
         var promptTokens = extractMandatoryInteger(usageMap, INPUT_TOKENS_FIELD);
         var completionTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
@@ -216,7 +237,7 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockStart(XContentParser parser)
+    private Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockStart(XContentParser parser)
         throws IOException {
         var outerMap = parser.map();
         var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
@@ -229,18 +250,25 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
         } else if (type.equals(TOOL_USE_TYPE)) {
             var id = extractMandatoryString(contentBlockMap, ID_FIELD);
             var name = extractMandatoryString(contentBlockMap, NAME_FIELD);
-            var input = extractOptionalField(contentBlockMap, INPUT_FIELD, Object.class);
-            var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(
-                input != null ? input.toString() : null,
-                name
+            var toolCallIndex = toolCallCount++;
+            contentBlockIndexToToolCallIndex.put(index, toolCallIndex);
+            // A tool_use content block start always carries an empty input object; the actual tool input arrives
+            // as input_json_delta fragments, which clients concatenate onto the arguments, so seed them empty.
+            var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function("", name);
+            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(
+                toolCallIndex,
+                id,
+                function,
+                null
             );
-            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, id, function, null);
             delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(null, null, null, List.of(toolCall));
         } else {
             logger.debug("Unknown content block start type [{}] for line [{}].", type, outerMap);
             return Stream.empty();
         }
-        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
+        // Anthropic streams a single message, so the chunk always holds one choice at index 0; parallel tool calls are
+        // distinguished by the tool call index, not the choice index.
+        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, 0);
         var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
         return Stream.of(chunk);
     }
@@ -272,7 +300,7 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    private static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockDelta(XContentParser parser)
+    private Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseContentBlockDelta(XContentParser parser)
         throws IOException {
         var outerMap = parser.map();
         var index = extractMandatoryInteger(outerMap, INDEX_FIELD);
@@ -283,9 +311,19 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
             var text = extractMandatoryString(deltaMap, TEXT_FIELD);
             delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(text, null, null, null, null, null);
         } else if (type.equals(INPUT_JSON_DELTA_TYPE)) {
+            var toolCallIndex = contentBlockIndexToToolCallIndex.get(index);
+            if (toolCallIndex == null) {
+                logger.warn("Received [{}] for unknown content block index [{}].", INPUT_JSON_DELTA_TYPE, index);
+                return Stream.empty();
+            }
             var partialJson = extractMandatoryString(deltaMap, PARTIAL_JSON_FIELD);
             var function = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall.Function(partialJson, null);
-            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(0, null, function, null);
+            var toolCall = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta.ToolCall(
+                toolCallIndex,
+                null,
+                function,
+                null
+            );
             delta = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice.Delta(
                 null,
                 null,
@@ -299,7 +337,9 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
             return Stream.empty();
         }
 
-        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, index);
+        // Anthropic streams a single message, so the chunk always holds one choice at index 0; parallel tool calls are
+        // distinguished by the tool call index, not the choice index.
+        var choice = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk.Choice(delta, null, 0);
         var chunk = new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, null);
 
         return Stream.of(chunk);
@@ -336,11 +376,10 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
      * @return a stream of {@link StreamingUnifiedChatCompletionResults.ChatCompletionChunk}
      * @throws IOException if parsing fails
      */
-    public static Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageDelta(XContentParser parser)
-        throws IOException {
+    public Stream<StreamingUnifiedChatCompletionResults.ChatCompletionChunk> parseMessageDelta(XContentParser parser) throws IOException {
         var outerMap = parser.map();
         var deltaMap = extractInnerStringObjectMap(outerMap, DELTA_FIELD);
-        var finishReason = extractOptionalString(deltaMap, STOP_REASON_FIELD);
+        var finishReason = convertStopReason(extractOptionalString(deltaMap, STOP_REASON_FIELD));
         var usageMap = extractInnerStringObjectMap(outerMap, USAGE_FIELD);
         var totalTokens = extractMandatoryInteger(usageMap, OUTPUT_TOKENS_FIELD);
 
@@ -360,6 +399,28 @@ public class AnthropicChatCompletionStreamingProcessor extends DelegatingProcess
             0
         );
         return new StreamingUnifiedChatCompletionResults.ChatCompletionChunk(null, List.of(choice), null, null, usage);
+    }
+
+    /**
+     * Converts an Anthropic stop reason to the equivalent OpenAI finish reason, so that OpenAI-compatible clients can
+     * rely on the unified vocabulary (e.g. checking for [tool_calls] to decide whether to run tools). A null stop
+     * reason means the message is still in progress and is passed through unchanged.
+     */
+    @Nullable
+    private static String convertStopReason(@Nullable String stopReason) {
+        if (stopReason == null) {
+            return null;
+        }
+        return switch (stopReason) {
+            case END_TURN_STOP_REASON, STOP_SEQUENCE_STOP_REASON, PAUSE_TURN_STOP_REASON -> STOP_FINISH_REASON;
+            case MAX_TOKENS_STOP_REASON -> LENGTH_FINISH_REASON;
+            case TOOL_USE_STOP_REASON -> TOOL_CALLS_FINISH_REASON;
+            case REFUSAL_STOP_REASON -> CONTENT_FILTER_FINISH_REASON;
+            default -> {
+                logger.warn("Unhandled Anthropic stop reason [{}], defaulting to [{}].", stopReason, STOP_FINISH_REASON);
+                yield STOP_FINISH_REASON;
+            }
+        };
     }
 
     private static String extractMandatoryString(Map<String, Object> map, String fieldName) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtils.java
@@ -9,22 +9,42 @@ package org.elasticsearch.xpack.inference.services.anthropic.request;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.inference.InferenceString;
+import org.elasticsearch.inference.completion.Content;
+import org.elasticsearch.inference.completion.ContentObject;
+import org.elasticsearch.inference.completion.ContentObject.ContentObjectFile;
+import org.elasticsearch.inference.completion.ContentObject.ContentObjectImage;
+import org.elasticsearch.inference.completion.ContentObject.ContentObjectText;
+import org.elasticsearch.inference.completion.ContentObjects;
+import org.elasticsearch.inference.completion.ContentString;
+import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.inference.completion.Tool;
 import org.elasticsearch.inference.completion.ToolChoice;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceObject;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceString;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.CONTENT_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.DESCRIPTION_FIELD;
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.ID_FIELD;
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MESSAGES_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.NAME_FIELD;
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.ROLE_FIELD;
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TEXT_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TOOL_CHOICE_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TOOL_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TYPE_FIELD;
+import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.URL_FIELD;
 
 /**
  * Serializes the tool-calling portion of a unified {@code chat_completion} request into the shape expected by the
@@ -42,7 +62,306 @@ public final class AnthropicToolUtils {
     private static final String PROPERTIES_FIELD = "properties";
     private static final String REQUIRED_FIELD = "required";
 
+    private static final String TOOL_ROLE = "tool";
+    private static final String USER_ROLE = "user";
+    private static final String ASSISTANT_ROLE = "assistant";
+    private static final String TEXT_TYPE = "text";
+    private static final String TOOL_USE_TYPE = "tool_use";
+    private static final String TOOL_RESULT_TYPE = "tool_result";
+    private static final String TOOL_USE_ID_FIELD = "tool_use_id";
+    private static final String INPUT_FIELD = "input";
+
+    private static final String IMAGE_TYPE = "image";
+    private static final String DOCUMENT_TYPE = "document";
+    private static final String SOURCE_FIELD = "source";
+    private static final String BASE64_SOURCE_TYPE = "base64";
+    private static final String URL_SOURCE_TYPE = "url";
+    private static final String MEDIA_TYPE_FIELD = "media_type";
+    private static final String DATA_FIELD = "data";
+    private static final String TITLE_FIELD = "title";
+    private static final String PDF_MEDIA_TYPE = "application/pdf";
+    private static final String PLAIN_TEXT_MEDIA_TYPE = "text/plain";
+
     private AnthropicToolUtils() {}
+
+    /**
+     * Writes the {@code messages} array, translating the unified (OpenAI-shaped) tool-calling messages into the content-block shape
+     * required by the <a href="https://platform.claude.com/docs/en/api/messages/create">Anthropic Messages API</a>. Anthropic does
+     * not understand OpenAI's {@code role: "tool"} messages or the {@code tool_calls} field on an assistant message, so forwarding
+     * them verbatim causes a {@code 400 messages: Unexpected role "tool"} on the second turn of any tool-calling conversation.
+     *
+     * <p>Two message shapes are translated:
+     * <ul>
+     *     <li>An assistant message carrying {@code tool_calls} becomes an {@code assistant} message whose {@code content} is an array
+     *         of {@code tool_use} blocks ({@code {"type":"tool_use","id":...,"name":...,"input":{...}}}). Any accompanying text
+     *         content is emitted as a leading {@code text} block. The OpenAI {@code arguments} string is parsed back into the JSON
+     *         object Anthropic expects under {@code input}.</li>
+     *     <li>A {@code role: "tool"} message becomes a {@code user} message whose {@code content} is a single {@code tool_result}
+     *         block ({@code {"type":"tool_result","tool_use_id":...,"content":[...]}}). The unified API accepts the tool message's
+     *         {@code content} as either a plain string (emitted as a single {@code text} block) or an array of content objects,
+     *         each translated like a user message's content objects below — {@code text}, {@code image} and {@code document} are
+     *         exactly the block types Anthropic allows inside a {@code tool_result}.</li>
+     *     <li>Any other message whose {@code content} is an array of content objects has each item translated into the Anthropic
+     *         block shape: {@code text} objects become {@code text} blocks, OpenAI {@code image_url} objects become {@code image}
+     *         blocks and {@code file} objects become {@code document} blocks, since Anthropic rejects the OpenAI shapes.</li>
+     * </ul>
+     *
+     * <p>Every message is emitted with array-shaped {@code content}: plain-string content becomes a single {@code text} block, and
+     * a user or assistant message whose content is empty or absent (and that carries no tool calls) is normalized to a single
+     * empty {@code text} block, since Anthropic requires {@code content} on every message.
+     * Both the direct Anthropic service and the Google Model Garden Anthropic provider share this logic so they emit identical
+     * Anthropic-shaped messages.
+     */
+    public static void writeMessages(XContentBuilder builder, List<Message> messages) throws IOException {
+        builder.startArray(MESSAGES_FIELD);
+        for (var message : messages) {
+            if (USER_ROLE.equals(message.role())) {
+                writePlainMessage(builder, USER_ROLE, message);
+            } else if (ASSISTANT_ROLE.equals(message.role())) {
+                writeAssistantMessage(builder, message);
+            } else if (TOOL_ROLE.equals(message.role())) {
+                writeToolResult(builder, message);
+            } else {
+                throw new ElasticsearchStatusException(
+                    Strings.format("Unsupported role [%s] for the Anthropic chat completion API.", message.role()),
+                    RestStatus.BAD_REQUEST
+                );
+            }
+        }
+        builder.endArray();
+    }
+
+    /**
+     * Writes a message that carries no tool calls: a user message, or an assistant message without {@code tool_calls}. Non-empty
+     * plain-string content is wrapped in a single text block; content objects are translated into Anthropic blocks; empty or
+     * absent content is normalized to a single empty text block since Anthropic rejects messages without content.
+     */
+    private static void writePlainMessage(XContentBuilder builder, String role, Message message) throws IOException {
+        if (message.content() instanceof ContentString(String content) && content.isEmpty() == false) {
+            writeContentObjectsMessage(builder, role, List.of(new ContentObjectText(content)));
+        } else if (message.content() instanceof ContentObjects(List<ContentObject> contentObjects) && contentObjects.isEmpty() == false) {
+            writeContentObjectsMessage(builder, role, contentObjects);
+        } else {
+            writeContentObjectsMessage(builder, role, List.of(new ContentObjectText("")));
+        }
+    }
+
+    private static void writeAssistantMessage(XContentBuilder builder, Message message) throws IOException {
+        var toolCalls = message.toolCalls();
+        if (toolCalls == null || toolCalls.isEmpty()) {
+            writePlainMessage(builder, ASSISTANT_ROLE, message);
+            return;
+        }
+
+        builder.startObject();
+        builder.field(ROLE_FIELD, ASSISTANT_ROLE);
+        builder.startArray(CONTENT_FIELD);
+
+        // Anthropic allows a leading text block alongside tool_use blocks; the unified assistant message often carries empty content.
+        var text = extractText(message.content());
+        if (text.isEmpty() == false) {
+            writeTextBlock(builder, text);
+        }
+        for (var toolCall : toolCalls) {
+            builder.startObject();
+            builder.field(TYPE_FIELD, TOOL_USE_TYPE);
+            builder.field(ID_FIELD, toolCall.id());
+            builder.field(NAME_FIELD, toolCall.function().name());
+            writeToolCallInput(builder, toolCall.function().arguments());
+            builder.endObject();
+        }
+
+        builder.endArray();
+        builder.endObject();
+    }
+
+    private static void writeToolResult(XContentBuilder builder, Message message) throws IOException {
+        // Anthropic requires tool_use_id on every tool_result block, so a tool message without a tool_call_id cannot be translated.
+        if (message.toolCallId() == null) {
+            throw new ElasticsearchStatusException(
+                "Field [tool_call_id] is required in a tool message for the Anthropic chat completion API.",
+                RestStatus.BAD_REQUEST
+            );
+        }
+        builder.startObject();
+        builder.field(ROLE_FIELD, USER_ROLE);
+        builder.startArray(CONTENT_FIELD);
+        builder.startObject();
+        builder.field(TYPE_FIELD, TOOL_RESULT_TYPE);
+        builder.field(TOOL_USE_ID_FIELD, message.toolCallId());
+        writeToolResultContent(builder, message.content());
+        builder.endObject();
+        builder.endArray();
+        builder.endObject();
+    }
+
+    /**
+     * Writes a {@code tool_result} block's {@code content}. Anthropic accepts either a plain string or an array of content blocks
+     * here; the array form is always emitted, so the unified API's two tool-message content shapes serialize uniformly: a
+     * {@link ContentString} becomes a single {@code text} block and each item of a {@link ContentObjects} is translated via
+     * {@link #writeContentBlock} - {@code text}, {@code image} and {@code document} are exactly the block types Anthropic allows
+     * inside a {@code tool_result}. A {@code null} content writes no {@code content} field, which Anthropic permits on a
+     * {@code tool_result}.
+     */
+    private static void writeToolResultContent(XContentBuilder builder, Content content) throws IOException {
+        if (content instanceof ContentString(String text)) {
+            builder.startArray(CONTENT_FIELD);
+            writeTextBlock(builder, text);
+            builder.endArray();
+        } else if (content instanceof ContentObjects(List<ContentObject> contentObjects)) {
+            builder.startArray(CONTENT_FIELD);
+            for (var contentObject : contentObjects) {
+                writeContentBlock(builder, contentObject);
+            }
+            builder.endArray();
+        }
+    }
+
+    private static void writeContentObjectsMessage(XContentBuilder builder, String role, List<ContentObject> contentObjects)
+        throws IOException {
+        builder.startObject();
+        builder.field(ROLE_FIELD, role);
+        builder.startArray(CONTENT_FIELD);
+        for (var contentObject : contentObjects) {
+            writeContentBlock(builder, contentObject);
+        }
+        builder.endArray();
+        builder.endObject();
+    }
+
+    private static void writeContentBlock(XContentBuilder builder, ContentObject contentObject) throws IOException {
+        switch (contentObject) {
+            case ContentObjectText text -> writeTextBlock(builder, text.text());
+            case ContentObjectImage image -> writeImageBlock(builder, image.imageUrl().url());
+            case ContentObjectFile file -> writeDocumentBlock(builder, file.fileFields());
+        }
+    }
+
+    private static void writeTextBlock(XContentBuilder builder, String text) throws IOException {
+        builder.startObject();
+        builder.field(TYPE_FIELD, TEXT_TYPE);
+        builder.field(TEXT_FIELD, text);
+        builder.endObject();
+    }
+
+    /**
+     * Writes an Anthropic {@code image} content block. Anthropic requires an explicit media type on base64 image data, so a
+     * base64 image must arrive as a data URI declaring it ({@code data:{MIME-type};base64,...}, the same contract
+     * {@link InferenceString} enforces for base64 inputs) and maps onto a {@code base64} source; a plain HTTP(S) URL maps onto a
+     * {@code url} source. Bare base64 without the data-URI prefix is rejected since the media type cannot be determined.
+     */
+    private static void writeImageBlock(XContentBuilder builder, String url) throws IOException {
+        var dataUri = InferenceString.tryParseDataUri(url);
+        if (dataUri == null && url.startsWith("http://") == false && url.startsWith("https://") == false) {
+            throw new ElasticsearchStatusException(
+                "Image URLs must be HTTP(S) URLs or base64 data URIs with the format [data:{MIME-type};base64,...] "
+                    + "for the Anthropic chat completion API.",
+                RestStatus.BAD_REQUEST
+            );
+        }
+        builder.startObject();
+        builder.field(TYPE_FIELD, IMAGE_TYPE);
+        builder.startObject(SOURCE_FIELD);
+        if (dataUri != null) {
+            builder.field(TYPE_FIELD, BASE64_SOURCE_TYPE);
+            builder.field(MEDIA_TYPE_FIELD, normalizeMediaType(dataUri.mediaType()));
+            builder.field(DATA_FIELD, dataUri.base64Data());
+        } else {
+            builder.field(TYPE_FIELD, URL_SOURCE_TYPE);
+            builder.field(URL_FIELD, url);
+        }
+        builder.endObject();
+        builder.endObject();
+    }
+
+    /**
+     * Writes an Anthropic {@code document} content block for a unified {@code file} content object. Anthropic requires the media
+     * type, so {@code file_data} must be a data URI declaring it (the same contract {@link InferenceString} enforces for base64
+     * inputs). PDFs map onto a {@code base64} source and plain text onto a {@code text} source carrying the decoded text - the
+     * two document types Anthropic supports, matching the EIS gateway. The filename, when present, becomes the document's
+     * {@code title}.
+     */
+    private static void writeDocumentBlock(XContentBuilder builder, ContentObjectFile.ContentObjectFileFields fileFields)
+        throws IOException {
+        if (fileFields.fileData() == null) {
+            throw new ElasticsearchStatusException(
+                "File content requires [file_data] for the Anthropic chat completion API.",
+                RestStatus.BAD_REQUEST
+            );
+        }
+        var dataUri = InferenceString.tryParseDataUri(fileFields.fileData());
+        if (dataUri == null) {
+            throw new ElasticsearchStatusException(
+                "File data must be a base64 data URI with the format [data:{MIME-type};base64,...] "
+                    + "for the Anthropic chat completion API.",
+                RestStatus.BAD_REQUEST
+            );
+        }
+        var mediaType = normalizeMediaType(dataUri.mediaType());
+        builder.startObject();
+        builder.field(TYPE_FIELD, DOCUMENT_TYPE);
+        builder.startObject(SOURCE_FIELD);
+        switch (mediaType) {
+            case PDF_MEDIA_TYPE -> {
+                builder.field(TYPE_FIELD, BASE64_SOURCE_TYPE);
+                builder.field(MEDIA_TYPE_FIELD, PDF_MEDIA_TYPE);
+                builder.field(DATA_FIELD, dataUri.base64Data());
+            }
+            case PLAIN_TEXT_MEDIA_TYPE -> {
+                builder.field(TYPE_FIELD, TEXT_TYPE);
+                builder.field(MEDIA_TYPE_FIELD, PLAIN_TEXT_MEDIA_TYPE);
+                builder.field(DATA_FIELD, decodePlainTextData(dataUri));
+            }
+            default -> throw new ElasticsearchStatusException(
+                Strings.format(
+                    "Unsupported file media type [%s] for the Anthropic chat completion API; supported types are [%s, %s].",
+                    mediaType,
+                    PDF_MEDIA_TYPE,
+                    PLAIN_TEXT_MEDIA_TYPE
+                ),
+                RestStatus.BAD_REQUEST
+            );
+        }
+        builder.endObject();
+        if (fileFields.filename() != null) {
+            builder.field(TITLE_FIELD, fileFields.filename());
+        }
+        builder.endObject();
+    }
+
+    /** Anthropic's plain-text document source carries the decoded text, not the base64 payload. */
+    private static String decodePlainTextData(InferenceString.DataUri dataUri) {
+        try {
+            return new String(Base64.getDecoder().decode(dataUri.base64Data()), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new ElasticsearchStatusException("Invalid base64 payload in the file data URI.", RestStatus.BAD_REQUEST, e);
+        }
+    }
+
+    /**
+     * Normalizes a data URI's declared media type for Anthropic: RFC 2397 parameters (e.g. {@code ;charset=utf-8}) are stripped
+     * and the common non-standard {@code image/jpg} alias is mapped to {@code image/jpeg}.
+     */
+    private static String normalizeMediaType(String mediaType) {
+        var paramsStart = mediaType.indexOf(';');
+        var normalized = (paramsStart >= 0 ? mediaType.substring(0, paramsStart) : mediaType).trim();
+        return "image/jpg".equals(normalized) ? "image/jpeg" : normalized;
+    }
+
+    /**
+     * Writes a tool call's {@code input}. OpenAI carries the tool arguments as a JSON-encoded string, whereas Anthropic expects the
+     * decoded JSON object. Parses the string back into an object; a {@code null} or blank arguments string yields an empty object.
+     */
+    private static void writeToolCallInput(XContentBuilder builder, String arguments) throws IOException {
+        builder.field(INPUT_FIELD);
+        if (arguments == null || arguments.isBlank()) {
+            builder.startObject().endObject();
+            return;
+        }
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, arguments)) {
+            builder.map(parser.mapOrdered());
+        }
+    }
 
     /**
      * Writes the {@code tool_choice} field, translating OpenAI's representation into Anthropic's. Does nothing when
@@ -140,4 +459,21 @@ public final class AnthropicToolUtils {
         }
         builder.endObject();
     }
+
+    public static String extractText(Content content) {
+        if (content instanceof ContentString(String text)) {
+            return text;
+        }
+        if (content instanceof ContentObjects(List<ContentObject> contentObjects)) {
+            var text = new StringBuilder();
+            for (var contentObject : contentObjects) {
+                if (contentObject instanceof ContentObject.ContentObjectText textObject) {
+                    text.append(textObject.text());
+                }
+            }
+            return text.toString();
+        }
+        return "";
+    }
+
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestEntity.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.anthropic.request;
 
 import org.elasticsearch.inference.UnifiedCompletionRequest;
-import org.elasticsearch.inference.completion.ContentString;
 import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -21,12 +20,12 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MAX_TOKENS_FIELD;
-import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MESSAGES_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MODEL_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TEMPERATURE_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TEXT_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TOP_P_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TYPE_FIELD;
+import static org.elasticsearch.xpack.inference.services.anthropic.request.AnthropicToolUtils.extractText;
 
 /**
  * Builds the request body for the Anthropic Messages API
@@ -100,15 +99,13 @@ public class AnthropicUnifiedChatCompletionRequestEntity implements ToXContentOb
             for (var msg : systemMessages) {
                 builder.startObject();
                 builder.field(TYPE_FIELD, TEXT_TYPE);
-                if (msg.content() instanceof ContentString cs) {
-                    builder.field(TEXT_FIELD, cs.content());
-                }
+                builder.field(TEXT_FIELD, extractText(msg.content()));
                 builder.endObject();
             }
             builder.endArray();
         }
 
-        builder.field(MESSAGES_FIELD, nonSystemMessages);
+        AnthropicToolUtils.writeMessages(builder, nonSystemMessages);
 
         var stop = unifiedRequest.stop();
         if (stop != null && stop.isEmpty() == false) {
@@ -144,4 +141,5 @@ public class AnthropicUnifiedChatCompletionRequestEntity implements ToXContentOb
         builder.endObject();
         return builder;
     }
+
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntity.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.completion.Goog
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.MESSAGES_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TEMPERATURE_FIELD;
 import static org.elasticsearch.inference.completion.UnifiedCompletionUtils.TOP_P_FIELD;
 import static org.elasticsearch.xpack.inference.services.mistral.MistralConstants.MAX_TOKENS_FIELD;
@@ -63,7 +62,7 @@ public class GoogleModelGardenAnthropicChatCompletionRequestEntity implements To
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(ANTHROPIC_VERSION, VERTEX_2023_10_16);
-        builder.field(MESSAGES_FIELD, unifiedRequest.messages());
+        AnthropicToolUtils.writeMessages(builder, unifiedRequest.messages());
         if (unifiedRequest.temperature() != null) {
             builder.field(TEMPERATURE_FIELD, unifiedRequest.temperature());
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionStreamingProcessorTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.inference.services.anthropic;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
@@ -118,13 +119,13 @@ public class AnthropicChatCompletionStreamingProcessorTests extends ESTestCase {
             assertContent(response, "World");
         }
         {
-            assertToolUseContentStartBlock(response);
+            assertToolUseContentStartBlock(response, 0, "toolu_vrtx_01GooUb1exnL7s8QrUgAQvQj", "get_weather");
         }
         {
-            assertToolUseArguments(response, "Hello");
+            assertToolUseArguments(response, 0, "Hello");
         }
         {
-            assertToolUseArguments(response, "World");
+            assertToolUseArguments(response, 0, "World");
         }
         {
             assertMessageDeltaBlock(response);
@@ -170,7 +171,7 @@ public class AnthropicChatCompletionStreamingProcessorTests extends ESTestCase {
         assertThat(choices.getFirst().index(), is(0));
         assertNull(choices.getFirst().delta().toolCalls());
         assertNull(choices.getFirst().delta().content());
-        assertThat(choices.getFirst().finishReason(), is("tool_use"));
+        assertThat(choices.getFirst().finishReason(), is("tool_calls"));
         assertUsage(chatCompletionChunk.usage(), 99, 0, 99);
     }
 
@@ -185,26 +186,35 @@ public class AnthropicChatCompletionStreamingProcessorTests extends ESTestCase {
         assertThat(choice.delta().role(), is("assistant"));
     }
 
-    private static void assertToolUseContentStartBlock(StreamingUnifiedChatCompletionResults.Results response) {
+    private static void assertToolUseContentStartBlock(
+        StreamingUnifiedChatCompletionResults.Results response,
+        int toolCallIndex,
+        String id,
+        String name
+    ) {
         var choices = response.chunks().remove().choices();
         assertThat(choices.size(), is(1));
-        assertThat(choices.getFirst().index(), is(1));
+        assertThat(choices.getFirst().index(), is(0));
         var toolCalls = choices.getFirst().delta().toolCalls();
         assertThat(toolCalls.size(), is(1));
-        assertThat(toolCalls.getFirst().index(), is(0));
-        assertThat(toolCalls.getFirst().id(), is("toolu_vrtx_01GooUb1exnL7s8QrUgAQvQj"));
+        assertThat(toolCalls.getFirst().index(), is(toolCallIndex));
+        assertThat(toolCalls.getFirst().id(), is(id));
         var function = toolCalls.getFirst().function();
-        assertThat(function.arguments(), is("{}"));
-        assertThat(function.name(), is("get_weather"));
+        assertThat(function.arguments(), is(""));
+        assertThat(function.name(), is(name));
     }
 
-    private static void assertToolUseArguments(StreamingUnifiedChatCompletionResults.Results response, String arguments) {
+    private static void assertToolUseArguments(
+        StreamingUnifiedChatCompletionResults.Results response,
+        int toolCallIndex,
+        String arguments
+    ) {
         var choices = response.chunks().remove().choices();
         assertThat(choices.size(), is(1));
-        assertThat(choices.getFirst().index(), is(1));
+        assertThat(choices.getFirst().index(), is(0));
         var toolCalls = choices.getFirst().delta().toolCalls();
         assertThat(toolCalls.size(), is(1));
-        assertThat(toolCalls.getFirst().index(), is(0));
+        assertThat(toolCalls.getFirst().index(), is(toolCallIndex));
         assertNull(toolCalls.getFirst().id());
         var function = toolCalls.getFirst().function();
         assertThat(function.arguments(), Matchers.is(arguments));
@@ -227,6 +237,116 @@ public class AnthropicChatCompletionStreamingProcessorTests extends ESTestCase {
         assertThat(usage.completionTokens(), is(completion));
         assertThat(usage.promptTokens(), is(prompt));
         assertThat(usage.totalTokens(), is(total));
+    }
+
+    public void testParseParallelToolCallsKeepsDistinctIndices() {
+        // Two tool_use blocks (Anthropic content block indices 1 and 2, after a text block at 0) must stream as tool calls
+        // with distinct monotonically increasing indices, so a client accumulating arguments by index does not merge them.
+        var item = events(List.of(Pair.of("content_block_start", """
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {}}
+            }
+            """), Pair.of("content_block_delta", """
+            {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "input_json_delta", "partial_json": "{\\"location\\": \\"San Francisco\\"}"}
+            }
+            """), Pair.of("content_block_start", """
+            {
+                "type": "content_block_start",
+                "index": 2,
+                "content_block": {"type": "tool_use", "id": "toolu_02", "name": "get_time", "input": {}}
+            }
+            """), Pair.of("content_block_delta", """
+            {
+                "type": "content_block_delta",
+                "index": 2,
+                "delta": {"type": "input_json_delta", "partial_json": "{\\"timezone\\": \\"PST\\"}"}
+            }
+            """)));
+
+        var response = onNext(new AnthropicChatCompletionStreamingProcessor((noOp1, noOp2) -> {
+            fail("This should not be called");
+            return null;
+        }), item);
+        assertThat(response.chunks().size(), equalTo(4));
+        {
+            assertToolUseContentStartBlock(response, 0, "toolu_01", "get_weather");
+        }
+        {
+            assertToolUseArguments(response, 0, "{\"location\": \"San Francisco\"}");
+        }
+        {
+            assertToolUseContentStartBlock(response, 1, "toolu_02", "get_time");
+        }
+        {
+            assertToolUseArguments(response, 1, "{\"timezone\": \"PST\"}");
+        }
+    }
+
+    public void testInputJsonDeltaForUnknownContentBlockIsSkipped() throws Exception {
+        // An input_json_delta whose content block index was never announced by a tool_use content_block_start cannot be
+        // attributed to a tool call, so it is dropped and more data is requested instead of emitting a chunk.
+        var item = events(List.of(Pair.of("content_block_delta", """
+            {
+                "type": "content_block_delta",
+                "index": 5,
+                "delta": {"type": "input_json_delta", "partial_json": "{\\"location\\": \\"San Francisco\\"}"}
+            }
+            """)));
+
+        var processor = new AnthropicChatCompletionStreamingProcessor((noOp1, noOp2) -> {
+            fail("This should not be called");
+            return null;
+        });
+
+        Flow.Subscriber<ChunkedToXContent> downstream = mock();
+        processor.subscribe(downstream);
+
+        Flow.Subscription upstream = mock();
+        processor.onSubscribe(upstream);
+
+        processor.next(item);
+
+        verify(upstream, times(1)).request(1);
+        verify(downstream, times(0)).onNext(any());
+    }
+
+    public void testStopReasonConvertedToOpenAiFinishReason() {
+        assertFinishReasonForStopReason("end_turn", "stop");
+        assertFinishReasonForStopReason("stop_sequence", "stop");
+        assertFinishReasonForStopReason("pause_turn", "stop");
+        assertFinishReasonForStopReason("max_tokens", "length");
+        assertFinishReasonForStopReason("tool_use", "tool_calls");
+        assertFinishReasonForStopReason("refusal", "content_filter");
+        assertFinishReasonForStopReason("some_unknown_stop_reason", "stop");
+    }
+
+    private static void assertFinishReasonForStopReason(String stopReason, String expectedFinishReason) {
+        var item = events(List.of(Pair.of("message_delta", Strings.format("""
+            {
+                "type": "message_delta",
+                "delta": {
+                    "stop_reason": "%s",
+                    "stop_sequence": null
+                },
+                "usage": {
+                    "output_tokens": 10
+                }
+            }
+            """, stopReason))));
+
+        var response = onNext(new AnthropicChatCompletionStreamingProcessor((noOp1, noOp2) -> {
+            fail("This should not be called");
+            return null;
+        }), item);
+        assertThat(response.chunks().size(), equalTo(1));
+        var choices = response.chunks().remove().choices();
+        assertThat(choices.size(), is(1));
+        assertThat(choices.getFirst().finishReason(), is(expectedFinishReason));
     }
 
     public void testEmptyResultsRequestsMoreData() throws Exception {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -652,7 +652,7 @@ public class AnthropicServiceTests extends InferenceServiceTestCase {
                 .hasEvent(XContentHelper.stripWhitespace("""
                     {
                         "id": null,
-                        "choices": [{"delta": {}, "finish_reason": "end_turn", "index": 0}],
+                        "choices": [{"delta": {}, "finish_reason": "stop", "index": 0}],
                         "model": null,
                         "object": null,
                         "usage": {"completion_tokens": 5, "prompt_tokens": 0, "total_tokens": 5}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicToolUtilsTests.java
@@ -10,7 +10,12 @@ package org.elasticsearch.xpack.inference.services.anthropic.request;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.inference.completion.ContentObject;
+import org.elasticsearch.inference.completion.ContentObjects;
+import org.elasticsearch.inference.completion.ContentString;
+import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.inference.completion.Tool;
+import org.elasticsearch.inference.completion.ToolCall;
 import org.elasticsearch.inference.completion.ToolChoice;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceObject;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceString;
@@ -19,10 +24,14 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class AnthropicToolUtilsTests extends ESTestCase {
 
@@ -208,6 +217,522 @@ public class AnthropicToolUtilsTests extends ESTestCase {
                 ]
             }
             """, TOOL_NAME, TOOL_DESCRIPTION));
+    }
+
+    public void testWriteMessages_translatesAssistantToolCallsToToolUseBlocks() throws IOException {
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        // All empty content shapes yield the same output: tool_use blocks with no leading text block.
+        var content = randomFrom(new ContentString(""), new ContentObjects(List.of()), null);
+        var message = new Message(content, "assistant", null, List.of(toolCall));
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "get_weather",
+                                "input": {"location": "San Francisco"}
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesToolResultToUserMessage() throws IOException {
+        var message = new Message(new ContentString("72F and sunny"), "tool", "call_1", null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_1",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "72F and sunny"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesToolResultContentObjectsToTextBlocks() throws IOException {
+        // OpenAI also accepts a tool message whose content is an array of text objects; each becomes an Anthropic text block.
+        var content = new ContentObjects(
+            List.of(new ContentObject.ContentObjectText("72F and sunny"), new ContentObject.ContentObjectText("Humidity is 40%"))
+        );
+        var message = new Message(content, "tool", "call_1", null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_1",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "72F and sunny"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "text": "Humidity is 40%"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesToolResultImageToImageBlock() throws IOException {
+        var imageUrl = new ContentObject.ContentObjectImage.ContentObjectImageUrl("data:image/png;base64,iVBORw==", null);
+        var content = new ContentObjects(List.of(new ContentObject.ContentObjectImage(imageUrl)));
+        var message = new Message(content, "tool", "call_1", null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_1",
+                                "content": [
+                                    {
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": "image/png",
+                                            "data": "iVBORw=="
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesUserMultimodalContentToAnthropicBlocks() throws IOException {
+        // The non-standard "image/jpg" media type is normalized to "image/jpeg", which is what Anthropic accepts.
+        var text = new ContentObject.ContentObjectText("What do the image and the report show?");
+        var image = new ContentObject.ContentObjectImage(
+            new ContentObject.ContentObjectImage.ContentObjectImageUrl("data:image/jpg;base64,iVBORw==", null)
+        );
+        var file = new ContentObject.ContentObjectFile(
+            new ContentObject.ContentObjectFile.ContentObjectFileFields("data:application/pdf;base64,JVBERg==", null, "report.pdf")
+        );
+        var message = new Message(new ContentObjects(List.of(text, image, file)), "user", null, null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "What do the image and the report show?"
+                            },
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/jpeg",
+                                    "data": "iVBORw=="
+                                }
+                            },
+                            {
+                                "type": "document",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "application/pdf",
+                                    "data": "JVBERg=="
+                                },
+                                "title": "report.pdf"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesHttpImageUrlToUrlSource() throws IOException {
+        var image = new ContentObject.ContentObjectImage(
+            new ContentObject.ContentObjectImage.ContentObjectImageUrl("https://example.com/image.png", null)
+        );
+        var message = new Message(new ContentObjects(List.of(image)), "user", null, null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "url",
+                                    "url": "https://example.com/image.png"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_translatesPlainTextFileToTextSource() throws IOException {
+        // A text/plain document maps onto Anthropic's text source, which carries the decoded text rather than base64. The declared
+        // media type's RFC 2397 parameters (";charset=utf-8") are stripped.
+        var encoded = Base64.getEncoder().encodeToString("72F and sunny".getBytes(StandardCharsets.UTF_8));
+        var file = new ContentObject.ContentObjectFile(
+            new ContentObject.ContentObjectFile.ContentObjectFileFields(
+                "data:text/plain;charset=utf-8;base64," + encoded,
+                null,
+                "weather.txt"
+            )
+        );
+        var message = new Message(new ContentObjects(List.of(file)), "user", null, null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "document",
+                                "source": {
+                                    "type": "text",
+                                    "media_type": "text/plain",
+                                    "data": "72F and sunny"
+                                },
+                                "title": "weather.txt"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_imageWithBareBase64Throws() {
+        // Bare base64 carries no media type, which Anthropic requires; the value must be a data URI declaring it.
+        var image = new ContentObject.ContentObjectImage(new ContentObject.ContentObjectImage.ContentObjectImageUrl("iVBORw==", null));
+        var message = new Message(new ContentObjects(List.of(image)), "user", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(
+            exception.getMessage(),
+            is(
+                "Image URLs must be HTTP(S) URLs or base64 data URIs with the format [data:{MIME-type};base64,...] "
+                    + "for the Anthropic chat completion API."
+            )
+        );
+    }
+
+    public void testWriteMessages_fileWithoutDataUriThrows() {
+        var file = new ContentObject.ContentObjectFile(
+            new ContentObject.ContentObjectFile.ContentObjectFileFields("JVBERg==", null, "report.pdf")
+        );
+        var message = new Message(new ContentObjects(List.of(file)), "user", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(
+            exception.getMessage(),
+            is(
+                "File data must be a base64 data URI with the format [data:{MIME-type};base64,...] "
+                    + "for the Anthropic chat completion API."
+            )
+        );
+    }
+
+    public void testWriteMessages_fileWithoutFileDataThrows() {
+        var file = new ContentObject.ContentObjectFile(new ContentObject.ContentObjectFile.ContentObjectFileFields(null, null, "a.pdf"));
+        var message = new Message(new ContentObjects(List.of(file)), "user", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is("File content requires [file_data] for the Anthropic chat completion API."));
+    }
+
+    public void testWriteMessages_fileWithUnsupportedMediaTypeThrows() {
+        var file = new ContentObject.ContentObjectFile(
+            new ContentObject.ContentObjectFile.ContentObjectFileFields("data:image/png;base64,iVBORw==", null, "image.png")
+        );
+        var message = new Message(new ContentObjects(List.of(file)), "user", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(
+            exception.getMessage(),
+            is(
+                "Unsupported file media type [image/png] for the Anthropic chat completion API; "
+                    + "supported types are [application/pdf, text/plain]."
+            )
+        );
+    }
+
+    public void testWriteMessages_fileWithInvalidBase64PayloadThrows() {
+        var file = new ContentObject.ContentObjectFile(
+            new ContentObject.ContentObjectFile.ContentObjectFileFields("data:text/plain;base64,!!!", null, "notes.txt")
+        );
+        var message = new Message(new ContentObjects(List.of(file)), "user", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is("Invalid base64 payload in the file data URI."));
+    }
+
+    public void testWriteMessages_toolResultWithoutToolCallIdThrows() {
+        // Anthropic requires tool_use_id on every tool_result block, so a tool message must carry a tool_call_id.
+        var message = new Message(new ContentString("72F and sunny"), "tool", null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is("Field [tool_call_id] is required in a tool message for the Anthropic chat completion API."));
+    }
+
+    public void testWriteMessages_emitsLeadingTextBlockWhenAssistantHasContent() throws IOException {
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        var message = new Message(new ContentString("Let me check the weather."), "assistant", null, List.of(toolCall));
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Let me check the weather."
+                            },
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "get_weather",
+                                "input": {"location": "San Francisco"}
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_emitsLeadingTextBlockFromAssistantContentObjects() throws IOException {
+        // A tool-calling assistant message may carry its text as content objects; their text items are concatenated into the
+        // single leading text block, matching the ContentString shape.
+        var content = new ContentObjects(
+            List.of(new ContentObject.ContentObjectText("Let me check "), new ContentObject.ContentObjectText("the weather."))
+        );
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        var message = new Message(content, "assistant", null, List.of(toolCall));
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Let me check the weather."
+                            },
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "get_weather",
+                                "input": {"location": "San Francisco"}
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_wrapsAssistantStringContentInTextBlock() throws IOException {
+        // An assistant message with no tool calls also gets the array-shaped content.
+        var message = new Message(new ContentString("The weather is sunny."), "assistant", null, null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "The weather is sunny."
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_emptyUserContentBecomesEmptyTextBlock() throws IOException {
+        // Anthropic rejects messages without content, so empty or absent user content is normalized to a single empty text block.
+        var expectedJson = """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": ""
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        assertMessagesJson(List.of(new Message(new ContentString(""), "user", null, null)), expectedJson);
+        assertMessagesJson(List.of(new Message(new ContentObjects(List.of()), "user", null, null)), expectedJson);
+        assertMessagesJson(List.of(new Message(null, "user", null, null)), expectedJson);
+    }
+
+    public void testWriteMessages_emptyAssistantContentBecomesEmptyTextBlock() throws IOException {
+        // An assistant message with no tool calls and empty or absent content is normalized to a single empty text block, which is
+        // a fallback when no content blocks were produced.
+        var toolCalls = randomBoolean() ? null : List.<ToolCall>of();
+        var expectedJson = """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": ""
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+        assertMessagesJson(List.of(new Message(new ContentString(""), "assistant", null, toolCalls)), expectedJson);
+        assertMessagesJson(List.of(new Message(new ContentObjects(List.of()), "assistant", null, toolCalls)), expectedJson);
+        assertMessagesJson(List.of(new Message(null, "assistant", null, toolCalls)), expectedJson);
+    }
+
+    public void testWriteMessages_unsupportedRoleThrows() {
+        // Only user/assistant/tool messages can be translated; system messages must be extracted into the top-level "system"
+        // field before writeMessages is called.
+        var role = randomFrom("system", "developer");
+        var message = new Message(new ContentString("You are a helpful assistant."), role, null, null);
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> renderMessages(List.of(message)));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(exception.getMessage(), is(Strings.format("Unsupported role [%s] for the Anthropic chat completion API.", role)));
+    }
+
+    public void testWriteMessages_blankArgumentsYieldEmptyInputObject() throws IOException {
+        // A parameterless tool call carries no arguments; Anthropic still requires an "input" object, so we emit an empty one.
+        var arguments = randomBoolean() ? null : "";
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField(arguments, "get_time"), "function");
+        var message = new Message(new ContentString(""), "assistant", null, List.of(toolCall));
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "get_time",
+                                "input": {}
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testWriteMessages_wrapsUserStringContentInTextBlock() throws IOException {
+        // Plain-string content is wrapped in a single text block so every message carries array-shaped content.
+        var message = new Message(new ContentString("Hello!"), "user", null, null);
+        assertMessagesJson(List.of(message), """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Hello!"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """);
+    }
+
+    public void testExtractText_returnsStringContent() {
+        assertThat(AnthropicToolUtils.extractText(new ContentString("Hello!")), is("Hello!"));
+    }
+
+    public void testExtractText_concatenatesTextObjectsAndIgnoresOthers() {
+        var image = new ContentObject.ContentObjectImage(
+            new ContentObject.ContentObjectImage.ContentObjectImageUrl("https://example.com/image.png", null)
+        );
+        var content = new ContentObjects(
+            List.of(new ContentObject.ContentObjectText("Hello"), image, new ContentObject.ContentObjectText(" world"))
+        );
+        assertThat(AnthropicToolUtils.extractText(content), is("Hello world"));
+    }
+
+    public void testExtractText_emptyOrAbsentContentYieldsEmptyString() {
+        assertThat(AnthropicToolUtils.extractText(null), is(""));
+        assertThat(AnthropicToolUtils.extractText(new ContentString("")), is(""));
+        assertThat(AnthropicToolUtils.extractText(new ContentObjects(List.of())), is(""));
+    }
+
+    public void testWriteMessages_multiTurnToolConversationHasNoUnifiedToolFields() throws IOException {
+        // Regression guard for the second-turn 400: the serialized request must not contain the unified "role":"tool" message or the
+        // "tool_calls" field, and must contain the Anthropic tool_use / tool_result blocks instead.
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        var messages = List.of(
+            new Message(new ContentString("What is the weather in San Francisco?"), "user", null, null),
+            new Message(new ContentString(""), "assistant", null, List.of(toolCall)),
+            new Message(new ContentString("72F and sunny"), "tool", "call_1", null)
+        );
+        var actual = renderMessages(messages);
+        assertThat(actual, not(containsString("\"role\":\"tool\"")));
+        assertThat(actual, not(containsString("\"tool_calls\"")));
+        assertThat(actual, containsString("\"type\":\"tool_use\""));
+        assertThat(actual, containsString("\"type\":\"tool_result\""));
+        assertThat(actual, containsString("\"tool_use_id\":\"call_1\""));
+    }
+
+    private static void assertMessagesJson(List<Message> messages, String expectedJson) throws IOException {
+        assertThat(renderMessages(messages), is(XContentHelper.stripWhitespace(expectedJson)));
+    }
+
+    private static String renderMessages(List<Message> messages) throws IOException {
+        try (var builder = JsonXContent.contentBuilder()) {
+            builder.startObject();
+            AnthropicToolUtils.writeMessages(builder, messages);
+            builder.endObject();
+            return Strings.toString(builder);
+        }
     }
 
     private static void assertStringToolChoiceTranslation(String openAiValue, String anthropicType) throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestEntityTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.inference.completion.ContentString;
 import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.inference.completion.Tool;
+import org.elasticsearch.inference.completion.ToolCall;
 import org.elasticsearch.inference.completion.ToolChoice;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -28,7 +29,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase {
 
@@ -41,11 +44,11 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, null, null, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_NonStreamingRequest() throws IOException {
@@ -53,11 +56,11 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(false, null, null, null, null, null, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "stream": false,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_RequestOverridesTaskSettings() throws IOException {
@@ -76,13 +79,13 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
             Strings.format("""
                 {
                     "model": "%s",
-                    "messages": [{"content": "%s", "role": "%s"}],
+                    "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                     "temperature": %s,
                     "top_p": %s,
                     "stream": true,
                     "max_tokens": %d
                 }
-                """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, requestTemperature, requestTopP, requestMaxTokens)
+                """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, requestTemperature, requestTopP, requestMaxTokens)
         );
     }
 
@@ -91,14 +94,14 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, null, null, taskSettings(maxTokens, 0.7, 0.9, 50), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "temperature": 0.7,
                 "top_p": 0.9,
                 "top_k": 50,
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolDefinitionsEmitsAnthropicShape() throws IOException {
@@ -107,7 +110,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(tool), null, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tools": [
                     {
                         "name": "get_price",
@@ -118,7 +121,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolStrictFieldIgnored() throws IOException {
@@ -131,7 +134,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(tool), null, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tools": [
                     {
                         "name": "get_price",
@@ -142,7 +145,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolChoiceObjectEmitsAnthropicShape() throws IOException {
@@ -151,12 +154,12 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(), toolChoice, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tool_choice": {"type": "tool", "name": "get_price"},
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolChoiceStringNoneTranslatesToAnthropicNone() throws IOException {
@@ -165,12 +168,12 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(), toolChoice, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tool_choice": {"type": "none"},
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolChoiceStringAutoTranslatesToAnthropicAuto() throws IOException {
@@ -179,12 +182,12 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(), toolChoice, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tool_choice": {"type": "auto"},
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithToolChoiceStringRequiredTranslatesToAnthropicAny() throws IOException {
@@ -193,12 +196,12 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         testToXContent(true, null, null, null, List.of(), toolChoice, taskSettings(maxTokens, null, null, null), Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "tool_choice": {"type": "any"},
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens));
     }
 
     public void testToXContent_WithSystemMessageExtractedToTopLevelField() throws IOException {
@@ -211,7 +214,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
             {
                 "model": "%s",
                 "system": [{"type": "text", "text": "You are a pirate."}],
-                "messages": [{"content": "Hello!", "role": "user"}],
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}],
                 "stream": true,
                 "max_tokens": %d
             }
@@ -232,7 +235,7 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
                     {"type": "text", "text": "You are a pirate."},
                     {"type": "text", "text": "Always respond in verse."}
                 ],
-                "messages": [{"content": "Hello!", "role": "user"}],
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}],
                 "stream": true,
                 "max_tokens": %d
             }
@@ -261,12 +264,58 @@ public class AnthropicUnifiedChatCompletionRequestEntityTests extends ESTestCase
         assertThat(Strings.toString(builder), is(XContentHelper.stripWhitespace(Strings.format("""
             {
                 "model": "%s",
-                "messages": [{"content": "%s", "role": "%s"}],
+                "messages": [{"role": "%s", "content": [{"type": "text", "text": "%s"}]}],
                 "stop_sequences": ["END", "STOP"],
                 "stream": true,
                 "max_tokens": %d
             }
-            """, MODEL_ID, INPUT_VALUE, ROLE_VALUE, maxTokens))));
+            """, MODEL_ID, ROLE_VALUE, INPUT_VALUE, maxTokens))));
+    }
+
+    public void testToXContent_MultiTurnToolConversationEmitsAnthropicBlocks() throws IOException {
+        // End-to-end regression for the second-turn 400: a full request carrying an assistant tool_call and a tool result must
+        // serialize as Anthropic tool_use / tool_result content blocks rather than the unified "tool_calls" / "role":"tool" shape.
+        var maxTokens = 1024;
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        var messages = List.of(
+            new Message(new ContentString("What is the weather in San Francisco?"), "user", null, null),
+            new Message(new ContentString(""), "assistant", null, List.of(toolCall)),
+            new Message(new ContentString("72F and sunny"), "tool", "call_1", null)
+        );
+        var unifiedRequest = new UnifiedCompletionRequest(messages, null, null, null, null, null, null, null);
+        var entity = new AnthropicUnifiedChatCompletionRequestEntity(
+            new UnifiedChatInput(unifiedRequest, true),
+            MODEL_ID,
+            taskSettings(maxTokens, null, null, null)
+        );
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        var actual = Strings.toString(builder);
+
+        assertThat(actual, is(XContentHelper.stripWhitespace(Strings.format("""
+            {
+                "model": "%s",
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "What is the weather in San Francisco?"}]},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"location": "San Francisco"}}
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": "call_1", "content": [{"type": "text", "text": "72F and sunny"}]}
+                        ]
+                    }
+                ],
+                "stream": true,
+                "max_tokens": %d
+            }
+            """, MODEL_ID, maxTokens))));
+        assertThat(actual, not(containsString("\"role\":\"tool\"")));
+        assertThat(actual, not(containsString("\"tool_calls\"")));
     }
 
     public void testToXContent_WithToolChoiceStringUnknownValueRejected() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicUnifiedChatCompletionRequestTests.java
@@ -58,7 +58,10 @@ public class AnthropicUnifiedChatCompletionRequestTests extends ESTestCase {
         assertThat(requestMap.get("model"), is(MODEL_NAME));
         assertThat(requestMap.get("stream"), is(true));
         assertThat(requestMap.get("max_tokens"), is(maxTokens));
-        assertThat(requestMap.get("messages"), is(List.of(Map.of("content", INPUT, "role", ROLE))));
+        assertThat(
+            requestMap.get("messages"),
+            is(List.of(Map.of("role", ROLE, "content", List.of(Map.of("type", "text", "text", INPUT)))))
+        );
     }
 
     public void testCreateHttpRequestNonStreaming() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleModelGardenAnthropicChatCompletionRequestEntityTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.inference.completion.ContentString;
 import org.elasticsearch.inference.completion.Message;
 import org.elasticsearch.inference.completion.Tool;
+import org.elasticsearch.inference.completion.ToolCall;
 import org.elasticsearch.inference.completion.ToolChoice;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceObject;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceString;
@@ -28,7 +29,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class GoogleModelGardenAnthropicChatCompletionRequestEntityTests extends ESTestCase {
 
@@ -112,6 +115,49 @@ public class GoogleModelGardenAnthropicChatCompletionRequestEntityTests extends 
         assertThat(actual, is(expectedRequestJson(null, toolChoiceJson, null, false, 1024)));
     }
 
+    public void testMultiTurnToolConversationEmitsAnthropicBlocks() throws IOException {
+        // End-to-end regression for the second-turn 400 on the Model Garden path: a request carrying an assistant tool_call and a
+        // tool result must serialize as Anthropic tool_use / tool_result content blocks, not the unified "tool_calls" / "role":"tool".
+        var toolCall = new ToolCall("call_1", new ToolCall.FunctionField("{\"location\":\"San Francisco\"}", "get_weather"), "function");
+        var messages = List.of(
+            new Message(new ContentString("What is the weather in San Francisco?"), "user", null, null),
+            new Message(new ContentString(""), "assistant", null, List.of(toolCall)),
+            new Message(new ContentString("72F and sunny"), "tool", "call_1", null)
+        );
+        var unifiedRequest = new UnifiedCompletionRequest(messages, null, null, null, null, null, null, null);
+        var entity = new GoogleModelGardenAnthropicChatCompletionRequestEntity(unifiedRequest, false, EMPTY_SETTINGS);
+        String actual;
+        try (var builder = JsonXContent.contentBuilder()) {
+            entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            actual = Strings.toString(builder);
+        }
+
+        assertThat(actual, is(XContentHelper.stripWhitespace(Strings.format("""
+            {
+                "anthropic_version": "%s",
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "What is the weather in San Francisco?"}]},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"location": "San Francisco"}}
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": "call_1", "content": [{"type": "text", "text": "72F and sunny"}]}
+                        ]
+                    }
+                ],
+                "stream": false,
+                "max_tokens": 1024
+            }
+            """, ANTHROPIC_VERSION))));
+        assertThat(actual, not(containsString("\"role\":\"tool\"")));
+        assertThat(actual, not(containsString("\"tool_calls\"")));
+    }
+
     private static void assertToolChoiceStringTranslation(String openAiValue, String anthropicType) throws IOException {
         var actual = render(new ToolChoiceString(openAiValue), List.of(TOOL), null, null, null, false, EMPTY_SETTINGS);
         var toolChoiceJson = Strings.format("""
@@ -134,8 +180,13 @@ public class GoogleModelGardenAnthropicChatCompletionRequestEntityTests extends 
                         "anthropic_version": "%s",
                         "messages": [
                             {
-                                "content": "%s",
-                                "role": "user"
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "%s"
+                                    }
+                                ]
                             }
                         ],
                         %s

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestTests.java
@@ -57,7 +57,7 @@ public class GoogleVertexAiUnifiedChatCompletionRequestTests extends ESTestCase 
                     "max_tokens",
                     1024,
                     "messages",
-                    List.of(Map.of("role", "user", "content", "Hello Gemini!")),
+                    List.of(Map.of("role", "user", "content", List.of(Map.of("type", "text", "text", "Hello Gemini!")))),
                     "anthropic_version",
                     "vertex-2023-10-16"
                 )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Inference API] Translate unified tool-calling message blocks to Anthropic format (#154607)](https://github.com/elastic/elasticsearch/pull/154607)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)