### PR TITLE
[9.5] ES|QL: Fix MV-unsafe evaluator in Parquet late-mat filter (#156604)

### DIFF
--- a/docs/changelog/156604.yaml
+++ b/docs/changelog/156604.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 156604
+summary: Fix MV-unsafe evaluator in Parquet late-mat filter
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -173,11 +173,13 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
      * {@link ParquetPushedExpressions#evaluateExpression} that AND-s out the null mask before
      * negating, so both bare and negated forms are YES.
      *
-     * <p>Other predicate families ({@code Eq}, {@code In}, {@code Range}, {@code IsNull},
-     * {@code IsNotNull}) stay {@link Pushability#RECHECK} because the generic bitwise negate
-     * is not TVL-correct for their nulls; the {@code FilterExec} safety net applies them
-     * per-row. {@code Not(And(...))} likewise stays RECHECK — bitwise {@code ~(m1 & m2)} is
-     * not {@code NOT (a AND b)} under TVL when either arm holds null.
+     * <p>{@code Not(EsqlBinaryComparison)}, {@code Not(In)}, and {@code Not(Range)} on a single
+     * column are now also TVL-correct: {@code valueColumnBlockForNot} extracts the column block
+     * so that {@code tvlNegate} can AND-out null/MV positions before negating, exactly as the
+     * LIKE-family does. These predicates could therefore be promoted to {@link Pushability#YES}
+     * (dropping the double-evaluation RECHECK cost), but that promotion is left as a follow-up.
+     * {@code IsNull}/{@code IsNotNull} and {@code Not(And(...))} stay {@link Pushability#RECHECK}:
+     * the null/MV gate can't be derived from a single column block for those forms.
      *
      * <p>{@code AND} of YES-eligible predicates is YES (a {@code 0} on either side blocks the
      * row regardless of provenance). {@code OR} is excluded: {@code evaluateExpression}'s
@@ -189,7 +191,9 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
             return true;
         }
         if (expr instanceof Not not) {
-            // Only the LIKE-family inner predicates have a TVL-aware evaluator special case.
+            // LIKE-family and simple single-column comparisons (Eq/In/Range) are TVL-correct.
+            // The comparison cases are handled via valueColumnBlockForNot + tvlNegate in
+            // ParquetPushedExpressions. Promoting those to YES is a follow-up TODO.
             return isLikeFamily(not.field());
         }
         if (expr instanceof And and) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -445,8 +445,7 @@ final class ParquetPushedExpressions {
         // IS NULL / IS NOT NULL (null-valued EQ/NOT_EQ) over a list column (resolves to a LIST group,
         // not a primitive) must decline: pushing notEq(column("v"), null) names a leaf-absent column
         // that parquet-mr drops entirely. The null-mask evaluator that answers instead is multivalue-safe.
-        // esql-planning#1056. Value predicates (comparisons/IN/LIKE) are deliberately NOT declined here —
-        // their decoded-block evaluator reads by position index and is not multivalue-safe.
+        // esql-planning#1056.
         if (value == null && resolveNestedPrimitive(schema, columnName) == null) {
             return null;
         }
@@ -1469,6 +1468,14 @@ final class ParquetPushedExpressions {
             }
             WordMask inner = evaluateExpression(not.field(), blocks, rowCount, intermediateMask, dictCache);
             if (inner != null) {
+                // For value predicates on a single column, MV positions were correctly set to bit 0
+                // by the inner evaluator. A plain negate() would flip them to bit 1 (survivors),
+                // causing unnecessary Parquet decoding for every MV row. The RECHECK safety net
+                // still corrects results, but tvlNegate avoids the decoding cost.
+                Block valueBlock = valueColumnBlockForNot(not.field(), blocks);
+                if (valueBlock != null) {
+                    return tvlNegate(inner, valueBlock, rowCount);
+                }
                 inner.negate();
                 return inner;
             }
@@ -1506,6 +1513,27 @@ final class ParquetPushedExpressions {
         return null;
     }
 
+    /**
+     * Returns the single column block referenced by a value predicate so the generic {@code Not}
+     * handler can call {@link #tvlNegate} and avoid materialising MV rows unnecessarily.
+     * Returns {@code null} for position-level predicates ({@code IsNull}/{@code IsNotNull}) whose
+     * MV semantics are already correct without zeroing, and for compound sub-expressions where no
+     * single block dominates.
+     */
+    @Nullable
+    private static Block valueColumnBlockForNot(Expression inner, Map<String, Block> blocks) {
+        if (inner instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne) {
+            return blocks.get(ne.name());
+        }
+        if (inner instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            return blocks.get(ne.name());
+        }
+        if (inner instanceof Range range && range.value() instanceof NamedExpression ne) {
+            return blocks.get(ne.name());
+        }
+        return null;
+    }
+
     private static WordMask evaluateComparison(
         EsqlBinaryComparison bc,
         Block block,
@@ -1517,9 +1545,17 @@ final class ParquetPushedExpressions {
         mask.reset(rowCount);
         if (block instanceof IntBlock ib) {
             int val = ((Number) literal).intValue();
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && compareResult(Integer.compare(ib.getInt(i), val), bc)) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && compareResult(Integer.compare(ib.getInt(block.getFirstValueIndex(i)), val), bc)) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && compareResult(Integer.compare(ib.getInt(i), val), bc)) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof LongBlock lb) {
@@ -1528,16 +1564,32 @@ final class ParquetPushedExpressions {
                 return null;
             }
             long val = boxed;
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && compareResult(Long.compare(lb.getLong(i), val), bc)) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && compareResult(Long.compare(lb.getLong(block.getFirstValueIndex(i)), val), bc)) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && compareResult(Long.compare(lb.getLong(i), val), bc)) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof DoubleBlock db) {
             double val = ((Number) literal).doubleValue();
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && compareResult(Double.compare(db.getDouble(i), val), bc)) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && compareResult(Double.compare(db.getDouble(block.getFirstValueIndex(i)), val), bc)) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && compareResult(Double.compare(db.getDouble(i), val), bc)) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
@@ -1555,16 +1607,33 @@ final class ParquetPushedExpressions {
             BytesRef val = toByteRef(literal);
             Predicate<BytesRef> matcher = bytesRefComparisonMatcher(bc, val);
             BytesRef scratch = new BytesRef();
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && matcher.test(bb.getBytesRef(i, scratch))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && matcher.test(bb.getBytesRef(block.getFirstValueIndex(i), scratch))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && matcher.test(bb.getBytesRef(i, scratch))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof BooleanBlock boolBlock) {
             boolean val = (Boolean) literal;
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && compareResult(Boolean.compare(boolBlock.getBoolean(i), val), bc)) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1
+                        && compareResult(Boolean.compare(boolBlock.getBoolean(block.getFirstValueIndex(i)), val), bc)) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && compareResult(Boolean.compare(boolBlock.getBoolean(i), val), bc)) {
+                        mask.set(i);
+                    }
                 }
             }
         } else {
@@ -1644,9 +1713,17 @@ final class ParquetPushedExpressions {
             for (Object v : values) {
                 intSet.add(((Number) v).intValue());
             }
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && intSet.contains(ib.getInt(i))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && intSet.contains(ib.getInt(block.getFirstValueIndex(i)))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && intSet.contains(ib.getInt(i))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof LongBlock lb) {
@@ -1654,9 +1731,17 @@ final class ParquetPushedExpressions {
             for (Object v : values) {
                 longSet.add(((Number) v).longValue());
             }
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && longSet.contains(lb.getLong(i))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && longSet.contains(lb.getLong(block.getFirstValueIndex(i)))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && longSet.contains(lb.getLong(i))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof DoubleBlock db) {
@@ -1664,9 +1749,17 @@ final class ParquetPushedExpressions {
             for (Object v : values) {
                 doubleSet.add(((Number) v).doubleValue());
             }
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && doubleSet.contains(db.getDouble(i))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && doubleSet.contains(db.getDouble(block.getFirstValueIndex(i)))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && doubleSet.contains(db.getDouble(i))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
@@ -1682,9 +1775,17 @@ final class ParquetPushedExpressions {
                 refSet.add(toByteRef(v));
             }
             BytesRef scratch = new BytesRef();
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && refSet.contains(bb.getBytesRef(i, scratch))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && refSet.contains(bb.getBytesRef(block.getFirstValueIndex(i), scratch))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && refSet.contains(bb.getBytesRef(i, scratch))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof BooleanBlock boolBlock) {
@@ -1692,9 +1793,17 @@ final class ParquetPushedExpressions {
             for (Object v : values) {
                 boolSet.add((Boolean) v);
             }
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && boolSet.contains(boolBlock.getBoolean(i))) {
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1 && boolSet.contains(boolBlock.getBoolean(block.getFirstValueIndex(i)))) {
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false && boolSet.contains(boolBlock.getBoolean(i))) {
+                        mask.set(i);
+                    }
                 }
             }
         } else {
@@ -1718,12 +1827,23 @@ final class ParquetPushedExpressions {
             boolean hasHi = upper != null;
             int lo = hasLo ? ((Number) lower).intValue() : 0;
             int hi = hasHi ? ((Number) upper).intValue() : 0;
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false) {
-                    int val = ib.getInt(i);
-                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
-                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1) {
+                        int val = ib.getInt(block.getFirstValueIndex(i));
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false) {
+                        int val = ib.getInt(i);
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof LongBlock lb) {
@@ -1731,12 +1851,23 @@ final class ParquetPushedExpressions {
             boolean hasHi = upper != null;
             long lo = hasLo ? ((Number) lower).longValue() : 0;
             long hi = hasHi ? ((Number) upper).longValue() : 0;
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false) {
-                    long val = lb.getLong(i);
-                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
-                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1) {
+                        long val = lb.getLong(block.getFirstValueIndex(i));
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false) {
+                        long val = lb.getLong(i);
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
                 }
             }
         } else if (block instanceof DoubleBlock db) {
@@ -1744,12 +1875,23 @@ final class ParquetPushedExpressions {
             boolean hasHi = upper != null;
             double lo = hasLo ? ((Number) lower).doubleValue() : 0;
             double hi = hasHi ? ((Number) upper).doubleValue() : 0;
-            for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false) {
-                    double val = db.getDouble(i);
-                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
-                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
-                    mask.set(i);
+            if (block.mayHaveMultivaluedFields()) {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.getValueCount(i) == 1) {
+                        double val = db.getDouble(block.getFirstValueIndex(i));
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
+                }
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false) {
+                        double val = db.getDouble(i);
+                        if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                        if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                        mask.set(i);
+                    }
                 }
             }
         } else {
@@ -1857,21 +1999,7 @@ final class ParquetPushedExpressions {
             return mask;
         }
         if (block instanceof BytesRefBlock bb) {
-            WordMask mask = new WordMask();
-            mask.reset(rowCount);
-            BytesRef scratch = new BytesRef();
-            for (int i = 0; i < rowCount; i++) {
-                if (intermediateMask != null && intermediateMask.get(i) == false) {
-                    continue;
-                }
-                if (block.isNull(i) == false) {
-                    BytesRef val = bb.getBytesRef(i, scratch);
-                    if (matcher.test(val)) {
-                        mask.set(i);
-                    }
-                }
-            }
-            return mask;
+            return applyMatcherToBytesRefBlock(bb, rowCount, intermediateMask, matcher);
         }
         return null;
     }
@@ -1888,12 +2016,12 @@ final class ParquetPushedExpressions {
         if (likeMask == null) {
             return null;
         }
-        // Set bit i for null rows so the subsequent negate turns them into 0 (filtered out).
-        // mayHaveNulls() is a cheap pre-check that lets the all-non-nulls common case skip
-        // the per-row scan; matches the WildcardLike scalar path.
-        if (block.mayHaveNulls()) {
+        // Set bit i for null/MV rows so the subsequent negate turns them into 0 (filtered out).
+        // mayHaveNulls()/mayHaveMultivaluedFields() are cheap pre-checks that let the common
+        // case (all single-valued, non-null) skip the per-row scan entirely.
+        if (block.mayHaveNulls() || block.mayHaveMultivaluedFields()) {
             for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i)) {
+                if (block.getValueCount(i) != 1) {
                     likeMask.set(i);
                 }
             }
@@ -1954,7 +2082,7 @@ final class ParquetPushedExpressions {
             return null;
         }
         if (compiled.matchesAll) {
-            return maskNonNullRows(block, rowCount);
+            return maskSingleValuedRows(block, rowCount);
         }
         // Use the affix-contains dispatch when the pattern matches that shape; see CompiledWildcard.
         Predicate<BytesRef> matcher = matcherFor(compiled);
@@ -1966,21 +2094,7 @@ final class ParquetPushedExpressions {
             return mask;
         }
         if (block instanceof BytesRefBlock bb) {
-            WordMask mask = new WordMask();
-            mask.reset(rowCount);
-            BytesRef scratch = new BytesRef();
-            for (int i = 0; i < rowCount; i++) {
-                if (intermediateMask != null && intermediateMask.get(i) == false) {
-                    continue;
-                }
-                if (block.isNull(i) == false) {
-                    BytesRef val = bb.getBytesRef(i, scratch);
-                    if (matcher.test(val)) {
-                        mask.set(i);
-                    }
-                }
-            }
-            return mask;
+            return applyMatcherToBytesRefBlock(bb, rowCount, intermediateMask, matcher);
         }
         return null;
     }
@@ -2080,6 +2194,26 @@ final class ParquetPushedExpressions {
     }
 
     /**
+     * Returns a mask with bit {@code i} set iff position {@code i} holds exactly one value
+     * (i.e. {@code getValueCount(i) == 1}). Null positions (count 0) and multivalue positions
+     * (count &gt; 1) are excluded. For flat blocks ({@code mayHaveMultivaluedFields() == false})
+     * this is equivalent to {@link #maskNonNullRows} and delegates to it.
+     */
+    private static WordMask maskSingleValuedRows(Block block, int rowCount) {
+        if (block.mayHaveMultivaluedFields() == false) {
+            return maskNonNullRows(block, rowCount);
+        }
+        WordMask mask = new WordMask();
+        mask.reset(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            if (block.getValueCount(i) == 1) {
+                mask.set(i);
+            }
+        }
+        return mask;
+    }
+
+    /**
      * Populates {@code mask} so that bit {@code i} is set iff {@code block.isNull(i)} is
      * false. The caller owns the mask; this method does not allocate. Mirrors
      * {@link #maskNonNullRows} which is the allocating wrapper. Both the {@code IsNotNull}
@@ -2174,7 +2308,7 @@ final class ParquetPushedExpressions {
      * The minimum of 10 positions avoids the boolean[] allocation overhead for tiny blocks.
      */
     private static boolean shouldShortCircuitOnDictionary(OrdinalBytesRefBlock block) {
-        return block.getPositionCount() >= 10;
+        return block.getPositionCount() >= 10 && block.getOrdinalsBlock().mayHaveMultivaluedFields() == false;
     }
 
     /**
@@ -2249,11 +2383,13 @@ final class ParquetPushedExpressions {
      * without compromising correctness — we are looking at the actual per-row-group
      * dictionary, not at file-level metadata.
      *
-     * <p>This relies on the ordinals block being <strong>single-valued</strong>: position
-     * {@code i} maps directly to value index {@code i}. The Parquet reader's dictionary
-     * path always satisfies this — see {@code PageColumnReader#buildOrdinalsBlock}, which
-     * constructs the ordinals block with {@code firstValueIndexes == null}. The assertion
-     * below documents and guards the invariant for any future producer.
+     * <p>The ordinals block must be <strong>single-valued per position</strong> (no MV):
+     * the assertion below guards this. It may, however, be a non-vector block (i.e.
+     * {@link IntBlock#asVector()} returns {@code null}): nullable Parquet columns produce
+     * null entries in the ordinals block, and null positions consume no slot in the values
+     * array, so {@code getFirstValueIndex(i) != i} for positions after a null. Each
+     * position is therefore looked up via {@link IntBlock#getFirstValueIndex} before
+     * calling {@link IntBlock#getInt}.
      */
     private static void applyDictionaryMatches(OrdinalBytesRefBlock block, boolean[] dictMatches, WordMask mask, int rowCount) {
         IntBlock ordinals = block.getOrdinalsBlock();
@@ -2273,10 +2409,56 @@ final class ParquetPushedExpressions {
             return;
         }
         for (int i = 0; i < rowCount; i++) {
-            if (block.isNull(i) == false && dictMatches[ordinals.getInt(i)]) {
+            // ordinals.getInt takes a VALUE index, not a position index. When the ordinals
+            // block is non-flat (null gaps present), getFirstValueIndex(i) != i.
+            if (block.isNull(i) == false && dictMatches[ordinals.getInt(ordinals.getFirstValueIndex(i))]) {
                 mask.set(i);
             }
         }
+    }
+
+    /**
+     * Scans a {@link BytesRefBlock} row-by-row, setting the survivor bit for each
+     * single-valued non-null position where {@code matcher} returns {@code true}.
+     *
+     * <p>Shared by {@link #evaluateLiteralPredicate} and {@link #evaluateWildcardLike} to
+     * avoid duplicating the MV-guarded dual-loop pattern.
+     */
+    private static WordMask applyMatcherToBytesRefBlock(
+        BytesRefBlock bb,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        Predicate<BytesRef> matcher
+    ) {
+        WordMask mask = new WordMask();
+        mask.reset(rowCount);
+        BytesRef scratch = new BytesRef();
+        if (bb.mayHaveMultivaluedFields()) {
+            for (int i = 0; i < rowCount; i++) {
+                if (intermediateMask != null && intermediateMask.get(i) == false) {
+                    continue;
+                }
+                if (bb.getValueCount(i) == 1) {
+                    BytesRef val = bb.getBytesRef(bb.getFirstValueIndex(i), scratch);
+                    if (matcher.test(val)) {
+                        mask.set(i);
+                    }
+                }
+            }
+        } else {
+            for (int i = 0; i < rowCount; i++) {
+                if (intermediateMask != null && intermediateMask.get(i) == false) {
+                    continue;
+                }
+                if (bb.isNull(i) == false) {
+                    BytesRef val = bb.getBytesRef(i, scratch);
+                    if (matcher.test(val)) {
+                        mask.set(i);
+                    }
+                }
+            }
+        }
+        return mask;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -1317,6 +1317,24 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         }
     }
 
+    public void testOrdinalEqualsWithNullGapsUsesCorrectValueIndex() {
+        // Regression test for the applyDictionaryMatches bug: ordinals.getInt(i) must use
+        // getFirstValueIndex(i) as the value index, not the raw position index i.
+        // A null at position 2 shifts subsequent value indices; without the fix, position 3
+        // (ordinal 2 = "gamma") reads values[3] (wrong ordinal) instead of values[2].
+        String[] dict = { "alpha", "beta", "gamma" };
+        int[] ordinals = { 0, 1, 0, 2, 0, 1, 2, 0, 1, 2, 2 };
+        boolean[] nulls = { false, false, true, false, false, false, false, false, false, false, false };
+        Block block = ordinalBlock(dict, ordinals, nulls);
+        try (block) {
+            Map<String, Block> blocks = Map.of("x", block);
+            WordMask reusable = new WordMask();
+            int[] expected = positionsWithOrdinalAndNotNull(ordinals, nulls, 2);
+            Expression expr = new Equals(Source.EMPTY, attr("x", DataType.KEYWORD), lit(new BytesRef("gamma"), DataType.KEYWORD), null);
+            assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, ordinals.length, reusable, expected);
+        }
+    }
+
     // ---- Test: WildcardLike (LIKE) evaluation ----
 
     public void testWildcardLikeBasicScalar() {
@@ -2057,6 +2075,151 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
             System.arraycopy(pattern, 0, out, t * pattern.length, pattern.length);
         }
         return out;
+    }
+
+    // ---- Multivalue block tests (esql-planning#1070) ----
+
+    // Block layout for most MV int tests: pos0=[1,2] (MV), pos1=[3] (SV), pos2=null, pos3=[7,5] (MV)
+
+    public void testEqualsOnMultivalueIntBlock() {
+        Block block = buildMvIntBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("v", block);
+            WordMask reusable = new WordMask();
+            Equals equals = new Equals(Source.EMPTY, attr("v", DataType.INTEGER), lit(3, DataType.INTEGER), null);
+            // only pos1 (single-value 3) must survive; pos0 and pos3 are MV, pos2 is null
+            assertSurvivors(new ParquetPushedExpressions(List.of(equals)), blocks, 4, reusable, new int[] { 1 });
+        }
+    }
+
+    public void testNotEqualsOnMultivalueIntBlock() {
+        Block block = buildMvIntBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("v", block);
+            WordMask reusable = new WordMask();
+            // NOT(v == 7): pos1 (single-value 3, not equal to 7) survives; MV/null positions excluded
+            Not not = new Not(Source.EMPTY, new Equals(Source.EMPTY, attr("v", DataType.INTEGER), lit(7, DataType.INTEGER), null));
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 4, reusable, new int[] { 1 });
+        }
+    }
+
+    public void testInOnMultivalueIntBlock() {
+        Block block = buildMvIntBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("v", block);
+            WordMask reusable = new WordMask();
+            In in = new In(Source.EMPTY, attr("v", DataType.INTEGER), List.of(lit(3, DataType.INTEGER), lit(7, DataType.INTEGER)));
+            // pos3 has value 7 but is MV — must not survive; only pos1 (single-value 3) survives
+            assertSurvivors(new ParquetPushedExpressions(List.of(in)), blocks, 4, reusable, new int[] { 1 });
+        }
+    }
+
+    public void testRangeOnMultivalueIntBlock() {
+        Block block = buildMvIntBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("v", block);
+            WordMask reusable = new WordMask();
+            Range range = new Range(
+                Source.EMPTY,
+                attr("v", DataType.INTEGER),
+                lit(2, DataType.INTEGER),
+                true,
+                lit(6, DataType.INTEGER),
+                true,
+                ZoneOffset.UTC
+            );
+            // pos1 (value 3) is in [2,6]; MV and null positions excluded
+            assertSurvivors(new ParquetPushedExpressions(List.of(range)), blocks, 4, reusable, new int[] { 1 });
+        }
+    }
+
+    // Block layout for int MV tests: pos0=[1,2] (MV), pos1=3 (SV), pos2=null, pos3=[7,5] (MV)
+
+    private Block buildMvIntBlock() {
+        try (var b = blockFactory.newIntBlockBuilder(4)) {
+            b.beginPositionEntry().appendInt(1).appendInt(2).endPositionEntry();
+            b.appendInt(3);
+            b.appendNull();
+            b.beginPositionEntry().appendInt(7).appendInt(5).endPositionEntry();
+            return b.build();
+        }
+    }
+
+    // Block layout for BytesRef MV tests: pos0=["Senior Dev"] (SV), pos1=["Architect","Senior X"] (MV), pos2=["Manager"] (SV)
+
+    private Block buildTagsMvBlock() {
+        try (var b = blockFactory.newBytesRefBlockBuilder(3)) {
+            b.beginPositionEntry().appendBytesRef(new BytesRef("Senior Dev")).endPositionEntry();
+            b.beginPositionEntry().appendBytesRef(new BytesRef("Architect")).appendBytesRef(new BytesRef("Senior X")).endPositionEntry();
+            b.beginPositionEntry().appendBytesRef(new BytesRef("Manager")).endPositionEntry();
+            return b.build();
+        }
+    }
+
+    public void testStartsWithOnMultivalueBytesRefBlock() {
+        Block block = buildTagsMvBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("tags", block);
+            WordMask reusable = new WordMask();
+            StartsWith startsWith = new StartsWith(
+                Source.EMPTY,
+                attr("tags", DataType.KEYWORD),
+                lit(new BytesRef("Sen"), DataType.KEYWORD)
+            );
+            // pos0 (single-value "Senior Dev") starts with "Sen"; pos1 is MV (excluded even though "Senior X" matches)
+            assertSurvivors(new ParquetPushedExpressions(List.of(startsWith)), blocks, 3, reusable, new int[] { 0 });
+        }
+    }
+
+    public void testNotStartsWithOnMultivalueBytesRefBlock() {
+        Block block = buildTagsMvBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("tags", block);
+            WordMask reusable = new WordMask();
+            Not not = new Not(
+                Source.EMPTY,
+                new StartsWith(Source.EMPTY, attr("tags", DataType.KEYWORD), lit(new BytesRef("Sen"), DataType.KEYWORD))
+            );
+            // pos0 matches → excluded; pos1 is MV → excluded; pos2 ("Manager") doesn't match → survives
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 3, reusable, new int[] { 2 });
+        }
+    }
+
+    public void testWildcardLikeMatchesAllOnMultivalueBytesRefBlock() {
+        // Block: pos0=["hello"] (SV), pos1=["a","b"] (MV), pos2=null
+        try (var b = blockFactory.newBytesRefBlockBuilder(3)) {
+            b.beginPositionEntry().appendBytesRef(new BytesRef("hello")).endPositionEntry();
+            b.beginPositionEntry().appendBytesRef(new BytesRef("a")).appendBytesRef(new BytesRef("b")).endPositionEntry();
+            b.appendNull();
+            Block block = b.build();
+            Map<String, Block> blocks = Map.of("tags", block);
+            WordMask reusable = new WordMask();
+            WildcardLike wildcard = new WildcardLike(Source.EMPTY, attr("tags", DataType.KEYWORD), new WildcardPattern("*"));
+            // "LIKE *" on MV row is null in scalar context; only SV non-null pos0 survives
+            assertSurvivors(new ParquetPushedExpressions(List.of(wildcard)), blocks, 3, reusable, new int[] { 0 });
+        }
+    }
+
+    public void testWildcardLikeOnMultivalueBytesRefBlock() {
+        Block block = buildTagsMvBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("tags", block);
+            WordMask reusable = new WordMask();
+            WildcardLike wildcard = new WildcardLike(Source.EMPTY, attr("tags", DataType.KEYWORD), new WildcardPattern("Senior*"));
+            // pos0 (single-value "Senior Dev") matches; pos1 is MV (excluded even though "Senior X" matches)
+            assertSurvivors(new ParquetPushedExpressions(List.of(wildcard)), blocks, 3, reusable, new int[] { 0 });
+        }
+    }
+
+    public void testNotWildcardLikeOnMultivalueBytesRefBlock() {
+        Block block = buildTagsMvBlock();
+        try (block) {
+            Map<String, Block> blocks = Map.of("tags", block);
+            WordMask reusable = new WordMask();
+            Not not = new Not(Source.EMPTY, new WildcardLike(Source.EMPTY, attr("tags", DataType.KEYWORD), new WildcardPattern("Senior*")));
+            // pos0 matches → excluded; pos1 is MV → excluded by MV semantics in NOT; pos2 ("Manager") → survives
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 3, reusable, new int[] { 2 });
+        }
     }
 
     private static int[] positionsWithOrdinal(int[] ordinals, int target) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -20,6 +20,7 @@ import org.apache.parquet.hadoop.example.GroupReadSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -56,6 +57,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
@@ -395,6 +397,129 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
     public void testNotAndOrLikeLikeXTransitiveSilentDrop() throws IOException {
         Expression filter = not(and(or(like(URL, "*google*"), like(URL, "*github*")), lt(ID, (long) (ROW_COUNT / 2), DataType.LONG)));
         runDifferential(filter);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // List-column (multivalue) regression — esql-planning#1070
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Verifies that value predicates over Parquet optional-list columns correctly exclude MV
+     * and null positions. The late-mat evaluator used to read by position index (== value index
+     * for flat blocks) which produces wrong results for MV blocks produced by list columns.
+     *
+     * <p>Dataset: 4 rows — row0: v=[1,2]/tags=["Senior Dev"], row1: v=[3]/tags=["Architect","Senior X"],
+     * row2: v=null/tags=null, row3: v=[7,5]/tags=["Manager"].
+     * Scalar ESQL semantics: MV position → null → predicate false → excluded.
+     */
+    public void testListColumnPredicates() throws IOException {
+        // 3-level optional list schema (standard Parquet LIST encoding)
+        MessageType mvSchema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optionalGroup()
+            .as(LogicalTypeAnnotation.listType())
+            .repeatedGroup()
+            .optional(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("element")
+            .named("list")
+            .named("v")
+            .optionalGroup()
+            .as(LogicalTypeAnnotation.listType())
+            .repeatedGroup()
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("element")
+            .named("list")
+            .named("tags")
+            .named("mv_list_schema");
+
+        byte[] bytes = writeMvParquet(mvSchema);
+
+        ReferenceAttribute v = attr("v", DataType.INTEGER);
+        ReferenceAttribute tags = attr("tags", DataType.KEYWORD);
+
+        // v == 3: row1 (single-valued 3); row3 has 7 but is MV → excluded
+        assertMvSurvivors(bytes, eq(v, 3, DataType.INTEGER), Set.of(1L));
+        // v IN (3, 7): row3 is MV → excluded even though 7 matches
+        assertMvSurvivors(bytes, new In(Source.EMPTY, v, List.of(lit(3, DataType.INTEGER), lit(7, DataType.INTEGER))), Set.of(1L));
+        // 2 <= v <= 6: only row1 (value 3 in range)
+        assertMvSurvivors(
+            bytes,
+            new Range(Source.EMPTY, v, lit(2, DataType.INTEGER), true, lit(6, DataType.INTEGER), true, ZoneOffset.UTC),
+            Set.of(1L)
+        );
+        // tags LIKE "Sen*": row0 single-value "Senior Dev" matches; row1 is MV → excluded
+        assertMvSurvivors(bytes, like(tags, "Sen*"), Set.of(0L));
+        // NOT(tags LIKE "Sen*"): row1 MV → excluded by MV semantics in NOT; row3 "Manager" survives
+        assertMvSurvivors(bytes, not(like(tags, "Sen*")), Set.of(3L));
+    }
+
+    private byte[] writeMvParquet(MessageType schema) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            // Row 0: id=0, v=[1,2], tags=["Senior Dev"]
+            Group r0 = factory.newGroup();
+            r0.add("id", 0L);
+            Group v0 = r0.addGroup("v");
+            v0.addGroup("list").add("element", 1);
+            v0.addGroup("list").add("element", 2);
+            Group t0 = r0.addGroup("tags");
+            t0.addGroup("list").add("element", Binary.fromString("Senior Dev"));
+            writer.write(r0);
+
+            // Row 1: id=1, v=[3], tags=["Architect","Senior X"]
+            Group r1 = factory.newGroup();
+            r1.add("id", 1L);
+            r1.addGroup("v").addGroup("list").add("element", 3);
+            Group t1 = r1.addGroup("tags");
+            t1.addGroup("list").add("element", Binary.fromString("Architect"));
+            t1.addGroup("list").add("element", Binary.fromString("Senior X"));
+            writer.write(r1);
+
+            // Row 2: id=2, v=null, tags=null (omit both groups)
+            Group r2 = factory.newGroup();
+            r2.add("id", 2L);
+            writer.write(r2);
+
+            // Row 3: id=3, v=[7,5], tags=["Manager"]
+            Group r3 = factory.newGroup();
+            r3.add("id", 3L);
+            Group v3 = r3.addGroup("v");
+            v3.addGroup("list").add("element", 7);
+            v3.addGroup("list").add("element", 5);
+            r3.addGroup("tags").addGroup("list").add("element", Binary.fromString("Manager"));
+            writer.write(r3);
+        }
+        return out.toByteArray();
+    }
+
+    private void assertMvSurvivors(byte[] parquetBytes, Expression filter, Set<Long> expected) throws IOException {
+        Set<Long> actual = new TreeSet<>();
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(splitTopLevelAnd(filter));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        try (CloseableIterator<Page> iter = reader.read(inMemoryStorageObject(parquetBytes), FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    LongBlock idBlock = (LongBlock) page.getBlock(0);
+                    for (int i = 0; i < page.getPositionCount(); i++) {
+                        actual.add(idBlock.getLong(i));
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        assertEquals("filter: " + filter, expected, actual);
     }
 
     // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL: Fix MV-unsafe evaluator in Parquet late-mat filter (#156604)