### PR TITLE
[8.19] Fix assertion: XContentGenerator structural check (#156591)

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
@@ -626,7 +626,7 @@ public class JsonXContentGenerator implements XContentGenerator {
             generator.close();
         } catch (YAMLException e) {
             // ignore the SnakeYAML exception, our own structural check handles the same case
-            assert failsStructuralCheck : "Should fail the structural check, but didn't: " + e.getMessage();
+            assert allowIllFormed || failsStructuralCheck : "Should fail the structural check, but didn't: " + e.getMessage();
         } catch (IOException e) {
             if (exception == null) {
                 exception = e;

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -58,9 +58,6 @@ tests:
 - class: org.elasticsearch.gradle.reaper.ReaperPluginFuncTest
   method: can launch reaper
   issue: https://github.com/elastic/elasticsearch/issues/156707
-- class: org.elasticsearch.common.xcontent.builder.XContentBuilderTests
-  method: testCloseAllowIllFormedDoesNotValidateStructuralCorrectness
-  issue: https://github.com/elastic/elasticsearch/issues/156563
 
 # Examples:
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix assertion: XContentGenerator structural check (#156591)](https://github.com/elastic/elasticsearch/pull/156591)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)