### PR TITLE
Temporarily disable daily Java EA pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -137,6 +137,8 @@ spec:
           branch: main
           cronline: "0 4 * * * America/New_York"
           message: "Run java EA tests 1x per day"
+          # Temporarily disabled: EA runs generate muted-test noise until JDK 27 mute cleanup settles.
+          enabled: false
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -178,7 +178,8 @@ spec:
           branch: main
           cronline: "0 6 * * * UTC"
           message: "Check for new java pre release build 1x per day"
-          enabled: true
+          # Temporarily disabled alongside periodic-java-ea to stop muted-test noise.
+          enabled: false
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
Temporarily disable the daily Buildkite schedules for both Java EA pipelines as they are generating muted-test noise. 