### PR TITLE
Use constant for empty `ActionFilters`

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -57,7 +56,7 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
 
         TransportUpdateByQueryAction transportAction = new TransportUpdateByQueryAction(
             threadPool,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             null,
             transportService,
             scriptService,

--- a/server/src/main/java/org/elasticsearch/action/support/ActionFilters.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActionFilters.java
@@ -18,6 +18,8 @@ import java.util.Set;
  */
 public class ActionFilters {
 
+    public static final ActionFilters EMPTY = new ActionFilters(Set.of());
+
     private final ActionFilter[] filters;
 
     public ActionFilters(Set<ActionFilter> actionFilters) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
@@ -52,7 +52,7 @@ public class TransportClusterAllocationExplainActionTests extends ESTestCase {
             transportService,
             clusterService,
             threadPool,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             () -> ClusterInfo.EMPTY,
             EmptySnapshotsInfoService.INSTANCE,
             new AllocationDeciders(List.of()),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsActionTests.java
@@ -96,7 +96,7 @@ public class TransportGetAllocationStatsActionTests extends ESTestCase {
             transportService,
             clusterService,
             threadPool,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             allocationStatsService,
             featureService
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -131,7 +131,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
             transportService,
             clusterService,
             threadPool,
-            new ActionFilters(emptySet()),
+            ActionFilters.EMPTY,
             reconfigurator
         ); // registers action
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -88,13 +88,8 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         );
         reconfigurator = new TransportAddVotingConfigExclusionsActionTests.FakeReconfigurator();
 
-        new TransportClearVotingConfigExclusionsAction(
-            transportService,
-            clusterService,
-            threadPool,
-            new ActionFilters(emptySet()),
-            reconfigurator
-        ); // registers action
+        // calling the constructor registers the action with transportService
+        new TransportClearVotingConfigExclusionsAction(transportService, clusterService, threadPool, ActionFilters.EMPTY, reconfigurator);
 
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -53,7 +53,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -151,7 +150,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
                 actionName,
                 clusterService,
                 transportService,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 nodeRequest,
                 threadPool.executor(ThreadPool.Names.GENERIC)
             );
@@ -200,7 +199,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
             transportService.start();
             clusterService = createClusterService(threadPool, discoveryNode.get());
             clusterService.addStateApplier(transportService.getTaskManager());
-            ActionFilters actionFilters = new ActionFilters(emptySet());
+            ActionFilters actionFilters = ActionFilters.EMPTY;
             transportListTasksAction = new TransportListTasksAction(clusterService, transportService, actionFilters);
             transportCancelTasksAction = new TransportCancelTasksAction(clusterService, transportService, actionFilters);
             transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -58,7 +58,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -251,7 +250,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
                 TEST_TASK_ACTION.name(),
                 clusterService,
                 transportService,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 NodeRequest::new,
                 threadPool.executor(ThreadPool.Names.GENERIC)
             );
@@ -368,7 +367,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
                 UNBLOCK_TASK_ACTION.name(),
                 clusterService,
                 transportService,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 UnblockTestTasksRequest::new,
                 UnblockTestTaskResponse::new,
                 transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -56,7 +56,6 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -249,7 +248,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                 actionName,
                 clusterService,
                 transportService,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 TestTasksRequest::new,
                 TestTaskResponse::new,
                 transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -108,7 +108,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
 
         final RemoteClusterNodesAction.TransportAction action = new RemoteClusterNodesAction.TransportAction(
             mock(TransportService.class),
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             new AbstractClient(Settings.EMPTY, threadPool) {
                 @SuppressWarnings("unchecked")
                 @Override
@@ -186,7 +186,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
 
         final RemoteClusterNodesAction.TransportAction action = new RemoteClusterNodesAction.TransportAction(
             mock(TransportService.class),
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             new AbstractClient(Settings.EMPTY, threadPool) {
                 @SuppressWarnings("unchecked")
                 @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
@@ -288,7 +288,7 @@ public class TransportAnalyzeIndexDiskUsageActionTests extends ESTestCase {
             clusterService,
             transportService,
             mock(IndicesService.class),
-            new ActionFilters(new HashSet<>()),
+            ActionFilters.EMPTY,
             new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY), EmptySystemIndices.INSTANCE) {
                 @Override
                 public String[] concreteIndexNames(ClusterState state, IndicesRequest request) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -117,7 +117,7 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
                 GetIndexActionTests.this.clusterService,
                 GetIndexActionTests.this.threadPool,
                 settingsFilter,
-                new ActionFilters(emptySet()),
+                ActionFilters.EMPTY,
                 new GetIndexActionTests.Resolver(),
                 indicesService,
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -56,7 +56,7 @@ public class GetSettingsActionTests extends ESTestCase {
                 GetSettingsActionTests.this.clusterService,
                 GetSettingsActionTests.this.threadPool,
                 settingsFilter,
-                new ActionFilters(Collections.emptySet()),
+                ActionFilters.EMPTY,
                 new Resolver(),
                 IndexScopedSettings.DEFAULT_SCOPED_SETTINGS
             );

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
@@ -236,7 +236,7 @@ public class TransportIndicesShardStoresActionTests extends ESTestCase {
                 transportService,
                 clusterService,
                 threadPool,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 new IndexNameExpressionResolver(threadPool.getThreadContext(), new SystemIndices(List.of())),
                 null
             ) {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -155,7 +155,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
                 ingestService,
                 mockFeatureService,
                 new NodeClient(Settings.EMPTY, TransportBulkActionIngestTests.this.threadPool),
-                new ActionFilters(Collections.emptySet()),
+                ActionFilters.EMPTY,
                 TestIndexNameExpressionResolver.newInstance(),
                 new IndexingPressure(SETTINGS),
                 EmptySystemIndices.INSTANCE,
@@ -190,7 +190,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
             super(
                 TransportIndexAction.NAME,
                 TransportBulkActionIngestTests.this.transportService,
-                new ActionFilters(Collections.emptySet()),
+                ActionFilters.EMPTY,
                 IndexRequest::new,
                 bulkAction
             );

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -114,7 +114,7 @@ public class TransportBulkActionTests extends ESTestCase {
                 null,
                 mockFeatureService,
                 new NodeClient(Settings.EMPTY, TransportBulkActionTests.this.threadPool),
-                new ActionFilters(Collections.emptySet()),
+                ActionFilters.EMPTY,
                 new Resolver(),
                 new IndexingPressure(Settings.EMPTY),
                 EmptySystemIndices.INSTANCE,

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -53,7 +53,6 @@ import org.junit.BeforeClass;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -113,7 +112,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
         transportService.start();
         transportService.acceptIncomingRequests();
         IndexNameExpressionResolver resolver = new Resolver();
-        ActionFilters actionFilters = new ActionFilters(new HashSet<>());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
 
         NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
             @Override

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportSimulateBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportSimulateBulkActionTests.java
@@ -88,7 +88,7 @@ public class TransportSimulateBulkActionTests extends ESTestCase {
                 transportService,
                 TransportSimulateBulkActionTests.this.clusterService,
                 null,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 new IndexingPressure(Settings.EMPTY),
                 EmptySystemIndices.INSTANCE,
                 indicesService,

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -59,7 +58,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             .put("node.name", TransportFieldCapabilitiesActionTests.class.getSimpleName())
             .put(SearchService.CCS_VERSION_CHECK_SETTING.getKey(), "true")
             .build();
-        ActionFilters actionFilters = new ActionFilters(Set.of());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
         TransportVersion transportVersion = TransportVersionUtils.getNextVersion(TransportVersion.minimumCCSVersion(), true);
         try {
             TransportService transportService = MockTransportService.createNewService(
@@ -114,7 +113,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testNodeHandlerAbortedWhenTaskCancelled() throws Exception {
-        ActionFilters actionFilters = new ActionFilters(Set.of());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
         ClusterService clusterService = new ClusterService(
             Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
@@ -174,7 +174,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             transportService,
             clusterService,
             client,
-            new ActionFilters(emptySet()),
+            ActionFilters.EMPTY,
             new Resolver(),
             mock(IndicesService.class)
         ) {
@@ -207,7 +207,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             transportService,
             clusterService,
             client,
-            new ActionFilters(emptySet()),
+            ActionFilters.EMPTY,
             new Resolver(),
             mock(IndicesService.class)
         ) {

--- a/server/src/test/java/org/elasticsearch/action/resync/TransportResyncReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/resync/TransportResyncReplicationActionTests.java
@@ -50,7 +50,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -172,7 +171,7 @@ public class TransportResyncReplicationActionTests extends ESTestCase {
                     indexServices,
                     threadPool,
                     shardStateAction,
-                    new ActionFilters(new HashSet<>()),
+                    ActionFilters.EMPTY,
                     new IndexingPressure(Settings.EMPTY),
                     EmptySystemIndices.INSTANCE
                 );

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Queue;
 import java.util.Set;
@@ -128,7 +127,7 @@ public class MultiSearchActionTookTests extends ESTestCase {
             null,
             Collections.emptySet()
         );
-        ActionFilters actionFilters = new ActionFilters(new HashSet<>());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test")).build());
 

--- a/server/src/test/java/org/elasticsearch/action/support/TransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/TransportActionTests.java
@@ -132,7 +132,7 @@ public class TransportActionTests extends ESTestCase {
     }
 
     private TransportAction<TestRequest, TestResponse> getTestTransportAction(String actionName, Executor executor) {
-        ActionFilters actionFilters = new ActionFilters(Collections.emptySet());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
         TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<>(
             actionName,
             actionFilters,

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -175,7 +175,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
                 actionName,
                 TransportBroadcastByNodeActionTests.this.clusterService,
                 TransportBroadcastByNodeActionTests.this.transportService,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 new MyResolver(),
                 Request::new,
                 TransportBroadcastByNodeActionTests.this.transportService.getThreadPool().executor(TEST_THREAD_POOL_NAME)

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableActionTests.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -128,7 +127,7 @@ public class TransportBroadcastUnpromotableActionTests extends ESTestCase {
                 TransportBroadcastUnpromotableActionTests.this.clusterService,
                 TransportBroadcastUnpromotableActionTests.this.transportService,
                 shardStateAction,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 TestBroadcastUnpromotableRequest::new,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE
             );

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -75,7 +75,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -250,16 +249,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             ThreadPool threadPool,
             Executor executor
         ) {
-            super(
-                actionName,
-                transportService,
-                clusterService,
-                threadPool,
-                new ActionFilters(new HashSet<>()),
-                Request::new,
-                Response::new,
-                executor
-            );
+            super(actionName, transportService, clusterService, threadPool, ActionFilters.EMPTY, Request::new, Response::new, executor);
         }
 
         @Override
@@ -297,7 +287,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 transportService,
                 clusterService,
                 threadPool,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 ClusterUpdateSettingsRequest::new,
                 Response::new,
                 executor

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -271,7 +271,7 @@ public class TransportNodesActionTests extends ESTestCase {
                 "indices:admin/test",
                 clusterService,
                 transportService,
-                new ActionFilters(Collections.emptySet()),
+                ActionFilters.EMPTY,
                 TestNodeRequest::new,
                 THREAD_POOL.executor(ThreadPool.Names.GENERIC)
             ) {
@@ -326,7 +326,7 @@ public class TransportNodesActionTests extends ESTestCase {
         final var action = new TestTransportNodesAction(
             clusterService,
             transportService,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             TestNodeRequest::new,
             THREAD_POOL.executor(ThreadPool.Names.GENERIC)
         ) {
@@ -521,7 +521,7 @@ public class TransportNodesActionTests extends ESTestCase {
         return new TestTransportNodesAction(
             clusterService,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             TestNodeRequest::new,
             THREAD_POOL.executor(ThreadPool.Names.GENERIC)
         );
@@ -531,7 +531,7 @@ public class TransportNodesActionTests extends ESTestCase {
         return new DataNodesOnlyTransportNodesAction(
             clusterService,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             TestNodeRequest::new,
             THREAD_POOL.executor(ThreadPool.Names.GENERIC)
         );

--- a/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -112,7 +111,7 @@ public class BroadcastReplicationTests extends ESTestCase {
         broadcastReplicationAction = new TestBroadcastReplicationAction(
             clusterService,
             transportService,
-            new ActionFilters(new HashSet<>()),
+            ActionFilters.EMPTY,
             TestIndexNameExpressionResolver.newInstance(threadPool.getThreadContext())
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -90,7 +90,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -1515,7 +1514,7 @@ public class TransportReplicationActionTests extends ESTestCase {
                 indicesService,
                 threadPool,
                 shardStateAction,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 Request::new,
                 Request::new,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -457,7 +457,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                 mockIndicesService(shardId, executedOnPrimary, primary, replica),
                 threadPool,
                 shardStateAction,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 Request::new,
                 Request::new,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -62,7 +62,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -423,7 +422,7 @@ public class TransportWriteActionTests extends ESTestCase {
                 null,
                 TransportWriteActionTests.threadPool,
                 null,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 TestRequest::new,
                 TestRequest::new,
                 (service, ignore) -> EsExecutors.DIRECT_EXECUTOR_SERVICE,
@@ -452,7 +451,7 @@ public class TransportWriteActionTests extends ESTestCase {
                 mockIndicesService(clusterService),
                 threadPool,
                 shardStateAction,
-                new ActionFilters(new HashSet<>()),
+                ActionFilters.EMPTY,
                 TestRequest::new,
                 TestRequest::new,
                 (service, ignore) -> EsExecutors.DIRECT_EXECUTOR_SERVICE,

--- a/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
@@ -51,7 +51,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -175,7 +174,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         action = new TestTransportInstanceSingleOperationAction(
             "indices:admin/test",
             transportService,
-            new ActionFilters(new HashSet<>()),
+            ActionFilters.EMPTY,
             new MyResolver(),
             Request::new
         );
@@ -324,7 +323,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         action = new TestTransportInstanceSingleOperationAction(
             "indices:admin/test_unresolvable",
             transportService,
-            new ActionFilters(new HashSet<>()),
+            ActionFilters.EMPTY,
             new MyResolver(),
             Request::new
         ) {

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
@@ -172,7 +172,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             transportService,
             clusterService,
             client,
-            new ActionFilters(emptySet()),
+            ActionFilters.EMPTY,
             new Resolver()
         ) {
             @Override
@@ -204,7 +204,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             transportService,
             clusterService,
             client,
-            new ActionFilters(emptySet()),
+            ActionFilters.EMPTY,
             new Resolver()
         ) {
             @Override

--- a/server/src/test/java/org/elasticsearch/client/internal/node/NodeClientHeadersTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/node/NodeClientHeadersTests.java
@@ -30,8 +30,6 @@ import static org.mockito.Mockito.mock;
 
 public class NodeClientHeadersTests extends AbstractClientHeadersTestCase {
 
-    private static final ActionFilters EMPTY_FILTERS = new ActionFilters(Collections.emptySet());
-
     @Override
     protected Client buildClient(Settings headersSettings, ActionType<?>[] testedActions) {
         Settings settings = HEADER_SETTINGS;
@@ -56,7 +54,7 @@ public class NodeClientHeadersTests extends AbstractClientHeadersTestCase {
     private static class InternalTransportAction extends TransportAction<ActionRequest, ActionResponse> {
 
         private InternalTransportAction(String actionName, TaskManager taskManager) {
-            super(actionName, EMPTY_FILTERS, taskManager, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+            super(actionName, ActionFilters.EMPTY, taskManager, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -152,7 +152,7 @@ public class ClusterStateHealthTests extends ESTestCase {
             transportService,
             clusterService,
             threadPool,
-            new ActionFilters(new HashSet<>()),
+            ActionFilters.EMPTY,
             indexNameExpressionResolver,
             new AllocationService(null, new TestGatewayAllocator(), null, null, null, TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY)
         );

--- a/server/src/test/java/org/elasticsearch/health/node/FetchHealthInfoCacheActionTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/FetchHealthInfoCacheActionTests.java
@@ -110,7 +110,7 @@ public class FetchHealthInfoCacheActionTests extends ESTestCase {
                 transportService,
                 clusterService,
                 threadPool,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 healthInfoCache
             ),
             null,

--- a/server/src/test/java/org/elasticsearch/health/node/UpdateHealthInfoCacheActionTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/UpdateHealthInfoCacheActionTests.java
@@ -100,7 +100,7 @@ public class UpdateHealthInfoCacheActionTests extends ESTestCase {
                 transportService,
                 clusterService,
                 threadPool,
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 healthInfoCache
             ),
             null,

--- a/server/src/test/java/org/elasticsearch/health/node/action/TransportHealthNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/action/TransportHealthNodeActionTests.java
@@ -41,7 +41,6 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -170,16 +169,7 @@ public class TransportHealthNodeActionTests extends ESTestCase {
             ThreadPool threadPool,
             Executor executor
         ) {
-            super(
-                actionName,
-                transportService,
-                clusterService,
-                threadPool,
-                new ActionFilters(new HashSet<>()),
-                Request::new,
-                Response::new,
-                executor
-            );
+            super(actionName, transportService, clusterService, threadPool, ActionFilters.EMPTY, Request::new, Response::new, executor);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncActionTests.java
@@ -119,7 +119,7 @@ public class GlobalCheckpointSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            ActionFilters.EMPTY
         );
         final GlobalCheckpointSyncAction.Request primaryRequest = new GlobalCheckpointSyncAction.Request(indexShard.shardId());
         if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -98,7 +98,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            ActionFilters.EMPTY
         );
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseBackgroundSyncAction.Request request = new RetentionLeaseBackgroundSyncAction.Request(
@@ -137,7 +137,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            ActionFilters.EMPTY
         );
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseBackgroundSyncAction.Request request = new RetentionLeaseBackgroundSyncAction.Request(
@@ -179,7 +179,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            ActionFilters.EMPTY
         );
 
         assertNull(action.indexBlockLevel());

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -107,7 +107,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             new IndexingPressure(Settings.EMPTY),
             EmptySystemIndices.INSTANCE
         );
@@ -144,7 +144,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             new IndexingPressure(Settings.EMPTY),
             EmptySystemIndices.INSTANCE
         );
@@ -185,7 +185,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             new IndexingPressure(Settings.EMPTY),
             EmptySystemIndices.INSTANCE
         );

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -169,7 +169,7 @@ public class ClusterStateChanges {
         );
         shardFailedClusterStateTaskExecutor = new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocationService, null);
         shardStartedClusterStateTaskExecutor = new ShardStateAction.ShardStartedClusterStateTaskExecutor(allocationService, null);
-        ActionFilters actionFilters = new ActionFilters(Collections.emptySet());
+        ActionFilters actionFilters = ActionFilters.EMPTY;
         IndexNameExpressionResolver indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
         DestructiveOperations destructiveOperations = new DestructiveOperations(SETTINGS, clusterSettings);
         Environment environment = TestEnvironment.newEnvironment(SETTINGS);

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -94,7 +94,7 @@ public class RepositoriesServiceTests extends ESTestCase {
 
         DiscoveryNode localNode = DiscoveryNodeUtils.builder("local").name("local").roles(Set.of(DiscoveryNodeRole.MASTER_ROLE)).build();
         NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-        var actionFilters = new ActionFilters(Set.of());
+        var actionFilters = ActionFilters.EMPTY;
         client.initialize(
             Map.of(
                 VerifyNodeRepositoryCoordinationAction.TYPE,

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -75,7 +75,7 @@ public class RestValidateQueryActionTests extends AbstractSearchTestCase {
 
         final TransportAction<? extends ActionRequest, ? extends ActionResponse> transportAction = new TransportAction<>(
             ValidateQueryAction.NAME,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             taskManager,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         ) {

--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -339,7 +339,7 @@ public class TaskManagerTests extends ESTestCase {
             "testType",
             new TransportAction<ActionRequest, ActionResponse>(
                 "actionName",
-                new ActionFilters(Set.of()),
+                ActionFilters.EMPTY,
                 taskManager,
                 EsExecutors.DIRECT_EXECUTOR_SERVICE
             ) {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1184,15 +1184,15 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 client.initialize(
                     Map.of(
                         TransportNodesHotThreadsAction.TYPE,
-                        new TransportNodesHotThreadsAction(threadPool, clusterService, transportService, new ActionFilters(emptySet())),
+                        new TransportNodesHotThreadsAction(threadPool, clusterService, transportService, ActionFilters.EMPTY),
                         MasterHistoryAction.INSTANCE,
-                        new MasterHistoryAction.TransportAction(transportService, new ActionFilters(Set.of()), masterHistoryService),
+                        new MasterHistoryAction.TransportAction(transportService, ActionFilters.EMPTY, masterHistoryService),
                         ClusterFormationInfoAction.INSTANCE,
-                        new ClusterFormationInfoAction.TransportAction(transportService, new ActionFilters(Set.of()), coordinator),
+                        new ClusterFormationInfoAction.TransportAction(transportService, ActionFilters.EMPTY, coordinator),
                         CoordinationDiagnosticsAction.INSTANCE,
                         new CoordinationDiagnosticsAction.TransportAction(
                             transportService,
-                            new ActionFilters(Set.of()),
+                            ActionFilters.EMPTY,
                             coordinationDiagnosticsService
                         )
                     ),

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
@@ -31,7 +31,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -70,13 +69,7 @@ public class TransportAnalyticsStatsActionTests extends ESTestCase {
         when(clusterState.getMetadata()).thenReturn(Metadata.EMPTY_METADATA);
         when(clusterService.state()).thenReturn(clusterState);
 
-        return new TransportAnalyticsStatsAction(
-            transportService,
-            clusterService,
-            threadPool,
-            new ActionFilters(Collections.emptySet()),
-            usage
-        );
+        return new TransportAnalyticsStatsAction(transportService, clusterService, threadPool, ActionFilters.EMPTY, usage);
     }
 
     public void test() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/action/RestTermsEnumActionTests.java
@@ -71,7 +71,7 @@ public class RestTermsEnumActionTests extends ESTestCase {
 
         final TransportAction<? extends ActionRequest, ? extends ActionResponse> transportAction = new TransportAction<>(
             TermsEnumAction.NAME,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             taskManager,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         ) {

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -68,7 +68,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -160,7 +159,7 @@ public class TransportDownsampleActionTests extends ESTestCase {
             mock(TransportService.class),
             threadPool,
             mock(MetadataCreateIndexService.class),
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             persistentTaskService,
             downsampleMetrics,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
@@ -33,7 +33,6 @@ import org.elasticsearch.xpack.security.Security;
 
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -141,7 +140,7 @@ public class LocalStateMachineLearning extends LocalStateCompositeXPackPlugin {
             public MockedRollupIndexCapsTransport(TransportService transportService) {
                 super(
                     GetRollupIndexCapsAction.NAME,
-                    new ActionFilters(new HashSet<>()),
+                    ActionFilters.EMPTY,
                     transportService.getTaskManager(),
                     EsExecutors.DIRECT_EXECUTOR_SERVICE
                 );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/job/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/job/TransportDeleteExpiredDataActionTests.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.time.Clock;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -69,7 +68,7 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
             threadPool,
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             mock(TransportService.class),
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             client,
             clusterService,
             mock(JobConfigProvider.class),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyActionTests.java
@@ -89,7 +89,7 @@ public class TransportGrantApiKeyActionTests extends ESTestCase {
 
         action = new TransportGrantApiKeyAction(
             transportService,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             threadContext,
             authenticationService,
             authorizationService,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportCreateServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportCreateServiceAccountTokenActionTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
@@ -45,7 +44,7 @@ public class TransportCreateServiceAccountTokenActionTests extends ESTestCase {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportCreateServiceAccountTokenAction = new TransportCreateServiceAccountTokenAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             serviceAccountService,
             securityContext
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
@@ -18,8 +18,6 @@ import org.elasticsearch.xpack.core.security.action.service.DeleteServiceAccount
 import org.elasticsearch.xpack.security.authc.service.ServiceAccountService;
 import org.junit.Before;
 
-import java.util.Collections;
-
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -36,7 +34,7 @@ public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportDeleteServiceAccountTokenAction = new TransportDeleteServiceAccountTokenAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             serviceAccountService
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xpack.core.security.action.service.ServiceAccountInfo;
 import org.junit.Before;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -32,10 +31,7 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
     @Before
     public void init() {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
-        transportGetServiceAccountAction = new TransportGetServiceAccountAction(
-            transportService,
-            new ActionFilters(Collections.emptySet())
-        );
+        transportGetServiceAccountAction = new TransportGetServiceAccountAction(transportService, ActionFilters.EMPTY);
     }
 
     public void testDoExecute() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountCredentialsActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountCredentialsActionTests.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
 
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
@@ -63,7 +62,7 @@ public class TransportGetServiceAccountCredentialsActionTests extends ESTestCase
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         transportGetServiceAccountCredentialsAction = new TransportGetServiceAccountCredentialsAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             serviceAccountService
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -60,7 +60,6 @@ import org.mockito.Mockito;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -219,7 +218,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService,
             authenticationService,
             securityContext
@@ -260,7 +259,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService,
             authenticationService,
             securityContext
@@ -303,7 +302,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService,
             authenticationService,
             securityContext
@@ -356,7 +355,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService,
             authenticationService,
             securityContext
@@ -395,7 +394,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         final TransportCreateTokenAction action = new TransportCreateTokenAction(
             threadPool,
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService,
             authenticationService,
             securityContext

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
@@ -38,7 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.time.Clock;
-import java.util.Collections;
 
 import static org.elasticsearch.xpack.core.security.action.token.InvalidateTokenRequest.Type.ACCESS_TOKEN;
 import static org.elasticsearch.xpack.core.security.action.token.InvalidateTokenRequest.Type.REFRESH_TOKEN;
@@ -97,7 +96,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
         );
         final TransportInvalidateTokenAction action = new TransportInvalidateTokenAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService
         );
 
@@ -146,7 +145,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
         );
         final TransportInvalidateTokenAction action = new TransportInvalidateTokenAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             tokenService
         );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesActionTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.xpack.security.authz.store.NativePrivilegeStore;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.elasticsearch.test.ActionListenerUtils.anyCollection;
@@ -62,7 +61,7 @@ public class TransportHasPrivilegesActionTests extends ESTestCase {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final TransportHasPrivilegesAction transportHasPrivilegesAction = new TransportHasPrivilegesAction(
             transportService,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             mock(AuthorizationService.class),
             mock(NativePrivilegeStore.class),
             context
@@ -104,7 +103,7 @@ public class TransportHasPrivilegesActionTests extends ESTestCase {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final TransportHasPrivilegesAction transportHasPrivilegesAction = new TransportHasPrivilegesAction(
             transportService,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             mock(AuthorizationService.class),
             mock(NativePrivilegeStore.class),
             context
@@ -158,7 +157,7 @@ public class TransportHasPrivilegesActionTests extends ESTestCase {
         TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final var action = new TransportHasPrivilegesAction(
             transportService,
-            new ActionFilters(Set.of()),
+            ActionFilters.EMPTY,
             authorizationService,
             privilegeStore,
             context

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/TransportSLMGetExpiredSnapshotsActionTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/TransportSLMGetExpiredSnapshotsActionTests.java
@@ -139,7 +139,7 @@ public class TransportSLMGetExpiredSnapshotsActionTests extends ESTestCase {
             }
         });
 
-        final var action = new TransportSLMGetExpiredSnapshotsAction(transportService, repositoriesService, new ActionFilters(Set.of()));
+        final var action = new TransportSLMGetExpiredSnapshotsAction(transportService, repositoriesService, ActionFilters.EMPTY);
         final var task = new Task(1, "direct", TransportSLMGetExpiredSnapshotsAction.INSTANCE.name(), "", TaskId.EMPTY_TASK_ID, Map.of());
 
         final var policyMap = createPolicies(

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -84,13 +83,7 @@ public class SpatialStatsTransportActionTests extends ESTestCase {
     }
 
     private SpatialStatsTransportAction toAction(SpatialUsage nodeUsage) {
-        return new SpatialStatsTransportAction(
-            transportService,
-            clusterService,
-            threadPool,
-            new ActionFilters(Collections.emptySet()),
-            nodeUsage
-        );
+        return new SpatialStatsTransportAction(transportService, clusterService, threadPool, ActionFilters.EMPTY, nodeUsage);
     }
 
     private ObjectPath buildSpatialStatsResponse(SpatialUsage... nodeUsages) throws IOException {

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
@@ -217,7 +217,7 @@ public class TransformGetCheckpointTests extends ESSingleNodeTestCase {
     class TestTransportGetCheckpointAction extends TransportGetCheckpointAction {
 
         TestTransportGetCheckpointAction() {
-            super(transportService, new ActionFilters(emptySet()), indicesService, clusterService, indexNameExpressionResolver, client);
+            super(transportService, ActionFilters.EMPTY, indicesService, clusterService, indexNameExpressionResolver, client);
         }
 
         @Override
@@ -232,7 +232,7 @@ public class TransformGetCheckpointTests extends ESSingleNodeTestCase {
         private int calls;
 
         TestTransportGetCheckpointNodeAction() {
-            super(transportService, new ActionFilters(emptySet()), indicesService);
+            super(transportService, ActionFilters.EMPTY, indicesService);
             calls = 0;
             mockIndicesService = mock(IndicesService.class);
             for (int i = 0; i < numberOfIndices; ++i) {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
@@ -66,7 +66,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         action = new TransportAckWatchAction(
             transportService,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             new ClockHolder(Clock.systemUTC()),
             TestUtils.newTestLicenseState(),
             watchParser,

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.xpack.watcher.watch.WatchParser;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -91,7 +90,7 @@ public class TransportPutWatchActionTests extends ESTestCase {
         action = new TransportPutWatchAction(
             transportService,
             threadPool,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             new ClockHolder(new ClockMock()),
             TestUtils.newTestLicenseState(),
             parser,

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
@@ -88,7 +88,7 @@ public class TransportWatcherStatsActionTests extends ESTestCase {
             transportService,
             clusterService,
             threadPool,
-            new ActionFilters(Collections.emptySet()),
+            ActionFilters.EMPTY,
             watcherLifeCycleService,
             executionService,
             triggerService


### PR DESCRIPTION
We make loads of these things in tests and it's kinda awkward to have to
make a fresh instance each time. Let's introduce a constant for the very
common case of an empty `ActionFilters` chain.

Backport of #156995 to 8.19