### PR TITLE
[9.5] Skip negative number_of_fragments test in mixed-cluster BWC runs (#156783)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -89,6 +89,13 @@ excludeList.add("cat.shards/10_basic/Help")
 // so the circuit breaker limit is never enforced and sub-search 1 succeeds instead of returning 429.
 excludeList.add('msearch/50_circuit_breaker/msearch circuit breaker trips and returns failure item without aborting the request')
 
+excludeList.add('search.highlight/70_number_of_fragments/number_of_fragments above the maximum should FAIL')
+excludeList.add('search.highlight/70_number_of_fragments/negative number_of_fragments should FAIL')
+excludeList.add('search.highlight/70_number_of_fragments/raising index.highlight.max_number_of_fragments should allow more fragments')
+excludeList.add(
+  'search.highlight/70_number_of_fragments/lowering index.highlight.max_number_of_fragments should reject the default number of fragments'
+)
+
 def clusterPath = getPath()
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Skip negative number_of_fragments test in mixed-cluster BWC runs (#156783)](https://github.com/elastic/elasticsearch/pull/156783)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)