### PR TITLE
[9.5] Reset thread context for bulk timeout task cancellation (#156217)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -617,6 +617,7 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             final CountDownLatch readyForCancellation = new CountDownLatch(1);
             final AtomicBoolean childTaskBanned = new AtomicBoolean(false);
+            final AtomicBoolean banSentInUserlessContext = new AtomicBoolean(false);
 
             IncrementalBulkService.Handler handler2 = incrementalBulkService.newBulkRequest();
 
@@ -626,11 +627,14 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             refCounted.incRef();
             handler2.addItems(List.of(notCancelled), refCounted::decRef, () -> {
-                // Verify child task banned.
+                // Verify child task banned and that the ban is sent without caller-owned headers.
                 primaryTransportService.addRequestHandlingBehavior(
                     TaskCancellationService.BAN_PARENT_ACTION_NAME,
                     (transportRequestHandler, request, channel, task) -> {
                         childTaskBanned.set(true);
+                        banSentInUserlessContext.set(
+                            primaryTransportService.getThreadPool().getThreadContext().getHeader("test.ban.sentinel") == null
+                        );
                         transportRequestHandler.messageReceived(request, channel, task);
                     }
                 );
@@ -666,6 +670,10 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             BulkResponse bulkResponse = future2.actionGet();
             assertThat(childTaskBanned.get(), is(true));
+            assertTrue(
+                "ban was sent with caller header in context; stashContext() missing from Handler#cancel",
+                banSentInUserlessContext.get()
+            );
             assertThat(bulkResponse.getItems().length, is(3));
             assertThat(bulkResponse.getItems()[0].getFailure(), nullValue());
             assertThat(bulkResponse.getItems()[0].isFailed(), is(false));

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -276,8 +277,17 @@ public class IncrementalBulkService {
             }
         }
 
+        /**
+         * Stashes the thread context before propagating the cancellation. {@code internal:admin/tasks/ban}
+         * (and its matching unban) can never be granted to a user and must run as the system user.
+         * {@link ThreadPool#schedule} preserves the REST caller's context into the timeout lambda, so
+         * without the stash the security interceptor would deny the ban request. Mirrors
+         * {@link org.elasticsearch.tasks.TaskCancellationService} sending {@code cancel_child}.
+         */
         public void cancel(String reason, Runnable listener) {
-            taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
+            try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
+                taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
+            }
         }
 
         public IndexingPressure.Incremental getIncrementalOperation() {
@@ -385,12 +395,7 @@ public class IncrementalBulkService {
                 releasables.forEach(Releasable::close);
                 releasables.clear();
                 if (taskManager.getCancellableTask(bulkSessionTask.getId()) != null) {
-                    taskManager.cancelTaskAndDescendants(
-                        bulkSessionTask,
-                        "handler closed",
-                        false,
-                        ActionListener.running(() -> taskManager.unregister(bulkSessionTask))
-                    );
+                    cancel("handler closed", () -> taskManager.unregister(bulkSessionTask));
                 }
             }
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Reset thread context for bulk timeout task cancellation (#156217)](https://github.com/elastic/elasticsearch/pull/156217)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)