### PR TITLE
[9.5] Fix shard result bytes assertion caused by stack trace stripping (#153769)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -463,9 +463,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/156829
-- class: org.elasticsearch.search.telemetry.SearchCoordinatorPhaseShardBytesMetricsIT
-  method: testBatchedQueryPhaseShardErrorRecordsBothRequestAndResultBytes
-  issue: https://github.com/elastic/elasticsearch/issues/156831
 - class: org.elasticsearch.xpack.esql.action.CrossClusterLoggingIT
   method: testRemoteQueryLogging
   issue: https://github.com/elastic/elasticsearch/issues/156834

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/telemetry/SearchCoordinatorPhaseShardBytesMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/telemetry/SearchCoordinatorPhaseShardBytesMetricsIT.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -666,7 +667,11 @@ public class SearchCoordinatorPhaseShardBytesMetricsIT extends ESIntegTestCase {
                 INDEX_NAME
             );
 
-            Client coordOnlyNodeClient = client(coordOnlyNode);
+            // Shards on a node share one deserialized failingQuery; doWriteTo always serializes
+            // its failure field regardless of whether the shard throws. Without error_trace=true,
+            // SearchService strips the stack trace in place when INDEX_NAME shards throw it, so
+            // localIndex shards echo a stripped exception — fewer bytes despite more shards.
+            Client coordOnlyNodeClient = client(coordOnlyNode).filterWithHeader(Map.of("error_trace", "true"));
             // query only the local index and record the baseline for result bytes
             assertSearchHitsWithoutFailures(
                 coordOnlyNodeClient.prepareSearch(localIndex).setQuery(failingQuery).setAllowPartialSearchResults(true),


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix shard result bytes assertion caused by stack trace stripping (#153769)
