### PR TITLE
ES|QL: Fix external source IT fixture startup order (backport #153666 to 9.4)

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvCompressedFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -28,8 +29,10 @@ public class CsvCompressedFormatSpecIT extends AbstractExternalSourceSpecTestCas
 
     private static final List<String> COMPRESSED_FORMATS = List.of("csv.gz", "csv.zst", "csv.zstd", "csv.bz2", "csv.bz");
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public CsvCompressedFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/csv/CsvFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -26,8 +27,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class CsvFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public CsvFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/IcebergSpecIT.java
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/IcebergSpecIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -24,8 +25,10 @@ import java.util.List;
 public class IcebergSpecIT extends IcebergSpecTestCase {
 
     /** Elasticsearch cluster with S3 fixture and Iceberg catalog for testing. */
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public IcebergSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonCompressedFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -28,8 +29,10 @@ public class NdJsonCompressedFormatSpecIT extends AbstractExternalSourceSpecTest
 
     private static final List<String> COMPRESSED_FORMATS = List.of("ndjson.gz", "ndjson.zst", "ndjson.zstd", "ndjson.bz2", "ndjson.bz");
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public NdJsonCompressedFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-ndjson/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/ndjson/NdJsonFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -26,8 +27,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class NdJsonFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public NdJsonFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/orc/OrcFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-orc/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/orc/OrcFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -26,8 +27,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class OrcFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public OrcFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetFormatSpecIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 
@@ -26,8 +27,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class ParquetFormatSpecIT extends AbstractExternalSourceSpecTestCase {
 
-    @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    @ClassRule
+    public static TestRule ruleChain = chainFixturesBeforeCluster(cluster);
 
     public ParquetFormatSpecIT(
         String fileName,

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/ExternalDistributedSpecIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
 import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
@@ -50,13 +49,16 @@ public class ExternalDistributedSpecIT extends AbstractExternalSourceSpecTestCas
     private static final ElasticsearchCluster CLUSTER_INSTANCE = ExternalDistributedClusters.testCluster(() -> s3Fixture.getAddress());
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule((base, description) -> new org.junit.runners.model.Statement() {
-        @Override
-        public void evaluate() throws Throwable {
-            assumeFalse("FIPS mode requires security enabled; this test uses plain HTTP S3 fixtures", inFipsJvm());
-            base.evaluate();
-        }
-    }).around(CLUSTER_INSTANCE);
+    public static TestRule ruleChain = chainOuterRuleBeforeFixturesAndCluster(
+        (base, description) -> new org.junit.runners.model.Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assumeFalse("FIPS mode requires security enabled; this test uses plain HTTP S3 fixtures", inFipsJvm());
+                base.evaluate();
+            }
+        },
+        CLUSTER_INSTANCE
+    );
 
     private final String distributionMode;
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -22,6 +22,8 @@ import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3Http
 import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.S3RequestLog;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.net.URL;
@@ -150,14 +152,31 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         return parameterizedTests;
     }
 
-    @ClassRule
     public static DataSourcesS3HttpFixture s3Fixture = new DataSourcesS3HttpFixture();
 
-    @ClassRule
     public static DataSourcesAzureHttpFixture azureFixture = new DataSourcesAzureHttpFixture();
 
-    @ClassRule
     public static DataSourcesGcsHttpFixture gcsFixture = new DataSourcesGcsHttpFixture();
+
+    /**
+     * Builds a {@link ClassRule} that starts object-store fixtures before the test cluster. Without an
+     * explicit order, JUnit may boot the cluster while fixtures are not yet listening and external reads
+     * fail with transient {@code Connection is closed} errors (especially on Azure).
+     * <p>
+     * The cluster is taken as a {@link TestRule} because {@code test-clusters} is only on the classpath of
+     * the {@code javaRestTest} source sets, not of this shared one.
+     */
+    protected static TestRule chainFixturesBeforeCluster(TestRule cluster) {
+        return RuleChain.outerRule(s3Fixture).around(gcsFixture).around(azureFixture).around(cluster);
+    }
+
+    /**
+     * Like {@link #chainFixturesBeforeCluster(TestRule)} but runs {@code outer} first (e.g.
+     * an {@code assumeFalse} guard) before bringing up fixtures and the cluster.
+     */
+    protected static TestRule chainOuterRuleBeforeFixturesAndCluster(TestRule outer, TestRule cluster) {
+        return RuleChain.outerRule(outer).around(s3Fixture).around(gcsFixture).around(azureFixture).around(cluster);
+    }
 
     /** Cached path to local fixtures directory */
     private static Path localFixturesPath;


### PR DESCRIPTION
## Summary

Backport of #153666 to `9.4` (the `9.5` backport is #154261), requested in
https://github.com/elastic/elasticsearch/pull/153666#issuecomment-5314761870.

S3, GCS, Azure and the test cluster were declared as separate `@ClassRule` fields. JUnit does not
guarantee startup order, so the cluster could boot while the fixtures were not yet listening. That
race produces transient `org.apache.http.ConnectionClosedException: Connection is closed` failures.
This PR chains them into a single `RuleChain` so the order is deterministic:
**S3 → GCS → Azure → cluster**.

## ⚠️ This does not fix the Windows periodic failures

The backport was requested to fix the `9.4` Windows failures in `CsvCompressedFormatSpecIT`,
`NdJsonCompressedFormatSpecIT` and `OrcFormatSpecIT`. I checked
[build 12630](https://buildkite.com/elastic/elasticsearch-periodic-platform-support/builds/12630)
and **those failures have a different root cause**:

- The build has **zero** `Connection is closed` / `ConnectionClosedException` occurrences.
- All 360 failures are `Object not found: <uri>` — the fixtures are up and answering, the blobs are
  just not registered under the requested keys.
- They fail **uniformly across every backend** (S3, GCS, Azure, HTTP in equal numbers). A startup
  race would hit whichever fixture lost it, not all of them identically.
- The whole suite fails, deterministically, on Windows only. That is not a race.

The actual bug is a path-separator issue in fixture loading:
[`FixtureUtils.java:131`](https://github.com/elastic/elasticsearch/blob/9.4/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/FixtureUtils.java#L131)
uses `fixturesPath.relativize(file).toString()`, which yields `standalone\employees.orc` on Windows.
`S3FixtureUtils#loadFixturesFromResources` then stores the blob under
`warehouse/standalone\employees.orc`, while queries request `warehouse/standalone/employees.orc`.
The JAR branch of the same method is unaffected because JAR entry names always use `/`.

So this PR is worth having on its own merits — the ordering race is real and it removes a class of
transient failures — but it should not be expected to turn the Windows periodic builds green. That
needs a separate fix normalizing the separator in `forEachFixtureEntryFromFilesystem`.

## Change

`AbstractExternalSourceSpecTestCase` drops the standalone `@ClassRule` on each fixture and instead
exposes two helpers that build a single `RuleChain`:

- `chainFixturesBeforeCluster(TestRule cluster)`
- `chainOuterRuleBeforeFixturesAndCluster(TestRule outer, TestRule cluster)` — for suites with an
  outer assume/guard rule

Wired into every subclass: `CsvFormatSpecIT`, `CsvCompressedFormatSpecIT`, `NdJsonFormatSpecIT`,
`NdJsonCompressedFormatSpecIT`, `ParquetFormatSpecIT`, `OrcFormatSpecIT`, `IcebergSpecIT`,
`ExternalDistributedSpecIT`.

## Differences from the 9.5 backport

Both are forced by the `9.4` layout, not by choice:

1. `9.4` has no `Abstract{Csv,NdJson,Parquet}ExternalSpecTestCase` bases and no `parquet-rs` module,
   so the chain is wired into the concrete `*FormatSpecIT` classes. That also covers the two
   compressed suites, which on `9.4` are separate classes rather than parameterizations of a shared
   base.
2. The helpers take `TestRule` instead of `ElasticsearchCluster`. `:test:test-clusters` is only put
   on `javaRestTest` source-set classpaths by `InternalJavaRestTestPlugin`, and the base class lives
   in the shared `x-pack/plugin/esql/qa/server` *main* source set, which does not have it.
   `ElasticsearchCluster extends TestRule`, so callers are unaffected.

## Testing

Run locally against this branch (on macOS, so these exercise the ordering change, not the Windows
path bug):

- `:x-pack:plugin:esql-datasource-ndjson:qa:javaRestTest -Dtests.class=...NdJsonCompressedFormatSpecIT -Dtests.method="*AZURE*"` — passed
- `:x-pack:plugin:esql-datasource-csv:qa:javaRestTest -Dtests.class=...CsvCompressedFormatSpecIT -Dtests.method="*AZURE*"` — passed
- `:x-pack:plugin:esql-datasource-orc:qa:javaRestTest -Dtests.class=...OrcFormatSpecIT` — passed

No `muted-tests.yml` entries exist for these suites on `9.4`, so nothing to unmute.
