### PR TITLE
[9.5] removed the experimental flag for the auto_calibrate configuration (#156623)

### DIFF
--- a/docs/changelog/156623.yaml
+++ b/docs/changelog/156623.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 156623
+summary: Remove the experimental flag for the `auto_calibrate` configuration
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1975,11 +1975,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 }
 
                 boolean doPrecondition = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("precondition"), false);
-
-                boolean autoCalibrate = false;
-                if (experimentalFeaturesEnabled) {
-                    autoCalibrate = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("auto_calibrate"), false);
-                }
+                boolean autoCalibrate = XContentMapValues.nodeBooleanValue(indexOptionsMap.remove("auto_calibrate"), false);
 
                 MappingParser.checkNoRemainingFields(fieldName, indexOptionsMap);
                 return new BBQIVFIndexOptions(


### PR DESCRIPTION
Backports the following commits to 9.5:
 - removed the experimental flag for the auto_calibrate configuration (#156623)