### PR TITLE
[9.4] Fix WriteLoadConstraintDeciderIT testAverageWriteLoadMetricIsPublished test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -158,9 +158,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=indices.put_alias/all_path_options/put alias with missing name}
   issue: https://github.com/elastic/elasticsearch/issues/156886
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testAverageWriteLoadMetricIsPublished
-  issue: https://github.com/elastic/elasticsearch/issues/157125
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -668,6 +668,9 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             .build();
         final var dataNodes = internalCluster().startNodes(3, settings);
         ensureStableCluster(3);
+        // Metrics might have been computed when the cluster is still forming and hence not include
+        // all the nodes. Collect them once to enable computation again so that we get metrics for all nodes.
+        getMostRecentAverageWriteLoadMetrics();
 
         // Refresh cluster info (should trigger polling)
         refreshClusterInfo();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -667,6 +667,7 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             .put(onlyRoles(Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.INDEX_ROLE)))
             .build();
         final var dataNodes = internalCluster().startNodes(3, settings);
+        ensureStableCluster(3);
 
         // Refresh cluster info (should trigger polling)
         refreshClusterInfo();


### PR DESCRIPTION
This issue was solved by two PR in the 9.6 branch.

Backporting: https://github.com/elastic/elasticsearch/pull/152237 and https://github.com/elastic/elasticsearch/pull/145950

Closes: #157125