### PR TITLE
Fix EQL sequence crash on string timestamps

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/30_keyword_timestamp.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/30_keyword_timestamp.yml
@@ -1,0 +1,63 @@
+---
+setup:
+  - do:
+      indices.create:
+          index:  eql_keyword_ts
+          body:
+            mappings:
+              properties:
+                "@timestamp":
+                  type: keyword
+                event:
+                  properties:
+                    category:
+                      type: keyword
+                user:
+                  type: keyword
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: eql_keyword_ts
+              _id:    "1"
+          - event:
+              - category: process
+            "@timestamp": "2020-02-03T12:34:56.000Z"
+            user: SYSTEM
+          - index:
+              _index: eql_keyword_ts
+              _id:    "2"
+          - event:
+              - category: process
+            "@timestamp": "2020-02-04T12:34:56.000Z"
+            user: SYSTEM
+          - index:
+              _index: eql_keyword_ts
+              _id:    "3"
+          - event:
+              - category: process
+            "@timestamp": "2020-02-05T12:34:56.000Z"
+            user: SYSTEM
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: eql_keyword_ts
+        ignore: 404
+
+---
+"Sequence matching accepts ISO-8601 strings when timestamp is mapped as keyword":
+  - do:
+      eql.search:
+        index: eql_keyword_ts
+        body:
+          query: 'sequence by user [process where true] [process where true]'
+  - match: {timed_out: false}
+  - match: {hits.total.value: 2}
+  - match: {hits.total.relation: "eq"}
+  - match: {hits.sequences.0.events.0._id: "1"}
+  - match: {hits.sequences.0.events.1._id: "2"}
+  - match: {hits.sequences.1.events.0._id: "2"}
+  - match: {hits.sequences.1.events.1._id: "3"}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceCriterion.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceCriterion.java
@@ -74,10 +74,7 @@ public class SequenceCriterion extends Criterion<BoxedQueryRequest> {
 
     @SuppressWarnings({ "unchecked" })
     public Ordinal ordinal(SearchHit hit) {
-        Object ts = timestamp.extract(hit);
-        if (ts instanceof Timestamp == false) {
-            throw new EqlIllegalArgumentException("Expected timestamp as a Timestamp but got {}", ts.getClass());
-        }
+        Timestamp ts = Timestamp.from(timestamp.extract(hit));
 
         Comparable<Object> tbreaker = null;
         if (tiebreaker != null) {
@@ -93,7 +90,7 @@ public class SequenceCriterion extends Criterion<BoxedQueryRequest> {
             throw new EqlIllegalArgumentException("Expected _shard_doc/implicit tiebreaker as long but got [{}]", implicitTbreaker);
         }
         long timebreakerValue = ((Number) implicitTbreaker).longValue();
-        return new Ordinal((Timestamp) ts, tbreaker, timebreakerValue);
+        return new Ordinal(ts, tbreaker, timebreakerValue);
     }
 
     public boolean missing() {
@@ -101,11 +98,7 @@ public class SequenceCriterion extends Criterion<BoxedQueryRequest> {
     }
 
     public Timestamp timestamp(SearchHit hit) {
-        Object ts = timestamp.extract(hit);
-        if (ts instanceof Timestamp == false) {
-            throw new EqlIllegalArgumentException("Expected timestamp as a Timestamp but got {}", ts.getClass());
-        }
-        return (Timestamp) ts;
+        return Timestamp.from(timestamp.extract(hit));
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Timestamp.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/Timestamp.java
@@ -7,7 +7,13 @@
 
 package org.elasticsearch.xpack.eql.execution.search;
 
+import org.elasticsearch.common.time.DateFormatters;
+import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.util.DateUtils;
+
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 import static java.time.temporal.ChronoUnit.NANOS;
 
@@ -23,6 +29,44 @@ public abstract class Timestamp {
 
     int compareTo(Timestamp other) {
         return instant().compareTo(other.instant());
+    }
+
+    /**
+     * Converts a value extracted from a search hit into a {@link Timestamp}.
+     * Sequence matching requests {@code epoch_millis} (or {@code millis.micros}) strings, but the fields
+     * API can also return ISO-8601 strings when the timestamp is not mapped as {@code date}, or when a
+     * fetch format other than {@code epoch_millis} wins.
+     */
+    public static Timestamp from(Object value) {
+        if (value instanceof Timestamp timestamp) {
+            return timestamp;
+        }
+        if (value instanceof String str) {
+            return parseString(str);
+        }
+        if (value instanceof Number number) {
+            return of(Long.toString(number.longValue()));
+        }
+        if (value instanceof ZonedDateTime zonedDateTime) {
+            return of(Long.toString(zonedDateTime.toInstant().toEpochMilli()));
+        }
+        if (value == null) {
+            throw new EqlIllegalArgumentException("Expected timestamp as a Timestamp but got null");
+        }
+        throw new EqlIllegalArgumentException("Expected timestamp as a Timestamp but got {}", value.getClass());
+    }
+
+    private static Timestamp parseString(String value) {
+        try {
+            return of(value);
+        } catch (NumberFormatException e) {
+            try {
+                Instant instant = DateFormatters.from(DateUtils.UTC_DATE_TIME_FORMATTER.parse(value)).toInstant();
+                return of(Long.toString(instant.toEpochMilli()));
+            } catch (DateTimeParseException | IllegalArgumentException parseException) {
+                throw new EqlIllegalArgumentException("Expected timestamp as a Timestamp but got {}", value.getClass());
+            }
+        }
     }
 
     public static Timestamp of(String milliseconds) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/extractor/TimestampFieldHitExtractor.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/extractor/TimestampFieldHitExtractor.java
@@ -16,7 +16,15 @@ public class TimestampFieldHitExtractor extends FieldHitExtractor {
     }
 
     @Override
+    protected Object unwrapCustomValue(Object values) {
+        if (values instanceof String || values instanceof Number || values instanceof Timestamp) {
+            return Timestamp.from(values);
+        }
+        return super.unwrapCustomValue(values);
+    }
+
+    @Override
     protected Object parseEpochMillisAsString(String str) {
-        return Timestamp.of(str);
+        return Timestamp.from(str);
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/CriterionOrdinalExtractionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.eql.EqlIllegalArgumentException;
 import org.elasticsearch.xpack.eql.execution.assembler.SequenceCriterion;
 import org.elasticsearch.xpack.eql.execution.search.extractor.FieldHitExtractor;
 import org.elasticsearch.xpack.eql.execution.search.extractor.ImplicitTiebreakerHitExtractor;
+import org.elasticsearch.xpack.eql.execution.search.extractor.TimestampFieldHitExtractor;
 import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.junit.After;
@@ -77,6 +78,21 @@ public class CriterionOrdinalExtractionTests extends ESTestCase {
         Ordinal ordinal = ordinal(searchHit(time, null), true);
         assertEquals(time, ordinal.timestamp());
         assertNull(ordinal.tiebreaker());
+    }
+
+    public void testTimeAsEpochMillisString() throws Exception {
+        long millis = 1_580_733_296_000L;
+        HitExtractor extractor = new TimestampFieldHitExtractor(new FieldHitExtractor(tsField, DataTypes.KEYWORD, null, null, FULL));
+        SearchHit hit = searchHit(Long.toString(millis), null);
+        SequenceCriterion criterion = new SequenceCriterion(0, null, emptyList(), extractor, null, implicitTbExtractor, false, false);
+        assertEquals(millis, criterion.ordinal(hit).timestamp().instant().toEpochMilli());
+    }
+
+    public void testTimeAsIso8601String() throws Exception {
+        HitExtractor extractor = new TimestampFieldHitExtractor(new FieldHitExtractor(tsField, DataTypes.KEYWORD, null, null, FULL));
+        SearchHit hit = searchHit("2020-02-03T12:34:56.000Z", null);
+        SequenceCriterion criterion = new SequenceCriterion(0, null, emptyList(), extractor, null, implicitTbExtractor, false, false);
+        assertEquals(1_580_733_296_000L, criterion.ordinal(hit).timestamp().instant().toEpochMilli());
     }
 
     public void testTimeNotComparable() throws Exception {


### PR DESCRIPTION
## Summary
EQL sequence queries can fail with:

`EqlIllegalArgumentException: Expected timestamp as a Timestamp but got class java.lang.String`

This happens when sequence matching reads `@timestamp` from a search hit and the fields API returns a string (for example a keyword mapping, a runtime mapping, or an ISO-8601 value instead of `epoch_millis`). Matching assumed a `Timestamp` object and threw.

Closes #156605

## Change
- Add `Timestamp.from()` to accept `Timestamp`, epoch-millis / `millis.micros` strings, ISO-8601 strings, and numbers.
- Use it in `SequenceCriterion` and `TimestampFieldHitExtractor`.

Timestamp fields should still be mapped as `date`. This change avoids an internal crash when the extracted value is a string.

## Test plan
- Reproduced with `@timestamp` mapped as `keyword` and
  `sequence by user [process where true] [process where true]`.
- Same request returns `hits.sequences` after the fix.
- Unit tests: `CriterionOrdinalExtractionTests` (epoch-millis and ISO-8601 strings).
- YAML REST test: `eql/30_keyword_timestamp.yml`.