### PR TITLE
[8.19] Fix testCloseOrReallocateDuringPartialSnapshot

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -50,9 +50,6 @@ tests:
 - class: org.elasticsearch.search.SearchWithRejectionsIT
   method: testOpenContextsAfterRejections
   issue: https://github.com/elastic/elasticsearch/issues/156244
-- class: org.elasticsearch.snapshots.SharedClusterSnapshotRestoreIT
-  method: testCloseOrReallocateDuringPartialSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/156342
 - class: org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImplTests
   issue: https://github.com/elastic/elasticsearch/issues/156628
 - class: org.elasticsearch.gradle.reaper.ReaperPluginFuncTest

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1440,12 +1440,11 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         safeAwait(barrier);
 
         final var snapshotName = randomIdentifier();
-        final var partialSnapshot = randomBoolean();
         ActionFuture<CreateSnapshotResponse> snapshotFuture = clusterAdmin().prepareCreateSnapshot(
             TEST_REQUEST_TIMEOUT,
             repoName,
             snapshotName
-        ).setIndices(indexName).setWaitForCompletion(true).setPartial(partialSnapshot).execute();
+        ).setIndices(indexName).setWaitForCompletion(true).setPartial(true).execute();
 
         // we have currently blocked the start-snapshot task from running, and it will be followed by at least three blob uploads
         // (segments_N, .cfe, .cfs), executed one-at-a-time because of throttling to the max threadpool size, so it's safe to let up to
@@ -1459,7 +1458,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertFalse(snapshotFuture.isDone());
 
         try {
-            if (partialSnapshot && randomBoolean()) {
+            if (randomBoolean()) {
                 logger.info("--> closing index [{}]", indexName);
                 safeGet(indicesAdmin().prepareClose(indexName).execute());
                 ensureGreen(indexName);


### PR DESCRIPTION
Backports: https://github.com/elastic/elasticsearch/pull/132049

There was race between setting a shard as failed and a concurrent non-partial snapshot, causing a snapshot failure because a primary shard ended up being unassigned. This was fixed on main in #132049 but not on branch 8.19, where it originally failed.


Closes: https://github.com/elastic/elasticsearch/issues/156342
