### PR TITLE
Unmute ClientYamlTestSuiteIT 131_knn_query_nested_inner_hits_score

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -690,9 +690,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/160_union_types/CASE}
   issue: https://github.com/elastic/elasticsearch/issues/156729
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/131_knn_query_nested_inner_hits_score/nested kNN inner_hits are scored like the query phase on a quantized field}
-  issue: https://github.com/elastic/elasticsearch/issues/156753
 - class: org.elasticsearch.xpack.inference.common.amazon.AwsSecretSettingsTests
   method: testSerialization
   issue: https://github.com/elastic/elasticsearch/issues/156776


### PR DESCRIPTION
this unmutes ClientYamlTestSuiteIT {yaml=search.vectors/131_knn_query_nested_inner_hits_score/*}, see https://github.com/elastic/elasticsearch/issues/156737


Closes #156753