### PR TITLE
ESQL: test field_extract in date-function keyword params

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -360,6 +360,7 @@ public class CsvTestsDataLoader {
         new TestDataset("ts_window", "ts_window-mappings.json", "ts_window.csv", "ts_window-settings.json").withIndex("ts_window_nanos")
             .withTypeMapping(Map.of("@timestamp", "date_nanos")),
         new TestDataset("date_extract_fields", "mapping-date_extract_fields.json", "date_extract_fields.csv"),
+        new TestDataset("date_fn_fields", "mapping-date_fn_fields.json", "date_fn_fields.csv"),
         new TestDataset("trim_test")
     ).collect(toMap(TestDataset::indexName, Function.identity()));
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/date_fn_fields.csv
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/data/date_fn_fields.csv
@@ -1,0 +1,4 @@
+date_format:keyword,date_pattern:keyword,date_string:keyword,to_unit:keyword,from_unit:keyword,date_val:date
+yyyy-MM-dd,yyyy-MM-dd,2024-02-15,day,month,2024-02-15T14:30:00.000Z
+yyyy,yyyy-MM-dd,2023-02-10,day,month,2023-02-10T00:00:00.000Z
+HH:mm,yyyy-MM-dd,2021-12-25,hour,day,2021-12-25T08:15:00.000Z

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1156,6 +1156,48 @@ month_of_year     | 5
 year              | 2022
 ;
 
+dateFormatFromFields
+required_capability: fn_date_format
+
+FROM date_fn_fields
+| EVAL formatted = DATE_FORMAT(date_format, date_val)
+| KEEP date_format, date_val, formatted
+| SORT date_val;
+
+date_format:keyword | date_val:date            | formatted:keyword
+HH:mm               | 2021-12-25T08:15:00.000Z | 08:15
+yyyy                | 2023-02-10T00:00:00.000Z | 2023
+yyyy-MM-dd          | 2024-02-15T14:30:00.000Z | 2024-02-15
+;
+
+dateParseFromFields
+required_capability: fn_date_parse
+
+FROM date_fn_fields
+| EVAL parsed = DATE_PARSE(date_pattern, date_string)
+| KEEP date_pattern, date_string, parsed
+| SORT date_string;
+
+date_pattern:keyword | date_string:keyword | parsed:date
+yyyy-MM-dd           | 2021-12-25          | 2021-12-25T00:00:00.000Z
+yyyy-MM-dd           | 2023-02-10          | 2023-02-10T00:00:00.000Z
+yyyy-MM-dd           | 2024-02-15          | 2024-02-15T00:00:00.000Z
+;
+
+dateUnitCountFromFields
+required_capability: esql_date_unit_count_fn
+
+FROM date_fn_fields
+| EVAL n = DATE_UNIT_COUNT(to_unit, from_unit, date_val)
+| KEEP to_unit, from_unit, date_val, n
+| SORT date_val;
+
+to_unit:keyword | from_unit:keyword | date_val:date            | n:long
+hour            | day               | 2021-12-25T08:15:00.000Z | 24
+day             | month             | 2023-02-10T00:00:00.000Z | 28
+day             | month             | 2024-02-15T14:30:00.000Z | 29
+;
+
 docsDateFormat
 // tag::docsDateFormat[]
 FROM employees

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-date_fn_fields.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/mapping-date_fn_fields.json
@@ -1,0 +1,22 @@
+{
+    "properties": {
+        "date_format": {
+            "type": "keyword"
+        },
+        "date_pattern": {
+            "type": "keyword"
+        },
+        "date_string": {
+            "type": "keyword"
+        },
+        "to_unit": {
+            "type": "keyword"
+        },
+        "from_unit": {
+            "type": "keyword"
+        },
+        "date_val": {
+            "type": "date"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds csv-spec coverage for `FIELD_EXTRACT` in the keyword-parameter position of three date functions. These functions previously had no test that sourced their keyword parameter from an index field (only string literals / `ROW`), so `CsvFlattenedKeywordIT` never exercised `field_extract` there.

Following the established pattern from #151430 (DATE_EXTRACT), this adds a small `date_fn_fields` dataset with keyword fields for each parameter and three `date.csv-spec` tests:

- `dateFormatFromFields` — `DATE_FORMAT(date_format, date_val)` with a field-sourced format
- `dateParseFromFields` — `DATE_PARSE(date_pattern, date_string)` with field-sourced pattern and string
- `dateUnitCountFromFields` — `DATE_UNIT_COUNT(to_unit, from_unit, date_val)` with field-sourced units

All three pass both the base `CsvIT` runner and the `CsvFlattenedKeywordIT` flattened variant (i.e. `field_extract` is exercised in the keyword position).

> `dateUnitCountFromFields` originally exposed a planner "missing references" bug in the flattened variant, which is now fixed on `main` by #156980 (decouple type-check exactness from pushdown exactness). This PR is rebased on that fix and runs the flattened variant un-silenced.

## Test plan

- [x] `:x-pack:plugin:esql:internalClusterTest --tests "*.CsvIT.*FromFields*"`
- [x] `:x-pack:plugin:esql:internalClusterTest --tests "*.CsvFlattenedKeywordIT.*FromFields*"`