### PR TITLE
[9.5] Mute XContentBuilderTests#testCloseAllowIllFormedDoesNotValidateStructuralCorrectness

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -454,3 +454,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesCountDistinctOverTimeIT
   method: test {csv-spec:k8s-timeseries-count-distinct-over-time.valuesNull}
   issue: https://github.com/elastic/elasticsearch/issues/156746
+- class: org.elasticsearch.common.xcontent.builder.XContentBuilderTests
+  method: testCloseAllowIllFormedDoesNotValidateStructuralCorrectness
+  issue: https://github.com/elastic/elasticsearch/issues/156563


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/156563