### PR TITLE
[9.5] ESQL: decouple type-check exactness from pushdown exactness (#156980)

### DIFF
--- a/docs/changelog/156980.yaml
+++ b/docs/changelog/156980.yaml
@@ -1,0 +1,6 @@
+pr: 156980
+summary: Decouple type-check exactness from pushdown exactness for fused block-loader
+  functions
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/FunctionEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/FunctionEsField.java
@@ -71,14 +71,14 @@ public class FunctionEsField extends EsField {
         return Objects.hash(super.hashCode(), functionConfig);
     }
 
-    @Override
-    public Exact getExactInfo() {
-        /*
-         * We force and "inexact" field info to prevent pushing
-         * expressions like `WHERE LENGTH(kwd) > 2`. `LENGTH(kwd)`
-         * is a `FunctionEsField` which *looks* pushable without
-         * the inexact match.
-         */
-        return new Exact(false, "merged with " + functionConfig.function());
-    }
+    /*
+     * Note on exactness: a FunctionEsField carries an exact, non-analyzed value produced by the block
+     * loader (e.g. the keyword extracted by field_extract, or the integer from LENGTH), so it reports
+     * itself as exact via the inherited getExactInfo(). That lets consuming functions which type-check
+     * their arguments with isStringAndExact (DATE_UNIT_COUNT, DATE_FORMAT, DATE_PARSE, CIDR_MATCH, ...)
+     * stay resolved after fusion. Pushdown eligibility is a separate concern: there is no indexed Lucene
+     * field behind a FunctionEsField, so predicates and TopN over it must not be pushed. That is enforced
+     * explicitly in LucenePushdownPredicates / BinarySpatialFunction by excluding FunctionEsField rather
+     * than by overloading exactness here.
+     */
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
@@ -321,7 +322,13 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
     }
 
     private static boolean isPushableSpatialAttribute(Expression exp, LucenePushdownPredicates p) {
-        return exp instanceof FieldAttribute fa && DataType.isSpatial(fa.dataType()) && fa.getExactInfo().hasExact() && p.isIndexed(fa);
+        // A FunctionEsField is synthesized by the block loader and has no indexed Lucene field behind it, so it must not be pushed,
+        // even though it now reports itself as exact (see FunctionEsField).
+        return exp instanceof FieldAttribute fa
+            && fa.field() instanceof FunctionEsField == false
+            && DataType.isSpatial(fa.dataType())
+            && fa.getExactInfo().hasExact()
+            && p.isIndexed(fa);
     }
 
     private static boolean isPushableLiteralAttribute(Expression exp) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/LucenePushdownPredicates.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TypedAttribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedKeywordEsField;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
@@ -94,10 +95,13 @@ public interface LucenePushdownPredicates {
      * support it, and relying on the compute engine for the nodes that do not.
      */
     default boolean isPushableFieldAttribute(Expression exp) {
-        // Potentially unmapped fields are not pushabled: the field may be unmapped on some shards, and pushing down would produce wrong
+        // Potentially unmapped fields are not pushable: the field may be unmapped on some shards, and pushing down would produce wrong
         // results (e.g., missing rows when the predicate is pushed to Lucene).
+        // FunctionEsField values are synthesized by the block loader (e.g. LENGTH(kwd), field_extract(...)); there is no indexed Lucene
+        // field behind them, so predicates and TopN over them must stay in the compute engine even though they are exact values.
         if (exp instanceof FieldAttribute fa
             && fa.field() instanceof PotentiallyUnmappedKeywordEsField == false
+            && fa.field() instanceof FunctionEsField == false
             && fa.getExactInfo().hasExact()
             && isIndexedAndHasDocValues(fa)) {
             return fa.dataType() != DataType.TEXT || hasExactSubfield(fa);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractPushdownTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractPushdownTests.java
@@ -14,10 +14,13 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
 import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression.PushedBlockLoaderExpression;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
 import java.util.Collections;
@@ -109,6 +112,31 @@ public class FieldExtractPushdownTests extends ESTestCase {
 
         assertNotNull(pushed);
         assertEquals(new ExtractFlattenedSubfieldConfig(dottedKey), pushed.config());
+    }
+
+    public void testFusedFieldExtractIsExactForTypeChecksButNotPushable() {
+        // When field_extract fuses, PushExpressionsToFieldLoad replaces the call with a FieldAttribute backed by a
+        // FunctionEsField. Consumers that type-check an argument with isStringAndExact (DATE_UNIT_COUNT, DATE_FORMAT,
+        // DATE_PARSE, CIDR_MATCH, ...) must stay resolved after that swap: the fused value is an exact keyword produced
+        // by the block loader. Previously FunctionEsField reported itself as inexact (to block pushdown), which also
+        // failed those type-checks and left the consumer unresolved, tripping plan verification. Exactness for
+        // type-checks is now decoupled from pushdown eligibility.
+        FunctionEsField fused = new FunctionEsField(
+            FLATTENED_ROOT.field(),
+            DataType.KEYWORD,
+            new ExtractFlattenedSubfieldConfig("host.name")
+        );
+        FieldAttribute fa = new FieldAttribute(Source.EMPTY, "host.name", fused);
+
+        assertTrue("a fused field_extract value is an exact keyword for type-checks", fa.getExactInfo().hasExact());
+        assertTrue(
+            "isStringAndExact must accept a fused field_extract argument",
+            TypeResolutions.isStringAndExact(fa, "TEST", TypeResolutions.ParamOrdinal.FIRST).resolved()
+        );
+        assertFalse(
+            "there is no indexed Lucene field behind a FunctionEsField, so it must not be pushable",
+            LucenePushdownPredicates.DEFAULT.isPushableFieldAttribute(fa)
+        );
     }
 
     private static FieldAttribute flattenedField(String name) {


### PR DESCRIPTION
Backport of #156980 to `9.5`.

Fixes an ES|QL physical-optimization correctness bug: fusing `field_extract(...)` into an argument that is type-checked with `isStringAndExact` (`DATE_UNIT_COUNT`, `DATE_FORMAT`, `DATE_PARSE`, `CIDR_MATCH`, `NetworkDirection`, `Split`, `DateExtract`, LIKE/RLIKE) left the consuming expression unresolved, tripping post-optimization plan verification.

A single signal — `EsField.getExactInfo().hasExact()` — was overloaded for two unrelated jobs: type-check exactness (is this a non-analyzed string value?) and pushdown exactness (is there an indexed Lucene field to push to?). A fused `field_extract` is backed by a `FunctionEsField`, which *is* an exact keyword but has no indexed field behind it. It previously reported itself inexact purely to block pushdown, which also (incorrectly) failed the type-checks.

This decouples the two:
- Drop the `FunctionEsField.getExactInfo()` override so it reports as exact → consumers stay resolved after fusion.
- Block pushdown explicitly by excluding `FunctionEsField` in `LucenePushdownPredicates` / `BinarySpatialFunction`.

`field_extract` is tech-preview on 9.5 (`preview = true`), and its fusion into exact-string arguments is reachable on this branch, so the correctness fix applies.

## Backport notes

- The three production changes and the changelog cherry-picked cleanly.
- The upstream regression test lives in `PushExpressionsToFieldLoadTests` and relies on flattened planner-test scaffolding that does not exist on 9.5 (9.5 keeps `field_extract` fusion tests in a separate `FieldExtractPushdownTests`). The test was therefore adapted to `FieldExtractPushdownTests`: it builds the `FunctionEsField` the fusion rule produces (`ExtractFlattenedSubfieldConfig`) and asserts the fused attribute (a) passes `isStringAndExact` — the actual regression — and (b) is still not pushable. This fails on unpatched 9.5 and passes with the fix.

## Test plan

- [x] `:x-pack:plugin:esql:test --tests "*.FieldExtractPushdownTests"`

Made with [Cursor](https://cursor.com)