### PR TITLE
unmute #112731

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -4,9 +4,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search/500_date_range/from, to, include_lower, include_upper deprecated}
   issue: https://github.com/elastic/elasticsearch/pull/113286
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-  method: testTracingCrossCluster
-  issue: https://github.com/elastic/elasticsearch/issues/112731
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithApmTracingRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithApmTracingRestIT.java
@@ -111,11 +111,6 @@ public class RemoteClusterSecurityWithApmTracingRestIT extends AbstractRemoteClu
                 allTrue(
                     transactionValue("name", equalTo("GET /_resolve/cluster/{name}")),
                     transactionValue("trace_id", equalTo(traceIdValue))
-                ),
-                // transport action on fulfilling cluster
-                allTrue(
-                    transactionValue("name", equalTo("indices:admin/resolve/cluster")),
-                    transactionValue("trace_id", equalTo(traceIdValue))
                 )
             )
         );


### PR DESCRIPTION
Resolves #112731

See #147680

We can't backport the previous fix because it depends on other changes not present on 8.19. 

The change in this PR follows the logic:
 - On main, cross cluster requests aren't traced on the fulfilling cluster
 - Therefore we don't care whether actions on the fulfilling cluster are traced
 - Therefore we can remove the assertion