### PR TITLE
[9.4] Null-safe async instrument (#157161)

### DIFF
--- a/docs/changelog/157161.yaml
+++ b/docs/changelog/157161.yaml
@@ -1,0 +1,5 @@
+area: Infra/Metrics
+issues: []
+pr: 157161
+summary: Null-safe async instrument
+type: bug

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
@@ -693,7 +693,11 @@ public class NodeMetrics extends AbstractLifecycleComponent {
                 "The total time flushes have been executed excluding waiting time on locks",
                 "milliseconds",
                 () -> new LongWithAttributes(
-                    stats.getOrRefresh() != null ? stats.getOrRefresh().getIndices().getFlush().getTotalTimeInMillis() : 0L
+                    Optional.ofNullable(stats.getOrRefresh())
+                        .map(o -> o.getIndices())
+                        .map(o -> o.getFlush())
+                        .map(o -> o.getTotalTimeInMillis())
+                        .orElse(0L)
                 )
             )
         );
@@ -704,9 +708,11 @@ public class NodeMetrics extends AbstractLifecycleComponent {
                 "The total time flushes have been executed excluding waiting time on locks",
                 "milliseconds",
                 () -> new LongWithAttributes(
-                    stats.getOrRefresh() != null
-                        ? stats.getOrRefresh().getIndices().getFlush().getTotalTimeExcludingWaitingOnLockMillis()
-                        : 0L
+                    Optional.ofNullable(stats.getOrRefresh())
+                        .map(o -> o.getIndices())
+                        .map(o -> o.getFlush())
+                        .map(o -> o.getTotalTimeExcludingWaitingOnLockMillis())
+                        .orElse(0L)
                 )
             )
         );


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Null-safe async instrument (#157161)