### PR TITLE
ESQL: skip field_extract fusion that breaks type resolution

### DIFF
--- a/docs/changelog/156979.yaml
+++ b/docs/changelog/156979.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 156979
+summary: Skip `field_extract` fusion that breaks type resolution
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
@@ -164,6 +164,10 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
         }
 
         private PhysicalPlan transformPotentialInvocation(PhysicalPlan plan) {
+            // Snapshot the pushed-attribute bookkeeping so we can roll back cleanly if the fusion
+            // below turns out to break resolution (see the guard after the transform).
+            Map<Attribute.IdIgnoringWrapper, Attribute> addedAttrsBefore = new HashMap<>(addedAttrs);
+
             PhysicalPlan transformedPlan = plan.transformExpressionsOnly(Expression.class, e -> {
                 if (e instanceof BlockLoaderExpression ble) {
                     return transformExpression(plan, e, ble);
@@ -177,8 +181,26 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
                  */
                 return plan;
             }
+            /*
+             * Fusion replaces a field_extract(...) invocation with a FieldAttribute backed by an
+             * intentionally "inexact" FunctionEsField (inexact so predicates like WHERE LENGTH(kwd) > 2
+             * are not pushed down to Lucene). Some consuming functions type-check that argument with
+             * isStringAndExact, which then fails, leaving the enclosing expression unresolved. A physical
+             * rewrite must not invalidate an expression that resolved during analysis, so if fusing broke
+             * resolution we roll back and keep the per-row evaluator, which loads and evaluates correctly.
+             */
+            if (allExpressionsResolved(plan) && allExpressionsResolved(transformedPlan) == false) {
+                addedAttrs.clear();
+                addedAttrs.putAll(addedAttrsBefore);
+                addedNewAttribute = false;
+                return plan;
+            }
             // return new ProjectExec(Source.EMPTY, transformedPlan, transformedPlan.output());
             return transformedPlan;
+        }
+
+        private static boolean allExpressionsResolved(PhysicalPlan plan) {
+            return plan.expressions().stream().allMatch(Expression::resolved);
         }
 
         private Expression transformExpression(PhysicalPlan nodeWithExpression, Expression e, BlockLoaderExpression ble) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
@@ -133,6 +133,13 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
     private class PushRule {
         private final Map<Attribute.IdIgnoringWrapper, Attribute> addedAttrs = new HashMap<>();
 
+        /**
+         * Keys freshly inserted into {@link #addedAttrs} during the current
+         * {@link #transformPotentialInvocation} call, so we can roll just those back
+         * (rather than snapshotting the whole map) if the fusion breaks resolution.
+         */
+        private final List<Attribute.IdIgnoringWrapper> keysAddedThisInvocation = new ArrayList<>();
+
         private final LocalPhysicalOptimizerContext context;
         private final Primaries primaries = new Primaries();
 
@@ -164,9 +171,8 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
         }
 
         private PhysicalPlan transformPotentialInvocation(PhysicalPlan plan) {
-            // Snapshot the pushed-attribute bookkeeping so we can roll back cleanly if the fusion
-            // below turns out to break resolution (see the guard after the transform).
-            Map<Attribute.IdIgnoringWrapper, Attribute> addedAttrsBefore = new HashMap<>(addedAttrs);
+            // Records attributes added below so we can roll them back cheaply if fusion breaks resolution.
+            keysAddedThisInvocation.clear();
 
             PhysicalPlan transformedPlan = plan.transformExpressionsOnly(Expression.class, e -> {
                 if (e instanceof BlockLoaderExpression ble) {
@@ -190,8 +196,7 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
              * resolution we roll back and keep the per-row evaluator, which loads and evaluates correctly.
              */
             if (allExpressionsResolved(plan) && allExpressionsResolved(transformedPlan) == false) {
-                addedAttrs.clear();
-                addedAttrs.putAll(addedAttrsBefore);
+                keysAddedThisInvocation.forEach(addedAttrs::remove);
                 addedNewAttribute = false;
                 return plan;
             }
@@ -265,6 +270,7 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
             }
 
             addedAttrs.put(key, newFunctionAttr);
+            keysAddedThisInvocation.add(key);
             return newFunctionAttr;
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoadTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoadTests.java
@@ -846,6 +846,25 @@ public class PushExpressionsToFieldLoadTests extends AbstractLocalPhysicalPlanOp
         );
     }
 
+    // ---- field_extract into a function that requires an exact string argument ----
+
+    public void testFieldExtractIntoExactStringArgumentIsNotFused() {
+        assumeTrue("field_extract must be part of this build", FieldExtract.isFnFieldExtractCapabilityMet());
+        // DATE_UNIT_COUNT type-checks its unit arguments with isStringAndExact. Fusing field_extract would replace
+        // them with attributes backed by an intentionally-inexact FunctionEsField, leaving DATE_UNIT_COUNT unresolved
+        // and tripping post-optimization plan verification. The rule must instead skip the fusion
+        // and keep the per-row field_extract evaluator, producing a valid plan.
+        PhysicalPlan plan = flattenedPlannerOptimizer.plan("""
+            FROM test
+            | EVAL n = DATE_UNIT_COUNT(field_extract(data, "to"), field_extract(data, "from"), "2024-01-01T00:00:00Z"::datetime)
+            | SORT id
+            | KEEP n
+            """);
+
+        List<FieldAttribute> pushed = findPushedFields(plan, "data", BlockLoaderFunctionConfig.Function.EXTRACT_FLATTENED_SUBFIELD);
+        assertThat("field_extract feeding an exact-string argument must not fuse", pushed, hasSize(0));
+    }
+
     // ---- Lookup join test (Primaries check) ----
 
     public void testPushDownFunctionsLookupJoin() {


### PR DESCRIPTION
## Summary

`field_extract` fusion (`PushExpressionsToFieldLoad`) replaces a `field_extract(...)` invocation with a `FieldAttribute` backed by an intentionally **inexact** `FunctionEsField` (inexact so predicates like `WHERE LENGTH(kwd) > 2` are not pushed down to Lucene).

A consuming function that type-checks that argument with `isStringAndExact` then fails `isExact` **after** fusion, leaving the enclosing expression unresolved. The post-optimization physical plan verifier then reports a spurious *"optimized incorrectly due to missing references"* error (the `EVAL` alias degrades to an unresolved attribute).

This was surfaced by `DATE_UNIT_COUNT` (both unit arguments are `isStringAndExact`), but it is a latent, general issue: other functions using `isStringAndExact` on a fused argument (`CIDRMatch`, `DateExtract`, `DateFormat`, `DateParse`, `NetworkDirection`, `Split`, LIKE/RLIKE) are equally exposed — some merely escape today due to resolution-caching timing.

## Fix

A physical rewrite must not invalidate an expression that resolved during analysis. After the fusion transform, if the node's expressions were resolved before but not after, roll back the pushed-attribute bookkeeping and keep the per-row `field_extract` evaluator (which loads and evaluates the value correctly — the same path the non-flattened form uses). This forgoes only the fusion micro-optimization for these specific shapes, in exchange for correctness.

## Test

- `PushExpressionsToFieldLoadTests#testFieldExtractIntoExactStringArgumentIsNotFused`: the `DATE_UNIT_COUNT(field_extract(...), field_extract(...), <date>)` shape now plans without a verification error and the `field_extract` is not fused.
