### PR TITLE
[9.5] Add link to docs from `LagDetector` warning (#157001)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
@@ -182,11 +182,14 @@ public class LagDetector {
             }
 
             logger.warn(
-                "node [{}] is lagging at cluster state version [{}], although publication of cluster state version [{}] completed [{}] ago",
+                """
+                    node [{}] is lagging at cluster state version [{}], although publication of \
+                    cluster state version [{}] completed [{}] ago; see {} for further information""",
                 discoveryNode,
                 appliedVersion,
                 version,
-                clusterStateApplicationTimeout
+                clusterStateApplicationTimeout,
+                ReferenceDocs.LAGGING_NODE_TROUBLESHOOTING
             );
             lagListener.onLagDetected(discoveryNode, appliedVersion, version);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1875,15 +1875,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 );
 
                 mockLog.addExpectation(
-                    new MockLog.SeenEventExpectation(
-                        "lag warning",
-                        LagDetector.class.getCanonicalName(),
-                        Level.WARN,
-                        "node ["
-                            + brokenNode
-                            + "] is lagging at cluster state version [*], "
-                            + "although publication of cluster state version [*] completed [*] ago"
-                    )
+                    new MockLog.SeenEventExpectation("lag warning", LagDetector.class.getCanonicalName(), Level.WARN, Strings.format("""
+                        node [%s] is lagging at cluster state version [*], although publication of cluster state version [*] \
+                        completed [*] ago; see https://*/troubleshoot/*-lagging for further information""", brokenNode))
                 );
 
                 mockLog.addExpectation(


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Add link to docs from `LagDetector` warning (#157001)