### PR TITLE
ESQL  HIGHLIGHT: Reject HIGHLIGHT query fields outside ON

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -976,20 +976,6 @@ The One Ring was forged by Sauron in the fires of <em>Mount</em> Doom.
 ;
 
 
-# A term qualified on a different field parses but never highlights (require_field_match: true), yielding null.
-highlightFieldQualifiedTermYieldsNull
-required_capability: highlight_v6
-
-ROW content = "The One Ring was forged by Sauron."
-| HIGHLIGHT "title:ring" ON content
-| KEEP highlight_content
-;
-
-highlight_content:keyword
-null
-;
-
-
 # Grouping with parentheses combines a disjunction and a required term; both matched terms are wrapped.
 highlightGrouping
 required_capability: highlight_v6
@@ -1218,23 +1204,6 @@ book_no:keyword | highlight_title:keyword
 ;
 
 
-# A required KQL field outside ON prevents a highlight even when the ON field clause matches.
-highlightKqlRequiredFieldOutsideOnIsNull
-required_capability: highlight_v6
-
-FROM books
-| WHERE MATCH(title, "Return")
-| HIGHLIGHT KQL("title: return AND author: tolkien") ON title
-| KEEP book_no, highlight_title
-| SORT book_no
-;
-
-book_no:keyword | highlight_title:keyword
-2714            | null
-7350            | null
-;
-
-
 # QSTR default_field restricts an unqualified term to one ON field; the other ON field is left un-highlighted (null).
 highlightQueryStringDefaultField
 required_capability: highlight_v6
@@ -1292,21 +1261,6 @@ ROW title = "Return of the King", body = "A wise king ruled"
 
 highlight_title:keyword | highlight_body:keyword
 null                    | A wise <em>king</em> ruled
-;
-
-
-# A term qualified on a field outside ON can never highlight (require_field_match parity), so the row is null.
-highlightQueryStringFieldQualifiedOutsideOnYieldsNull
-required_capability: highlight_v6
-required_capability: qstr_function
-
-ROW content = "The One Ring was forged by Sauron."
-| HIGHLIGHT QSTR("title:ring") ON content
-| KEEP highlight_content
-;
-
-highlight_content:keyword
-null
 ;
 
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuilders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuilders.java
@@ -111,9 +111,9 @@ public final class HighlightQueryBuilders {
         if (literal == null) {
             verifyQueryStructure(queryExpr, onFields);
         }
+        // Translate before planning to catch invalid options, syntax, and fields outside ON.
         try {
-            // Translate now to report invalid options and syntax before planning.
-            translate(queryExpr, onFields, analyzer);
+            translate(queryExpr, onFields, runtimeContext(onFields, analyzer));
         } catch (RuntimeException e) {
             throw new IllegalArgumentException(
                 "Invalid query [" + (literal != null ? literal : queryExpr.sourceText()) + "] in HIGHLIGHT: " + e.getMessage(),
@@ -179,18 +179,25 @@ public final class HighlightQueryBuilders {
         return context.toQuery(builder).query();
     }
 
+    private static RuntimeSearchExecutionContext runtimeContext(List<String> fieldNames, Analyzer analyzer) {
+        NamedAnalyzer namedAnalyzer = analyzer instanceof NamedAnalyzer na
+            ? na
+            : new NamedAnalyzer("_override", AnalyzerScope.GLOBAL, analyzer);
+        return RuntimeSearchExecutionContext.create(fieldNames, namedAnalyzer);
+    }
+
+    private static TranslatedQuery translate(Expression queryExpr, List<String> fieldNames, RuntimeSearchExecutionContext context) {
+        String literal = queryTextIfLiteral(queryExpr);
+        String queryText = literal != null ? literal : queryExpr.sourceText();
+        Query query = toLuceneQuery(toQueryBuilder(queryExpr, fieldNames), context);
+        return new TranslatedQuery(queryText, query, context.searchAnalyzer());
+    }
+
     /**
      * Builds the runtime query with the analyzer used to index each row's text.
      */
     private static TranslatedQuery translate(Expression queryExpr, List<String> fieldNames, Analyzer analyzer) {
-        String literal = queryTextIfLiteral(queryExpr);
-        String queryText = literal != null ? literal : queryExpr.sourceText();
-        NamedAnalyzer namedAnalyzer = analyzer instanceof NamedAnalyzer na
-            ? na
-            : new NamedAnalyzer("_override", AnalyzerScope.GLOBAL, analyzer);
-        RuntimeSearchExecutionContext context = RuntimeSearchExecutionContext.create(fieldNames, namedAnalyzer);
-        Query query = toLuceneQuery(toQueryBuilder(queryExpr, fieldNames), context);
-        return new TranslatedQuery(queryText, query, context.searchAnalyzer());
+        return translate(queryExpr, fieldNames, runtimeContext(fieldNames, analyzer));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/RuntimeSearchExecutionContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/RuntimeSearchExecutionContext.java
@@ -42,6 +42,10 @@ import java.util.stream.Collectors;
 /**
  * A shard-free {@link SearchExecutionContext} for runtime ES|QL columns. It exposes each column as an indexed text
  * field and provides the analyzer callers need when indexing values for the resulting query.
+ *
+ * <p>Exact field names outside the exposed columns cause {@link #getMatchingFieldNames} to throw an
+ * {@link IllegalArgumentException}. This lets callers reject queries that reference unavailable fields. Direct
+ * {@link #getFieldType} lookups return {@code null} for unmapped names, as required by the base contract.
  */
 public final class RuntimeSearchExecutionContext extends SearchExecutionContext {
 
@@ -146,7 +150,11 @@ public final class RuntimeSearchExecutionContext extends SearchExecutionContext 
     @Override
     public Set<String> getMatchingFieldNames(String pattern) {
         if (Regex.isSimpleMatchPattern(pattern) == false) {
-            return fields.containsKey(pattern) ? Set.of(pattern) : Set.of();
+            if (fields.containsKey(pattern)) {
+                return Set.of(pattern);
+            }
+            // Exact fields outside this context must fail instead of silently matching nothing.
+            throw new IllegalArgumentException("field [" + pattern + "] is not one of the searchable fields " + fields.keySet());
         }
         return fields.keySet().stream().filter(f -> Regex.simpleMatch(pattern, f)).collect(Collectors.toSet());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -4782,6 +4782,28 @@ public class VerifierTests extends ESTestCase {
             "FROM test | HIGHLIGHT QSTR(\"fox\", {\"default_field\": \"title\"}) ON body",
             containsString("HIGHLIGHT query field [title] is not in ON fields [body]")
         );
+        // Reject field references outside ON while translating the query.
+        fullText().error(
+            "FROM test | HIGHLIGHT \"title:fox\" ON body",
+            allOf(containsString("in HIGHLIGHT:"), containsString("field [title] is not one of the searchable fields [body]"))
+        );
+        fullText().error(
+            "FROM test | HIGHLIGHT QSTR(\"title:fox\") ON body",
+            allOf(containsString("in HIGHLIGHT:"), containsString("field [title] is not one of the searchable fields [body]"))
+        );
+        fullText().error(
+            "FROM test | HIGHLIGHT KQL(\"title: fox\") ON body",
+            allOf(containsString("in HIGHLIGHT:"), containsString("field [title] is not one of the searchable fields [body]"))
+        );
+        // Report the first field outside ON.
+        fullText().error(
+            "FROM test | HIGHLIGHT \"body:fox OR tags:dog\" ON title",
+            allOf(containsString("in HIGHLIGHT:"), containsString("field [body] is not one of the searchable fields [title]"))
+        );
+        fullText().error(
+            "FROM test | HIGHLIGHT QSTR(\"body:fox OR tags:dog\") ON title",
+            allOf(containsString("in HIGHLIGHT:"), containsString("field [body] is not one of the searchable fields [title]"))
+        );
         // KQL syntax is checked while building the query.
         fullText().error("FROM test | HIGHLIGHT KQL(\"title: (fox\") ON title", containsString("in HIGHLIGHT:"));
         fullText().error(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuildersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/HighlightQueryBuildersTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
 import org.elasticsearch.test.ESTestCase;
@@ -324,8 +325,12 @@ public class HighlightQueryBuildersTests extends ESTestCase {
         assertThat(translate(matchPhrase("body", "quick fox", null), TITLE), instanceOf(MatchNoDocsQuery.class));
     }
 
-    public void testQueryStringDefaultFieldOutsideOnIsMatchNone() {
-        assertThat(translate(queryString("fox", options("default_field", "body")), TITLE), instanceOf(MatchNoDocsQuery.class));
+    public void testQueryStringDefaultFieldOutsideOnThrows() {
+        QueryShardException e = expectThrows(
+            QueryShardException.class,
+            () -> translate(queryString("fox", options("default_field", "body")), TITLE)
+        );
+        assertThat(e.getMessage(), containsString("field [body] is not one of the searchable fields [title]"));
     }
 
     public void testMatchInvalidOperatorThrows() {
@@ -346,9 +351,10 @@ public class HighlightQueryBuildersTests extends ESTestCase {
         assertThat(term.getTerm(), equalTo(new Term("title", "fox")));
     }
 
-    public void testKqlFieldOutsideOnIsMatchNone() {
+    public void testKqlFieldOutsideOnThrows() {
         Kql kql = new Kql(EMPTY, of("body: fox"), null, TEST_CFG);
-        assertThat(translate(kql, TITLE), instanceOf(MatchNoDocsQuery.class));
+        QueryShardException e = expectThrows(QueryShardException.class, () -> translate(kql, TITLE));
+        assertThat(e.getMessage(), containsString("field [body] is not one of the searchable fields [title]"));
     }
 
     private static List<Term> terms(Query query) {


### PR DESCRIPTION
## Summary

HIGHLIGHT now rejects exact field names in query text when they are not listed in `ON`.

`RuntimeSearchExecutionContext` records exact field lookups that cannot be resolved against its synthetic fields. `HighlightQueryBuilders` checks those lookups after query translation and reports the invalid fields.

Removed CSV cases that asserted the previous silent-null behavior. Error coverage lives in verifier tests, where errors can be asserted directly.

