### PR TITLE
[9.5] Fix PR reference in 156644 changelog entry

### DIFF
--- a/docs/changelog/156644.yaml
+++ b/docs/changelog/156644.yaml
@@ -1,4 +1,4 @@
-pr: 156644
+pr: 156665
 summary: Fix Google VertexAI chat completion tool call arguments serialization for non-string values
 area: Inference
 type: bug


### PR DESCRIPTION
Companion to #157036 for the `9.5` branch. Same one-line change.

The changelog entry `docs/changelog/156644.yaml` records `pr: 156644`, but 156644 is the [issue](https://github.com/elastic/elasticsearch/issues/156644). The change was made by #156665, backported to this branch as #156699. This points `pr:` at the PR and leaves the issue reference intact.

**This one is time-sensitive.** The 9.5.2 release notes are bundled from this branch (`bundleChangelogs --branch 9.5`), so the incorrect reference will appear in the generated 9.5.2 notes unless this lands first. The release-notes job runs roughly one day after the 9.5.2 build candidate.

**Rendered release note**

Before:
```
* Fix Google VertexAI chat completion tool call arguments serialization for non-string values [#156644](https://github.com/elastic/elasticsearch/pull/156644) (issue: [#156644](https://github.com/elastic/elasticsearch/issues/156644))
```

After:
```
* Fix Google VertexAI chat completion tool call arguments serialization for non-string values [#156665](https://github.com/elastic/elasticsearch/pull/156665) (issue: [#156644](https://github.com/elastic/elasticsearch/issues/156644))
```

**Notes for reviewers**

* The filename is deliberately **not** renamed to `156665.yaml`. The 9.5.2 build candidate is cut from this branch, and `BundleChangelogsTask` adds changelogs from branch HEAD on top of the BC tree without deleting files removed at HEAD — so a rename after the BC would list this fix twice in the release notes. An in-place field edit is safe whether this merges before or after the BC.
* Verified with `./gradlew validateChangelogs` on this branch (BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)