### PR TITLE
[9.5] [Test] Ensure write load metrics from all nodes (#152237)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -668,6 +668,9 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             .build();
         final var dataNodes = internalCluster().startNodes(3, settings);
         ensureStableCluster(3);
+        // Metrics might have been computed when the cluster is still forming and hence not include
+        // all the nodes. Collect them once to enable computation again so that we get metrics for all nodes.
+        getMostRecentAverageWriteLoadMetrics();
 
         // Refresh cluster info (should trigger polling)
         refreshClusterInfo();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Test] Ensure write load metrics from all nodes (#152237)](https://github.com/elastic/elasticsearch/pull/152237)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)