### PR TITLE
[8.19] Account for transient thread in use in SearchWithRejectionsIT (#156812)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,12 +34,15 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class SearchWithRejectionsIT extends ESIntegTestCase {
+
+    private static final int SEARCH_QUEUE_SIZE = 1;
+
     @Override
     public Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put("thread_pool.search.size", 1)
-            .put("thread_pool.search.queue_size", 1)
+            .put("thread_pool.search.queue_size", SEARCH_QUEUE_SIZE)
             .build();
     }
 
@@ -149,19 +153,25 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         // Not try-with-resources: on this branch ExecutorService is not AutoCloseable.
         final ExecutorService searchExecutor = new StoppableExecutorServiceWrapper(threadPool.executor(ThreadPool.Names.SEARCH));
         try {
-            for (int i = 0; i < threads; i++) {
-                searchExecutor.execute(() -> {
-                    started.countDown();
-                    awaitQuietly(block);
-                });
-            }
+            AtomicInteger submitted = new AtomicInteger();
+            // Submit one execution per thread, plus enough to block all queue slots
+            int executions = threads + SEARCH_QUEUE_SIZE;
+            assertBusy(() -> {
+                int toSubmit = executions - submitted.get();
+                for (int i = 0; i < toSubmit; ++i) {
+                    try {
+                        searchExecutor.execute(() -> {
+                            started.countDown();
+                            awaitQuietly(block);
+                        });
+                        submitted.incrementAndGet();
+                    } catch (EsRejectedExecutionException e) {
+                        // one of the search threads was already in use by some transient thing, we'll try resubmitting
+                    }
+                }
+                assertThat("Could not saturate the search thread pool and queue", submitted.get(), equalTo(executions));
+            });
             safeAwait(started);
-            // Fill the queue slot (queue_size=1). With all workers blocked, the next submit rejects.
-            try {
-                searchExecutor.execute(() -> awaitQuietly(block));
-            } catch (EsRejectedExecutionException e) {
-                // already full
-            }
             expectThrows(EsRejectedExecutionException.class, () -> searchExecutor.execute(() -> {}));
         } catch (Throwable t) {
             // The cluster is shared by the whole suite, so never leave SEARCH threads blocked on a setup failure.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Account for transient thread in use in SearchWithRejectionsIT (#156812)](https://github.com/elastic/elasticsearch/pull/156812)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)