### PR TITLE
Add ability to throttle merges in stateless

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -2474,6 +2474,16 @@ public abstract class Engine implements Closeable {
     public abstract void resumeThrottling();
 
     /**
+     * Activates throttling of merges if the engine supports this functionality.
+     */
+    public void activateMergeThrottling() {}
+
+    /**
+     * Reverses a previous {@link #activateMergeThrottling()} call.
+     */
+    public void deactivateMergeThrottling() {}
+
+    /**
      * This method replays translog to restore the Lucene index which might be reverted previously.
      * This ensures that all acknowledged writes are restored correctly when this engine is promoted.
      *

--- a/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ThreadPoolMergeScheduler.java
@@ -224,6 +224,15 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
     }
 
     /**
+     * Returns true if scheduled merges should be put in the backlog instead of executed
+     * even if there is capacity to do so.
+     * This is intended to temporarily reduce the impact of merges on other parts of the system.
+     */
+    protected boolean shouldBacklogMerges() {
+        return false;
+    }
+
+    /**
      * Returns true if IO-throttling is enabled
      */
     protected boolean isAutoThrottle() {
@@ -330,9 +339,15 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
             return Schedule.ABORT;
         } else if (shouldSkipMerge()) {
             if (verbose()) {
-                message(String.format(Locale.ROOT, "skipping merge task %s", mergeTask));
+                message(String.format(Locale.ROOT, "skipping merge task %s due to shouldSkipMerge()", mergeTask));
             }
             return Schedule.ABORT;
+        } else if (shouldBacklogMerges()) {
+            if (verbose()) {
+                message(String.format(Locale.ROOT, "queuing merge task %s due to shouldBacklogMerges()", mergeTask));
+            }
+            backloggedMergeTasks.add(mergeTask);
+            return Schedule.BACKLOG;
         } else if (runningMergeTasks.size() < getMaxThreadCount()) {
             boolean added = runningMergeTasks.put(mergeTask.onGoingMerge.getMerge(), mergeTask) == null;
             assert added : "starting merge task [" + mergeTask + "] registered as already running";
@@ -468,7 +483,11 @@ public class ThreadPoolMergeScheduler extends MergeScheduler implements Elastics
         threadPoolMergeExecutorService.abortMergeTask(mergeTask);
     }
 
-    private synchronized void enqueueBackloggedTasks() {
+    protected final synchronized void enqueueBackloggedTasks() {
+        if (closed == false && shouldBacklogMerges()) {
+            // No reason to re-enqueue the tasks if we know they will be backlogged again.
+            return;
+        }
         int maxBackloggedTasksToEnqueue = getMaxThreadCount() - runningMergeTasks.size();
         // enqueue all backlogged tasks when closing, as the queue expects all backlogged tasks to always be enqueued back
         while (closed || maxBackloggedTasksToEnqueue-- > 0) {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3046,6 +3046,27 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    /**
+     * Activates throttling of merges if this is supported by the engine.
+     * Merge throttling means that new merges will not be executed while it is active and will be put in the backlog.
+     */
+    public void activateMergeThrottling() {
+        withEngine(engine -> {
+            engine.activateMergeThrottling();
+            return null;
+        });
+    }
+
+    /**
+     * Deactivates throttling of merges if this is supported by the engine.
+     */
+    public void deactivateMergeThrottling() {
+        withEngine(engine -> {
+            engine.deactivateMergeThrottling();
+            return null;
+        });
+    }
+
     private void handleRefreshException(Exception e) {
         if (e instanceof AlreadyClosedException) {
             // ignore

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergeIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessMergeIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stateless;
 
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -403,6 +404,33 @@ public class StatelessMergeIT extends AbstractStatelessPluginIntegTestCase {
             assertThat(queuedEstimated.getLast().getLong(), is(0L));
         });
 
+    }
+
+    public void testMergeThrottling() throws Exception {
+        String indexNode = startMasterAndIndexNode();
+
+        final String indexName = randomIdentifier();
+        createIndex(indexName, indexSettings(1, 0).build());
+
+        var indexShard = findIndexShard(resolveIndex(indexName), 0, indexNode);
+        indexShard.activateMergeThrottling();
+
+        for (int i = 0; i < 2; i++) {
+            indexDocs(indexName, randomIntBetween(10, 20));
+            refresh(indexName);
+        }
+
+        var mergeFuture = client().admin().indices().prepareForceMerge(indexName).setMaxNumSegments(1).execute();
+
+        var indexEngine = (IndexEngine) indexShard.getEngineOrNull();
+        assertBusy(() -> assertThat(indexEngine.hasQueuedOrRunningMerges(), is(true)));
+
+        assertThrows(ElasticsearchTimeoutException.class, () -> mergeFuture.actionGet(TimeValue.timeValueMillis(100)));
+
+        indexShard.deactivateMergeThrottling();
+        safeGet(mergeFuture);
+
+        assertThat(indexEngine.hasQueuedOrRunningMerges(), is(false));
     }
 
     public static void blockMergePool(ThreadPool threadPool, CountDownLatch finishLatch) {

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java
@@ -1001,6 +1001,20 @@ public class IndexEngine extends InternalEngine {
     }
 
     @Override
+    public void activateMergeThrottling() {
+        if (getMergeScheduler() instanceof StatelessThreadPoolMergeScheduler scheduler) {
+            scheduler.activateMergeThrottling();
+        }
+    }
+
+    @Override
+    public void deactivateMergeThrottling() {
+        if (getMergeScheduler() instanceof StatelessThreadPoolMergeScheduler scheduler) {
+            scheduler.deactivateMergeThrottling();
+        }
+    }
+
+    @Override
     protected void notifyLastDocIdAndVersionLookup() {
         lastDocIdAndVersionLookupMillis.accumulateAndGet(engineConfig.getThreadPool().relativeTimeInMillis(), Math::max);
     }
@@ -1055,6 +1069,8 @@ public class IndexEngine extends InternalEngine {
     final class StatelessThreadPoolMergeScheduler extends org.elasticsearch.index.engine.ThreadPoolMergeScheduler {
         private final boolean prewarm;
 
+        private final AtomicBoolean throttlingActive;
+
         StatelessThreadPoolMergeScheduler(
             ShardId shardId,
             IndexSettings indexSettings,
@@ -1064,6 +1080,20 @@ public class IndexEngine extends InternalEngine {
         ) {
             super(shardId, indexSettings, threadPoolMergeExecutorService, mergeMemoryEstimateProvider, mergeMetrics);
             prewarm = MERGE_PREWARM.get(indexSettings.getSettings());
+            throttlingActive = new AtomicBoolean(false);
+        }
+
+        public void activateMergeThrottling() {
+            throttlingActive.compareAndSet(false, true);
+        }
+
+        public void deactivateMergeThrottling() {
+            if (throttlingActive.compareAndSet(true, false)) {
+                // It is possible that all active merges are currently in the backlog
+                // so we need to give the scheduler chance to execute them
+                // now that we are not throttling anymore.
+                enqueueBackloggedTasks();
+            }
         }
 
         @Override
@@ -1124,6 +1154,11 @@ public class IndexEngine extends InternalEngine {
         @Override
         protected boolean shouldSkipMerge() {
             return IndexEngine.this.shouldSkipMerge();
+        }
+
+        @Override
+        protected boolean shouldBacklogMerges() {
+            return throttlingActive.get();
         }
 
         @Override


### PR DESCRIPTION
These APIs will be called by `UploadQueueControllerService` as a next step. This is based on the previous draft https://github.com/elastic/elasticsearch/pull/154025.

Contributes to https://github.com/elastic/elasticsearch-team/issues/4415. 