### PR TITLE
[9.5] [Build tools] Disable TestKit cache cleanup in build-tools func tests (#156899)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -388,11 +388,23 @@ dependencies {
 tasks.named('test').configure {
   useJUnitPlatform()
 }
+
 tasks.register("integTest", Test) {
   systemProperty 'test.version_under_test', version
   testClassesDirs = sourceSets.integTest.output.classesDirs
   classpath = sourceSets.integTest.runtimeClasspath
   useJUnitPlatform()
+  // ElasticsearchTestBasePlugin cannot apply itself, so java.io.tmpdir must be set manually here.
+  // Without it, JUnit/Spock create temp dirs under /tmp (root fs) instead of the build dir (/dev/shm in CI).
+  // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+  // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+  def tempDir = temporaryDir
+  // Pin the TestKit Gradle user home instead of letting TestKit derive it from java.io.tmpdir, so that
+  // AbstractGradleFuncTest knows exactly where to seed its cache-cleanup init script.
+  def testKitDir = new File(temporaryDir, ".gradle-test-kit")
+  jvmArgumentProviders.add({
+    ["-Djava.io.tmpdir=${tempDir}", "-Dorg.gradle.testkit.dir=${testKitDir}"] as List<String>
+  } as CommandLineArgumentProvider)
 }
 
 tasks.named("check").configure { dependsOn("integTest") }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -185,6 +185,15 @@ tasks.named('test').configure {
 tasks.register("integTest", Test) {
     testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
+    // The nested Gradle TestKit runners require an absolute path, so a relative value is not an option here.
+    // A CommandLineArgumentProvider keeps that absolute path out of the task inputs so it stays cache relocatable.
+    def tempDir = temporaryDir
+    // Pin the TestKit Gradle user home instead of letting TestKit derive it from java.io.tmpdir, so that
+    // AbstractGradleFuncTest knows exactly where to seed its cache-cleanup init script.
+    def testKitDir = new File(temporaryDir, ".gradle-test-kit")
+    jvmArgumentProviders.add({
+        ["-Djava.io.tmpdir=${tempDir}", "-Dorg.gradle.testkit.dir=${testKitDir}"] as List<String>
+    } as CommandLineArgumentProvider)
     useJUnitPlatform()
 }
 

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -27,6 +27,9 @@ import org.junit.rules.TemporaryFolder
 
 import java.lang.management.ManagementFactory
 import java.nio.charset.StandardCharsets
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
@@ -146,8 +149,9 @@ abstract class AbstractGradleFuncTest extends Specification {
                 .withProjectDir(projectDir)
                 .withPluginClasspath()
                 .forwardOutput()
-        File userHome = customGradleUserHome()
+        File userHome = customGradleUserHome() ?: testKitDir()
         if (userHome != null) {
+            disableCacheCleanup(userHome)
             runner = runner.withTestKitDir(userHome)
         }
         return new NormalizeOutputGradleRunner(
@@ -162,11 +166,77 @@ abstract class AbstractGradleFuncTest extends Specification {
      * Override to supply a custom Gradle user home directory for the TestKit runner.
      * TestKit will set {@code GRADLE_USER_HOME} to this directory for every forked
      * Gradle process, including any {@code ./gradlew} subprocesses spawned by build
-     * logic.  Returns {@code null} by default, letting TestKit manage its own
-     * temporary directory.
+     * logic.  Returns {@code null} by default, in which case the shared directory declared by the
+     * owning {@code integTest} task via {@code org.gradle.testkit.dir} is used, if present
+     * (see {@link #testKitDir()}).
      */
     protected File customGradleUserHome() {
         return null
+    }
+
+    /**
+     * The TestKit Gradle user home. Uses the directory declared explicitly via
+     * {@code org.gradle.testkit.dir} when running under the {@code integTest} task, so that
+     * {@link #disableCacheCleanup} is guaranteed to seed its init script into the directory the
+     * nested builds actually use.
+     * <p>
+     * Falls back to TestKit's own default (letting {@link GradleRunner} derive it, e.g. from
+     * {@code java.io.tmpdir}) when the property is absent, which is the case for ad-hoc runs from
+     * an IDE that does not delegate test execution to Gradle. Such runs execute a single test at a
+     * time, so they are not exposed to the cross-worker cache cleanup race this fixes; disabling
+     * cleanup for them is a nice-to-have; falling back to null here has {@link #gradleRunner} skip
+     * seeding it rather than fail the run outright.
+     */
+    private static File testKitDir() {
+        String testKitDir = System.getProperty("org.gradle.testkit.dir")
+        return testKitDir == null ? null : new File(testKitDir)
+    }
+
+    /**
+     * Disables Gradle user home cache cleanup for the given TestKit dir.
+     *
+     * Our func test tasks run with {@code maxParallelForks} set to the number of physical cores,
+     * and every worker shares a single TestKit Gradle user home. Cleanup triggered by one nested
+     * daemon then races with another worker's daemon reading or creating entries under
+     * {@code caches/<version>/groovy-dsl/**}{@code /instrumented}, which surfaces as a
+     * {@code NoSuchFileException} while the settings script is being compiled
+     * (see https://github.com/gradle/gradle/issues/6354).
+     *
+     * Cleanup has no value for this directory anyway: it lives under {@code build/} locally and on
+     * an ephemeral CI agent otherwise, so it never survives long enough to need pruning.
+     *
+     * Cache cleanup can only be configured from an init script in the Gradle user home, not from a
+     * settings script, so the setting is seeded into {@code init.d}. Writing it there (rather than
+     * passing {@code --init-script}) also keeps it out of the asserted build arguments and applies
+     * it to nested {@code ./gradlew} subprocesses, which inherit {@code GRADLE_USER_HOME}.
+     */
+    private static void disableCacheCleanup(File testKitDir) {
+        File initScriptDir = new File(testKitDir, "init.d")
+        File initScript = new File(initScriptDir, "disable-cache-cleanup.init.gradle")
+        if (initScript.exists()) {
+            return
+        }
+        // Creates testKitDir too, which must exist before staging the temp file inside it.
+        initScriptDir.mkdirs()
+        // Staged outside init.d, under a suffix Gradle does not treat as an init script, and only
+        // then moved in atomically. Gradle applies every *.init.gradle(.kts) it finds in init.d, so
+        // staging a *.init.gradle temp file inside that directory would let a concurrent nested
+        // build apply a partially written script, or list one that is renamed out from under it a
+        // moment later - the very failure mode this method exists to prevent.
+        File tmpScript = File.createTempFile("disable-cache-cleanup", ".tmp", testKitDir)
+        tmpScript.text = """
+            beforeSettings { settings ->
+                settings.caches {
+                    cleanup = org.gradle.api.cache.Cleanup.DISABLED
+                }
+            }
+        """.stripIndent()
+        try {
+            Files.move(tmpScript.toPath(), initScript.toPath(), StandardCopyOption.ATOMIC_MOVE)
+        } catch (FileAlreadyExistsException e) {
+            // Another worker won the race; its script is equivalent so there is nothing left to do.
+            tmpScript.delete()
+        }
     }
 
     def assertOutputContains(String givenOutput, String expected) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Build tools] Disable TestKit cache cleanup in build-tools func tests (#156899)](https://github.com/elastic/elasticsearch/pull/156899)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)