### PR TITLE
ESQL: decouple type-check exactness from pushdown exactness

### DIFF
--- a/docs/changelog/156980.yaml
+++ b/docs/changelog/156980.yaml
@@ -1,0 +1,6 @@
+pr: 156980
+summary: Decouple type-check exactness from pushdown exactness for fused block-loader
+  functions
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/FunctionEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/FunctionEsField.java
@@ -71,14 +71,14 @@ public class FunctionEsField extends EsField {
         return Objects.hash(super.hashCode(), functionConfig);
     }
 
-    @Override
-    public Exact getExactInfo() {
-        /*
-         * We force and "inexact" field info to prevent pushing
-         * expressions like `WHERE LENGTH(kwd) > 2`. `LENGTH(kwd)`
-         * is a `FunctionEsField` which *looks* pushable without
-         * the inexact match.
-         */
-        return new Exact(false, "merged with " + functionConfig.function());
-    }
+    /*
+     * Note on exactness: a FunctionEsField carries an exact, non-analyzed value produced by the block
+     * loader (e.g. the keyword extracted by field_extract, or the integer from LENGTH), so it reports
+     * itself as exact via the inherited getExactInfo(). That lets consuming functions which type-check
+     * their arguments with isStringAndExact (DATE_UNIT_COUNT, DATE_FORMAT, DATE_PARSE, CIDR_MATCH, ...)
+     * stay resolved after fusion. Pushdown eligibility is a separate concern: there is no indexed Lucene
+     * field behind a FunctionEsField, so predicates and TopN over it must not be pushed. That is enforced
+     * explicitly in LucenePushdownPredicates / BinarySpatialFunction by excluding FunctionEsField rather
+     * than by overloading exactness here.
+     */
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
@@ -321,7 +322,13 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
     }
 
     private static boolean isPushableSpatialAttribute(Expression exp, LucenePushdownPredicates p) {
-        return exp instanceof FieldAttribute fa && DataType.isSpatial(fa.dataType()) && fa.getExactInfo().hasExact() && p.isIndexed(fa);
+        // A FunctionEsField is synthesized by the block loader and has no indexed Lucene field behind it, so it must not be pushed,
+        // even though it now reports itself as exact (see FunctionEsField).
+        return exp instanceof FieldAttribute fa
+            && fa.field() instanceof FunctionEsField == false
+            && DataType.isSpatial(fa.dataType())
+            && fa.getExactInfo().hasExact()
+            && p.isIndexed(fa);
     }
 
     private static boolean isPushableLiteralAttribute(Expression exp) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TypedAttribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
@@ -96,8 +97,11 @@ public interface LucenePushdownPredicates {
     default boolean isPushableFieldAttribute(Expression exp) {
         // Potentially unmapped fields are not pushabled: the field may be unmapped on some shards, and pushing down would produce wrong
         // results (e.g., missing rows when the predicate is pushed to Lucene).
+        // FunctionEsField values are synthesized by the block loader (e.g. LENGTH(kwd), field_extract(...)); there is no indexed Lucene
+        // field behind them, so predicates and TopN over them must stay in the compute engine even though they are exact values.
         if (exp instanceof FieldAttribute fa
             && fa.field() instanceof PotentiallyUnmappedKeywordEsField == false
+            && fa.field() instanceof FunctionEsField == false
             && fa.getExactInfo().hasExact()
             && isIndexedAndHasDocValues(fa)) {
             return fa.dataType() != DataType.TEXT || hasExactSubfield(fa);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
@@ -95,7 +95,7 @@ public interface LucenePushdownPredicates {
      * support it, and relying on the compute engine for the nodes that do not.
      */
     default boolean isPushableFieldAttribute(Expression exp) {
-        // Potentially unmapped fields are not pushabled: the field may be unmapped on some shards, and pushing down would produce wrong
+        // Potentially unmapped fields are not pushable: the field may be unmapped on some shards, and pushing down would produce wrong
         // results (e.g., missing rows when the predicate is pushed to Lucene).
         // FunctionEsField values are synthesized by the block loader (e.g. LENGTH(kwd), field_extract(...)); there is no indexed Lucene
         // field behind them, so predicates and TopN over them must stay in the compute engine even though they are exact values.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoadTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoadTests.java
@@ -846,6 +846,29 @@ public class PushExpressionsToFieldLoadTests extends AbstractLocalPhysicalPlanOp
         );
     }
 
+    // ---- field_extract into a function that requires an exact string argument ----
+
+    public void testFieldExtractIntoExactStringArgumentIsFused() {
+        assumeTrue("field_extract must be part of this build", FieldExtract.isFnFieldExtractCapabilityMet());
+        // DATE_UNIT_COUNT type-checks its unit arguments with isStringAndExact. A fused field_extract produces an
+        // attribute backed by a FunctionEsField, which reports itself as exact (its value is a keyword extracted by
+        // the block loader), so DATE_UNIT_COUNT stays resolved after fusion and both field_extract invocations fuse.
+        // Pushdown exactness is decoupled from type-check exactness, so this no longer leaves the plan unresolved.
+        PhysicalPlan plan = flattenedPlannerOptimizer.plan("""
+            FROM test
+            | EVAL n = DATE_UNIT_COUNT(field_extract(data, "to"), field_extract(data, "from"), "2024-01-01T00:00:00Z"::datetime)
+            | SORT id
+            | KEEP n
+            """);
+
+        // Both field_extract(data, "to") and field_extract(data, "from") fuse into the data field load.
+        List<FieldAttribute> pushed = findPushedFields(plan, "data", BlockLoaderFunctionConfig.Function.EXTRACT_FLATTENED_SUBFIELD);
+        assertThat("both field_extract invocations feeding DATE_UNIT_COUNT should fuse", pushed, hasSize(2));
+
+        // The whole point of decoupling: fusion must not invalidate an expression that resolved during analysis.
+        plan.forEachExpressionDown(Expression.class, e -> assertThat("plan must stay resolved after fusion", e.resolved(), is(true)));
+    }
+
     // ---- Lookup join test (Primaries check) ----
 
     public void testPushDownFunctionsLookupJoin() {


### PR DESCRIPTION
## Summary

Fixes an ES|QL physical-optimization correctness bug: fusing `field_extract(...)` into an argument that is type-checked with `isStringAndExact` (`DATE_UNIT_COUNT`, `DATE_FORMAT`, `DATE_PARSE`, `CIDR_MATCH`, `NetworkDirection`, `Split`, `DateExtract`, regex, ...) left the consuming expression unresolved, tripping post-optimization plan verification.

The root cause is that a single signal — `EsField.getExactInfo().hasExact()` — is overloaded for two unrelated jobs:

- **Type-check exactness** — "is this a non-analyzed string value?" (read by `TypeResolutions.isExact` / `isStringAndExact`).
- **Pushdown exactness** — "is there an indexed Lucene field to push a predicate/TopN to?" (read by `LucenePushdownPredicates` / `BinarySpatialFunction`).

A `FunctionEsField` backs a value **synthesized by the block loader** (the keyword from `field_extract`, the int from `LENGTH`). It *is* an exact value, but it has no indexed field behind it. It previously reported itself as **inexact** purely to block pushdown — which also (incorrectly) failed the type-checks.

This PR **decouples** the two:

- Drop the `FunctionEsField.getExactInfo()` override so it reports itself as exact → consumers stay resolved after fusion.
- Block pushdown **explicitly** by excluding `FunctionEsField` in `LucenePushdownPredicates.isPushableFieldAttribute` and `BinarySpatialFunction`, rather than by overloading exactness.

Net effect: exact-string consumers of `field_extract` (and other block-loader functions) once again **fuse** and gain the fast doc-values path, while predicates/TopN over synthesized values correctly stay in the compute engine. Pushdown behaviour is unchanged — the `FunctionEsField` exclusion just moves from "report inexact" to an explicit `instanceof` check.

## Test plan

- [x] `PushExpressionsToFieldLoadTests` — new `testFieldExtractIntoExactStringArgumentIsFused` asserts both `field_extract` invocations fuse **and** the plan stays fully resolved; the `WHERE LENGTH(kwd) > 1` no-pushdown guard still holds.
- [x] `PhysicalPlanOptimizerTests`, `LocalPhysicalPlanOptimizerTests`, `optimizer.rules.physical.local.*`
- [x] `CsvFlattenedKeywordIT` end-to-end slice (`string`, `where`, `date`) — exercises fusion + WHERE/TopN pushdown over flattened keys

## Notes

- This supersedes the earlier defensive-rollback approach (#156979, now closed): the decouple removes the unresolved-plan state at its source, so a rollback guard is never needed for this case.
- Follow-up once this lands: un-silence the `dateUnitCountFromFields` case that #156754 gated with `skip_flattened_rewrite` — it should now pass.