### PR TITLE
Fix invalid index.mode leaking internal enum path

### DIFF
--- a/docs/changelog/157015.yaml
+++ b/docs/changelog/157015.yaml
@@ -1,4 +1,4 @@
-area: Vector Search
+area: Indices APIs
 issues: []
 pr: 157015
 summary: Fix invalid `index.mode` leaking internal enum path

--- a/docs/changelog/157015.yaml
+++ b/docs/changelog/157015.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 157015
+summary: Fix invalid `index.mode` leaking internal enum path
+type: bug

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -64,7 +64,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -222,13 +221,13 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
             Settings addlSettings = builder.build();
             var rawMode = addlSettings.get(IndexSettings.MODE.getKey());
             if (rawMode != null) {
-                indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
+                indexMode = IndexMode.fromString(rawMode);
             }
         }
         if (indexMode == null) {
             String rawMode = settings.get(IndexSettings.MODE.getKey());
             if (rawMode != null) {
-                indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
+                indexMode = IndexMode.fromString(rawMode);
             }
         }
         return indexMode;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ProjectMetadata.java
@@ -62,7 +62,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -1111,7 +1110,7 @@ public class ProjectMetadata implements Iterable<IndexMetadata>, Diffable<Projec
         var settings = MetadataIndexTemplateService.resolveSettings(indexTemplate, componentTemplates());
         // Not using IndexSettings.MODE.get() to avoid validation that may fail at this point.
         var rawIndexMode = settings.get(IndexSettings.MODE.getKey());
-        return rawIndexMode != null ? Enum.valueOf(IndexMode.class, rawIndexMode.toUpperCase(Locale.ROOT)) : null;
+        return rawIndexMode != null ? IndexMode.fromString(rawIndexMode) : null;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/ES95CodecClusterSettingProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/ES95CodecClusterSettingProvider.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Cluster wide opt-out for the ES95 TSDB doc values codec, complementing the per-index
@@ -76,7 +75,7 @@ public final class ES95CodecClusterSettingProvider implements IndexSettingProvid
             return templateIndexMode;
         }
         final String modeName = settings.get(IndexSettings.MODE.getKey());
-        return modeName == null ? null : IndexMode.valueOf(modeName.toUpperCase(Locale.ROOT));
+        return modeName == null ? null : IndexMode.fromString(modeName);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -1083,7 +1083,7 @@ public enum IndexMode {
             if (indexMode == null) {
                 String modeName = indexTemplateAndCreateRequestSettings.get(IndexSettings.MODE.getKey());
                 if (modeName != null) {
-                    indexMode = IndexMode.valueOf(modeName.toUpperCase(Locale.ROOT));
+                    indexMode = IndexMode.fromString(modeName);
                 }
             }
             if (indexMode == LOOKUP) {

--- a/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
@@ -107,7 +107,6 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
         Settings userSettings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb").build();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> runProvider(userSettings, Settings.builder()));
         assertThat(e.getMessage(), containsString("[vectordb] is an invalid index mode"));
-        assertThat(e.getMessage(), not(containsString("No enum constant")));
     }
 
     private static void runProvider(Settings userSettings, Settings.Builder additional) {

--- a/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
@@ -103,6 +103,13 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
         );
     }
 
+    public void testProviderRejectsUnrecognizedIndexModeWithUserFriendlyError() {
+        Settings userSettings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb").build();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> runProvider(userSettings, Settings.builder()));
+        assertThat(e.getMessage(), containsString("[vectordb] is an invalid index mode"));
+        assertThat(e.getMessage(), not(containsString("No enum constant")));
+    }
+
     private static void runProvider(Settings userSettings, Settings.Builder additional) {
         new IndexMode.IndexModeSettingsProvider().provideAdditionalSettings(
             "test_index",

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -270,7 +270,7 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
     }
 
     private static IndexMode resolveIndexMode(final String mode) {
-        return mode != null ? Enum.valueOf(IndexMode.class, mode.toUpperCase(Locale.ROOT)) : null;
+        return mode != null ? IndexMode.fromString(mode) : null;
     }
 
     MappingHints getMappingHints(


### PR DESCRIPTION
## Summary

- Replaces `IndexMode.valueOf()` with `IndexMode.fromString()` in `IndexModeSettingsProvider` and `ES95CodecClusterSettingProvider`
- An unrecognised `index.mode` value such as `"vectordb"` now returns `[vectordb] is an invalid index mode, valid modes are: [...]` instead of leaking `No enum constant org.elasticsearch.index.IndexMode.VECTORDB`
- Adds a regression test in `VectordbDocumentIndexModeTests` that exercises the exact `IndexModeSettingsProvider` code path
