### PR TITLE
Support indexed date fields in columnar indexing

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -115,9 +115,8 @@ public final class DateFieldMapper extends FieldMapper {
     public static final DateFormatter DEFAULT_DATE_TIME_NANOS_FORMATTER = DateFormatter.forPattern(
         "strict_date_optional_time_nanos||epoch_millis"
     ).withLocale(DEFAULT_LOCALE);
-    private static final DateMathParser EPOCH_MILLIS_PARSER = DateFormatter.forPattern("epoch_millis")
-        .withLocale(DEFAULT_LOCALE)
-        .toDateMathParser();
+    private static final DateFormatter EPOCH_MILLIS_FORMATTER = DateFormatter.forPattern("epoch_millis").withLocale(DEFAULT_LOCALE);
+    private static final DateMathParser EPOCH_MILLIS_PARSER = EPOCH_MILLIS_FORMATTER.toDateMathParser();
     public static final NodeFeature INVALID_DATE_FIX = new NodeFeature("mapper.range.invalid_date_fix");
 
     // FieldType constants for the Lucene field variants emitted by the columnar parse path.
@@ -1338,7 +1337,7 @@ public final class DateFieldMapper extends FieldMapper {
             final var dateFormatter = fieldType().dateTimeFormatter();
             epochCompatible = dateFormatter.equals(DEFAULT_DATE_TIME_FORMATTER)
                 || dateFormatter.equals(DEFAULT_DATE_TIME_NANOS_FORMATTER)
-                || dateFormatter.equals(EPOCH_MILLIS_PARSER);
+                || dateFormatter.equals(EPOCH_MILLIS_FORMATTER);
         }
         EscfColumnBuilder builder = new EscfColumnBuilder(EscfColumnBuilder.CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
         builder.lockScalar(EscfColumnKind.LONG);
@@ -1416,7 +1415,7 @@ public final class DateFieldMapper extends FieldMapper {
             && context.parser().numberType() == XContentParser.NumberType.LONG
             && (dateFormatter.equals(DEFAULT_DATE_TIME_FORMATTER)
                 || dateFormatter.equals(DEFAULT_DATE_TIME_NANOS_FORMATTER)
-                || dateFormatter.equals(EPOCH_MILLIS_PARSER));
+                || dateFormatter.equals(EPOCH_MILLIS_FORMATTER));
     }
 
     private void indexValue(DocumentParserContext context, long timestamp) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -120,8 +120,9 @@ public final class DateFieldMapper extends FieldMapper {
         .toDateMathParser();
     public static final NodeFeature INVALID_DATE_FIX = new NodeFeature("mapper.range.invalid_date_fix");
 
-    // FieldType constants for the two SortedNumericDocValuesField variants emitted by dvFactory.addNumericField.
-    // The compat harness compares frozen FieldType, so the column must carry exactly the same type.
+    // FieldType constants for the Lucene field variants emitted by the columnar parse path.
+    // The compat harness compares frozen FieldType, so the column must carry exactly the same type
+    // as the corresponding field produced by the row-major path.
     private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE = SortedNumericDocValuesField.TYPE;
     private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
         .fieldType();
@@ -1275,8 +1276,8 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
-        // Columnar support requires strict-columnar index mode and a plain doc-values-only date
-        // field. doc_values.multi_value and ignore_malformed are not implemented by mapColumnBatch
+        // Columnar support requires strict-columnar index mode and a doc-values date field.
+        // doc_values.multi_value and ignore_malformed are not implemented by mapColumnBatch
         // but are deliberately not rejected here instead rejected at parse time.
         return indexSettings.getMode().isStrictColumnar()
             && docValuesParameters.enabled()

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -125,6 +125,7 @@ public final class DateFieldMapper extends FieldMapper {
     private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE = SortedNumericDocValuesField.TYPE;
     private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
         .fieldType();
+    private static final IndexableFieldType LONG_FIELD_TYPE = new LongField("_sentinel", 0L, Field.Store.NO).fieldType();
 
     public enum Resolution {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE, DateMillisDocValuesField::new) {
@@ -1279,7 +1280,6 @@ public final class DateFieldMapper extends FieldMapper {
         // but are deliberately not rejected here instead rejected at parse time.
         return indexSettings.getMode().isStrictColumnar()
             && docValuesParameters.enabled()
-            && indexed == false
             && store == false
             && hasScript() == false
             && copyTo().copyToFields().isEmpty()
@@ -1300,9 +1300,14 @@ public final class DateFieldMapper extends FieldMapper {
                     + "]"
             );
         };
-        final IndexableFieldType columnFieldType = fieldType().hasDocValuesSkipper()
-            ? SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE
-            : SORTED_NUMERIC_DV_FIELD_TYPE;
+        final IndexableFieldType columnFieldType;
+        if (fieldType().hasDocValuesSkipper()) {
+            columnFieldType = SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE;
+        } else if (indexed) {
+            columnFieldType = LONG_FIELD_TYPE;
+        } else {
+            columnFieldType = SORTED_NUMERIC_DV_FIELD_TYPE;
+        }
         ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), columnFieldType, LongColumn.NumericKind.LONG));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
@@ -159,6 +159,51 @@ public class DateFieldMapperColumnarCompatibilityTests extends AbstractColumnarM
         );
     }
 
+    public void testIndexedStringValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("index", true).endObject()),
+            columnarSettings(),
+            batch("indexed string value", 1L, doc("d1", 1L, "{\"f\":\"2024-01-15T12:00:00.000Z\"}"))
+        );
+    }
+
+    public void testIndexedLongValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("index", true).endObject()),
+            columnarSettings(),
+            batch("indexed long value", 1L, doc("d1", 1L, "{\"f\":1705320000000}"))
+        );
+    }
+
+    public void testIndexedWithAbsentDoc() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("index", true).endObject()),
+            columnarSettings(),
+            batch(
+                "indexed with absent doc",
+                1L,
+                doc("d1", 1L, "{\"f\":\"2024-01-01T00:00:00.000Z\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"2024-03-15T08:30:00.000Z\"}")
+            )
+        );
+    }
+
+    public void testIndexedMultipleDocs() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "date").field("index", true).endObject()),
+            columnarSettings(),
+            batch(
+                "indexed multiple docs",
+                1L,
+                doc("d1", 1L, "{\"f\":\"2020-01-01T00:00:00.000Z\"}"),
+                doc("d2", 2L, "{\"f\":\"2021-06-15T12:00:00.000Z\"}"),
+                doc("d3", 3L, "{\"f\":\"2022-12-31T23:59:59.999Z\"}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
     /**
      * Columnar-mode settings leaving {@code doc_values.multi_value} at its default of {@code true},
      * so array values reach the mapper instead of being rejected at parse time.


### PR DESCRIPTION
Date fields with `index: true` were previously excluded from the strict-columnar parse path. This removes that restriction so that indexed date fields participate in columnar indexing alongside doc-values-only fields.

The columnar field-type selection in `mapColumnBatch` now mirrors the three-way logic in indexValue: doc-values-skipper fields use `SORTED_NUMERIC_DV_INDEXED`, indexed+doc-values fields use `LONG_FIELD_TYPE` (matching the `LongField` the row-major path emits), and doc-values-only fields use `SORTED_NUMERIC_DV`.

Also fixes a latent bug on the epoch_millis fast path: the equals checks in `datesFromLongs` and `isEpochMillis` were comparing a `DateFormatter` against a `DateMathParser`, which always returned false. A new `EPOCH_MILLIS_FORMATTER` constant (`DateFormatter`) is introduced; `EPOCH_MILLIS_PARSER` is now derived from it rather than constructed independently.