### PR TITLE
[9.5] Speed up StaleIndicesGCIT tests (#156681)

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/gc/StaleIndicesGCIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/objectstore/gc/StaleIndicesGCIT.java
@@ -62,6 +62,12 @@ import static org.hamcrest.Matchers.not;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0, autoManageMasterNodes = false)
 public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
 
+    private static final TimeValue GC_INTERVAL = TimeValue.timeValueSeconds(1);
+
+    /// How long to wait when asserting that the GC did *not* delete something. Such an assertion can only be made after giving the GC
+    /// loop a chance to run, so it is expressed as a small multiple of [#GC_INTERVAL] rather than an arbitrary duration.
+    private static final long SEVERAL_GC_INTERVALS = 3 * GC_INTERVAL.millis();
+
     @Override
     protected boolean addMockFsRepository() {
         return false;
@@ -75,7 +81,35 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
     @Override
     protected Settings.Builder nodeSettings() {
         return super.nodeSettings().put(ObjectStoreService.TYPE_SETTING.getKey(), ObjectStoreService.ObjectStoreType.MOCK)
-            .put(ObjectStoreGCTask.GC_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(1));
+            .put(ObjectStoreGCTask.GC_INTERVAL_SETTING.getKey(), GC_INTERVAL);
+    }
+
+    /// Most tests here pin their indices to a single index node with `index.routing.allocation.require._name` and then stop that
+    /// node, so when the test ends some primaries can never be assigned again.
+    ///
+    /// [AbstractStatelessPluginIntegTestCase#beforeIndexDeletion] flushes *every* index to release commits held by the current
+    /// VBCC, and a flush against an unassigned primary does not give up until the timeout (one minute by default) has elapsed.
+    /// That stall dominated the runtime of this suite. An unassigned shard has no engine and therefore holds no commit, so
+    /// restricting the flush to indices whose primaries are assigned releases exactly the same commits without the wait.
+    @Override
+    protected void beforeIndexDeletion() throws Exception {
+        if (internalCluster().size() > 0) {
+            final var indicesToFlush = indicesWithActivePrimaries();
+            if (indicesToFlush.length > 0) {
+                flush(indicesToFlush);
+            }
+        }
+        // Deliberately skips the superclass, whose flush covers indices whose primaries cannot be assigned.
+        internalCluster().beforeIndexDeletion();
+    }
+
+    private static String[] indicesWithActivePrimaries() {
+        final var state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        final var routingTable = state.routingTable(ProjectId.DEFAULT);
+        return state.metadata().getProject().indices().keySet().stream().filter(indexName -> {
+            final var indexRoutingTable = routingTable.index(indexName);
+            return indexRoutingTable != null && indexRoutingTable.allPrimaryShardsActive();
+        }).toArray(String[]::new);
     }
 
     public void testStaleIndicesAreCleanedEventually() throws Exception {
@@ -189,7 +223,7 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
         final int numDeleted = between(1, indexNames.length);
         client().admin().indices().prepareDelete(subArray(indexNames, 0, numDeleted)).get();
 
-        safeSleep(5000);
+        safeSleep(SEVERAL_GC_INTERVALS);
         assertIndexExistsInObjectStore(indexUUIDs);
     }
 
@@ -208,8 +242,11 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
 
     public void doTestNoNewIndexDataIsDeletedUnderDisruptions(DisruptionScenario disruptionScenario) throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
+        // The node running the GC task is disrupted below, so it never acknowledges a cluster state it is sent and the master waits out
+        // this timeout on every single publication. The state is already committed by then (the master is the only master-eligible node,
+        // so it is its own quorum), and the publication just takes this long to complete, so keep the timeout short.
         var masterNode = startMasterNode(
-            Settings.builder().put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(5)).build()
+            Settings.builder().put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1)).build()
         );
 
         var indexNode = startIndexNode();
@@ -248,7 +285,10 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
                         .put("index.routing.allocation.require._name", nodeWhereIndexIsAllocated)
                         .build()
                 )
-                .setTimeout(TimeValue.timeValueSeconds(10)) // No need to wait long for the disrupted node to ack
+                // The disrupted node never acks, so this request always burns its full timeout before returning an unacknowledged
+                // response. Keep it short: the index is committed on the master regardless, and the green-health check below is what
+                // actually establishes that the shard is ready.
+                .setTimeout(TimeValue.timeValueSeconds(1))
                 .execute()
                 .get();
         }
@@ -275,7 +315,7 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
         executingTaskNodeRepositoryStrategy.unblockGetChildren();
         // Ensure that the isolated node has enough time to go through the listed files
         // and waits for the latest cluster state instead of deleting the newly created files
-        safeSleep(5000);
+        safeSleep(SEVERAL_GC_INTERVALS);
 
         assertIndexExistsInObjectStore(masterNode, indexUUIDs);
         disruption.stopDisrupting();
@@ -463,9 +503,12 @@ public class StaleIndicesGCIT extends AbstractStatelessPluginIntegTestCase {
                     .put("index.routing.allocation.require._name", indexNode)
                     .build()
             );
-            var numberOfSegments = randomIntBetween(5, 10);
+            // These tests only assert on the presence or absence of the per-index blob containers, so a handful of docs spread over a
+            // couple of commits is enough to give the GC something to list and delete. Larger indices only slow the suite down, since
+            // every flush uploads to the object store and every extra segment adds merge work to wait for after the test.
+            var numberOfSegments = randomIntBetween(2, 3);
             for (int i = 0; i < numberOfSegments; i++) {
-                indexDocs(indexName, 1000);
+                indexDocs(indexName, 10);
                 flush(indexName);
             }
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Speed up StaleIndicesGCIT tests (#156681)](https://github.com/elastic/elasticsearch/pull/156681)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)