### PR TITLE
ESQL: Wires missing CI job

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/build.gradle
@@ -38,19 +38,13 @@ esqlCsvSpecTests {
 
 def currentVersion = buildParams.bwcVersions.currentVersion
 
-def currentToCurrent = tasks.register("v${currentVersion}#csvSpecTests", StandaloneRestIntegTestTask) {
+def currentToCurrent = tasks.register("csvSpecTestsCurrentToCurrent", StandaloneRestIntegTestTask) {
   systemProperty("tests.version.remote_cluster", currentVersion)
   systemProperty("tests.version.local_cluster", currentVersion)
   maxParallelForks = 1
   testClassesDirs = sourceSets.csvSpecTest.output.classesDirs
   classpath = sourceSets.csvSpecTest.runtimeClasspath
   dependsOn generateEsqlSpecTests
-}
-
-tasks.named("bwcTest").configure {
-  if (project.bwc_tests_enabled) {
-    dependsOn currentToCurrent
-  }
 }
 
 // The federation remote-dataset gates drive the federation setting on one of the two clusters: one registers a dataset
@@ -60,7 +54,7 @@ tasks.named("bwcTest").configure {
 // javaRestTest task is disabled by the bwc-test plugin, so they get their own current-to-current runner wired into
 // `check` for the configuration that always applies.
 def federationGateTestPattern = "org.elasticsearch.xpack.esql.ccq.Federation*GateRestIT"
-def federationRemoteDatasetGateTest = tasks.register("v${currentVersion}#federationRemoteDatasetGateTest", StandaloneRestIntegTestTask) {
+def federationRemoteDatasetGateTest = tasks.register("federationRemoteDatasetGateTest", StandaloneRestIntegTestTask) {
   systemProperty("tests.version.remote_cluster", currentVersion)
   systemProperty("tests.version.local_cluster", currentVersion)
   maxParallelForks = 1
@@ -72,6 +66,7 @@ def federationRemoteDatasetGateTest = tasks.register("v${currentVersion}#federat
 }
 tasks.named("check").configure {
   dependsOn federationRemoteDatasetGateTest
+  dependsOn currentToCurrent
 }
 
 def supportedVersion = bwcVersion -> {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/highlight.csv-spec
@@ -1055,6 +1055,7 @@ book_no:keyword | highlight_title:keyword
 # query matches literal terms in the returned text. Only the row containing the literal term "prosper" is highlighted.
 highlightMatchOnSemanticText
 required_capability: highlight_v6
+required_capability: semantic_text_field_caps
 
 FROM semantic_text
 | WHERE match(semantic_text_field, "prosper")
@@ -1073,6 +1074,7 @@ live long and prosper                                                 | live lon
 # MATCH_PHRASE on a semantic_text field also matches literal terms, wrapping the whole phrase in a single span.
 highlightMatchPhraseOnSemanticText
 required_capability: highlight_v6
+required_capability: semantic_text_field_caps
 
 FROM semantic_text
 | WHERE match(semantic_text_field, "prosper")


### PR DESCRIPTION
## Summary 
 `v${currentVersion}#csvSpecTests` (current-to-current multi-cluster CSV spec tests) had no CI coverage. It became clear in [this comment](https://github.com/elastic/elasticsearch/pull/156796#discussion_r3805385680) despite the CI being green.

  - The `bwcTest` aggregate task, which held the only dependsOn currentToCurrent, is never directly invoked by any CI pipeline (intake and periodic pipelines would ignore multi cluster mixing the same version here [here](https://github.com/elastic/elasticsearch/blob/4a52fc94e094a24b1bb7a5442aa47839a18ebb3a/x-pack/plugin/esql/qa/server/multi-clusters/build.gradle#L79)).
  - releaseTestCheckEsqlQa3 → releaseTestCheck → check did not include currentToCurrent. Same for `checkPart3`.
  - Task names matching `v[0-9\.]+#.*` are gated by `onlyIf { bwc_tests_enabled }` in elasticsearch.bwc-test.gradle. Since bwc_tests_enabled = false for CI split tasks (like releaseTestCheckEsqlQa3), any such task wired to check would still be skipped. Hence why I had to change the name of the task.

## Caveats

I've wired it so that it's `releaseTestCheckEsqlQa3` and `checkPart3` executing those tests (snapshot vs release). We could try to make the job run in the `bwc-snapshots` pipelines instead. The first job I've mentioned seems a better fit to me for a test that is checking a bunch of clusters for the current version work together as expected.