### PR TITLE
Allow more than 1 thread for freeing contexts (#156779)

### DIFF
--- a/docs/changelog/156779.yaml
+++ b/docs/changelog/156779.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 156779
+summary: Allow more than 1 thread for freeing contexts
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -536,14 +537,15 @@ public class SearchTransportService {
     public static void registerRequestHandler(
         TransportService transportService,
         SearchService searchService,
-        NamedWriteableRegistry namedWriteableRegistry
+        NamedWriteableRegistry namedWriteableRegistry,
+        Settings settings
     ) {
         final TransportRequestHandler<ScrollFreeContextRequest> freeContextHandler = (request, channel, task) -> {
             boolean freed = searchService.freeReaderContext(request.id());
             logger.trace("releasing search context [{}], [{}]", request.id(), freed);
             channel.sendResponse(SearchFreeContextResponse.of(freed));
         };
-        final Executor freeContextExecutor = buildFreeContextExecutor(transportService);
+        final Executor freeContextExecutor = buildFreeContextExecutor(transportService, settings);
         transportService.registerRequestHandler(
             FREE_CONTEXT_SCROLL_ACTION_NAME,
             freeContextExecutor,
@@ -870,10 +872,15 @@ public class SearchTransportService {
         }
     }
 
-    private static Executor buildFreeContextExecutor(TransportService transportService) {
+    // package-private for testing
+    static int freeContextConcurrency(Settings settings) {
+        return Math.max(1, EsExecutors.allocatedProcessors(settings) / 2);
+    }
+
+    private static Executor buildFreeContextExecutor(TransportService transportService, Settings settings) {
         final ThrottledTaskRunner throttledTaskRunner = new ThrottledTaskRunner(
             "free_context",
-            1,
+            freeContextConcurrency(settings),
             transportService.getThreadPool().generic()
         );
         return r -> throttledTaskRunner.enqueueTask(new ActionListener<>() {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -222,7 +222,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.searchPhaseController = searchPhaseController;
         this.searchTransportService = searchTransportService;
         this.remoteClusterService = searchTransportService.getRemoteClusterService();
-        SearchTransportService.registerRequestHandler(transportService, searchService, namedWriteableRegistry);
+        SearchTransportService.registerRequestHandler(
+            transportService,
+            searchService,
+            namedWriteableRegistry,
+            clusterService.getSettings()
+        );
         SearchQueryThenFetchAsyncAction.registerNodeSearchAction(
             searchTransportService,
             searchService,

--- a/server/src/test/java/org/elasticsearch/action/search/SearchTransportServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchTransportServiceTests.java
@@ -12,6 +12,8 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.AbstractTransportRequest;
 
@@ -19,8 +21,31 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class SearchTransportServiceTests extends ESTestCase {
+
+    /**
+     * Verifies that the free-context executor concurrency is half the allocated processors, with a minimum of 1.
+     * A node with many processors must be able to drain free-context requests concurrently; with a single drainer
+     * the queue can grow unboundedly under burst traffic and exhaust the heap.
+     */
+    public void testFreeContextConcurrency() {
+        // single processor → minimum of 1
+        assertThat(SearchTransportService.freeContextConcurrency(settings(1)), equalTo(1));
+        // two processors → 1
+        assertThat(SearchTransportService.freeContextConcurrency(settings(2)), equalTo(1));
+        // four processors → 2
+        assertThat(SearchTransportService.freeContextConcurrency(settings(4)), equalTo(2));
+        // eight processors → 4
+        assertThat(SearchTransportService.freeContextConcurrency(settings(8)), equalTo(4));
+        // default settings use Runtime.availableProcessors() → at least 1
+        assertThat(SearchTransportService.freeContextConcurrency(Settings.EMPTY), greaterThanOrEqualTo(1));
+    }
+
+    private static Settings settings(int processors) {
+        return Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), processors).build();
+    }
 
     /**
      * Verifies that {@link SearchTransportService#countingRequest} and


### PR DESCRIPTION
We had a case where we accumulated many tasks and GB held, it seems there is a bit more work involved in edge cases.

The mechanism to limit to 1 thread were introduced in #111156

(cherry picked from commit 7edd08b64582b23fdc62195247cd6bf0a69b7db6)
