### PR TITLE
Register gauges after the initialisation to avoid caching noop

### DIFF
--- a/docs/changelog/156798.yaml
+++ b/docs/changelog/156798.yaml
@@ -1,0 +1,5 @@
+area: Infra/Metrics
+issues: []
+pr: 156798
+summary: Register gauges after the initialisation to avoid caching noop
+type: bug

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/BufferingMetricExporter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/BufferingMetricExporter.java
@@ -109,7 +109,6 @@ public class BufferingMetricExporter implements MetricExporter {
             EsExecutors.daemonThreadFactory(settings, "metrics_buffer_disk"),
             new EsAbortPolicy()
         );
-        refreshDiskStats();
     }
 
     @Override
@@ -260,6 +259,8 @@ public class BufferingMetricExporter implements MetricExporter {
 
         private static final String METRIC_PREFIX = "es.apm.metrics.disk_buffer.";
 
+        private static final LongGauge NOOP_LONG_GAUGE = MeterProvider.noop().get("noop").gaugeBuilder("noop").ofLongs().build();
+
         private final Supplier<MeterProvider> meterProviderSupplier;
 
         @Nullable
@@ -311,7 +312,9 @@ public class BufferingMetricExporter implements MetricExporter {
             var gauge = this.cachedFiles;
             if (gauge == null) {
                 gauge = longGauge("files", "Metric batches currently pending replay on disk", "1");
-                this.cachedFiles = gauge;
+                if (gauge != NOOP_LONG_GAUGE) {
+                    this.cachedFiles = gauge;
+                }
             }
             return gauge;
         }
@@ -320,7 +323,9 @@ public class BufferingMetricExporter implements MetricExporter {
             var gauge = this.cachedBytes;
             if (gauge == null) {
                 gauge = longGauge("bytes", "Total bytes currently used by the on-disk metric buffer", "By");
-                this.cachedBytes = gauge;
+                if (gauge != NOOP_LONG_GAUGE) {
+                    this.cachedBytes = gauge;
+                }
             }
             return gauge;
         }
@@ -335,8 +340,11 @@ public class BufferingMetricExporter implements MetricExporter {
         }
 
         private LongGauge longGauge(String suffix, String description, String unit) {
-            return meterProviderSupplier.get()
-                .get("elasticsearch")
+            MeterProvider provider = meterProviderSupplier.get();
+            if (provider == MeterProvider.noop()) {
+                return NOOP_LONG_GAUGE;
+            }
+            return provider.get("elasticsearch")
                 .gaugeBuilder(METRIC_PREFIX + suffix)
                 .ofLongs()
                 .setDescription(description)

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.LongGaugeBuilder;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
@@ -560,10 +561,38 @@ public class RecordingOtelMeter implements Meter {
         }
 
         @Override
+        public LongGauge build() {
+            SyncLongGaugeRecorder gauge = new SyncLongGaugeRecorder(name);
+            recorder.register(gauge, gauge.getInstrument(), name, description, unit);
+            return gauge;
+        }
+
+        @Override
         public ObservableLongMeasurement buildObserver() {
             LongMeasurementRecorder measurement = new LongMeasurementRecorder(name);
             recorder.register(measurement, measurement.getInstrument(), name, description, unit);
             return measurement;
+        }
+    }
+
+    private class SyncLongGaugeRecorder extends AbstractInstrument implements LongGauge, OtelInstrument {
+        SyncLongGaugeRecorder(String name) {
+            super(name, InstrumentType.LONG_GAUGE);
+        }
+
+        @Override
+        public void set(long value) {
+            recorder.call(instrument, name, value, Map.of());
+        }
+
+        @Override
+        public void set(long value, Attributes attributes) {
+            recorder.call(instrument, name, value, toMap(attributes));
+        }
+
+        @Override
+        public void set(long value, Attributes attributes, Context context) {
+            recorder.call(instrument, name, value, toMap(attributes));
         }
     }
 

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/BufferingMetricExporterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/BufferingMetricExporterTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.telemetry.apm.internal.export.otelsdk;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -31,8 +32,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.telemetry.InstrumentType.LONG_COUNTER;
+import static org.elasticsearch.telemetry.InstrumentType.LONG_GAUGE;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -82,6 +85,14 @@ public class BufferingMetricExporterTests extends ESTestCase {
         assertTrue("buffered batch must report success", exportAndWait("buf").isSuccess());
         assertBusy(() -> assertThat(countBufferFiles(), greaterThanOrEqualTo(1)));
         assertThat(counter("writes"), hasSize(1));
+        assertBusy(() -> {
+            List<Measurement> files = gauge("files");
+            assertThat(files, not(empty()));
+            assertThat(files.getLast().getLong(), greaterThanOrEqualTo(1L));
+            List<Measurement> bytes = gauge("bytes");
+            assertThat(bytes, not(empty()));
+            assertThat(bytes.getLast().getLong(), greaterThanOrEqualTo(1L));
+        });
 
         delegate.setShouldFail(false);
         safeSleep(200); // let the write window (100ms) expire so the reader can force-close and promote the file
@@ -131,8 +142,33 @@ public class BufferingMetricExporterTests extends ESTestCase {
         assertThat("buffered file must remain on disk for next startup", countBufferFiles(), greaterThanOrEqualTo(1));
     }
 
+    public void testGaugesRecoverAfterNoopMeterProvider() throws Exception {
+        var meterRef = new AtomicReference<>(MeterProvider.noop());
+        Settings merged = Settings.builder()
+            .put("telemetry.metrics.buffer.disk_size", "10mb")
+            .put("telemetry.metrics.buffer.ttl", "5m")
+            .build();
+        exporter = new BufferingMetricExporter(delegate, merged, bufferDir, meterRef::get, 100);
+        meterRef.set(meterProvider);
+
+        delegate.setShouldFail(true);
+        assertTrue(exportAndWait("buf").isSuccess());
+        assertBusy(() -> assertThat(countBufferFiles(), greaterThanOrEqualTo(1)));
+        assertThat(counter("writes"), hasSize(1));
+        assertBusy(() -> {
+            assertThat(gauge("files"), not(empty()));
+            assertThat(gauge("files").getLast().getLong(), greaterThanOrEqualTo(1L));
+            assertThat(gauge("bytes"), not(empty()));
+            assertThat(gauge("bytes").getLast().getLong(), greaterThanOrEqualTo(1L));
+        });
+    }
+
     private List<Measurement> counter(String suffix) {
         return meterProvider.meter().getRecorder().getMeasurements(LONG_COUNTER, "es.apm.metrics.disk_buffer." + suffix);
+    }
+
+    private List<Measurement> gauge(String suffix) {
+        return meterProvider.meter().getRecorder().getMeasurements(LONG_GAUGE, "es.apm.metrics.disk_buffer." + suffix);
     }
 
     private int countBufferFiles() throws Exception {


### PR DESCRIPTION
BufferingMetricExporter was registering disk-buffer gauges while the meter supplier still returned MeterProvider.noop(), so files/bytes stayed noop forever. Skip caching noop gauges and only bind them once a real provider is available. 

Relates to: elastic/elasticsearch-team#4391