### PR TITLE
Ensure `Error` propagates out of `S3BlobContainer`

### DIFF
--- a/docs/changelog/156765.yaml
+++ b/docs/changelog/156765.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 156765
+summary: Ensure `Error` propagates out of `S3BlobContainer`
+type: bug

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -242,9 +242,7 @@ class S3BlobContainer extends AbstractBlobContainer {
 
                 @Override
                 protected void onFailure() {
-                    if (Strings.hasText(uploadId.get())) {
-                        abortMultiPartUpload(purpose, uploadId.get(), absoluteBlobKey);
-                    }
+                    abortMultiPartUploadOnFailure(purpose, uploadId.get(), absoluteBlobKey);
                 }
             }
         ) {
@@ -296,6 +294,32 @@ class S3BlobContainer extends AbstractBlobContainer {
         final var abortMultipartUploadRequest = abortMultipartUploadRequestBuilder.build();
         try (var clientReference = blobStore.clientReference()) {
             clientReference.client().abortMultipartUpload(abortMultipartUploadRequest);
+        }
+    }
+
+    /// Attempt to abort the given MPU, logging any failures without throwing anything out of this method. Suitable for use when trying to
+    /// clean up a MPU because some earlier operation failed, because in a `finally` block or similar this will allow the original failure
+    /// to propagate.
+    ///
+    /// @param uploadId identifies the multipart upload to abort; if blank (e.g. because the MPU succeeded) then this method is a no-op
+    private void abortMultiPartUploadOnFailure(OperationPurpose purpose, String uploadId, String blobName) {
+        if (Strings.hasText(uploadId) == false) {
+            return;
+        }
+
+        try {
+            abortMultiPartUpload(purpose, uploadId, blobName);
+        } catch (Exception e) {
+            if (e instanceof SdkServiceException sdkServiceException
+                && sdkServiceException.statusCode() == RestStatus.NOT_FOUND.getStatus()) {
+                // NOT_FOUND is what we wanted
+                logger.atDebug().withThrowable(e).log("multipart upload of [{}] with ID [{}] not found on abort", blobName, uploadId);
+            } else {
+                // aborting the upload on failure is a best-effort cleanup step - if it fails then we must just move on
+                logger.atWarn()
+                    .withThrowable(e)
+                    .log("failed to clean up multipart upload of [{}] with ID [{}] after earlier failure", blobName, uploadId);
+            }
         }
     }
 
@@ -381,12 +405,12 @@ class S3BlobContainer extends AbstractBlobContainer {
             final CompletedPart[] completedParts = new CompletedPart[nbParts];
             final AtomicInteger nextPart = new AtomicInteger(1);
             final CountDownLatch latch = new CountDownLatch(nbParts);
-            final AtomicReference<Throwable> firstError = new AtomicReference<>();
+            final AtomicReference<Exception> firstException = new AtomicReference<>();
 
             final Runnable worker = () -> {
                 int partNum;
                 while ((partNum = nextPart.getAndIncrement()) <= nbParts) {
-                    if (firstError.get() == null) {
+                    if (firstException.get() == null) {
                         final boolean lastPart = (partNum == nbParts);
                         final long curPartSize = lastPart ? lastPartSize : partSize;
                         final long offset = (long) (partNum - 1) * partSize;
@@ -408,8 +432,8 @@ class S3BlobContainer extends AbstractBlobContainer {
                                     .eTag(uploadResponse.eTag())
                                     .build();
                             }
-                        } catch (Throwable t) {
-                            firstError.compareAndSet(null, t);
+                        } catch (Exception e) {
+                            firstException.compareAndSet(null, e);
                         }
                     }
                     latch.countDown();
@@ -430,12 +454,12 @@ class S3BlobContainer extends AbstractBlobContainer {
                 latch.await();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                firstError.compareAndSet(null, e);
+                firstException.compareAndSet(null, e);
             }
 
-            final Throwable error = firstError.get();
-            if (error != null) {
-                throw new IOException("Failed to upload parts for [" + blobName + "]", error);
+            final Exception exception = firstException.get();
+            if (exception != null) {
+                throw new IOException("Failed to upload parts for [" + blobName + "]", exception);
             }
 
             final var completeRequestBuilder = CompleteMultipartUploadRequest.builder()
@@ -460,26 +484,7 @@ class S3BlobContainer extends AbstractBlobContainer {
             throw new IOException("Unable to upload object [" + blobName + "] using concurrent multipart upload", e);
         } finally {
             if (succeeded == false) {
-                try {
-                    abortMultiPartUpload(purpose, uploadId, absoluteBlobKey);
-                } catch (Exception e) {
-                    if (e instanceof SdkServiceException sdkServiceException
-                        && sdkServiceException.statusCode() == RestStatus.NOT_FOUND.getStatus()) {
-                        // NOT_FOUND is what we wanted
-                        logger.atDebug()
-                            .withThrowable(e)
-                            .log("multipart upload of [{}] with ID [{}] not found on abort", absoluteBlobKey, uploadId);
-                    } else {
-                        // aborting the upload on failure is a best-effort cleanup step - if it fails then we must just move on
-                        logger.atWarn()
-                            .withThrowable(e)
-                            .log(
-                                "failed to clean up multipart upload of [{}] with ID [{}] after earlier failure",
-                                absoluteBlobKey,
-                                uploadId
-                            );
-                    }
-                }
+                abortMultiPartUploadOnFailure(purpose, uploadId, absoluteBlobKey);
             }
         }
     }
@@ -793,30 +798,11 @@ class S3BlobContainer extends AbstractBlobContainer {
         final long lastPartSize = multiparts.v2();
         assert blobSize == (((nbParts - 1) * partSize) + lastPartSize) : "blobSize does not match multipart sizes";
 
-        final List<Runnable> cleanupOnFailureActions = new ArrayList<>(1);
         final String bucketName = s3BlobStore.bucket();
+        String uploadId = "";
         try {
-            final String uploadId;
             try (AmazonS3Reference clientReference = s3BlobStore.clientReference()) {
                 uploadId = clientReference.client().createMultipartUpload(createMultipartUpload(purpose, operation, blobName)).uploadId();
-                cleanupOnFailureActions.add(() -> {
-                    try {
-                        abortMultiPartUpload(purpose, uploadId, blobName);
-                    } catch (Exception e) {
-                        if (e instanceof SdkServiceException sdkServiceException
-                            && sdkServiceException.statusCode() == RestStatus.NOT_FOUND.getStatus()) {
-                            // NOT_FOUND is what we wanted
-                            logger.atDebug()
-                                .withThrowable(e)
-                                .log("multipart upload of [{}] with ID [{}] not found on abort", blobName, uploadId);
-                        } else {
-                            // aborting the upload on failure is a best-effort cleanup step - if it fails then we must just move on
-                            logger.atWarn()
-                                .withThrowable(e)
-                                .log("failed to clean up multipart upload of [{}] with ID [{}] after earlier failure", blobName, uploadId);
-                        }
-                    }
-                });
             }
             if (Strings.isEmpty(uploadId)) {
                 throw new IOException("Failed to initialize multipart operation for " + blobName);
@@ -864,14 +850,14 @@ class S3BlobContainer extends AbstractBlobContainer {
             try (var clientReference = s3BlobStore.clientReference()) {
                 clientReference.client().completeMultipartUpload(completeMultipartUploadRequest);
             }
-            cleanupOnFailureActions.clear();
+            uploadId = ""; // skip cleanup
         } catch (final SdkException e) {
             if (e instanceof SdkServiceException sse && sse.statusCode() == RestStatus.NOT_FOUND.getStatus()) {
                 throw new NoSuchFileException(blobName, null, e.getMessage());
             }
             throw new IOException("Unable to upload or copy object [" + blobName + "] using multipart upload", e);
         } finally {
-            cleanupOnFailureActions.forEach(Runnable::run);
+            abortMultiPartUploadOnFailure(purpose, uploadId, blobName);
         }
     }
 

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -39,8 +39,12 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStoreException;
 import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.ArgumentCaptor;
 
@@ -62,7 +66,9 @@ import static org.elasticsearch.repositories.s3.S3BlobContainer.ConditionalOpera
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -601,6 +607,102 @@ public class S3BlobStoreContainerTests extends ESTestCase {
         assertEquals(uploadId, abortRequest.uploadId());
 
         closeMockClient(blobStore);
+    }
+
+    public void testWriteMetadataBlobPropagatesErrorWhenAbortFails() {
+        new PropagatesErrorWhenAbortFailsTestCase() {
+            @Override
+            protected void doMultipartUpload() throws IOException {
+                container.writeMetadataBlob(
+                    OperationPurpose.SNAPSHOT_METADATA,
+                    blobName,
+                    false,
+                    false,
+                    out -> out.write(randomByteArrayOfLength(Math.toIntExact(bufferSize)))
+                );
+            }
+        }.run();
+    }
+
+    public void testExecuteMultipartUploadPropagatesErrorWhenAbortFails() {
+        new PropagatesErrorWhenAbortFailsTestCase() {
+            @Override
+            protected void doMultipartUpload() throws IOException {
+                container.executeMultipartUpload(
+                    randomPurpose(),
+                    blobStore,
+                    blobName,
+                    new ByteArrayInputStream(new byte[0]),
+                    blobSize,
+                    randomCondition()
+                );
+            }
+        }.run();
+    }
+
+    public void testWriteBlobAtomicPropagatesErrorWhenAbortFails() {
+        new PropagatesErrorWhenAbortFailsTestCase() {
+            @Override
+            protected void doMultipartUpload() throws IOException {
+                container.writeBlobAtomic(
+                    randomPurpose(),
+                    blobName,
+                    blobSize,
+                    (offset, length) -> new ByteArrayInputStream(new byte[0]),
+                    randomBoolean(),
+                    Runnable::run
+                );
+            }
+        }.run();
+    }
+
+    /**
+     * Verifies that a fatal {@link Error} from the MPU upload path is not masked when best-effort MPU abort fails.
+     */
+    private abstract class PropagatesErrorWhenAbortFailsTestCase {
+
+        protected final long bufferSize = S3Repository.MIN_PART_SIZE_USING_MULTIPART.getBytes();
+        protected final long blobSize = bufferSize + 1;
+
+        protected final String bucketName = randomIdentifier("bucket-");
+        protected final String blobName = randomIdentifier("blob-");
+        protected final String uploadId = randomIdentifier("upload-");
+        protected final Error simulatedError = new Error("simulated error");
+
+        protected final S3BlobStore blobStore = mock(S3BlobStore.class);
+        protected final S3BlobContainer container = new S3BlobContainer(BlobPath.EMPTY, blobStore);
+        protected S3Client client;
+
+        protected abstract void doMultipartUpload() throws IOException;
+
+        final void run() {
+            when(blobStore.bucket()).thenReturn(bucketName);
+            when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
+            when(blobStore.bigArrays()).thenReturn(
+                new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService())
+            );
+            when(blobStore.resolveStorageClass(any(OperationPurpose.class))).thenReturn(randomFrom(StorageClass.values()));
+            when(blobStore.serverSideEncryption()).thenReturn(false);
+            when(blobStore.supportsConditionalWrites()).thenReturn(false);
+
+            client = configureMockClient(blobStore);
+            when(client.createMultipartUpload(any(CreateMultipartUploadRequest.class))).thenReturn(
+                CreateMultipartUploadResponse.builder().uploadId(uploadId).build()
+            );
+            when(client.abortMultipartUpload(any(AbortMultipartUploadRequest.class))).thenThrow(
+                S3Exception.builder().message("abort failed").build()
+            );
+            when(client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class))).thenThrow(simulatedError);
+
+            final Error thrown = expectThrows(Error.class, this::doMultipartUpload);
+            assertSame(simulatedError, thrown);
+            assertEquals(0, simulatedError.getSuppressed().length);
+            verify(client, times(1)).createMultipartUpload(any(CreateMultipartUploadRequest.class));
+            verify(client, atLeastOnce()).uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
+            verify(client, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+            verify(client, times(1)).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+            closeMockClient(blobStore);
+        }
     }
 
     public void testConcurrentWriteBlobAtomicSingleThread() throws Exception {


### PR DESCRIPTION
If an `Error` is thrown during a S3 multipart upload then we will
attempt to abort the upload; if the abort itself fails with an
`Exception` then today this `Exception` propagates out, carrying the
`Error` as a suppressed exception, which usually means it does not reach
the uncaught exception handler and halt the node.

With this commit we instead drop exceptions thrown while aborting the
upload, allowing the original cause to propagate and ensuring we treat
thrown `Error` instances properly.