### PR TITLE
Fix synthetic id seekCeil skipper overshoot

### DIFF
--- a/docs/changelog/156903.yaml
+++ b/docs/changelog/156903.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 151326
+pr: 156903
+summary: Fix synthetic id `seekCeil` skipper overshoot
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -211,9 +211,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecChangePointIT
   method: test {csv-spec:change_point.values null column}
   issue: https://github.com/elastic/elasticsearch/issues/151132
-- class: org.elasticsearch.xpack.ccr.CcrTimeSeriesDataStreamsIT
-  method: testCrossClusterReplicationForTSDBWithSyntheticId
-  issue: https://github.com/elastic/elasticsearch/issues/151326
 - class: org.elasticsearch.xpack.esql.optimizer.promql.PromqlGoldenTests
   method: testBinaryWithDifferentSelectors
   issue: https://github.com/elastic/elasticsearch/issues/151327

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdDocValuesHolder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdDocValuesHolder.java
@@ -190,13 +190,14 @@ class TSDBSyntheticIdDocValuesHolder {
 
     /**
      * Use a doc values skipper to find a starting document ID for the provided _tsid ordinal. The returned document ID might have the
-     * exact _tsid ordinal provided, or a lower one.
+     * exact _tsid ordinal provided, or a lower one; every document before it is guaranteed to have a lower _tsid ordinal. Returns
+     * {@link DocIdSetIterator#NO_MORE_DOCS} if the provided ordinal is greater than every ordinal in the segment.
      *
      * @param tsIdOrd the _tsid ordinal
      * @return a docID to start scanning documents from in order to find the first document ID matching the provided _tsid
      * @throws IOException if any I/O exception occurs
      */
-    private int findStartDocIDForTsIdOrd(int tsIdOrd) throws IOException {
+    int findStartDocIDForTsIdOrd(int tsIdOrd) throws IOException {
         assert tsIdOrd >= 0 : tsIdOrd;
         if (hasTsIdSkipper == false) {
             return 0;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -295,8 +295,15 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
                     return SeekStatus.END;
                 }
                 skipper.advance(firstDocID);
-                skipper.advance(timestamp, Long.MAX_VALUE);
-
+                // Within the _tsid, documents are sorted by descending timestamp, so blocks whose minimum timestamp is greater than the
+                // one we're looking for only contain documents that precede the ceiling and can be skipped. Blocks that may contain
+                // documents of the next _tsid must not be skipped: the ceiling might be their first document, whatever its timestamp.
+                final int nextTsIdStartDocID = docValues.findStartDocIDForTsIdOrd(tsIdOrd + 1);
+                while (skipper.minDocID(0) != DocIdSetIterator.NO_MORE_DOCS
+                    && skipper.maxDocID(0) < nextTsIdStartDocID
+                    && skipper.minValue(0) > timestamp) {
+                    skipper.advance(skipper.maxDocID(0) + 1);
+                }
                 if (skipper.minDocID(0) != DocIdSetIterator.NO_MORE_DOCS) {
                     nextDocID = Math.max(firstDocID, skipper.minDocID(0));
                 } else {

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
@@ -494,10 +495,111 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
                     final var status = syntheticIdTermsEnum.seekCeil(lookupTerm);
                     switch (status) {
                         case FOUND -> assertThat(syntheticIdTermsEnum.term(), equalTo(lookupTerm));
-                        case NOT_FOUND -> assertThat(syntheticIdTermsEnum.term(), greaterThan(lookupTerm));
+                        case NOT_FOUND -> assertThat(syntheticIdTermsEnum.term(), equalTo(finalDocs.ceilingKey(lookupTerm)));
                         case END -> assertNull(finalDocs.ceilingKey(lookupTerm));
                     }
                 }
+            }
+        });
+    }
+
+    public void testSoftUpdateResolvesEveryIdAcrossSegments() throws IOException {
+        runTest((writer, parser) -> {
+            final int routing = randomNonNegativeInt();
+            // Matches the failing shard: ~7000 docs over consecutive milliseconds, 4 time series, flushed in irregular batches
+            final int totalToIndex = randomIntBetween(5000, 8000);
+
+            final var docs = new ArrayList<Doc>();
+            long timestamp = Instant.now().toEpochMilli();
+            int untilFlush = randomIntBetween(1000, 2500);
+            for (int doc = 0; doc < totalToIndex; doc++) {
+                var testDoc = new Doc(timestamp++, "vm-dev0" + randomInt(3), "cpu-load", randomInt(), 1, routing);
+                writer.addDocument(parser.parse(testDoc));
+                docs.add(testDoc);
+                if (--untilFlush == 0) {
+                    writer.flush();
+                    untilFlush = randomIntBetween(1000, 2500);
+                }
+            }
+            writer.flush();
+
+            final int totalDocs = docs.size();
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat(reader.numDocs(), equalTo(totalDocs));
+            }
+
+            // Soft-update a random subset. Lucene applies the buffered delete terms in sorted order, per segment, so each of these must
+            // resolve to the existing document rather than adding a second live copy.
+            final var updated = randomSubsetOf(randomIntBetween(totalDocs / 2, totalDocs), docs);
+            int untilRefresh = randomIntBetween(1000, 2500);
+            for (var previousDoc : updated) {
+                // An update keeps the fields the synthetic id derives from, so the replacement carries the same _id
+                var updatedDoc = new Doc(
+                    previousDoc.timestamp(),
+                    previousDoc.hostName(),
+                    previousDoc.metricField(),
+                    previousDoc.metricValue(),
+                    previousDoc.version() + 1,
+                    previousDoc.routing()
+                );
+                writer.softUpdateDocument(
+                    new Term(IdFieldMapper.NAME, uidEncodedSyntheticId(previousDoc)),
+                    parser.parse(updatedDoc),
+                    Lucene.newSoftDeletesField()
+                );
+                if (--untilRefresh == 0) {
+                    // Deletes are resolved against whatever segments exist when they are applied, so flush in between
+                    writer.flush();
+                    untilRefresh = randomIntBetween(1000, 2500);
+                }
+            }
+
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat(
+                    "soft updates that failed to resolve their _id term left extra live documents behind",
+                    reader.numDocs(),
+                    equalTo(totalDocs)
+                );
+            }
+        });
+    }
+
+    public void testSeekCeilWithTimestampAboveTsidMaxAcrossSkipperBlocks() throws IOException {
+        runTest((writer, parser) -> {
+            var segment = indexMultiBlockSegment(writer, parser);
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat(reader.leaves(), hasSize(1));
+                var leaf = reader.leaves().getFirst().reader();
+
+                // smallest term >= idInTimestampGap
+                BytesRef expectedCeiling = null;
+                var iter = leaf.terms(IdFieldMapper.NAME).iterator();
+                for (BytesRef term = iter.next(); term != null; term = iter.next()) {
+                    if (term.compareTo(segment.idInTimestampGap()) >= 0) {
+                        expectedCeiling = BytesRef.deepCopyOf(term);
+                        break;
+                    }
+                }
+                assertThat(expectedCeiling, notNullValue());
+
+                var termsEnum = leaf.terms(IdFieldMapper.NAME).iterator();
+                assertThat(termsEnum.seekCeil(segment.idInTimestampGap()), is(TermsEnum.SeekStatus.NOT_FOUND));
+                assertThat("seekCeil overshot the ceiling", termsEnum.term(), equalTo(expectedCeiling));
+            }
+        });
+    }
+
+    public void testSortedDeleteTermsResolveAcrossSkipperBlocks() throws IOException {
+        runTest((writer, parser) -> {
+            var segment = indexMultiBlockSegment(writer, parser);
+            var deletes = new ArrayList<>(segment.ids());
+            deletes.add(segment.idInTimestampGap());
+            Collections.shuffle(deletes, random());
+            for (var uid : deletes) {
+                writer.softUpdateDocument(new Term(IdFieldMapper.NAME, uid), syntheticIdTombstone(uid), Lucene.newSoftDeletesField());
+            }
+            try (var reader = DirectoryReader.open(writer)) {
+                assertThat("the sorted delete-term walk dropped deletes", reader.numDocs(), equalTo(0));
             }
         });
     }
@@ -538,7 +640,7 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
                             startLatch.await();
                             for (int i = 0; i < iterationsPerThread; i++) {
                                 final BytesRef id = ids.get((i + threadIdx) % ids.size());
-                                termsEnum.seekExact(id);
+                                assertTrue(termsEnum.seekExact(id));
                             }
                         } catch (Throwable e) {
                             logger.error("unexpected exception", e);
@@ -988,4 +1090,50 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
         return id;
     }
 
+    private static Iterable<? extends IndexableField> syntheticIdTombstone(BytesRef uid) {
+        var tombstone = ParsedDocument.deleteTombstone(
+            // Must match the _seq_no field shape of the parsed documents, see buildIndexSettings
+            SeqNoFieldMapper.SeqNoIndexOptions.DOC_VALUES_ONLY,
+            true,
+            true,
+            false,
+            Uid.decodeId(uid.bytes, uid.offset, uid.length),
+            uid
+        );
+        var doc = tombstone.docs().getFirst();
+        doc.add(Lucene.newSoftDeletesField());
+        return doc;
+    }
+
+    private record MultiBlockSegment(List<BytesRef> ids, BytesRef idInTimestampGap) {}
+
+    private static MultiBlockSegment indexMultiBlockSegment(IndexWriter writer, TestDocParser parser) throws IOException {
+        writer.getConfig().setRAMBufferSizeMB(64);
+        final int routing = randomNonNegativeInt();
+        // Order the hosts by their _tsid, since that is the order their documents take in the segment
+        final var hostsByTsId = new TreeMap<BytesRef, String>();
+        for (var host : List.of("vm-dev-a", "vm-dev-b", "vm-dev-c")) {
+            hostsByTsId.put(buildTsId(new Doc(0L, host, "cpu-load", 0, 1, routing)), host);
+        }
+        final var hosts = List.copyOf(hostsByTsId.values());
+
+        final long baseTimestamp = Instant.now().toEpochMilli();
+        final long timestampGap = 10_000_000L;
+        final var ids = new ArrayList<BytesRef>();
+        final int[] docCounts = { randomIntBetween(50, 200), randomIntBetween(4_500, 5_000), randomIntBetween(1_000, 2_000) };
+        for (int tsid = 0; tsid < hosts.size(); tsid++) {
+            for (int i = 0; i < docCounts[tsid]; i++) {
+                long timestamp = (tsid == 2 ? baseTimestamp + timestampGap : baseTimestamp) + i;
+                var doc = new Doc(timestamp, hosts.get(tsid), "cpu-load", randomInt(), 1, routing);
+                writer.addDocument(parser.parse(doc));
+                ids.add(uidEncodedSyntheticId(doc));
+            }
+        }
+        writer.flush();
+
+        // An id of the middle time series with a timestamp above that time series' maximum in the segment, but below the segment-wide
+        // maximum. It does not exist in the segment; its ceiling is the very first id of the middle time series.
+        var idInTimestampGap = uidEncodedSyntheticId(new Doc(baseTimestamp + timestampGap / 2, hosts.get(1), "cpu-load", 0, 1, routing));
+        return new MultiBlockSegment(ids, idInTimestampGap);
+    }
 }


### PR DESCRIPTION
SyntheticIdTermsEnum#seekCeil advanced the timestamp doc values
skipper with a [timestamp, Long.MAX_VALUE] window, skipping blocks
whose maximum timestamp is below the sought one. Documents are
sorted by _tsid ascending and timestamp descending, so when the
sought timestamp is above the _tsid's per-segment maximum (but
below the segment-wide maximum) those blocks are exactly the ones
holding the ceiling, and the enum lands past the end of the _tsid.

Lucene resolves buffered delete terms by walking them in sorted
order against a reused terms enum, caching the last term seekCeil
landed on and dropping, without seeking, any delete term that sorts
below it. An overshoot therefore silently drops contiguous runs of
delete terms, leaving deleted documents live on one shard copy but
not the other.

Skip only blocks fully contained in the sought _tsid whose minimum
timestamp is above the sought one, stopping at the first document
of the next _tsid. Unmute the CCR test that surfaced the
divergence.

Backport of #156903
