### PR TITLE
[9.5] Rolling upgrade from 9.4.x to main fails: `Template` deserialization stream misalignment in BWC tests [#156594] (#156602)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSystemPropertyProvider.java
@@ -26,6 +26,22 @@ public class DefaultSystemPropertyProvider implements SystemPropertyProvider {
             properties.put("tests.testfeatures.enabled", "true");
         }
 
+        // DLM frozen tier serialization is gated on both a feature flag and a pre-GA transport
+        // version (searchable_snapshots_dlm, within the 9.4 line's range), so snapshot builds
+        // (flag on by default) and release builds (flag off) disagree on the wire format when
+        // communicating with a 9.4.x node. Force the flag off on every test cluster node so
+        // serialization is consistent regardless of build type.
+        // This guard is skipped when the cluster spec requests the flag via feature(FeatureFlag.X)
+        // to avoid overriding an explicit enable: feature-flag properties are emitted earlier
+        // in ES_JAVA_OPTS than resolved system properties, and the JVM takes the last -D value.
+        // A per-suite .systemProperty(...) call also overrides this default via map precedence.
+        // See https://github.com/elastic/elasticsearch/issues/156594.
+        String dlmFlagProperty = "es.dlm_searchable_snapshots_feature_flag_enabled";
+        boolean dlmFlagRequested = nodeSpec.getFeatures().stream().anyMatch(f -> f.systemProperty.startsWith(dlmFlagProperty + "="));
+        if (dlmFlagRequested == false) {
+            properties.put(dlmFlagProperty, "false");
+        }
+
         return Collections.unmodifiableMap(properties);
     }
 }

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -48,11 +48,7 @@ public class Clusters {
             .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
             .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))
             .configFile("ingest-geoip/GeoLite2-ASN.mmdb", Resource.fromClasspath("GeoLite2-ASN.mmdb"))
-            .setting("ingest.geoip.downloader.enabled", "false")
-            // DLM frozen tier serialization is gated on both a feature flag and a transport version, so nodes in a mixed cluster can
-            // disagree on the wire format when their build types differ (snapshot vs release). Disable the flag on every node so
-            // serialization is consistent regardless of build type. See https://github.com/elastic/elasticsearch/issues/153679.
-            .systemProperty("es.dlm_searchable_snapshots_feature_flag_enabled", "false");
+            .setting("ingest.geoip.downloader.enabled", "false");
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Rolling upgrade from 9.4.x to main fails: `Template` deserialization stream misalignment in BWC tests [#156594] (#156602)](https://github.com/elastic/elasticsearch/pull/156602)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)