### PR TITLE
[9.5] ESQL: fix partial-prefix compound TopN pushdown (#155923)

### DIFF
--- a/docs/changelog/155923.yaml
+++ b/docs/changelog/155923.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 155923
+summary: Fix partial-prefix compound TopN pushdown
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -140,7 +140,6 @@ Vishv          |Zockler        |1.42
 ;
 
 docsSortDesc
-skip_flattened_rewrite: field_extract_multivalue_null
 // tag::sortDesc[]
 FROM employees
 | KEEP first_name, last_name, height
@@ -156,7 +155,6 @@ Saniya         |Kalloufi       |2.1
 ;
 
 docsSortTie
-skip_flattened_rewrite: field_extract_multivalue_null
 // tag::sortTie[]
 FROM employees
 | KEEP first_name, last_name, height
@@ -308,7 +306,6 @@ Bernatsky      |true
 ;
 
 docsRound
-skip_flattened_rewrite: field_extract_multivalue_null
 // tag::round[]
 FROM employees
 | KEEP first_name, last_name, height

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -202,3 +202,30 @@ FROM mv_* | SORT decade | LIMIT 1000 | WHERE date_range IS NOT NULL | STATS MAX(
 MAX(decade):integer
 2000
 ;
+
+
+compoundSortWithNonPushableTrailingKeyNotPartiallyPushed
+required_capability: fix_partial_prefix_compound_topn_pushdown
+
+// Regression test for https://github.com/elastic/elasticsearch/pull/155923.
+// 'languages' is pushable but the trailing 'tiebreak' expression is not, so the compound SORT must not be partially
+// pushed to Lucene. Within emp_no <= 10019, 'languages' has ties (four rows =1, five rows =2) that straddle the
+// LIMIT 6 boundary, and the full sort orders those ties by emp_no DESC (tiebreak = 0 - emp_no). Before the fix Lucene
+// truncated to six documents by 'languages' alone, dropping the high-emp_no languages=2 rows (10018, 10017) at the
+// source so they could never be recovered - returning 10008 and 10001 instead.
+FROM employees
+| WHERE emp_no <= 10019
+| EVAL tiebreak = 0 - emp_no
+| SORT languages ASC, tiebreak ASC
+| LIMIT 6
+| KEEP emp_no, languages
+;
+
+emp_no:integer | languages:integer
+10019          | 1
+10013          | 1
+10009          | 1
+10005          | 1
+10018          | 2
+10017          | 2
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3513,6 +3513,17 @@ public class EsqlCapabilities {
          */
         FIX_TS_STATS_ALIAS_GROUPING_SHADOW,
 
+        /**
+         * Fix for {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushTopNToSource} pushing only a
+         * pushable <em>prefix</em> of a compound {@code SORT}'s keys together with the full {@code LIMIT}. Lucene then
+         * truncated to {@code LIMIT} documents ordered by that prefix alone, so when the prefix had ties straddling the
+         * limit boundary, documents the full sort would have ranked into the top-N were dropped at the source and could
+         * never be recovered - returning wrong results (e.g. {@code SORT score, ABS(x) | LIMIT n}). The compound TopN is
+         * now pushed only when every sort key is pushable.
+         * See <a href="https://github.com/elastic/elasticsearch/pull/155923">#155923</a>.
+         */
+        FIX_PARTIAL_PREFIX_COMPOUND_TOPN_PUSHDOWN,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
@@ -209,7 +209,15 @@ public class PushTopNToSource extends PhysicalOptimizerRules.ParameterizedOptimi
                     break;
                 }
             }
-            if (pushableSorts.isEmpty() == false && tooManyKeywordFieldSorts(pushableSorts, maxKeywordSortFields) == false) {
+            // Only push down when every sort key is pushable. Pushing a strict prefix of the sort keys together with the
+            // limit (see PushableCompoundExec#rewrite) lets Lucene truncate to `limit` documents ordered by that prefix
+            // alone; any remaining, non-pushed sort keys are then applied only to the survivors. When the pushed prefix has
+            // ties that straddle the limit boundary, documents the full sort would have ranked into the top-N are dropped at
+            // the source and can never be recovered, so the query returns wrong results (e.g. a non-pushable trailing key
+            // such as `SORT score, ABS(x) | LIMIT n`). Requiring full coverage mirrors the all-or-nothing PushableQueryExec
+            // path (see canPushDownOrders) and keeps the compute-layer TopN authoritative whenever a non-pushable key is
+            // present.
+            if (pushableSorts.size() == orders.size() && tooManyKeywordFieldSorts(pushableSorts, maxKeywordSortFields) == false) {
                 return new PushableCompoundExec(evalExec, queryExec, pushableSorts);
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -7916,7 +7916,13 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         );
         var extract = as(project.child(), FieldExtractExec.class);
         assertThat(names(extract.attributesToExtract()), contains("abbrev", "city", "country", "name"));
-        var evalExec = as(extract.child(), EvalExec.class);
+        // The trailing sort keys 'scale' and 'loc' are not pushable, so the four-key sort is not fully coverable and the
+        // TopN is not pushed to the source. Pushing only the pushable 'distance, scalerank' prefix together with the limit
+        // would let Lucene truncate to five documents ordered by that prefix alone, dropping documents the full sort would
+        // rank into the top-five whenever the prefix ties (see PushTopNToSource). A local TopN therefore stays in the plan.
+        var topNChild = as(extract.child(), TopNExec.class);
+        assertThat(topNChild.order().size(), is(4));
+        var evalExec = as(topNChild.child(), EvalExec.class);
         var alias = as(evalExec.fields().get(0), Alias.class);
         assertThat(alias.name(), is("distance"));
         var stDistance = as(alias.child(), StDistance.class);
@@ -7925,23 +7931,9 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(names(extract.attributesToExtract()), contains("location", "scalerank"));
         var source = source(extract.child());
 
-        // Assert that the TopN(distance) is pushed down as geo-sort(location)
-        assertThat(source.limit(), is(topN.limit()));
-        Set<String> orderSet = orderAsSet(topN.order().subList(0, 2));
-        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
-        assertThat(orderSet, is(sortsSet));
-
-        // Fine-grained checks on the pushed down sort
-        assertThat(source.limit(), is(l(5)));
-        assertThat(source.sorts().size(), is(2));
-        EsQueryExec.Sort sort = source.sorts().get(0);
-        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
-        assertThat(name(sort.field()), is("location"));
-        assertThat(sort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
-        sort = source.sorts().get(1);
-        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
-        assertThat(name(sort.field()), is("scalerank"));
-        assertThat(sort.sortBuilder(), isA(FieldSortBuilder.class));
+        // The TopN is not pushed down: the source carries no sort or limit and only the WHERE filter is pushed.
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
 
         // Fine-grained checks on the pushed down query
         var bool = as(source.query(), BoolQueryBuilder.class);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -202,8 +202,11 @@ public class PushTopNToSourceTests extends ESTestCase {
     public void testPartiallyPushableSort() {
         // FROM index | EVAL sum = 1 + integer | SORT integer, sum, field | LIMIT 10
         var query = from("index").eval("sum", b -> b.add(b.i(1), b.field("integer"))).sort("integer").sort("sum").sort("field").limit(10);
-        // Both integer and field can be pushed down, but we can only push down the leading sortable fields, so the 'sum' blocks 'field'
-        assertPushdownSort(query, List.of(query.orders.get(0)), null, List.of(EvalExec.class, EsQueryExec.class));
+        // 'integer' and 'field' are pushable but the non-pushable 'sum' sits between them. Pushing only the leading 'integer'
+        // sort together with the limit would let Lucene truncate to 10 documents ordered by 'integer' alone, dropping documents
+        // that the full 'integer, sum, field' sort would rank into the top-10 whenever 'integer' ties straddle the limit. Since
+        // the sort keys are not fully pushable, nothing is pushed and the compute-layer TopN stays authoritative.
+        assertNoPushdownSort(query, "when a non-pushable sort key prevents full sort pushdown");
         assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
     }
 


### PR DESCRIPTION
Backport of #155923 to `9.5`.

## Summary
`PushTopNToSource` pushed a pushable *prefix* of a compound `SORT`'s keys together with the full `LIMIT` to Lucene. When the pushed prefix had ties straddling the limit boundary, documents the full sort would have ranked into the top-N were dropped at the source and could never be recovered (e.g. `SORT score, ABS(x) | LIMIT n`). The compound TopN is now pushed only when every sort key is pushable, gated by the new `FIX_PARTIAL_PREFIX_COMPOUND_TOPN_PUSHDOWN` capability for mixed-version safety.

Clean cherry-pick. `9.5` carries the flattened `CsvFlattenedKeywordIT` harness, so the `docs.csv-spec` un-silencing of `docsSortDesc`/`docsSortTie`/`docsRound` is included as on `main`.

## Test plan
- New `topN.csv-spec` regression `compoundSortWithNonPushableTrailingKeyNotPartiallyPushed` (fails before the fix).
- Updated `PushTopNToSourceTests` and `PhysicalPlanOptimizerTests`.
