### PR TITLE
Add stash support to close_to for YAML tests (#141459)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -364,9 +364,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
   method: testInfoParameters {class org.elasticsearch.xpack.esql.plan.physical.MergeExec}
   issue: https://github.com/elastic/elasticsearch/issues/155683
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: initializationError
-  issue: https://github.com/elastic/elasticsearch/issues/156737
 - class: org.elasticsearch.join.ParentChildClientYamlTestSuiteIT
   method: test {yaml=/20_parent_join/join field named _type is not returned as root metadata}
   issue: https://github.com/elastic/elasticsearch/issues/156742

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -140,6 +140,7 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   task.skipTest("tsdb/10_settings/set start_time and end_time without timeseries mode", "we don't validate for index_mode=tsdb when setting start_date/end_date anymore")
   task.skipTest("tsdb/10_settings/set start_time, end_time and routing_path via put settings api without time_series mode", "we don't validate for index_mode=tsdb when setting start_date/end_date anymore")
   task.skipTest("search/140_pre_filter_search_shards/prefilter on non-indexed date fields", "prefiltering can now use skippers on dv-only fields")
+  task.skipTest("search.vectors/131_knn_query_nested_inner_hits_score/nested kNN inner_hits are scored like the query phase on a quantized field", "inner_hits scoring requires search.vectors.nested_knn_inner_hits_match_query_phase_scoring")
   // Expected deprecation warning to compat yaml tests:
   task.addAllowedWarningRegex("Use of the \\[max_size\\] rollover condition has been deprecated in favour of the \\[max_primary_shard_size\\] condition and will be removed in a later version")
 })

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
@@ -37,14 +37,14 @@ public class CloseToAssertion extends Assertion {
                 throw new IllegalArgumentException("expected a map with value and error but got a map with " + map.size() + " fields");
             }
             Object valObj = map.get("value");
-            if (valObj instanceof Number == false) {
-                throw new IllegalArgumentException("value is missing or not a number");
+            if (valObj == null) {
+                throw new IllegalArgumentException("value is missing");
             }
             Object errObj = map.get("error");
             if (errObj instanceof Number == false) {
                 throw new IllegalArgumentException("error is missing or not a number");
             }
-            return new CloseToAssertion(location, fieldValueTuple.v1(), ((Number) valObj).doubleValue(), ((Number) errObj).doubleValue());
+            return new CloseToAssertion(location, fieldValueTuple.v1(), valObj, ((Number) errObj).doubleValue());
         } else {
             throw new IllegalArgumentException(
                 "expected a map with value and error but got " + fieldValueTuple.v2().getClass().getSimpleName()
@@ -57,7 +57,7 @@ public class CloseToAssertion extends Assertion {
 
     private final double error;
 
-    public CloseToAssertion(XContentLocation location, String field, Double expectedValue, Double error) {
+    public CloseToAssertion(XContentLocation location, String field, Object expectedValue, Double error) {
         super(location, field, expectedValue);
         this.error = error;
     }
@@ -69,10 +69,14 @@ public class CloseToAssertion extends Assertion {
     @Override
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is close to [{}] with error [{}] (field [{}])", actualValue, expectedValue, error, getField());
+        if ((expectedValue instanceof Number) == false) {
+            throw new AssertionError("Expected value should be a number, but was [" + expectedValue + "], which is not a number");
+        }
+
         if (actualValue instanceof Number actualValueNumber) {
-            assertThat(actualValueNumber.doubleValue(), closeTo((Double) expectedValue, error));
+            assertThat(actualValueNumber.doubleValue(), closeTo(((Number) expectedValue).doubleValue(), error));
         } else {
-            throw new AssertionError("excpected a value close to " + expectedValue + " but got " + actualValue + ", which is not a number");
+            throw new AssertionError("expected a value close to " + expectedValue + " but got " + actualValue + ", which is not a number");
         }
     }
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -168,7 +168,7 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
 
     public void testInvalidCloseTo() throws Exception {
         parser = createParser(YamlXContent.yamlXContent, "{ field: 42 }");
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> CloseToAssertion.parse(parser));
+        Throwable exception = expectThrows(IllegalArgumentException.class, () -> CloseToAssertion.parse(parser));
         assertThat(exception.getMessage(), equalTo("expected a map with value and error but got Integer"));
 
         parser = createParser(YamlXContent.yamlXContent, "{ field: {  } }");
@@ -181,7 +181,12 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         parser = createParser(YamlXContent.yamlXContent, "{ field: { foo: 13, bar: 15 } }");
         exception = expectThrows(IllegalArgumentException.class, () -> CloseToAssertion.parse(parser));
-        assertThat(exception.getMessage(), equalTo("value is missing or not a number"));
+        assertThat(exception.getMessage(), equalTo("value is missing"));
+
+        parser = createParser(YamlXContent.yamlXContent, "{ field: { value: \"foo\", error: 0.001 } }");
+        CloseToAssertion closeToAssertion = CloseToAssertion.parse(parser);
+        exception = expectThrows(AssertionError.class, () -> closeToAssertion.doAssert(42, closeToAssertion.getExpectedValue()));
+        assertThat(exception.getMessage(), equalTo("Expected value should be a number, but was [foo], which is not a number"));
     }
 
     public void testExists() throws IOException {


### PR DESCRIPTION
Fixes #156737 on `9.3`, the only branch affected.

### Why 9.3 fails

`9.3` rest-compat runs the previous version's yaml tests, which gained `search.vectors/131_knn_query_nested_inner_hits_score` when #156332 was backported to `8.19` (#156614) on 13 Aug. That test asserts:

```yaml
- set: { hits.hits.0._score: parent_score_0 }
- close_to: { hits.hits.0.inner_hits.nested.hits.max_score: { value: $parent_score_0, error: 0.0001 } }
```

`$parent_score_0` is a `String` at parse time, and 9.3's `CloseToAssertion.parse` rejects any non-`Number` value:

```java
if (valObj instanceof Number == false) {
    throw new IllegalArgumentException("value is missing or not a number");
}
```

so the file cannot be parsed:

```
java.io.IOException: Error parsing search.vectors/131_knn_query_nested_inner_hits_score
```

Parsing happens in the `@ParametersFactory` (`ESClientYamlSuiteTestCase#createParameters`), while JUnit is still enumerating tests — before any cluster exists. So this surfaces as `ClientYamlTestSuiteIT#initializationError`, a **suite level** failure that takes down every test in the suite, not just this one.

### Only 9.3

Stash support in `close_to` was added by #141459 (`337e8b225665`, 30 Jan). `main`, `9.5` and `9.4` all have it; `9.3` does not. Hence this backport, and no `auto-backport` label — there is nothing to propagate.

### What this does

1. **Cherry-picks #141459.** It does not loosen validation, it moves it: parse time only checks the value is non-null, and the numeric check moves to `doAssert`, after the stash is resolved.

2. **Adds a compat `skipTest` for the test.** Parsing was only half the problem. Once the file parses, the test *runs* on 9.3 and fails, because 9.3 does not have #156332:
   ```
   Expected: a numeric value within <1.0E-4> of <0.5725435>
        but: <0.58870894> differed by <0.016065439999999976>
   ```
   The test's own `requires: cluster_features` gate does **not** skip it during compat runs — the same was already observed on 9.4 in #156759, where it ran and failed while 9.4 did not publish the feature.

   Note the ordering: a skip alone would not have worked. `skipTest` injects a `skip` clause into the transformed yaml, and that clause has to be parsed to be honoured, so the parser fix is a prerequisite for the skip.

3. **Removes the `ClientYamlTestSuiteIT#initializationError` mute.** That mute hid **every** `ClientYamlTestSuiteIT` initialization problem on 9.3, not just this one.

### Verification

- `:test:yaml-rest-runner:test --tests "...AssertionTests"` + spotless — BUILD SUCCESSFUL, **15 tests, 0 failures**
- `:rest-api-spec:yamlRestCompatTestTransform` — BUILD SUCCESSFUL, and the transformed yaml now carries the skip:
  ```yaml
  nested kNN inner_hits are scored like the query phase on a quantized field:
  - skip:
      awaits_fix: "9.3 does not have #156332, so inner_hits scores against the quantized
        vectors while the query phase rescores"
  ```
