### PR TITLE
Remove timezone support limitation

### DIFF
--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -273,11 +273,6 @@ Work around this limitation by converting the field to single value with one of 
 [multivalue functions](/reference/query-languages/esql/functions-operators/mv-functions.md).
 
 
-## Timezone support [esql-limitations-timezone]
-
-{{esql}} only supports the UTC timezone.
-
-
 ## INLINE STATS limitations [esql-limitations-inlinestats]
 
 [`CATEGORIZE`](/reference/query-languages/esql/functions-operators/grouping-functions/categorize.md) grouping function is not currently supported.


### PR DESCRIPTION
`SET time_zone` is GA since 9.4 according to https://www.elastic.co/docs/reference/query-languages/esql/esql-rest#esql-timezones

