### PR TITLE
[9.5] Grant Fleet profiling queue cleanup permissions (#155440)

### DIFF
--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -5,5 +5,6 @@ dependencies {
   javaRestTestImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':x-pack:plugin:security')
   clusterModules(project(":modules:analysis-common"))
+  clusterModules(project(":modules:reindex"))
   clusterModules(project(":modules:rest-root"))
 }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.SecureString;
@@ -142,6 +143,17 @@ public class ServiceAccountIT extends ESRestTestCase {
                   "privileges": [
                     "read",
                     "write"
+                  ],
+                  "allow_restricted_indices": false
+                },
+                {
+                  "names": [
+                    ".profiling-sq-*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "maintenance"
                   ],
                   "allow_restricted_indices": false
                 },
@@ -411,6 +423,7 @@ public class ServiceAccountIT extends ESRestTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .nodes(2)
         .module("analysis-common")
+        .module("reindex")
         .module("rest-root")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
@@ -760,6 +773,126 @@ public class ServiceAccountIT extends ESRestTestCase {
         assertThat(invalidateApiKeysResponseMap.get("invalidated_api_keys"), equalTo(List.of(apiKeyId1)));
 
         assertApiKeys(apiKeyId1, "key-1", true, requestOptions);
+    }
+
+    public void testFleetServerApiKeyCanDeleteByQueryFromProfilingQueueAlias() throws IOException {
+        final String concreteIndex = ".profiling-sq-leafframes-v001";
+        final String queueAlias = "profiling-sq-leafframes";
+        final Request createIndexRequest = new Request("PUT", "/" + concreteIndex);
+        createIndexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+        createIndexRequest.setJsonEntity(Strings.format("""
+            {
+              "aliases": {
+                "%s": {
+                  "is_write_index": true
+                }
+              }
+            }""", queueAlias));
+        assertOK(adminClient().performRequest(createIndexRequest));
+
+        String legacyApiKeyId = null;
+        String apiKeyId = null;
+        try {
+            final Request indexDocumentRequest = new Request("PUT", "/" + queueAlias + "/_doc/stale?refresh=true");
+            indexDocumentRequest.setJsonEntity("""
+                {
+                  "Time": {
+                    "created": 0
+                  }
+                }""");
+            assertOK(adminClient().performRequest(indexDocumentRequest));
+
+            final Map<String, Object> legacyApiKeyResponse = createProfilingApiKey(false);
+            legacyApiKeyId = (String) legacyApiKeyResponse.get("id");
+            final ResponseException bulkAuthorizationFailure = expectThrows(
+                ResponseException.class,
+                () -> client().performRequest(deleteByQueryRequest(queueAlias, encodeApiKey(legacyApiKeyResponse)))
+            );
+            assertThat(bulkAuthorizationFailure.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            assertThat(bulkAuthorizationFailure.getMessage(), containsString("action [indices:data/write/bulk[s]] is unauthorized"));
+            assertThat(bulkAuthorizationFailure.getMessage(), containsString("on indices [.profiling-sq-leafframes-v001]"));
+
+            final Map<String, Object> createApiKeyResponse = createProfilingApiKey(true);
+            apiKeyId = (String) createApiKeyResponse.get("id");
+            final Map<String, Object> deleteByQueryResponse = responseAsMap(
+                client().performRequest(deleteByQueryRequest(queueAlias, encodeApiKey(createApiKeyResponse)))
+            );
+            assertThat(deleteByQueryResponse.get("deleted"), equalTo(1));
+            assertThat(deleteByQueryResponse.get("failures"), equalTo(List.of()));
+        } finally {
+            if (legacyApiKeyId != null) {
+                invalidateApiKey(legacyApiKeyId);
+            }
+            if (apiKeyId != null) {
+                invalidateApiKey(apiKeyId);
+            }
+            final Request deleteIndexRequest = new Request("DELETE", "/" + concreteIndex);
+            deleteIndexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+            assertOK(adminClient().performRequest(deleteIndexRequest));
+        }
+    }
+
+    private Map<String, Object> createProfilingApiKey(boolean grantQueuePrivileges) throws IOException {
+        final Request createApiKeyRequest = new Request("PUT", "/_security/api_key");
+        createApiKeyRequest.setJsonEntity(grantQueuePrivileges ? """
+            {
+              "name": "profiling-symbolizer-queue-fixed",
+              "role_descriptors": {
+                "profiling-symbolizer": {
+                  "indices": [
+                    {
+                      "names": [ "profiling-*" ],
+                      "privileges": [ "read", "write" ]
+                    },
+                    {
+                      "names": [ ".profiling-sq-*" ],
+                      "privileges": [ "read", "write", "maintenance" ]
+                    }
+                  ]
+                }
+              }
+            }""" : """
+            {
+              "name": "profiling-symbolizer-queue-legacy",
+              "role_descriptors": {
+                "profiling-symbolizer": {
+                  "indices": [
+                    {
+                      "names": [ "profiling-*" ],
+                      "privileges": [ "read", "write" ]
+                    }
+                  ]
+                }
+              }
+            }""");
+        createApiKeyRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Bearer " + VALID_SERVICE_TOKEN));
+        return responseAsMap(client().performRequest(createApiKeyRequest));
+    }
+
+    private static String encodeApiKey(Map<String, Object> apiKeyResponse) {
+        return Base64.getEncoder()
+            .encodeToString((apiKeyResponse.get("id") + ":" + apiKeyResponse.get("api_key")).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Request deleteByQueryRequest(String queueAlias, String encodedApiKey) {
+        final Request request = new Request("POST", "/" + queueAlias + "/_delete_by_query?refresh=true");
+        request.setJsonEntity("""
+            {
+              "query": {
+                "match_all": {}
+              }
+            }""");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "ApiKey " + encodedApiKey));
+        return request;
+    }
+
+    private void invalidateApiKey(String apiKeyId) throws IOException {
+        final Request request = new Request("DELETE", "/_security/api_key");
+        request.setJsonEntity(Strings.format("""
+            {
+              "ids": [ "%s" ]
+            }""", apiKeyId));
+        assertOK(adminClient().performRequest(request));
     }
 
     private void assertApiKeys(String apiKeyId, String name, boolean invalidated, RequestOptions.Builder requestOptions)

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -62,6 +62,8 @@ final class ElasticServiceAccounts {
                     .privileges("write", "create_index", "auto_configure")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("profiling-*").privileges("read", "write").build(),
+                // Symbolizer uses delete-by-query with refresh enabled when cleaning stale queue documents.
+                RoleDescriptor.IndicesPrivileges.builder().indices(".profiling-sq-*").privileges("read", "write", "maintenance").build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     // APM Server (and hence Fleet Server, which issues its API Keys) needs additional privileges
                     // for the non-sensitive "sampled traces" data stream:

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -245,7 +245,27 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         assertThat(role.indices().allowedIndicesMatcher(TransportMultiGetAction.NAME).test(profilingIndex), is(true));
         assertThat(role.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(profilingIndex), is(true));
         assertThat(role.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(profilingIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(RefreshAction.NAME).test(profilingIndex), is(false));
         assertThat(role.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(profilingIndex), is(false));
+
+        List.of(
+            ".profiling-sq-leafframes-v" + randomAlphaOfLengthBetween(1, 20),
+            ".profiling-sq-executables-v" + randomAlphaOfLengthBetween(1, 20)
+        ).stream().map(this::mockIndexAbstraction).forEach(queueIndex -> {
+            assertThat(role.indices().allowedIndicesMatcher(TransportAutoPutMappingAction.TYPE.name()).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(queueIndex), is(false));
+            assertThat(role.indices().allowedIndicesMatcher(TransportDeleteAction.NAME).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportCreateIndexAction.TYPE.name()).test(queueIndex), is(false));
+            assertThat(role.indices().allowedIndicesMatcher(TransportIndexAction.NAME).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportBulkAction.NAME).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportDeleteIndexAction.TYPE.name()).test(queueIndex), is(false));
+            assertThat(role.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportMultiGetAction.NAME).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(RefreshAction.NAME).test(queueIndex), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(queueIndex), is(false));
+        });
 
         List.of("synthetics-" + randomAlphaOfLengthBetween(1, 20)).stream().map(this::mockIndexAbstraction).forEach(index -> {
             assertThat(role.indices().allowedIndicesMatcher(TransportAutoPutMappingAction.TYPE.name()).test(index), is(true));


### PR DESCRIPTION
# Backport
Backport of https://github.com/elastic/elasticsearch/pull/155440


Automation failed I needed to run `npx backport --pr 155440`