### PR TITLE
Wait for source PIT contexts before checking the PIT id

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -929,9 +929,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerInSubqueryGoldenTests
   method: testRowMainMultiColumnInSubqueryWithTsSource {current}
   issue: https://github.com/elastic/elasticsearch/issues/156833
-- class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
-  method: testPointInTimeRelocationReferencingTheSameCommit
-  issue: https://github.com/elastic/elasticsearch/issues/156835
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerInSubqueryGoldenTests
   method: testTsMainMultiColumnInSubqueryWithRowSource {historical}
   issue: https://github.com/elastic/elasticsearch/issues/156842

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
@@ -1087,7 +1087,7 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
         closePointInTime(updatedPit2.get());
     }
 
-    public void testPointInTimeRelocationReferencingTheSameCommit() {
+    public void testPointInTimeRelocationReferencingTheSameCommit() throws Exception {
         assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
@@ -1125,6 +1125,9 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", searchNodeCurrent));
         ensureGreen(indexName);
         assertThat(internalCluster().nodesInclude(indexName), hasItem(searchNodeNext));
+
+        // ensureGreen is not enough, the source node serves this PIT with the old id until its PIT contexts are gone.
+        waitForNoPITContextOnNode(searchNodeCurrent, 5);
 
         // PIT search should still work after relocation, with an updated PIT id
         var updatedPitId = new AtomicReference<BytesReference>();


### PR DESCRIPTION
`testPointInTimeRelocationReferencingTheSameCommit` moves the search shard to another node and then searches with the original PIT id, expecting a changed id back. After starting the relocation the test only calls `ensureGreen` and checks `nodesInclude`. Both read cluster state, so they only tell us the master moved the shard in the routing table. The source node still has to apply that state, close the shard, and run `PITRelocationService.afterIndexShardClosed`, which is what marks its PIT contexts as relocating.

Until that happens the source node keeps serving the PIT. It is tried first, because `getLocalShardsIteratorFromPointInTime` prefers the node encoded in the PIT id while that node is alive, and `SearchService.getShard` keeps using the reader context while it is not marked relocating. The PIT context holds its own searcher, so the search still succeeds there even once the shard is closed. The serving node then matches the node in the PIT id, `maybeReEncodeNodeIds` has nothing to rewrite, and the test fails with `PIT id should have changed after relocation.`.

This is the only test in the class that checks the PIT id changed without first waiting for the source node to drain. The others call `waitForNoPITContextOnNode` or stop the source node.

The fix adds the same wait after `ensureGreen`. Once the source node has no PIT contexts it can no longer serve the PIT, so the search goes to the new node and the id is rewritten.

Closes #156835