### PR TITLE
Add columnar batch-mapping support to VersionStringFieldMapper

### DIFF
--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -453,17 +453,9 @@ public class VersionStringFieldMapper extends FieldMapper {
      * canonical {@code toString} form. This means a source document written as {@code {"f": 1.50}}
      * produces the columnar term {@code "1.5"}, whereas the row path captures the original source
      * text {@code "1.50"} via {@code parser.getText()} — indexing a <em>different</em> term for the
-     * same document. Similarly, {@code 1e3} → {@code "1000.0"} on the columnar path. For the
-     * {@code version} field type this is especially surprising because bare JSON numbers are a
-     * plausible (if non-standard) way to write version components. This divergence is accepted for
-     * consistency with {@code keyword} and {@code ip} fields; the fix requires a future option that
-     * keeps source columns as raw strings instead of re-parsing them. A test for this case is muted
-     * with {@code @AwaitsFix} until that option is available.
-     *
-     * <p>Throwing {@link UnsupportedOperationException} from this method is the sanctioned
-     * deoptimize signal: {@code ShardBatchMapper} catches it, logs
-     * {@code "columnar batch mapping failed on [{}], falling back"}, and re-runs the whole batch on
-     * the row path, which handles the error with correct per-document semantics.
+     * same document. Similarly, {@code 1e3} → {@code "1000.0"} on the columnar path. The fix requires
+     * a future option that keeps source columns as raw strings instead of re-parsing them. A test for
+     * this case is muted with {@code @AwaitsFix} until that option is available.
      */
     @Override
     public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
@@ -491,9 +483,7 @@ public class VersionStringFieldMapper extends FieldMapper {
         if (encoded.isEmpty() == false) {
             // One serialization, two field-type wrappers with disjoint Lucene feature masks: the frozen
             // mapper FieldType carries inversion (docValuesType == NONE) and SortedSetDocValuesField.TYPE
-            // carries doc values (indexOptions == NONE). This mirrors the two fields parseCreateField adds
-            // and is required for the compatibility harness (AbstractColumnarMapperCompatibilityTestCase)
-            // to see field-set parity between the row and columnar paths.
+            // carries doc values (indexOptions == NONE).
             final EscfColumnData data = encoded.finish(docCount);
             ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), fieldType));
             ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), SortedSetDocValuesField.TYPE));

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.versionfield;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.FilteredTermsEnum;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
@@ -17,6 +18,7 @@ import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MultiTermQuery;
@@ -35,10 +37,19 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnData;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.EscfColumnTransforms;
+import org.elasticsearch.escf.LuceneBinaryColumn;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
+import org.elasticsearch.index.mapper.BatchMappingContext;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
@@ -57,6 +68,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlo
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.versionfield.VersionEncoder.EncodedVersion;
 
@@ -399,6 +411,93 @@ public class VersionStringFieldMapper extends FieldMapper {
     @Override
     protected String contentType() {
         return CONTENT_TYPE;
+    }
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // version fields have no store/script/null_value/ignore_malformed/dimension parameters
+        // and are always both indexed and doc-valued, so only copy_to and multi-fields need gating.
+        return indexSettings.getMode().isStrictColumnar()
+            && hasScript() == false
+            && copyTo().copyToFields().isEmpty()
+            && multiFields().iterator().hasNext() == false;
+    }
+
+    /**
+     * Encodes one UTF-8 version value into the sortable binary form used by both the inverted index
+     * and doc values. Wraps {@link IllegalArgumentException} (digit group longer than 127 characters)
+     * in {@link UnsupportedOperationException} so that {@code ShardBatchMapper} falls back to the row
+     * path, which raises the correct per-document error.
+     * <p>
+     * TODO: {@link VersionEncoder#encodeVersion(String)} is String/regex based end to end, so this
+     * costs one String allocation per value. A future byte-level encoder entry point would remove it.
+     */
+    private static BytesRef encodeVersionValue(BytesRef utf8) {
+        try {
+            return encodeVersion(utf8.utf8ToString()).bytesRef;
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException("mapColumnBatch: cannot encode version [" + utf8.utf8ToString() + "]", e);
+        }
+    }
+
+    /**
+     * Columnar bulk-indexing path for {@code version} fields.
+     *
+     * <p>The source column is stringified via {@link EscfColumnTransforms#utf8Cursor}: strings pass
+     * through as-is, JSON arrays are flattened to one tuple per element (with the same doc-id
+     * repeated), absent rows and empty arrays emit nothing, and JSON {@code null} emits a tuple whose
+     * {@code value()} is {@code null}.
+     *
+     * <p><b>IMPORTANT — non-canonical numeric literals diverge from the row path.</b>
+     * {@code utf8Cursor} converts non-STRING ESCF leaves (longs, doubles, booleans) using their
+     * canonical {@code toString} form. This means a source document written as {@code {"f": 1.50}}
+     * produces the columnar term {@code "1.5"}, whereas the row path captures the original source
+     * text {@code "1.50"} via {@code parser.getText()} — indexing a <em>different</em> term for the
+     * same document. Similarly, {@code 1e3} → {@code "1000.0"} on the columnar path. For the
+     * {@code version} field type this is especially surprising because bare JSON numbers are a
+     * plausible (if non-standard) way to write version components. This divergence is accepted for
+     * consistency with {@code keyword} and {@code ip} fields; the fix requires a future option that
+     * keeps source columns as raw strings instead of re-parsing them. A test for this case is muted
+     * with {@code @AwaitsFix} until that option is available.
+     *
+     * <p>Throwing {@link UnsupportedOperationException} from this method is the sanctioned
+     * deoptimize signal: {@code ShardBatchMapper} catches it, logs
+     * {@code "columnar batch mapping failed on [{}], falling back"}, and re-runs the whole batch on
+     * the row path, which handles the error with correct per-document semantics.
+     */
+    @Override
+    public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+        final int docCount = ctx.docCount();
+        // retainValues=false: every value is encoded within one loop iteration, before the cursor advances.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
+        final EscfColumnBuilder encoded = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        encoded.lockScalar(EscfColumnKind.STRING);
+
+        int doc;
+        while ((doc = cursor.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            final BytesRef utf8Value = cursor.value();
+            if (utf8Value == null) {
+                // JSON null emits nothing, mirroring parseCreateField's VALUE_NULL / textOrNull() == null
+                // early returns. version has no null_value parameter.
+                continue;
+            }
+            // Repeated setString for the same doc promotes the row to an ARRAY cell (CollisionPolicy.MERGE),
+            // which becomes a SPARSE column emitting one tuple per element — matching the row path, which
+            // adds one Field + one SortedSetDocValuesField per array element.
+            encoded.setString(doc, encodeVersionValue(utf8Value));
+        }
+
+        if (encoded.isEmpty() == false) {
+            // One serialization, two field-type wrappers with disjoint Lucene feature masks: the frozen
+            // mapper FieldType carries inversion (docValuesType == NONE) and SortedSetDocValuesField.TYPE
+            // carries doc values (indexOptions == NONE). This mirrors the two fields parseCreateField adds
+            // and is required for the compatibility harness (AbstractColumnarMapperCompatibilityTestCase)
+            // to see field-set parity between the row and columnar paths.
+            final EscfColumnData data = encoded.finish(docCount);
+            ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), fieldType));
+            ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), SortedSetDocValuesField.TYPE));
+        }
     }
 
     @Override

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperColumnarCompatibilityTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperColumnarCompatibilityTests.java
@@ -18,11 +18,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * Parity tests ensuring that {@link VersionStringFieldMapper#mapColumnBatch} produces byte-identical
- * Lucene field sets (name + frozen FieldType + value) compared with the x-content row path for every
- * combination of presence, absence, arrays, and version string variants.
- */
 public class VersionStringFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
 
     private static final String FIELD = "f";
@@ -38,10 +33,6 @@ public class VersionStringFieldMapperColumnarCompatibilityTests extends Abstract
             .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
             .build();
     }
-
-    // -------------------------------------------------------------------------
-    // Single-valued / presence tests
-    // -------------------------------------------------------------------------
 
     public void testSingleValue() throws IOException {
         assertColumnarMatchesXContent(
@@ -247,10 +238,6 @@ public class VersionStringFieldMapperColumnarCompatibilityTests extends Abstract
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Non-canonical numeric source literals — known divergence, muted
-    // -------------------------------------------------------------------------
-
     /**
      * Verifies that a canonical integer literal in the source (e.g. {@code {"f": 1}}) is stringified
      * correctly to {@code "1"} on the columnar path and produces the same term as the row path.
@@ -266,12 +253,7 @@ public class VersionStringFieldMapperColumnarCompatibilityTests extends Abstract
         );
     }
 
-    @AwaitsFix(
-        bugUrl = "columnar mapColumnBatch stringifies numeric source literals canonically "
-            + "(e.g. 1.50 -> \"1.5\"), diverging from the row path's parser.getText() which preserves "
-            + "\"1.50\"; the two paths index different terms for the same document. "
-            + "See VersionStringFieldMapper#mapColumnBatch javadoc for details."
-    )
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch-team/issues/4920")
     public void testNonCanonicalNumericLiteral() throws IOException {
         // {"f": 1.50}: row path -> parser.getText() = "1.50"; columnar path -> utf8Cursor = "1.5".
         // These produce different encoded terms, causing a parity failure.

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperColumnarCompatibilityTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperColumnarCompatibilityTests.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.versionfield;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.AbstractColumnarMapperCompatibilityTestCase;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Parity tests ensuring that {@link VersionStringFieldMapper#mapColumnBatch} produces byte-identical
+ * Lucene field sets (name + frozen FieldType + value) compared with the x-content row path for every
+ * combination of presence, absence, arrays, and version string variants.
+ */
+public class VersionStringFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
+
+    private static final String FIELD = "f";
+
+    @Override
+    protected Collection<Plugin> getPlugins() {
+        return List.of(new VersionFieldPlugin(Settings.EMPTY));
+    }
+
+    private static Settings columnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Single-valued / presence tests
+    // -------------------------------------------------------------------------
+
+    public void testSingleValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("single value", 1L, doc("d1", 1L, "{\"f\":\"1.2.3\"}"))
+        );
+    }
+
+    public void testAllPresentDense() throws IOException {
+        // Every doc has a value; exercises the DENSE (validity==null) column wrap.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch(
+                "all present dense",
+                1L,
+                doc("d1", 1L, "{\"f\":\"1.0.0\"}"),
+                doc("d2", 2L, "{\"f\":\"2.0.0\"}"),
+                doc("d3", 3L, "{\"f\":\"3.0.0\"}")
+            )
+        );
+    }
+
+    public void testAbsentDoc() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("absent doc", 1L, doc("d1", 1L, "{}"))
+        );
+    }
+
+    public void testMixedAbsentPresent() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("mixed absent present", 1L, doc("d1", 1L, "{\"f\":\"1.0.0\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"2.0.0\"}"))
+        );
+    }
+
+    public void testExplicitNull() throws IOException {
+        // Explicit JSON null and absent doc both produce no fields; version has no null_value parameter.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("explicit null", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-valued tests
+    // -------------------------------------------------------------------------
+
+    public void testMultiValueArray() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("multi-value array", 1L, doc("d1", 1L, "{\"f\":[\"1.0.0\",\"2.0.0\"]}"))
+        );
+    }
+
+    public void testArrayValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch(
+                "array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"1.0.0\"]}"),
+                doc("d2", 2L, "{\"f\":[\"2.0.0\",\"3.0.0\",\"4.0.0\"]}"),
+                doc("d3", 3L, "{\"f\":[]}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testArrayContainingNull() throws IOException {
+        // Nulls in an array are silently ignored (no null_value substitution).
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("array containing null", 1L, doc("d1", 1L, "{\"f\":[\"1.0.0\",null,\"2.0.0\"]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testDuplicateValuesInArray() throws IOException {
+        // The SORTED_SET doc-values writer deduplicates ordinals; the inverted-index writer deduplicates
+        // terms. Both the row and columnar paths rely on Lucene to handle deduplication identically.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("duplicate values in array", 1L, doc("d1", 1L, "{\"f\":[\"1.0.0\",\"1.0.0\",\"2.0.0\"]}"))
+        );
+    }
+
+    public void testNestedArrayFlattening() throws IOException {
+        // Nested arrays are flattened, matching the row-path behaviour in DocumentParser.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("nested array flattening", 1L, doc("d1", 1L, "{\"f\":[[\"1.0.0\",\"2.0.0\"],[\"3.0.0\"]]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Encoder coverage — version-specific variants
+    // -------------------------------------------------------------------------
+
+    public void testPreRelease() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch(
+                "pre-release versions",
+                1L,
+                doc("d1", 1L, "{\"f\":\"1.0.0-alpha\"}"),
+                doc("d2", 2L, "{\"f\":\"1.0.0-alpha.1\"}"),
+                doc("d3", 3L, "{\"f\":\"1.0.0-0.3.7\"}")
+            )
+        );
+    }
+
+    public void testBuildSuffix() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("build suffix versions", 1L, doc("d1", 1L, "{\"f\":\"1.0.0+build.1\"}"), doc("d2", 2L, "{\"f\":\"1.0.0-alpha+001\"}"))
+        );
+    }
+
+    public void testIllegalVersionStrings() throws IOException {
+        // Non-semver strings hit the isLegal==false path, which encodes the raw string bytes.
+        // This verifies that the columnar encoder produces the same raw-bytes result as the row path.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch(
+                "illegal version strings",
+                1L,
+                doc("d1", 1L, "{\"f\":\"not-a-version\"}"),
+                doc("d2", 2L, "{\"f\":\"1.2.3.4.5-SNAPSHOT\"}"),
+                doc("d3", 3L, "{\"f\":\"v1.0\"}")
+            )
+        );
+    }
+
+    public void testEmptyString() throws IOException {
+        // Empty string exercises VersionEncoder's ENCODED_EMPTY_STRING special case.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("empty string", 1L, doc("d1", 1L, "{\"f\":\"\"}"))
+        );
+    }
+
+    public void testLongDigitGroups() throws IOException {
+        // A multi-digit numeric group exercises the NUMERIC_MARKER_BYTE + length prefix encoding in
+        // prefixDigitGroupsWithLength. The group must fit in Integer.MAX_VALUE (VersionEncoder parses
+        // numeric identifiers with Integer.valueOf), so we use a 9-digit number safely below 2^31-1.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("long digit groups", 1L, doc("d1", 1L, "{\"f\":\"1.0.999999999\"}"))
+        );
+    }
+
+    public void testManyIdentifiers() throws IOException {
+        // More than MAX_LEGAL_VERSION_IDENTIFIERS (32) dot-separated identifiers triggers the
+        // tooManyIdentifiers() path, which falls back to raw-string encoding (isLegal==false).
+        String manyDots = "1." + "0.".repeat(33) + "0";
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("many identifiers", 1L, doc("d1", 1L, "{\"f\":\"" + manyDots + "\"}"))
+        );
+    }
+
+    public void testNonAscii() throws IOException {
+        // Multi-byte UTF-8 string hits the isLegal==false path; verifies the utf8ToString()
+        // round-trip preserves the original bytes.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("non-ascii version string", 1L, doc("d1", 1L, "{\"f\":\"1.0.0-é\"}"))
+        );
+    }
+
+    public void testLargeMixedBatch() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch(
+                "large mixed batch",
+                1L,
+                doc("d1", 1L, "{\"f\":\"1.0.0\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":[\"2.0.0\",\"3.0.0-beta\"]}"),
+                doc("d4", 4L, "{\"f\":\"4.0.0+build.1\"}"),
+                doc("d5", 5L, "{}"),
+                doc("d6", 6L, "{\"f\":\"not-a-version\"}"),
+                doc("d7", 7L, "{}")
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-canonical numeric source literals — known divergence, muted
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that a canonical integer literal in the source (e.g. {@code {"f": 1}}) is stringified
+     * correctly to {@code "1"} on the columnar path and produces the same term as the row path.
+     */
+    public void testNumericSourceValue() throws IOException {
+        // {"f": 1} -> utf8Cursor yields "1" (canonical toString), encodeVersion("1") produces
+        // the same bytes as encodeVersion(parser.getText()) on the row path. This test exercises
+        // the number-to-string conversion for a canonical literal.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("numeric source value canonical", 1L, doc("d1", 1L, "{\"f\":1}"))
+        );
+    }
+
+    @AwaitsFix(
+        bugUrl = "columnar mapColumnBatch stringifies numeric source literals canonically "
+            + "(e.g. 1.50 -> \"1.5\"), diverging from the row path's parser.getText() which preserves "
+            + "\"1.50\"; the two paths index different terms for the same document. "
+            + "See VersionStringFieldMapper#mapColumnBatch javadoc for details."
+    )
+    public void testNonCanonicalNumericLiteral() throws IOException {
+        // {"f": 1.50}: row path -> parser.getText() = "1.50"; columnar path -> utf8Cursor = "1.5".
+        // These produce different encoded terms, causing a parity failure.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "version").endObject()),
+            columnarSettings(),
+            batch("non-canonical numeric literal", 1L, doc("d1", 1L, "{\"f\":1.50}"), doc("d2", 2L, "{\"f\":\"2.0.0\"}"))
+        );
+    }
+}


### PR DESCRIPTION
supportsColumnarParse + mapColumnBatch on VersionStringFieldMapper, plus a new
VersionStringFieldMapperColumnarCompatibilityTests parity test.