### PR TITLE
Further loosen HNSW graph floor size for IndexDiskUsageAnalyzerTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -134,9 +134,6 @@ tests:
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerStatsTests
   method: testResumableWrite
   issue: https://github.com/elastic/elasticsearch/issues/156513
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/156756
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=search.vectors/131_knn_query_nested_inner_hits_score/nested kNN inner_hits are scored like the query phase on a quantized field}
   issue: https://github.com/elastic/elasticsearch/issues/156759

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
@@ -282,10 +282,10 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
             long dataBytes = elementType == DenseVectorFieldMapper.ElementType.FLOAT
                 ? ((long) numDocs * dimension * Float.BYTES)
                 : ((long) numDocs * dimension);
-            long indexBytesEstimate = (long) numDocs * (Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN / 4); // rough size of HNSW graph
+            long indexBytesEstimate = (long) numDocs * (Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN / 8);
             assertThat("numDocs=" + numDocs + ";dimension=" + dimension, stats.total().getKnnVectorsBytes(), greaterThan(dataBytes));
             long connectionOverhead = stats.total().getKnnVectorsBytes() - dataBytes;
-            assertThat("numDocs=" + numDocs, connectionOverhead, greaterThan(indexBytesEstimate));
+            assertThat("numDocs=" + numDocs + ";dimension=" + dimension, connectionOverhead, greaterThan(indexBytesEstimate));
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/156756