### PR TITLE
Unmute RethrottleTests.testDeleteByQuery

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -693,9 +693,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.ash.AsymmetricHashingQuantizerTests
   method: testReconstructedDotProductApproximatesTrueDotProduct
   issue: https://github.com/elastic/elasticsearch/issues/156708
-- class: org.elasticsearch.reindex.RethrottleTests
-  method: testDeleteByQuery
-  issue: https://github.com/elastic/elasticsearch/issues/156709
 - class: org.elasticsearch.xpack.core.inference.action.PutCCMConfigurationActionRequestTests
   method: testBwcSerialization
   issue: https://github.com/elastic/elasticsearch/issues/156714


### PR DESCRIPTION
It was incorrectly muted by an EA JVM run on Windows.

See #156709 