### PR TITLE
[ML] Remove invalid params within Usage

### DIFF
--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlUsageIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlUsageIT.java
@@ -47,4 +47,30 @@ public class MlUsageIT extends ESRestTestCase {
         assertThat(memoryUsage.toString(), (Integer) memoryUsage.get("pytorch_inference_memory_bytes"), greaterThanOrEqualTo(0));
         assertThat(memoryUsage.toString(), (Integer) memoryUsage.get("total_used_memory_bytes"), greaterThanOrEqualTo(0));
     }
+
+    /**
+     * Regression test for the calendars telemetry collector: it must not build a
+     * {@code GetCalendarsAction.Request} that sets both a calendar id and paging, which fails
+     * validation and silently drops the calendar config-size histogram. When the fetch succeeds
+     * the {@code calendars} entry (with its {@code config_sizes}) is present under {@code ml.jobs}.
+     */
+    @SuppressWarnings("unchecked")
+    public void testMLUsageIncludesCalendarConfigSizes() throws IOException {
+        Request putCalendar = new Request("PUT", "/_ml/calendars/usage-cal");
+        putCalendar.setJsonEntity("""
+            { "description": "usage telemetry regression calendar" }
+            """);
+        client().performRequest(putCalendar);
+
+        Request request = new Request("GET", "/_xpack/usage");
+        var usage = entityAsMap(client().performRequest(request).getEntity());
+
+        var ml = (Map<String, Object>) usage.get("ml");
+        assertNotNull(usage.toString(), ml);
+        var jobsUsage = (Map<String, Object>) ml.get("jobs");
+        assertNotNull(ml.toString(), jobsUsage);
+        var calendars = (Map<String, Object>) jobsUsage.get("calendars");
+        assertNotNull(jobsUsage.toString(), calendars);
+        assertNotNull(calendars.toString(), calendars.get("config_sizes"));
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -752,7 +752,6 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
 
     private void addAuxiliaryAdConfigUsage(Map<String, Object> jobsUsage, ActionListener<Void> listener) {
         GetCalendarsAction.Request calendarsRequest = new GetCalendarsAction.Request();
-        calendarsRequest.setCalendarId(GetCalendarsAction.Request.ALL);
         calendarsRequest.setPageParams(new PageParams(0, 10_000));
         client.execute(GetCalendarsAction.INSTANCE, calendarsRequest, ActionListener.wrap(calendarsResponse -> {
             MlConfigSizeUsage.putAuxiliaryConfigSizes(


### PR DESCRIPTION
Usage is currently calling GetCalendarsAction with an invalid combination of parameters. Removing the `_all` parameter and leaving in the 0->10000, matching the parameters in the internal calls.
