### PR TITLE
Add 9.5.2 connector release notes

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,11 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.5.2 [connectors-9.5.2-release-notes]
+
+### Fixes [connectors-9.5.2-fixes]
+* Fix long-running syncs being falsely marked as idle when Elasticsearch was temporarily slow or refresh calls timed out. The connector service no longer forces an index refresh on every job status check, keeps the ingestion heartbeat alive through transient errors, and retries job status checks during active syncs. [#4367](https://github.com/elastic/connectors/pull/4367), [#4311](https://github.com/elastic/connectors/issues/4311)
+
 ## 9.5.1 [connectors-9.5.1-release-notes]
 
 ### Fixes [connectors-9.5.1-fixes]


### PR DESCRIPTION
Adds the 9.5.2 connector release notes. Covers elastic/connectors#4367 (backport of the fix for elastic/connectors#4311).