### PR TITLE
[9.3] Skip negative number_of_fragments test in mixed-cluster BWC runs (#156783)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -367,18 +367,12 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: initializationError
   issue: https://github.com/elastic/elasticsearch/issues/156737
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.highlight/70_number_of_fragments/number_of_fragments above the maximum should FAIL}
-  issue: https://github.com/elastic/elasticsearch/issues/156739
 - class: org.elasticsearch.join.ParentChildClientYamlTestSuiteIT
   method: test {yaml=/20_parent_join/join field named _type is not returned as root metadata}
   issue: https://github.com/elastic/elasticsearch/issues/156742
 - class: org.elasticsearch.join.ParentChildClientYamlTestSuiteIT
   method: test {yaml=/20_parent_join/keyword field named _type is not returned as root metadata}
   issue: https://github.com/elastic/elasticsearch/issues/156743
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.highlight/70_number_of_fragments/negative number_of_fragments should FAIL}
-  issue: https://github.com/elastic/elasticsearch/issues/155977
 
 # Examples:
 #

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -71,6 +71,13 @@ excludeList.add('aggregations/percentiles_hdr_metric/Negative values test')
 // sync_id is removed in 9.0
 excludeList.add("cat.shards/10_basic/Help")
 
+excludeList.add('search.highlight/70_number_of_fragments/number_of_fragments above the maximum should FAIL')
+excludeList.add('search.highlight/70_number_of_fragments/negative number_of_fragments should FAIL')
+excludeList.add('search.highlight/70_number_of_fragments/raising index.highlight.max_number_of_fragments should allow more fragments')
+excludeList.add(
+  'search.highlight/70_number_of_fragments/lowering index.highlight.max_number_of_fragments should reject the default number of fragments'
+)
+
 def clusterPath = getPath()
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Skip negative number_of_fragments test in mixed-cluster BWC runs (#156783)](https://github.com/elastic/elasticsearch/pull/156783)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)