### PR TITLE
[8.19] Migrate mixed-tier-cluster to JUnit rule clusters (#156096)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -33,7 +33,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":qa:multi-cluster-search");
         map.put(LegacyRestTestBasePlugin.class, ":qa:rolling-upgrade-legacy");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:mixed-tier-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:repository-old-versions");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:rolling-upgrade");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:rolling-upgrade-basic");

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -1,9 +1,15 @@
-apply plugin: 'elasticsearch.legacy-java-rest-test'
-apply plugin: 'elasticsearch.bwc-test'
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
 
 import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.bwc-test'
 
 dependencies {
   javaRestTestImplementation project(':x-pack:qa')
@@ -12,47 +18,17 @@ dependencies {
 // Only run tests for 7.9+, since the node.roles setting was introduced in 7.9.0
 buildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
         v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
-
-  def baseCluster = testClusters.register(baseName) {
-    versions = [bwcVersion.toString(), project.version]
-    numberOfNodes = 3
-    testDistribution = 'DEFAULT'
-    setting 'xpack.security.enabled', 'false'
-    setting 'xpack.watcher.enabled', 'false'
-    setting 'xpack.ml.enabled', 'false'
-    setting 'xpack.license.self_generated.type', 'trial'
-    nodes."${baseName}-0".setting 'node.roles', '["master"]'
-    // data_* roles were introduced in 7.10.0, so use 'data' for older versions
-    if (bwcVersion.before('7.10.0')) {
-      nodes."${baseName}-1".setting 'node.roles', '["data"]'
-    } else {
-      nodes."${baseName}-1".setting 'node.roles', '["data_content", "data_hot"]'
-    }
-    nodes."${baseName}-2".setting 'node.roles', '["master"]'
-  }
-
-  tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-    useCluster baseCluster
-    mustRunAfter("precommit")
-    def beforeEndpoints = getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") }
-    doFirst {
-      // Getting the endpoints causes a wait for the cluster
-      println "Endpoints are: ${-> beforeEndpoints.get()}"
-      getRegistry().get().nextNodeToNextVersion(baseCluster)
-    }
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.clustername', baseName)
-    onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
-  }
-
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#mixedClusterTest"
+  tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.old_cluster_version", bwcVersion.toString().replace('-SNAPSHOT', ''))
   }
 }
 
+tasks.named("javaRestTest") {
+  enabled = false
+}
+
+// Security is explicitly disabled, do not run tests in FIPS mode
 tasks.withType(Test).configureEach {
-  classpath = sourceSets.javaRestTest.runtimeClasspath
-  testClassesDirs = sourceSets.javaRestTest.output.classesDirs
-  // Security is explicitly disabled, do not run tests in FIPS mode
   buildParams.withFipsEnabledOnly(it)
 }

--- a/x-pack/qa/mixed-tier-cluster/src/javaRestTest/java/org/elasticsearch/mixed/DataTierMixedIT.java
+++ b/x-pack/qa/mixed-tier-cluster/src/javaRestTest/java/org/elasticsearch/mixed/DataTierMixedIT.java
@@ -7,9 +7,41 @@
 
 package org.elasticsearch.mixed;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.ClassRule;
 
 public class DataTierMixedIT extends ESRestTestCase {
+
+    private static final String OLD_CLUSTER_VERSION = System.getProperty("tests.old_cluster_version");
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    private static ElasticsearchCluster buildCluster() {
+        Version oldVersion = Version.fromString(OLD_CLUSTER_VERSION);
+        // data_* roles were introduced in 7.10.0, so use 'data' for older versions
+        String dataNodeRoles = oldVersion.before("7.10.0") ? "[\"data\"]" : "[\"data_content\", \"data_hot\"]";
+
+        return ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.watcher.enabled", "false")
+            .setting("xpack.ml.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial")
+            // Node 0 runs the current version from the start, forming a mixed-version cluster with nodes 1 and 2.
+            .withNode(node -> node.version(Version.CURRENT).setting("node.roles", "[\"master\"]"))
+            .withNode(node -> node.version(oldVersion).setting("node.roles", dataNodeRoles))
+            .withNode(node -> node.version(oldVersion).setting("node.roles", "[\"master\"]"))
+            .build();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     public void testMixedTierCompatibility() throws Exception {
         createIndex("test-index", indexSettings(1, 0).build());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate mixed-tier-cluster to JUnit rule clusters (#156096)](https://github.com/elastic/elasticsearch/pull/156096)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)