### PR TITLE
[ESQL] Improve memory-test coverage

### DIFF
--- a/docs/changelog/156997.yaml
+++ b/docs/changelog/156997.yaml
@@ -1,5 +1,0 @@
-area: ES|QL
-issues: []
-pr: 156997
-summary: Stop overclaiming memory-test coverage
-type: enhancement

--- a/docs/changelog/156997.yaml
+++ b/docs/changelog/156997.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 156997
+summary: Stop overclaiming memory-test coverage
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -238,10 +238,10 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                         FormatReadContext.of(null, 1024)
                     )
                 ) {
-                    if (iter.hasNext()) {
-                        Page page = iter.next();
-                        page.releaseBlocks();
-                    }
+                    assertTrue("optimized reader must produce a page before early close", iter.hasNext());
+                    Page page = iter.next();
+                    assertTrue("page must contain rows", page.getPositionCount() > 0);
+                    page.releaseBlocks();
                     hold.await(30, TimeUnit.SECONDS);
                 }
             } catch (Exception e) {
@@ -254,6 +254,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             pipeline.allocBaseline,
             pipeline.blockFactory.arrowAllocator().getAllocatedMemory()
         );
+        assertTrue("Prefetch should have reserved breaker bytes before early close", pipeline.breaker.peakUsed.get() > 0);
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -39,7 +39,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -175,6 +177,92 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertEquals("Breaker should return to zero after early close", 0, breaker.getUsed());
+    }
+
+    /**
+     * N concurrent optimized readers share one breaker and one Arrow allocator. After every
+     * thread finishes iterating, both accounts must return to baseline. Uses zstd so the
+     * decompress path (bug #1) is exercised under concurrency, not only uncompressed prefetch.
+     */
+    public void testConcurrentReadersShareBreaker() throws Exception {
+        int readers = 4;
+        MessageType wideSchema = buildWideSchema(8);
+        byte[] parquetData = createMultiRowGroupFile(wideSchema, 3000, 2048, CompressionCodecName.ZSTD);
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(256));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+        long allocBaseline = blockFactory.arrowAllocator().getAllocatedMemory();
+
+        startInParallel(readers, i -> {
+            StorageObject storage = new InMemoryStorageObject(parquetData);
+            int totalRows = 0;
+            try {
+                try (
+                    CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
+                        storage,
+                        FormatReadContext.of(null, 1024)
+                    )
+                ) {
+                    while (iter.hasNext()) {
+                        Page page = iter.next();
+                        totalRows += page.getPositionCount();
+                        page.releaseBlocks();
+                    }
+                }
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+            assertTrue("Should have read rows", totalRows > 0);
+        });
+        assertEquals("Breaker should return to zero after concurrent readers finish", 0, breaker.getUsed());
+        assertEquals(
+            "Arrow allocator should return to baseline after concurrent readers finish",
+            allocBaseline,
+            blockFactory.arrowAllocator().getAllocatedMemory()
+        );
+        assertTrue("Prefetch should have reserved breaker bytes", breaker.peakUsed.get() > 0);
+    }
+
+    /**
+     * N concurrent readers each consume one page, wait together so prefetch is in-flight,
+     * then close on the iterating thread (query cancel on the driver thread). Breaker and
+     * allocator must return to baseline.
+     */
+    public void testConcurrentCancelReclaimsMemory() throws Exception {
+        int readers = 4;
+        MessageType wideSchema = buildWideSchema(8);
+        byte[] parquetData = createMultiRowGroupFile(wideSchema, 5000, 2048, CompressionCodecName.ZSTD);
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(256));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+        long allocBaseline = blockFactory.arrowAllocator().getAllocatedMemory();
+
+        CyclicBarrier hold = new CyclicBarrier(readers);
+        startInParallel(readers, i -> {
+            StorageObject storage = new InMemoryStorageObject(parquetData);
+            try {
+                try (
+                    CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
+                        storage,
+                        FormatReadContext.of(null, 1024)
+                    )
+                ) {
+                    if (iter.hasNext()) {
+                        Page page = iter.next();
+                        page.releaseBlocks();
+                    }
+                    hold.await(30, TimeUnit.SECONDS);
+                }
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        });
+        assertBusy(() -> {
+            assertEquals("Breaker should return to zero after concurrent cancel", 0, breaker.getUsed());
+            assertEquals(
+                "Arrow allocator should return to baseline after concurrent cancel",
+                allocBaseline,
+                blockFactory.arrowAllocator().getAllocatedMemory()
+            );
+        });
     }
 
     // --- Helpers ---
@@ -317,11 +405,58 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         return builder.named("wide_schema");
     }
 
+    /**
+     * In-memory {@link StorageObject} that uses the default {@code readBytesAsync} path so
+     * prefetch buffers are allocated through the supplied {@link DirectBufferFactory}.
+     */
+    private static final class InMemoryStorageObject implements StorageObject {
+        private final byte[] data;
+
+        InMemoryStorageObject(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://breaker-concurrent.parquet");
+        }
+    }
+
     private byte[] createMultiRowGroupFile(int rowCount, int rowGroupSize) throws IOException {
-        return createMultiRowGroupFile(SCHEMA, rowCount, rowGroupSize);
+        return createMultiRowGroupFile(SCHEMA, rowCount, rowGroupSize, CompressionCodecName.UNCOMPRESSED);
     }
 
     private byte[] createMultiRowGroupFile(MessageType schema, int rowCount, int rowGroupSize) throws IOException {
+        return createMultiRowGroupFile(schema, rowCount, rowGroupSize, CompressionCodecName.UNCOMPRESSED);
+    }
+
+    private byte[] createMultiRowGroupFile(MessageType schema, int rowCount, int rowGroupSize, CompressionCodecName codec)
+        throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         OutputFile outputFile = createOutputFile(outputStream);
         SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -334,7 +469,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 .withConf(new PlainParquetConfiguration())
                 .withCodecFactory(new PlainCompressionCodecFactory())
                 .withType(schema)
-                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withCompressionCodec(codec)
                 .withRowGroupSize(rowGroupSize)
                 .withPageSize(256)
                 .build()

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -182,23 +182,20 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
     /**
      * N concurrent optimized readers share one breaker and one Arrow allocator. After every
      * thread finishes iterating, both accounts must return to baseline. Uses zstd so the
-     * decompress path (bug #1) is exercised under concurrency, not only uncompressed prefetch.
+     * decompress path is exercised under concurrency, not only uncompressed prefetch.
+     * Peak is not compared to N times a single-reader peak: N concurrent windows can
+     * legitimately reach about N times one window. Sharing is the accounts returning to zero.
      */
     public void testConcurrentReadersShareBreaker() throws Exception {
         int readers = 4;
-        MessageType wideSchema = buildWideSchema(8);
-        byte[] parquetData = createMultiRowGroupFile(wideSchema, 3000, 2048, CompressionCodecName.ZSTD);
-        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(256));
-        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
-        long allocBaseline = blockFactory.arrowAllocator().getAllocatedMemory();
+        ConcurrentPipeline pipeline = newConcurrentPipeline(3000);
 
         startInParallel(readers, i -> {
-            StorageObject storage = new InMemoryStorageObject(parquetData);
             int totalRows = 0;
             try {
                 try (
-                    CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
-                        storage,
+                    CloseableIterator<Page> iter = new ParquetFormatReader(pipeline.blockFactory, true).read(
+                        pipeline.storage(),
                         FormatReadContext.of(null, 1024)
                     )
                 ) {
@@ -213,35 +210,31 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
             assertTrue("Should have read rows", totalRows > 0);
         });
-        assertEquals("Breaker should return to zero after concurrent readers finish", 0, breaker.getUsed());
+        assertEquals("Breaker should return to zero after concurrent readers finish", 0, pipeline.breaker.getUsed());
         assertEquals(
             "Arrow allocator should return to baseline after concurrent readers finish",
-            allocBaseline,
-            blockFactory.arrowAllocator().getAllocatedMemory()
+            pipeline.allocBaseline,
+            pipeline.blockFactory.arrowAllocator().getAllocatedMemory()
         );
-        assertTrue("Prefetch should have reserved breaker bytes", breaker.peakUsed.get() > 0);
+        assertTrue("Prefetch should have reserved breaker bytes", pipeline.breaker.peakUsed.get() > 0);
     }
 
     /**
-     * N concurrent readers each consume one page, wait together so prefetch is in-flight,
-     * then close on the iterating thread (query cancel on the driver thread). Breaker and
-     * allocator must return to baseline.
+     * Concurrent early close of the optimized iterator after a synchronized partial read.
+     * Each worker consumes one page, waits so all hold an open iterator, then closes on the
+     * iterating thread. This is not {@code AsyncExternalSourceBuffer.discardPages} cancel
+     * (covered in {@code AsyncExternalSourceBufferTests}) and not other-thread close.
      */
-    public void testConcurrentCancelReclaimsMemory() throws Exception {
+    public void testConcurrentEarlyCloseReclaimsMemory() throws Exception {
         int readers = 4;
-        MessageType wideSchema = buildWideSchema(8);
-        byte[] parquetData = createMultiRowGroupFile(wideSchema, 5000, 2048, CompressionCodecName.ZSTD);
-        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(256));
-        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
-        long allocBaseline = blockFactory.arrowAllocator().getAllocatedMemory();
+        ConcurrentPipeline pipeline = newConcurrentPipeline(5000);
 
         CyclicBarrier hold = new CyclicBarrier(readers);
         startInParallel(readers, i -> {
-            StorageObject storage = new InMemoryStorageObject(parquetData);
             try {
                 try (
-                    CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(
-                        storage,
+                    CloseableIterator<Page> iter = new ParquetFormatReader(pipeline.blockFactory, true).read(
+                        pipeline.storage(),
                         FormatReadContext.of(null, 1024)
                     )
                 ) {
@@ -255,14 +248,12 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 throw new AssertionError(e);
             }
         });
-        assertBusy(() -> {
-            assertEquals("Breaker should return to zero after concurrent cancel", 0, breaker.getUsed());
-            assertEquals(
-                "Arrow allocator should return to baseline after concurrent cancel",
-                allocBaseline,
-                blockFactory.arrowAllocator().getAllocatedMemory()
-            );
-        });
+        assertEquals("Breaker should return to zero after concurrent early close", 0, pipeline.breaker.getUsed());
+        assertEquals(
+            "Arrow allocator should return to baseline after concurrent early close",
+            pipeline.allocBaseline,
+            pipeline.blockFactory.arrowAllocator().getAllocatedMemory()
+        );
     }
 
     // --- Helpers ---
@@ -406,8 +397,10 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
     }
 
     /**
-     * In-memory {@link StorageObject} that uses the default {@code readBytesAsync} path so
-     * prefetch buffers are allocated through the supplied {@link DirectBufferFactory}.
+     * Allocator-backed in-memory storage: default {@code readBytesAsync} allocates through
+     * {@link DirectBufferFactory}. Distinct from {@link #createAsyncStorageObject}, which uses a
+     * heap {@code ByteBuffer} and a no-op closer so older breaker tests do not charge Arrow for
+     * prefetch bytes. Do not merge the two stubs.
      */
     private static final class InMemoryStorageObject implements StorageObject {
         private final byte[] data;
@@ -444,6 +437,19 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         @Override
         public StoragePath path() {
             return StoragePath.of("memory://breaker-concurrent.parquet");
+        }
+    }
+
+    private ConcurrentPipeline newConcurrentPipeline(int rowCount) throws IOException {
+        byte[] parquetData = createMultiRowGroupFile(buildWideSchema(8), rowCount, 2048, CompressionCodecName.ZSTD);
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(256));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+        return new ConcurrentPipeline(parquetData, breaker, blockFactory, blockFactory.arrowAllocator().getAllocatedMemory());
+    }
+
+    private record ConcurrentPipeline(byte[] parquetData, TrackingBreaker breaker, BlockFactory blockFactory, long allocBaseline) {
+        StorageObject storage() {
+            return new InMemoryStorageObject(parquetData);
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -49,7 +49,6 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
     private static final int PAGES_PER_ITERATION = 50;
     private static final int PAGE_PAYLOAD_BYTES = 64 * 1024;          // 64 KB decompressed
     private static final long MAX_DIRECT_GROWTH_BYTES = 64L * 1024 * 1024; // 64 MB ceiling
-    private static final int STABILIZE_CYCLES = 100;
     private static final int CONCURRENT_READERS = 4;
     private static final int CONCURRENT_ITERS_PER_READER = 50;
 
@@ -72,7 +71,8 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
     public void testRepeatedZstdDecompressionStaysWithinDirectMemoryBudget() throws IOException {
         ZstdPageFixture fixture = compressedZstdPages();
 
-        long baseline = directMemoryUsedBytes();
+        long directBaseline = directMemoryUsedBytes();
+        long allocBaseline = allocator.getAllocatedMemory();
 
         for (int i = 0; i < ITERATIONS; i++) {
             try (
@@ -89,10 +89,11 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                     consume(page);
                 }
             }
+            assertEquals("allocator must return to baseline after cycle " + i, allocBaseline, allocator.getAllocatedMemory());
         }
 
         long after = directMemoryUsedBytes();
-        long grew = after - baseline;
+        long grew = after - directBaseline;
         assertThat(
             "direct-memory grew "
                 + (grew >>> 20)
@@ -107,33 +108,6 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
             grew,
             lessThanOrEqualTo(MAX_DIRECT_GROWTH_BYTES)
         );
-    }
-
-    /**
-     * Full open-read-close cycles must return Arrow allocator accounting to the exact baseline
-     * after every cycle. A slow per-query leak (e.g. 0.5 MB per drop) is invisible in a single
-     * run but fails this loop immediately.
-     */
-    public void testAllocatorMemoryStabilizes() throws IOException {
-        ZstdPageFixture fixture = compressedZstdPages();
-        long baseline = allocator.getAllocatedMemory();
-        for (int i = 0; i < STABILIZE_CYCLES; i++) {
-            try (
-                PrefetchedPageReader reader = new PrefetchedPageReader(
-                    codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                    allocator,
-                    fixture.copyPages(),
-                    null,
-                    (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
-                )
-            ) {
-                DataPage page;
-                while ((page = reader.readPage()) != null) {
-                    consume(page);
-                }
-            }
-            assertEquals("allocator must return to baseline after cycle " + i, baseline, allocator.getAllocatedMemory());
-        }
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -49,6 +49,9 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
     private static final int PAGES_PER_ITERATION = 50;
     private static final int PAGE_PAYLOAD_BYTES = 64 * 1024;          // 64 KB decompressed
     private static final long MAX_DIRECT_GROWTH_BYTES = 64L * 1024 * 1024; // 64 MB ceiling
+    private static final int STABILIZE_CYCLES = 100;
+    private static final int CONCURRENT_READERS = 4;
+    private static final int CONCURRENT_ITERS_PER_READER = 50;
 
     private PlainCompressionCodecFactory codecFactory;
     private BlockFactory blockFactory;
@@ -67,25 +70,7 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
     }
 
     public void testRepeatedZstdDecompressionStaysWithinDirectMemoryBudget() throws IOException {
-        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
-        List<PrefetchedPageReader.CompressedPage> template = new ArrayList<>(PAGES_PER_ITERATION);
-        for (int p = 0; p < PAGES_PER_ITERATION; p++) {
-            byte[] payload = randomBytesOfLength(PAGE_PAYLOAD_BYTES);
-            // Materialize the compressed bytes to a stable heap byte[] so the same template
-            // is replayable across all iterations (the compressor's BytesInput may otherwise
-            // hold a reference into compressor-internal scratch state).
-            byte[] compressedBytes = compressor.compress(BytesInput.from(payload)).toByteArray();
-            DataPageV1 v1 = new DataPageV1(
-                BytesInput.from(compressedBytes),
-                PAGE_PAYLOAD_BYTES / 4,
-                payload.length,
-                new IntStatistics(),
-                Encoding.RLE,
-                Encoding.RLE,
-                Encoding.PLAIN
-            );
-            template.add(new PrefetchedPageReader.CompressedPage(v1, -1L));
-        }
+        ZstdPageFixture fixture = compressedZstdPages();
 
         long baseline = directMemoryUsedBytes();
 
@@ -94,7 +79,7 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                     allocator,
-                    template,
+                    fixture.copyPages(),
                     null,
                     (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
                 )
@@ -124,6 +109,111 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
         );
     }
 
+    /**
+     * Full open-read-close cycles must return Arrow allocator accounting to the exact baseline
+     * after every cycle. A slow per-query leak (e.g. 0.5 MB per drop) is invisible in a single
+     * run but fails this loop immediately.
+     */
+    public void testAllocatorMemoryStabilizes() throws IOException {
+        ZstdPageFixture fixture = compressedZstdPages();
+        long baseline = allocator.getAllocatedMemory();
+        for (int i = 0; i < STABILIZE_CYCLES; i++) {
+            try (
+                PrefetchedPageReader reader = new PrefetchedPageReader(
+                    codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+                    allocator,
+                    fixture.copyPages(),
+                    null,
+                    (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
+                )
+            ) {
+                DataPage page;
+                while ((page = reader.readPage()) != null) {
+                    consume(page);
+                }
+            }
+            assertEquals("allocator must return to baseline after cycle " + i, baseline, allocator.getAllocatedMemory());
+        }
+    }
+
+    /**
+     * Concurrent zstd decompress loops must not accumulate native memory. Arrow accounting is
+     * exact (zero after join); MXBean remains a coarse JVM-wide ceiling matching the
+     * single-threaded regression.
+     */
+    public void testDirectMemoryStableUnderConcurrentReads() throws Exception {
+        ZstdPageFixture fixture = compressedZstdPages();
+        long allocBaseline = allocator.getAllocatedMemory();
+        long directBaseline = directMemoryUsedBytes();
+
+        startInParallel(CONCURRENT_READERS, i -> {
+            try {
+                for (int iter = 0; iter < CONCURRENT_ITERS_PER_READER; iter++) {
+                    try (
+                        PrefetchedPageReader reader = new PrefetchedPageReader(
+                            codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+                            allocator,
+                            fixture.copyPages(),
+                            null,
+                            (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
+                        )
+                    ) {
+                        DataPage page;
+                        while ((page = reader.readPage()) != null) {
+                            consume(page);
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        });
+        assertEquals("allocator must return to baseline after concurrent reads", allocBaseline, allocator.getAllocatedMemory());
+        long grew = directMemoryUsedBytes() - directBaseline;
+        assertThat(
+            "direct-memory grew "
+                + (grew >>> 20)
+                + " MB under concurrent zstd reads; expected <= "
+                + (MAX_DIRECT_GROWTH_BYTES >>> 20)
+                + " MB",
+            grew,
+            lessThanOrEqualTo(MAX_DIRECT_GROWTH_BYTES)
+        );
+    }
+
+    private ZstdPageFixture compressedZstdPages() throws IOException {
+        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
+        byte[][] compressed = new byte[PAGES_PER_ITERATION][];
+        for (int p = 0; p < PAGES_PER_ITERATION; p++) {
+            byte[] payload = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+            compressed[p] = compressor.compress(BytesInput.from(payload)).toByteArray();
+        }
+        return new ZstdPageFixture(compressed);
+    }
+
+    /**
+     * Immutable compressed payloads. {@link #copyPages()} builds a fresh {@link BytesInput} per
+     * page so concurrent readers never share mutable parquet-mr page state.
+     */
+    private record ZstdPageFixture(byte[][] compressed) {
+        List<PrefetchedPageReader.CompressedPage> copyPages() {
+            List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(compressed.length);
+            for (byte[] compressedBytes : compressed) {
+                DataPageV1 v1 = new DataPageV1(
+                    BytesInput.from(compressedBytes),
+                    PAGE_PAYLOAD_BYTES / 4,
+                    PAGE_PAYLOAD_BYTES,
+                    new IntStatistics(),
+                    Encoding.RLE,
+                    Encoding.RLE,
+                    Encoding.PLAIN
+                );
+                pages.add(new PrefetchedPageReader.CompressedPage(v1, -1L));
+            }
+            return pages;
+        }
+    }
+
     private static void consume(DataPage page) throws IOException {
         // Force the BytesInput contents through to a heap copy (simulates the Block-construction
         // consumer) and let the array go out of scope. The copy must complete before the reader
@@ -142,11 +232,5 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
             }
         }
         return 0;
-    }
-
-    private byte[] randomBytesOfLength(int len) {
-        byte[] bytes = new byte[len];
-        random().nextBytes(bytes);
-        return bytes;
     }
 }


### PR DESCRIPTION
Beef up testing to validate more memory case scenarios.
assert accounts hit zero when close returns so a leak fails immediately.