### PR TITLE
unmute synthetic vs columnar stored source tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -499,9 +499,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.RestartIT
   method: testRestart {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/155609
-- class: org.elasticsearch.index.mapper.SyntheticVersusColumnarStoredSourceIT
-  method: testMultiValueViolationRestoredIdenticallyAcrossSourceModes
-  issue: https://github.com/elastic/elasticsearch/issues/155610
 - class: org.elasticsearch.xpack.slm.SLMStatDisruptionIT
   method: testCurrentlyRunningSnapshotNotRecordedAsFailure
   issue: https://github.com/elastic/elasticsearch/issues/155621
@@ -711,9 +708,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test {feature:PARQUET_DATASET}
   issue: https://github.com/elastic/elasticsearch/issues/156789
-- class: org.elasticsearch.index.mapper.SyntheticVersusColumnarStoredSourceIT
-  method: testFallbackMultiValueViolationRestoredIdenticallyAcrossSourceModes
-  issue: https://github.com/elastic/elasticsearch/issues/156830
 - class: org.elasticsearch.xpack.logsdb.qa.StandardVersusLogsdbFieldLevelSecurityChallengeRestIT
   method: testFieldLevelSecuritySourceEquivalence
   issue: https://github.com/elastic/elasticsearch/issues/156629


### PR DESCRIPTION
these failures were fixed in https://github.com/elastic/elasticsearch/pull/156447/changes/897f8de1dd8cd536a568b4c0e92b761d838cc4ac

/closes https://github.com/elastic/elasticsearch/issues/156830