### PR TITLE
Guard ASH's learned projection against degenerate (structureless) training data

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizer.java
@@ -233,7 +233,39 @@ public final class AsymmetricHashingQuantizer {
         return new EncodedVector(xEnc, scale, offset);
     }
 
+    /**
+     * Margin over the isotropic baseline that held-out captured variance must clear to be
+     * trusted (see {@link #isProjectionDegenerate}). Empirically, held-out captured-variance
+     * ratios cluster tightly around 1.0x baseline for isotropic (structureless) data and around
+     * 2.0x baseline for data with real directional structure -- even weak structure -- across a
+     * wide range of dimensions and sample sizes, leaving a wide gap for this margin to sit in.
+     */
+    private static final double DEGENERACY_VARIANCE_MARGIN = 1.25;
+
+    /**
+     * Minimum training sample size, as a multiple of {@code nDims}, before attempting the
+     * degeneracy check in {@link #isProjectionDegenerate}. Below this, splitting the data in
+     * half would leave too few samples per half for a meaningful fit/held-out comparison, so we
+     * skip the check and proceed with PCA as before (no worse than pre-existing behavior).
+     */
+    private static final int MIN_TRAINING_SIZE_FOR_DEGENERACY_CHECK = 4;
+
     private float[] learnedTraining(float[] xTraining, int nTraining, int originalDim, int nDims) {
+        if (nDims < originalDim
+            && nTraining >= nDims * MIN_TRAINING_SIZE_FOR_DEGENERACY_CHECK
+            && isProjectionDegenerate(xTraining, nTraining, originalDim, nDims, seed)) {
+            // A PCA subspace fit on half the training data captures no more variance, on the
+            // OTHER (held-out) half, than a random nDims-dimensional subspace would under
+            // isotropic data. This means the training vectors (e.g. near-duplicate vectors
+            // within a cluster, or otherwise low-diversity input) have no real directional
+            // structure for PCA to exploit -- what looks like structure on this sample is just
+            // sampling noise that won't generalize to query vectors at search time. Refining
+            // these noise-driven axes via Procrustes would just overfit further, and can produce
+            // a projection that discards exactly the components a given query needs, tanking
+            // recall for that query. A random orthogonal projection is at least as good here.
+            return randomOrthogonal(originalDim, nDims);
+        }
+
         // PCA initialization: extract top nDims right singular vectors via power iteration
         // This is much faster than full SVD when nDims << originalDim
         float[] topVectors = SvdUtil.topKRightSingularVectors(xTraining, nTraining, originalDim, nDims, seed);
@@ -277,6 +309,36 @@ public final class AsymmetricHashingQuantizer {
 
         // W = P @ R (originalDim x nDims)
         return matMul(p, r, originalDim, nDims, nDims);
+    }
+
+    /**
+     * Returns true if a PCA subspace fit on the first half of {@code xTraining} captures no
+     * more variance -- measured on the other (held-out) half -- than a uniformly random
+     * nDims-dimensional subspace would under isotropic data (a {@code nDims / originalDim}
+     * share, by construction). This is a generalization check: sampling noise that happens to
+     * look like structure on one half of the data won't carry over to an independent half,
+     * whereas real, reproducible directional structure will.
+     */
+    private static boolean isProjectionDegenerate(float[] xTraining, int nTraining, int originalDim, int nDims, long seed) {
+        int nFit = nTraining / 2;
+        int nHeldOut = nTraining - nFit;
+        float[] fitData = Arrays.copyOfRange(xTraining, 0, nFit * originalDim);
+        float[] heldOutData = Arrays.copyOfRange(xTraining, nFit * originalDim, nTraining * originalDim);
+
+        float[] topVectors = SvdUtil.topKRightSingularVectors(fitData, nFit, originalDim, nDims, seed);
+        float[] p = ESVectorUtil.transposeMatrix(topVectors, nDims, originalDim);
+        float[] projected = matMul(heldOutData, p, nHeldOut, originalDim, nDims);
+
+        double capturedVariance = 0;
+        for (float v : projected) {
+            capturedVariance = Math.fma((double) v, v, capturedVariance);
+        }
+        double totalVariance = 0;
+        for (float v : heldOutData) {
+            totalVariance = Math.fma((double) v, v, totalVariance);
+        }
+        double isotropicBaseline = (double) nDims / originalDim;
+        return capturedVariance < totalVariance * isotropicBaseline * DEGENERACY_VARIANCE_MARGIN;
     }
 
     private float[] randomOrthogonal(int originalDim, int nDims) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ash/AsymmetricHashingQuantizerTests.java
@@ -404,6 +404,103 @@ public class AsymmetricHashingQuantizerTests extends ESTestCase {
         assertEquals(dim * nDims, w.length);
     }
 
+    public void testFallbackToRandomWhenDataIsIsotropic() throws IOException {
+        // Purely isotropic vectors (i.i.d. Gaussian, no dominant directions) give PCA nothing
+        // real to exploit -- the learned method should recognize this and fall back to exactly
+        // the same random orthogonal projection that Method.RANDOM would produce for these
+        // dimensions/seed, rather than fitting sampling noise. Uses a fixed local Random seed
+        // (not ESTestCase's harness-seeded random()) so this assertion never depends on the
+        // suite's random seed.
+        int nVectors = 200;
+        int dim = 64;
+        float projectedDimsFraction = 0.25f; // nDims = 16
+        long seed = 42L;
+
+        Random rng = new Random(123456789L);
+        float[][] vectors = new float[nVectors][];
+        for (int i = 0; i < nVectors; i++) {
+            vectors[i] = SvdUtil.randomGaussians(rng, dim);
+        }
+        float[][] centroids = new float[1][dim];
+        CheckedIntFunction<float[], IOException> centroidGetter = i -> centroids[0];
+
+        AsymmetricHashingQuantizer learned = new AsymmetricHashingQuantizer(
+            projectedDimsFraction,
+            2,
+            AsymmetricHashingQuantizer.Method.LEARNED,
+            5,
+            10,
+            seed
+        );
+        AsymmetricHashingQuantizer randomOnly = new AsymmetricHashingQuantizer(
+            projectedDimsFraction,
+            2,
+            AsymmetricHashingQuantizer.Method.RANDOM,
+            5,
+            10,
+            seed
+        );
+
+        float[] wLearned = learned.train(vectors, centroidGetter);
+        float[] wRandom = randomOnly.train(vectors, centroidGetter);
+
+        assertArrayEquals(wRandom, wLearned, 0f);
+    }
+
+    public void testLearnedMethodUsesRealStructureWhenPresent() throws IOException {
+        // Vectors with genuine (rotated, non-axis-aligned) low-rank structure plus noise --
+        // closer to real embedding anisotropy than an axis-aligned variance difference -- give
+        // PCA a real signal, far above the isotropic baseline. The learned method should keep
+        // the PCA + Procrustes path rather than falling back to the random projection
+        // Method.RANDOM would produce. Fixed local Random seed, same reasoning as above.
+        int nVectors = 200;
+        int dim = 64;
+        int rank = 8;
+        float projectedDimsFraction = 0.25f; // nDims = 16
+        long seed = 42L;
+
+        float[] basis = SvdUtil.randomGaussians(new Random(555L), rank * dim);
+        Random rng = new Random(987654321L);
+        float[][] vectors = new float[nVectors][];
+        for (int i = 0; i < nVectors; i++) {
+            float[] v = new float[dim];
+            for (int r = 0; r < rank; r++) {
+                float coeff = (float) (rng.nextGaussian() * 10.0);
+                for (int d = 0; d < dim; d++) {
+                    v[d] += coeff * basis[r * dim + d];
+                }
+            }
+            for (int d = 0; d < dim; d++) {
+                v[d] += (float) (rng.nextGaussian() * 0.1);
+            }
+            vectors[i] = v;
+        }
+        float[][] centroids = new float[1][dim];
+        CheckedIntFunction<float[], IOException> centroidGetter = i -> centroids[0];
+
+        AsymmetricHashingQuantizer learned = new AsymmetricHashingQuantizer(
+            projectedDimsFraction,
+            2,
+            AsymmetricHashingQuantizer.Method.LEARNED,
+            5,
+            10,
+            seed
+        );
+        AsymmetricHashingQuantizer randomOnly = new AsymmetricHashingQuantizer(
+            projectedDimsFraction,
+            2,
+            AsymmetricHashingQuantizer.Method.RANDOM,
+            5,
+            10,
+            seed
+        );
+
+        float[] wLearned = learned.train(vectors, centroidGetter);
+        float[] wRandom = randomOnly.train(vectors, centroidGetter);
+
+        assertFalse("Expected PCA-trained W to differ from the random fallback", Arrays.equals(wLearned, wRandom));
+    }
+
     public void testMultiBitPackAndScore() {
         // 2-bit quantizer: levels are -1.5, -0.5, 0.5, 1.5
         int bitsPerDim = 2;


### PR DESCRIPTION
## Summary
- ASH's `AsymmetricHashingQuantizer` learns a projection matrix `W` via PCA + Procrustes iterations. When the training vectors for a cluster have no real directional structure (e.g. near-duplicate/low-diversity vectors, or otherwise isotropic data), PCA fits sampling noise instead of a genuine signal, producing a projection that can discard exactly the components a given query needs and tank recall for that query.
- Adds a held-out generalization check before trusting the PCA fit: fit PCA on half the training data, measure how much variance that subspace captures on the *other* half, and compare against the isotropic baseline (`nDims / originalDim`). If the fitted subspace doesn't clear that baseline by a margin, fall back to the existing `randomOrthogonal()` projection instead of refining noise-driven axes via Procrustes.
- The margin (1.25x baseline) was calibrated empirically rather than guessed: across a range of dimensions and sample sizes, held-out captured-variance ratios cluster tightly around 1.0x baseline for isotropic/structureless data and around 2.0x baseline for data with real directional structure (even weak, non-axis-aligned structure), leaving a wide, clean gap.

## Context
This grew out of investigating `testAshEuclideanScoreCorrectness`'s flakiness (#156719 / #156727). That investigation surfaced a real, separate, unresolved failure mode — certain random training draws produce near-zero recall regardless of projection method (learned vs. random) or similarity function, which this guard does not explain or fix. That's being tracked separately; this PR is scoped to the specific, validated fix: preventing PCA from overfitting when training data genuinely lacks structure for it to exploit.

## Test plan
- [x] Two new unit tests in `AsymmetricHashingQuantizerTests`: isotropic training data causes `learnedTraining` to reproduce exactly the same projection `Method.RANDOM` would produce (same seed); genuinely structured (rotated, non-axis-aligned low-rank) data causes it to diverge from that random fallback.
- [x] Full existing `AsymmetricHashingQuantizerTests` and `ESNextDiskASHVectorsFormatTests` suites pass unchanged.
- [x] Empirically calibrated the degeneracy margin and threshold via a throwaway diagnostic harness across isotropic/weakly-structured/strongly-structured data at multiple dimensions and sample sizes (not included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)