### PR TITLE
ESQL: Reproduce warning loss from pre-9.6 data nodes

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/WarningsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/WarningsIT.java
@@ -10,12 +10,16 @@ package org.elasticsearch.xpack.esql.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.plugin.ComputeService;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.Collection;
@@ -23,11 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class WarningsIT extends AbstractEsqlIntegTestCase {
+
+    private static final String OLD_NODE_WARNING = "warning from a data node without esql_driver_warnings support";
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -199,6 +208,97 @@ public class WarningsIT extends AbstractEsqlIntegTestCase {
         } finally {
             coordinatorTs.clearAllRules();
         }
+    }
+
+    /**
+     * Regression test for warnings raised by a data node too old to report them in
+     * {@link org.elasticsearch.compute.operator.DriverCompletionInfo#warnings()}.
+     * <p>
+     * Such a node predates the {@code esql_driver_warnings} wire field, so it raises warnings through
+     * {@link HeaderWarning} instead. Those only reach the coordinator as transport response headers, serialised
+     * from the thread context of whichever thread sends the data node response. The coordinator must then carry
+     * them from the thread that handles that response to the thread that renders the final response.
+     * <p>
+     * The old node is simulated by adding a warning to the data node's thread context immediately before its
+     * channel serialises the response, which is exactly where an old node's warnings would already be sitting.
+     * The warning deliberately never exists in the completion info, so it can only reach the client if the
+     * coordinator handles header-only warnings.
+     */
+    public void testWarningsArrivingOnlyAsResponseHeaders() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        String dataNodeName = randomDataNode().getName();
+        // the coordinator must be a different node, so the data node's response crosses the transport layer
+        String coordinatorName = randomValueOtherThan(dataNodeName, () -> randomDataNode().getName());
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("legacy-warnings")
+                .setSettings(
+                    Settings.builder()
+                        .put("index.routing.allocation.require._name", dataNodeName)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                )
+                .setMapping("value", "type=long")
+        );
+        client().prepareIndex("legacy-warnings").setSource("value", 1).get();
+        client().admin().indices().prepareRefresh("legacy-warnings").get();
+
+        AtomicInteger injected = new AtomicInteger();
+        var dataNodeTs = asInstanceOf(MockTransportService.class, internalCluster().getInstance(TransportService.class, dataNodeName));
+        // deliberately not HeaderWarning.addWarning, which writes to every registered thread context: in a single JVM
+        // that includes the coordinator's, which would let the warning reach the response without being serialised
+        var dataNodeThreadContext = dataNodeTs.getThreadPool().getThreadContext();
+        dataNodeTs.addRequestHandlingBehavior(
+            ComputeService.DATA_ACTION_NAME,
+            (handler, request, channel, task) -> handler.messageReceived(request, new TransportChannel() {
+                @Override
+                public String getProfileName() {
+                    return channel.getProfileName();
+                }
+
+                @Override
+                public void sendResponse(TransportResponse response) {
+                    // where an old node's warnings already sit when its channel serialises the response
+                    dataNodeThreadContext.addResponseHeader("Warning", HeaderWarning.formatWarning(OLD_NODE_WARNING));
+                    injected.incrementAndGet();
+                    channel.sendResponse(response);
+                }
+
+                @Override
+                public void sendResponse(Exception exception) {
+                    channel.sendResponse(exception);
+                }
+            }, task)
+        );
+
+        // captured inside the listener because the response headers only live on the thread that rendered the response
+        AtomicReference<List<String>> responseWarnings = new AtomicReference<>(List.of());
+        CountDownLatch latch = new CountDownLatch(1);
+        try {
+            EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest("FROM legacy-warnings | LIMIT 10");
+            client(coordinatorName).execute(EsqlQueryAction.INSTANCE, request, ActionListener.running(() -> {
+                try {
+                    var threadPool = internalCluster().getInstance(TransportService.class, coordinatorName).getThreadPool();
+                    responseWarnings.set(threadPool.getThreadContext().getResponseHeaders().getOrDefault("Warning", List.of()));
+                } finally {
+                    latch.countDown();
+                }
+            }));
+            assertTrue("query did not complete", latch.await(30, TimeUnit.SECONDS));
+        } finally {
+            dataNodeTs.clearAllRules();
+        }
+
+        // guards against the query being planned without a remote data node request, which would make the test vacuous
+        assertThat("the data node never responded, so no warning was injected", injected.get(), greaterThanOrEqualTo(1));
+        assertThat(
+            "a warning that exists only as a response header on the data node response should reach the client",
+            responseWarnings.get().stream().filter(w -> w.contains(OLD_NODE_WARNING)).toList(),
+            hasSize(greaterThanOrEqualTo(1))
+        );
     }
 
     private DiscoveryNode randomDataNode() {


### PR DESCRIPTION
Reproduction only. No production code changes, so this branch is expected to fail CI. The candidate fix is in #156540.

## What this reproduces

#155976 moved ES|QL warnings out of thread locals into `DriverContext`, behind a new `DriverCompletionInfo.warnings` wire field gated on the `esql_driver_warnings` transport version (9495000, `main` only).

A data node older than that gate runs the old code and reports its warnings through `HeaderWarning`, so they reach the coordinator **only** as transport response headers, serialised from the thread context of whichever thread sends the data node response. The coordinator must then carry them from the thread that handles that response to the thread that renders the final response. That is what the `ResponseHeadersCollector` in `ComputeListener` did. #155976 removed it and nothing replaced it.

## How the old node is simulated

There is no way to make a node in a single-JVM internal cluster report an older `TransportVersion`, so the test reproduces the old node's observable behaviour instead. It intercepts `ComputeService.DATA_ACTION_NAME` on the data node and adds a warning to that node's thread context immediately before its channel serialises the response, which is exactly where an old node's warnings already sit.

The warning deliberately never exists in the completion info, so it can only reach the client if the coordinator handles header-only warnings.

Two details make the result trustworthy:

- It does **not** use `HeaderWarning.addWarning`, which writes into every registered `ThreadContext`. In a single JVM that static set includes the coordinator's, which would let the warning appear in the response without ever being serialised, and the test would pass for the wrong reason.
- It counts injections and asserts the count is non-zero, so it cannot pass vacuously if the query is ever planned without a remote data node request. That guard never tripped across 350 runs.

## Measurements

Run with `-Dtests.iters` on `:x-pack:plugin:esql:internalClusterTest`:

| Code under test | Runs | Failures |
|---|---|---|
| This branch (upstream `main`) | 50 | 44 |
| With `ResponseHeadersCollector` restored | 50 | 0 |
| With `ResponseHeadersCollector` restored | 300 | 0 |

A single run usually passes even on broken code, so this needs repeated iterations in a warm JVM to show up. That is worth knowing: it is why earlier attempts to reproduce the failure with one-off BWC runs came back clean and made the mechanism look innocent.

## Why this is worth landing separately

The assertion is written against the observable outcome, not the mechanism. It says a warning arriving only as a response header must reach the client, and says nothing about how the coordinator achieves that. So it validates the receiving-side alternative, converting incoming `Warning` headers into `DriverCompletionInfo.warnings` at the version boundary, exactly as well as it validates restoring the collector. It can serve as the red test for either design, and it stays useful once the collector is removed again.

## What this does not establish

This simulates an old node rather than running against a real 8.19/9.4/9.5 binary, so it proves the mechanism is broken but does not by itself prove it is the cause of the 38 `MixedClusterEsqlSpec*IT` failures filed after #155976 merged. Those failures do carry a matching signature, `expected "...treating result as null..." but was <missing>`. Closing that last gap needs a real mixed-version BWC run with those tests unmuted, fixed and unfixed.

Note also that roughly 15 issues with the same signature predate #155976, between Jul 12 and Aug 10, so a lower-rate source of missing warnings existed before this regression.

## Test plan

- [x] Fails 44/50 on this branch.
- [x] Passes 300/300 with the candidate fix applied.
- [x] The injection guard never trips, so the path is always exercised.
- [x] Full `WarningsIT` (3 tests) and `ComputeListenerTests` (4 tests) pass with the fix applied.
- [x] `:x-pack:plugin:esql:spotlessJavaCheck` clean.
- [ ] Real mixed-version BWC run against 8.19.20 / 9.4.5 / 9.5.1.
