### PR TITLE
Unmute LogsdbTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -744,8 +744,6 @@ tests:
 - class: org.elasticsearch.xpack.core.transform.action.ResetTransformActionRequestTests
   method: testCloudCredentialRoundTripPreservesValue
   issue: https://github.com/elastic/elasticsearch/issues/156851
-- class: org.elasticsearch.xpack.logsdb.LogsdbTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/156852
 - class: org.elasticsearch.cluster.action.shard.ShardStartedTaskExecutorTests
   issue: https://github.com/elastic/elasticsearch/issues/156853
 - class: org.elasticsearch.common.util.BigArraysTests


### PR DESCRIPTION
Tests were muted due to failures on the `java-ea` task. The failures seem infra-related, and so this test shouldn't be muted on main.

Fixes #156852