### PR TITLE
[DOCS] Add ES|QL privilege prerequisites

### DIFF
--- a/docs/reference/elasticsearch/security-privileges.md
+++ b/docs/reference/elasticsearch/security-privileges.md
@@ -205,7 +205,7 @@ When creating roles, refer to this page for a complete list of available privile
 :   All read-only operations related to managing and executing enrich policies.
 
 `monitor_esql` {applies_to}`stack: ga 9.1`
-:   All read-only operations related to ES|QL queries.
+:   All read-only operations for listing and inspecting currently running ES|QL queries (`GET /_query/queries` and `GET /_query/queries/{id}`). This privilege does not grant the ability to run ES|QL queries or retrieve async query results. To run a query, you need the index `read` privilege on the queried indices.
 
 `monitor_inference`
 :   All read-only operations related to {{infer}}.
@@ -376,7 +376,7 @@ When creating roles, refer to this page for a complete list of available privile
 :   All actions that are required for monitoring (recovery, segments info, index stats and status).
 
 `read`
-:   Read-only access to actions (count, explain, get, mget, get indexed scripts, more like this, multi percolate/search/termvector, percolate, scroll, clear_scroll, search, suggest, tv).
+:   Read-only access to actions (count, explain, get, mget, get indexed scripts, more like this, multi percolate/search/termvector, percolate, scroll, clear_scroll, search, suggest, tv, ES|QL query, async ES|QL get, and async ES|QL stop).
 
 `read_cross_cluster` {applies_to}`serverless: unavailable`
 :   Read-only access to the search action from a [remote cluster](docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md).

--- a/docs/reference/query-languages/esql/esql-rest.md
+++ b/docs/reference/query-languages/esql/esql-rest.md
@@ -41,6 +41,14 @@ James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00.000Z
 % TESTRESPONSE[s/\|/\\|/ s/\+/\\+/]
 % TESTRESPONSE[non_json]
 
+## Prerequisites [esql-rest-prerequisites]
+
+To run an {{esql}} query with [`POST /_query`]({{es-apis}}operation/operation-esql-query) or [`POST /_query/async`]({{es-apis}}operation/operation-esql-async-query), you need the [`read`](/reference/elasticsearch/security-privileges.md#privileges-list-indices) index privilege on the indices, data streams, aliases, or views you query.
+
+The [`monitor_esql`](/reference/elasticsearch/security-privileges.md#privileges-list-cluster) cluster privilege is only for inspecting queries that are currently running.
+It doesn't grant the ability to run queries or to retrieve async results.
+
+
 ## Run the {{esql}} query API in Console [esql-kibana-console]
 
 We recommend using [Console](docs-content://explore-analyze/query-filter/tools/console.md) to run the {{esql}} query API, because of its rich autocomplete features.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/6568

This PR adds a prerequisites section to https://www.elastic.co/docs/reference/query-languages/esql/esql-rest and clarifies the `monitor_esql` and `read` privileges in https://www.elastic.co/docs/reference/elasticsearch/security-privileges