### PR TITLE
Add known issue for 9.5.1 terms query false positive

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -8,6 +8,20 @@ mapped_pages:
 
 Known issues are significant defects or limitations that may impact your implementation. These issues are actively being worked on and will be addressed in a future release. Review the Elasticsearch known issues to help you make informed decisions, such as upgrading to a new version.
 
+## 9.5.1 [elasticsearch-9.5.1-known-issues]
+
+* Boolean queries containing a `must`, `filter`, or `should` clause using a `terms` query
+  (multi-value), along with a `must_not` clause, on fields with disabled indexing can still return
+  false-positive matches despite the partial fix in 9.5.1. The 9.5.1 fix
+  ([#155936](https://github.com/elastic/elasticsearch/pull/155936)) addressed the bulk-scorer defect
+  for `term` and range query paths, but the multi-value `terms` query uses a different Lucene query
+  type that was not covered by that fix. [TSDB](https://www.elastic.co/docs/manage-data/data-store/data-streams/time-series-data-stream-tsds)
+  and [columnar](https://www.elastic.co/docs/reference/elasticsearch/columnar) indices and data
+  streams remain affected for this query shape.
+
+  The full fix, which upgrades Elasticsearch to Lucene 10.5.1 ([apache/lucene#16450](https://github.com/apache/lucene/pull/16450)),
+  is included in a future release.
+
 ## 9.5.0 [elasticsearch-9.5.0-known-issues]
 
 * Boolean queries containing a `must`, `filter`, or `should` clause, along with a `must_not` clause, on fields with disabled indexing can return false-positive matches. This occurs when a DSL or ES|QL query selects Lucene's bulk-scoring path due to an iterator evaluation defect in Lucene ([apache/lucene#16450](https://github.com/apache/lucene/pull/16450)). [TSDB](https://www.elastic.co/docs/manage-data/data-store/data-streams/time-series-data-stream-tsds) and [columnar](https://www.elastic.co/docs/reference/elasticsearch/columnar) indices and data streams are affected, since they disable indexing on all fields by default.

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -14,7 +14,7 @@ Known issues are significant defects or limitations that may impact your impleme
   (multi-value), along with a `must_not` clause, on fields with disabled indexing can still return
   false-positive matches despite the partial fix in 9.5.1. The 9.5.1 fix
   ([#155936](https://github.com/elastic/elasticsearch/pull/155936)) addressed the bulk-scorer defect
-  for `term` and range query paths, but the multi-value `terms` query uses a different Lucene query
+  for `term` and `range` query paths, but the multi-value `terms` query uses a different Lucene query
   type that was not covered by that fix. [TSDB](https://www.elastic.co/docs/manage-data/data-store/data-streams/time-series-data-stream-tsds)
   and [columnar](https://www.elastic.co/docs/reference/elasticsearch/columnar) indices and data
   streams remain affected for this query shape.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/155653
Underlying issue fixed in https://github.com/elastic/elasticsearch/pull/156643