### PR TITLE
ES|QL HIGHLIGHT: drop FastVectorHighlighter-only no-op options

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/HighlightGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/HighlightGenerator.java
@@ -54,11 +54,7 @@ public class HighlightGenerator implements CommandGenerator {
         { "order", "\"none\"", "\"score\"" },
         { "no_match_size", "0", "30", "100", "200" },
         // max_analyzed_offset must be a positive integer or -1 (0 is invalid).
-        { "max_analyzed_offset", "-1", "100", "1000" },
-        // Accepted for Query DSL parity but no-ops for the unified highlighter HIGHLIGHT uses.
-        { "boundary_chars", "\".,!?\"" },
-        { "boundary_max_scan", "10", "20" },
-        { "phrase_limit", "128", "256" } };
+        { "max_analyzed_offset", "-1", "100", "1000" } };
 
     @Override
     public CommandDescription generate(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -603,20 +603,6 @@ null
 ;
 
 
-# boundary_chars, boundary_max_scan and phrase_limit are FastVectorHighlighter-only, so they are accepted but no-ops.
-highlightUnifiedNoOpOptions
-required_capability: highlight_v6
-
-ROW content = "The One Ring was forged by Sauron."
-| HIGHLIGHT "ring" ON content WITH { "boundary_chars": ".,!?", "boundary_max_scan": 10, "phrase_limit": 64 }
-| KEEP highlight_content
-;
-
-highlight_content:keyword
-The One <em>Ring</em> was forged by Sauron.
-;
-
-
 # Unquoted adjacent terms wrap independently; use a quoted phrase for a single span.
 highlightAdjacentMatchesWrappedIndependently
 required_capability: highlight_v6

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Highlight.java
@@ -65,12 +65,6 @@ public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPl
     public static final String ORDER = "order";
     public static final String MAX_ANALYZED_OFFSET = "max_analyzed_offset";
 
-    // Accepted for Query DSL parity but only used by the FastVectorHighlighter, so they are no-ops for the unified
-    // highlighter that HIGHLIGHT always uses.
-    public static final String BOUNDARY_CHARS = "boundary_chars";
-    public static final String BOUNDARY_MAX_SCAN = "boundary_max_scan";
-    public static final String PHRASE_LIMIT = "phrase_limit";
-
     private static final List<String> VALID_OPTION_NAMES = List.of(
         PRE_TAGS,
         POST_TAGS,
@@ -80,12 +74,9 @@ public class Highlight extends UnaryPlan implements TelemetryAware, GeneratingPl
         ANALYZER,
         BOUNDARY_SCANNER,
         BOUNDARY_SCANNER_LOCALE,
-        BOUNDARY_CHARS,
-        BOUNDARY_MAX_SCAN,
         ORDER,
         NO_MATCH_SIZE,
-        MAX_ANALYZED_OFFSET,
-        PHRASE_LIMIT
+        MAX_ANALYZED_OFFSET
     );
 
     private final String prefix;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptions.java
@@ -22,10 +22,6 @@ import java.util.Locale;
  * Built once at local-execution-planning time from the (foldable) {@link MapExpression} so the operator factory only
  * deals with primitives.
  * <p>
- * {@code boundary_chars}, {@code boundary_max_scan} and {@code phrase_limit} are accepted for Query DSL parity but are
- * only honoured by the FastVectorHighlighter. HIGHLIGHT always uses the unified highlighter, so they are grammar-only
- * no-ops that never reach this record.
- * <p>
  * The validation done while building this record is also the single source of truth for analysis-time checks:
  * {@link Highlight#postAnalysisVerification} reuses {@link #validate} so invalid values fail during analysis rather
  * than only later during local planning.
@@ -127,26 +123,18 @@ public record HighlightOptions(
     /**
      * Type/range-checks a single (non-null, foldable) option value by parsing it exactly as {@link #from} would and
      * discarding the result, throwing {@link IllegalArgumentException} on a bad value. Enum options ({@code encoder},
-     * {@code boundary_scanner}, {@code order}) are checked separately against their {@link EnumOption} descriptor, and
-     * {@code phrase_limit} is grammar-only, so all of them are no-ops here. {@code boundary_chars} and
-     * {@code boundary_max_scan} are FastVectorHighlighter-only at execution but we still type-check them for Query DSL
-     * parity.
+     * {@code boundary_scanner}, {@code order}) are no-ops here because they are checked separately against their
+     * {@link EnumOption} descriptor.
      */
     public static void validate(String name, Expression value, FoldContext foldContext) {
         switch (name) {
             case Highlight.PRE_TAGS, Highlight.POST_TAGS -> string(name, value, foldContext, null);
             case Highlight.ANALYZER -> analyzerName(name, value, foldContext);
-            case Highlight.BOUNDARY_CHARS -> requireString(name, value.fold(foldContext));
             case Highlight.BOUNDARY_SCANNER_LOCALE -> locale(name, value, foldContext);
-            case Highlight.NUMBER_OF_FRAGMENTS, Highlight.FRAGMENT_SIZE, Highlight.NO_MATCH_SIZE, Highlight.BOUNDARY_MAX_SCAN -> integer(
-                name,
-                value,
-                foldContext,
-                0
-            );
+            case Highlight.NUMBER_OF_FRAGMENTS, Highlight.FRAGMENT_SIZE, Highlight.NO_MATCH_SIZE -> integer(name, value, foldContext, 0);
             case Highlight.MAX_ANALYZED_OFFSET -> maxAnalyzedOffset(name, value, foldContext);
-            case Highlight.ENCODER, Highlight.BOUNDARY_SCANNER, Highlight.ORDER, Highlight.PHRASE_LIMIT -> {
-                // Handled elsewhere (enums against EnumOption, phrase_limit is grammar-only).
+            case Highlight.ENCODER, Highlight.BOUNDARY_SCANNER, Highlight.ORDER -> {
+                // Handled separately against their EnumOption descriptor.
             }
             // Unreachable: the parser already rejected anything not in VALID_OPTION_NAMES.
             default -> throw new AssertionError("Unexpected option [" + name + "] in HIGHLIGHT");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -4652,8 +4652,6 @@ public class VerifierTests extends ESTestCase {
             "123",
             containsString("Option [boundary_scanner_locale] must be a string")
         );
-        assertInvalidHighlightOptionValue("boundary_chars", "10", containsString("Option [boundary_chars] must be a string"));
-        assertInvalidHighlightOptionValue("boundary_max_scan", "\"far\"", containsString("Option [boundary_max_scan] must be numeric"));
         assertInvalidHighlightOptionValue(
             "boundary_scanner_locale",
             "\"en_US\"",
@@ -4668,7 +4666,6 @@ public class VerifierTests extends ESTestCase {
         assertInvalidHighlightOptionValue("number_of_fragments", "-1", containsString("Option [number_of_fragments] must be >= 0"));
         assertInvalidHighlightOptionValue("fragment_size", "-1", containsString("Option [fragment_size] must be >= 0"));
         assertInvalidHighlightOptionValue("no_match_size", "-1", containsString("Option [no_match_size] must be >= 0"));
-        assertInvalidHighlightOptionValue("boundary_max_scan", "-1", containsString("Option [boundary_max_scan] must be >= 0"));
         assertInvalidHighlightOptionValue(
             "max_analyzed_offset",
             "0",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1330,9 +1330,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
             FROM foo | HIGHLIGHT "elasticsearch" ON title WITH {
               "pre_tags": ["<b>"], "post_tags": ["</b>"], "encoder": "html",
               "number_of_fragments": 2, "fragment_size": 150, "no_match_size": 100,
-              "boundary_scanner": "word", "boundary_scanner_locale": "en-US",
-              "boundary_chars": ".,!?", "boundary_max_scan": 10, "order": "score",
-              "analyzer": "standard", "max_analyzed_offset": 500, "phrase_limit": 64 }""");
+              "boundary_scanner": "word", "boundary_scanner_locale": "en-US", "order": "score",
+              "analyzer": "standard", "max_analyzed_offset": 500 }""");
         Highlight highlight = as(plan, Highlight.class);
         assertThat(highlight.options().keyFoldedMap().keySet(), equalTo(Set.copyOf(Highlight.validOptionNames())));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/HighlightOptionsTests.java
@@ -99,13 +99,10 @@ public class HighlightOptionsTests extends ESTestCase {
     }
 
     public void testMaxAnalyzedOffsetIsParsed() {
-        MapExpression map = map(
-            Highlight.MAX_ANALYZED_OFFSET,
-            Literal.integer(Source.EMPTY, 500),
-            Highlight.PHRASE_LIMIT,
-            Literal.integer(Source.EMPTY, 64)
+        HighlightOptions options = HighlightOptions.from(
+            map(Highlight.MAX_ANALYZED_OFFSET, Literal.integer(Source.EMPTY, 500)),
+            FoldContext.small()
         );
-        HighlightOptions options = HighlightOptions.from(map, FoldContext.small());
         assertThat(options.maxAnalyzedOffset(), equalTo(500));
     }
 
@@ -147,14 +144,6 @@ public class HighlightOptionsTests extends ESTestCase {
             );
             assertThat(e.getMessage(), containsString("Option [" + name + "] must be <= " + Integer.MAX_VALUE + ", found [" + value + "]"));
         }
-    }
-
-    public void testPhraseLimitIsAcceptedButIgnored() {
-        HighlightOptions options = HighlightOptions.from(
-            map(Highlight.PHRASE_LIMIT, Literal.integer(Source.EMPTY, -1), Highlight.NUMBER_OF_FRAGMENTS, Literal.integer(Source.EMPTY, 3)),
-            FoldContext.small()
-        );
-        assertThat(options.numberOfFragments(), equalTo(3));
     }
 
     public void testTagAsScalarString() {


### PR DESCRIPTION
`boundary_chars`, `boundary_max_scan`, and `phrase_limit` were accepted "for Query DSL parity" but only the `FVH` honors them. `HIGHLIGHT` always uses the `unified` highlighter, so they were silent no-ops (and `phrase_limit` skipped type validation entirely). They're removed from `VALID_OPTION_NAMES` and their validate cases, so the parser's unknown-option check now rejects them with the standard "expected one of [...]" error.

 - Remove csv-spec case, generator entries, and option tests.