### PR TITLE
[9.4] Fix RateTests for subsecond intervals

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -149,18 +149,6 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=search.vectors/131_knn_query_nested_inner_hits_score/nested kNN inner_hits are scored like the query phase on a quantized field}
   issue: https://github.com/elastic/elasticsearch/issues/156759
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<positive longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/156838
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<big positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/156839
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<small positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/156840
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<positive ints>}
-  issue: https://github.com/elastic/elasticsearch/issues/156841
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValuesByteRefGroupingAggregatorFunctionTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/155069

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
@@ -122,6 +122,12 @@ public class RateTests extends AbstractAggregationTestCase {
                 DataType.LONG,
                 "_max_timestamp"
             );
+            List<Long> nonNullTimestamps = new ArrayList<>();
+            for (int i = 0; i < dataRows.size(); i++) {
+                if (dataRows.get(i) != null) {
+                    nonNullTimestamps.add(timestamps.get(timestamps.size() - i - 1));
+                }
+            }
             dataRows = dataRows.stream().filter(Objects::nonNull).toList();
             final Matcher<?> matcher;
             if (dataRows.size() < 2) {
@@ -142,6 +148,10 @@ public class RateTests extends AbstractAggregationTestCase {
                 // If the minrate is greater than 0, we need to adjust the maxrate accordingly
                 minrate = Math.min(minrate, 0);
                 maxrate = Math.max(maxrate, maxrate - minrate);
+                long timeRangeMillis = nonNullTimestamps.getFirst() - nonNullTimestamps.getLast();
+                if (timeRangeMillis < 1000) {
+                    maxrate *= 1000.0 / timeRangeMillis;
+                }
                 matcher = Matchers.allOf(Matchers.greaterThanOrEqualTo(minrate), Matchers.lessThanOrEqualTo(maxrate));
             }
             return new TestCaseSupplier.TestCase(


### PR DESCRIPTION
Fixes #156838
Fixes #156839
Fixes #156840
Fixes #156841

Fixes the same root cause https://github.com/elastic/elasticsearch/pull/150575 already fixed for 9.5+: If our time interval is smaller than one second, the `rate` can actually exceed the absolute counter increase. We can't just backport https://github.com/elastic/elasticsearch/pull/150575, as in the meantime temporality was introduced and substantially changed the test code.