### PR TITLE
Fix PR reference in 156644 changelog entry

### DIFF
--- a/docs/changelog/156644.yaml
+++ b/docs/changelog/156644.yaml
@@ -1,4 +1,4 @@
-pr: 156644
+pr: 156665
 summary: Fix Google VertexAI chat completion tool call arguments serialization for non-string values
 area: Inference
 type: bug


### PR DESCRIPTION
The changelog entry `docs/changelog/156644.yaml` records `pr: 156644`, but 156644 is the [issue](https://github.com/elastic/elasticsearch/issues/156644). The change was made by #156665, which is also the commit that added this file.

This points `pr:` at the PR and leaves the issue reference intact.

**Rendered release note**

Before:
```
* Fix Google VertexAI chat completion tool call arguments serialization for non-string values [#156644](https://github.com/elastic/elasticsearch/pull/156644) (issue: [#156644](https://github.com/elastic/elasticsearch/issues/156644))
```

After:
```
* Fix Google VertexAI chat completion tool call arguments serialization for non-string values [#156665](https://github.com/elastic/elasticsearch/pull/156665) (issue: [#156644](https://github.com/elastic/elasticsearch/issues/156644))
```

The `/pull/156644` link resolved to the issue rather than the fix, and the entry cited itself as its own issue.

**Notes for reviewers**

* The filename is deliberately left as `156644.yaml` rather than renamed to match the PR. `BundleChangelogsTask` overlays branch-HEAD changelogs on top of the build-candidate tree without deleting files removed at HEAD, so renaming after a BC exists causes the entry to be listed twice. Keeping the filename identical across branches also avoids divergence.
* No `auto-backport` label: the 9.5 change is opened separately as a companion PR, since it needs to land before the 9.5.2 release notes are generated.
* Verified with `./gradlew validateChangelogs` (BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)