### PR TITLE
ES|QL: Fix PruneColumns corrupting inner FORK branch projections

### DIFF
--- a/docs/changelog/157122.yaml
+++ b/docs/changelog/157122.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157122
+summary: Fix `PruneColumns` corrupting inner FORK branch projections
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -1469,3 +1469,30 @@ FROM employees
 max_max:integer
 5
 ;
+
+// Regression: PruneColumns used to descend past the branch root into an inner projection when the
+// branch root was not a Project (e.g. Aggregate from a double-STATS branch), silently dropping
+// columns consumed by inner nodes such as the packed dimension grouping feeding UnpackDims.
+forkWithTsDoubleStatsAndPrunedForkOutput
+required_capability: fork_v9
+required_capability: ts_command_v0
+required_capability: tdigest_time_series_metric
+required_capability: fork_prune_columns_inner_project_fix
+
+TS tdigest_timeseries_index
+| WHERE NOT STARTS_WITH(instance, "hand-rolled") AND instance != "multi-row-td"
+| FORK
+    (STATS cnt = COUNT(responseTime) BY instance | STATS cnt = MAX(cnt) BY instance)
+    (STATS cnt = COUNT(responseTime) BY instance)
+| KEEP _fork, instance, cnt
+| SORT _fork, instance
+;
+
+_fork:keyword | instance:keyword | cnt:long
+fork1         | instance-0       | 8841
+fork1         | instance-1       | 3250
+fork1         | instance-2       | 3380
+fork2         | instance-0       | 8841
+fork2         | instance-1       | 3250
+fork2         | instance-2       | 3380
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -3700,6 +3700,15 @@ public class EsqlCapabilities {
          */
         FIX_PARTIAL_PREFIX_COMPOUND_TOPN_PUSHDOWN,
 
+        /**
+         * Fix for {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneColumns} descending into an inner
+         * projection when restricting the output of a {@code FORK} branch whose root is not a {@code Project} — for
+         * example a branch ending in {@code STATS}, which leaves an {@code Aggregate} on top. The misdirected filter
+         * could drop columns consumed by inner nodes such as the packed dimension grouping feeding
+         * {@code UnpackDims}, causing {@code Plan [...] optimized incorrectly due to missing references}.
+         */
+        FORK_PRUNE_COLUMNS_INNER_PROJECT_FIX,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -38,7 +38,11 @@ import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneEmptyPlans.skipPlan;
@@ -326,20 +330,9 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                 var outputAttrs = localRelation.output().stream().filter(x -> forkOutputNames.contains(x.name())).toList();
                 newSubPlan = new LocalRelation(localRelation.source(), outputAttrs, localRelation.supplier());
             } else {
-                // otherwise, we first prune the projections of the top-level Project of each subplan
+                // otherwise, we first restrict the subplan's own output to the pruned fork output
                 subPlan.outputSet().stream().filter(x -> forkOutputNames.contains(x.name())).forEach(usedAttrs::add);
-
-                Holder<Boolean> projectVisited = new Holder<>(false);
-                newSubPlan = subPlan.transformDown(Project.class, p -> {
-                    if (projectVisited.get()) {
-                        return p;
-                    }
-                    projectVisited.set(true);
-                    // filter projections based on fork output attributes
-                    var prunedAttrs = p.projections().stream().filter(x -> forkOutputNames.contains(x.name())).toList();
-                    return new Project(p.source(), p.child(), prunedAttrs);
-                });
-                newSubPlan = pruneColumns(newSubPlan, usedAttrs, false);
+                newSubPlan = pruneColumns(restrictBranchOutput(subPlan, prunedForkAttrs, forkOutputNames), usedAttrs, false);
             }
             if (false == newSubPlan.equals(subPlan)) {
                 subPlanChanged = true;
@@ -350,6 +343,37 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
             fork = fork.replaceSubPlansAndOutput(newChildren, prunedForkAttrs);
         }
         return fork;
+    }
+
+    /**
+     * Restricts a Fork branch's output to the (already pruned) Fork output columns. Matching is by name because a branch
+     * and the Fork output never share attribute ids.
+     * <p>
+     * Only the branch's own output node is rewritten. Descending to the first {@link Project} instead would corrupt any
+     * branch whose root is not a Project - for instance one ending in {@code STATS}, which leaves an
+     * {@link Aggregate} on top. The filter would then apply to an internal projection and drop columns that are not part
+     * of the Fork's user-visible output but are still consumed inside the branch, such as the packed dimensions feeding
+     * {@link org.elasticsearch.xpack.esql.plan.logical.UnpackDims}.
+     */
+    private static LogicalPlan restrictBranchOutput(LogicalPlan branch, List<Attribute> forkOutput, Set<String> forkOutputNames) {
+        if (branch instanceof Project project) {
+            return new Project(
+                project.source(),
+                project.child(),
+                project.projections().stream().filter(x -> forkOutputNames.contains(x.name())).toList()
+            );
+        }
+        // Follow the Fork output order rather than the branch's own: each branch becomes a MergeExec child, and MergeExec
+        // lines a child's columns up with its output positionally, so a branch surfacing them in a different order would
+        // silently mix up columns across branches.
+        Map<String, Attribute> branchOutputByName = new LinkedHashMap<>();
+        for (Attribute attribute : branch.output()) {
+            branchOutputByName.putIfAbsent(attribute.name(), attribute);
+        }
+        List<Attribute> retained = forkOutput.stream().map(a -> branchOutputByName.get(a.name())).filter(Objects::nonNull).toList();
+        // A Project added here never compares equal to the branch it wraps, so adding one unconditionally would report a
+        // change on every pass and the rule would not converge. Only wrap when it actually changes the branch's output.
+        return retained.equals(branch.output()) ? branch : new Project(branch.source(), branch, retained);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.TsInfo;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnpackDims;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
@@ -73,6 +74,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -864,6 +866,33 @@ public class PruneColumnsTests extends AbstractLogicalPlanOptimizerTests {
                 new ReferenceAttribute(EMPTY, "gender", KEYWORD)
             )
         );
+    }
+
+    /**
+     * A branch ending in {@code STATS} has an {@link Aggregate}, not a {@link Project}, as its root. Restricting the
+     * branch output to the Fork output columns must not reach past that root into an internal projection: here the
+     * internal projection carries the packed time-series dimensions that {@code UnpackDims} above it consumes, and the
+     * second {@code STATS} is what leaves the {@code Aggregate} on top.
+     */
+    public void testPruneColumnsKeepsInternalProjectionsInForkBranchEndingInStats() {
+        var query = """
+            TS k8s
+            | FORK
+                (STATS latest = AVG(AVG_OVER_TIME(network.eth0.rx)) BY pod | STATS latest = MAX(latest) BY pod)
+                (STATS latest = AVG(AVG_OVER_TIME(network.eth0.rx)) BY pod | STATS latest = MAX(latest) BY pod)
+            | KEEP pod, latest
+            """;
+
+        var plan = planMetrics(query);
+
+        var fork = as(as(as(plan, Project.class).child(), Limit.class).child(), Fork.class);
+        assertThat(Expressions.names(fork.output()), containsInAnyOrder("pod", "latest"));
+        for (LogicalPlan branch : fork.children()) {
+            var unpackDims = branch.collectFirstChildren(p -> p instanceof UnpackDims);
+            assertThat(unpackDims, hasSize(1));
+            var unpack = as(unpackDims.get(0), UnpackDims.class);
+            assertThat(unpack.child().outputSet(), hasItem(unpack.packed()));
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

`PruneColumns.pruneColumnsInFork` used `transformDown(Project.class, …)` to restrict a FORK branch's output to the fork's visible columns. When a branch root was not a `Project` — for example a branch ending in a double `STATS` whose alignment `Project` had been merged away by `CombineProjections` — the traversal descended past the branch root into internal projections and silently dropped columns consumed by inner nodes.

The missing column was typically `_$packed_grouping_dims`, the packed time-series dimension grouping that `UnpackDims` reads. Its removal caused `Plan […] optimized incorrectly due to missing references` on `FORK` queries against time-series indices.

Fix: replace the `transformDown` approach with `restrictBranchOutput`, which only touches the branch root. If the root is a `Project`, its projections are filtered in-place. If the root is anything else (e.g. `Aggregate`), a new wrapping `Project` is inserted that restricts output to the fork's visible columns, following fork-output order to preserve `MergeExec`'s positional column alignment.

**Note:** this bug requires a double-`STATS` branch (the second `STATS` is what allows `CombineProjections` to merge the alignment `Project` cleanly, leaving an `Aggregate` as branch root). It was found during investigation of elastic/incident-management#2704; the actual cause of that incident is tracked separately.

## Test plan

- [x] Unit regression test in `PruneColumnsTests`: verifies that after optimization each branch's `UnpackDims` node still has `_$packed_grouping_dims` in its child's output
- [x] csv-spec regression test `forkWithTsDoubleStatsAndPrunedForkOutput` in `fork.csv-spec`: exercises FORK with a double-STATS TS branch against `tdigest_timeseries_index`; gated on `fork_prune_columns_inner_project_fix`
- [x] All existing optimizer and csv-spec suites green

Relates to elastic/incident-management#2704.