### PR TITLE
[9.5] Fix assertion: XContentGenerator structural check (#156591)

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
@@ -636,7 +636,7 @@ public class JsonXContentGenerator implements XContentGenerator {
             generator.close();
         } catch (YAMLException e) {
             // ignore the SnakeYAML exception, our own structural check handles the same case
-            assert failsStructuralCheck : "Should fail the structural check, but didn't: " + e.getMessage();
+            assert allowIllFormed || failsStructuralCheck : "Should fail the structural check, but didn't: " + e.getMessage();
         } catch (IOException e) {
             if (exception == null) {
                 exception = e;

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -451,9 +451,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecK8sTimeseriesCountDistinctOverTimeIT
   method: test {csv-spec:k8s-timeseries-count-distinct-over-time.valuesNull}
   issue: https://github.com/elastic/elasticsearch/issues/156746
-- class: org.elasticsearch.common.xcontent.builder.XContentBuilderTests
-  method: testCloseAllowIllFormedDoesNotValidateStructuralCorrectness
-  issue: https://github.com/elastic/elasticsearch/issues/156563
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:unsigned_long.unsignedLongInWithNull}
   issue: https://github.com/elastic/elasticsearch/issues/156782


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix assertion: XContentGenerator structural check (#156591)](https://github.com/elastic/elasticsearch/pull/156591)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)