### PR TITLE
ES|QL HIGHLIGHT: reject map option values at parse time

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1536,6 +1536,20 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                 Highlight.validOptionNames()
             );
         }
+        // Every HIGHLIGHT option takes a constant; the grammar also admits a nested map. Rejecting here keeps the source
+        // position: a non-literal value is not foldable, so analysis skips it and it would otherwise fail while folding
+        // on every data node, with no position to report.
+        for (Map.Entry<String, Expression> option : optionsMap.entrySet()) {
+            Expression value = option.getValue();
+            if (value instanceof Literal == false) {
+                throw new ParsingException(
+                    value.source(),
+                    "Invalid value for option [{}] in HIGHLIGHT, expected a constant, found [{}]",
+                    option.getKey(),
+                    value.sourceText()
+                );
+            }
+        }
         return h.withOptions(options);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
@@ -306,8 +306,8 @@ public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPl
         }
     }
 
-    // Non-foldable values (WITH { ... } allows constants, nested maps and parameters) are skipped here and fail later at
-    // fold time.
+    // WITH { ... } yields constants and parameters, which all fold; the parser rejects map values. Anything else is
+    // skipped here and fails later at fold time.
     private Expression foldableOption(String name) {
         Expression value = options.get(name);
         return value != null && value.foldable() ? value : null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1346,6 +1346,15 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
     }
 
+    public void testHighlightRejectsMapOptionValue() {
+        assumeTrue("requires HIGHLIGHT_V6 capability", EsqlCapabilities.Cap.HIGHLIGHT_V6.isEnabled());
+        expectThrows(
+            ParsingException.class,
+            containsString("Invalid value for option [pre_tags] in HIGHLIGHT, expected a constant, found [{ \"tag\": \"<b>\" }]"),
+            () -> query("FROM foo | HIGHLIGHT \"elasticsearch\" ON title WITH { \"pre_tags\": { \"tag\": \"<b>\" } }")
+        );
+    }
+
     public void testHighlightAcceptsFunctionQuery() {
         assumeTrue("requires HIGHLIGHT_V6 capability", EsqlCapabilities.Cap.HIGHLIGHT_V6.isEnabled());
         LogicalPlan plan = query("FROM foo | HIGHLIGHT MATCH(title, \"x\") ON title");


### PR DESCRIPTION
 The grammar admits a nested map as any option value, but no `HIGHLIGHT` option takes a map. Such a value is non-foldable, so analysis skipped it and it blew up while folding on every data node, an internal error mid-flight with no source position (e.g. ... `WITH {"pre_tags": {"tag": "<b>"}}`). 
`applyHighlightOptions` now rejects any non-Literal option value in the parser with a `ParsingException` that keeps the source position. 

- Adds `StatementParserTests#testHighlightRejectsMapOptionValue`