### PR TITLE
[9.5] Count failed msearch sub-search responses against the circuit breaker (#156683)

### DIFF
--- a/docs/changelog/156683.yaml
+++ b/docs/changelog/156683.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 156683
+summary: Count failed msearch sub-search responses against the circuit breaker
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/50_circuit_breaker.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/50_circuit_breaker.yml
@@ -218,6 +218,8 @@ teardown:
           - { query: { match_all: {} }, size: 80 }
           - index: msearch-cb-test
           - { query: { match_all: {} }, size: 80 }
+          - index: msearch-cb-test-missing
+          - { query: { match_all: {} } }
 
   # Sub-search 0 completes normally.
   - match: { responses.0.status: 200 }
@@ -225,3 +227,6 @@ teardown:
   # Sub-search 1 is rejected by the circuit breaker; the overall request still returns HTTP 200.
   - match: { responses.1.status: 429 }
   - match: { responses.1.error.type: circuit_breaking_exception }
+  # Sub-search 2 fails independently (missing index) and is still returned correctly.
+  - match: { responses.2.status: 404 }
+  - match: { responses.2.error.type: index_not_found_exception }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
@@ -53,7 +53,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class MultiSearchIT extends ESIntegTestCase {
 
@@ -117,11 +116,7 @@ public class MultiSearchIT extends ESIntegTestCase {
         ensureGreen(index);
 
         assertBusy(
-            () -> assertThat(
-                "request breaker should be at baseline before msearch",
-                requestBreakerEstimated(coordinatorNode),
-                lessThanOrEqualTo(0L)
-            )
+            () -> assertThat("request breaker should be at baseline before msearch", requestBreakerEstimated(coordinatorNode), equalTo(0L))
         );
         long baseline = requestBreakerEstimated(coordinatorNode);
 
@@ -166,7 +161,39 @@ public class MultiSearchIT extends ESIntegTestCase {
             () -> assertThat(
                 "request breaker should return to baseline after msearch completes",
                 requestBreakerEstimated(coordinatorNode),
-                lessThanOrEqualTo(baseline)
+                equalTo(baseline)
+            )
+        );
+    }
+
+    public void testBreakerAccountingEndToEndOnFailure() throws Exception {
+        String coordinatorNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        assumeFalse("coordinator uses a noop request breaker, skipping test", noopBreakerUsed(coordinatorNode));
+
+        int numSearches = 10;
+
+        assertBusy(
+            () -> assertThat("request breaker should be at baseline before msearch", requestBreakerEstimated(coordinatorNode), equalTo(0L))
+        );
+        long baseline = requestBreakerEstimated(coordinatorNode);
+
+        MultiSearchRequest request = new MultiSearchRequest();
+        var coordinatorClient = internalCluster().client(coordinatorNode);
+        for (int i = 0; i < numSearches; i++) {
+            request.add(coordinatorClient.prepareSearch("msearch-breaker-it-missing-" + i).request());
+        }
+        assertResponse(coordinatorClient.multiSearch(request), response -> {
+            assertThat(response.getResponses().length, equalTo(numSearches));
+            for (Item item : response) {
+                assertTrue(item.isFailure());
+            }
+        });
+
+        assertBusy(
+            () -> assertThat(
+                "request breaker should return to baseline after an all-failure msearch completes",
+                requestBreakerEstimated(coordinatorNode),
+                equalTo(baseline)
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -160,6 +160,9 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
      */
     static final long SERIALISED_BYTES_FAILURE_FALLBACK = 1024L;
 
+    /** Fixed overhead for a failure {@code MultiSearchResponse.Item} shell plus its array slot. */
+    static final long BASE_FAILURE_ITEM_OVERHEAD = 64L;
+
     private final int allocatedProcessors;
     private final ClusterService clusterService;
     private final LongSupplier relativeTimeProvider;
@@ -232,8 +235,8 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         final AtomicArray<MultiSearchResponse.Item> responses = new AtomicArray<>(numRequests);
         final AtomicInteger responseCounter = new AtomicInteger(numRequests);
         // Each completed sub-search stays in {@code responses} until the last one finishes. Incremental bytes (hits,
-        // suggest, etc.) are reserved here; query-phase aggregation bytes are handed off from {@link QueryPhaseResultConsumer}
-        // and released together when the combined {@link MultiSearchResponse} is delivered.
+        // suggest, etc.) and failure-item bytes are reserved here; query-phase aggregation bytes are handed off from
+        // {@link QueryPhaseResultConsumer} and released together when the combined {@link MultiSearchResponse} is delivered.
         final MultiSearchBreakerAccounting breakerAccounting = new MultiSearchBreakerAccounting();
         final ActionListener<MultiSearchResponse> breakerReleasingListener = ActionListener.runAfter(
             listener,
@@ -326,17 +329,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             }
         }
 
-        ShardSearchFailure[] failures = response.getShardFailures();
-        for (ShardSearchFailure failure : failures) {
-            bytes += PER_SHARD_FAILURE_OVERHEAD + estimateExceptionBytes(failure.getCause());
-            // reason() is ExceptionsHelper.stackTrace(e) — the full stack trace as a formatted String.
-            // It duplicates information in the cause but is a distinct heap object and can be large
-            // for deep stacks, so it must be counted explicitly.
-            String reason = failure.reason();
-            if (reason != null) {
-                bytes += RamUsageEstimator.sizeOf(reason);
-            }
-        }
+        bytes += estimateShardFailureBytes(response.getShardFailures());
 
         Suggest suggest = response.getSuggest();
         if (suggest != null) {
@@ -428,6 +421,36 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         bytes += estimateExceptionBytes(t.getCause(), depthRemaining - 1);
         for (Throwable suppressed : t.getSuppressed()) {
             bytes += estimateExceptionBytes(suppressed, depthRemaining - 1);
+        }
+        return bytes;
+    }
+
+    /**
+     * Estimates coordinator heap for a {@link ShardSearchFailure} array, including
+     * {@link ShardSearchFailure#reason()} — a distinct heap object duplicating the cause chain.
+     */
+    private static long estimateShardFailureBytes(ShardSearchFailure[] failures) {
+        long bytes = 0;
+        for (ShardSearchFailure failure : failures) {
+            bytes += PER_SHARD_FAILURE_OVERHEAD + estimateExceptionBytes(failure.getCause());
+            String reason = failure.reason();
+            if (reason != null) {
+                bytes += RamUsageEstimator.sizeOf(reason);
+            }
+        }
+        return bytes;
+    }
+
+    /**
+     * Estimates coordinator heap for a failure {@link MultiSearchResponse.Item}: {@link #estimateExceptionBytes}
+     * plus, for {@link SearchPhaseExecutionException}, its {@code shardFailures} — held in a distinct field
+     * not reachable through the cause chain, so it must be walked explicitly via {@link #estimateShardFailureBytes}.
+     */
+    public static long estimateFailureBytes(Exception e) {
+        long bytes = BASE_FAILURE_ITEM_OVERHEAD;
+        bytes += estimateExceptionBytes(e);
+        if (e instanceof SearchPhaseExecutionException spee) {
+            bytes += estimateShardFailureBytes(spee.shardFailures());
         }
         return bytes;
     }
@@ -623,7 +646,10 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
                 handleResponse(request.responseSlot, new MultiSearchResponse.Item(null, e));
             }
 
-            private void handleResponse(final int responseSlot, final MultiSearchResponse.Item item) {
+            private void handleResponse(final int responseSlot, MultiSearchResponse.Item item) {
+                if (item.isFailure()) {
+                    item = accountOrSubstituteFailureItem(breakerAccounting, item);
+                }
                 responses.set(responseSlot, item);
                 if (responseCounter.decrementAndGet() == 0) {
                     assert requests.isEmpty();
@@ -659,6 +685,53 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         return false;
     }
 
+    /**
+     * Reserves breaker bytes for a failure item. A failure item can't simply be discarded like an
+     * over-sized response can, but its size (e.g. a {@link SearchPhaseExecutionException} with many
+     * {@link ShardSearchFailure} entries) is unbounded, so a genuine trip is handled by substituting the
+     * small, bounded {@link CircuitBreakingException} itself via {@link #accountBoundedFailureSubstitute}
+     * instead of force-adding the original. Any other exception is treated as a breaker bug rather than a
+     * legitimate trip: it's logged, and the original bytes are force-added so a defect here can't hang
+     * the msearch.
+     */
+    private MultiSearchResponse.Item accountOrSubstituteFailureItem(
+        MultiSearchBreakerAccounting breakerAccounting,
+        MultiSearchResponse.Item item
+    ) {
+        long bytes = estimateFailureBytes(item.getFailure());
+        try {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, "<msearch_failure>");
+        } catch (CircuitBreakingException tripped) {
+            return accountBoundedFailureSubstitute(breakerAccounting, tripped);
+        } catch (Exception unexpected) {
+            logger.warn("msearch circuit breaker: failed to reserve bytes for failure item", unexpected);
+            circuitBreaker.addWithoutBreaking(bytes);
+            breakerAccounting.add(bytes, 0);
+            return item;
+        }
+        breakerAccounting.add(bytes, 0);
+        return item;
+    }
+
+    /**
+     * Accounts for a small, bounded {@link CircuitBreakingException} substituted for a failure item that
+     * didn't fit. If even this substitute doesn't fit, it's force-added rather than dropped: not risk-free,
+     * but its size is capped, unlike the original's, so forcing it through risks far less overshoot.
+     */
+    private MultiSearchResponse.Item accountBoundedFailureSubstitute(
+        MultiSearchBreakerAccounting breakerAccounting,
+        CircuitBreakingException substitute
+    ) {
+        long substituteBytes = estimateFailureBytes(substitute);
+        try {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(substituteBytes, "<msearch_failure>");
+        } catch (CircuitBreakingException stillTripped) {
+            circuitBreaker.addWithoutBreaking(substituteBytes);
+        }
+        breakerAccounting.add(substituteBytes, 0);
+        return new MultiSearchResponse.Item(null, substitute);
+    }
+
     record SearchRequestSlot(SearchRequest request, int responseSlot) {
 
     }
@@ -666,6 +739,8 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
     /**
      * Tracks REQUEST breaker bytes reserved while sub-search responses are buffered: incremental estimates from
      * {@link #estimateActualBytes} plus query-phase aggregation bytes handed off from {@link QueryPhaseResultConsumer}.
+     * Also tracks bytes reserved for failure items via {@link #accountOrSubstituteFailureItem}, whether from a genuine
+     * sub-search failure or from a {@link CircuitBreakingException} substituted for an over-sized item.
      */
     final class MultiSearchBreakerAccounting {
         private final AtomicLong incrementalBytes = new AtomicLong();

--- a/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
@@ -73,12 +73,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
@@ -551,6 +554,29 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         assertThat(deepBytes - shallowBytes, equalTo(expectedFrameDelta));
     }
 
+    public void testEstimateFailureBytesIncludesShardFailures() {
+        RuntimeException bare = new RuntimeException("bare failure, no shard detail");
+        long bareBytes = TransportMultiSearchAction.estimateFailureBytes(bare);
+
+        SearchPhaseExecutionException fewFailures = searchPhaseExecutionExceptionWithShardFailures(4);
+        long fewFailuresBytes = TransportMultiSearchAction.estimateFailureBytes(fewFailures);
+        assertThat(fewFailuresBytes, greaterThan(bareBytes));
+
+        SearchPhaseExecutionException manyFailures = searchPhaseExecutionExceptionWithShardFailures(28);
+        long manyFailuresBytes = TransportMultiSearchAction.estimateFailureBytes(manyFailures);
+        assertThat("estimate should scale with shard failure count", manyFailuresBytes, greaterThan(fewFailuresBytes));
+    }
+
+    public void testEstimateFailureBytesIsAtLeastActualHeap() {
+        SearchPhaseExecutionException failure = searchPhaseExecutionExceptionWithShardFailures(5);
+        long estimate = TransportMultiSearchAction.estimateFailureBytes(failure);
+        long measured = RamUsageEstimator.sizeOfObject(failure);
+        assertTrue(
+            "estimateFailureBytes (" + estimate + ") must not under-count RamUsageEstimator (" + measured + ")",
+            estimate >= measured
+        );
+    }
+
     public void testEstimateSuggest() throws Exception {
         TermSuggestion termSuggestion = new TermSuggestion("my-suggest", 5, SortBy.SCORE);
         // Suggest sorts the list in-place, so it must be mutable.
@@ -735,13 +761,21 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
     public void testBreakerReleasedOnSubSearchFailure() throws Exception {
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1);
-        AtomicInteger call = new AtomicInteger();
+        Exception failure = searchPhaseExecutionExceptionWithShardFailures(5);
+        long failureBytes = TransportMultiSearchAction.estimateFailureBytes(failure);
         SearchResponse emptyResponse = SearchResponse.emptyResponseBuilder().tookInMillis(1L).build();
         try {
             long perResponseBytes = TransportMultiSearchAction.estimateActualBytes(emptyResponse);
-            runMsearchWithBreaker(breaker, 2, () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(), call);
+            runMsearchWithBreaker(
+                breaker,
+                2,
+                () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+                index -> index == 0,
+                () -> failure,
+                null
+            );
             assertThat(breaker.getUsed(), equalTo(0L));
-            assertThat(breaker.totalReserved(), equalTo(perResponseBytes));
+            assertThat(breaker.totalReserved(), equalTo(perResponseBytes + failureBytes));
         } finally {
             emptyResponse.decRef();
         }
@@ -840,6 +874,136 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
+    public void testBreakerAccountsFailureItems() throws Exception {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1);
+        int numRequests = 4;
+        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
+        AtomicLong usedWhilePending = new AtomicLong(-1);
+        runMsearchWithBreaker(
+            breaker,
+            numRequests,
+            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+            index -> true,
+            () -> searchPhaseExecutionExceptionWithShardFailures(3),
+            captured -> {
+                System.arraycopy(captured, 0, items, 0, numRequests);
+                usedWhilePending.set(breaker.getUsed());
+            }
+        );
+        long expectedTotal = 0;
+        for (MultiSearchResponse.Item item : items) {
+            assertTrue(item.isFailure());
+            expectedTotal += TransportMultiSearchAction.estimateFailureBytes(item.getFailure());
+        }
+        assertThat(usedWhilePending.get(), equalTo(expectedTotal));
+        assertThat(breaker.getUsed(), equalTo(0L));
+        assertThat(breaker.totalReserved(), equalTo(expectedTotal));
+    }
+
+    public void testBreakerAccountsCircuitBreakingFailureItem() throws Exception {
+        int tripOn = 2;
+        int numRequests = 3;
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(tripOn);
+        SearchResponse emptyResponse = SearchResponse.emptyResponseBuilder().tookInMillis(1L).build();
+        long perResponseBytes;
+        try {
+            perResponseBytes = TransportMultiSearchAction.estimateActualBytes(emptyResponse);
+        } finally {
+            emptyResponse.decRef();
+        }
+        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
+        AtomicLong usedWhilePending = new AtomicLong(-1);
+        runMsearchWithBreaker(
+            breaker,
+            numRequests,
+            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+            null,
+            null,
+            captured -> {
+                System.arraycopy(captured, 0, items, 0, numRequests);
+                usedWhilePending.set(breaker.getUsed());
+            }
+        );
+        assertTrue(items[1].isFailure());
+        assertThat(items[1].getFailure(), instanceOf(CircuitBreakingException.class));
+        long cbeItemBytes = TransportMultiSearchAction.estimateFailureBytes(items[1].getFailure());
+
+        assertThat(usedWhilePending.get(), equalTo(2 * perResponseBytes + cbeItemBytes));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testAllSubSearchesFailStillTripsBreaker() throws Exception {
+        int numRequests = 20;
+        int numOriginalFailuresKept = 2;
+
+        MultiSearchResponse.Item[] uncappedItems = new MultiSearchResponse.Item[numRequests];
+        runMsearchWithBreaker(
+            new TrackingCircuitBreaker(-1),
+            numRequests,
+            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+            index -> true,
+            () -> searchPhaseExecutionExceptionWithShardFailures(10),
+            captured -> System.arraycopy(captured, 0, uncappedItems, 0, numRequests)
+        );
+        long originalFailureBytes = TransportMultiSearchAction.estimateFailureBytes(uncappedItems[0].getFailure());
+
+        long byteLimit = numOriginalFailuresKept * originalFailureBytes;
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(byteLimit);
+        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
+        runMsearchWithBreaker(
+            breaker,
+            numRequests,
+            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+            index -> true,
+            () -> searchPhaseExecutionExceptionWithShardFailures(10),
+            captured -> System.arraycopy(captured, 0, items, 0, numRequests)
+        );
+
+        for (int i = 0; i < items.length; i++) {
+            assertTrue(items[i].isFailure());
+            if (i < numOriginalFailuresKept) {
+                assertThat(items[i].getFailure(), instanceOf(SearchPhaseExecutionException.class));
+            } else {
+                assertThat(items[i].getFailure(), instanceOf(CircuitBreakingException.class));
+            }
+        }
+        assertThat(breaker.largestAddWithoutBreaking(), allOf(greaterThan(0L), lessThan(originalFailureBytes)));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testAccountFailureItemSubstitutesBoundedExceptionWhenTripped() throws Exception {
+        // The failure that actually reaches accountOrSubstituteFailureItem() is somewhat bigger than this,
+        // since it's thrown from deeper inside the real action execution chain than the one built here, which
+        // adds more stack trace frames. That's fine here: we only need the limit to sit below the real failure's
+        // size to trip the breaker, not to match it exactly.
+        long largeFailureBytes = TransportMultiSearchAction.estimateFailureBytes(searchPhaseExecutionExceptionWithShardFailures(50));
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(largeFailureBytes);
+
+        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[1];
+        runMsearchWithBreaker(
+            breaker,
+            1,
+            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+            index -> true,
+            () -> searchPhaseExecutionExceptionWithShardFailures(50),
+            captured -> items[0] = captured[0]
+        );
+
+        assertTrue(items[0].isFailure());
+        assertThat(items[0].getFailure(), instanceOf(CircuitBreakingException.class));
+        assertThat(items[0].getFailure(), not(instanceOf(SearchPhaseExecutionException.class)));
+        assertThat(breaker.largestAddWithoutBreaking(), equalTo(0L));
+        assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    private static SearchPhaseExecutionException searchPhaseExecutionExceptionWithShardFailures(int numShardFailures) {
+        ShardSearchFailure[] failures = new ShardSearchFailure[numShardFailures];
+        for (int i = 0; i < numShardFailures; i++) {
+            failures[i] = new ShardSearchFailure(new RuntimeException("simulated shard failure " + i));
+        }
+        return new SearchPhaseExecutionException("query", "all shards failed", failures);
+    }
+
     private static SearchResponse responseWithHits(SearchHit... hits) {
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1f);
         SearchResponse response = SearchResponseUtils.response(searchHits).build();
@@ -849,23 +1013,25 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
     private void runMsearchWithBreaker(TrackingCircuitBreaker breaker, int numRequests, Supplier<SearchResponse> responseSupplier)
         throws Exception {
-        runMsearchWithBreaker(breaker, numRequests, responseSupplier, null, null);
+        runMsearchWithBreaker(breaker, numRequests, responseSupplier, null, null, null);
     }
 
     private void runMsearchWithBreaker(
         TrackingCircuitBreaker breaker,
         int numRequests,
         Supplier<SearchResponse> responseSupplier,
-        AtomicInteger failFirstSearch
+        IntPredicate failSearch,
+        Consumer<MultiSearchResponse.Item[]> responseItemsConsumer
     ) throws Exception {
-        runMsearchWithBreaker(breaker, numRequests, responseSupplier, failFirstSearch, null);
+        runMsearchWithBreaker(breaker, numRequests, responseSupplier, failSearch, null, responseItemsConsumer);
     }
 
     private void runMsearchWithBreaker(
         TrackingCircuitBreaker breaker,
         int numRequests,
         Supplier<SearchResponse> responseSupplier,
-        AtomicInteger failFirstSearch,
+        IntPredicate failSearch,
+        Supplier<Exception> failureSupplier,
         Consumer<MultiSearchResponse.Item[]> responseItemsConsumer
     ) throws Exception {
         Settings settings = Settings.builder().put("node.name", "msearch-breaker-test").build();
@@ -891,11 +1057,13 @@ public class TransportMultiSearchActionTests extends ESTestCase {
             for (int i = 0; i < numRequests; i++) {
                 multiSearchRequest.add(new SearchRequest());
             }
+            AtomicInteger callIndex = new AtomicInteger();
             NodeClient client = new NodeClient(settings, threadPool, TestProjectResolvers.alwaysThrow()) {
                 @Override
                 public void search(SearchRequest request, ActionListener<SearchResponse> listener) {
-                    if (failFirstSearch != null && failFirstSearch.getAndIncrement() == 0) {
-                        listener.onFailure(new RuntimeException("simulated failure"));
+                    if (failSearch != null && failSearch.test(callIndex.getAndIncrement())) {
+                        Exception failure = failureSupplier != null ? failureSupplier.get() : new RuntimeException("simulated failure");
+                        listener.onFailure(failure);
                         return;
                     }
                     SearchResponse response = responseSupplier.get();
@@ -939,18 +1107,29 @@ public class TransportMultiSearchActionTests extends ESTestCase {
     private static final class TrackingCircuitBreaker implements CircuitBreaker {
         private final AtomicLong used = new AtomicLong();
         private final AtomicLong totalReserved = new AtomicLong();
+        private final AtomicLong largestAddWithoutBreaking = new AtomicLong();
         private final AtomicInteger reservationCalls = new AtomicInteger();
         private final int tripOnCall;
+        private final long byteLimit;
 
         private final RuntimeException reservationRuntimeException;
 
         TrackingCircuitBreaker(int tripOnCall) {
-            this(tripOnCall, null);
+            this(tripOnCall, null, -1L);
         }
 
         TrackingCircuitBreaker(int tripOnCall, RuntimeException reservationRuntimeException) {
+            this(tripOnCall, reservationRuntimeException, -1L);
+        }
+
+        TrackingCircuitBreaker(long byteLimit) {
+            this(-1, null, byteLimit);
+        }
+
+        private TrackingCircuitBreaker(int tripOnCall, RuntimeException reservationRuntimeException, long byteLimit) {
             this.tripOnCall = tripOnCall;
             this.reservationRuntimeException = reservationRuntimeException;
+            this.byteLimit = byteLimit;
         }
 
         @Override
@@ -964,6 +1143,9 @@ public class TransportMultiSearchActionTests extends ESTestCase {
             if (tripOnCall >= 0 && reservationCalls.incrementAndGet() == tripOnCall) {
                 throw new CircuitBreakingException("tripped", getDurability());
             }
+            if (byteLimit >= 0 && used.get() + bytes > byteLimit) {
+                throw new CircuitBreakingException("tripped", getDurability());
+            }
             used.addAndGet(bytes);
             totalReserved.addAndGet(bytes);
         }
@@ -971,6 +1153,9 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         @Override
         public void addWithoutBreaking(long bytes) {
             used.addAndGet(bytes);
+            if (bytes > 0) {
+                largestAddWithoutBreaking.updateAndGet(current -> Math.max(current, bytes));
+            }
         }
 
         @Override
@@ -1008,6 +1193,10 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
         long totalReserved() {
             return totalReserved.get();
+        }
+
+        long largestAddWithoutBreaking() {
+            return largestAddWithoutBreaking.get();
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Count failed msearch sub-search responses against the circuit breaker (#156683)