### PR TITLE
[9.5] Add top-level catch to ensure batched queries always respond (#155908)

### DIFF
--- a/docs/changelog/155908.yaml
+++ b/docs/changelog/155908.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 155908
+summary: Add top-level catch to ensure batched queries always respond
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -352,7 +352,8 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
      * Request for starting the query phase for multiple shards.
      */
     public static final class NodeQueryRequest extends AbstractTransportRequest implements IndicesRequest {
-        private final List<ShardToQuery> shards;
+        // package-private for testing
+        final List<ShardToQuery> shards;
         private final SearchRequest searchRequest;
         private final Map<String, AliasFilter> aliasFilters;
         private final int totalShards;
@@ -360,7 +361,8 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
         private final String localClusterAlias;
         private final boolean enableShardResultsSkipRequest;
 
-        private NodeQueryRequest(SearchRequest searchRequest, int totalShards, long absoluteStartMillis, String localClusterAlias) {
+        // package-private for testing
+        NodeQueryRequest(SearchRequest searchRequest, int totalShards, long absoluteStartMillis, String localClusterAlias) {
             this.shards = new ArrayList<>();
             this.searchRequest = searchRequest;
             this.aliasFilters = new HashMap<>();
@@ -423,7 +425,8 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
         }
     }
 
-    private record ShardToQuery(
+    // package-private for testing
+    record ShardToQuery(
         float boost,
         String[] originalIndices,
         int shardIndex,
@@ -928,14 +931,28 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
             if (countDown.countDown() == false) {
                 return;
             }
-            if (channel.getVersion().supports(BATCHED_RESPONSE_MIGHT_INCLUDE_REDUCTION_FAILURE) == false) {
-                bwcRespond();
+            ChannelActionListener<BytesTransportResponse> channelListener = new ChannelActionListener<>(channel);
+            final BytesTransportResponse response;
+            try {
+                response = buildResponse();
+            } catch (Exception e) {
+                try {
+                    releaseAllResultsContexts();
+                } catch (Exception releaseException) {
+                    logger.trace("failed to release contexts after batched query response failure", releaseException);
+                }
+                channelListener.onFailure(e);
                 return;
             }
-            var channelListener = new ChannelActionListener<>(channel);
+            ActionListener.respondAndRelease(channelListener, response);
+        }
+
+        private BytesTransportResponse buildResponse() throws Exception {
+            if (channel.getVersion().supports(BATCHED_RESPONSE_MIGHT_INCLUDE_REDUCTION_FAILURE) == false) {
+                return bwcBuildResponse();
+            }
             RecyclerBytesStreamOutput out = dependencies.transportService.newNetworkBytesStream(null);
             out.setTransportVersion(channel.getVersion());
-
             boolean success = false;
             try (queryPhaseResultConsumer) {
                 Exception reductionFailure = queryPhaseResultConsumer.failure.get();
@@ -945,20 +962,12 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                     writeReductionFailureResponse(out, reductionFailure);
                 }
                 success = true;
-            } catch (IOException e) {
-                releaseAllResultsContexts();
-                channelListener.onFailure(e);
-                return;
             } finally {
                 if (success == false) {
                     out.close();
                 }
             }
-
-            ActionListener.respondAndRelease(
-                channelListener,
-                new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion())
-            );
+            return new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion());
         }
 
         // Writes the "successful" response (see NodeQueryResponse for the corresponding read logic)
@@ -1032,29 +1041,22 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
          * This code is strictly for _snapshot_ backwards compatibility. The feature flag guarding batched execution
          * was not turned on when the transport version
          * {@link SearchQueryThenFetchAsyncAction#BATCHED_RESPONSE_MIGHT_INCLUDE_REDUCTION_FAILURE} was introduced.
+         * <p>
+         * Any exception thrown here propagates to the wrapper in {@link #onShardDone()}, which is
+         * responsible for releasing all result contexts and responding to the channel with an error.
          */
-        void bwcRespond() {
+        private BytesTransportResponse bwcBuildResponse() throws Exception {
             RecyclerBytesStreamOutput out = null;
             boolean success = false;
-            var channelListener = new ChannelActionListener<>(channel);
             try (queryPhaseResultConsumer) {
                 var failure = queryPhaseResultConsumer.failure.get();
                 if (failure != null) {
-                    releaseAllResultsContexts();
-                    channelListener.onFailure(failure);
-                    return;
+                    throw failure;
                 }
-                final QueryPhaseResultConsumer.MergeResult mergeResult;
-                try {
-                    mergeResult = Objects.requireNonNullElse(
-                        queryPhaseResultConsumer.consumePartialMergeResultDataNode(),
-                        EMPTY_PARTIAL_MERGE_RESULT
-                    );
-                } catch (Exception e) {
-                    releaseAllResultsContexts();
-                    channelListener.onFailure(e);
-                    return;
-                }
+                final QueryPhaseResultConsumer.MergeResult mergeResult = Objects.requireNonNullElse(
+                    queryPhaseResultConsumer.consumePartialMergeResultDataNode(),
+                    EMPTY_PARTIAL_MERGE_RESULT
+                );
                 // translate shard indices to those on the coordinator so that it can interpret the merge result without adjustments,
                 // also collect the set of indices that may be part of a subsequent fetch operation here so that we can release all other
                 // indices without a roundtrip to the coordinating node
@@ -1069,34 +1071,25 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                 final int resultCount = queryPhaseResultConsumer.getNumShards();
                 out = dependencies.transportService.newNetworkBytesStream(null);
                 out.setTransportVersion(channel.getVersion());
-                try {
-                    out.writeVInt(resultCount);
-                    for (int i = 0; i < resultCount; i++) {
-                        var result = queryPhaseResultConsumer.results.get(i);
-                        if (result == null) {
-                            NodeQueryResponse.writePerShardException(out, failures.remove(i));
-                        } else {
-                            // free context id and remove it from the result right away in case we don't need it anymore
-                            maybeFreeContext(result, relevantShardIndices, namedWriteableRegistry);
-                            NodeQueryResponse.writePerShardResult(out, result);
-                        }
+                out.writeVInt(resultCount);
+                for (int i = 0; i < resultCount; i++) {
+                    var result = queryPhaseResultConsumer.results.get(i);
+                    if (result == null) {
+                        NodeQueryResponse.writePerShardException(out, failures.remove(i));
+                    } else {
+                        // free context id and remove it from the result right away in case we don't need it anymore
+                        maybeFreeContext(result, relevantShardIndices, namedWriteableRegistry);
+                        NodeQueryResponse.writePerShardResult(out, result);
                     }
-                    NodeQueryResponse.writeMergeResult(out, mergeResult, queryPhaseResultConsumer.topDocsStats);
-                    success = true;
-                } catch (IOException e) {
-                    releaseAllResultsContexts();
-                    channelListener.onFailure(e);
-                    return;
                 }
+                NodeQueryResponse.writeMergeResult(out, mergeResult, queryPhaseResultConsumer.topDocsStats);
+                success = true;
             } finally {
                 if (success == false && out != null) {
                     out.close();
                 }
             }
-            ActionListener.respondAndRelease(
-                channelListener,
-                new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion())
-            );
+            return new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion());
         }
 
         private void maybeFreeContext(

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -10,42 +10,64 @@
 package org.elasticsearch.action.search;
 
 import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.cluster.routing.SplitShardCountSummary;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.lucene.grouping.TopFieldGroups;
 import org.elasticsearch.rest.action.search.SearchResponseMetrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchPhaseResult;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
+import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.transport.RequestHandlerRegistry;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -55,6 +77,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
@@ -448,6 +471,161 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             SearchPhaseController.ReducedQueryPhase phase = action.results.reduce();
             assertThat(phase.numReducePhases(), greaterThanOrEqualTo(1));
             assertThat(phase.totalHits().value(), equalTo(2L));
+        }
+    }
+
+    /**
+     * Ensure the batched query handler always responds to the coordinator channel even when an
+     * exception is thrown during response serialization.
+     */
+    public void testBatchedNodeResponseExceptionReachesCoordinator() throws Exception {
+        assertSerializationExceptionReachesCoordinator(TransportVersion.current());
+    }
+
+    /**
+     * Ensure the batched query handler always responds to the coordinator channel even when an
+     * exception is thrown during response serialization on the backwards-compatible
+     * {@code bwcBuildResponse} path.
+     */
+    public void testBwcBuildResponseExceptionReachesCoordinator() throws Exception {
+        // batched_query_phase_version predates batched_response_might_include_reduction_failure,
+        // so using it as the channel version steers buildResponse() into bwcBuildResponse().
+        assertSerializationExceptionReachesCoordinator(TransportVersion.fromName("batched_query_phase_version"));
+    }
+
+    private void assertSerializationExceptionReachesCoordinator(TransportVersion channelVersion) throws Exception {
+        TestThreadPool threadPool = new TestThreadPool(getTestName());
+        var innerTransport = MockTransportService.newMockTransport(Settings.EMPTY, TransportVersion.current(), threadPool);
+        String nodeId = UUIDs.randomBase64UUID();
+        MockTransportService transport = new MockTransportService(
+            Settings.EMPTY,
+            innerTransport,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundAddress -> DiscoveryNodeUtils.builder(nodeId)
+                .address(boundAddress.publishAddress())
+                .version(VersionInformation.CURRENT)
+                .build(),
+            null,
+            Collections.emptySet(),
+            nodeId
+        ) {
+            // This stream will throw on first write
+            @Override
+            public RecyclerBytesStreamOutput newNetworkBytesStream(CircuitBreaker circuitBreaker) {
+                return new RecyclerBytesStreamOutput(
+                    new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(Long.MAX_VALUE)).bytesRefRecycler()
+                ) {
+                    @Override
+                    public void writeVInt(int i) {
+                        throw new RuntimeException("simulated write failure");
+                    }
+                };
+            }
+        };
+        ClusterService clusterService = new ClusterService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool,
+            null
+        );
+        List<QuerySearchResult> resultsToRelease = Collections.synchronizedList(new ArrayList<>());
+        SearchService searchService = new SearchService(
+            clusterService,
+            null,
+            threadPool,
+            null,
+            null,
+            new FetchPhase(Collections.emptyList()),
+            newLimitedBreakerService(ByteSizeValue.ofMb(10)),
+            EmptySystemIndices.INSTANCE.getExecutorSelector(),
+            Tracer.NOOP,
+            OnlinePrewarmingService.NOOP
+        ) {
+            @Override
+            public void executeQueryPhase(ShardSearchRequest req, CancellableTask task, ActionListener<SearchPhaseResult> listener) {
+                QuerySearchResult result = new QuerySearchResult(
+                    new ShardSearchContextId(UUIDs.randomBase64UUID(), 1),
+                    new SearchShardTarget(transport.getLocalNode().getId(), req.shardId(), null),
+                    null
+                );
+                result.topDocs(
+                    new TopDocsAndMaxScore(new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]), Float.NaN),
+                    new DocValueFormat[0]
+                );
+                result.from(0);
+                result.size(0);
+                resultsToRelease.add(result);
+                listener.onResponse(result);
+            }
+        };
+        try {
+            transport.start();
+
+            SearchQueryThenFetchAsyncAction.registerNodeSearchAction(
+                new SearchTransportService(transport, null, null),
+                searchService,
+                new SearchPhaseController((t, r) -> InternalAggregationTestCase.emptyReduceContextBuilder()),
+                new NamedWriteableRegistry(List.of())
+            );
+
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().size(0));
+            var nodeQueryRequest = new SearchQueryThenFetchAsyncAction.NodeQueryRequest(searchRequest, 2, 0L, null);
+            nodeQueryRequest.shards.add(
+                new SearchQueryThenFetchAsyncAction.ShardToQuery(
+                    1.0f,
+                    new String[] { "idx" },
+                    0,
+                    new ShardId("idx", "uuid", 0),
+                    null,
+                    SplitShardCountSummary.UNSET
+                )
+            );
+            nodeQueryRequest.shards.add(
+                new SearchQueryThenFetchAsyncAction.ShardToQuery(
+                    1.0f,
+                    new String[] { "idx" },
+                    1,
+                    new ShardId("idx", "uuid", 1),
+                    null,
+                    SplitShardCountSummary.UNSET
+                )
+            );
+
+            CountDownLatch latch = new CountDownLatch(1);
+            TransportChannel channel = new TransportChannel() {
+                @Override
+                public String getProfileName() {
+                    return "";
+                }
+
+                @Override
+                public TransportVersion getVersion() {
+                    return channelVersion;
+                }
+
+                @Override
+                public void sendResponse(TransportResponse response) {}
+
+                @Override
+                public void sendResponse(Exception exception) {
+                    latch.countDown();
+                }
+            };
+
+            @SuppressWarnings("unchecked")
+            RequestHandlerRegistry<SearchQueryThenFetchAsyncAction.NodeQueryRequest> handler = (RequestHandlerRegistry<
+                SearchQueryThenFetchAsyncAction.NodeQueryRequest>) transport.getRequestHandler(
+                    SearchQueryThenFetchAsyncAction.NODE_SEARCH_ACTION_NAME
+                );
+            handler.processMessageReceived(nodeQueryRequest, channel);
+
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            resultsToRelease.forEach(QuerySearchResult::decRef);
+            assertTrue("channel was not responded to within 10 seconds", completed);
+        } finally {
+            IOUtils.closeWhileHandlingException(searchService, clusterService, transport, threadPool);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Add top-level catch to ensure batched queries always respond (#155908)