### PR TITLE
Fix HealthInfoCache to only accept FileSettingsHealthInfo from current master

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthInfoPublisher.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthInfoPublisher.java
@@ -98,7 +98,7 @@ public class DataStreamLifecycleHealthInfoPublisher {
             client.execute(
                 UpdateHealthInfoCacheAction.INSTANCE,
                 new UpdateHealthInfoCacheAction.Request(
-                    healthNodeId,
+                    clusterService.localNode().getId(),
                     new DataStreamLifecycleHealthInfo(errorEntriesToSignal, errorStore.getTotalErrorEntries())
                 ),
                 actionListener

--- a/server/src/main/java/org/elasticsearch/health/node/HealthInfoCache.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthInfoCache.java
@@ -56,14 +56,18 @@ public class HealthInfoCache implements ClusterStateListener {
         if (diskHealthInfo != null) {
             diskInfoByNode.put(nodeId, diskHealthInfo);
         }
-        if (latestDslHealthInfo != null) {
-            dslHealthInfo = latestDslHealthInfo;
-        }
         if (repositoriesHealthInfo != null) {
             repositoriesInfoByNode.put(nodeId, repositoriesHealthInfo);
         }
-        if (fileSettingsHealthInfo != null && nodeId.equals(masterNodeId)) {
-            this.fileSettingsHealthInfo = fileSettingsHealthInfo;
+        // the following health infos must be published by the current master node only.
+        // discard stale responses from a previous master node.
+        if (nodeId.equals(masterNodeId)) {
+            if (latestDslHealthInfo != null) {
+                dslHealthInfo = latestDslHealthInfo;
+            }
+            if (fileSettingsHealthInfo != null) {
+                this.fileSettingsHealthInfo = fileSettingsHealthInfo;
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/health/node/HealthInfoCache.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthInfoCache.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.health.node.selection.HealthNode;
@@ -34,6 +35,8 @@ public class HealthInfoCache implements ClusterStateListener {
     private volatile DataStreamLifecycleHealthInfo dslHealthInfo = null;
     private volatile ConcurrentHashMap<String, RepositoriesHealthInfo> repositoriesInfoByNode = new ConcurrentHashMap<>();
     private volatile FileSettingsHealthInfo fileSettingsHealthInfo = INDETERMINATE;
+    @Nullable
+    private volatile String masterNodeId = null;
 
     private HealthInfoCache() {}
 
@@ -59,16 +62,20 @@ public class HealthInfoCache implements ClusterStateListener {
         if (repositoriesHealthInfo != null) {
             repositoriesInfoByNode.put(nodeId, repositoriesHealthInfo);
         }
-        if (fileSettingsHealthInfo != null) {
+        if (fileSettingsHealthInfo != null && nodeId.equals(masterNodeId)) {
             this.fileSettingsHealthInfo = fileSettingsHealthInfo;
         }
     }
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
+        DiscoveryNodes nodes = event.state().nodes();
         DiscoveryNode currentHealthNode = HealthNode.findHealthNode(event.state());
-        DiscoveryNode localNode = event.state().nodes().getLocalNode();
+        DiscoveryNode localNode = nodes.getLocalNode();
         if (currentHealthNode != null && localNode.getId().equals(currentHealthNode.getId())) {
+            if (nodes.getMasterNodeId() != null && (event.masterChanged() || masterNodeId == null)) {
+                masterNodeId = nodes.getMasterNodeId();
+            }
             if (event.nodesRemoved()) {
                 for (DiscoveryNode removedNode : event.nodesDelta().removedNodes()) {
                     diskInfoByNode.remove(removedNode.getId());
@@ -79,13 +86,18 @@ public class HealthInfoCache implements ClusterStateListener {
             // Processing a delayed update after the cache has been emptied because
             // the node is not the health node anymore has small impact since it will
             // be reset in the next round again.
-        } else if (diskInfoByNode.isEmpty() == false || dslHealthInfo != null || repositoriesInfoByNode.isEmpty() == false) {
-            logger.debug("Node [{}][{}] is no longer the health node, emptying the cache.", localNode.getName(), localNode.getId());
-            diskInfoByNode = new ConcurrentHashMap<>();
-            dslHealthInfo = null;
-            repositoriesInfoByNode = new ConcurrentHashMap<>();
-            fileSettingsHealthInfo = INDETERMINATE;
-        }
+        } else if (diskInfoByNode.isEmpty() == false
+            || dslHealthInfo != null
+            || repositoriesInfoByNode.isEmpty() == false
+            || fileSettingsHealthInfo != INDETERMINATE
+            || masterNodeId != null) {
+                logger.debug("Node [{}][{}] is no longer the health node, emptying the cache.", localNode.getName(), localNode.getId());
+                diskInfoByNode = new ConcurrentHashMap<>();
+                dslHealthInfo = null;
+                repositoriesInfoByNode = new ConcurrentHashMap<>();
+                fileSettingsHealthInfo = INDETERMINATE;
+                masterNodeId = null;
+            }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/health/node/HealthInfoCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/HealthInfoCacheTests.java
@@ -47,6 +47,9 @@ public class HealthInfoCacheTests extends ESTestCase {
 
     public void testAddHealthInfo() {
         HealthInfoCache healthInfoCache = HealthInfoCache.create(clusterService);
+        // node1 is local node, master, and health node
+        ClusterState state = ClusterStateCreationUtils.state(node1, node1, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", state, state));
         DataStreamLifecycleHealthInfo latestDslHealthInfo = randomDslHealthInfo();
         var repoHealthInfo = randomRepoHealthInfo();
         healthInfoCache.updateNodeHealth(node1.getId(), GREEN, latestDslHealthInfo, repoHealthInfo, FileSettingsHealthInfo.INDETERMINATE);
@@ -64,20 +67,22 @@ public class HealthInfoCacheTests extends ESTestCase {
 
     public void testRemoveNodeFromTheCluster() {
         HealthInfoCache healthInfoCache = HealthInfoCache.create(clusterService);
-        healthInfoCache.updateNodeHealth(node1.getId(), GREEN, null, null, FileSettingsHealthInfo.INDETERMINATE);
+        // node1 is local node, master, and health node
+        ClusterState previous = ClusterStateCreationUtils.state(node1, node1, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", previous, previous));
         DataStreamLifecycleHealthInfo latestDslHealthInfo = randomDslHealthInfo();
         var repoHealthInfo = randomRepoHealthInfo();
-        healthInfoCache.updateNodeHealth(node2.getId(), RED, latestDslHealthInfo, repoHealthInfo, FileSettingsHealthInfo.INDETERMINATE);
+        // DSL health info is published by the master (node1), disk/repo health from node2
+        healthInfoCache.updateNodeHealth(node1.getId(), GREEN, latestDslHealthInfo, repoHealthInfo, FileSettingsHealthInfo.INDETERMINATE);
+        healthInfoCache.updateNodeHealth(node2.getId(), RED, null, null, FileSettingsHealthInfo.INDETERMINATE);
 
-        ClusterState previous = ClusterStateCreationUtils.state(node1, node1, node1, allNodes);
         ClusterState current = ClusterStateCreationUtils.state(node1, node1, node1, new DiscoveryNode[] { node1 });
         healthInfoCache.clusterChanged(new ClusterChangedEvent("test", current, previous));
 
         Map<String, DiskHealthInfo> diskHealthInfo = healthInfoCache.getHealthInfo().diskInfoByNode();
         assertThat(diskHealthInfo.get(node1.getId()), equalTo(GREEN));
         assertThat(diskHealthInfo.get(node2.getId()), nullValue());
-        // the dsl info is not removed when the node that reported it leaves the cluster as the next DSL run will report it and
-        // override it (if the health node stops being the designated health node the health cache nullifies the existing DSL info)
+        // the dsl info is not removed when a non-master node leaves the cluster; it is only reset when the health node changes
         assertThat(healthInfoCache.getHealthInfo().dslHealthInfo(), is(latestDslHealthInfo));
     }
 

--- a/server/src/test/java/org/elasticsearch/health/node/HealthInfoCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/HealthInfoCacheTests.java
@@ -81,6 +81,57 @@ public class HealthInfoCacheTests extends ESTestCase {
         assertThat(healthInfoCache.getHealthInfo().dslHealthInfo(), is(latestDslHealthInfo));
     }
 
+    public void testFileSettingsHealthInfoOnlyAcceptedFromMaster() {
+        HealthInfoCache healthInfoCache = HealthInfoCache.create(clusterService);
+        // node1 is local node, master, and health node
+        ClusterState state = ClusterStateCreationUtils.state(node1, node1, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", state, state));
+
+        var failing = new FileSettingsHealthInfo(true, 1L, 1, "some error");
+        var green = FileSettingsHealthInfo.INITIAL_ACTIVE.successful();
+
+        // update from master (node1) is accepted
+        healthInfoCache.updateNodeHealth(node1.getId(), GREEN, null, null, failing);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+
+        // update from non-master (node2) is rejected
+        healthInfoCache.updateNodeHealth(node2.getId(), RED, null, null, green);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+    }
+
+    public void testStaleFileSettingsHealthInfoRejectedAfterMasterChange() {
+        HealthInfoCache healthInfoCache = HealthInfoCache.create(clusterService);
+        // node1 is local/health node, node2 is master
+        ClusterState withNode2AsMaster = ClusterStateCreationUtils.state(node1, node2, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", withNode2AsMaster, withNode2AsMaster));
+
+        var failing = new FileSettingsHealthInfo(true, 1L, 1, "some error");
+        // old master (node2) publishes a failure
+        healthInfoCache.updateNodeHealth(node2.getId(), RED, null, null, failing);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+
+        // master election in progress (no master): old value is preserved and old master's late arrivals are still accepted
+        ClusterState noMaster = ClusterStateCreationUtils.state(node1, null, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", noMaster, withNode2AsMaster));
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+        healthInfoCache.updateNodeHealth(node2.getId(), RED, null, null, failing);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+
+        // new master (node1) elected: old value is kept until new master reports
+        ClusterState withNode1AsMaster = ClusterStateCreationUtils.state(node1, node1, node1, allNodes);
+        healthInfoCache.clusterChanged(new ClusterChangedEvent("test", withNode1AsMaster, noMaster));
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+
+        // delayed update from old master (node2) is rejected; old value is still kept
+        healthInfoCache.updateNodeHealth(node2.getId(), RED, null, null, failing);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(failing));
+
+        // new master (node1) publishes green — accepted
+        var green = FileSettingsHealthInfo.INITIAL_ACTIVE.successful();
+        healthInfoCache.updateNodeHealth(node1.getId(), GREEN, null, null, green);
+        assertThat(healthInfoCache.getHealthInfo().fileSettingsHealthInfo(), equalTo(green));
+    }
+
     public void testNotAHealthNode() {
         HealthInfoCache healthInfoCache = HealthInfoCache.create(clusterService);
         healthInfoCache.updateNodeHealth(
@@ -102,4 +153,5 @@ public class HealthInfoCacheTests extends ESTestCase {
         Map<String, RepositoriesHealthInfo> repoHealthInfo = healthInfoCache.getHealthInfo().repositoriesInfoByNode();
         assertThat(repoHealthInfo.isEmpty(), equalTo(true));
     }
+
 }


### PR DESCRIPTION
`FileSettingsService` and hence `FileSettingsHealthTracker` are only running on the master node and publish an updated health info whenever it changes.

`HealthInfoCache` suffered from a race where a slightly late response of an old master could overwrite the `FileSettingsHealthInfo` of the current master. The new master won't publish a new update (until there's another change). With that one of the old master remains stale in the cache.

The same race exists for `DataStreamLifecycleHealthInfo`. This is only published by `DataStreamLifecycleService`
which also runs on the master node only.

Fixes #elastic/incident-management#2630