### PR TITLE
[ES|QL] KNN function on runtime expressions.

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3680,6 +3680,11 @@ public class EsqlCapabilities {
          */
         CHANGE_POINT_MULTIPLE_EVENTS,
 
+        /**
+         * KNN function support for runtime expressions, not just ES mapped fields.
+         */
+        KNN_SUPPORT_RUNTIME_FIELD(Build.current().isSnapshot()),
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.vectors.ExactKnnQueryBuilder;
 import org.elasticsearch.search.vectors.VectorData;
@@ -20,6 +24,7 @@ import org.elasticsearch.xpack.esql.common.Failure;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
@@ -36,11 +41,14 @@ import org.elasticsearch.xpack.esql.expression.function.MapParam;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Options;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.SingleFieldFullTextFunction;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.querydsl.query.KnnQuery;
+import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,11 +74,15 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 public class Knn extends SingleFieldFullTextFunction implements OptionalArgument, VectorFunction, PostOptimizationVerificationAware {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Knn", Knn::readFrom);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Knn.class).ternary(Knn::new).name("knn");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Knn.class)
+        .ternaryConfig(Knn::new)
+        .snapshotCapabilities("runtime_field")
+        .name("knn");
 
     private final Integer implicitK;
     // Expressions to be used as prefilters in knn query
     private final List<Expression> filterExpressions;
+    private final Configuration configuration;
 
     public static final String MIN_CANDIDATES_OPTION = "min_candidates";
 
@@ -163,9 +175,10 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
             description = "(Optional) kNN additional options as <<esql-function-named-params,function named parameters>>."
                 + " See [knn query](/reference/query-languages/query-dsl/query-dsl-knn-query.md) for more information.",
             optional = true
-        ) Expression options
+        ) Expression options,
+        Configuration configuration
     ) {
-        this(source, field, query, options, null, null, List.of());
+        this(source, field, query, options, null, null, List.of(), configuration);
     }
 
     public Knn(
@@ -175,11 +188,13 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
         Expression options,
         Integer implicitK,
         QueryBuilder queryBuilder,
-        List<Expression> filterExpressions
+        List<Expression> filterExpressions,
+        Configuration configuration
     ) {
         super(source, field, query, options, expressionList(field, query, options), queryBuilder);
         this.implicitK = implicitK;
         this.filterExpressions = filterExpressions;
+        this.configuration = configuration;
     }
 
     private static List<Expression> expressionList(Expression field, Expression query, Expression options) {
@@ -202,7 +217,7 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
 
     public Knn withImplicitK(Integer k) {
         Check.notNull(k, "k must not be null");
-        return new Knn(source(), field(), query(), options(), k, queryBuilder(), filterExpressions());
+        return new Knn(source(), field(), query(), options(), k, queryBuilder(), filterExpressions(), configuration);
     }
 
     public List<Number> queryAsObject() {
@@ -218,11 +233,33 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
 
     @Override
     public Expression replaceQueryBuilder(QueryBuilder queryBuilder) {
-        return new Knn(source(), field(), query(), options(), implicitK(), queryBuilder, filterExpressions());
+        return new Knn(source(), field(), query(), options(), implicitK(), queryBuilder, filterExpressions(), configuration);
+    }
+
+    @Override
+    public boolean isRuntimeSearch() {
+        if (false == (Build.current().isSnapshot() && configuration.pragmas().runtimeKnnSearch())) {
+            return false;
+        }
+        FieldAttribute fieldAttribute = fieldAsFieldAttribute();
+        if (fieldAttribute == null) {
+            // This isn't a field in the index OR a pushed block loader
+            return true;
+        }
+
+        if (fieldAttribute.isPotentiallyUnmapped()) {
+            // A potentially unmapped field cannot be pushed down: the Lucene query would silently miss the rows of the
+            // indices where the field is unmapped, so it is matched at runtime instead.
+            return true;
+        }
+        return false;
     }
 
     @Override
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
+        if (isRuntimeSearch()) {
+            return Translatable.NO;
+        }
         Translatable translatable = super.translatable(pushdownPredicates);
         // We need to check whether filter expressions are translatable as well
         for (Expression filterExpression : filterExpressions()) {
@@ -230,6 +267,69 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
         }
 
         return translatable;
+    }
+
+    @Override
+    protected void fieldVerifier(
+        LogicalPlan plan,
+        FullTextFunction function,
+        Expression field,
+        @Nullable AnalysisRegistry analysisRegistry,
+        Failures failures
+    ) {
+        super.fieldVerifier(plan, function, field, analysisRegistry, failures);
+        if (isRuntimeSearch() == false) {
+            return;
+        }
+
+        if (field.dataType() != DENSE_VECTOR) {
+            failures.add(
+                Failure.fail(
+                    query(),
+                    "[KNN] cannot operate on [{}] of type [{}]; a non-index-mapped field must be a dense_vector expression",
+                    field.sourceText(),
+                    field.dataType().typeName()
+                )
+            );
+        }
+        // The query value can only be converted to the field's runtime type once it has been folded down to a
+        // Literal; if it hasn't yet (e.g. pre-optimization), this check is skipped here and retried once
+        // postOptimizationPlanVerification runs.
+        // TODO: this may be dead code
+        if (query() instanceof Literal) {
+            if (query().dataType() != DENSE_VECTOR) {
+                failures.add(
+                    Failure.fail(
+                        query(),
+                        "[KNN] cannot operate on [{}] of type [{}]; a non-index-mapped field must be a dense_vector expression",
+                        query().sourceText(),
+                        query().dataType().typeName()
+                    )
+                );
+            }
+        }
+
+        if (options() != null) {
+            failures.add(
+                Failure.fail(
+                    field,
+                    "Options are currently not supported for [KNN] function call on non-index-mapped field [{}]",
+                    field.sourceText()
+                )
+            );
+        }
+    }
+
+    @Override
+    public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        if (false == isRuntimeSearch()) {
+            return super.toEvaluator(toEvaluator);
+        }
+        if (dataType() != DENSE_VECTOR) {
+            throw EsqlIllegalArgumentException.illegalDataType(field.dataType());
+        }
+        // TODO: implement a runtime evaluator for knn function
+        throw new UnsupportedOperationException("Runtime KNN evaluator is not yet implemented");
     }
 
     @Override
@@ -269,7 +369,7 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
     }
 
     public Expression withFilters(List<Expression> filterExpressions) {
-        return new Knn(source(), field(), query(), options(), implicitK(), queryBuilder(), filterExpressions);
+        return new Knn(source(), field(), query(), options(), implicitK(), queryBuilder(), filterExpressions, configuration);
     }
 
     private Map<String, Object> queryOptions() throws InvalidArgumentException {
@@ -310,13 +410,24 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
             newChildren.size() > 2 ? newChildren.get(2) : null,
             implicitK(),
             queryBuilder(),
-            filterExpressions()
+            filterExpressions(),
+            configuration
         );
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, Knn::new, field(), query(), options(), implicitK(), queryBuilder(), filterExpressions());
+        return NodeInfo.create(
+            this,
+            Knn::new,
+            field(),
+            query(),
+            options(),
+            implicitK(),
+            queryBuilder(),
+            filterExpressions(),
+            configuration
+        );
     }
 
     @Override
@@ -334,7 +445,8 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
             ? in.readOptionalNamedWriteable(Expression.class)
             : null;
         Integer implicitK = in.getTransportVersion().supports(ESQL_OPTIONS_FOR_SEARCH_FUNCTIONS) ? in.readOptionalInt() : null;
-        return new Knn(source, field, query, options, implicitK, queryBuilder, filterExpressions);
+        Configuration configuration = ((PlanStreamInput) in).configuration();
+        return new Knn(source, field, query, options, implicitK, queryBuilder, filterExpressions, configuration);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
@@ -207,6 +207,10 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
         return result;
     }
 
+    public Integer explicitK() {
+        return (Integer) queryOptions().get(K_FIELD.getPreferredName());
+    }
+
     public Integer implicitK() {
         return implicitK;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Knn.java
@@ -321,6 +321,11 @@ public class Knn extends SingleFieldFullTextFunction implements OptionalArgument
     }
 
     @Override
+    public boolean contributesToScore() {
+        return true;
+    }
+
+    @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         if (false == isRuntimeSearch()) {
             return super.toEvaluator(toEvaluator);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -77,6 +77,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceSparklineAggr
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredOrNullAggWithEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStringCasingWithInsensitiveEquals;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceTrivialTypeConversions;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.RewriteRuntimeKnnToTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.RewriteSumOfExpressionPlusConstant;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.SetAsOptimized;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.SimplifyComparisonsArithmetics;
@@ -244,6 +245,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new PushLimitToKnn(),
             new PushDownAndCombineFilters(),
             new PushDownConjunctionsToKnnPrefilters(),
+            new RewriteRuntimeKnnToTopN(),
             new PushDownAndCombineSample(),
             new PushDownInferencePlan(),
             new PushDownEval(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RewriteRuntimeKnnToTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/RewriteRuntimeKnnToTopN.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarity;
+import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Rewrites a {@code Filter} involving runtime-field KNN function into an exact brute-force plan
+ * which can be executed entirely in the compute engine:
+ * <p>
+ * For an example ESQL query like,
+ * <pre>
+ *   WHERE knn(expr, query) [AND prefilter...]
+ *   LIMIT k
+ * </pre>
+ *
+ * The pre-optimization plan is:
+ *
+ * <pre>
+ *  Project(outputs)
+ *    Filter[KNN(expr, query) AND prefilter...]
+ *      child
+ * </pre>
+ *
+ * After optimization, KNN is rewritten to an Eval(similarity) + TopN plan applied after rest of the filters.
+ *
+ * <pre>
+ *   Project(original outputs)
+ *     TopN($$knn_similarity$$ DESC, k)
+ *       Eval($$knn_similarity$$ = v_cosine(expr, query))
+ *         [Filter(prefilter)]
+ *           original child
+ * </pre>
+ *
+ * A KNN is treated as a runtime search when its field argument is not an indexed
+ * {@code dense_vector} FieldAttribute — for example a column produced by EVAL or
+ * read from a federated data source.  In that case Lucene pushdown is impossible
+ * and this rewrite provides the execution path.
+ *
+ * Non-KNN conjuncts in the WHERE clause become a prefilter applied before the
+ * similarity computation, mirroring the prefilter semantics of the pushdown path.
+ *
+ * The rule fires only after {@link PushLimitToKnn} has populated {@code implicitK};
+ * if that has not happened yet the rule is a no-op and defers to the next optimizer
+ * iteration.  A KNN nested inside a disjunction (OR) is left untouched — only
+ * top-level conjunctions in the WHERE are handled.
+ */
+public class RewriteRuntimeKnnToTopN extends OptimizerRules.OptimizerRule<Filter> {
+    public static String TEMP_COL_NAME = "$$knn_similarity$$";
+
+    @Override
+    protected LogicalPlan rule(Filter filter) {
+        List<Knn> runtimeKnns = new ArrayList<>();
+        List<Expression> nonKnnConjuncts = new ArrayList<>();
+        collectFromConjunction(filter.condition(), runtimeKnns, nonKnnConjuncts);
+
+        if (runtimeKnns.isEmpty()) {
+            return filter;
+        }
+        // Multiple runtime KNNs in one WHERE are not yet supported
+        if (runtimeKnns.size() != 1) {
+            return filter;
+        }
+
+        Knn knn = runtimeKnns.get(0);
+        // Make sure we apply transformation only to KNN on runtime fields
+        assert knn.isRuntimeSearch() : "RewriteRuntimeKnnToTopN should only be applied to runtime KNNs";
+
+        // implicitK is populated by PushLimitToKnn; defer until it runs
+        if (knn.implicitK() == null) {
+            return filter;
+        }
+
+        Source source = knn.source();
+        LogicalPlan child = filter.child();
+
+        // Apply non-runtime-KNN conjuncts as a prefilter below the similarity computation
+        if (nonKnnConjuncts.isEmpty() == false) {
+            // TODO: check if source is correct here.
+            child = new Filter(source, child, combineConjuncts(nonKnnConjuncts, source));
+        }
+
+        // Compute cosine similarity for every (pre-filtered) row
+        // TODO: accept similarity metric.
+        var similarityExpr = new CosineSimilarity(source, knn.field(), knn.query());
+        // TODO: is the name unique?
+        var simAlias = new Alias(source, TEMP_COL_NAME, similarityExpr, null, true);
+        var eval = new Eval(source, child, List.of(simAlias));
+
+        // Select the k rows with the highest similarity
+        var simRef = simAlias.toAttribute();
+        var order = new Order(source, simRef, Order.OrderDirection.DESC, Order.NullsPosition.LAST);
+        var kLiteral = new Literal(source, knn.explicitK() != null ? knn.explicitK() : knn.implicitK(), DataType.INTEGER);
+        var topN = new TopN(source, eval, List.of(order), kLiteral, false);
+
+        // Drop the synthetic similarity column; expose the same attributes the Filter did
+        return new Project(source, topN, filter.output());
+    }
+
+    /**
+     * Walks a flat AND chain and partitions its leaves into runtime KNN functions
+     * and everything else. A KNN nested inside an OR is ignored (treated as a non-KNN term)
+     * because we cannot safely rewrite disjunctions this way.
+     */
+    private static void collectFromConjunction(Expression expr, List<Knn> runtimeKnns, List<Expression> others) {
+        if (expr instanceof And and) {
+            collectFromConjunction(and.left(), runtimeKnns, others);
+            collectFromConjunction(and.right(), runtimeKnns, others);
+        } else if (expr instanceof Knn knn && knn.isRuntimeSearch()) {
+            runtimeKnns.add(knn);
+        } else {
+            others.add(expr);
+        }
+    }
+
+    private static Expression combineConjuncts(List<Expression> exprs, Source source) {
+        assert exprs.isEmpty() == false;
+        Expression result = exprs.get(0);
+        for (int i = 1; i < exprs.size(); i++) {
+            result = new And(source, result, exprs.get(i));
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -190,6 +190,11 @@ public final class QueryPragmas implements Writeable {
      */
     public static final Setting<Integer> MIN_DOCS_PER_SLICE = Setting.intSetting("min_docs_per_slice", -1, -1);
 
+    /**
+     *  When {@code true}, it allows KNN function to be used with expressions that are not indexed fields.
+     */
+    public static final Setting<Boolean> RUNTIME_KNN_SEARCH = Setting.boolSetting("runtime_knn_search", false);
+
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
 
     public static final List<String> VALID_PRAGMA_NAMES = Stream.of(
@@ -214,7 +219,9 @@ public final class QueryPragmas implements Writeable {
         MAX_CONCURRENT_OPEN_SEGMENTS,
         MAX_RECORD_SIZE,
         FORCE_DOC_SEQUENCE,
-        PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS
+        PlannerSettings.TIME_SERIES_TARGET_CHUNK_ROWS,
+        RUNTIME_KNN_SEARCH
+
     ).map(Setting::getKey).toList();
 
     private final Settings settings;
@@ -414,6 +421,13 @@ public final class QueryPragmas implements Writeable {
     public int minDocsPerSlice(int defaultMinDocsPerSlice) {
         int override = MIN_DOCS_PER_SLICE.get(settings);
         return override > 0 ? override : defaultMinDocsPerSlice;
+    }
+
+    /**
+     * When {@code true}, it allows KNN function to be used with expressions that are not indexed fields.
+     */
+    public boolean runtimeKnnSearch() {
+        return RUNTIME_KNN_SEARCH.get(settings);
     }
 
     public boolean isEmpty() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -39,7 +40,16 @@ public class KnnErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Knn(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, null, null, List.of());
+        return new Knn(
+            source,
+            args.get(0),
+            args.get(1),
+            args.size() > 2 ? args.get(2) : null,
+            null,
+            null,
+            List.of(),
+            EsqlTestUtils.TEST_CFG
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnSerializationTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
@@ -26,7 +27,7 @@ public class KnnSerializationTests extends AbstractExpressionSerializationTests<
         Expression options = randomOptions();
         Integer implicitK = randomIntBetween(10, 100);
         List<Expression> filterExpressions = randomList(0, 3, AbstractExpressionSerializationTests::randomChild);
-        return new Knn(source, field, query, options, implicitK, null, filterExpressions);
+        return new Knn(source, field, query, options, implicitK, null, filterExpressions, EsqlTestUtils.TEST_CFG);
     }
 
     @Override
@@ -47,7 +48,7 @@ public class KnnSerializationTests extends AbstractExpressionSerializationTests<
             );
             case 4 -> implicitK = randomValueOtherThan(instance.implicitK(), () -> randomIntBetween(10, 100));
         }
-        return new Knn(source, field, query, options, implicitK, null, filterExpressions);
+        return new Knn(source, field, query, options, implicitK, null, filterExpressions, EsqlTestUtils.TEST_CFG);
     }
 
     private Expression randomOptions() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
@@ -94,6 +95,15 @@ public class KnnTests extends SingleFieldFullTextFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Knn(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, null, null, List.of());
+        return new Knn(
+            source,
+            args.get(0),
+            args.get(1),
+            args.size() > 2 ? args.get(2) : null,
+            null,
+            null,
+            List.of(),
+            EsqlTestUtils.TEST_CFG
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.compute.aggregation.QuantileStates;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntBlock;
@@ -48,6 +49,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.DateUtils;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.expression.Foldables;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.WindowFilter;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
@@ -90,6 +92,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Concat;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToLower;
+import org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarity;
 import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -113,15 +116,19 @@ import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.EsIndexGenerator;
 import org.elasticsearch.xpack.esql.index.IndexProperties;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.ConstantFolding;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.LiteralsOnTheRight;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneRedundantOrderBy;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownAndCombineLimits;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownAndCombineOrderBy;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownConjunctionsToKnnPrefilters;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownEnrich;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownEval;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownInferencePlan;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownRegexExtract;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushLimitToKnn;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.RewriteRuntimeKnnToTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.SplitInWithFoldableValue;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
@@ -163,6 +170,7 @@ import org.elasticsearch.xpack.esql.plan.logical.join.LookupJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.EmptyLocalSupplier;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.rule.RuleExecutor;
 
 import java.time.Duration;
@@ -218,6 +226,7 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.DeduplicateAg
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.DOWN;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.UP;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneColumnsTests.assertCommonIncompatibleDataTypesEsRelation;
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.RewriteRuntimeKnnToTopN.TEMP_COL_NAME;
 import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
@@ -9679,6 +9688,147 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             typesError("from types metadata _score | where knn(dense_vector, [0, 1, 2]) | sort _score | limit 10 by keyword | limit 5"),
             containsString("Knn function must be used with a LIMIT clause")
         );
+    }
+
+    // --- Runtime KNN → TopN rewrite tests ---
+
+    /**
+     * Helper that builds a minimal optimizer running only the KNN-specific logical rules with a
+     * configuration that has {@code runtime_knn_search = true}, so that the inlining rules that would
+     * otherwise resolve {@code EVAL v = dense_vector} back to the underlying FieldAttribute don't run.
+     * That keeps {@code knn.field()} as a ReferenceAttribute, causing {@code isRuntimeSearch()} to
+     * return true and triggering {@link RewriteRuntimeKnnToTopN}.
+     */
+    private LogicalPlan optimizeWithRuntimeKnnRules(String query) {
+        var pragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.RUNTIME_KNN_SEARCH.getKey(), true).build());
+        var cfg = EsqlTestUtils.configuration(pragmas);
+        // Analyze (but don't optimize) using a configuration with runtime_knn_search=true so that
+        // the Knn expression stores that configuration, which isRuntimeSearch() later inspects.
+        var analyzed = typesAnalyzer().configuration(cfg).query(query);
+        // Custom optimizer: only the KNN rules. The inlining rules are intentionally omitted so that
+        // the EVAL'd v remains a ReferenceAttribute inside the KNN, not a FieldAttribute.
+        var ctx = new LogicalOptimizerContext(cfg, FoldContext.small(), TransportVersionUtils.randomCompatibleVersion());
+        var customOptimizer = new LogicalPlanOptimizer(ctx) {
+            @Override
+            protected List<RuleExecutor.Batch<LogicalPlan>> batches() {
+                return List.of(
+                    new RuleExecutor.Batch<>(
+                        "KNN rules",
+                        // Combine the analyzer-injected cap Limit with the user's LIMIT before
+                        // PushLimitToKnn runs, so it sees a single correct Limit value.
+                        new ConstantFolding(),
+                        new PushDownAndCombineLimits(),
+                        new PushLimitToKnn(),
+                        new PushDownConjunctionsToKnnPrefilters(),
+                        new RewriteRuntimeKnnToTopN()
+                    )
+                );
+            }
+        };
+        return customOptimizer.optimize(analyzed);
+    }
+
+    /**
+     * {@code EVAL v = dense_vector | WHERE knn(v, [...]) | LIMIT k} with runtime_knn_search enabled
+     * must be rewritten to a brute-force plan. After {@link PushDownAndCombineLimits} runs in the same
+     * batch, the outer Limit is pushed through the Project, producing:
+     * {@code Project(drop sim) → Limit(k) → TopN(sim DESC, k) → Eval(sim=v_cosine) → Eval(v) → EsRelation}.
+     */
+    public void testRuntimeKnnRewrittenToTopN() {
+        assumeTrue("requires snapshot build for runtime KNN", Build.current().isSnapshot());
+        var plan = optimizeWithRuntimeKnnRules("""
+            FROM types
+            | EVAL v = dense_vector
+            | WHERE knn(v, [0, 1, 2])
+            | LIMIT 5
+            """);
+
+        // Project drops the synthetic similarity column, keeping only what the Filter exposed
+        var project = as(plan, Project.class);
+        assertThat(project.projections().stream().anyMatch(a -> a.name().startsWith(TEMP_COL_NAME)), is(false));
+
+        // Limit (pushed through the Project by PushDownAndCombineLimits)
+        var limit = as(project.child(), Limit.class);
+        assertThat(Foldables.limitValue(limit.limit(), "LIMIT"), equalTo(5));
+
+        // TopN selects the k rows with highest similarity (DESC order)
+        var topN = as(limit.child(), TopN.class);
+        assertThat(Foldables.limitValue(topN.limit(), "TopN"), equalTo(5));
+        assertThat(topN.order().size(), equalTo(1));
+        var order = topN.order().getFirst();
+        assertThat(order.child(), instanceOf(ReferenceAttribute.class));
+        assertThat(as(order.child(), ReferenceAttribute.class).name(), equalTo(TEMP_COL_NAME));
+        assertThat(order.direction(), equalTo(Order.OrderDirection.DESC));
+
+        // First Eval computes cosine similarity
+        var simEval = as(topN.child(), Eval.class);
+        assertThat(simEval.fields().size(), equalTo(1));
+
+        var alias = simEval.fields().getFirst();
+        assertThat(alias.name(), equalTo(TEMP_COL_NAME));
+        assertThat(alias.child() instanceof CosineSimilarity, is(true));
+
+        // Second Eval is the original EVAL v = dense_vector
+        var vEval = as(simEval.child(), Eval.class);
+        as(vEval.child(), EsRelation.class);
+    }
+
+    /**
+     * Non-KNN conjuncts in the WHERE become a prefilter below the TopN.
+     */
+    public void testRuntimeKnnPrefilterConjuncts() {
+        assumeTrue("requires snapshot build for runtime KNN", Build.current().isSnapshot());
+        var plan = optimizeWithRuntimeKnnRules("""
+            FROM types
+            | EVAL v = dense_vector
+            | WHERE knn(v, [0, 1, 2]) AND integer > 10
+            | LIMIT 5
+            """);
+
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        var topN = as(limit.child(), TopN.class);
+
+        // The prefilter (integer > 10) sits below the TopN, below the similarity Eval
+        var simEval = as(topN.child(), Eval.class);
+        var prefilter = as(simEval.child(), Filter.class);
+        assertThat(prefilter.condition(), instanceOf(GreaterThan.class));
+    }
+
+    /**
+     * A KNN inside a disjunction must NOT be rewritten: the Filter is left unchanged.
+     */
+    public void testRuntimeKnnInDisjunctionNotRewritten() {
+        assumeTrue("requires snapshot build for runtime KNN", Build.current().isSnapshot());
+        var plan = optimizeWithRuntimeKnnRules("""
+            FROM types
+            | EVAL v = dense_vector
+            | WHERE knn(v, [0, 1, 2]) OR integer > 10
+            | LIMIT 5
+            """);
+
+        // The plan should still contain a Filter (no TopN rewrite for OR conditions)
+        var limit = as(plan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        assertThat(filter.condition(), instanceOf(Or.class));
+    }
+
+    /**
+     * Multiple KNNs inside a disjunction is not supported yet.
+     */
+    public void testMutipleRuntimeKnnInConjuncts() {
+        assumeTrue("requires snapshot build for runtime KNN", Build.current().isSnapshot());
+        var plan = optimizeWithRuntimeKnnRules("""
+            FROM types
+            | EVAL v1 = dense_vector, v2 = dense_vector
+            | WHERE knn(v1, [0, 1, 2]) AND knn(v2, [1, 2, 3]) AND integer > 10
+            | LIMIT 5
+            """);
+
+        // The plan should still contain a Filter (no TopN rewrite for OR conditions)
+        var limit = as(plan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+        assertThat(filter.condition(), instanceOf(And.class));
     }
 
     private LogicalPlanOptimizer getCustomRulesLogicalPlanOptimizer(


### PR DESCRIPTION
- Today KNN() only works on indexed fields; throws an error when used on runtime fields/expressions.
- This PR adds limited support for KNN() on runtime expressions.
- Support limited to single runtime KNN() in `WHERE` clause which participates in a Conjunction (IOW, it can be reached only by `AND`s)

### Implementation
Implemented via logical plan transformation in `RewriteRuntimeKnnToTopN` optimizer.

Steps:
1. Identify the candidate runtime `KNN` in the `Filter` expression.
2. Add `Eval(similarity) + TopN` to the logical plan to perform the `KNN`.
3. Separate out the `KNN` from `Filter` expression and add it as child of `Eval`.


Example of queries that will be transformed
```
FROM ..
| EVAL embeddings = ...
| WHERE (KNN(embeddings, [1.0, 2.0, 3.0])
| ... 

FROM ..
| EVAL embeddings = ...
| WHERE (id > 10 AND KNN(embeddings, [1.0, 2.0, 3.0])) OR MATCH(text, "fox")
| ... 

FROM ..
| EVAL embeddings = ...
| WHERE id > 10 AND KNN(embeddings, [1.0, 2.0, 3.0]) AND KNN(dense_vector_field, [1.0, 2.0, 3.0])
| ... 

FROM ..
| EVAL embeddings = ...
| WHERE id > 10 AND KNN(embeddings, [1.0, 2.0, 3.0]) AND (MATCH(text, "fox") OR status:"400")
| ... 

```

Example of queries that won't be transformed

```
## OR clause
FROM ..
| EVAL embeddings = ...
| WHERE KNN(embeddings, [1.0, 2.0, 3.0]) OR MATCH(text, "fox")
| ... 

## Two runtime KNNs not supported
FROM ..
| EVAL embeddings1 = ... , embeddings2 = ..
| WHERE id > 10 AND KNN(embeddings1, [1.0, 2.0, 3.0]) AND KNN(embeddings2, [1.0, 2.0, 3.0])
| ... 

```