### PR TITLE
[9.5] ESQL:DS: Fix unsigned_long comparisons (#156653)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -198,6 +198,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      */
     private final boolean sortColumnAnnotationScales;
     /**
+     * Whether the sort column's ESQL type is {@code UNSIGNED_LONG} — i.e. the scan sign-flip-encodes every value it
+     * reads (see {@code PageColumnReader#readLongColumn}, keyed on the ESQL type rather than the physical
+     * annotation). For a physical {@code UINT_64}, a raw footer/page-index bound must go through the identical
+     * {@link ParquetColumnDecoding#encodeUnsignedLong} transform before it is compared against the threshold, which
+     * is published from already-encoded blocks; otherwise any value at or above 2^63 sign-wraps to a domain the
+     * comparison never accounts for. A plain signed {@code INT64} declared as
+     * {@code UNSIGNED_LONG} also sets this flag, but its statistics use signed ordering and therefore cannot be
+     * transformed safely; {@link #unsignedLongStat(long)} declines threshold pruning for that shape. A column
+     * explicitly declared as signed {@code LONG} over a physical UINT64 keeps {@code sortType == LONG}, so this stays
+     * {@code false} for it and the raw pass-through below is unaffected — that declaration's block values are never
+     * sign-flipped either.
+     */
+    private final boolean sortColumnIsUnsignedLong;
+    /**
      * High bits OR-ed into every emitted {@code _rowPosition} value once
      * {@link #setExtractorId(int)} has been called: {@code ((long) extractorId) << LOCAL_POSITION_BITS}.
      * The factory installs the id between {@link #createColumnExtractor(Consumer)} and the first call to
@@ -397,6 +411,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         this.sortColumnAnnotationScales = sortColumnPrimitiveType != null
             && sortColumnPrimitiveType.getLogicalTypeAnnotation() != null
             && ParquetColumnDecoding.integralDecodeScalesRelativeToRawStats(sortColumnPrimitiveType.getLogicalTypeAnnotation());
+        this.sortColumnIsUnsignedLong = sortType == DataType.UNSIGNED_LONG;
         this.sortDecodeRelation = resolveSortDecodeRelation(sortColumnPrimitiveType, sortType, sortInfo);
         this.codecFactory = codecFactory;
         this.counters = counters;
@@ -633,6 +648,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     yield null;
                 }
                 long raw = ((Number) value).longValue();
+                // An unsigned_long sort column's blocks are sign-flip-encoded (ESQL's canonical representation).
+                // Transform only UINT_64 stats, whose unsigned ordering is preserved by that encoding; a plain
+                // signed INT64 declared unsigned_long has signed-ordered stats and must decline.
+                if (sortColumnIsUnsignedLong) {
+                    yield unsignedLongStat(raw);
+                }
                 // A plain long sort column has no relation and its raw value is its decoded value. A rescaled temporal
                 // one must be mapped into the decoded domain the threshold bound lives in, or the comparison skips the
                 // wrong groups. A null relation on a temporal column (TIME/DECIMAL/unsigned) declines the skip — safe.
@@ -676,6 +697,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     yield null;
                 }
                 long raw = ordered.getLong();
+                // Same mapping and physical-ordering gate as rawValueFromStats.
+                if (sortColumnIsUnsignedLong) {
+                    yield unsignedLongStat(raw);
+                }
                 // Same mapping as rawValueFromStats: a rescaled temporal column's page bound must reach the decoded
                 // domain the threshold lives in; a plain long is the identity; a temporal column with no exact
                 // relation declines the page skip.
@@ -703,6 +728,16 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 : null;
             default -> null;
         };
+    }
+
+    /**
+     * Maps a raw {@code UINT_64} statistic into the sign-flip-encoded domain used by ESQL blocks and the TopN
+     * threshold. A plain signed {@code INT64} declared as {@code UNSIGNED_LONG} cannot use this mapping: its min/max
+     * were selected under signed ordering, so a range spanning both sign halves would have its endpoints reversed
+     * after the sign flip and could make threshold pruning discard competitive rows.
+     */
+    private Long unsignedLongStat(long raw) {
+        return ParquetColumnDecoding.isUnsignedInt64(sortColumnPrimitiveType) ? ParquetColumnDecoding.encodeUnsignedLong(raw) : null;
     }
 
     private static final long DEEPER_PREFETCH_BYTES = 32_000_000L;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -452,6 +452,7 @@ final class ParquetPushedExpressions {
         return switch (dataType) {
             case INTEGER -> buildIntPredicate(columnName, value, op, schema);
             case LONG -> buildLongPredicate(columnName, value, op, schema);
+            case UNSIGNED_LONG -> buildUnsignedLongPredicate(columnName, value, op, schema);
             case DOUBLE -> {
                 if (isPhysicalDouble(schema, columnName)) {
                     yield orderedPredicate(FilterApi.doubleColumn(columnName), value != null ? ((Number) value).doubleValue() : null, op);
@@ -592,6 +593,37 @@ final class ParquetPushedExpressions {
             }
             default -> null;
         };
+    }
+
+    /**
+     * Builds a predicate for an ESQL {@code UNSIGNED_LONG} column — the mirror image of
+     * {@link #buildLongPredicate}'s UNSIGNED_64 arm. ESQL stores {@code UNSIGNED_LONG} values sign-flip-encoded
+     * ({@code value ^ 2^63}, see {@link ParquetColumnDecoding#encodeUnsignedLong}), which is the domain the literal
+     * arrives in here; un-flipping it (the encode is its own inverse) recovers the file's raw physical {@code INT64}
+     * bits to push.
+     * <p>
+     * {@code eq}/{@code notEq} are bit-pattern exact regardless of which comparator parquet-mr applies (row-group
+     * min/max always bounds the group's raw values under whatever consistent order computed them, so a point
+     * membership test against that same order can never produce a false negative) and always push. An ORDERED
+     * comparison (lt/lte/gt/gte), however, needs parquet-mr to apply an UNSIGNED comparator over the row-group
+     * RANGE to agree with ESQL's true-unsigned ordering — which only happens when the physical column carries the
+     * {@code UINT_64} annotation ({@link ParquetColumnDecoding#isUnsignedInt64}). A physical column WITHOUT that
+     * annotation (e.g. a plain signed {@code INT64} declared {@code unsigned_long}) has footer stats computed under
+     * the file's own SIGNED comparator, which disagrees with ESQL's unsigned semantics for a row group spanning both
+     * bit-pattern halves — pushing an ordered predicate there would silently skip row groups holding the true
+     * unsigned extrema, so those decline. IS NULL/IS NOT NULL (value == null) is exempt,
+     * matching {@link #buildLongPredicate}: nullability is comparator-agnostic.
+     */
+    private static FilterPredicate buildUnsignedLongPredicate(String columnName, Object value, PredicateOp op, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+            return null;
+        }
+        if (value != null && op != PredicateOp.EQ && op != PredicateOp.NOT_EQ && ParquetColumnDecoding.isUnsignedInt64(ptype) == false) {
+            return null;
+        }
+        Long rawValue = value != null ? ParquetColumnDecoding.encodeUnsignedLong(((Number) value).longValue()) : null;
+        return orderedPredicate(FilterApi.longColumn(columnName), rawValue, op);
     }
 
     /**
@@ -982,6 +1014,7 @@ final class ParquetPushedExpressions {
         return switch (dataType) {
             case INTEGER -> translateIntIn(columnName, rawValues, schema);
             case LONG -> translateLongIn(columnName, rawValues, schema);
+            case UNSIGNED_LONG -> translateUnsignedLongIn(columnName, rawValues, schema);
             case DOUBLE -> {
                 if (isPhysicalDouble(schema, columnName)) {
                     yield inPredicate(FilterApi.doubleColumn(columnName), rawValues, v -> ((Number) v).doubleValue());
@@ -1042,6 +1075,42 @@ final class ParquetPushedExpressions {
             }
             default -> null;
         };
+    }
+
+    /**
+     * {@code IN} counterpart to {@link #buildUnsignedLongPredicate}: rawValues arrive sign-flip-encoded (ESQL's
+     * canonical {@code UNSIGNED_LONG} domain) and are un-flipped back to raw physical {@code INT64} bits before
+     * pushing (the encode is its own inverse). Mirrors {@link #translateLongIn}'s combined-min/max sign-mix decline:
+     * parquet-mr reduces the pushed set to one min/max pair using natural (signed) {@code Long} ordering, which
+     * only disagrees with the row-group stats' own comparator when the physical column carries the {@code UINT_64}
+     * annotation — so the raw-bit sign-mix decline applies only in that case (same-sign sets, including
+     * all-negative, and any set over a non-annotated physical column stay exact and pushable).
+     */
+    private static FilterPredicate translateUnsignedLongIn(String columnName, List<Object> rawValues, MessageType schema) {
+        PrimitiveType ptype = resolveNestedPrimitive(schema, columnName);
+        if (ptype == null || ptype.getPrimitiveTypeName() != PrimitiveType.PrimitiveTypeName.INT64) {
+            return null;
+        }
+        if (ParquetColumnDecoding.isUnsignedInt64(ptype)) {
+            boolean hasNegativeRaw = false;
+            boolean hasNonNegativeRaw = false;
+            for (Object v : rawValues) {
+                long raw = ParquetColumnDecoding.encodeUnsignedLong(((Number) v).longValue());
+                if (raw < 0) {
+                    hasNegativeRaw = true;
+                } else {
+                    hasNonNegativeRaw = true;
+                }
+            }
+            if (hasNegativeRaw && hasNonNegativeRaw) {
+                return null;
+            }
+        }
+        return inPredicate(
+            FilterApi.longColumn(columnName),
+            rawValues,
+            v -> ParquetColumnDecoding.encodeUnsignedLong(((Number) v).longValue())
+        );
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
@@ -34,7 +34,12 @@ import org.elasticsearch.compute.operator.topn.SharedNumericThreshold;
 import org.elasticsearch.compute.operator.topn.TopNEncoder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.DynamicThreshold;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -48,6 +53,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -61,6 +67,12 @@ public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
         .named("dynamic_threshold_test");
     private static final MessageType OPTIONAL_LONG_SCHEMA = Types.buildMessage()
         .optional(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("id")
+        .named("dynamic_threshold_test");
+    /** Physical {@code UINT_64}: inferred as ESQL {@code UNSIGNED_LONG}, sign-flip-encoded in every block it reads. */
+    private static final MessageType UNSIGNED_LONG_SCHEMA = Types.buildMessage()
+        .required(PrimitiveType.PrimitiveTypeName.INT64)
+        .as(LogicalTypeAnnotation.intType(64, false))
         .named("id")
         .named("dynamic_threshold_test");
     private static final MessageType REQUIRED_STRING_SCHEMA = Types.buildMessage()
@@ -117,6 +129,97 @@ public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
         List<Long> rows = readIdsWithThreshold(data, threshold(9L, true, false));
 
         assertThat(rows.size(), equalTo(2_000));
+    }
+
+    /**
+     * Raw physical {@code INT64} bits for the unsigned magnitude {@code 2^63 - 500 + i}. Plain {@code long}
+     * wraparound arithmetic is bit-identical to unsigned-mod-2^64 arithmetic, so this crosses the sign-bit
+     * boundary (raw goes from positive to negative) exactly at {@code i == 500} without any BigInteger
+     * bit-twiddling: {@link Long#MAX_VALUE} - 499 is the smallest magnitude in the set, {@code + 999} the
+     * largest, and the two halves straddle {@code 2^63} to reproduce the unsigned-ordering boundary.
+     */
+    private static long unsignedRaw(int i) {
+        return (Long.MAX_VALUE - 499L) + i;
+    }
+
+    public void testUnsignedLongRowGroupSkipAscendingCrossesSignBoundary() throws Exception {
+        byte[] data = writeLongParquet(
+            UNSIGNED_LONG_SCHEMA,
+            1L,
+            2 * 1024 * 1024,
+            1_000,
+            OptimizedParquetDynamicThresholdTests::unsignedRaw
+        );
+
+        long bound = ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(9));
+        List<Long> rows = readIdsWithThreshold(data, threshold(bound, true, false));
+
+        assertThat(rows.size(), lessThan(1_000));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(0))));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(9))));
+        // Row 900's unsigned magnitude (2^63 + 400) is far above the bound; its raw physical bits are
+        // NEGATIVE, so a rail comparing raw signed bits instead of the sign-flip-encoded form would see it
+        // as "small" and wrongly keep it.
+        assertFalse(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(900))));
+    }
+
+    public void testUnsignedLongRowGroupSkipDescendingCrossesSignBoundary() throws Exception {
+        byte[] data = writeLongParquet(
+            UNSIGNED_LONG_SCHEMA,
+            1L,
+            2 * 1024 * 1024,
+            1_000,
+            OptimizedParquetDynamicThresholdTests::unsignedRaw
+        );
+
+        long bound = ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(990));
+        List<Long> rows = readIdsWithThreshold(data, threshold(bound, false, false));
+
+        assertThat(rows.size(), lessThan(1_000));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(999))));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(990))));
+        // Row 0's unsigned magnitude (2^63 - 500) is far below the bound but has POSITIVE raw bits; a
+        // signed-raw rail would see it as "large" and wrongly keep it.
+        assertFalse(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(0))));
+    }
+
+    public void testUnsignedLongPageLevelSkipCrossesSignBoundary() throws Exception {
+        byte[] data = writeLongParquet(
+            UNSIGNED_LONG_SCHEMA,
+            64L * 1024 * 1024,
+            64,
+            2_000,
+            OptimizedParquetDynamicThresholdTests::unsignedRaw
+        );
+
+        long bound = ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(9));
+        List<Long> rows = readIdsWithThreshold(data, threshold(bound, true, false));
+
+        assertThat(rows.size(), lessThan(2_000));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(0))));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(9))));
+        assertFalse(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(1_900))));
+    }
+
+    public void testDeclaredUnsignedLongOverPlainInt64DeclinesThresholdPruning() throws Exception {
+        byte[] data = writeLongParquet(
+            REQUIRED_LONG_SCHEMA,
+            64L * 1024 * 1024,
+            2 * 1024 * 1024,
+            1_000,
+            OptimizedParquetDynamicThresholdTests::unsignedRaw
+        );
+
+        long bound = ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(9));
+        List<Long> rows = readDeclaredUnsignedLongIdsWithThreshold(data, threshold(bound, true, false));
+
+        // The physical statistics use signed ordering, while valid declared values use unsigned ordering and
+        // negative physical values become null under the permissive policy. The iterator must decline both
+        // row-group and page pruning instead of sign-flipping incompatible bounds and dropping the valid half.
+        assertThat(rows.size(), equalTo(1_000));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(0))));
+        assertTrue(rows.contains(ParquetColumnDecoding.encodeUnsignedLong(unsignedRaw(499))));
+        assertThat(rows.stream().filter(v -> v == null).count(), equalTo(500L));
     }
 
     public void testNoFurtherCandidatesExhaustsImmediately() throws Exception {
@@ -366,6 +469,33 @@ public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
                 FormatReadContext.of(List.of("id"), 128)
             )
         ) {
+            List<Long> values = new ArrayList<>();
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                try {
+                    LongBlock block = page.getBlock(0);
+                    for (int p = 0; p < block.getPositionCount(); p++) {
+                        values.add(block.isNull(p) ? null : block.getLong(block.getFirstValueIndex(p)));
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            return values;
+        }
+    }
+
+    private List<Long> readDeclaredUnsignedLongIdsWithThreshold(byte[] data, DynamicThreshold threshold) throws IOException {
+        List<Attribute> readSchema = List.of(new ReferenceAttribute(Source.EMPTY, "id", DataType.UNSIGNED_LONG));
+        FormatReadContext context = FormatReadContext.builder()
+            .projectedColumns(List.of("id"))
+            .batchSize(128)
+            .readSchema(readSchema)
+            .errorPolicy(ErrorPolicy.PERMISSIVE)
+            .informationalWarningSink(ignored -> {})
+            .build();
+        ParquetFormatReader reader = (ParquetFormatReader) reader(threshold).withDeclaredTypeColumns(Set.of("id"));
+        try (threshold; CloseableIterator<Page> iterator = reader.read(storageObject(data), context)) {
             List<Long> values = new ArrayList<>();
             while (iterator.hasNext()) {
                 Page page = iterator.next();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -131,6 +131,65 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         );
     }
 
+    // ---- Test 1b: UNSIGNED_LONG comparisons implement unsigned ordering over the encoded LongBlock ----
+
+    /**
+     * {@code UNSIGNED_LONG} blocks and literals both live in ESQL's canonical sign-flip-encoded domain (see
+     * {@link ParquetColumnDecoding#encodeUnsignedLong}); this dispatch is type-blind on the block's runtime class
+     * (see {@code evaluateComparison}'s {@code instanceof LongBlock} branch above), so ordinary signed
+     * {@link Long#compare} over that encoded form must already implement TRUE unsigned ordering across the 2^63
+     * boundary, with no {@code UNSIGNED_LONG}-specific branch needed.
+     */
+    public void testComparisonOpsWithUnsignedLongBlockAcrossSignBoundary() {
+        // True unsigned magnitudes 2^63-2 .. 2^63+2 sign-flip-encode to -2 .. 2.
+        long[] encoded = {
+            ParquetColumnDecoding.encodeUnsignedLong(Long.MAX_VALUE - 1), // 2^63 - 2 -> -2
+            ParquetColumnDecoding.encodeUnsignedLong(Long.MAX_VALUE),     // 2^63 - 1 -> -1
+            ParquetColumnDecoding.encodeUnsignedLong(Long.MIN_VALUE),     // 2^63 -> 0
+            ParquetColumnDecoding.encodeUnsignedLong(Long.MIN_VALUE + 1), // 2^63 + 1 -> 1
+            ParquetColumnDecoding.encodeUnsignedLong(Long.MIN_VALUE + 2)  // 2^63 + 2 -> 2
+        };
+        Block block = blockFactory.newLongArrayVector(encoded, encoded.length).asBlock();
+        Map<String, Block> blocks = Map.of("u", block);
+        int rowCount = 5;
+        WordMask reusable = new WordMask();
+
+        long boundary = ParquetColumnDecoding.encodeUnsignedLong(Long.MIN_VALUE); // literal 2^63, encodes to 0
+
+        // u > 2^63 -> the two truly-larger unsigned magnitudes, positions [3, 4]
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new GreaterThan(Source.EMPTY, attr("u", DataType.UNSIGNED_LONG), lit(boundary, DataType.UNSIGNED_LONG), null))
+            ),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 3, 4 }
+        );
+
+        // u < 2^63 -> the two truly-smaller unsigned magnitudes, positions [0, 1]
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new LessThan(Source.EMPTY, attr("u", DataType.UNSIGNED_LONG), lit(boundary, DataType.UNSIGNED_LONG), null))
+            ),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 0, 1 }
+        );
+
+        // u == 2^63 -> position [2]
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new Equals(Source.EMPTY, attr("u", DataType.UNSIGNED_LONG), lit(boundary, DataType.UNSIGNED_LONG), null))
+            ),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 2 }
+        );
+    }
+
     // ---- Test 2: Equals across all 5 block types ----
 
     public void testEqualsWithIntBlock() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -820,6 +820,122 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
         assertThat(fp.toString(), containsString("100"));
     }
 
+    // --- Genuine ESQL UNSIGNED_LONG column ---
+
+    /**
+     * Over a genuine {@code UINT_64}-annotated physical column, every comparison — ordered included — pushes: the
+     * sign-flip-encoded literal is un-flipped back to the file's raw bits (the encode is its own inverse), and
+     * parquet-mr applies its native UNSIGNED comparator to those bits, which agrees with ESQL's true-unsigned
+     * ordering.
+     */
+    public void testUnsignedLongOverUint64PushesOrderedAndUnflipsLiteral() {
+        MessageType schema = uint64Schema();
+
+        // raw == 5: a "large" unsigned magnitude (2^63 + 5) whose sign-flip-encoded literal is negative.
+        long encodedLiteral = ParquetColumnDecoding.encodeUnsignedLong(5L);
+        Expression gt = new GreaterThan(
+            Source.EMPTY,
+            attr("u64", DataType.UNSIGNED_LONG),
+            lit(encodedLiteral, DataType.UNSIGNED_LONG),
+            null
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(gt)).toFilterPredicate(schema);
+        assertNotNull("ordered comparison over a genuine uint64 column must push", fp);
+        assertThat(
+            "the pushed predicate must carry the raw (un-flipped) bits, not the encoded literal",
+            fp.toString(),
+            containsString("gt(u64, 5)")
+        );
+    }
+
+    public void testUnsignedLongOverUint64EqPushes() {
+        MessageType schema = uint64Schema();
+        long encodedLiteral = ParquetColumnDecoding.encodeUnsignedLong(5L);
+        Expression expr = eq("u64", DataType.UNSIGNED_LONG, encodedLiteral);
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(expr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("eq(u64, 5)"));
+    }
+
+    /**
+     * A column DECLARED {@code unsigned_long} over a plain (non-annotated) physical {@code INT64} decodes its
+     * blocks sign-flip-encoded regardless of the missing annotation, but the file's own footer stats were computed
+     * under a SIGNED comparator — disagreeing with ESQL's unsigned ordering for any row group spanning both
+     * bit-pattern halves. Every ordered comparison must decline; eq/notEq are bit-exact
+     * membership tests and remain safe.
+     */
+    public void testUnsignedLongOverPlainInt64OrderedDeclinesButEqStillPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).named("u").named("test");
+        long encodedLiteral = ParquetColumnDecoding.encodeUnsignedLong(100L);
+
+        Expression gt = new GreaterThan(Source.EMPTY, attr("u", DataType.UNSIGNED_LONG), lit(encodedLiteral, DataType.UNSIGNED_LONG), null);
+        assertNull(
+            "ordered comparison over a plain (non-annotated) INT64 must decline",
+            new ParquetPushedExpressions(List.of(gt)).toFilterPredicate(schema)
+        );
+
+        Expression eqExpr = eq("u", DataType.UNSIGNED_LONG, encodedLiteral);
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(eqExpr)).toFilterPredicate(schema);
+        assertNotNull("eq is bit-exact and must still push", fp);
+        assertThat(fp.toString(), containsString("eq(u, 100)"));
+    }
+
+    /**
+     * parquet-mr's IN pruning reduces the pushed set to one combined min/max pair using natural (signed) ordering;
+     * over a genuine uint64 column (row-group stats compared with the UNSIGNED comparator instead) that reduction
+     * corrupts the range whenever the raw bits straddle both sign halves.
+     */
+    public void testUnsignedLongInMixedSignOverUint64IsNotPushed() {
+        MessageType schema = uint64Schema();
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("u64", DataType.UNSIGNED_LONG),
+            List.of(
+                lit(ParquetColumnDecoding.encodeUnsignedLong(100_000L), DataType.UNSIGNED_LONG),
+                lit(ParquetColumnDecoding.encodeUnsignedLong(-1L), DataType.UNSIGNED_LONG)
+            )
+        );
+        assertNull(
+            "a raw-bit sign-mixed IN set against a genuine uint64 column must not be pushed",
+            new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema)
+        );
+    }
+
+    public void testUnsignedLongInAllSameSignOverUint64StillPushes() {
+        MessageType schema = uint64Schema();
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("u64", DataType.UNSIGNED_LONG),
+            List.of(
+                lit(ParquetColumnDecoding.encodeUnsignedLong(-1L), DataType.UNSIGNED_LONG),
+                lit(ParquetColumnDecoding.encodeUnsignedLong(-2L), DataType.UNSIGNED_LONG)
+            )
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull(fp);
+        assertThat(fp.toString(), containsString("in(u64"));
+    }
+
+    /**
+     * Over a plain (non-annotated) physical column, the row-group stats and parquet-mr's internal query-set
+     * summary both use the same (signed) comparator, so there is no combined-range corruption to guard against —
+     * a raw-bit sign mix still pushes.
+     */
+    public void testUnsignedLongInOverPlainInt64AlwaysPushes() {
+        MessageType schema = Types.buildMessage().required(INT64).named("u").named("test");
+        Expression inExpr = new In(
+            Source.EMPTY,
+            attr("u", DataType.UNSIGNED_LONG),
+            List.of(
+                lit(ParquetColumnDecoding.encodeUnsignedLong(100_000L), DataType.UNSIGNED_LONG),
+                lit(ParquetColumnDecoding.encodeUnsignedLong(-1L), DataType.UNSIGNED_LONG)
+            )
+        );
+        FilterPredicate fp = new ParquetPushedExpressions(List.of(inExpr)).toFilterPredicate(schema);
+        assertNotNull("a sign-mixed IN set over a plain INT64 column has no combined-range hazard and must push", fp);
+        assertThat(fp.toString(), containsString("in(u"));
+    }
+
     // --- INT96 (skip pushdown) ---
 
     public void testToFilterPredicateInt96SkipsPushdown() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/NumericTopNOperator.java
@@ -42,9 +42,13 @@ import java.util.Locale;
  * <ul>
  *     <li>Exactly one sort key.</li>
  *     <li>Sort key {@link ElementType} is {@link ElementType#LONG}, {@link ElementType#INT},
- *         {@link ElementType#DOUBLE}, or {@link ElementType#BOOLEAN}. ESQL DATETIME and
- *         DATE_NANOS map to LONG at planning time, so they go through the LONG path. ESQL FLOAT,
- *         HALF_FLOAT and SCALED_FLOAT widen to DOUBLE on load so they reach this operator as
+ *         {@link ElementType#DOUBLE}, or {@link ElementType#BOOLEAN}. ESQL DATETIME, DATE_NANOS,
+ *         and UNSIGNED_LONG map to LONG at planning time, so they go through the LONG path.
+ *         UNSIGNED_LONG blocks are already sign-flip-encoded (see
+ *         {@code ParquetColumnDecoding#encodeUnsignedLong} for the Parquet producer of that
+ *         encoding), which is order-preserving, so the plain LONG heap ordering and threshold
+ *         publication apply unchanged. ESQL FLOAT, HALF_FLOAT and
+ *         SCALED_FLOAT widen to DOUBLE on load so they reach this operator as
  *         {@link org.elasticsearch.compute.data.DoubleBlock}.</li>
  *     <li>Input page has exactly 2 channels in this fixed order:
  *         {@code [sortKey, _rowPosition]}. Enforced by
@@ -56,7 +60,7 @@ import java.util.Locale;
  *         {@link NumericSortKeyExtractor} for the per-type breakdown.</li>
  * </ul>
  *
- * <p>Out of scope (deferred PRs): multi-key sorts, byte-keyed sorts, UNSIGNED_LONG sort keys.
+ * <p>Out of scope (deferred PRs): multi-key sorts, byte-keyed sorts.
  */
 public final class NumericTopNOperator implements Operator {
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -13,8 +13,11 @@ import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.DatasetFieldMapping;
@@ -41,6 +44,7 @@ import org.junit.Before;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -3143,6 +3147,121 @@ public class FromDatasetIT extends AbstractExternalDataSourceIT {
             file,
             rawMicros.length
         );
+    }
+
+    /**
+     * Wide, multi-row-group {@code UINT_64} differential: ground truth comes from an unpruned
+     * scan; filter pushdown, TopN threshold pruning (ASC and DESC), and stats-answered MIN/MAX must all agree with
+     * it across the 2^63 boundary. The fixture is 4 columns wide (so the TopN deferred-extraction threshold rail
+     * engages, mirroring {@link #writeScalingFixture}) and spans several small row groups, with the true unsigned
+     * maximum sitting in a later row group than the smallest RAW bit pattern — exactly the layout a signed-raw-bits
+     * comparison mis-prunes.
+     */
+    public void testUnsignedLongParquetDifferentialAcrossFilterSortAndAggregate() throws Exception {
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+
+        // Raw physical INT64 bits for the unsigned magnitude 2^63 - 1000 + i: plain long wraparound arithmetic is
+        // bit-identical to unsigned-mod-2^64 arithmetic, so this crosses the sign-bit boundary at i == 1000 — the
+        // smallest magnitude's raw bits are POSITIVE, the largest's are NEGATIVE.
+        int rowCount = 2000;
+        long base = Long.MAX_VALUE - 999L;
+        long[] rawBits = new long[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            rawBits[i] = base + i;
+        }
+        Path file = writeUnsignedLongFixture("unsigned_diff", rawBits);
+
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                new PutDatasetAction.Request(
+                    TIMEOUT,
+                    TIMEOUT,
+                    "unsigned_diff_ds",
+                    "local_ds",
+                    file.toUri().toString(),
+                    null,
+                    new HashMap<>(Map.of("format", "parquet")),
+                    null
+                )
+            )
+        );
+
+        // Ground truth: an unpruned scan (no filter/sort/aggregate) observes decode only.
+        List<BigInteger> truth = new ArrayList<>();
+        try (var response = run(syncEsqlQueryRequest("FROM unsigned_diff_ds | KEEP u | LIMIT 5000"), TIMEOUT)) {
+            for (List<Object> row : getValuesList(response)) {
+                truth.add(new BigInteger(row.get(0).toString()));
+            }
+        }
+        assertThat("ground truth must see every row", truth, hasSize(rowCount));
+        truth.sort(BigInteger::compareTo);
+        BigInteger min = truth.get(0);
+        BigInteger max = truth.get(rowCount - 1);
+
+        record Probe(String what, String query, String expected) {}
+        List<Probe> probes = List.of(
+            new Probe("WHERE == min", "FROM unsigned_diff_ds | WHERE u == \"" + min + "\"::unsigned_long | STATS c = COUNT(*)", "1"),
+            new Probe("WHERE >= max", "FROM unsigned_diff_ds | WHERE u >= \"" + max + "\"::unsigned_long | STATS c = COUNT(*)", "1"),
+            new Probe("SORT ASC LIMIT 1 (wide)", "FROM unsigned_diff_ds | SORT u ASC | LIMIT 1 | KEEP u, id, pri, msg", min.toString()),
+            new Probe("SORT DESC LIMIT 1 (wide)", "FROM unsigned_diff_ds | SORT u DESC | LIMIT 1 | KEEP u, id, pri, msg", max.toString()),
+            new Probe("STATS MIN", "FROM unsigned_diff_ds | STATS m = MIN(u)", min.toString()),
+            new Probe("STATS MAX", "FROM unsigned_diff_ds | STATS m = MAX(u)", max.toString())
+        );
+        List<String> failures = new ArrayList<>();
+        for (Probe probe : probes) {
+            try (var response = run(syncEsqlQueryRequest(probe.query()), TIMEOUT)) {
+                List<List<Object>> rows = getValuesList(response);
+                Object actual = rows.isEmpty() ? null : rows.get(0).get(0);
+                String actualStr = actual == null ? null : actual.toString();
+                if (Objects.equals(probe.expected(), actualStr) == false) {
+                    failures.add(
+                        "[" + probe.what() + "] expected " + probe.expected() + " but got " + actualStr + "  (query: " + probe.query() + ")"
+                    );
+                }
+            }
+        }
+        assertTrue("the engine disagreed with fully-decoded ground truth:\n  " + String.join("\n  ", failures), failures.isEmpty());
+    }
+
+    /** Multi-row-group {@code UINT_64} fixture: 4 columns wide, small row groups, mirroring {@link #writeScalingFixture}. */
+    private Path writeUnsignedLongFixture(String name, long[] rawBits) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.intType(64, false))
+            .named("u")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("pri")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("msg")
+            .named("unsigned_diff");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        PlainParquetConfiguration conf = new PlainParquetConfiguration();
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(baos))
+                .withConf(conf)
+                .withType(schema)
+                .withRowGroupSize(256L)
+                .withPageSize(64)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int i = 0; i < rawBits.length; i++) {
+                Group g = factory.newGroup();
+                g.add("u", rawBits[i]);
+                g.add("id", (long) i);
+                g.add("pri", i);
+                g.add("msg", "m" + i);
+                writer.write(g);
+            }
+        }
+        Path tempFile = createTempDir().resolve(name + ".parquet");
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
     }
 
     /** A cell of the scaling differential: one dataset declaration over the shared fixture. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -922,8 +922,8 @@ public class LocalExecutionPlanner {
      * <ul>
      *     <li>Exactly one sort {@link Order} (Tier 1 is single-key).</li>
      *     <li>The sort attribute is a plain {@link Attribute} (no expressions over the field) of
-     *         a fixed-width numeric type — currently LONG, INTEGER, DOUBLE, BOOLEAN, DATETIME, or
-     *         DATE_NANOS. FLOAT, UNSIGNED_LONG, HALF_FLOAT, and SCALED_FLOAT are deferred to a
+     *         a fixed-width numeric type — currently LONG, INTEGER, DOUBLE, BOOLEAN, DATETIME,
+     *         DATE_NANOS, or UNSIGNED_LONG. FLOAT, HALF_FLOAT, and SCALED_FLOAT are deferred to a
      *         follow-up PR; they need a tiny encoding addition but no operator surface change.</li>
      *     <li>The limit is a literal foldable to a positive {@code int}. Non-literal limits go
      *         to the generic operator (the bytes-encoding path doesn't need a literal).</li>
@@ -1027,12 +1027,14 @@ public class LocalExecutionPlanner {
      * go through the LONG path. Keeping the predicate here rather than on the operator lets the
      * planner cleanly skip the optimisation without instantiating the factory.
      *
+     * <p>{@code UNSIGNED_LONG} is included: ESQL stores it sign-flip-encoded
+     * ({@code raw ^ Long.MIN_VALUE}) so that signed-long ordering over the encoded form already
+     * matches unsigned ordering over the true value. The operator's own
+     * {@code ~raw} ASC/DESC bit flip then applies on top of that encoding exactly as it does for
+     * a plain {@code LONG} sort key — no operator change needed.
+     *
      * <p>Deliberately excluded:
      * <ul>
-     *     <li>{@code UNSIGNED_LONG}: maps to {@link ElementType#LONG} but the operator's
-     *         {@code ~raw} encoding does not preserve unsigned ordering. Supporting it needs a
-     *         different encoding ({@code raw ^ Long.MIN_VALUE}, sign-bit flip) and is parked for
-     *         a follow-up.</li>
      *     <li>{@code FLOAT}, {@code HALF_FLOAT}, {@code SCALED_FLOAT}: ESQL widens these to
      *         {@link DataType#DOUBLE} at load time, so a sort attribute with one of these data
      *         types never reaches this predicate in practice — {@link PlannerUtils#toElementType}
@@ -1046,7 +1048,8 @@ public class LocalExecutionPlanner {
             || dataType == DataType.DOUBLE
             || dataType == DataType.BOOLEAN
             || dataType == DataType.DATETIME
-            || dataType == DataType.DATE_NANOS;
+            || dataType == DataType.DATE_NANOS
+            || dataType == DataType.UNSIGNED_LONG;
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL:DS: Fix unsigned_long comparisons (#156653)