### PR TITLE
Expanded FLS + ESQL coverage to logsdb and logsdb_columnar index modes

### DIFF
--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -164,23 +164,16 @@ public class EsqlSecurityIT extends ESRestTestCase {
         client().performRequest(indexDoc);
     }
 
-    /**
-     * Settings applied to the source-bearing FLS indices ({@code index}, {@code index-user*}, {@code indexpartial},
-     * {@link #INDEX_PARTIAL_MAPPING}, {@link #INDEX_FULL_MAPPING}). Defaults to {@link Settings#EMPTY} (standard, stored
-     * {@code _source}). Subclasses override this to rerun the whole FLS suite over a synthetic-source / {@code _ignored_source}
-     * index mode (e.g. {@code logsdb}, {@code logsdb_columnar}) and prove FLS parity across storage layouts. The {@code lookup-*}
-     * indices are intentionally excluded — {@code index.mode=lookup} cannot combine with logsdb.
-     */
-    protected Settings flsIndexSettings() {
+    protected Settings indexSettings() {
         return Settings.EMPTY;
     }
 
     /**
-     * Disables the data-stream {@code @timestamp} metadata field that logsdb / logsdb_columnar enable by default, so the shared
-     * timestamp-less test documents index unchanged. A no-op in standard mode, where the field is already disabled.
+     * Prefix prepended to every test index mapping. Empty in standard mode; the logsdb / logsdb_columnar subclasses override it to
+     * disable the data-stream {@code @timestamp} metadata field those modes enable by default, so the shared documents index unchanged.
      */
-    protected String flsMappingPrefix() {
-        return "\"_data_stream_timestamp\":{\"enabled\":false},";
+    protected String mappingPrefix() {
+        return "";
     }
 
     @Before
@@ -190,22 +183,22 @@ public class EsqlSecurityIT extends ESRestTestCase {
             "properties":{"value": {"type": "double"}, "org": {"type": "keyword"}, "other": {"type": "keyword"}}
             """;
 
-        createIndex("index", flsIndexSettings(), flsMappingPrefix() + mapping);
+        createIndex("index", indexSettings(), mappingPrefix() + mapping);
         indexDocument("index", 1, 10.0, "sales");
         indexDocument("index", 2, 20.0, "engineering");
         refresh("index");
 
-        createIndex("index-user1", flsIndexSettings(), flsMappingPrefix() + mapping);
+        createIndex("index-user1", indexSettings(), mappingPrefix() + mapping);
         indexDocument("index-user1", 1, 12.0, "engineering");
         indexDocument("index-user1", 2, 31.0, "sales");
         refresh("index-user1");
 
-        createIndex("index-user2", flsIndexSettings(), flsMappingPrefix() + mapping);
+        createIndex("index-user2", indexSettings(), mappingPrefix() + mapping);
         indexDocument("index-user2", 1, 32.0, "marketing");
         indexDocument("index-user2", 2, 40.0, "sales");
         refresh("index-user2");
 
-        createIndex("indexpartial", flsIndexSettings(), flsMappingPrefix() + mapping);
+        createIndex("indexpartial", indexSettings(), mappingPrefix() + mapping);
         indexDocument("indexpartial", 1, 32.0, "marketing");
         indexDocument("indexpartial", 2, 40.0, "sales");
         refresh("indexpartial");
@@ -220,7 +213,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         String mappingPartial = """
             "dynamic":"false","properties":{"value": {"type": "double"}}
             """;
-        createIndex(INDEX_PARTIAL_MAPPING, flsIndexSettings(), flsMappingPrefix() + mappingPartial);
+        createIndex(INDEX_PARTIAL_MAPPING, indexSettings(), mappingPrefix() + mappingPartial);
         indexFlsTestDocument(INDEX_PARTIAL_MAPPING, 1, 10.0, "sales", 100000L, "2024-01-01", "10.0.0.1");
         indexFlsTestDocument(INDEX_PARTIAL_MAPPING, 2, 20.0, "engineering", 200000L, "2023-06-15", "10.0.0.2");
         refresh(INDEX_PARTIAL_MAPPING);
@@ -229,7 +222,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             "properties":{"value":{"type":"double"},"org":{"type":"keyword"},"salary":{"type":"long"},\
             "hire_date":{"type":"date"},"ip_addr":{"type":"ip"}}
             """;
-        createIndex(INDEX_FULL_MAPPING, flsIndexSettings(), flsMappingPrefix() + mappingFull);
+        createIndex(INDEX_FULL_MAPPING, indexSettings(), mappingPrefix() + mappingFull);
         indexFlsTestDocument(INDEX_FULL_MAPPING, 1, 30.0, "marketing", 300000L, "2022-03-01", "10.0.0.3");
         indexFlsTestDocument(INDEX_FULL_MAPPING, 2, 40.0, "support", 400000L, "2021-11-20", "10.0.0.4");
         refresh(INDEX_FULL_MAPPING);

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class EsqlSecurityIT extends ESRestTestCase {
-    private static final String INDEX_PARTIAL_MAPPING = "index-partial-mapping";
+    protected static final String INDEX_PARTIAL_MAPPING = "index-partial-mapping";
     private static final String INDEX_FULL_MAPPING = "index-full-mapping";
     private static final String SECURITY_IT_SHARED_DATASOURCE = "security_it_shared_ds";
     private static final String SECURITY_IT_OTHER_DATASOURCE = "other_tenant_ds";
@@ -164,6 +164,25 @@ public class EsqlSecurityIT extends ESRestTestCase {
         client().performRequest(indexDoc);
     }
 
+    /**
+     * Settings applied to the source-bearing FLS indices ({@code index}, {@code index-user*}, {@code indexpartial},
+     * {@link #INDEX_PARTIAL_MAPPING}, {@link #INDEX_FULL_MAPPING}). Defaults to {@link Settings#EMPTY} (standard, stored
+     * {@code _source}). Subclasses override this to rerun the whole FLS suite over a synthetic-source / {@code _ignored_source}
+     * index mode (e.g. {@code logsdb}, {@code logsdb_columnar}) and prove FLS parity across storage layouts. The {@code lookup-*}
+     * indices are intentionally excluded — {@code index.mode=lookup} cannot combine with logsdb.
+     */
+    protected Settings flsIndexSettings() {
+        return Settings.EMPTY;
+    }
+
+    /**
+     * Disables the data-stream {@code @timestamp} metadata field that logsdb / logsdb_columnar enable by default, so the shared
+     * timestamp-less test documents index unchanged. A no-op in standard mode, where the field is already disabled.
+     */
+    protected String flsMappingPrefix() {
+        return "\"_data_stream_timestamp\":{\"enabled\":false},";
+    }
+
     @Before
     public void indexDocuments() throws IOException {
         Settings lookupSettings = Settings.builder().put("index.mode", "lookup").build();
@@ -171,22 +190,22 @@ public class EsqlSecurityIT extends ESRestTestCase {
             "properties":{"value": {"type": "double"}, "org": {"type": "keyword"}, "other": {"type": "keyword"}}
             """;
 
-        createIndex("index", Settings.EMPTY, mapping);
+        createIndex("index", flsIndexSettings(), flsMappingPrefix() + mapping);
         indexDocument("index", 1, 10.0, "sales");
         indexDocument("index", 2, 20.0, "engineering");
         refresh("index");
 
-        createIndex("index-user1", Settings.EMPTY, mapping);
+        createIndex("index-user1", flsIndexSettings(), flsMappingPrefix() + mapping);
         indexDocument("index-user1", 1, 12.0, "engineering");
         indexDocument("index-user1", 2, 31.0, "sales");
         refresh("index-user1");
 
-        createIndex("index-user2", Settings.EMPTY, mapping);
+        createIndex("index-user2", flsIndexSettings(), flsMappingPrefix() + mapping);
         indexDocument("index-user2", 1, 32.0, "marketing");
         indexDocument("index-user2", 2, 40.0, "sales");
         refresh("index-user2");
 
-        createIndex("indexpartial", Settings.EMPTY, mapping);
+        createIndex("indexpartial", flsIndexSettings(), flsMappingPrefix() + mapping);
         indexDocument("indexpartial", 1, 32.0, "marketing");
         indexDocument("indexpartial", 2, 40.0, "sales");
         refresh("indexpartial");
@@ -201,7 +220,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         String mappingPartial = """
             "dynamic":"false","properties":{"value": {"type": "double"}}
             """;
-        createIndex(INDEX_PARTIAL_MAPPING, Settings.EMPTY, mappingPartial);
+        createIndex(INDEX_PARTIAL_MAPPING, flsIndexSettings(), flsMappingPrefix() + mappingPartial);
         indexFlsTestDocument(INDEX_PARTIAL_MAPPING, 1, 10.0, "sales", 100000L, "2024-01-01", "10.0.0.1");
         indexFlsTestDocument(INDEX_PARTIAL_MAPPING, 2, 20.0, "engineering", 200000L, "2023-06-15", "10.0.0.2");
         refresh(INDEX_PARTIAL_MAPPING);
@@ -210,7 +229,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             "properties":{"value":{"type":"double"},"org":{"type":"keyword"},"salary":{"type":"long"},\
             "hire_date":{"type":"date"},"ip_addr":{"type":"ip"}}
             """;
-        createIndex(INDEX_FULL_MAPPING, Settings.EMPTY, mappingFull);
+        createIndex(INDEX_FULL_MAPPING, flsIndexSettings(), flsMappingPrefix() + mappingFull);
         indexFlsTestDocument(INDEX_FULL_MAPPING, 1, 30.0, "marketing", 300000L, "2022-03-01", "10.0.0.3");
         indexFlsTestDocument(INDEX_FULL_MAPPING, 2, 40.0, "support", 400000L, "2021-11-20", "10.0.0.4");
         refresh(INDEX_FULL_MAPPING);

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbColumnarIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbColumnarIT.java
@@ -31,8 +31,17 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 public class EsqlSecurityLogsdbColumnarIT extends EsqlSecurityIT {
 
     @Override
-    protected Settings flsIndexSettings() {
+    protected Settings indexSettings() {
         return Settings.builder().put("index.mode", "logsdb_columnar").build();
+    }
+
+    /**
+     * Disables the data-stream {@code @timestamp} metadata field that logsdb_columnar enables by default, so the shared
+     * timestamp-less test documents index unchanged.
+     */
+    @Override
+    protected String mappingPrefix() {
+        return "\"_data_stream_timestamp\":{\"enabled\":false},";
     }
 
     /**

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbColumnarIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbColumnarIT.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Reruns the {@link EsqlSecurityIT} field-level-security suite with the FLS indices in {@code logsdb_columnar} mode. The
+ * {@code logsdb} counterpart is {@link EsqlSecurityLogsdbIT}; see its javadoc for why the two modes are separate single-mode classes.
+ *
+ * <p>Columnar has two documented design differences that the overrides below assert per-mode:
+ * <ol>
+ *   <li>It disables auto-text, so a dynamically-mapped string is a {@code keyword} rather than {@code text}.</li>
+ *   <li>It drops {@code dynamic:false} unmapped fields at index time, so they load as null for every user.</li>
+ * </ol>
+ */
+public class EsqlSecurityLogsdbColumnarIT extends EsqlSecurityIT {
+
+    @Override
+    protected Settings flsIndexSettings() {
+        return Settings.builder().put("index.mode", "logsdb_columnar").build();
+    }
+
+    /**
+     * Columnar disables auto-text, so the dynamically-mapped {@code partial} string is a {@code keyword} rather than {@code text};
+     * the value is unchanged.
+     */
+    @Override
+    public void testFieldLevelSecurityAllow() throws Exception {
+        Response resp = runESQLCommand("fls_user", "FROM index* | SORT value | LIMIT 1");
+        assertOK(resp);
+        assertMap(
+            entityAsMap(resp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "partial").entry("type", "keyword"),
+                        matchesMap().entry("name", "value").entry("type", "double")
+                    )
+                )
+                .entry("values", List.of(List.of("sales10.0", 10.0)))
+        );
+    }
+
+    /**
+     * Columnar types {@code partial} as {@code keyword}; sorting a keyword rather than a text field also flips which row {@code LIMIT 1}
+     * keeps.
+     */
+    @Override
+    public void testFieldLevelSecurityAllowPartial() throws Exception {
+        Response resp = runESQLCommand("fls_user", "FROM index* | SORT partial | LIMIT 1");
+        assertOK(resp);
+        assertMap(
+            entityAsMap(resp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "partial").entry("type", "keyword"),
+                        matchesMap().entry("name", "value").entry("type", "double")
+                    )
+                )
+                .entry("values", List.of(List.of("sales10.0", 10.0)))
+        );
+    }
+
+    /**
+     * Columnar drops the {@code dynamic:false} unmapped fields at index time, so they load as null for every user - including the
+     * admin, who sees real values under standard/logsdb source. The FLS-restricted users already expect null, so only the admin
+     * response diverges from the base assertion.
+     */
+    @Override
+    public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoad() throws Exception {
+        String query = "SET unmapped_fields=\"load\"; FROM "
+            + INDEX_PARTIAL_MAPPING
+            + " | KEEP value, org, salary, hire_date, ip_addr | SORT value | LIMIT 10";
+        var expectedColumns = List.of(
+            matchesMap().entry("name", "value").entry("type", "double"),
+            matchesMap().entry("name", "org").entry("type", "keyword"),
+            matchesMap().entry("name", "salary").entry("type", "keyword"),
+            matchesMap().entry("name", "hire_date").entry("type", "keyword"),
+            matchesMap().entry("name", "ip_addr").entry("type", "keyword")
+        );
+
+        // Admin: the unmapped fields were dropped at index time, so they come back null despite the JSON having contained values.
+        Response adminResp = runESQLCommand("test-admin", query);
+        assertOK(adminResp);
+        assertMap(
+            entityAsMap(adminResp),
+            matchesMap().extraOk()
+                .entry("columns", expectedColumns)
+                .entry("values", List.of(Arrays.asList(10.0, null, null, null, null), Arrays.asList(20.0, null, null, null, null)))
+        );
+
+        Response noSourceResp = runESQLCommand("fls_partial_no_source_user", query);
+        assertOK(noSourceResp);
+        assertMap(
+            entityAsMap(noSourceResp),
+            matchesMap().extraOk()
+                .entry("columns", expectedColumns)
+                .entry("values", List.of(Arrays.asList(10.0, null, null, null, null), Arrays.asList(20.0, null, null, null, null)))
+        );
+
+        Response noSourceNoValueResp = runESQLCommand("fls_no_source_no_value_user", query);
+        assertOK(noSourceNoValueResp);
+        assertMap(
+            entityAsMap(noSourceNoValueResp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "value").entry("type", "keyword"),
+                        matchesMap().entry("name", "org").entry("type", "keyword"),
+                        matchesMap().entry("name", "salary").entry("type", "keyword"),
+                        matchesMap().entry("name", "hire_date").entry("type", "keyword"),
+                        matchesMap().entry("name", "ip_addr").entry("type", "keyword")
+                    )
+                )
+                .entry("values", List.of(Arrays.asList(null, null, null, null, null), Arrays.asList(null, null, null, null, null)))
+        );
+    }
+
+    /**
+     * Cast variant of {@link #testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoad}: columnar drops the {@code dynamic:false}
+     * unmapped fields at index time, so even the admin's cast columns come back null. The restricted user already expects null.
+     */
+    @Override
+    public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoadAndCast() throws Exception {
+        String query = "SET unmapped_fields=\"load\"; FROM "
+            + INDEX_PARTIAL_MAPPING
+            + " | EVAL salary = salary::long, hire_date = hire_date::date, ip_addr = ip_addr::ip "
+            + "| KEEP value, salary, hire_date, ip_addr | SORT value | LIMIT 10";
+        var expectedColumns = List.of(
+            matchesMap().entry("name", "value").entry("type", "double"),
+            matchesMap().entry("name", "salary").entry("type", "long"),
+            matchesMap().entry("name", "hire_date").entry("type", "date"),
+            matchesMap().entry("name", "ip_addr").entry("type", "ip")
+        );
+
+        Response adminResp = runESQLCommand("test-admin", query);
+        assertOK(adminResp);
+        assertMap(
+            entityAsMap(adminResp),
+            matchesMap().extraOk()
+                .entry("columns", expectedColumns)
+                .entry("values", List.of(Arrays.asList(10.0, null, null, null), Arrays.asList(20.0, null, null, null)))
+        );
+
+        Response restrictedResp = runESQLCommand("fls_partial_no_source_user", query);
+        assertOK(restrictedResp);
+        assertMap(
+            entityAsMap(restrictedResp),
+            matchesMap().extraOk()
+                .entry("columns", expectedColumns)
+                .entry("values", List.of(Arrays.asList(10.0, null, null, null), Arrays.asList(20.0, null, null, null)))
+        );
+    }
+
+    /**
+     * Columnar drops the {@code dynamic:false} unmapped {@code org} at index time, so the admin sees null where standard/logsdb
+     * source yields "sales"/"engineering". The restricted user already expects null for both the denied {@code value} and {@code org}.
+     */
+    @Override
+    public void testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoad() throws Exception {
+        String query = "SET unmapped_fields=\"load\"; FROM " + INDEX_PARTIAL_MAPPING + " | KEEP value, org | SORT value | LIMIT 10";
+
+        Response adminResp = runESQLCommand("test-admin", query);
+        assertOK(adminResp);
+        assertMap(
+            entityAsMap(adminResp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "value").entry("type", "double"),
+                        matchesMap().entry("name", "org").entry("type", "keyword")
+                    )
+                )
+                .entry("values", List.of(Arrays.asList(10.0, null), Arrays.asList(20.0, null)))
+        );
+
+        Response restrictedResp = runESQLCommand("fls_deny_value_org_user", query);
+        assertOK(restrictedResp);
+        assertMap(
+            entityAsMap(restrictedResp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "value").entry("type", "keyword"),
+                        matchesMap().entry("name", "org").entry("type", "keyword")
+                    )
+                )
+                .entry("values", List.of(Arrays.asList(null, null), Arrays.asList(null, null)))
+        );
+    }
+
+    /**
+     * Columnar drops the {@code dynamic:false} unmapped fields at index time, so {@code LOAD_ALL} only surfaces the mapped
+     * {@code value} plus the {@code salary} that {@code SORT} references (as null); the default {@code @timestamp} column is dropped.
+     * The FLS-denied {@code value} and {@code org} still never appear for the restricted user.
+     */
+    @Override
+    public void testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll() throws Exception {
+        String query = "SET unmapped_fields=\"LOAD_ALL\"; FROM " + INDEX_PARTIAL_MAPPING + " | SORT salary | LIMIT 10 | DROP @timestamp";
+
+        // SORT salary is a no-op on all-null values, so the two admin rows come back in an unspecified order.
+        Response adminResp = runESQLCommand("test-admin", query);
+        assertOK(adminResp);
+        Map<String, Object> adminMap = entityAsMap(adminResp);
+        assertMap(
+            adminMap,
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "value").entry("type", "double"),
+                        matchesMap().entry("name", "salary").entry("type", "keyword")
+                    )
+                )
+        );
+        @SuppressWarnings("unchecked")
+        List<List<Object>> adminValues = (List<List<Object>>) adminMap.get("values");
+        assertThat(adminValues, containsInAnyOrder(Arrays.asList(10.0, null), Arrays.asList(20.0, null)));
+
+        Response restrictedResp = runESQLCommand("fls_deny_value_org_user", query);
+        assertOK(restrictedResp);
+        assertMap(
+            entityAsMap(restrictedResp),
+            matchesMap().extraOk()
+                .entry("columns", List.of(matchesMap().entry("name", "salary").entry("type", "keyword")))
+                .entry("values", List.of(Arrays.asList((Object) null), Arrays.asList((Object) null)))
+        );
+    }
+}

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
@@ -23,7 +23,7 @@ import static org.elasticsearch.test.MapMatcher.matchesMap;
  * rather than one {@code @ParametersFactory} because behavior differs between the two index modes - notably, {@code logsdb_columnar}
  * drops {@code dynamic:false} unmapped fields at index time.
  *
- * <p>Two tracked FLS x synthetic-source bugs are muted for this class in {@code muted-tests.yml}:
+ * <p>Two tracked FLS x synthetic-source bugs are disabled for this class via {@code @AwaitsFix} overrides at the bottom of the file:
  * <ol>
  *   <li>FLS drops the keyword synthetic-source delegate so a granted text field reconstructs to null (elastic/security#6714).</li>
  *   <li>{@code except:_source} fails to strip values reconstructed from {@code _ignored_source} (elastic/security#13332).</li>
@@ -32,8 +32,17 @@ import static org.elasticsearch.test.MapMatcher.matchesMap;
 public class EsqlSecurityLogsdbIT extends EsqlSecurityIT {
 
     @Override
-    protected Settings flsIndexSettings() {
+    protected Settings indexSettings() {
         return Settings.builder().put("index.mode", "logsdb").build();
+    }
+
+    /**
+     * Disables the data-stream {@code @timestamp} metadata field that logsdb enables by default, so the shared timestamp-less test
+     * documents index unchanged.
+     */
+    @Override
+    protected String mappingPrefix() {
+        return "\"_data_stream_timestamp\":{\"enabled\":false},";
     }
 
     /**
@@ -85,4 +94,40 @@ public class EsqlSecurityLogsdbIT extends EsqlSecurityIT {
                 .entry("values", List.of(List.of("100000", "2024-01-01", "10.0.0.1"), List.of("200000", "2023-06-15", "10.0.0.2")))
         );
     }
+
+    // FLS drops the keyword synthetic-source delegate so a granted text field reconstructs to null (elastic/security#6714).
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    public void testFieldLevelSecurityAllow() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    public void testFieldLevelSecurityAllowPartial() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    public void testFieldLevelSecurityPartiallyUnmappedLoad() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    public void testFieldLevelSecurityPartiallyUnmappedNullify() throws Exception {}
+
+    // except:_source fails to strip values reconstructed from _ignored_source (elastic/security#13332).
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    public void testFieldLevelSecuritySourceDisabledMultiIndex() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    public void testFieldLevelSecuritySourceDisabledMultiIndexPartialMappingNonKeyword() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoad() throws Exception {}
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoadAndCast() throws Exception {}
 }

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql;
+
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+
+/**
+ * Reruns the entire {@link EsqlSecurityIT} field-level-security suite with the FLS indices in {@code logsdb} mode, proving that ESQL
+ * FLS enforcement is identical whether {@code _source} is stored or reconstructed from doc values / {@code _ignored_source}.
+ *
+ * <p>The {@code logsdb_columnar} counterpart lives in {@link EsqlSecurityLogsdbColumnarIT}; the two are separate single-mode classes
+ * rather than one {@code @ParametersFactory} because behavior differs between the two index modes - notably, {@code logsdb_columnar}
+ * drops {@code dynamic:false} unmapped fields at index time.
+ *
+ * <p>Two tracked FLS x synthetic-source bugs are muted for this class in {@code muted-tests.yml}:
+ * <ol>
+ *   <li>FLS drops the keyword synthetic-source delegate so a granted text field reconstructs to null (elastic/security#6714).</li>
+ *   <li>{@code except:_source} fails to strip values reconstructed from {@code _ignored_source} (elastic/security#13332).</li>
+ * </ol>
+ */
+public class EsqlSecurityLogsdbIT extends EsqlSecurityIT {
+
+    @Override
+    protected Settings flsIndexSettings() {
+        return Settings.builder().put("index.mode", "logsdb").build();
+    }
+
+    /**
+     * Override this test because LOAD_ALL surfaces an extra empty {@code @timestamp} column. We must drop this field in order to line up
+     * the columns with the base run.
+     */
+    @Override
+    public void testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll() throws Exception {
+        // drop timestamp as described in the javadoc
+        String query = "SET unmapped_fields=\"LOAD_ALL\"; FROM " + INDEX_PARTIAL_MAPPING + " | SORT salary | LIMIT 10 | DROP @timestamp";
+
+        Response adminResp = runESQLCommand("test-admin", query);
+        assertOK(adminResp);
+        assertMap(
+            entityAsMap(adminResp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "value").entry("type", "double"),
+                        matchesMap().entry("name", "salary").entry("type", "keyword"),
+                        matchesMap().entry("name", "hire_date").entry("type", "keyword"),
+                        matchesMap().entry("name", "ip_addr").entry("type", "keyword"),
+                        matchesMap().entry("name", "org").entry("type", "keyword")
+                    )
+                )
+                .entry(
+                    "values",
+                    List.of(
+                        List.of(10.0, "100000", "2024-01-01", "10.0.0.1", "sales"),
+                        List.of(20.0, "200000", "2023-06-15", "10.0.0.2", "engineering")
+                    )
+                )
+        );
+
+        Response restrictedResp = runESQLCommand("fls_deny_value_org_user", query);
+        assertOK(restrictedResp);
+        assertMap(
+            entityAsMap(restrictedResp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "salary").entry("type", "keyword"),
+                        matchesMap().entry("name", "hire_date").entry("type", "keyword"),
+                        matchesMap().entry("name", "ip_addr").entry("type", "keyword")
+                    )
+                )
+                .entry("values", List.of(List.of("100000", "2024-01-01", "10.0.0.1"), List.of("200000", "2023-06-15", "10.0.0.2")))
+        );
+    }
+}

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityLogsdbIT.java
@@ -95,39 +95,39 @@ public class EsqlSecurityLogsdbIT extends EsqlSecurityIT {
         );
     }
 
-    // FLS drops the keyword synthetic-source delegate so a granted text field reconstructs to null (elastic/security#6714).
+    // FLS drops the keyword synthetic-source delegate so a granted text field reconstructs to null
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecurityAllow() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecurityAllowPartial() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecurityPartiallyUnmappedLoad() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/6714")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecurityPartiallyUnmappedNullify() throws Exception {}
 
-    // except:_source fails to strip values reconstructed from _ignored_source (elastic/security#13332).
+    // except:_source fails to strip values reconstructed from _ignored_source
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecuritySourceDisabledMultiIndex() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecuritySourceDisabledMultiIndexPartialMappingNonKeyword() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoad() throws Exception {}
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/security/issues/13332")
+    @AwaitsFix(bugUrl = "TODO")
     public void testFieldLevelSecuritySourceDisabledWithUnmappedFieldsLoadAndCast() throws Exception {}
 }


### PR DESCRIPTION
This is a continuation of https://github.com/elastic/elasticsearch/pull/156341.

Currently, we don't have much test coverage around FLS with synthetic source (in logsdb and logsdb_columnar). This PR adds coverage for the ESQL side of things. https://github.com/elastic/elasticsearch/pull/156341 already added coverage for search.