### PR TITLE
[9.4] [Gradle] Improve forbidden-apis task input determinism for better cacheability (#148668)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -16,10 +16,10 @@ import de.thetaphi.forbiddenapis.Logger;
 import de.thetaphi.forbiddenapis.ParseException;
 import groovy.lang.Closure;
 
+import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -59,7 +59,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.RetentionPolicy;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -72,6 +71,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import javax.inject.Inject;
 
@@ -83,7 +84,8 @@ import static de.thetaphi.forbiddenapis.Checker.Option.FAIL_ON_VIOLATION;
 @CacheableTask
 public abstract class CheckForbiddenApisTask extends DefaultTask implements PatternFilterable, VerificationTask, Constants {
 
-    public static final Set<String> BUNDLED_SIGNATURE_DEFAULTS = Set.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out");
+    /** Default bundled JDK signature ids applied by {@link ForbiddenApisPrecommitPlugin}. */
+    public static final List<String> BUNDLED_SIGNATURE_DEFAULTS = List.of("jdk-unsafe", "jdk-non-portable", "jdk-system-out");
 
     private static final String NL = System.getProperty("line.separator", "\n");
     private final PatternSet patternSet = new PatternSet().include("**/*.class");
@@ -103,29 +105,109 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     private boolean ignoreFailures = false;
     private boolean ignoreMissingClasses = false;
 
-    @Input
-    @Optional
-    abstract SetProperty<String> getBundledSignatures();
+    /**
+     * Gradle cannot decorate {@link CheckForbiddenApisTask} with abstract {@link SetProperty} accessors (see task creation);
+     * these are created via {@link ObjectFactory} instead.
+     */
+    private final SetProperty<String> bundledSignatures;
+    private final SetProperty<String> suppressAnnotations;
 
     /**
-     * List of a custom Java annotations (full class names) that are used in the checked
-     * code to suppress errors. Those annotations must have at least
-     * {@link RetentionPolicy#CLASS}. They can be applied to classes, their methods,
-     * or fields. By default, {@code @de.thetaphi.forbiddenapis.SuppressForbidden}
-     * can always be used, but needs the {@code forbidden-apis.jar} file in classpath
-     * of compiled project, which may not be wanted.
-     * Instead of a full class name, a glob pattern may be used (e.g.,
-     * {@code **.SuppressForbidden}).
+     * Applies edits to bundled JDK signatures before they are stored in deterministic sorted order for caching.
      */
-    @Input
-    @Optional
-    abstract SetProperty<String> getSuppressAnnotations();
+    public interface BundledSignaturesSpec {
+        /** Adds a forbidden-apis bundled signatures resource id (e.g. {@code jdk-internal}). */
+        void add(String bundledSignature);
+
+        /** Removes a bundled signatures resource id (e.g. {@code jdk-non-portable}). */
+        void remove(String bundledSignature);
+    }
 
     @Inject
     public CheckForbiddenApisTask(ObjectFactory factory, ProjectLayout projectLayout) {
         signaturesFiles = factory.fileCollection();
         this.objectFactory = factory;
         this.projectLayout = projectLayout;
+        this.bundledSignatures = factory.setProperty(String.class);
+        this.suppressAnnotations = factory.setProperty(String.class);
+        getBundledSignatures().convention(new TreeSet<>());
+        getSuppressAnnotations().convention(new TreeSet<>());
+    }
+
+    /**
+     * Replaces bundled JDK signatures; values are deduplicated and stored in stable sorted order (implementation uses a {@link TreeSet}).
+     */
+    public void setBundledSignatures(Iterable<String> bundledSignatures) {
+        getBundledSignatures().set(copySortedStrings(bundledSignatures));
+    }
+
+    /** Mutates the current bundled signatures, then commits them in sorted order. */
+    public void configureBundledSignatures(Action<? super BundledSignaturesSpec> action) {
+        configureBundledSignaturesFromSeed(getBundledSignatures().get(), action);
+    }
+
+    /**
+     * Starts from {@link #BUNDLED_SIGNATURE_DEFAULTS}, applies edits, then commits bundled signatures in sorted order.
+     */
+    public void configureBundledSignaturesFromDefaults(Action<? super BundledSignaturesSpec> action) {
+        configureBundledSignaturesFromSeed(BUNDLED_SIGNATURE_DEFAULTS, action);
+    }
+
+    private void configureBundledSignaturesFromSeed(Iterable<String> seed, Action<? super BundledSignaturesSpec> action) {
+        LinkedHashSet<String> working = new LinkedHashSet<>();
+        for (String s : seed) {
+            working.add(Objects.requireNonNull(s, "bundledSignature"));
+        }
+        BundledSignaturesSpec spec = new BundledSignaturesSpec() {
+            @Override
+            public void add(String bundledSignature) {
+                working.add(Objects.requireNonNull(bundledSignature, "bundledSignature"));
+            }
+
+            @Override
+            public void remove(String bundledSignature) {
+                working.remove(Objects.requireNonNull(bundledSignature, "bundledSignature"));
+            }
+        };
+        action.execute(spec);
+        getBundledSignatures().set(copySortedStrings(working));
+    }
+
+    /**
+     * Replaces suppression annotations; values are deduplicated and stored in stable sorted order.
+     */
+    public void setSuppressAnnotations(Iterable<String> suppressAnnotations) {
+        getSuppressAnnotations().set(copySortedStrings(suppressAnnotations));
+    }
+
+    private static SortedSet<String> copySortedStrings(Iterable<String> values) {
+        TreeSet<String> sorted = new TreeSet<>();
+        for (String v : values) {
+            sorted.add(Objects.requireNonNull(v, "value"));
+        }
+        return sorted;
+    }
+
+    /**
+     * Forbidden-apis bundled JDK signature ids tracked as a task input.
+     * Values are normally assigned via {@link #setBundledSignatures} or {@link #configureBundledSignaturesFromDefaults}
+     * so they are stored in sorted order for stable fingerprints; assigning directly via {@link SetProperty#set}
+     * with an unordered collection may produce unstable cache keys.
+     */
+    @Input
+    @Optional
+    public SetProperty<String> getBundledSignatures() {
+        return bundledSignatures;
+    }
+
+    /**
+     * Suppression annotations tracked as a task input.
+     * Prefer {@link #setSuppressAnnotations} so values are stored in sorted order for stable fingerprints.
+     */
+    @Input
+    @Optional
+    public SetProperty<String> getSuppressAnnotations() {
+        return suppressAnnotations;
     }
 
     @OutputFile
@@ -198,10 +280,6 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     /** @see #getSignaturesFiles */
     public void setSignaturesFiles(FileCollection signaturesFiles) {
         this.signaturesFiles = signaturesFiles;
-    }
-
-    public void modifyBundledSignatures(Transformer<Set<String>, Set<String>> transformer) {
-        getBundledSignatures().set(transformer.transform(getBundledSignatures().get()));
     }
 
     public void replaceSignatureFiles(String... signatureFiles) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -24,7 +24,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.io.File;
-import java.util.Set;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -71,7 +71,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
                 t.dependsOn(resourcesTask);
                 t.setClasspath(sourceSet.getRuntimeClasspath().plus(sourceSet.getCompileClasspath()));
                 t.setTargetCompatibility(buildParams.getMinimumRuntimeVersion().getMajorVersion());
-                t.getBundledSignatures().set(BUNDLED_SIGNATURE_DEFAULTS);
+                t.setBundledSignatures(BUNDLED_SIGNATURE_DEFAULTS);
                 t.setSignaturesFiles(
                     project.files(
                         resourcesDir.toPath().resolve("forbidden/jdk-signatures.txt"),
@@ -79,7 +79,7 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
                         resourcesDir.toPath().resolve("forbidden/jdk-deprecated.txt")
                     )
                 );
-                t.getSuppressAnnotations().set(Set.of("**.SuppressForbidden"));
+                t.setSuppressAnnotations(List.of("**.SuppressForbidden"));
                 if (buildParams.getMinimumRuntimeVersion().equals(JavaVersion.current()) == false) {
                     t.getJavaLauncher().set(javaToolchains.launcherFor(spec -> {
                         spec.getLanguageVersion().set(JavaLanguageVersion.of(buildParams.getMinimumRuntimeVersion().getMajorVersion()));

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTaskSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTaskSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.precommit
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class CheckForbiddenApisTaskSpec extends Specification {
+
+    def "setBundledSignatures sorts values"() {
+        given:
+        Project project = ProjectBuilder.builder().build()
+        CheckForbiddenApisTask task = project.tasks.register("checkForbiddenApis", CheckForbiddenApisTask).get()
+
+        when:
+        task.setBundledSignatures(["jdk-unsafe", "jdk-non-portable"])
+
+        then:
+        task.bundledSignatures.get().toList() == ["jdk-non-portable", "jdk-unsafe"]
+    }
+
+    def "configureBundledSignaturesFromDefaults updates and sorts"() {
+        given:
+        Project project = ProjectBuilder.builder().build()
+        CheckForbiddenApisTask task = project.tasks.register("checkForbiddenApis", CheckForbiddenApisTask).get()
+
+        when:
+        task.configureBundledSignaturesFromDefaults { spec ->
+            spec.remove("jdk-non-portable")
+            spec.add("jdk-internal")
+        }
+
+        then:
+        task.bundledSignatures.get().toList() == ["jdk-internal", "jdk-system-out", "jdk-unsafe"]
+        !task.bundledSignatures.get().contains("jdk-non-portable")
+    }
+}

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -72,10 +72,9 @@ tasks.named("forbiddenPatterns").configure {
 
 tasks.named('forbiddenApisTest').configure {
   //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
-  modifyBundledSignatures { signatures ->
-    signatures -= 'jdk-non-portable'
-    signatures += 'jdk-internal'
-    signatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
 }
 

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -58,10 +58,9 @@ tasks.named('forbiddenApisMain').configure {
 
 tasks.named('forbiddenApisTest').configure {
   //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
-  modifyBundledSignatures { bundledSignatures ->
-    bundledSignatures -= 'jdk-non-portable'
-    bundledSignatures += 'jdk-internal'
-    bundledSignatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
 
   //client does not depend on server, so only jdk signatures should be checked

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -37,10 +37,9 @@ tasks.named('forbiddenApisMain').configure {
 
 tasks.named('forbiddenApisTest').configure {
   //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
-  modifyBundledSignatures { bundledSignatures ->
-    bundledSignatures -= 'jdk-non-portable'
-    bundledSignatures += 'jdk-internal'
-    bundledSignatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
   //client does not depend on core, so only jdk signatures should be checked
   replaceSignatureFiles 'jdk-signatures'

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -71,10 +71,9 @@ tasks.named("internalClusterTest") {
 
 tasks.named('forbiddenApisTest').configure {
   //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
-  modifyBundledSignatures { bundledSignatures ->
-    bundledSignatures -= 'jdk-non-portable'
-    bundledSignatures += 'jdk-internal'
-    bundledSignatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
 }
 

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -204,10 +204,9 @@ tasks.named('forbiddenApisMain').configure {
 
 tasks.named('forbiddenApisTest').configure {
   //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
-  modifyBundledSignatures { bundledSignatures ->
-    bundledSignatures -= 'jdk-non-portable'
-    bundledSignatures += 'jdk-internal'
-    bundledSignatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
 }
 

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -51,9 +51,8 @@ if (buildParams.inFipsJvm) {
   // Forbiden APIs non-portable checks fail because bouncy castle classes being used from the FIPS JDK since those are
   // not part of the Java specification - all of this is as designed, so we have to relax this check for FIPS.
   tasks.withType(CheckForbiddenApisTask).configureEach {
-    modifyBundledSignatures { bundledSignatures ->
-      bundledSignatures -= "jdk-non-portable"
-      bundledSignatures
+    configureBundledSignaturesFromDefaults {
+      remove 'jdk-non-portable'
     }
   }
 }

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -28,10 +28,9 @@ tasks.named('forbiddenApisMain').configure {
 }
 
 tasks.named('forbiddenApisTest').configure {
-  modifyBundledSignatures { bundledSignatures ->
-    bundledSignatures -= 'jdk-non-portable'
-    bundledSignatures += 'jdk-internal'
-    bundledSignatures
+  configureBundledSignaturesFromDefaults {
+    remove 'jdk-non-portable'
+    add 'jdk-internal'
   }
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Gradle] Improve forbidden-apis task input determinism for better cacheability (#148668)](https://github.com/elastic/elasticsearch/pull/148668)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)