### PR TITLE
[9.5] Fixing StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest() (#149429)

### DIFF
--- a/docs/changelog/149429.yaml
+++ b/docs/changelog/149429.yaml
@@ -1,0 +1,6 @@
+area: Engine
+issues:
+ - 149343
+pr: 149429
+summary: Fixing `StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest()`
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -133,9 +133,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133
-- class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
-  method: testTranslogLocalFailureOnlyStressRecoveryTest
-  issue: https://github.com/elastic/elasticsearch/issues/149343
 - class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
   method: test {csv-spec:csv-union-by-name.* [LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/149482

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
@@ -116,61 +116,71 @@ public class NodeTranslogBuffer implements Releasable {
             boolean dataToSync = false;
             var metadata = new HashMap<ShardId, TranslogMetadata>();
             var syncedLocations = new HashMap<ShardId, ShardSyncState.SyncMarker>();
-            var compoundTranslogStream = new ReleasableBytesStreamOutput(bigArrays);
-            var headerStream = new ReleasableBytesStreamOutput(bigArrays);
+            ReleasableBytesStreamOutput compoundTranslogStream = null;
+            ReleasableBytesStreamOutput headerStream = null;
+            boolean success = false;
+            try {
+                compoundTranslogStream = new ReleasableBytesStreamOutput(bigArrays);
+                headerStream = new ReleasableBytesStreamOutput(bigArrays);
+                for (var state : activeShards) {
+                    ShardId shardId = state.getShardId();
 
-            for (var state : activeShards) {
-                ShardId shardId = state.getShardId();
+                    long position = compoundTranslogStream.position();
+                    ShardBuffer buffer = buffers.get(state);
+                    TranslogMetadata.Directory directory = state.createDirectory(generation, buffer == null ? 0 : buffer.totalOps());
 
-                long position = compoundTranslogStream.position();
-                ShardBuffer buffer = buffers.get(state);
-                TranslogMetadata.Directory directory = state.createDirectory(generation, buffer == null ? 0 : buffer.totalOps());
-
-                // If the ShardSyncState is closed ignore. If shard has been closed, then there is a potentially a race with creating an
-                // accurate directory. The safest approach is to not include this shard in the translog metadata.
-                if (state.isClosed() == false) {
-                    if (buffer != null) {
-                        dataToSync = true;
-                        buffer.buffer().bytes().writeTo(compoundTranslogStream);
-                        metadata.put(shardId, metadata(buffer, position, compoundTranslogStream.position() - position, directory));
-                        syncedLocations.put(shardId, buffer.syncMarker());
-                    } else {
-                        metadata.put(shardId, metadata(null, position, compoundTranslogStream.position() - position, directory));
+                    // If the ShardSyncState is closed ignore. If shard has been closed, then there is a potentially a race with creating
+                    // an accurate directory. The safest approach is to not include this shard in the translog metadata.
+                    if (state.isClosed() == false) {
+                        if (buffer != null) {
+                            dataToSync = true;
+                            buffer.buffer().bytes().writeTo(compoundTranslogStream);
+                            metadata.put(shardId, metadata(buffer, position, compoundTranslogStream.position() - position, directory));
+                            syncedLocations.put(shardId, buffer.syncMarker());
+                        } else {
+                            metadata.put(shardId, metadata(null, position, compoundTranslogStream.position() - position, directory));
+                        }
                     }
                 }
+
+                // It is possible that there were operations in the buffer which are no longer associated with active shards.
+                // If there is no data to sync related to active shards, do not produce a translog to sync
+                if (dataToSync == false) {
+                    return null;
+                }
+
+                // Write the header to the stream
+                new CompoundTranslogHeader(metadata).writeToStore(headerStream);
+
+                final ReleasableBytesStreamOutput headerToClose = headerStream;
+                final ReleasableBytesStreamOutput compoundTranslogToClose = compoundTranslogStream;
+                TranslogReplicator.CompoundTranslogBytes compoundTranslogBytes = new TranslogReplicator.CompoundTranslogBytes(
+                    CompositeBytesReference.of(headerStream.bytes(), compoundTranslogStream.bytes()),
+                    () -> Releasables.close(headerToClose, compoundTranslogToClose)
+                );
+
+                // We do not need to store totalOps when they are equal to zero as it can simply be assumed when there is no entry
+                // for a specified ShardId. Storing them has a memory cost that is non-negligible in some scenarios.
+                // We also use toUnmodifiableMap as it has a lower memory usage than HashMap.
+                Map<ShardId, Long> totalOps = metadata.entrySet()
+                    .stream()
+                    .filter(e -> e.getValue().operations().totalOps() > 0)
+                    .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().operations().totalOps()));
+
+                TranslogReplicator.CompoundTranslogMetadata compoundMetadata = new TranslogReplicator.CompoundTranslogMetadata(
+                    Strings.format("%019d", generation),
+                    generation,
+                    totalOps,
+                    syncedLocations
+                );
+
+                success = true;
+                return new TranslogReplicator.CompoundTranslog(compoundMetadata, compoundTranslogBytes);
+            } finally {
+                if (success == false) {
+                    Releasables.close(headerStream, compoundTranslogStream);
+                } // else compoundTranslogBytes is responsible for closing the streams
             }
-
-            // It is possible that there were operations in the buffer which are no longer associated with active shards.
-            // If there is no data to sync related to active shards, do not produce a translog to sync
-            if (dataToSync == false) {
-                Releasables.close(headerStream, compoundTranslogStream);
-                return null;
-            }
-
-            // Write the header to the stream
-            new CompoundTranslogHeader(metadata).writeToStore(headerStream);
-
-            TranslogReplicator.CompoundTranslogBytes compoundTranslogBytes = new TranslogReplicator.CompoundTranslogBytes(
-                CompositeBytesReference.of(headerStream.bytes(), compoundTranslogStream.bytes()),
-                () -> Releasables.close(headerStream, compoundTranslogStream)
-            );
-
-            // We do not need to store totalOps when they are equal to zero as it can simply be assumed when there is no entry
-            // for a specified ShardId. Storing them has a memory cost that is non-negligible in some scenarios.
-            // We also use toUnmodifiableMap as it has a lower memory usage than HashMap.
-            Map<ShardId, Long> totalOps = metadata.entrySet()
-                .stream()
-                .filter(e -> e.getValue().operations().totalOps() > 0)
-                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().operations().totalOps()));
-
-            TranslogReplicator.CompoundTranslogMetadata compoundMetadata = new TranslogReplicator.CompoundTranslogMetadata(
-                Strings.format("%019d", generation),
-                generation,
-                totalOps,
-                syncedLocations
-            );
-
-            return new TranslogReplicator.CompoundTranslog(compoundMetadata, compoundTranslogBytes);
         } finally {
             buffers.clear();
         }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
@@ -697,6 +697,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
         private final AtomicLong currentGeneration = new AtomicLong(0);
         private final PriorityQueue<UploadTranslogTask> ongoingUploads = new PriorityQueue<>();
+        private boolean closed = false;
 
         private final AtomicLong validateClusterStateGeneration = new AtomicLong(0);
         private final PriorityQueue<ValidateClusterStateForUploadTask> ongoingValidateClusterState = new PriorityQueue<>();
@@ -705,8 +706,12 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
         private void markUploadStarting(final UploadTranslogTask uploadTranslogTask) {
             synchronized (ongoingUploads) {
-                ongoingUploads.add(uploadTranslogTask);
+                if (closed) {
+                    uploadTranslogTask.cancel(new ElasticsearchException("Node shutting down"));
+                    return;
+                }
 
+                ongoingUploads.add(uploadTranslogTask);
                 BlobTranslogFileImpl translogFile = uploadTranslogTask.translogFile;
                 CompoundTranslogMetadata metadata = uploadTranslogTask.translog.metadata();
                 for (Map.Entry<ShardId, ShardSyncState.SyncMarker> entry : metadata.syncedLocations().entrySet()) {
@@ -967,6 +972,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
         public void close() {
             synchronized (ongoingUploads) {
+                closed = true;
                 // Don't remove. Just cancel since this only happens on shutdown.
                 ongoingUploads.forEach(r -> r.cancel(new ElasticsearchException("Node shutting down")));
             }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
@@ -7,10 +7,17 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -140,6 +147,45 @@ public class NodeTranslogBufferTests extends ESTestCase {
         assertThat(translog.metadata().totalOps().size(), equalTo(1));
         assertThat(translog.metadata().syncedLocations().keySet(), hasItems(activeShardId));
         assertThat(translog.metadata().syncedLocations().size(), equalTo(1));
+    }
+
+    /**
+     * Tests that the compoundTranslogStream and headerStream are closed on exception
+     */
+    public void testStreamsAreReleasedWhenCompleteThrows() throws IOException {
+        CircuitBreakerService breakerService = LimitedBreaker.service(CircuitBreaker.REQUEST, ByteSizeValue.ofMb(1));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), breakerService);
+
+        ShardSyncState shardSyncState = mock(ShardSyncState.class);
+        when(shardSyncState.getShardId()).thenReturn(new ShardId("test", "_na_", 0));
+        // Fail partway through complete(), after the compound and header streams have already been allocated.
+        when(shardSyncState.createDirectory(1, 1)).thenThrow(new RuntimeException("simulated failure while building directory"));
+
+        NodeTranslogBuffer translogBuffer = new NodeTranslogBuffer(bigArrays, 1000);
+        assertTrue(translogBuffer.writeToBuffer(shardSyncState, serialized(new byte[40]), 1, new Translog.Location(0, 0, 50)));
+
+        var e = expectThrows(RuntimeException.class, () -> translogBuffer.complete(1, Set.of(shardSyncState)));
+        assertThat(e.getMessage(), equalTo("simulated failure while building directory"));
+
+        assertThat("streams allocated in complete() must be released when it throws", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testStreamsAreReleasedWhenThereIsNoDataToSync() throws IOException {
+        CircuitBreakerService breakerService = LimitedBreaker.service(CircuitBreaker.REQUEST, ByteSizeValue.ofMb(1));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        BigArrays bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), breakerService);
+
+        // The shard has buffered data but is not part of the active shards passed to complete(), so dataToSync stays false.
+        ShardSyncState inactiveShard = mock(ShardSyncState.class);
+        when(inactiveShard.getShardId()).thenReturn(new ShardId("inactive", "_na_", 0));
+
+        NodeTranslogBuffer translogBuffer = new NodeTranslogBuffer(bigArrays, 1000);
+        assertTrue(translogBuffer.writeToBuffer(inactiveShard, serialized(new byte[40]), 1, new Translog.Location(0, 0, 50)));
+
+        assertNull(translogBuffer.complete(0, Collections.emptySet()));
+
+        assertThat("streams allocated in complete() must be released on the no-data path", breaker.getUsed(), equalTo(0L));
     }
 
     private Translog.Serialized serialized(byte[] source) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fixing StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest() (#149429)