### PR TITLE
ES|QL HIGHLIGHT: reject integer options above Integer.MAX_VALUE

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
@@ -216,11 +216,15 @@ public record HighlightOptions(
         if (value == null) {
             return defaultValue;
         }
-        int intValue = integral(name, value.fold(foldContext));
-        if (intValue < 0) {
-            throw new IllegalArgumentException("Option [" + name + "] must be >= 0, found [" + intValue + "]");
+        Object folded = value.fold(foldContext);
+        long longValue = integral(name, folded);
+        if (longValue < 0) {
+            throw new IllegalArgumentException("Option [" + name + "] must be >= 0, found [" + folded + "]");
         }
-        return intValue;
+        if (longValue > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Option [" + name + "] must be <= " + Integer.MAX_VALUE + ", found [" + folded + "]");
+        }
+        return (int) longValue;
     }
 
     /**
@@ -232,18 +236,19 @@ public record HighlightOptions(
         if (value == null) {
             return DEFAULT_MAX_ANALYZED_OFFSET;
         }
-        int intValue = integral(name, value.fold(foldContext));
-        if (intValue < -1 || intValue == 0) {
-            throw new IllegalArgumentException("Option [" + name + "] must be a positive integer, or -1, found [" + intValue + "]");
+        Object folded = value.fold(foldContext);
+        long longValue = integral(name, folded);
+        if (longValue < -1 || longValue == 0) {
+            throw new IllegalArgumentException("Option [" + name + "] must be a positive integer, or -1, found [" + folded + "]");
         }
-        return intValue;
+        if (longValue > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Option [" + name + "] must be <= " + Integer.MAX_VALUE + ", found [" + folded + "]");
+        }
+        return (int) longValue;
     }
 
-    /**
-     * Extracts an int from a folded numeric option, rejecting non-numbers and fractional values (e.g. {@code 0.9})
-     * rather than silently truncating them.
-     */
-    private static int integral(String name, Object folded) {
+    /** Extracts a long from a numeric option without silently truncating fractional values. */
+    private static long integral(String name, Object folded) {
         if (folded instanceof Number number) {
             if (number instanceof Float || number instanceof Double) {
                 double doubleValue = number.doubleValue();
@@ -251,7 +256,7 @@ public record HighlightOptions(
                     throw new IllegalArgumentException("Option [" + name + "] must be an integer, found [" + folded + "]");
                 }
             }
-            return number.intValue();
+            return number.longValue();
         }
         throw new IllegalArgumentException("Option [" + name + "] must be numeric, found [" + folded + "]");
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
@@ -135,7 +135,7 @@ public class HighlightOptionsTests extends ESTestCase {
 
     public void testIntegerOptionsRejectValuesAboveIntRange() {
         long value = (1L << 32) + 1;
-        for (String name : List.of(Highlight.MAX_ANALYZED_OFFSET, Highlight.FRAGMENT_SIZE)) {
+        for (String name : List.of(Highlight.MAX_ANALYZED_OFFSET, Highlight.NUMBER_OF_FRAGMENTS, Highlight.FRAGMENT_SIZE, Highlight.NO_MATCH_SIZE)) {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
                 () -> HighlightOptions.from(map(name, Literal.fromLong(Source.EMPTY, value)), FoldContext.small())

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
@@ -133,6 +133,17 @@ public class HighlightOptionsTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Option [max_analyzed_offset] must be a positive integer, or -1"));
     }
 
+    public void testIntegerOptionsRejectValuesAboveIntRange() {
+        long value = (1L << 32) + 1;
+        for (String name : List.of(Highlight.MAX_ANALYZED_OFFSET, Highlight.FRAGMENT_SIZE)) {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> HighlightOptions.from(map(name, Literal.fromLong(Source.EMPTY, value)), FoldContext.small())
+            );
+            assertThat(e.getMessage(), containsString("Option [" + name + "] must be <= " + Integer.MAX_VALUE + ", found [" + value + "]"));
+        }
+    }
+
     public void testPhraseLimitIsAcceptedButIgnored() {
         HighlightOptions options = HighlightOptions.from(
             map(Highlight.PHRASE_LIMIT, Literal.integer(Source.EMPTY, -1), Highlight.NUMBER_OF_FRAGMENTS, Literal.integer(Source.EMPTY, 3)),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
@@ -135,7 +135,12 @@ public class HighlightOptionsTests extends ESTestCase {
 
     public void testIntegerOptionsRejectValuesAboveIntRange() {
         long value = (1L << 32) + 1;
-        for (String name : List.of(Highlight.MAX_ANALYZED_OFFSET, Highlight.NUMBER_OF_FRAGMENTS, Highlight.FRAGMENT_SIZE, Highlight.NO_MATCH_SIZE)) {
+        for (String name : List.of(
+            Highlight.MAX_ANALYZED_OFFSET,
+            Highlight.NUMBER_OF_FRAGMENTS,
+            Highlight.FRAGMENT_SIZE,
+            Highlight.NO_MATCH_SIZE
+        )) {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
                 () -> HighlightOptions.from(map(name, Literal.fromLong(Source.EMPTY, value)), FoldContext.small())


### PR DESCRIPTION
Numeric HIGHLIGHT options were narrowed with `Number.intValue()`, so a 64-bit literal silently wrapped, e.g. `WITH {"fragment_size": 4294967297}` became 1, and an `out-of-range max_analyzed_offset` was accepted. `integral(...)` now returns a `long,` and `fragment_size` / `number_of_fragments` / `no_match_size` / `max_analyzed_offset` reject any `value > Integer.MAX_VALUE` at analysis time with a clear message that echoes the user's literal.
- Adds HighlightOptionsTests#testIntegerOptionsRejectValuesAboveIntRange.