### PR TITLE
[9.5] Improve failure handling for shards (#156515)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -610,7 +610,12 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                                     onShardResult(q);
                                 }
                                 case null, default -> {
-                                    assert false : "impossible [" + response.results[i] + "]";
+                                    var e = new IllegalStateException("data node returned unexpected result for shard [" + s.shardId + "]");
+                                    logger.error(
+                                        "data node produced unexpected result[" + response.results[i] + "] for shard [" + s.shardId + "]",
+                                        e
+                                    );
+                                    onShardFailure(shardIdx, target, shardIterators[shardIdx], e);
                                 }
                             }
                         }
@@ -984,7 +989,7 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
             for (int i = 0; i < resultCount; i++) {
                 var result = queryPhaseResultConsumer.results.get(i);
                 if (result == null) {
-                    NodeQueryResponse.writePerShardException(out, failures.remove(i));
+                    NodeQueryResponse.writePerShardException(out, shardFailureOrUnknown(i));
                 } else {
                     // free context id and remove it from the result right away in case we don't need it anymore
                     maybeFreeContext(result, relevantShardIndices, namedWriteableRegistry);
@@ -1002,7 +1007,7 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
             for (int i = 0; i < resultCount; i++) {
                 var result = queryPhaseResultConsumer.results.get(i);
                 if (result == null) {
-                    NodeQueryResponse.writePerShardException(out, failures.remove(i));
+                    NodeQueryResponse.writePerShardException(out, shardFailureOrUnknown(i));
                 } else {
                     NodeQueryResponse.writePerShardResult(out, result);
                 }
@@ -1010,6 +1015,17 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
             out.writeBoolean(true); // does have a reduction failure
             out.writeException(reductionFailure);
             releaseAllResultsContexts();
+        }
+
+        private Exception shardFailureOrUnknown(int localIndex) {
+            Exception failure = failures.remove(localIndex);
+            if (failure == null) {
+                logger.error("data node produced null failure for shard [{}]", localIndex);
+                failure = new IllegalStateException(
+                    "shard [" + searchRequest.shards.get(localIndex).shardId + "] neither succeeded nor failed"
+                );
+            }
+            return failure;
         }
 
         /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Improve failure handling for shards (#156515)](https://github.com/elastic/elasticsearch/pull/156515)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)