### PR TITLE
Add link to docs from `LagDetector` warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
@@ -182,11 +182,14 @@ public class LagDetector {
             }
 
             logger.warn(
-                "node [{}] is lagging at cluster state version [{}], although publication of cluster state version [{}] completed [{}] ago",
+                """
+                    node [{}] is lagging at cluster state version [{}], although publication of \
+                    cluster state version [{}] completed [{}] ago; see {} for further information""",
                 discoveryNode,
                 appliedVersion,
                 version,
-                clusterStateApplicationTimeout
+                clusterStateApplicationTimeout,
+                ReferenceDocs.LAGGING_NODE_TROUBLESHOOTING
             );
             lagListener.onLagDetected(discoveryNode, appliedVersion, version);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1875,15 +1875,14 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 );
 
                 mockLog.addExpectation(
-                    new MockLog.SeenEventExpectation(
-                        "lag warning",
-                        LagDetector.class.getCanonicalName(),
-                        Level.WARN,
-                        "node ["
-                            + brokenNode
-                            + "] is lagging at cluster state version [*], "
-                            + "although publication of cluster state version [*] completed [*] ago"
-                    )
+                    new MockLog.SeenEventExpectation("lag warning", LagDetector.class.getCanonicalName(), Level.WARN, Strings.format("""
+                        node [%s] is lagging at cluster state version [*], although publication of cluster state version [*] \
+                        completed [*] ago; see https://*/troubleshoot/*-lagging for further information""", brokenNode)) {
+                        @Override
+                        public void match(LogEvent event) {
+                            super.match(event);
+                        }
+                    }
                 );
 
                 mockLog.addExpectation(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1877,12 +1877,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 mockLog.addExpectation(
                     new MockLog.SeenEventExpectation("lag warning", LagDetector.class.getCanonicalName(), Level.WARN, Strings.format("""
                         node [%s] is lagging at cluster state version [*], although publication of cluster state version [*] \
-                        completed [*] ago; see https://*/troubleshoot/*-lagging for further information""", brokenNode)) {
-                        @Override
-                        public void match(LogEvent event) {
-                            super.match(event);
-                        }
-                    }
+                        completed [*] ago; see https://*/troubleshoot/*-lagging for further information""", brokenNode))
                 );
 
                 mockLog.addExpectation(


### PR DESCRIPTION
We have docs for investigating this warning further but they need to be
linked from the warning or else users won't know how to proceed.