### PR TITLE
[9.4] Bump JDK to 26.0.2 (#156203)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 9.4.6
 lucene            = 10.4.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 26.0.1+8@458fda22e4c54d5ba572ab8d2b22eb83
+bundled_jdk = 26.0.2+10@818d462d89b645c7a1aad49066c454e5
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.20.0

--- a/docs/changelog/156203.yaml
+++ b/docs/changelog/156203.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 156203
+summary: Bump JDK to 26.0.2
+type: upgrade


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Bump JDK to 26.0.2 (#156203)