### PR TITLE
find_structure API fails to match NDSON when the last doc is corrupt

### DIFF
--- a/x-pack/plugin/text-structure/src/javaRestTest/java/org/elasticsearch/xpack/textstructure/rest/TextStructureNestedJsonIT.java
+++ b/x-pack/plugin/text-structure/src/javaRestTest/java/org/elasticsearch/xpack/textstructure/rest/TextStructureNestedJsonIT.java
@@ -50,6 +50,21 @@ public class TextStructureNestedJsonIT extends ESRestTestCase {
         assertKeyValue("message", "keyword", responseMap);
     }
 
+    public void testJsonObjectDetectionTruncatedFinalDocument() throws IOException {
+        String jsonSample = """
+            {"timestamp": "1478261151445", "id": 1, "message": "Connection established"}
+            {"timestamp": "1478261151446", "id": 2, "message": "Request processed"}
+            {"timestamp": "1478261151447", "id": 3, "message": "Data w
+            """;
+
+        Map<String, Object> responseMap = executeAndVerifyRequest(jsonSample, null);
+
+        assertKeyValue("timestamp", "date", responseMap);
+        assertKeyValue("id", "long", responseMap);
+        assertKeyValue("message", "keyword", responseMap);
+        assertThat(responseMap.get("num_messages_analyzed"), equalTo(2));
+    }
+
     public void testNestedJsonObjectDetectionDefaultBehavior() throws IOException {
         String nestedJsonSample = """
             {"host": {"id": 1, "category": "NETWORKING DEVICE"}, "timestamp": "1478261151445"}

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.textstructure.structurefinder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.FieldStats;
@@ -49,10 +50,19 @@ public class NdJsonTextStructureFinder implements TextStructureFinder {
         List<Map<String, ?>> sampleRecords = new ArrayList<>();
 
         List<String> sampleMessages = Arrays.asList(sample.split("\n"));
-        for (String sampleMessage : sampleMessages) {
+        for (int lineNum = 0; lineNum < sampleMessages.size(); ++lineNum) {
+            String sampleMessage = sampleMessages.get(lineNum);
             try (XContentParser parser = jsonXContent.createParser(XContentParserConfiguration.EMPTY, sampleMessage)) {
                 sampleRecords.add(parser.mapOrdered());
                 timeoutChecker.check("NDJSON parsing");
+            } catch (XContentEOFException e) {
+                // Mirrors the tolerance in NdJsonTextStructureFinderFactory#canCreateFromSample: a
+                // truncated final document (as opposed to malformed JSON) is assumed to result from
+                // the sample being cut off mid-document, and is dropped rather than treated as fatal.
+                if (lineNum == sampleMessages.size() - 1 && sampleRecords.isEmpty() == false) {
+                    break;
+                }
+                throw e;
             }
         }
 

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactory.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.textstructure.structurefinder;
 
+import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -29,38 +30,48 @@ public class NdJsonTextStructureFinderFactory implements TextStructureFinderFact
      * This format matches if the sample consists of one or more NDJSON documents.
      * If there is more than one, they must be newline-delimited.  The
      * documents must be non-empty, to prevent lines containing "{}" from matching.
+     * The final line is permitted to be an incomplete document (i.e. one that hits
+     * end-of-file partway through parsing), as long as it's preceded by at least one
+     * complete document. This tolerates samples that were truncated to a fixed byte
+     * size before being submitted, which necessarily cuts off mid-document unless the
+     * truncation point happens to fall exactly on a line boundary.
      */
     @Override
     public boolean canCreateFromSample(List<String> explanation, String sample, double allowedFractionOfBadLines) {
 
         int completeDocCount = 0;
 
-        try {
-            String[] sampleLines = sample.split("\n");
-            for (String sampleLine : sampleLines) {
-                try (
-                    XContentParser parser = jsonXContent.createParser(
-                        XContentParserConfiguration.EMPTY,
-                        new ContextPrintingStringReader(sampleLine)
-                    )
-                ) {
+        String[] sampleLines = sample.split("\n");
+        for (int lineNum = 0; lineNum < sampleLines.length; ++lineNum) {
+            String sampleLine = sampleLines[lineNum];
+            try (
+                XContentParser parser = jsonXContent.createParser(
+                    XContentParserConfiguration.EMPTY,
+                    new ContextPrintingStringReader(sampleLine)
+                )
+            ) {
 
-                    if (parser.map().isEmpty()) {
-                        explanation.add("Not NDJSON because an empty object was parsed: [" + sampleLine + "]");
-                        return false;
-                    }
-                    ++completeDocCount;
-                    if (parser.nextToken() != null) {
-                        explanation.add(
-                            "Not newline delimited NDJSON because a line contained more than a single object: [" + sampleLine + "]"
-                        );
-                        return false;
-                    }
+                if (parser.map().isEmpty()) {
+                    explanation.add("Not NDJSON because an empty object was parsed: [" + sampleLine + "]");
+                    return false;
                 }
+                ++completeDocCount;
+                if (parser.nextToken() != null) {
+                    explanation.add(
+                        "Not newline delimited NDJSON because a line contained more than a single object: [" + sampleLine + "]"
+                    );
+                    return false;
+                }
+            } catch (IOException | IllegalStateException | XContentParseException e) {
+                if (e instanceof XContentEOFException && lineNum == sampleLines.length - 1 && completeDocCount > 0) {
+                    explanation.add("Ignoring truncated final document, assumed to result from a sample cut off mid-document");
+                    break;
+                }
+                explanation.add(
+                    "Not NDJSON because there was a parsing exception: [" + e.getMessage().replaceAll("\\s?\r?\n\\s?", " ") + "]"
+                );
+                return false;
             }
-        } catch (IOException | IllegalStateException | XContentParseException e) {
-            explanation.add("Not NDJSON because there was a parsing exception: [" + e.getMessage().replaceAll("\\s?\r?\n\\s?", " ") + "]");
-            return false;
         }
 
         if (completeDocCount == 0) {

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactoryTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinderFactoryTests.java
@@ -18,6 +18,14 @@ public class NdJsonTextStructureFinderFactoryTests extends TextStructureTestCase
         assertTrue(factory.canCreateFromSample(explanation, NDJSON_SAMPLE, 0.0));
     }
 
+    public void testCanCreateFromSampleGivenNdJsonWithTruncatedFinalDoc() {
+        String truncatedNdJsonSample = NDJSON_SAMPLE.stripTrailing() + """
+            \n{"logger":"controller","timestamp":1478261151445,"level":"INFO","pid":42,"thread":"0x7fff7d2a8000","message":"message 3",\
+            "class":"ml","method":"core::SomeNoiseMaker","fil""";
+
+        assertTrue(factory.canCreateFromSample(explanation, truncatedNdJsonSample, 0.0));
+    }
+
     public void testCanCreateFromMessages() {
         List<String> messages = Arrays.asList(NDJSON_SAMPLE.split("\n"));
         assertTrue(factory.canCreateFromMessages(explanation, messages, 0.0));


### PR DESCRIPTION
Samples cut off mid-document (e.g. truncated before upload) were rejected as not-NDJSON even when preceded by many complete documents. 
Use XContentEOFException to distinguish a truncated final line from genuinely malformed JSON, and drop the truncated
line instead of failing detection/parsing.

Closes #156679