### PR TITLE
[9.5] Deprecate legacy monitoring REST apis.  (#152269)

### DIFF
--- a/docs/changelog/152269.yaml
+++ b/docs/changelog/152269.yaml
@@ -1,0 +1,14 @@
+area: "Monitoring"
+deprecation:
+  area: "REST API"
+  details: The `_monitoring/bulk` and `_monitoring/migrate/alerts` REST APIs, used
+    by the legacy internal collection method for Stack Monitoring, are deprecated
+    and will be removed in Elasticsearch 10.0.
+  impact: Users relying on internal collection for Stack Monitoring should migrate
+    to Metricbeat or Elastic Agent based monitoring. Calling either endpoint now
+    returns a deprecation warning.
+  title: Deprecate legacy monitoring REST apis.
+issues: []
+pr: 152269
+summary: Deprecate legacy monitoring REST apis.
+type: deprecation

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -5,6 +5,10 @@
       "description": "Send monitoring data"
     },
     "stability": "stable",
+    "deprecated": {
+      "version": "9.6.0",
+      "description": "Legacy monitoring is deprecated and will be removed in Elasticsearch 10.0."
+    },
     "visibility": "private",
     "headers": {
       "accept": [

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -207,6 +207,8 @@ tasks.named("yamlRestCompatTestTransform").configure(
     )
     task.skipTest("esql/180_match_operator/match on eval column", "Match works now with non-mapped columns")
     task.skipTest("esql/180_match_operator/match on overwritten column", "Match works now with non-mapped columns")
+    // Expected deprecation warning to compat yaml tests:
+    task.addAllowedWarningRegex("Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10\\.0\\.")
   }
 )
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
@@ -10,6 +10,9 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -34,6 +37,10 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestMonitoringBulkAction extends BaseRestHandler {
 
+    static final String DEPRECATION_MESSAGE = "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0.";
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestMonitoringBulkAction.class);
+
     public static final String MONITORING_ID = "system_id";
     public static final String MONITORING_VERSION = "system_api_version";
     public static final String INTERVAL = "interval";
@@ -54,7 +61,10 @@ public class RestMonitoringBulkAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_monitoring/bulk"), new Route(PUT, "/_monitoring/bulk"));
+        return List.of(
+            Route.builder(POST, "/_monitoring/bulk").deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build(),
+            Route.builder(PUT, "/_monitoring/bulk").deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build()
+        );
     }
 
     @Override
@@ -64,6 +74,8 @@ public class RestMonitoringBulkAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        // record a critical deprecation, the REST framework will only emit a warning
+        deprecationLogger.critical(DeprecationCategory.API, "monitoring-bulk-deprecated", DEPRECATION_MESSAGE);
 
         final String id = request.param(MONITORING_ID);
         if (Strings.isEmpty(id)) {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsAction.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.monitoring.rest.action;
 
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
@@ -27,9 +30,16 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestMonitoringMigrateAlertsAction extends BaseRestHandler {
 
+    static final String DEPRECATION_MESSAGE =
+        "Legacy monitoring API _monitoring/migrate/alerts is deprecated for removal in Elasticsearch 10.0.";
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestMonitoringMigrateAlertsAction.class);
+
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/_monitoring/migrate/alerts"));
+        return List.of(
+            Route.builder(POST, "/_monitoring/migrate/alerts").deprecatedForRemoval(DEPRECATION_MESSAGE, RestApiVersion.V_9).build()
+        );
     }
 
     @Override
@@ -39,6 +49,7 @@ public class RestMonitoringMigrateAlertsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        deprecationLogger.critical(DeprecationCategory.API, "monitoring-migrate-alerts-deprecated", DEPRECATION_MESSAGE);
         MonitoringMigrateAlertsRequest migrateRequest = new MonitoringMigrateAlertsRequest();
         return channel -> client.execute(MonitoringMigrateAlertsAction.INSTANCE, migrateRequest, getRestBuilderListener(channel));
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
@@ -11,7 +11,9 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestHandler.Route;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -46,6 +48,14 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
         assertThat(action.getName(), is("monitoring_bulk"));
     }
 
+    public void testRoutesAreDeprecatedForRemoval() {
+        for (Route route : action.routes()) {
+            assertTrue(route.isDeprecated());
+            assertThat(route.getDeprecationMessage(), is(RestMonitoringBulkAction.DEPRECATION_MESSAGE));
+            assertEquals(RestApiVersion.current(), route.getRestApiVersion());
+        }
+    }
+
     public void testSupportsBulkContent() {
         // if you change this, it's a very breaking change for Monitoring
         final var route = action.routes().get(0);
@@ -67,6 +77,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
 
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> prepareRequest(restRequest));
         assertThat(exception.getMessage(), containsString("no [system_id] for monitoring bulk request"));
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testMissingSystemApiVersion() {
@@ -74,6 +85,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
 
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> prepareRequest(restRequest));
         assertThat(exception.getMessage(), containsString("no [system_api_version] for monitoring bulk request"));
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testMissingInterval() {
@@ -81,6 +93,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
 
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> prepareRequest(restRequest));
         assertThat(exception.getMessage(), containsString("no [interval] for monitoring bulk request"));
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testWrongInterval() {
@@ -88,6 +101,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
 
         final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> prepareRequest(restRequest));
         assertThat(exception.getMessage(), containsString("failed to parse setting [interval] with value [null]"));
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testMissingContent() {
@@ -95,6 +109,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
 
         final ElasticsearchParseException exception = expectThrows(ElasticsearchParseException.class, () -> prepareRequest(restRequest));
         assertThat(exception.getMessage(), containsString("no body content for monitoring bulk request"));
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testUnsupportedSystemVersion() {
@@ -106,6 +121,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
             exception.getMessage(),
             containsString("system_api_version [" + systemApiVersion + "] is not supported by system_id [unknown]")
         );
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testUnknownSystemVersion() {
@@ -117,6 +133,7 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
             exception.getMessage(),
             containsString("system_api_version [0] is not supported by system_id [" + system.getSystem() + "]")
         );
+        assertWarnings(RestMonitoringBulkAction.DEPRECATION_MESSAGE);
     }
 
     public void testNoErrors() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsActionTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.monitoring.rest.action;
 
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestHandler.Route;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -35,6 +37,14 @@ public class RestMonitoringMigrateAlertsActionTests extends ESTestCase {
 
     public void testGetName() {
         assertThat(action.getName(), is("monitoring_migrate_alerts"));
+    }
+
+    public void testRoutesAreDeprecatedForRemoval() {
+        for (Route route : action.routes()) {
+            assertTrue(route.isDeprecated());
+            assertThat(route.getDeprecationMessage(), is(RestMonitoringMigrateAlertsAction.DEPRECATION_MESSAGE));
+            assertEquals(RestApiVersion.current(), route.getRestApiVersion());
+        }
     }
 
     public void testSupportsAllContentTypes() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "Bulk indexing of monitoring data":
   - skip:
-      features: ["allowed_warnings_regex"]
+      features: ["allowed_warnings_regex", "warnings"]
 
   - do:
       allowed_warnings_regex:
@@ -12,6 +12,8 @@
             xpack.monitoring.collection.enabled: true
 
   - do:
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "7"
@@ -48,6 +50,8 @@
   - match: { hits.total: 2 }
 
   - do:
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "7"
@@ -96,6 +100,8 @@
 
   # Old system_api_version should still be accepted
   - do:
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       monitoring.bulk:
         system_id:          "kibana"
         system_api_version: "6"
@@ -142,7 +148,7 @@
 ---
 "Bulk indexing of monitoring data on closed indices should throw an export exception":
   - skip:
-      features: ["allowed_warnings_regex"]
+      features: ["allowed_warnings_regex", "warnings"]
 
   - do:
       allowed_warnings_regex:
@@ -153,6 +159,8 @@
             xpack.monitoring.collection.enabled: true
 
   - do:
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       monitoring.bulk:
         system_id:          "beats"
         system_api_version: "7"
@@ -186,6 +194,8 @@
 
   - do:
       catch: /export_exception/
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       monitoring.bulk:
         system_id:          "beats"
         system_api_version: "7"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/20_privileges.yml
@@ -76,7 +76,7 @@ teardown:
 ---
 "Monitoring Bulk API":
   - skip:
-      features: ["catch_unauthorized", "allowed_warnings_regex"]
+      features: ["catch_unauthorized", "allowed_warnings_regex", "warnings"]
 
   - do:
       allowed_warnings_regex:
@@ -87,6 +87,8 @@ teardown:
             xpack.monitoring.collection.enabled: true
 
   - do:
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       headers:
         # Authorization: logstash_agent
         Authorization: "Basic bG9nc3Rhc2hfYWdlbnQ6czNrcml0LXBhc3N3b3Jk"
@@ -125,6 +127,8 @@ teardown:
 
   - do:
       catch: forbidden
+      warnings:
+        - "Legacy monitoring API _monitoring/bulk is deprecated for removal in Elasticsearch 10.0."
       headers:
         # Authorization: unknown_agent
         Authorization: "Basic dW5rbm93bl9hZ2VudDpzM2tyaXQtcGFzc3dvcmQ="


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Deprecate legacy monitoring REST apis.  (#152269)