### PR TITLE
Resolve OIDC provider endpoints via discovery document

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/security-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/security-settings.md
@@ -1156,28 +1156,36 @@ In addition to the [settings that are valid for all realms](#ref-realm-settings)
 `op.issuer` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) A verifiable Identifier for your OpenID Connect Provider. An Issuer Identifier is usually a case sensitive URL using the https scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components. The value for this setting should be provided by your OpenID Connect Provider.
 
-If any of `op.authorization_endpoint`, `op.token_endpoint`, `op.userinfo_endpoint`, `op.endsession_endpoint`, or `op.jwkset_path` is not explicitly configured, {{es}} resolves it from the OpenID Connect Provider's discovery document at `<op.issuer>/.well-known/openid-configuration`. Explicitly configured endpoint settings always take precedence over the discovered values.
+    {applies_to}`stack: ga 9.6` If any of `op.authorization_endpoint`, `op.token_endpoint`, `op.userinfo_endpoint`, `op.endsession_endpoint`, or `op.jwkset_path` is not explicitly configured, {{es}} resolves it from the OpenID Connect Provider's discovery document at `<op.issuer>/.well-known/openid-configuration`. Explicitly configured endpoint settings always take precedence over the discovered values.
 
 `op.authorization_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Authorization Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Authorization Endpoint at the OpenID Connect Provider.
+
+    {applies_to}`stack: ga 9.6` If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.token_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Token Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Token Endpoint at the OpenID Connect Provider.
+
+    {applies_to}`stack: ga 9.6` If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.userinfo_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the User Info Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the User Info Endpoint at the OpenID Connect Provider.
+
+    {applies_to}`stack: ga 9.6` If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.endsession_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the End Session Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the End Session Endpoint at the OpenID Connect Provider.
+
+    {applies_to}`stack: ga 9.6` If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.jwkset_path` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting))
 
-The file name or URL to a JSON Web Key Set (JWKS) with the public key material used to verify tokens and claims responses signed by the OpenID Connect Provider. A value is considered a file name if it does not begin with `https` or `http`. The file name is resolved relative to the {{es}} configuration directory.  Changes to the file are polled at a frequency determined by the global {{es}} `resource.reload.interval.high` setting, which defaults to 5 seconds.
+    The file name or URL to a JSON Web Key Set (JWKS) with the public key material used to verify tokens and claims responses signed by the OpenID Connect Provider. A value is considered a file name if it does not begin with `https` or `http`. The file name is resolved relative to the {{es}} configuration directory.  Changes to the file are polled at a frequency determined by the global {{es}} `resource.reload.interval.high` setting, which defaults to 5 seconds.
+    
+    If a URL is provided, then it must begin with `https://` or `http://`. {{es}} automatically caches the retrieved JWK and will attempt to refresh the JWK upon signature verification failure, as this might indicate that the OpenID Connect Provider has rotated the signing keys.
 
-+ If a URL is provided, then it must begin with `https://` or `http://`. {{es}} automatically caches the retrieved JWK and will attempt to refresh the JWK upon signature verification failure, as this might indicate that the OpenID Connect Provider has rotated the signing keys.
-
-+ If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
+    {applies_to}`stack: ga 9.6` If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `authorization_realms`
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The names of the realms that should be consulted for delegated authorization. If this setting is used, then the OpenID Connect realm does not perform role mapping and instead loads the user from the listed realms. See [Delegating authorization to another realm](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md#authorization_realms).
@@ -1275,7 +1283,7 @@ The file name or URL to a JSON Web Key Set (JWKS) with the public key material u
 `http.connection_pool_ttl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) Controls the behavior of the http client used for back-channel communication to the OpenID Connect Provider endpoints. Specifies the time-to-live of connections in the connection pool (default to 3 minutes). A connection is closed if it is idle for more than the specified timeout.
 
-The server can also set the `Keep-Alive` HTTP response header. The effective time-to-live value is the smaller value between this setting and the `Keep-Alive` response header. Configure this setting to `-1` to let the server dictate the value. If the header is not set by the server and the setting has value of `-1`, the time-to-live is infinite and connections never expire.
+    The server can also set the `Keep-Alive` HTTP response header. The effective time-to-live value is the smaller value between this setting and the `Keep-Alive` response header. Configure this setting to `-1` to let the server dictate the value. If the header is not set by the server and the setting has value of `-1`, the time-to-live is infinite and connections never expire.
 
 
 #### OpenID Connect realm SSL settings [ref-oidc-ssl-settings]

--- a/docs/reference/elasticsearch/configuration-reference/security-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/security-settings.md
@@ -1156,17 +1156,19 @@ In addition to the [settings that are valid for all realms](#ref-realm-settings)
 `op.issuer` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) A verifiable Identifier for your OpenID Connect Provider. An Issuer Identifier is usually a case sensitive URL using the https scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components. The value for this setting should be provided by your OpenID Connect Provider.
 
+If any of `op.authorization_endpoint`, `op.token_endpoint`, `op.userinfo_endpoint`, `op.endsession_endpoint`, or `op.jwkset_path` is not explicitly configured, {{es}} resolves it from the OpenID Connect Provider's discovery document at `<op.issuer>/.well-known/openid-configuration`. Explicitly configured endpoint settings always take precedence over the discovered values.
+
 `op.authorization_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Authorization Endpoint at the OpenID Connect Provider. The value for this setting should be provided by your OpenID Connect Provider.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Authorization Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.token_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Token Endpoint at the OpenID Connect Provider. The value for this setting should be provided by your OpenID Connect Provider.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the Token Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.userinfo_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the User Info Endpoint at the OpenID Connect Provider. The value for this setting should be provided by your OpenID Connect Provider.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the User Info Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.endsession_endpoint` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the End Session Endpoint at the OpenID Connect Provider. The value for this setting should be provided by your OpenID Connect Provider.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The URL for the End Session Endpoint at the OpenID Connect Provider. If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `op.jwkset_path` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting))
@@ -1174,6 +1176,8 @@ In addition to the [settings that are valid for all realms](#ref-realm-settings)
 The file name or URL to a JSON Web Key Set (JWKS) with the public key material used to verify tokens and claims responses signed by the OpenID Connect Provider. A value is considered a file name if it does not begin with `https` or `http`. The file name is resolved relative to the {{es}} configuration directory.  Changes to the file are polled at a frequency determined by the global {{es}} `resource.reload.interval.high` setting, which defaults to 5 seconds.
 
 + If a URL is provided, then it must begin with `https://` or `http://`. {{es}} automatically caches the retrieved JWK and will attempt to refresh the JWK upon signature verification failure, as this might indicate that the OpenID Connect Provider has rotated the signing keys.
+
++ If not set, this is resolved from the discovery document at `<op.issuer>/.well-known/openid-configuration`.
 
 `authorization_realms`
 :   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) The names of the realms that should be consulted for delegated authorization. If this setting is used, then the OpenID Connect realm does not perform role mapping and instead loads the user from the listed realms. See [Delegating authorization to another realm](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/realm-chains.md#authorization_realms).

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectProviderDiscoveryResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectProviderDiscoveryResolver.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.security.authc.oidc;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.core.ssl.SslProfile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings.HTTP_CONNECT_TIMEOUT;
+import static org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings.HTTP_PROXY_HOST;
+import static org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings.HTTP_PROXY_PORT;
+import static org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings.HTTP_PROXY_SCHEME;
+import static org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings.HTTP_SOCKET_TIMEOUT;
+
+/**
+ * Resolves an OpenID Connect Provider's {@code .well-known/openid-configuration} discovery document, so that
+ * {@code op.*} endpoint settings that are not explicitly configured can be derived from it, per
+ * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect Discovery 1.0</a>.
+ * The fetch is a one-shot, synchronous, blocking call performed at realm construction time; it is only invoked
+ * when at least one {@code op.*} endpoint setting has been left unset.
+ */
+final class OpenIdConnectProviderDiscoveryResolver {
+
+    private OpenIdConnectProviderDiscoveryResolver() {}
+
+    static OIDCProviderMetadata resolve(RealmConfig config, SSLService sslService, String issuer) {
+        final URI wellKnownUri = buildWellKnownUri(config, issuer);
+        final String body = fetch(config, sslService, wellKnownUri);
+        final OIDCProviderMetadata metadata;
+        try {
+            metadata = OIDCProviderMetadata.parse(body);
+        } catch (ParseException e) {
+            throw new SettingsException("Failed to parse the OpenID Connect provider metadata received from [" + wellKnownUri + "]", e);
+        }
+        if (metadata.getIssuer().getValue().equals(issuer) == false) {
+            throw new SettingsException(
+                "The configured issuer ["
+                    + issuer
+                    + "] does not match the issuer ["
+                    + metadata.getIssuer().getValue()
+                    + "] returned by the discovery document at ["
+                    + wellKnownUri
+                    + "]"
+            );
+        }
+        return metadata;
+    }
+
+    private static URI buildWellKnownUri(RealmConfig config, String issuer) {
+        final String normalizedIssuer = issuer.endsWith("/") ? issuer.substring(0, issuer.length() - 1) : issuer;
+        try {
+            return new URI(normalizedIssuer + "/.well-known/openid-configuration");
+        } catch (URISyntaxException e) {
+            throw new SettingsException(
+                "Invalid value ["
+                    + issuer
+                    + "] for ["
+                    + RealmSettings.getFullSettingKey(config, OpenIdConnectRealmSettings.OP_ISSUER)
+                    + "]. Not a valid URI.",
+                e
+            );
+        }
+    }
+
+    private static String fetch(RealmConfig config, SSLService sslService, URI wellKnownUri) {
+        final HttpClientBuilder builder = HttpClientBuilder.create();
+        final String sslKey = RealmSettings.realmSslPrefix(config.identifier());
+        final SslProfile sslProfile = sslService.profile(sslKey);
+        final SSLConnectionSocketFactory socketFactory = sslProfile.connectionSocketFactory();
+        builder.setSSLSocketFactory(socketFactory);
+
+        final RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(Math.toIntExact(config.getSetting(HTTP_CONNECT_TIMEOUT).getMillis()))
+            .setSocketTimeout(Math.toIntExact(config.getSetting(HTTP_SOCKET_TIMEOUT).getMillis()))
+            .build();
+        builder.setDefaultRequestConfig(requestConfig);
+
+        if (config.hasSetting(HTTP_PROXY_HOST)) {
+            builder.setProxy(
+                new HttpHost(config.getSetting(HTTP_PROXY_HOST), config.getSetting(HTTP_PROXY_PORT), config.getSetting(HTTP_PROXY_SCHEME))
+            );
+        }
+
+        try (CloseableHttpClient httpClient = builder.build()) {
+            try (CloseableHttpResponse response = httpClient.execute(new HttpGet(wellKnownUri))) {
+                final int statusCode = response.getStatusLine().getStatusCode();
+                final String body = EntityUtils.toString(response.getEntity());
+                if (statusCode != 200) {
+                    throw new SettingsException(
+                        "Failed to fetch OpenID Connect provider metadata from ["
+                            + wellKnownUri
+                            + "] for realm ["
+                            + RealmSettings.getFullSettingKey(config, OpenIdConnectRealmSettings.OP_ISSUER)
+                            + "]. Unexpected response status ["
+                            + statusCode
+                            + "]"
+                    );
+                }
+                return body;
+            }
+        } catch (IOException e) {
+            throw new SettingsException(
+                "Failed to fetch OpenID Connect provider metadata from ["
+                    + wellKnownUri
+                    + "] for realm ["
+                    + RealmSettings.getFullSettingKey(config, OpenIdConnectRealmSettings.OP_ISSUER)
+                    + "]",
+                e
+            );
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.LogoutRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
@@ -96,7 +97,7 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         super(config);
         this.roleMapper = roleMapper;
         this.rpConfiguration = buildRelyingPartyConfiguration(config);
-        this.opConfiguration = buildOpenIdConnectProviderConfiguration(config);
+        this.opConfiguration = buildOpenIdConnectProviderConfiguration(config, sslService);
         this.principalAttribute = ClaimParser.forSetting(logger, PRINCIPAL_CLAIM, config, true);
         this.groupsAttribute = ClaimParser.forSetting(logger, GROUPS_CLAIM, config, false);
         this.dnAttribute = ClaimParser.forSetting(logger, DN_CLAIM, config, false);
@@ -124,7 +125,9 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         super(config);
         this.roleMapper = roleMapper;
         this.rpConfiguration = buildRelyingPartyConfiguration(config);
-        this.opConfiguration = buildOpenIdConnectProviderConfiguration(config);
+        // Discovery is only triggered when an op.* endpoint setting is left unset; callers of this constructor
+        // must keep configuring every op.* endpoint explicitly, since no SSLService is available here to fetch one.
+        this.opConfiguration = buildOpenIdConnectProviderConfiguration(config, null);
         this.openIdConnectAuthenticator = authenticator;
         this.principalAttribute = ClaimParser.forSetting(logger, PRINCIPAL_CLAIM, config, true);
         this.groupsAttribute = ClaimParser.forSetting(logger, GROUPS_CLAIM, config, false);
@@ -286,20 +289,52 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         );
     }
 
-    private OpenIdConnectProviderConfiguration buildOpenIdConnectProviderConfiguration(RealmConfig config) {
+    private OpenIdConnectProviderConfiguration buildOpenIdConnectProviderConfiguration(
+        RealmConfig config,
+        @Nullable SSLService sslService
+    ) {
         Issuer issuer = new Issuer(require(config, OP_ISSUER));
 
-        String jwkSetUrl = require(config, OP_JWKSET_PATH);
+        // Only fetch the discovery document when one of the *required* op.* endpoints is left unset; a
+        // fully-explicit configuration (as required before this feature existed) never triggers a network call.
+        // op.userinfo_endpoint/op.endsession_endpoint are legitimately optional and their absence alone must not
+        // trigger discovery, otherwise every pre-existing config that omits them would start doing a network
+        // fetch at realm construction time.
+        final boolean tokenEndpointRequired = "code".equals(config.getSetting(RP_RESPONSE_TYPE));
+        final boolean needsDiscovery = config.getSetting(OP_AUTHORIZATION_ENDPOINT).isEmpty()
+            || config.getSetting(OP_JWKSET_PATH).isEmpty()
+            || (tokenEndpointRequired && config.getSetting(OP_TOKEN_ENDPOINT).isEmpty());
+        final OIDCProviderMetadata discovered = needsDiscovery
+            ? OpenIdConnectProviderDiscoveryResolver.resolve(config, sslService, issuer.getValue())
+            : null;
+
+        String jwkSetUrl = requireResolved(
+            config,
+            OP_JWKSET_PATH,
+            discovered == null || discovered.getJWKSetURI() == null ? null : discovered.getJWKSetURI().toString()
+        );
 
         URI authorizationEndpoint;
         try {
-            authorizationEndpoint = new URI(require(config, OP_AUTHORIZATION_ENDPOINT));
+            authorizationEndpoint = new URI(
+                requireResolved(
+                    config,
+                    OP_AUTHORIZATION_ENDPOINT,
+                    discovered == null || discovered.getAuthorizationEndpointURI() == null
+                        ? null
+                        : discovered.getAuthorizationEndpointURI().toString()
+                )
+            );
         } catch (URISyntaxException e) {
             // This should never happen as it's already validated in the settings
             throw new SettingsException("Invalid URI: " + OP_AUTHORIZATION_ENDPOINT.getKey(), e);
         }
         String responseType = require(config, RP_RESPONSE_TYPE);
-        String tokenEndpointString = config.getSetting(OP_TOKEN_ENDPOINT);
+        String tokenEndpointString = resolveSetting(
+            config,
+            OP_TOKEN_ENDPOINT,
+            discovered == null || discovered.getTokenEndpointURI() == null ? null : discovered.getTokenEndpointURI().toString()
+        );
         if (responseType.equals("code") && tokenEndpointString.isEmpty()) {
             throw new SettingsException(
                 "The configuration setting ["
@@ -318,18 +353,26 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         }
         URI userinfoEndpoint;
         try {
-            userinfoEndpoint = (config.getSetting(OP_USERINFO_ENDPOINT).isEmpty())
-                ? null
-                : new URI(config.getSetting(OP_USERINFO_ENDPOINT));
+            final String userinfoEndpointString = resolveSetting(
+                config,
+                OP_USERINFO_ENDPOINT,
+                discovered == null || discovered.getUserInfoEndpointURI() == null ? null : discovered.getUserInfoEndpointURI().toString()
+            );
+            userinfoEndpoint = userinfoEndpointString.isEmpty() ? null : new URI(userinfoEndpointString);
         } catch (URISyntaxException e) {
             // This should never happen as it's already validated in the settings
             throw new SettingsException("Invalid URI: " + OP_USERINFO_ENDPOINT.getKey(), e);
         }
         URI endsessionEndpoint;
         try {
-            endsessionEndpoint = (config.getSetting(OP_ENDSESSION_ENDPOINT).isEmpty())
-                ? null
-                : new URI(config.getSetting(OP_ENDSESSION_ENDPOINT));
+            final String endsessionEndpointString = resolveSetting(
+                config,
+                OP_ENDSESSION_ENDPOINT,
+                discovered == null || discovered.getEndSessionEndpointURI() == null
+                    ? null
+                    : discovered.getEndSessionEndpointURI().toString()
+            );
+            endsessionEndpoint = endsessionEndpointString.isEmpty() ? null : new URI(endsessionEndpointString);
         } catch (URISyntaxException e) {
             // This should never happen as it's already validated in the settings
             throw new SettingsException("Invalid URI: " + OP_ENDSESSION_ENDPOINT.getKey(), e);
@@ -347,6 +390,27 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
 
     private static String require(RealmConfig config, Setting.AffixSetting<String> setting) {
         final String value = config.getSetting(setting);
+        if (value.isEmpty()) {
+            throw new SettingsException("The configuration setting [" + RealmSettings.getFullSettingKey(config, setting) + "] is required");
+        }
+        return value;
+    }
+
+    /**
+     * Returns the explicitly configured value for {@code setting}, falling back to {@code discoveredValue} (which
+     * may be {@code null}) when the setting is unset. An explicitly configured value always takes precedence over
+     * a value resolved from the OpenID Connect provider's discovery document.
+     */
+    private static String resolveSetting(RealmConfig config, Setting.AffixSetting<String> setting, @Nullable String discoveredValue) {
+        final String explicit = config.getSetting(setting);
+        if (explicit.isEmpty() == false) {
+            return explicit;
+        }
+        return discoveredValue == null ? "" : discoveredValue;
+    }
+
+    private static String requireResolved(RealmConfig config, Setting.AffixSetting<String> setting, @Nullable String discoveredValue) {
+        final String value = resolveSetting(config, setting, discoveredValue);
         if (value.isEmpty()) {
             throw new SettingsException("The configuration setting [" + RealmSettings.getFullSettingKey(config, setting) + "] is required");
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmSettingsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmSettingsTests.java
@@ -6,19 +6,27 @@
  */
 package org.elasticsearch.xpack.security.authc.oidc;
 
+import com.sun.net.httpserver.HttpServer;
+
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
+import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
@@ -98,8 +106,13 @@ public class OpenIdConnectRealmSettingsTests extends ESTestCase {
     }
 
     public void testMissingAuthorizationEndpointThrowsError() {
+        // op.authorization_endpoint is left unset, so the realm now attempts to resolve it from the OP's discovery
+        // document at <op.issuer>/.well-known/openid-configuration; since op.issuer here doesn't serve one, that
+        // fetch fails and surfaces as a SettingsException naming the (unreachable) discovery URL.
+        final int closedPort = findClosedPort();
+        final String issuer = "http://" + InetAddresses.toUriString(InetAddress.getLoopbackAddress()) + ":" + closedPort;
         final Settings.Builder settingsBuilder = Settings.builder()
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), "https://op.example.com")
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_JWKSET_PATH), "https://op.example.com/jwks.json")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_TOKEN_ENDPOINT), "https://op.example.com/token")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
@@ -107,13 +120,12 @@ public class OpenIdConnectRealmSettingsTests extends ESTestCase {
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code");
         settingsBuilder.setSecureSettings(getSecureSettings());
-        SettingsException exception = expectThrows(SettingsException.class, () -> {
-            new OpenIdConnectRealm(buildConfig(settingsBuilder.build()), null, null);
-        });
-        assertThat(
-            exception.getMessage(),
-            Matchers.containsString(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_AUTHORIZATION_ENDPOINT))
+        final RealmConfig config = buildConfig(settingsBuilder.build());
+        SettingsException exception = expectThrows(
+            SettingsException.class,
+            () -> new OpenIdConnectRealm(config, sslServiceForDiscovery(), null, null)
         );
+        assertThat(exception.getMessage(), Matchers.containsString(issuer));
     }
 
     public void testInvalidAuthorizationEndpointThrowsError() {
@@ -136,23 +148,55 @@ public class OpenIdConnectRealmSettingsTests extends ESTestCase {
         );
     }
 
-    public void testMissingTokenEndpointThrowsErrorInCodeFlow() {
-        final Settings.Builder settingsBuilder = Settings.builder()
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_AUTHORIZATION_ENDPOINT), "https://op.example.com/login")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), "https://op.example.com")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_JWKSET_PATH), "https://op.example.com/jwks.json")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code");
-        settingsBuilder.setSecureSettings(getSecureSettings());
-        SettingsException exception = expectThrows(SettingsException.class, () -> {
-            new OpenIdConnectRealm(buildConfig(settingsBuilder.build()), null, null);
-        });
-        assertThat(
-            exception.getMessage(),
-            Matchers.containsString(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_TOKEN_ENDPOINT))
-        );
+    public void testMissingTokenEndpointThrowsErrorInCodeFlow() throws Exception {
+        // op.token_endpoint is left unset, and op.authorization_endpoint/op.jwkset_path are also left unset so that
+        // discovery is attempted; the served discovery document omits token_endpoint (optional per the OIDC
+        // discovery spec), so it remains missing even after discovery, and the "code" response type still requires
+        // it, producing the same "setting is required" SettingsException as before this feature existed.
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final InetSocketAddress address = httpServer.getAddress();
+            final String issuer = "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+            httpServer.createContext("/.well-known/openid-configuration", exchange -> {
+                final byte[] body = """
+                    {
+                      "issuer": "%s",
+                      "authorization_endpoint": "%s/login",
+                      "jwks_uri": "%s/jwks.json",
+                      "response_types_supported": ["code"],
+                      "subject_types_supported": ["public"],
+                      "id_token_signing_alg_values_supported": ["RS256"]
+                    }
+                    """.formatted(issuer, issuer, issuer).getBytes(StandardCharsets.UTF_8);
+                try {
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(200, body.length);
+                    exchange.getResponseBody().write(body);
+                } finally {
+                    exchange.close();
+                }
+            });
+
+            final Settings.Builder settingsBuilder = Settings.builder()
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code");
+            settingsBuilder.setSecureSettings(getSecureSettings());
+            final RealmConfig config = buildConfig(settingsBuilder.build());
+            SettingsException exception = expectThrows(
+                SettingsException.class,
+                () -> new OpenIdConnectRealm(config, sslServiceForDiscovery(), null, null)
+            );
+            assertThat(
+                exception.getMessage(),
+                Matchers.containsString(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_TOKEN_ENDPOINT))
+            );
+        } finally {
+            httpServer.stop(1);
+        }
     }
 
     public void testMissingTokenEndpointIsAllowedInImplicitFlow() {
@@ -190,21 +234,24 @@ public class OpenIdConnectRealmSettingsTests extends ESTestCase {
     }
 
     public void testMissingJwksUrlThrowsError() {
+        // op.jwkset_path is left unset, so the realm attempts to resolve it from the OP's discovery document;
+        // since op.issuer here doesn't serve one, that fetch fails with a SettingsException naming the discovery URL.
+        final int closedPort = findClosedPort();
+        final String issuer = "http://" + InetAddresses.toUriString(InetAddress.getLoopbackAddress()) + ":" + closedPort;
         final Settings.Builder settingsBuilder = Settings.builder()
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_AUTHORIZATION_ENDPOINT), "https://op.example.com/login")
-            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), "https://op.example.com")
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code");
         settingsBuilder.setSecureSettings(getSecureSettings());
-        SettingsException exception = expectThrows(SettingsException.class, () -> {
-            new OpenIdConnectRealm(buildConfig(settingsBuilder.build()), null, null);
-        });
-        assertThat(
-            exception.getMessage(),
-            Matchers.containsString(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_JWKSET_PATH))
+        final RealmConfig config = buildConfig(settingsBuilder.build());
+        SettingsException exception = expectThrows(
+            SettingsException.class,
+            () -> new OpenIdConnectRealm(config, sslServiceForDiscovery(), null, null)
         );
+        assertThat(exception.getMessage(), Matchers.containsString(issuer));
     }
 
     public void testMissingIssuerThrowsError() {
@@ -460,5 +507,25 @@ public class OpenIdConnectRealmSettingsTests extends ESTestCase {
             .build();
         final Environment env = TestEnvironment.newEnvironment(settings);
         return new RealmConfig(realmIdentifier, settings, env, threadContext);
+    }
+
+    private int findClosedPort() {
+        try (var socket = new java.net.ServerSocket(0, 0, InetAddress.getLoopbackAddress())) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * An {@link SSLService} whose realm SSL context is registered, for tests that need the realm's discovery
+     * resolver to make a real (albeit failing or loopback-only) HTTP connection.
+     */
+    private SSLService sslServiceForDiscovery() {
+        final Settings settings = Settings.builder()
+            .put("path.home", createTempDir())
+            .put("xpack.security.authc.realms.oidc." + REALM_NAME + ".ssl.verification_mode", "certificate")
+            .build();
+        return new SSLService(TestEnvironment.newEnvironment(settings));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -10,16 +10,21 @@ import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.Nonce;
+import com.sun.net.httpserver.HttpServer;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.rest.RequestParams;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.action.oidc.OpenIdConnectLogoutResponse;
 import org.elasticsearch.xpack.core.security.action.oidc.OpenIdConnectPrepareAuthenticationResponse;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -31,6 +36,7 @@ import org.elasticsearch.xpack.core.security.authc.support.ClaimSetting;
 import org.elasticsearch.xpack.core.security.authc.support.DelegatedAuthorizationSettings;
 import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
 import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.authc.support.ClaimParser;
 import org.elasticsearch.xpack.security.authc.support.MockLookupRealm;
@@ -38,6 +44,8 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.mockito.stubbing.Answer;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +83,11 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
 
     @Before
     public void setupEnv() {
-        globalSettings = Settings.builder().put("path.home", createTempDir()).build();
+        globalSettings = Settings.builder()
+            .put("path.home", createTempDir())
+            // Registers the realm's SSL context so that SSLService#profile(...) can resolve it in the discovery tests
+            .put("xpack.security.authc.realms.oidc." + REALM_NAME + ".ssl.verification_mode", "certificate")
+            .build();
         env = TestEnvironment.newEnvironment(globalSettings);
         threadContext = new ThreadContext(globalSettings);
     }
@@ -446,6 +458,222 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
                 + "&client_id=rp-my"
         );
         assertThat(response.getRealmName(), equalTo(REALM_NAME));
+    }
+
+    public void testProviderConfigurationIsDiscoveredWhenEndpointsAreUnset() throws Exception {
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final String issuer = issuerUrl(httpServer);
+            httpServer.createContext(
+                "/.well-known/openid-configuration",
+                exchange -> respondWithJson(
+                    exchange,
+                    discoveryDocument(issuer, issuer + "/login", issuer + "/token", issuer + "/jwks.json")
+                )
+            );
+
+            final Settings.Builder settingsBuilder = Settings.builder()
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com/cb")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code")
+                // Use an HMAC signature algorithm so that the (http, test-server-hosted) discovered jwks_uri is
+                // never dereferenced for token validation purposes; only the discovery/precedence wiring is under test.
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_SIGNATURE_ALGORITHM), "HS256")
+                .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
+                .setSecureSettings(getSecureSettings());
+            final OpenIdConnectRealm realm = new OpenIdConnectRealm(
+                buildConfig(settingsBuilder.build(), threadContext),
+                new SSLService(env),
+                null,
+                null
+            );
+            try {
+                final OpenIdConnectPrepareAuthenticationResponse response = realm.buildAuthenticationRequestUri(null, null, null);
+                assertThat(response.getAuthenticationRequestUrl(), containsString(issuer + "/login"));
+            } finally {
+                realm.close();
+            }
+        } finally {
+            httpServer.stop(1);
+        }
+    }
+
+    public void testExplicitEndpointOverridesDiscoveredValue() throws Exception {
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final String issuer = issuerUrl(httpServer);
+            httpServer.createContext(
+                "/.well-known/openid-configuration",
+                exchange -> respondWithJson(
+                    exchange,
+                    discoveryDocument(issuer, issuer + "/login", issuer + "/discovered-token", issuer + "/jwks.json")
+                )
+            );
+
+            final Settings.Builder settingsBuilder = Settings.builder()
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_TOKEN_ENDPOINT), "https://explicit.example.org/token")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com/cb")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_SIGNATURE_ALGORITHM), "HS256")
+                .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
+                .setSecureSettings(getSecureSettings());
+            final OpenIdConnectRealm realm = new OpenIdConnectRealm(
+                buildConfig(settingsBuilder.build(), threadContext),
+                new SSLService(env),
+                null,
+                null
+            );
+            try {
+                // Endpoint used only for logout, but proves the realm built successfully with the explicit token endpoint honoured;
+                // the token endpoint itself is exercised via OpenIdConnectAuthenticator, tested independently.
+                final OpenIdConnectPrepareAuthenticationResponse response = realm.buildAuthenticationRequestUri(null, null, null);
+                assertThat(response.getAuthenticationRequestUrl(), containsString(issuer + "/login"));
+            } finally {
+                realm.close();
+            }
+        } finally {
+            httpServer.stop(1);
+        }
+    }
+
+    public void testDiscoveryFailsOnIssuerMismatch() throws Exception {
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final String issuer = issuerUrl(httpServer);
+            final String otherIssuer = "https://not-the-configured-issuer.example.org";
+            httpServer.createContext(
+                "/.well-known/openid-configuration",
+                exchange -> respondWithJson(
+                    exchange,
+                    discoveryDocument(otherIssuer, issuer + "/login", issuer + "/token", issuer + "/jwks.json")
+                )
+            );
+
+            final Settings.Builder settingsBuilder = Settings.builder()
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com/cb")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code")
+                .setSecureSettings(getSecureSettings());
+            final RealmConfig config = buildConfig(settingsBuilder.build(), threadContext);
+            final SettingsException e = expectThrows(
+                SettingsException.class,
+                () -> new OpenIdConnectRealm(config, new SSLService(env), null, null)
+            );
+            assertThat(e.getMessage(), containsString(issuer));
+            assertThat(e.getMessage(), containsString(otherIssuer));
+        } finally {
+            httpServer.stop(1);
+        }
+    }
+
+    public void testDiscoveryFailsWhenUnreachable() {
+        // Bind and immediately release a port so the connection is refused
+        final int closedPort;
+        try (var socket = new java.net.ServerSocket(0, 0, InetAddress.getLoopbackAddress())) {
+            closedPort = socket.getLocalPort();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+        final String issuer = "http://" + InetAddresses.toUriString(InetAddress.getLoopbackAddress()) + ":" + closedPort;
+
+        final Settings.Builder settingsBuilder = Settings.builder()
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com/cb")
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+            .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code")
+            .setSecureSettings(getSecureSettings());
+        final RealmConfig config = buildConfig(settingsBuilder.build(), threadContext);
+        final SettingsException e = expectThrows(
+            SettingsException.class,
+            () -> new OpenIdConnectRealm(config, new SSLService(env), null, null)
+        );
+        assertThat(e.getMessage(), containsString(issuer));
+    }
+
+    public void testDiscoveryFailsOnMalformedJson() throws Exception {
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final String issuer = issuerUrl(httpServer);
+            httpServer.createContext("/.well-known/openid-configuration", exchange -> respondWithJson(exchange, "{not json"));
+
+            final Settings.Builder settingsBuilder = Settings.builder()
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ISSUER), issuer)
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.PRINCIPAL_CLAIM.getClaim()), "sub")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_REDIRECT_URI), "https://rp.my.com/cb")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_CLIENT_ID), "rp-my")
+                .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.RP_RESPONSE_TYPE), "code")
+                .setSecureSettings(getSecureSettings());
+            final RealmConfig config = buildConfig(settingsBuilder.build(), threadContext);
+            expectThrows(SettingsException.class, () -> new OpenIdConnectRealm(config, new SSLService(env), null, null));
+        } finally {
+            httpServer.stop(1);
+        }
+    }
+
+    public void testFullyExplicitConfigurationNeverTriggersDiscovery() throws Exception {
+        // Regression check: when every op.* endpoint is explicit (as in getBasicRealmSettings()), no HTTP request
+        // is made to a discovery endpoint, even one running locally.
+        final HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        try {
+            final AtomicReference<Boolean> called = new AtomicReference<>(false);
+            httpServer.createContext("/.well-known/openid-configuration", exchange -> {
+                called.set(true);
+                respondWithJson(exchange, "{}");
+            });
+            final Settings settings = getBasicRealmSettings().put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true).build();
+            final OpenIdConnectRealm realm = new OpenIdConnectRealm(buildConfig(settings, threadContext), new SSLService(env), null, null);
+            try {
+                realm.buildAuthenticationRequestUri(null, null, null);
+                assertThat(called.get(), equalTo(false));
+            } finally {
+                realm.close();
+            }
+        } finally {
+            httpServer.stop(1);
+        }
+    }
+
+    private static String issuerUrl(HttpServer httpServer) {
+        final InetSocketAddress address = httpServer.getAddress();
+        return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+    }
+
+    private static String discoveryDocument(String issuer, String authorizationEndpoint, String tokenEndpoint, String jwksUri) {
+        return """
+            {
+              "issuer": "%s",
+              "authorization_endpoint": "%s",
+              "token_endpoint": "%s",
+              "jwks_uri": "%s",
+              "response_types_supported": ["code"],
+              "subject_types_supported": ["public"],
+              "id_token_signing_alg_values_supported": ["RS256"]
+            }
+            """.formatted(issuer, authorizationEndpoint, tokenEndpoint, jwksUri);
+    }
+
+    private static void respondWithJson(com.sun.net.httpserver.HttpExchange exchange, String body) throws java.io.IOException {
+        try {
+            final byte[] bytes = body.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+        } finally {
+            exchange.close();
+        }
     }
 
     private void assertEqualUrlStrings(String actual, String expected) {


### PR DESCRIPTION
Let the OIDC realm derive unset op.* endpoints from the provider's .well-known/openid-configuration document, using op.issuer as the base URL. Explicit settings always take precedence, and discovery is only attempted when a required endpoint is left unset, so fully configured realms make no network calls.

Closes elastic/elasticsearch#42495
