### PR TITLE
[9.5] ESQL:DS: Fix leaks on AsyncExternalSourceOperatorFactory (#157051)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -2402,13 +2402,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 }
                 return opened;
             });
-            pages = applyRowPositionStrategy(reader, pages, projectedColumns);
-            pages = StatsCapturingIterator.wrap(pages, buffer.capturedSourceMetadataSink());
             // Wrap with the deferred-extraction encoder (no-op when not enabled), then with the
             // virtual-column iterator so {@code _file.*} columns flow through the producer pipeline
             // alongside the data columns.
             final CloseableIterator<Page> finalPages;
             try {
+                pages = applyRowPositionStrategy(reader, pages, projectedColumns);
+                pages = StatsCapturingIterator.wrap(pages, buffer.capturedSourceMetadataSink());
                 CloseableIterator<Page> withEncoder = wrapWithEncoderIfNeeded(pages, projectedColumns, driverContext);
                 finalPages = wrapWithVirtualColumns(withEncoder, mergeStandardMetadata(partitionValues), driverContext);
             } catch (Exception e) {
@@ -2545,15 +2545,17 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     /**
-     * Failure-only listener used by non-iterative paths ({@link #startSyncWrapperRead},
-     * {@link #consumePagesInBackground}) where {@code removeAsyncAction()} lives in the
-     * drain's {@code runAfter} callback. Do NOT use for the iterative slice-queue or
-     * multi-file paths — those use a single {@code completionListener} instead.
+     * Failure-only listener for {@link #startSyncWrapperRead}: fires when the blocking open or
+     * wrapping phase throws before the drain is reached, so the drain's own {@code runAfter}
+     * never executes. Mirrors the inline listener in {@link #consumePagesInBackground} — both
+     * must call {@code releaseOperator()} or the per-query concurrency budget never deregisters
+     * from the allocator.
      */
-    private static ActionListener<Void> failureListener(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
+    private ActionListener<Void> failureListener(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
         return ActionListener.wrap(v -> {}, e -> {
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
+            releaseOperator();
         });
     }
 
@@ -2798,26 +2800,20 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 CompressionDelegatingFormatReader cdr = (CompressionDelegatingFormatReader) reader;
                 SegmentableFormatReader seg = resolveSegmentableReader(reader);
                 DecompressionCodec codec = cdr.codec();
-                InputStream raw = obj.newStream();
-                InputStream decompressed;
+                // Route through the production decorator so every failure path releases both the codec's
+                // native handle (e.g. the PanamaZstdInputStream Arena) and the raw connection without
+                // draining it. DecompressingStorageObject.newStream() wraps raw in UncloseableInputStream
+                // before handing it to the codec, so the decompressor's close() never cascades into a
+                // draining raw.close(). On a parallelRead failure abortStream() closes the decompressor
+                // first (releasing the Arena) then aborts raw through the provider's abort path (S3
+                // ResponseInputStream.abort()), keeping both codecs with and without JDK Cleaner support
+                // on equal footing and matching the abort-chain contract tested in StorageObjectAbortChainTests.
+                DecompressingStorageObject decompressing = new DecompressingStorageObject(obj, codec);
+                InputStream stream = decompressing.newStream();
                 try {
-                    decompressed = codec.decompress(raw);
-                } catch (Exception e) {
-                    try {
-                        obj.abortStream(raw);
-                    } catch (IOException abortEx) {
-                        e.addSuppressed(abortEx);
-                    }
-                    throw e;
-                }
-                try {
-                    // The stream-only codecs reachable here (gzip via GZIPInputStream, zstd via
-                    // ZstdInputStream) follow the JDK FilterInputStream convention: closing the
-                    // wrapper closes the underlying `raw`. New stream-only codecs added to this
-                    // path must preserve that contract.
                     return StreamingParallelParsingCoordinator.parallelRead(
                         seg,
-                        decompressed,
+                        stream,
                         obj,
                         cols,
                         batchSize,
@@ -2836,7 +2832,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     );
                 } catch (Exception e) {
                     try {
-                        obj.abortStream(raw);
+                        decompressing.abortStream(stream);
                     } catch (IOException abortEx) {
                         e.addSuppressed(abortEx);
                     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DecompressingStorageObject.java
@@ -60,7 +60,8 @@ final class DecompressingStorageObject implements StorageObject {
             return new DecompressedStream(decompressed, raw);
         } catch (IOException | RuntimeException e) {
             try {
-                raw.close();
+                // Abort rather than close so providers like S3 skip the draining connection teardown.
+                delegate.abortStream(raw);
             } catch (IOException suppressed) {
                 e.addSuppressed(suppressed);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -479,6 +479,15 @@ public final class StreamingParallelParsingCoordinator {
         private final AtomicReference<SubscribableListener<Void>> pendingReady = new AtomicReference<>();
 
         /**
+         * The sequential decompressed stream being segmented. Closed exactly once by whichever path
+         * gets there first: {@link #runSegmentator}'s {@code finally}, {@link #onSegmentatorLaunchRejected}
+         * on a pool rejection, or {@link #close()} as a backstop for the segmentator-still-queued case.
+         * The {@link #streamClosed} CAS ensures only one caller's {@code close()} runs.
+         */
+        private final InputStream decompressedStream;
+        private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+
+        /**
          * Convenience overload for tests/benchmarks that supplies an {@link StreamingSegmentatorAdmission#unbounded()}
          * controller, so the segmentator is dispatched immediately (matching the pre-admission behavior) on an
          * isolated, generously-sized pool where saturation cannot arise.
@@ -581,11 +590,13 @@ public final class StreamingParallelParsingCoordinator {
             // where producer-loop drivers and sub-tasks of other iterators competed for the same slots.
             this.tasksOutstanding = new AtomicInteger(1);
 
+            this.decompressedStream = decompressedStream;
+
             // Gate the segmentator through the node-level admission controller so it is handed to the pool only when
             // a thread will remain free for its parser tasks; a rejection is surfaced through the firstError /
             // signalReady path. Tests that run on an isolated, generously-sized pool pass an unbounded controller,
             // which dispatches immediately (see StreamingSegmentatorAdmission#unbounded).
-            Runnable segmentatorTask = () -> runSegmentator(decompressedStream, this.chunkSize);
+            Runnable segmentatorTask = () -> runSegmentator(this.decompressedStream, this.chunkSize);
             admission.submit(segmentatorTask, executor, this::onSegmentatorLaunchRejected);
         }
 
@@ -596,8 +607,32 @@ public final class StreamingParallelParsingCoordinator {
          */
         private void onSegmentatorLaunchRejected(RejectedExecutionException e) {
             firstError.compareAndSet(null, e);
+            // The segmentator never ran, so its finally block never closed the stream. Release it
+            // promptly here; close() provides a backstop for any racing path.
+            closeStream();
             if (tasksOutstanding.decrementAndGet() == 0) {
                 signalReady();
+            }
+        }
+
+        /**
+         * Releases {@link #decompressedStream} exactly once regardless of which path reaches it first
+         * ({@link #runSegmentator}'s finally, {@link #onSegmentatorLaunchRejected}, or {@link #close()}).
+         * Uses abort semantics via {@link StorageObject#abortStream} when a {@link #storageObject} is
+         * available, so providers such as S3 can discard the underlying HTTP connection without draining
+         * the remaining response body.
+         */
+        private void closeStream() {
+            if (streamClosed.compareAndSet(false, true)) {
+                try {
+                    if (storageObject != null) {
+                        storageObject.abortStream(decompressedStream);
+                    } else {
+                        decompressedStream.close();
+                    }
+                } catch (IOException e) {
+                    logger.warn("Failed to release stream for [{}]", storageObject != null ? storageObject.path() : "<stream>", e);
+                }
             }
         }
 
@@ -826,9 +861,7 @@ public final class StreamingParallelParsingCoordinator {
                 firstError.compareAndSet(null, e);
                 signalReady();
             } finally {
-                try {
-                    stream.close();
-                } catch (IOException ignored) {}
+                closeStream();
                 // No POISON-to-parkers fan-out anymore: parser tasks are one-shot (one per chunk)
                 // and exit on their own after processing. Segmentator's done; decrement and signal
                 // so the consumer wakes if it's the last task standing (EOF condition is
@@ -1520,6 +1553,13 @@ public final class StreamingParallelParsingCoordinator {
                 Thread.currentThread().interrupt();
             }
             drainAllQueues();
+            // Backstop: if the segmentator was never promoted from the admission queue (still pending
+            // when the timeout fired) or if any code path did not call closeStream() themselves,
+            // release the stream now. In the timeout and interrupt paths tasksOutstanding may still
+            // be above 0, meaning the segmentator (or parsers) can be concurrently executing — the
+            // CAS in streamClosed is the safety mechanism that prevents a double-release race with a
+            // still-running segmentator's own closeStream() call.
+            closeStream();
             // Now safe to evaluate: chunksDispatched is final (the drain loop waited for every spawned
             // parser, including any dispatched in the close race window) and the consumer's currentChunk
             // is fixed. Clean = no error, the read was not truncated, and the consumer drained every

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -2760,6 +2760,75 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         assertEquals("abortStream must be invoked exactly once", 1, tracking.abortCalls.get());
     }
 
+    /**
+     * Regression guard: if {@code parallelRead} construction fails after the decompressing wrapper
+     * is created (e.g. the streaming iterator constructor throws), the wrapper must be
+     * closed to release codec-specific native handles (e.g. the {@code PanamaZstdInputStream}'s
+     * native {@code ZSTD_DStream} and {@code Arena.ofShared()} — resources with no JDK Cleaner
+     * fallback, unlike gzip's {@code Inflater}) and the raw stream must be aborted without a drain.
+     */
+    public void testOpenWithParallelismDecompressorReleasedOnParallelReadFailure() throws IOException {
+        AsyncExternalSourceOperatorFactory factory = factoryForOpenParallelismStreamingTests(
+            dummyFormatReaderForOpenParallelismTests(),
+            Runnable::run
+        );
+        // Force StreamingParallelIterator constructor to fail after the codec has successfully
+        // opened the decompressing stream — simulating an unexpected error mid-construction.
+        SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+        when(inner.minimumSegmentSize()).thenThrow(new RuntimeException("simulated parallelRead construction failure"));
+
+        // Codec that passes bytes through but tracks whether close() was called on its stream.
+        // The close-tracking stream is what DecompressingStorageObject.abortStream() must close
+        // first (before aborting raw) — this is the layer holding any codec-specific native handle.
+        AtomicBoolean wrapperClosed = new AtomicBoolean(false);
+        DecompressionCodec trackingPassThroughCodec = new DecompressionCodec() {
+            @Override
+            public String name() {
+                return "test-pass-through";
+            }
+
+            @Override
+            public List<String> extensions() {
+                return List.of(".gz");
+            }
+
+            @Override
+            public InputStream decompress(InputStream raw) {
+                return new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        return raw.read();
+                    }
+
+                    @Override
+                    public int read(byte[] buf, int off, int len) throws IOException {
+                        return raw.read(buf, off, len);
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        wrapperClosed.set(true);
+                        raw.close();
+                    }
+                };
+            }
+        };
+        CompressionDelegatingFormatReader cdr = new CompressionDelegatingFormatReader(inner, trackingPassThroughCodec);
+
+        byte[] payload = "{\"a\":1}\n".repeat(100).getBytes(StandardCharsets.UTF_8);
+        DrainSimulatingStorageObject.Tracking tracking = new DrainSimulatingStorageObject.Tracking();
+        StorageObject object = DrainSimulatingStorageObject.create(payload, tracking);
+
+        RuntimeException thrown = expectThrows(
+            RuntimeException.class,
+            () -> factory.openWithParallelism(cdr, object, List.of("a"), ErrorPolicy.STRICT, false, true, true, null, 0L, null, null, null)
+        );
+        assertEquals("simulated parallelRead construction failure", thrown.getMessage());
+        assertTrue("decompressor wrapper must be closed to release codec-specific native handles (e.g. zstd Arena)", wrapperClosed.get());
+        assertTrue("raw stream must be aborted when parallelRead fails", tracking.aborted.get());
+        assertEquals("abortStream must be invoked exactly once", 1, tracking.abortCalls.get());
+    }
+
     public void testOpenWithParallelismBareSegmentableReturnsIterator() throws IOException {
         ExecutorService exec = Executors.newFixedThreadPool(8);
         try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -66,7 +66,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
@@ -1665,6 +1667,56 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    /**
+     * Regression guard: when the executor rejects the segmentator task (e.g. pool shut down or
+     * saturated with no queue) {@link StreamingParallelParsingCoordinator.StreamingParallelIterator}
+     * must close the decompressed stream promptly via {@code onSegmentatorLaunchRejected}, not wait
+     * until the consumer calls {@link CloseableIterator#close()}.
+     */
+    public void testSegmentatorRejectionClosesDecompressedStream() throws Exception {
+        AtomicBoolean streamClosed = new AtomicBoolean(false);
+        InputStream trackingStream = new InputStream() {
+            private final ByteArrayInputStream backing = new ByteArrayInputStream("line-0000\n".getBytes(StandardCharsets.UTF_8));
+
+            @Override
+            public int read() throws IOException {
+                return backing.read();
+            }
+
+            @Override
+            public void close() {
+                streamClosed.set(true);
+            }
+        };
+        LineFormatReader reader = new LineFormatReader(1024);
+        Executor rejectingExecutor = r -> { throw new RejectedExecutionException("pool is shut down"); };
+
+        StreamingParallelParsingCoordinator.StreamingParallelIterator iterator =
+            new StreamingParallelParsingCoordinator.StreamingParallelIterator(
+                reader,
+                trackingStream,
+                null,
+                List.of("line"),
+                50,
+                4,
+                rejectingExecutor,
+                ErrorPolicy.STRICT,
+                null,
+                0L,
+                SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES,
+                null,
+                -1L,
+                StripeColumnScope.PROJECTED,
+                StreamingParallelParsingCoordinator.WarningSinks.NONE
+            );
+        // The rejection is synchronous: onSegmentatorLaunchRejected fires during admission.submit()
+        // inside the constructor, so the stream is already closed before the constructor returns.
+        assertTrue("stream must be closed promptly on segmentator rejection", streamClosed.get());
+        // Calling close() after the fact must be safe (CAS no-op on the already-closed stream).
+        iterator.close();
+        assertTrue("stream must remain closed after iterator.close()", streamClosed.get());
     }
 
     private static RecordSplitter neverBoundarySplitter(int maxRecordBytes) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL:DS: Fix leaks on AsyncExternalSourceOperatorFactory (#157051)