### PR TITLE
[9.5] ES|QL:Fix Tdigest percentiles circuit breaker (#155586)

### DIFF
--- a/docs/changelog/155586.yaml
+++ b/docs/changelog/155586.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155586
+summary: ES|QL:Fix/tdigest percentiles circuit breaker
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -142,7 +142,8 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
                 final AbstractInternalTDigestPercentiles percentiles = (AbstractInternalTDigestPercentiles) aggregation;
                 if (percentiles.state != null) {
                     if (merged == null) {
-                        merged = HistogramUnionState.createUsingParamsFrom(percentiles.state);
+                        // Shard results use NOOP_BREAKER after deserialization; the accumulator matches.
+                        merged = HistogramUnionState.createUsingParamsFrom(percentiles.state, HistogramUnionState.NOOP_BREAKER);
                     }
                     merged = merge(merged, percentiles.state);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -12,6 +12,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.search.DoubleValues;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -87,7 +88,7 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         states = bigArrays.grow(states, bucket + 1);
         HistogramUnionState state = states.get(bucket);
         if (state == null) {
-            state = HistogramUnionState.create(HistogramUnionState.NOOP_BREAKER, executionHint, compression);
+            state = HistogramUnionState.create(context.breaker(), executionHint, compression);
             states.set(bucket, state);
         }
         return state;
@@ -105,8 +106,38 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         return states.get(bucketOrd);
     }
 
+    /**
+     * Removes and returns the state for {@code bucketOrd}, releasing its breaker bytes now while
+     * the context is still open. Returns {@code null} if the bucket was never collected or already taken.
+     */
+    @Nullable
+    protected final HistogramUnionState takeState(long bucketOrd) {
+        if (bucketOrd >= states.size()) {
+            return null;
+        }
+        HistogramUnionState state = states.get(bucketOrd);
+        states.set(bucketOrd, null);
+        if (state != null) {
+            context.breaker().addWithoutBreaking(-state.ramBytesUsed());
+        }
+        return state;
+    }
+
     @Override
     protected void doClose() {
+        // super() registers this in the constructor, super() called first, object exists
+        // so doClose can be called before the constructor of this class
+        // finishes and states could be null
+        if (states == null) {
+            return;
+        }
+        // doClose can be called before this constructor finishes (same reason states can be null
+        // above), so cleanup may run while an exception is already propagating. Using
+        // closeWhileHandlingException ensures a failure during cleanup never replaces the original
+        // exception, and still closes every element even if one fails.
+        for (long i = 0; i < states.size(); i++) {
+            Releasables.closeWhileHandlingException(states.get(i));
+        }
         Releasables.close(states);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HistogramUnionState.java
@@ -124,10 +124,19 @@ public class HistogramUnionState implements Releasable, Accountable {
     }
 
     public static HistogramUnionState createUsingParamsFrom(HistogramUnionState otherState) {
+        return createUsingParamsFrom(otherState, otherState.breaker);
+    }
+
+    /**
+     * Creates an empty {@link HistogramUnionState} with the same parameters as {@code otherState}, charged to {@code breaker}.
+     * Use this when the original breaker is a {@code PreallocatedCircuitBreaker} that closes before the reduction phase runs
+     * on the coordinator. The input state is not modified.
+     */
+    public static HistogramUnionState createUsingParamsFrom(HistogramUnionState otherState, CircuitBreaker breaker) {
         if (otherState.tDigestState != null) {
-            return wrap(otherState.breaker, TDigestState.createUsingParamsFrom(otherState.tDigestState));
+            return wrap(breaker, TDigestState.createUsingParamsFrom(otherState.tDigestState, breaker));
         } else {
-            return createWithEmptyTDigest(otherState.breaker, otherState.tdigestInitParams, null);
+            return createWithEmptyTDigest(breaker, otherState.tdigestInitParams, null);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
@@ -36,7 +36,7 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        HistogramUnionState state = getState(owningBucketOrdinal);
+        HistogramUnionState state = takeState(owningBucketOrdinal);
         if (state == null) {
             return buildEmptyAggregation();
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
@@ -36,7 +36,7 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        HistogramUnionState state = getState(owningBucketOrdinal);
+        HistogramUnionState state = takeState(owningBucketOrdinal);
         if (state == null) {
             return buildEmptyAggregation();
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
@@ -139,11 +139,20 @@ public class TDigestState implements Releasable, Accountable {
      * @return a TDigestState object
      */
     public static TDigestState createUsingParamsFrom(TDigestState state) {
-        state.breaker.addEstimateBytesAndMaybeBreak(SHALLOW_SIZE, "tdigest-state-create-using-params-from");
+        return createUsingParamsFrom(state, state.breaker);
+    }
+
+    /**
+     * Creates an empty {@link TDigestState} with the same parameters as {@code state}, charged to {@code breaker}.
+     * Use this when the original breaker is a {@code PreallocatedCircuitBreaker} that closes before the reduction phase runs
+     * on the coordinator. The input state is not modified.
+     */
+    public static TDigestState createUsingParamsFrom(TDigestState state, CircuitBreaker breaker) {
+        breaker.addEstimateBytesAndMaybeBreak(SHALLOW_SIZE, "tdigest-state-create-using-params-from");
         try {
-            return new TDigestState(state.breaker, state.type, state.compression);
+            return new TDigestState(breaker, state.type, state.compression);
         } catch (Exception e) {
-            state.breaker.addWithoutBreaking(-SHALLOW_SIZE);
+            breaker.addWithoutBreaking(-SHALLOW_SIZE);
             throw e;
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
@@ -12,15 +12,27 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.indices.breaker.CircuitBreakerMetrics;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -32,6 +44,7 @@ import java.util.function.Consumer;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
+import static org.elasticsearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
@@ -158,6 +171,138 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
         assertThat(
             e.getMessage(),
             equalTo("Cannot set [numberOfSignificantValueDigits] because the " + "method has already been configured for TDigest")
+        );
+    }
+
+    public void testBreakerBytesReleasedAfterSuccessfulAggregation() throws IOException {
+        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
+        PercentilesAggregationBuilder aggBuilder = new PercentilesAggregationBuilder("p").field("number")
+            .percentilesConfig(new PercentilesConfig.TDigest());
+
+        HierarchyCircuitBreakerService breakerService = requestBreakerService("10mb");
+        withSequentialIndex(100, reader -> {
+            try (
+                AggregationContext context = createAggregationContext(
+                    reader,
+                    createIndexSettings(),
+                    Queries.ALL_DOCS_INSTANCE,
+                    breakerService,
+                    AggregationBuilder.DEFAULT_PREALLOCATION,
+                    DEFAULT_MAX_BUCKETS,
+                    false,
+                    false,
+                    fieldType
+                )
+            ) {
+                Aggregator aggregator = createAggregator(aggBuilder, context);
+                aggregator.preCollection();
+                context.searcher().search(Queries.ALL_DOCS_INSTANCE, aggregator.asCollector());
+                aggregator.postCollection();
+                aggregator.buildTopLevel();
+            }
+            assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        });
+    }
+
+    public void testBreakerTripsOnHighCardinalityTermsPercentiles() throws IOException {
+        // Reproduces the OOM scenario from the issue: a terms agg with many distinct values
+        // creates one TDigest sketch per bucket. With our fix each sketch charges the REQUEST
+        // breaker, so a tight limit trips the breaker instead of exhausting heap.
+        HierarchyCircuitBreakerService breakerService = requestBreakerService("50kb");
+        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
+
+        PercentilesAggregationBuilder percBuilder = new PercentilesAggregationBuilder("p").field("number")
+            .percentilesConfig(new PercentilesConfig.TDigest());
+        TermsAggregationBuilder termsBuilder = new TermsAggregationBuilder("terms").field("number").size(10000).subAggregation(percBuilder);
+
+        withSequentialIndex(500, reader -> {
+            expectThrows(CircuitBreakingException.class, () -> {
+                try (
+                    AggregationContext context = createAggregationContext(
+                        reader,
+                        createIndexSettings(),
+                        Queries.ALL_DOCS_INSTANCE,
+                        breakerService,
+                        0,
+                        DEFAULT_MAX_BUCKETS,
+                        false,
+                        false,
+                        fieldType
+                    )
+                ) {
+                    Aggregator aggregator = createAggregator(termsBuilder, context);
+                    aggregator.preCollection();
+                    context.searcher().search(Queries.ALL_DOCS_INSTANCE, aggregator.asCollector());
+                    aggregator.postCollection();
+                    aggregator.buildTopLevel();
+                }
+            });
+            assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        });
+    }
+
+    public void testBreakerTripReleasesAllBytes() throws IOException {
+        HierarchyCircuitBreakerService breakerService = requestBreakerService("1kb");
+        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
+        PercentilesAggregationBuilder aggBuilder = new PercentilesAggregationBuilder("p").field("number")
+            .percentilesConfig(new PercentilesConfig.TDigest());
+
+        withSequentialIndex(500, reader -> {
+            expectThrows(CircuitBreakingException.class, () -> collectWithBreaker(reader, breakerService, aggBuilder, fieldType));
+            assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+        });
+    }
+
+    private static void withSequentialIndex(int docCount, CheckedConsumer<DirectoryReader, IOException> body) throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                for (int i = 0; i < docCount; i++) {
+                    iw.addDocument(singleton(new SortedNumericDocValuesField("number", i)));
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                body.accept(reader);
+            }
+        }
+    }
+
+    private void collectWithBreaker(
+        DirectoryReader reader,
+        CircuitBreakerService breakerService,
+        PercentilesAggregationBuilder aggBuilder,
+        MappedFieldType fieldType
+    ) throws IOException {
+        try (
+            AggregationContext context = createAggregationContext(
+                reader,
+                createIndexSettings(),
+                Queries.ALL_DOCS_INSTANCE,
+                breakerService,
+                0,
+                DEFAULT_MAX_BUCKETS,
+                false,
+                false,
+                fieldType
+            )
+        ) {
+            Aggregator aggregator = createAggregator(aggBuilder, context);
+            aggregator.preCollection();
+            context.searcher().search(Queries.ALL_DOCS_INSTANCE, aggregator.asCollector());
+            aggregator.postCollection();
+            aggregator.buildTopLevel();
+        }
+    }
+
+    private static HierarchyCircuitBreakerService requestBreakerService(String requestLimit) {
+        Settings settings = Settings.builder()
+            .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), requestLimit)
+            .put(HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING.getKey(), false)
+            .build();
+        return new HierarchyCircuitBreakerService(
+            CircuitBreakerMetrics.NOOP,
+            settings,
+            List.of(),
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL:Fix Tdigest percentiles circuit breaker (#155586)