### PR TITLE
[9.5] [Test] Drop reseting EncryptionServiceRegistry in internal cluster tests (#154685)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -370,9 +370,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecSpatialShapesIT
   method: test {csv-spec:spatial_shapes.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/154157
-- class: org.elasticsearch.xpack.esql.action.CrossClusterLookupJoinFailuresIT
-  method: testLookupDisconnect
-  issue: https://github.com/elastic/elasticsearch/issues/155185
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecApproximationIT
   method: test {csv-spec:approximation.Rename stats group key}
   issue: https://github.com/elastic/elasticsearch/issues/155194
@@ -460,9 +457,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:METRICS}
   issue: https://github.com/elastic/elasticsearch/issues/156829
-- class: org.elasticsearch.xpack.esql.action.CrossClusterLoggingIT
-  method: testRemoteQueryLogging
-  issue: https://github.com/elastic/elasticsearch/issues/156834
 - class: org.elasticsearch.index.mapper.BinaryFieldMapperTests
   method: testSyntheticSourceWithTranslogSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/156860

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/TestEncryptionServicePlugin.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/datasource/TestEncryptionServicePlugin.java
@@ -26,10 +26,6 @@ public class TestEncryptionServicePlugin extends Plugin {
 
     public static final String TEST_KEY_ID = "test-key";
 
-    public TestEncryptionServicePlugin() {
-        EncryptionServiceRegistry.reset();
-    }
-
     @Override
     public Collection<?> createComponents(PluginServices services) {
         EncryptionService svc = new EncryptionService() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Test] Drop reseting EncryptionServiceRegistry in internal cluster tests (#154685)](https://github.com/elastic/elasticsearch/pull/154685)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)