### PR TITLE
ESQL:DS: Fix ArrowBuf leaks on throws

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/AbstractArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/AbstractArrowBufBlock.java
@@ -236,33 +236,34 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
         // ----- Single-valued block
         if (offsetBuffer == null) {
 
-            // Allocate buffers
             ArrowBuf newValues = null;
             ArrowBuf newValidity = null;
             boolean success = false;
             try {
+                // Allocate buffers
                 newValues = allocator.buffer((long) length * size);
                 if (validityBuffer != null) {
                     newValidity = allocator.buffer(validityBufferLength(length));
                     newValidity.setZero(0, newValidity.capacity());
                 }
+
+                // Copy values
+                for (int i = 0; i < length; i++) {
+                    int pos = positions[offset + i];
+                    newValues.setBytes((long) i * size, valueBuffer, (long) pos * size, size);
+                    if (newValidity != null && isNull(pos) == false) {
+                        setValidityBit(newValidity, i);
+                    }
+                }
+
+                B result = blockConstructor().create(newValues, newValidity, null, length, 0, blockFactory);
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newValidity);
                 }
             }
-
-            // Copy values
-            for (int i = 0; i < length; i++) {
-                int pos = positions[offset + i];
-                newValues.setBytes((long) i * size, valueBuffer, (long) pos * size, size);
-                if (newValidity != null && isNull(pos) == false) {
-                    setValidityBit(newValidity, i);
-                }
-            }
-
-            return blockConstructor().create(newValues, newValidity, null, length, 0, blockFactory);
         }
 
         // ----- Multivalued block
@@ -271,13 +272,13 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
             totalValues += getValueCount(positions[i]);
         }
 
-        // Allocate buffers
         ArrowBuf newValues = null;
         ArrowBuf newValidity = null;
         ArrowBuf newOffsets = null;
         boolean success = false;
 
         try {
+            // Allocate buffers
             newValues = allocator.buffer((long) totalValues * size);
             if (validityBuffer != null) {
                 newValidity = allocator.buffer(validityBufferLength(totalValues));
@@ -285,32 +286,33 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
             }
             // 32-bit offsets
             newOffsets = allocator.buffer((long) (length + 1) * Integer.BYTES);
+
+            int valueIdx = 0;
+            for (int i = 0; i < length; i++) {
+                int pos = positions[offset + i];
+                newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
+                if (isNull(pos) == false) {
+                    if (newValidity != null) {
+                        setValidityBit(newValidity, i);
+                    }
+                    int first = getFirstValueIndex(pos);
+                    int count = getValueCount(pos);
+                    if (count > 0) {
+                        newValues.setBytes((long) valueIdx * size, valueBuffer, (long) first * size, (long) count * size);
+                        valueIdx += count;
+                    }
+                }
+            }
+            newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
+
+            B result = blockConstructor().create(newValues, newValidity, newOffsets, length, length + 1, blockFactory);
             success = true;
+            return result;
         } finally {
             if (success == false) {
                 ArrowUtils.releaseBuffers(newValues, newValidity, newOffsets);
             }
         }
-
-        int valueIdx = 0;
-        for (int i = 0; i < length; i++) {
-            int pos = positions[offset + i];
-            newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
-            if (isNull(pos) == false) {
-                if (newValidity != null) {
-                    setValidityBit(newValidity, i);
-                }
-                int first = getFirstValueIndex(pos);
-                int count = getValueCount(pos);
-                if (count > 0) {
-                    newValues.setBytes((long) valueIdx * size, valueBuffer, (long) first * size, (long) count * size);
-                    valueIdx += count;
-                }
-            }
-        }
-        newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
-
-        return blockConstructor().create(newValues, newValidity, newOffsets, length, length + 1, blockFactory);
     }
 
     @SuppressWarnings("unchecked")
@@ -329,21 +331,33 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
         }
 
         var allocator = blockFactory.arrowAllocator();
-        ArrowBuf newValidity = allocator.buffer(validityBufferLength(valueCount));
-        newValidity.setZero(0, newValidity.capacity());
-        for (int i = 0; i < valueCount; i++) {
-            if (mask.getBoolean(i) && isNull(i) == false) {
-                setValidityBit(newValidity, i);
+        ArrowBuf newValidity = null;
+        boolean success = false;
+        boolean sharedRetained = false;
+        try {
+            newValidity = allocator.buffer(validityBufferLength(valueCount));
+            newValidity.setZero(0, newValidity.capacity());
+            for (int i = 0; i < valueCount; i++) {
+                if (mask.getBoolean(i) && isNull(i) == false) {
+                    setValidityBit(newValidity, i);
+                }
+            }
+
+            // Validity buffer is new, but values and offsets are shared
+            ArrowUtils.retainBuffers(valueBuffer, offsetBuffer);
+            sharedRetained = true;
+
+            B result = blockConstructor().create(valueBuffer, newValidity, offsetBuffer, valueCount, offsetCount, blockFactory);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                if (sharedRetained) {
+                    ArrowUtils.releaseBuffers(valueBuffer, offsetBuffer);
+                }
+                ArrowUtils.releaseBuffers(newValidity);
             }
         }
-
-        // Validity buffer is new, but values and offsets are shared
-        valueBuffer.getReferenceManager().retain();
-        if (offsetBuffer != null) {
-            offsetBuffer.getReferenceManager().retain();
-        }
-
-        return blockConstructor().create(valueBuffer, newValidity, offsetBuffer, valueCount, offsetCount, blockFactory);
     }
 
     @Override
@@ -410,41 +424,42 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
                 newOffsets = allocator.buffer((long) (batchSize + 1) * Integer.BYTES);
                 newValidity = allocator.buffer(validityBufferLength(batchSize));
                 newValidity.setZero(0, newValidity.capacity());
+
+                int valueIdx = 0;
+                for (int p = batchStart; p < batchEnd; p++) {
+                    int outPos = p - batchStart;
+                    newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
+                    int pStart = positions.getFirstValueIndex(p);
+                    int pEnd = pStart + positions.getValueCount(p);
+                    int valuesForPos = 0;
+                    for (int i = pStart; i < pEnd; i++) {
+                        int vp = positions.getInt(i);
+                        if (vp >= getPositionCount()) {
+                            continue;
+                        }
+                        int vStart = getFirstValueIndex(vp);
+                        int vCount = getValueCount(vp);
+                        if (vCount > 0) {
+                            newValues.setBytes((long) valueIdx * size, valueBuffer, (long) vStart * size, (long) vCount * size);
+                            valueIdx += vCount;
+                            valuesForPos += vCount;
+                        }
+                    }
+                    if (valuesForPos > 0) {
+                        setValidityBit(newValidity, outPos);
+                    }
+                }
+                newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
+                position = batchEnd;
+
+                B result = blockConstructor().create(newValues, newValidity, newOffsets, batchSize, batchSize + 1, factory);
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newOffsets, newValidity);
                 }
             }
-
-            int valueIdx = 0;
-            for (int p = batchStart; p < batchEnd; p++) {
-                int outPos = p - batchStart;
-                newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
-                int pStart = positions.getFirstValueIndex(p);
-                int pEnd = pStart + positions.getValueCount(p);
-                int valuesForPos = 0;
-                for (int i = pStart; i < pEnd; i++) {
-                    int vp = positions.getInt(i);
-                    if (vp >= getPositionCount()) {
-                        continue;
-                    }
-                    int vStart = getFirstValueIndex(vp);
-                    int vCount = getValueCount(vp);
-                    if (vCount > 0) {
-                        newValues.setBytes((long) valueIdx * size, valueBuffer, (long) vStart * size, (long) vCount * size);
-                        valueIdx += vCount;
-                        valuesForPos += vCount;
-                    }
-                }
-                if (valuesForPos > 0) {
-                    setValidityBit(newValidity, outPos);
-                }
-            }
-            newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
-            position = batchEnd;
-
-            return blockConstructor().create(newValues, newValidity, newOffsets, batchSize, batchSize + 1, factory);
         }
 
         @Override
@@ -473,22 +488,38 @@ public abstract class AbstractArrowBufBlock<V extends Vector, B extends Block> e
 
         int expandedPositionCount = getFirstValueIndex(valueCount);
         var allocator = blockFactory.arrowAllocator();
-        ArrowBuf newValidity = allocator.buffer(validityBufferLength(expandedPositionCount));
-        // All expanded positions are valid by default
-        for (int i = 0; i < newValidity.capacity(); i++) {
-            newValidity.setByte(i, (byte) 0xFF);
-        }
-        // Clear validity bits at expanded positions corresponding to original null positions
-        for (int p = 0; p < valueCount; p++) {
-            if (isNull(p)) {
-                int expandedPos = getFirstValueIndex(p);
-                int byteIndex = expandedPos / 8;
-                newValidity.setByte(byteIndex, newValidity.getByte(byteIndex) & ~(1 << (expandedPos % 8)));
+        ArrowBuf newValidity = null;
+        boolean success = false;
+        boolean sharedRetained = false;
+        try {
+            newValidity = allocator.buffer(validityBufferLength(expandedPositionCount));
+            // All expanded positions are valid by default
+            for (int i = 0; i < newValidity.capacity(); i++) {
+                newValidity.setByte(i, (byte) 0xFF);
+            }
+            // Clear validity bits at expanded positions corresponding to original null positions
+            for (int p = 0; p < valueCount; p++) {
+                if (isNull(p)) {
+                    int expandedPos = getFirstValueIndex(p);
+                    int byteIndex = expandedPos / 8;
+                    newValidity.setByte(byteIndex, newValidity.getByte(byteIndex) & ~(1 << (expandedPos % 8)));
+                }
+            }
+
+            ArrowUtils.retainBuffers(valueBuffer);
+            sharedRetained = true;
+
+            B result = blockConstructor().create(valueBuffer, newValidity, null, expandedPositionCount, 0, blockFactory);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                if (sharedRetained) {
+                    ArrowUtils.releaseBuffers(valueBuffer);
+                }
+                ArrowUtils.releaseBuffers(newValidity);
             }
         }
-
-        valueBuffer.getReferenceManager().retain();
-        return blockConstructor().create(valueBuffer, newValidity, null, expandedPositionCount, 0, blockFactory);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/AbstractArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/AbstractArrowBufVector.java
@@ -140,12 +140,22 @@ public abstract class AbstractArrowBufVector<V extends Vector, B extends Block> 
     public V filter(boolean mayContainDuplicates, int[] positions, int offset, int length) {
         final var allocator = blockFactory.arrowAllocator();
         final int size = byteSize();
-        final var buffer = allocator.buffer((long) length * size);
-        for (int i = 0; i < length; i++) {
-            int pos = positions[offset + i];
-            buffer.setBytes((long) i * size, valueBuffer, (long) pos * size, size);
+        ArrowBuf buffer = null;
+        boolean success = false;
+        try {
+            buffer = allocator.buffer((long) length * size);
+            for (int i = 0; i < length; i++) {
+                int pos = positions[offset + i];
+                buffer.setBytes((long) i * size, valueBuffer, (long) pos * size, size);
+            }
+            V result = vectorConstructor().create(buffer, length, blockFactory);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                ArrowUtils.releaseBuffers(buffer);
+            }
         }
-        return vectorConstructor().create(buffer, length, blockFactory);
     }
 
     // TODO

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufBlock.java
@@ -162,21 +162,23 @@ public final class BooleanArrowBufBlock extends AbstractArrowBufBlock<BooleanVec
                     newValidity = allocator.buffer(bitBufferLength(length));
                     newValidity.setZero(0, newValidity.capacity());
                 }
+
+                for (int i = 0; i < length; i++) {
+                    int pos = positions[offset + i];
+                    copyBit(valueBuffer, pos, newValues, i);
+                    if (newValidity != null && isNull(pos) == false) {
+                        setBit(newValidity, i);
+                    }
+                }
+
+                var result = new BooleanArrowBufBlock(newValues, newValidity, null, length, 0, blockFactory);
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newValidity);
                 }
             }
-
-            for (int i = 0; i < length; i++) {
-                int pos = positions[offset + i];
-                copyBit(valueBuffer, pos, newValues, i);
-                if (newValidity != null && isNull(pos) == false) {
-                    setBit(newValidity, i);
-                }
-            }
-            return new BooleanArrowBufBlock(newValues, newValidity, null, length, 0, blockFactory);
         }
 
         int totalValues = 0;
@@ -194,31 +196,33 @@ public final class BooleanArrowBufBlock extends AbstractArrowBufBlock<BooleanVec
                 newValidity.setZero(0, newValidity.capacity());
             }
             newOffsets = allocator.buffer((long) (length + 1) * Integer.BYTES);
+
+            int valueIdx = 0;
+            for (int i = 0; i < length; i++) {
+                int pos = positions[offset + i];
+                newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
+                if (isNull(pos) == false) {
+                    if (newValidity != null) {
+                        setBit(newValidity, i);
+                    }
+                    int first = getFirstValueIndex(pos);
+                    int count = getValueCount(pos);
+                    for (int j = 0; j < count; j++) {
+                        copyBit(valueBuffer, first + j, newValues, valueIdx + j);
+                    }
+                    valueIdx += count;
+                }
+            }
+            newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
+
+            var result = new BooleanArrowBufBlock(newValues, newValidity, newOffsets, length, length + 1, blockFactory);
             success = true;
+            return result;
         } finally {
             if (success == false) {
                 ArrowUtils.releaseBuffers(newValues, newValidity, newOffsets);
             }
         }
-
-        int valueIdx = 0;
-        for (int i = 0; i < length; i++) {
-            int pos = positions[offset + i];
-            newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
-            if (isNull(pos) == false) {
-                if (newValidity != null) {
-                    setBit(newValidity, i);
-                }
-                int first = getFirstValueIndex(pos);
-                int count = getValueCount(pos);
-                for (int j = 0; j < count; j++) {
-                    copyBit(valueBuffer, first + j, newValues, valueIdx + j);
-                }
-                valueIdx += count;
-            }
-        }
-        newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
-        return new BooleanArrowBufBlock(newValues, newValidity, newOffsets, length, length + 1, blockFactory);
     }
 
     @Override
@@ -283,41 +287,42 @@ public final class BooleanArrowBufBlock extends AbstractArrowBufBlock<BooleanVec
                 newOffsets = allocator.buffer((long) (batchSize + 1) * Integer.BYTES);
                 newValidity = allocator.buffer(bitBufferLength(batchSize));
                 newValidity.setZero(0, newValidity.capacity());
+
+                int valueIdx = 0;
+                for (int p = batchStart; p < batchEnd; p++) {
+                    int outPos = p - batchStart;
+                    newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
+                    int pStart = positions.getFirstValueIndex(p);
+                    int pEnd = pStart + positions.getValueCount(p);
+                    int valuesForPos = 0;
+                    for (int i = pStart; i < pEnd; i++) {
+                        int vp = positions.getInt(i);
+                        if (vp >= getPositionCount()) {
+                            continue;
+                        }
+                        int vStart = getFirstValueIndex(vp);
+                        int vCount = getValueCount(vp);
+                        for (int j = 0; j < vCount; j++) {
+                            copyBit(valueBuffer, vStart + j, newValues, valueIdx + j);
+                        }
+                        valueIdx += vCount;
+                        valuesForPos += vCount;
+                    }
+                    if (valuesForPos > 0) {
+                        setBit(newValidity, outPos);
+                    }
+                }
+                newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
+                position = batchEnd;
+
+                var result = new BooleanArrowBufBlock(newValues, newValidity, newOffsets, batchSize, batchSize + 1, factory);
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newOffsets, newValidity);
                 }
             }
-
-            int valueIdx = 0;
-            for (int p = batchStart; p < batchEnd; p++) {
-                int outPos = p - batchStart;
-                newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
-                int pStart = positions.getFirstValueIndex(p);
-                int pEnd = pStart + positions.getValueCount(p);
-                int valuesForPos = 0;
-                for (int i = pStart; i < pEnd; i++) {
-                    int vp = positions.getInt(i);
-                    if (vp >= getPositionCount()) {
-                        continue;
-                    }
-                    int vStart = getFirstValueIndex(vp);
-                    int vCount = getValueCount(vp);
-                    for (int j = 0; j < vCount; j++) {
-                        copyBit(valueBuffer, vStart + j, newValues, valueIdx + j);
-                    }
-                    valueIdx += vCount;
-                    valuesForPos += vCount;
-                }
-                if (valuesForPos > 0) {
-                    setBit(newValidity, outPos);
-                }
-            }
-            newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
-            position = batchEnd;
-
-            return new BooleanArrowBufBlock(newValues, newValidity, newOffsets, batchSize, batchSize + 1, factory);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufVector.java
@@ -113,16 +113,26 @@ public final class BooleanArrowBufVector extends AbstractArrowBufVector<BooleanV
     public BooleanVector filter(boolean mayContainDuplicates, int[] positions, int offset, int length) {
         var allocator = blockFactory.arrowAllocator();
         int bufLen = ((length + 63) / 64) * Long.BYTES;
-        var buffer = allocator.buffer(Math.max(1, bufLen));
-        buffer.setZero(0, buffer.capacity());
-        for (int i = 0; i < length; i++) {
-            if (getBoolean(positions[offset + i])) {
-                int byteIdx = i / 8;
-                buffer.setByte(byteIdx, buffer.getByte(byteIdx) | (1 << (i % 8)));
+        ArrowBuf buffer = null;
+        boolean success = false;
+        try {
+            buffer = allocator.buffer(Math.max(1, bufLen));
+            buffer.setZero(0, buffer.capacity());
+            for (int i = 0; i < length; i++) {
+                if (getBoolean(positions[offset + i])) {
+                    int byteIdx = i / 8;
+                    buffer.setByte(byteIdx, buffer.getByte(byteIdx) | (1 << (i % 8)));
+                }
+            }
+
+            BooleanVector result = vectorConstructor().create(buffer, length, blockFactory);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                ArrowUtils.releaseBuffers(buffer);
             }
         }
-
-        return vectorConstructor().create(buffer, length, blockFactory);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
@@ -272,31 +272,33 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
                     newValidity = allocator.buffer(validityBufferLength(length));
                     newValidity.setZero(0, newValidity.capacity());
                 }
+
+                int byteIdx = 0;
+                for (int i = 0; i < length; i++) {
+                    int pos = positions[offset + i];
+                    newValueOffsets.setInt((long) i * Integer.BYTES, byteIdx);
+                    if (isNull(pos) == false) {
+                        int srcStart = valueOffsetsBuffer.getInt((long) pos * Integer.BYTES);
+                        int byteLen = valueByteLength(pos);
+                        if (byteLen > 0) {
+                            newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
+                            byteIdx += byteLen;
+                        }
+                        if (newValidity != null) {
+                            setValidityBit(newValidity, i);
+                        }
+                    }
+                }
+                newValueOffsets.setInt((long) length * Integer.BYTES, byteIdx);
+
+                var result = new BytesRefArrowBufBlock(newValues, newValueOffsets, newValidity, null, length, 0, blockFactory);
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newValueOffsets, newValidity);
                 }
             }
-
-            int byteIdx = 0;
-            for (int i = 0; i < length; i++) {
-                int pos = positions[offset + i];
-                newValueOffsets.setInt((long) i * Integer.BYTES, byteIdx);
-                if (isNull(pos) == false) {
-                    int srcStart = valueOffsetsBuffer.getInt((long) pos * Integer.BYTES);
-                    int byteLen = valueByteLength(pos);
-                    if (byteLen > 0) {
-                        newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
-                        byteIdx += byteLen;
-                    }
-                    if (newValidity != null) {
-                        setValidityBit(newValidity, i);
-                    }
-                }
-            }
-            newValueOffsets.setInt((long) length * Integer.BYTES, byteIdx);
-            return new BytesRefArrowBufBlock(newValues, newValueOffsets, newValidity, null, length, 0, blockFactory);
         }
 
         // Multi-valued: compute total values and total bytes
@@ -322,39 +324,41 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
                 newValidity.setZero(0, newValidity.capacity());
             }
             newOffsets = allocator.buffer((long) (length + 1) * Integer.BYTES);
+
+            int byteIdx = 0;
+            int valueIdx = 0;
+            for (int i = 0; i < length; i++) {
+                int pos = positions[offset + i];
+                newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
+                if (isNull(pos) == false) {
+                    if (newValidity != null) {
+                        setValidityBit(newValidity, i);
+                    }
+                    int first = getFirstValueIndex(pos);
+                    int count = getValueCount(pos);
+                    for (int v = 0; v < count; v++) {
+                        int srcStart = valueOffsetsBuffer.getInt((long) (first + v) * Integer.BYTES);
+                        int byteLen = valueByteLength(first + v);
+                        newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
+                        if (byteLen > 0) {
+                            newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
+                            byteIdx += byteLen;
+                        }
+                        valueIdx++;
+                    }
+                }
+            }
+            newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
+            newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
+
+            var result = new BytesRefArrowBufBlock(newValues, newValueOffsets, newValidity, newOffsets, length, length + 1, blockFactory);
             success = true;
+            return result;
         } finally {
             if (success == false) {
                 ArrowUtils.releaseBuffers(newValues, newValueOffsets, newValidity, newOffsets);
             }
         }
-
-        int byteIdx = 0;
-        int valueIdx = 0;
-        for (int i = 0; i < length; i++) {
-            int pos = positions[offset + i];
-            newOffsets.setInt((long) i * Integer.BYTES, valueIdx);
-            if (isNull(pos) == false) {
-                if (newValidity != null) {
-                    setValidityBit(newValidity, i);
-                }
-                int first = getFirstValueIndex(pos);
-                int count = getValueCount(pos);
-                for (int v = 0; v < count; v++) {
-                    int srcStart = valueOffsetsBuffer.getInt((long) (first + v) * Integer.BYTES);
-                    int byteLen = valueByteLength(first + v);
-                    newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
-                    if (byteLen > 0) {
-                        newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
-                        byteIdx += byteLen;
-                    }
-                    valueIdx++;
-                }
-            }
-        }
-        newOffsets.setInt((long) length * Integer.BYTES, valueIdx);
-        newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
-        return new BytesRefArrowBufBlock(newValues, newValueOffsets, newValidity, newOffsets, length, length + 1, blockFactory);
     }
 
     @SuppressWarnings("unchecked")
@@ -372,16 +376,40 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
             return (BytesRefBlock) blockFactory().newConstantNullBlock(getPositionCount());
         }
         var allocator = blockFactory.arrowAllocator();
-        ArrowBuf newValidity = allocator.buffer(validityBufferLength(valueCount));
-        newValidity.setZero(0, newValidity.capacity());
-        for (int i = 0; i < valueCount; i++) {
-            if (mask.getBoolean(i) && isNull(i) == false) {
-                setValidityBit(newValidity, i);
+        ArrowBuf newValidity = null;
+        boolean success = false;
+        boolean sharedRetained = false;
+        try {
+            newValidity = allocator.buffer(validityBufferLength(valueCount));
+            newValidity.setZero(0, newValidity.capacity());
+            for (int i = 0; i < valueCount; i++) {
+                if (mask.getBoolean(i) && isNull(i) == false) {
+                    setValidityBit(newValidity, i);
+                }
+            }
+
+            ArrowUtils.retainBuffers(valueBuffer, valueOffsetsBuffer, offsetBuffer);
+            sharedRetained = true;
+
+            var result = new BytesRefArrowBufBlock(
+                valueBuffer,
+                valueOffsetsBuffer,
+                newValidity,
+                offsetBuffer,
+                valueCount,
+                offsetCount,
+                blockFactory
+            );
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                if (sharedRetained) {
+                    ArrowUtils.releaseBuffers(valueBuffer, valueOffsetsBuffer, offsetBuffer);
+                }
+                ArrowUtils.releaseBuffers(newValidity);
             }
         }
-
-        ArrowUtils.retainBuffers(valueBuffer, valueOffsetsBuffer, offsetBuffer);
-        return new BytesRefArrowBufBlock(valueBuffer, valueOffsetsBuffer, newValidity, offsetBuffer, valueCount, offsetCount, blockFactory);
     }
 
     @Override
@@ -396,19 +424,43 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
             return new BytesRefArrowBufBlock(valueBuffer, valueOffsetsBuffer, null, null, expandedPositionCount, 0, blockFactory);
         }
         var allocator = blockFactory.arrowAllocator();
-        ArrowBuf newValidity = allocator.buffer(validityBufferLength(expandedPositionCount));
-        for (int i = 0; i < newValidity.capacity(); i++) {
-            newValidity.setByte(i, (byte) 0xFF);
-        }
-        for (int p = 0; p < valueCount; p++) {
-            if (isNull(p)) {
-                int expandedPos = getFirstValueIndex(p);
-                int byteIndex = expandedPos / 8;
-                newValidity.setByte(byteIndex, newValidity.getByte(byteIndex) & ~(1 << (expandedPos % 8)));
+        ArrowBuf newValidity = null;
+        boolean success = false;
+        boolean sharedRetained = false;
+        try {
+            newValidity = allocator.buffer(validityBufferLength(expandedPositionCount));
+            for (int i = 0; i < newValidity.capacity(); i++) {
+                newValidity.setByte(i, (byte) 0xFF);
+            }
+            for (int p = 0; p < valueCount; p++) {
+                if (isNull(p)) {
+                    int expandedPos = getFirstValueIndex(p);
+                    int byteIndex = expandedPos / 8;
+                    newValidity.setByte(byteIndex, newValidity.getByte(byteIndex) & ~(1 << (expandedPos % 8)));
+                }
+            }
+            ArrowUtils.retainBuffers(valueBuffer, valueOffsetsBuffer);
+            sharedRetained = true;
+
+            var result = new BytesRefArrowBufBlock(
+                valueBuffer,
+                valueOffsetsBuffer,
+                newValidity,
+                null,
+                expandedPositionCount,
+                0,
+                blockFactory
+            );
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                if (sharedRetained) {
+                    ArrowUtils.releaseBuffers(valueBuffer, valueOffsetsBuffer);
+                }
+                ArrowUtils.releaseBuffers(newValidity);
             }
         }
-        ArrowUtils.retainBuffers(valueBuffer, valueOffsetsBuffer);
-        return new BytesRefArrowBufBlock(valueBuffer, valueOffsetsBuffer, newValidity, null, expandedPositionCount, 0, blockFactory);
     }
 
     @Override
@@ -479,49 +531,58 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
                 newOffsets = allocator.buffer((long) (batchSize + 1) * Integer.BYTES);
                 newValidity = allocator.buffer(validityBufferLength(batchSize));
                 newValidity.setZero(0, newValidity.capacity());
+
+                int byteIdx = 0;
+                int valueIdx = 0;
+                for (int p = batchStart; p < batchEnd; p++) {
+                    int outPos = p - batchStart;
+                    newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
+                    int pStart = positions.getFirstValueIndex(p);
+                    int pEnd = pStart + positions.getValueCount(p);
+                    int valuesForPos = 0;
+                    for (int i = pStart; i < pEnd; i++) {
+                        int vp = positions.getInt(i);
+                        if (vp >= getPositionCount()) {
+                            continue;
+                        }
+                        int vStart = getFirstValueIndex(vp);
+                        int vCount = getValueCount(vp);
+                        for (int v = 0; v < vCount; v++) {
+                            int srcStart = valueOffsetsBuffer.getInt((long) (vStart + v) * Integer.BYTES);
+                            int length = valueByteLength(vStart + v);
+                            newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
+                            if (length > 0) {
+                                newValues.setBytes(byteIdx, valueBuffer, srcStart, length);
+                                byteIdx += length;
+                            }
+                            valueIdx++;
+                            valuesForPos++;
+                        }
+                    }
+                    if (valuesForPos > 0) {
+                        setValidityBit(newValidity, outPos);
+                    }
+                }
+                newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
+                newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
+                position = batchEnd;
+
+                var result = new BytesRefArrowBufBlock(
+                    newValues,
+                    newValueOffsets,
+                    newValidity,
+                    newOffsets,
+                    batchSize,
+                    batchSize + 1,
+                    factory
+                );
                 success = true;
+                return result;
             } finally {
                 if (success == false) {
                     ArrowUtils.releaseBuffers(newValues, newValueOffsets, newOffsets, newValidity);
                 }
             }
-
-            int byteIdx = 0;
-            int valueIdx = 0;
-            for (int p = batchStart; p < batchEnd; p++) {
-                int outPos = p - batchStart;
-                newOffsets.setInt((long) outPos * Integer.BYTES, valueIdx);
-                int pStart = positions.getFirstValueIndex(p);
-                int pEnd = pStart + positions.getValueCount(p);
-                int valuesForPos = 0;
-                for (int i = pStart; i < pEnd; i++) {
-                    int vp = positions.getInt(i);
-                    if (vp >= getPositionCount()) {
-                        continue;
-                    }
-                    int vStart = getFirstValueIndex(vp);
-                    int vCount = getValueCount(vp);
-                    for (int v = 0; v < vCount; v++) {
-                        int srcStart = valueOffsetsBuffer.getInt((long) (vStart + v) * Integer.BYTES);
-                        int length = valueByteLength(vStart + v);
-                        newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
-                        if (length > 0) {
-                            newValues.setBytes(byteIdx, valueBuffer, srcStart, length);
-                            byteIdx += length;
-                        }
-                        valueIdx++;
-                        valuesForPos++;
-                    }
-                }
-                if (valuesForPos > 0) {
-                    setValidityBit(newValidity, outPos);
-                }
-            }
-            newOffsets.setInt((long) batchSize * Integer.BYTES, valueIdx);
-            newValueOffsets.setInt((long) valueIdx * Integer.BYTES, byteIdx);
-            position = batchEnd;
-
-            return new BytesRefArrowBufBlock(newValues, newValueOffsets, newValidity, newOffsets, batchSize, batchSize + 1, factory);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
@@ -175,26 +175,29 @@ public final class BytesRefArrowBufVector extends AbstractArrowBufVector<BytesRe
         try {
             newValues = allocator.buffer(totalBytes);
             newValueOffsets = allocator.buffer((long) (length + 1) * Integer.BYTES);
+
+            int byteIdx = 0;
+            for (int i = 0; i < length; i++) {
+                int pos = positions[offset + i];
+                newValueOffsets.setInt((long) i * Integer.BYTES, byteIdx);
+                int srcStart = valueOffsetsBuffer.getInt((long) pos * Integer.BYTES);
+                int srcEnd = valueOffsetsBuffer.getInt((long) (pos + 1) * Integer.BYTES);
+                int byteLen = srcEnd - srcStart;
+                if (byteLen > 0) {
+                    newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
+                    byteIdx += byteLen;
+                }
+            }
+            newValueOffsets.setInt((long) length * Integer.BYTES, byteIdx);
+
+            var result = new BytesRefArrowBufVector(newValues, newValueOffsets, length, blockFactory);
             success = true;
+            return result;
         } finally {
             if (success == false) {
                 ArrowUtils.releaseBuffers(newValues, newValueOffsets);
             }
         }
-        int byteIdx = 0;
-        for (int i = 0; i < length; i++) {
-            int pos = positions[offset + i];
-            newValueOffsets.setInt((long) i * Integer.BYTES, byteIdx);
-            int srcStart = valueOffsetsBuffer.getInt((long) pos * Integer.BYTES);
-            int srcEnd = valueOffsetsBuffer.getInt((long) (pos + 1) * Integer.BYTES);
-            int byteLen = srcEnd - srcStart;
-            if (byteLen > 0) {
-                newValues.setBytes(byteIdx, valueBuffer, srcStart, byteLen);
-                byteIdx += byteLen;
-            }
-        }
-        newValueOffsets.setInt((long) length * Integer.BYTES, byteIdx);
-        return new BytesRefArrowBufVector(newValues, newValueOffsets, length, blockFactory);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/ArrowBufLeakTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/ArrowBufLeakTests.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.BitVectorHelper;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Verifies that Arrow block/vector operations release their freshly allocated buffers when an
+ * exception is thrown while populating them, i.e. after allocation but before the resulting
+ * block or vector takes ownership. Failures are triggered either by corrupting the Arrow offset
+ * buffers shared with the block (modeling malformed or hostile file data) or by violating call
+ * invariants (out-of-range positions, an undersized mask). Without try/finally guards covering
+ * the population phase, each scenario leaks the new buffers: the memory stays accounted in the
+ * allocator (and thus charged to the circuit breaker) for the lifetime of the
+ * {@link BlockFactory}.
+ */
+public class ArrowBufLeakTests extends ESTestCase {
+
+    private BufferAllocator allocator;
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setup() {
+        blockFactory = new BlockFactory(new NoopCircuitBreaker("test-noop"), BigArrays.NON_RECYCLING_INSTANCE);
+        allocator = blockFactory.arrowAllocator();
+    }
+
+    @After
+    public void cleanup() {
+        allocator.close();
+    }
+
+    /**
+     * Runs {@code op}, expecting it to throw {@link IndexOutOfBoundsException} mid-population,
+     * and asserts that the allocator's outstanding memory is unchanged, i.e. that the buffers
+     * allocated by the failed operation were released.
+     */
+    private void assertNoLeak(ThrowingRunnable op) {
+        long before = allocator.getAllocatedMemory();
+        expectThrows(IndexOutOfBoundsException.class, op);
+        assertEquals("ArrowBuf leaked by failed operation", before, allocator.getAllocatedMemory());
+    }
+
+    // -- Long (exercises the AbstractArrowBufBlock / AbstractArrowBufVector implementations) --
+
+    public void testLongBlockExpandCorruptOffsets() {
+        try (ListVector listVector = createLongListVector()) {
+            try (var block = LongArrowBufBlock.of(listVector, blockFactory)) {
+                // Point the null position's offset far past the expanded position count: expand()
+                // sizes the new validity buffer from the last offset (6) but indexes it with this one.
+                listVector.getOffsetBuffer().setInt(1 * Integer.BYTES, 500_000);
+                assertNoLeak(block::expand);
+            }
+        }
+    }
+
+    public void testLongBlockFilterOutOfRangePosition() {
+        try (BigIntVector arrowVec = new BigIntVector("test", allocator)) {
+            arrowVec.allocateNew(4);
+            arrowVec.set(0, 10L);
+            arrowVec.setNull(1);
+            arrowVec.set(2, 30L);
+            arrowVec.set(3, 40L);
+            arrowVec.setValueCount(4);
+
+            try (var block = LongArrowBufBlock.of(arrowVec, blockFactory)) {
+                // Far out of range so the value copy reads the value buffer way past its capacity;
+                // barely-out-of-range positions can land in the buffer's rounded-up padding.
+                assertNoLeak(() -> block.filter(false, 1_000_000));
+            }
+        }
+    }
+
+    public void testLongBlockFilterMultiValuedCorruptOffsets() {
+        try (ListVector listVector = createLongListVector()) {
+            try (var block = LongArrowBufBlock.of(listVector, blockFactory)) {
+                // Non-monotonic offsets: position 2 now claims 4 values and position 3 claims -1,
+                // so the pre-scan undersizes the new buffers and the value copy overflows them.
+                listVector.getOffsetBuffer().setInt(3 * Integer.BYTES, 7);
+                assertNoLeak(() -> block.filter(false, 2, 3));
+            }
+        }
+    }
+
+    public void testLongBlockKeepMaskShortMask() {
+        try (BigIntVector arrowVec = new BigIntVector("test", allocator)) {
+            arrowVec.allocateNew(4);
+            arrowVec.set(0, 10L);
+            arrowVec.set(1, 20L);
+            arrowVec.set(2, 30L);
+            arrowVec.set(3, 40L);
+            arrowVec.setValueCount(4);
+
+            try (var block = LongArrowBufBlock.of(arrowVec, blockFactory)) {
+                // Undersized mask: keepMask reads one boolean per block position, and the mask's
+                // backing array is shorter, throwing after the new validity buffer is allocated.
+                try (var maskBuilder = blockFactory.newBooleanVectorFixedBuilder(2)) {
+                    maskBuilder.appendBoolean(true);
+                    maskBuilder.appendBoolean(false);
+                    try (BooleanVector mask = maskBuilder.build()) {
+                        assertNoLeak(() -> block.keepMask(mask));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testLongBlockLookupCorruptOffsets() {
+        try (ListVector listVector = createLongListVector()) {
+            try (var block = LongArrowBufBlock.of(listVector, blockFactory)) {
+                // Same corruption as the multivalued filter case: the batch pre-scan undersizes
+                // the new buffers and the value copy overflows them.
+                listVector.getOffsetBuffer().setInt(3 * Integer.BYTES, 7);
+                try (IntBlock.Builder posBuilder = blockFactory.newIntBlockBuilder(2)) {
+                    posBuilder.appendInt(2);
+                    posBuilder.appendInt(3);
+                    try (IntBlock positions = posBuilder.build()) {
+                        assertNoLeak(() -> {
+                            try (var iter = block.lookup(positions, ByteSizeValue.ofMb(1))) {
+                                iter.next();
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    public void testLongVectorFilterOutOfRangePosition() {
+        try (BigIntVector arrowVec = new BigIntVector("test", allocator)) {
+            arrowVec.allocateNew(4);
+            arrowVec.set(0, 10L);
+            arrowVec.set(1, 20L);
+            arrowVec.set(2, 30L);
+            arrowVec.set(3, 40L);
+            arrowVec.setValueCount(4);
+
+            try (var vector = LongArrowBufVector.of(arrowVec, blockFactory)) {
+                assertNoLeak(() -> vector.filter(false, 1_000_000));
+            }
+        }
+    }
+
+    // -- BytesRef (exercises the hand-written BytesRefArrowBufBlock / BytesRefArrowBufVector overrides) --
+
+    public void testBytesRefBlockFilterCorruptValueOffsets() {
+        try (VarCharVector arrowVec = new VarCharVector("test", allocator)) {
+            arrowVec.allocateNew(3);
+            arrowVec.set(0, "aaaa".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setNull(1);
+            arrowVec.set(2, "bb".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setValueCount(3);
+
+            try (var block = BytesRefArrowBufBlock.of(arrowVec, blockFactory)) {
+                // Keep the value's length (4) but point its bytes far past the data buffer, so
+                // the pre-scan sizes the buffers fine and the byte copy reads out of bounds.
+                ArrowBuf valueOffsets = arrowVec.getOffsetBuffer();
+                valueOffsets.setInt(2 * Integer.BYTES, 1_000_000);
+                valueOffsets.setInt(3 * Integer.BYTES, 1_000_004);
+                assertNoLeak(() -> block.filter(false, 2));
+            }
+        }
+    }
+
+    public void testBytesRefBlockFilterMultiValuedCorruptOffsets() {
+        try (ListVector listVector = createVarCharListVector()) {
+            try (var block = BytesRefArrowBufBlock.of(listVector, blockFactory)) {
+                listVector.getOffsetBuffer().setInt(3 * Integer.BYTES, 7);
+                assertNoLeak(() -> block.filter(false, 2, 3));
+            }
+        }
+    }
+
+    public void testBytesRefBlockKeepMaskShortMask() {
+        try (VarCharVector arrowVec = new VarCharVector("test", allocator)) {
+            arrowVec.allocateNew(3);
+            arrowVec.set(0, "aaaa".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setNull(1);
+            arrowVec.set(2, "bb".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setValueCount(3);
+
+            try (var block = BytesRefArrowBufBlock.of(arrowVec, blockFactory)) {
+                try (var maskBuilder = blockFactory.newBooleanVectorFixedBuilder(2)) {
+                    maskBuilder.appendBoolean(true);
+                    maskBuilder.appendBoolean(false);
+                    try (BooleanVector mask = maskBuilder.build()) {
+                        assertNoLeak(() -> block.keepMask(mask));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testBytesRefBlockExpandCorruptOffsets() {
+        try (ListVector listVector = createVarCharListVector()) {
+            try (var block = BytesRefArrowBufBlock.of(listVector, blockFactory)) {
+                listVector.getOffsetBuffer().setInt(1 * Integer.BYTES, 500_000);
+                assertNoLeak(block::expand);
+            }
+        }
+    }
+
+    public void testBytesRefBlockLookupCorruptOffsets() {
+        try (ListVector listVector = createVarCharListVector()) {
+            try (var block = BytesRefArrowBufBlock.of(listVector, blockFactory)) {
+                listVector.getOffsetBuffer().setInt(3 * Integer.BYTES, 7);
+                try (IntBlock.Builder posBuilder = blockFactory.newIntBlockBuilder(2)) {
+                    posBuilder.appendInt(2);
+                    posBuilder.appendInt(3);
+                    try (IntBlock positions = posBuilder.build()) {
+                        assertNoLeak(() -> {
+                            try (var iter = block.lookup(positions, ByteSizeValue.ofMb(1))) {
+                                iter.next();
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    public void testBytesRefVectorFilterCorruptValueOffsets() {
+        try (VarCharVector arrowVec = new VarCharVector("test", allocator)) {
+            arrowVec.allocateNew(3);
+            arrowVec.set(0, "aaaa".getBytes(StandardCharsets.UTF_8));
+            arrowVec.set(1, "bb".getBytes(StandardCharsets.UTF_8));
+            arrowVec.set(2, "c".getBytes(StandardCharsets.UTF_8));
+            arrowVec.setValueCount(3);
+
+            try (var vector = BytesRefArrowBufVector.of(arrowVec, blockFactory)) {
+                ArrowBuf valueOffsets = arrowVec.getOffsetBuffer();
+                valueOffsets.setInt(1 * Integer.BYTES, 1_000_000);
+                valueOffsets.setInt(2 * Integer.BYTES, 1_000_010);
+                assertNoLeak(() -> vector.filter(false, 1));
+            }
+        }
+    }
+
+    // -- Boolean (exercises the hand-written BooleanArrowBufBlock / BooleanArrowBufVector overrides) --
+
+    public void testBooleanBlockFilterOutOfRangePosition() {
+        try (BitVector bitVector = new BitVector("test", allocator)) {
+            bitVector.allocateNew(3);
+            bitVector.set(0, 1);
+            bitVector.setNull(1);
+            bitVector.set(2, 0);
+            bitVector.setValueCount(3);
+
+            try (var block = BooleanArrowBufBlock.of(bitVector, blockFactory)) {
+                // Bit-packed: position 1,000,000 reads value buffer byte 125,000.
+                assertNoLeak(() -> block.filter(false, 1_000_000));
+            }
+        }
+    }
+
+    public void testBooleanBlockFilterMultiValuedCorruptOffsets() {
+        try (var block = createCorruptMultiValuedBooleanBlock()) {
+            assertNoLeak(() -> block.filter(false, 2, 3));
+        }
+    }
+
+    public void testBooleanBlockLookupCorruptOffsets() {
+        try (var block = createCorruptMultiValuedBooleanBlock()) {
+            try (IntBlock.Builder posBuilder = blockFactory.newIntBlockBuilder(2)) {
+                posBuilder.appendInt(2);
+                posBuilder.appendInt(3);
+                try (IntBlock positions = posBuilder.build()) {
+                    assertNoLeak(() -> {
+                        try (var iter = block.lookup(positions, ByteSizeValue.ofMb(1))) {
+                            iter.next();
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    public void testBooleanVectorFilterOutOfRangePosition() {
+        try (BitVector bitVector = new BitVector("test", allocator)) {
+            bitVector.allocateNew(3);
+            bitVector.set(0, 1);
+            bitVector.set(1, 0);
+            bitVector.set(2, 1);
+            bitVector.setValueCount(3);
+
+            try (var vector = BooleanArrowBufVector.of(bitVector, blockFactory)) {
+                assertNoLeak(() -> vector.filter(false, 1_000_000));
+            }
+        }
+    }
+
+    // -- Fixtures --
+
+    /**
+     * Creates a ListVector with a BigIntVector child and the following layout (same layout as
+     * {@code LongArrowBufTests#createMultiValuedListVector}):
+     * <pre>
+     *   Position 0: [100, 200, 300]
+     *   Position 1: null
+     *   Position 2: [400]
+     *   Position 3: [500, 600]
+     * </pre>
+     * Tests corrupt the list's offset buffer after building a block over it, modeling malformed
+     * file-supplied data reaching the zero-copy block.
+     */
+    private ListVector createLongListVector() {
+        ListVector listVector = ListVector.empty("test", allocator);
+        listVector.addOrGetVector(FieldType.nullable(Types.MinorType.BIGINT.getType()));
+
+        // Allocate before populating to avoid buffer reallocation
+        listVector.allocateNew();
+        BigIntVector childVector = (BigIntVector) listVector.getDataVector();
+        childVector.allocateNew(6);
+
+        childVector.set(0, 100L);
+        childVector.set(1, 200L);
+        childVector.set(2, 300L);
+        childVector.set(3, 400L);
+        childVector.set(4, 500L);
+        childVector.set(5, 600L);
+        childVector.setValueCount(6);
+
+        ArrowBuf offsetBuf = listVector.getOffsetBuffer();
+        offsetBuf.setInt(0, 0);
+        offsetBuf.setInt(4, 3);
+        offsetBuf.setInt(8, 3);
+        offsetBuf.setInt(12, 4);
+        offsetBuf.setInt(16, 6);
+
+        ArrowBuf validityBuf = listVector.getValidityBuffer();
+        validityBuf.setZero(0, validityBuf.capacity());
+        BitVectorHelper.setBit(validityBuf, 0);
+        BitVectorHelper.setBit(validityBuf, 2);
+        BitVectorHelper.setBit(validityBuf, 3);
+
+        listVector.setLastSet(3);
+        listVector.setValueCount(4);
+        return listVector;
+    }
+
+    /**
+     * Creates a ListVector with a VarCharVector child and the following layout:
+     * <pre>
+     *   Position 0: ["a", "b", "c"]
+     *   Position 1: null
+     *   Position 2: ["d"]
+     *   Position 3: ["e", "f"]
+     * </pre>
+     */
+    private ListVector createVarCharListVector() {
+        ListVector listVector = ListVector.empty("test", allocator);
+        listVector.addOrGetVector(FieldType.nullable(Types.MinorType.VARCHAR.getType()));
+
+        // Allocate before populating to avoid buffer reallocation
+        listVector.allocateNew();
+        VarCharVector childVector = (VarCharVector) listVector.getDataVector();
+        childVector.allocateNew(6);
+
+        childVector.set(0, "a".getBytes(StandardCharsets.UTF_8));
+        childVector.set(1, "b".getBytes(StandardCharsets.UTF_8));
+        childVector.set(2, "c".getBytes(StandardCharsets.UTF_8));
+        childVector.set(3, "d".getBytes(StandardCharsets.UTF_8));
+        childVector.set(4, "e".getBytes(StandardCharsets.UTF_8));
+        childVector.set(5, "f".getBytes(StandardCharsets.UTF_8));
+        childVector.setValueCount(6);
+
+        ArrowBuf offsetBuf = listVector.getOffsetBuffer();
+        offsetBuf.setInt(0, 0);
+        offsetBuf.setInt(4, 3);
+        offsetBuf.setInt(8, 3);
+        offsetBuf.setInt(12, 4);
+        offsetBuf.setInt(16, 6);
+
+        ArrowBuf validityBuf = listVector.getValidityBuffer();
+        validityBuf.setZero(0, validityBuf.capacity());
+        BitVectorHelper.setBit(validityBuf, 0);
+        BitVectorHelper.setBit(validityBuf, 2);
+        BitVectorHelper.setBit(validityBuf, 3);
+
+        listVector.setLastSet(3);
+        listVector.setValueCount(4);
+        return listVector;
+    }
+
+    /**
+     * Hand-builds a multivalued boolean block (there is no boolean ListVector factory on
+     * {@code BooleanArrowBufBlock}) over 6 bit-packed values with the layout of
+     * {@link #createLongListVector} and an already corrupted last offset: position 3 claims
+     * values [4, 600), so value reads run far past the 8-byte value buffer while the counts
+     * stay under the lookup batch limit. The block takes ownership of the fresh buffers.
+     */
+    private BooleanArrowBufBlock createCorruptMultiValuedBooleanBlock() {
+        ArrowBuf valueBuf = allocator.buffer(8);
+        valueBuf.setZero(0, valueBuf.capacity());
+        valueBuf.setByte(0, 0b0010_1101);
+
+        ArrowBuf validityBuf = allocator.buffer(8);
+        validityBuf.setZero(0, validityBuf.capacity());
+        BitVectorHelper.setBit(validityBuf, 0);
+        BitVectorHelper.setBit(validityBuf, 2);
+        BitVectorHelper.setBit(validityBuf, 3);
+
+        ArrowBuf offsetBuf = allocator.buffer(5 * Integer.BYTES);
+        offsetBuf.setInt(0, 0);
+        offsetBuf.setInt(4, 3);
+        offsetBuf.setInt(8, 3);
+        offsetBuf.setInt(12, 4);
+        offsetBuf.setInt(16, 600);
+
+        return new BooleanArrowBufBlock(valueBuf, validityBuf, offsetBuf, 4, 5, blockFactory);
+    }
+}


### PR DESCRIPTION
Arrow block and vector operations allocated new buffers before populating them, but set the success flag (and thus the finally-guarded release) before the population loop rather than after, so any exception thrown during copying left the buffers leaked. This change moves the population loop and result construction inside the guarded region so that any mid-flight exception releases all freshly allocated buffers. It also tracks whether shared-buffer retain calls have been made in keepMask and expand, rolling them back on failure instead of relying on the assumption that constructors never throw.

Closes https://github.com/elastic/esql-planning/issues/1600
