### PR TITLE
[9.5] Fix Google VertexAI chat completion tool call args for non-string values (#156665)

### DIFF
--- a/docs/changelog/156644.yaml
+++ b/docs/changelog/156644.yaml
@@ -1,0 +1,6 @@
+pr: 156644
+summary: Fix Google VertexAI chat completion tool call arguments serialization for non-string values
+area: Inference
+type: bug
+issues:
+  - 156644

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntity.java
@@ -138,7 +138,7 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
 
     }
 
-    private static Map<String, String> jsonStringToMap(String jsonString) throws IOException {
+    private static Map<String, Object> jsonStringToMap(String jsonString) throws IOException {
         if (jsonString == null || jsonString.isEmpty()) {
             return null;
         }
@@ -149,7 +149,7 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntity implements ToXCont
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, jsonString)) {
             XContentParser.Token token = parser.nextToken();
             ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-            return parser.mapStrings();
+            return parser.map();
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestEntityTests.java
@@ -696,6 +696,64 @@ public class GoogleVertexAiUnifiedChatCompletionRequestEntityTests extends ESTes
         assertJsonEquals(jsonString, requestJson);
     }
 
+    public void testParseFunctionCallWithNonStringArgValues() throws IOException {
+        String requestJson = """
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [
+                            { "functionCall" : {
+                                "name": "get_index_mapping",
+                                "args": {
+                                    "indices": ["foo", "bar"],
+                                    "size": 10
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        var request = new UnifiedCompletionRequest(
+            List.of(
+                new Message(
+                    null,
+                    "assistant",
+                    null,
+                    List.of(
+                        new ToolCall(
+                            "call_1",
+                            new ToolCall.FunctionField("{\"indices\": [\"foo\", \"bar\"], \"size\": 10}", "get_index_mapping"),
+                            "function"
+                        )
+                    )
+                )
+            ),
+            "gemini-2.0",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        UnifiedChatInput unifiedChatInput = new UnifiedChatInput(request, true);
+        GoogleVertexAiUnifiedChatCompletionRequestEntity entity = new GoogleVertexAiUnifiedChatCompletionRequestEntity(
+            unifiedChatInput,
+            emptyThinkingConfig
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        entity.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String jsonString = Strings.toString(builder);
+        assertJsonEquals(jsonString, requestJson);
+    }
+
     public void testParseFunctionCallWithBadJson() throws IOException {
         int someNumber = 1;
         var illegalArguments = List.of("\"order_id\": \"order_12345\"}", "[]", Integer.toString(someNumber), "\"a\"");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix Google VertexAI chat completion tool call args for non-string values (#156665)](https://github.com/elastic/elasticsearch/pull/156665)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)