### PR TITLE
Bound mock HTTP server request read time in tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -224,6 +224,19 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
             test.systemProperty("io.netty.noKeySetOptimization", "true");
             test.systemProperty("io.netty.recycler.maxCapacityPerThread", "0");
 
+            // Bound how long a com.sun.net.httpserver worker may spend reading a single request. This defaults to -1,
+            // meaning no limit, so a request whose header block never completes parks a server thread indefinitely.
+            // The mock HTTP servers used by the blob store repository tests run on a 2-thread executor, so a single
+            // such request makes the whole fixture unresponsive until the client's own read timeout fires, failing the
+            // test. See https://github.com/elastic/elasticsearch/issues/156468. 30s is far longer than any legitimate
+            // request to an in-process mock server and well under the clients' read timeouts.
+            // Set on the JVM command line rather than from test code because sun.net.httpserver.ServerConfig reads
+            // this in its static initialiser, so setting it programmatically is silently ignored once any HttpServer
+            // has been created in the JVM.
+            if (System.getProperty("sun.net.httpserver.maxReqTime") == null) {
+                test.systemProperty("sun.net.httpserver.maxReqTime", "30");
+            }
+
             test.testLogging(logging -> {
                 logging.setShowExceptions(true);
                 logging.setShowCauses(true);

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -45,6 +45,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -61,9 +62,13 @@ import org.threeten.bp.Duration;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,6 +80,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
@@ -333,6 +339,76 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     @Override
     public void testRequestStats() throws Exception {
         super.testRequestStats();
+    }
+
+    /**
+     * Guards the {@code sun.net.httpserver.maxReqTime} setting applied to test JVMs by {@code ElasticsearchTestBasePlugin}.
+     *
+     * <p>Without it that setting defaults to {@code -1}, meaning a worker will block forever reading a request whose
+     * header block never terminates. The mock server runs on a two-thread executor and {@code sun.net.httpserver} will
+     * not dispatch a second exchange for a connection that already has one in flight, so a single such request makes
+     * the fixture unresponsive until the client's own read timeout fires — which is what failed
+     * {@link #testSnapshotWithLargeSegmentFiles} in issue 156468, by way of a shard snapshot failing and leaving the
+     * snapshot {@code PARTIAL}.
+     *
+     * <p>The wedging sockets are held open for the whole test: the only thing that can restore service is the server
+     * timing those requests out by itself. The test first confirms the fixture really is stalled, so that it cannot
+     * pass vacuously if the executor is ever given more threads.
+     */
+    public void testMockServerRecoversFromRequestThatNeverCompletes() throws Exception {
+        final String configured = System.getProperty("sun.net.httpserver.maxReqTime");
+        final int maxReqTimeSeconds = configured == null ? -1 : Integer.parseInt(configured);
+        assumeTrue("requires sun.net.httpserver.maxReqTime > 0, normally set for all test JVMs by the build", maxReqTimeSeconds > 0);
+
+        final InetSocketAddress address = httpServerAddress();
+        final List<Socket> wedgingSockets = new ArrayList<>();
+        try {
+            // One per mock server worker thread, so that no worker is left able to serve anything.
+            for (int i = 0; i < MOCK_SERVER_WORKER_THREADS; i++) {
+                final Socket socket = new Socket(address.getAddress(), address.getPort());
+                wedgingSockets.add(socket);
+                final OutputStream out = socket.getOutputStream();
+                // A request line and headers but no terminating blank line. Deliberately a plain list request: when
+                // these sockets are eventually closed the server treats EOF as end-of-head and runs the handler, so it
+                // has to be something the fixture can serve harmlessly.
+                out.write(("GET /storage/v1/b/bucket/o?prefix=never-completes-" + i + " HTTP/1.1\r\n").getBytes(StandardCharsets.US_ASCII));
+                out.write("Host: localhost\r\n".getBytes(StandardCharsets.US_ASCII));
+                out.write((CLIENT_ID_HEADER + ": never-completes\r\n").getBytes(StandardCharsets.US_ASCII));
+                out.flush();
+            }
+
+            assertBusy(
+                () -> assertFalse("fixture should be stalled while every worker is wedged", isServerResponsive(address, 2_000)),
+                30,
+                SECONDS
+            );
+
+            assertBusy(
+                () -> assertTrue(
+                    "fixture should recover by itself once maxReqTime closes the wedged requests",
+                    isServerResponsive(address, 5_000)
+                ),
+                maxReqTimeSeconds * 3L + 30,
+                SECONDS
+            );
+        } finally {
+            IOUtils.closeWhileHandlingException(wedgingSockets);
+        }
+    }
+
+    /** @return whether a well-formed request on a fresh connection is answered within {@code timeoutMillis}. */
+    private static boolean isServerResponsive(InetSocketAddress address, int timeoutMillis) throws IOException {
+        try (Socket probe = new Socket(address.getAddress(), address.getPort())) {
+            probe.setSoTimeout(timeoutMillis);
+            final OutputStream out = probe.getOutputStream();
+            out.write("GET /storage/v1/b/bucket/o?prefix=responsiveness-probe HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+            out.write((CLIENT_ID_HEADER + ": responsiveness-probe\r\n").getBytes(StandardCharsets.US_ASCII));
+            out.write("Host: localhost\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+            return probe.getInputStream().read() != -1;
+        } catch (SocketTimeoutException e) {
+            return false;
+        }
     }
 
     // todo(szybia): remove once problem is solved. issue #152286: SocketTimeoutException on GCP request.

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -45,7 +45,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -62,13 +61,9 @@ import org.threeten.bp.Duration;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -80,7 +75,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
@@ -339,76 +333,6 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     @Override
     public void testRequestStats() throws Exception {
         super.testRequestStats();
-    }
-
-    /**
-     * Guards the {@code sun.net.httpserver.maxReqTime} setting applied to test JVMs by {@code ElasticsearchTestBasePlugin}.
-     *
-     * <p>Without it that setting defaults to {@code -1}, meaning a worker will block forever reading a request whose
-     * header block never terminates. The mock server runs on a two-thread executor and {@code sun.net.httpserver} will
-     * not dispatch a second exchange for a connection that already has one in flight, so a single such request makes
-     * the fixture unresponsive until the client's own read timeout fires — which is what failed
-     * {@link #testSnapshotWithLargeSegmentFiles} in issue 156468, by way of a shard snapshot failing and leaving the
-     * snapshot {@code PARTIAL}.
-     *
-     * <p>The wedging sockets are held open for the whole test: the only thing that can restore service is the server
-     * timing those requests out by itself. The test first confirms the fixture really is stalled, so that it cannot
-     * pass vacuously if the executor is ever given more threads.
-     */
-    public void testMockServerRecoversFromRequestThatNeverCompletes() throws Exception {
-        final String configured = System.getProperty("sun.net.httpserver.maxReqTime");
-        final int maxReqTimeSeconds = configured == null ? -1 : Integer.parseInt(configured);
-        assumeTrue("requires sun.net.httpserver.maxReqTime > 0, normally set for all test JVMs by the build", maxReqTimeSeconds > 0);
-
-        final InetSocketAddress address = httpServerAddress();
-        final List<Socket> wedgingSockets = new ArrayList<>();
-        try {
-            // One per mock server worker thread, so that no worker is left able to serve anything.
-            for (int i = 0; i < MOCK_SERVER_WORKER_THREADS; i++) {
-                final Socket socket = new Socket(address.getAddress(), address.getPort());
-                wedgingSockets.add(socket);
-                final OutputStream out = socket.getOutputStream();
-                // A request line and headers but no terminating blank line. Deliberately a plain list request: when
-                // these sockets are eventually closed the server treats EOF as end-of-head and runs the handler, so it
-                // has to be something the fixture can serve harmlessly.
-                out.write(("GET /storage/v1/b/bucket/o?prefix=never-completes-" + i + " HTTP/1.1\r\n").getBytes(StandardCharsets.US_ASCII));
-                out.write("Host: localhost\r\n".getBytes(StandardCharsets.US_ASCII));
-                out.write((CLIENT_ID_HEADER + ": never-completes\r\n").getBytes(StandardCharsets.US_ASCII));
-                out.flush();
-            }
-
-            assertBusy(
-                () -> assertFalse("fixture should be stalled while every worker is wedged", isServerResponsive(address, 2_000)),
-                30,
-                SECONDS
-            );
-
-            assertBusy(
-                () -> assertTrue(
-                    "fixture should recover by itself once maxReqTime closes the wedged requests",
-                    isServerResponsive(address, 5_000)
-                ),
-                maxReqTimeSeconds * 3L + 30,
-                SECONDS
-            );
-        } finally {
-            IOUtils.closeWhileHandlingException(wedgingSockets);
-        }
-    }
-
-    /** @return whether a well-formed request on a fresh connection is answered within {@code timeoutMillis}. */
-    private static boolean isServerResponsive(InetSocketAddress address, int timeoutMillis) throws IOException {
-        try (Socket probe = new Socket(address.getAddress(), address.getPort())) {
-            probe.setSoTimeout(timeoutMillis);
-            final OutputStream out = probe.getOutputStream();
-            out.write("GET /storage/v1/b/bucket/o?prefix=responsiveness-probe HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
-            out.write((CLIENT_ID_HEADER + ": responsiveness-probe\r\n").getBytes(StandardCharsets.US_ASCII));
-            out.write("Host: localhost\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
-            out.flush();
-            return probe.getInputStream().read() != -1;
-        } catch (SocketTimeoutException e) {
-            return false;
-        }
     }
 
     // todo(szybia): remove once problem is solved. issue #152286: SocketTimeoutException on GCP request.

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -637,9 +637,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.external.http.sender.RequestTaskTests
   method: testRequest_ReleasesBytesTrackedByCircuitBreaker_OnTimedListenerTimeout
   issue: https://github.com/elastic/elasticsearch/issues/156467
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testSnapshotWithLargeSegmentFiles
-  issue: https://github.com/elastic/elasticsearch/issues/156468
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTargetRecoversAfterMasterRestartDuringHandoff
   issue: https://github.com/elastic/elasticsearch/issues/156561

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -79,23 +79,36 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
 
     private static final byte[] BUFFER = new byte[1024];
 
+    /**
+     * Maximum number of requests the mock server will service concurrently. Low, so tests exercise contention, which
+     * also means a single request that never finishes arriving can starve the fixture entirely — see
+     * {@code sun.net.httpserver.maxReqTime}, set for test JVMs by the build.
+     */
+    protected static final int MOCK_SERVER_WORKER_THREADS = 2;
+
     private static HttpServer httpServer;
     private static ExecutorService executorService;
     protected Map<String, HttpHandler> handlers;
+
+    private static final String WORKER_THREAD_NAME_MARKER = ESMockAPIBasedRepositoryIntegTestCase.class.getName();
+
+    /**
+     * Keeps the stall described in {@link MockHttpServerStallWatchdog} observable now that
+     * {@code sun.net.httpserver.maxReqTime} stops it from failing tests. Warns only; never fails a test.
+     */
+    private static final MockHttpServerStallWatchdog stallWatchdog = new MockHttpServerStallWatchdog(WORKER_THREAD_NAME_MARKER);
 
     private static final Logger log = LogManager.getLogger(ESMockAPIBasedRepositoryIntegTestCase.class);
 
     @BeforeClass
     public static void startHttpServer() throws Exception {
         httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
-        ThreadFactory threadFactory = TestEsExecutors.testOnlyDaemonThreadFactory(
-            "[" + ESMockAPIBasedRepositoryIntegTestCase.class.getName() + "]"
-        );
+        ThreadFactory threadFactory = TestEsExecutors.testOnlyDaemonThreadFactory("[" + WORKER_THREAD_NAME_MARKER + "]");
         // the EncryptedRepository can require more than one connection open at one time
         executorService = EsExecutors.newScaling(
             ESMockAPIBasedRepositoryIntegTestCase.class.getName(),
             1,
-            2,
+            MOCK_SERVER_WORKER_THREADS,
             60,
             TimeUnit.SECONDS,
             true,
@@ -113,6 +126,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             });
         });
         httpServer.start();
+        stallWatchdog.start();
     }
 
     @Before
@@ -124,6 +138,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
 
     @AfterClass
     public static void stopHttpServer() {
+        stallWatchdog.stop();
         httpServer.stop(0);
         ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
         httpServer = null;
@@ -252,6 +267,11 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             }
         }
         return Collections.emptyMap();
+    }
+
+    /** The mock server's address, for tests that need to drive it directly over sockets rather than through a client. */
+    protected static InetSocketAddress httpServerAddress() {
+        return httpServer.getAddress();
     }
 
     protected static String httpServerUrl() {
@@ -429,6 +449,8 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
 
         @Override
         public void handle(HttpExchange exchange) throws IOException {
+            final String request = exchange.getRequestMethod() + " " + exchange.getRequestURI();
+            stallWatchdog.requestStarted(request);
             try {
                 handler.handle(exchange);
             } catch (Throwable t) {
@@ -442,6 +464,8 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
                     t
                 );
                 throw t;
+            } finally {
+                stallWatchdog.requestFinished(request);
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -269,11 +269,6 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
         return Collections.emptyMap();
     }
 
-    /** The mock server's address, for tests that need to drive it directly over sockets rather than through a client. */
-    protected static InetSocketAddress httpServerAddress() {
-        return httpServer.getAddress();
-    }
-
     protected static String httpServerUrl() {
         return "http://" + serverUrl();
     }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/MockHttpServerStallWatchdog.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/MockHttpServerStallWatchdog.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Warns when a mock HTTP server worker gets stuck reading a request that never finishes arriving.
+ *
+ * <p>{@code com.sun.net.httpserver} hands a connection to a worker as soon as it becomes readable and then parses the
+ * request head on that worker. If the head never completes, the worker blocks in {@code sun.net.httpserver} indefinitely
+ * — and because the server will not dispatch a second exchange for a connection that already has one in flight, that
+ * connection is dead until something else intervenes. With the low worker count these fixtures use, a couple of such
+ * requests make the whole fixture unresponsive. That is what failed
+ * {@code GoogleCloudStorageBlobStoreRepositoryTests#testSnapshotWithLargeSegmentFiles}
+ * (<a href="https://github.com/elastic/elasticsearch/issues/156468">156468</a>).
+ *
+ * <p>{@code sun.net.httpserver.maxReqTime} (set for test JVMs by the build) now bounds that wait, so the server closes
+ * such a request instead of stalling until the client's own read timeout fires. The tests therefore pass — which means
+ * the condition would otherwise become invisible. It is not yet known what leaves a request incomplete, and the
+ * candidates include the client rather than the fixture, so this watchdog keeps the occurrences observable: it logs a
+ * warning and does <em>not</em> fail anything.
+ *
+ * <p>Whether a worker is "stuck" is decided from {@link #requestStarted}/{@link #requestFinished} bookkeeping rather
+ * than by matching package names on the stack. The executor that submits exchanges is declared in this package, so a
+ * package-prefix check matches every worker and never fires.
+ */
+class MockHttpServerStallWatchdog {
+
+    private static final Logger logger = LogManager.getLogger(MockHttpServerStallWatchdog.class);
+
+    /**
+     * Report a worker stuck for longer than this. Comfortably longer than any legitimate request to an in-process mock
+     * server, and shorter than {@code sun.net.httpserver.maxReqTime} so the evidence is captured before the server
+     * closes the request out from under us.
+     */
+    private static final long STALL_WARN_THRESHOLD_MILLIS = TimeUnit.SECONDS.toMillis(10);
+    private static final long SAMPLE_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(1);
+
+    private static final String JDK_HTTP_SERVER_PACKAGE = "sun.net.httpserver";
+
+    /** Requests currently being handled, per worker thread. */
+    private final Map<Thread, String> inFlightRequests = new ConcurrentHashMap<>();
+    /** The last request each worker completed, which is the best clue to what preceded a stall on that connection. */
+    private final Map<Thread, String> lastCompletedRequests = new ConcurrentHashMap<>();
+
+    private final String workerThreadNameMarker;
+    private volatile Thread watchdogThread;
+
+    MockHttpServerStallWatchdog(String workerThreadNameMarker) {
+        this.workerThreadNameMarker = workerThreadNameMarker;
+    }
+
+    void requestStarted(String request) {
+        inFlightRequests.put(Thread.currentThread(), request);
+    }
+
+    void requestFinished(String request) {
+        final Thread thread = Thread.currentThread();
+        inFlightRequests.remove(thread);
+        lastCompletedRequests.put(thread, request);
+    }
+
+    synchronized void start() {
+        if (watchdogThread != null) {
+            return;
+        }
+        final Thread thread = new Thread(this::run, "mock-http-server-stall-watchdog");
+        thread.setDaemon(true);
+        watchdogThread = thread;
+        thread.start();
+    }
+
+    synchronized void stop() {
+        final Thread thread = watchdogThread;
+        watchdogThread = null;
+        if (thread != null) {
+            thread.interrupt();
+        }
+        inFlightRequests.clear();
+        lastCompletedRequests.clear();
+    }
+
+    private void run() {
+        // Per-thread time at which the current stall was first seen, so a worker that is merely busy is not reported.
+        final Map<Thread, Long> stalledSince = new HashMap<>();
+        final Set<Thread> alreadyReported = new HashSet<>();
+        while (watchdogThread == Thread.currentThread()) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(SAMPLE_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                return;
+            }
+            try {
+                sample(stalledSince, alreadyReported);
+            } catch (Exception e) {
+                logger.warn("mock http server stall watchdog failed", e);
+            }
+        }
+    }
+
+    private void sample(Map<Thread, Long> stalledSince, Set<Thread> alreadyReported) {
+        final long now = System.currentTimeMillis();
+        final Map<Thread, StackTraceElement[]> stacks = Thread.getAllStackTraces();
+
+        stalledSince.keySet().retainAll(stacks.keySet());
+        alreadyReported.retainAll(stacks.keySet());
+
+        for (Map.Entry<Thread, StackTraceElement[]> entry : stacks.entrySet()) {
+            final Thread thread = entry.getKey();
+            if (thread.getName().contains(workerThreadNameMarker) == false) {
+                continue;
+            }
+            if (isStuckReadingRequest(thread, entry.getValue()) == false) {
+                stalledSince.remove(thread);
+                alreadyReported.remove(thread);
+                continue;
+            }
+            final long since = stalledSince.computeIfAbsent(thread, t -> now);
+            final long stalledForMillis = now - since;
+            if (stalledForMillis >= STALL_WARN_THRESHOLD_MILLIS && alreadyReported.add(thread)) {
+                warn(thread, entry.getValue(), stalledForMillis);
+            }
+        }
+    }
+
+    /** A worker inside the JDK http server but not inside a handler is parsing a request that has not fully arrived. */
+    private boolean isStuckReadingRequest(Thread thread, StackTraceElement[] stack) {
+        if (inFlightRequests.containsKey(thread)) {
+            return false;
+        }
+        for (StackTraceElement frame : stack) {
+            if (frame.getClassName().startsWith(JDK_HTTP_SERVER_PACKAGE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void warn(Thread thread, StackTraceElement[] stack, long stalledForMillis) {
+        final StringBuilder message = new StringBuilder();
+        message.append("mock http server worker [")
+            .append(thread.getName())
+            .append("] has been reading an incomplete request for [")
+            .append(stalledForMillis)
+            .append("ms]; this connection cannot serve anything until sun.net.httpserver.maxReqTime closes it. ")
+            .append("Last request completed by this worker was [")
+            .append(lastCompletedRequests.getOrDefault(thread, "none"))
+            .append("]. Other workers are handling ")
+            .append(inFlightRequests.values())
+            .append(". See https://github.com/elastic/elasticsearch/issues/156468\n");
+        for (StackTraceElement frame : stack) {
+            message.append("\tat ").append(frame).append('\n');
+        }
+        logger.warn(message.toString());
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/MockHttpServerStallWatchdog.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/MockHttpServerStallWatchdog.java
@@ -11,8 +11,13 @@ package org.elasticsearch.repositories.blobstore;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,14 +54,14 @@ class MockHttpServerStallWatchdog {
      * closes the request out from under us.
      */
     private static final long STALL_WARN_THRESHOLD_MILLIS = TimeUnit.SECONDS.toMillis(10);
-    private static final long SAMPLE_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(1);
+    private static final long SAMPLE_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(2);
 
     private static final String JDK_HTTP_SERVER_PACKAGE = "sun.net.httpserver";
 
-    /** Requests currently being handled, per worker thread. */
-    private final Map<Thread, String> inFlightRequests = new ConcurrentHashMap<>();
+    /** Requests currently being handled, keyed by worker thread id. */
+    private final Map<Long, String> inFlightRequests = new ConcurrentHashMap<>();
     /** The last request each worker completed, which is the best clue to what preceded a stall on that connection. */
-    private final Map<Thread, String> lastCompletedRequests = new ConcurrentHashMap<>();
+    private final Map<Long, String> lastCompletedRequests = new ConcurrentHashMap<>();
 
     private final String workerThreadNameMarker;
     private volatile Thread watchdogThread;
@@ -66,13 +71,13 @@ class MockHttpServerStallWatchdog {
     }
 
     void requestStarted(String request) {
-        inFlightRequests.put(Thread.currentThread(), request);
+        inFlightRequests.put(Thread.currentThread().threadId(), request);
     }
 
     void requestFinished(String request) {
-        final Thread thread = Thread.currentThread();
-        inFlightRequests.remove(thread);
-        lastCompletedRequests.put(thread, request);
+        final long threadId = Thread.currentThread().threadId();
+        inFlightRequests.remove(threadId);
+        lastCompletedRequests.put(threadId, request);
     }
 
     synchronized void start() {
@@ -97,8 +102,8 @@ class MockHttpServerStallWatchdog {
 
     private void run() {
         // Per-thread time at which the current stall was first seen, so a worker that is merely busy is not reported.
-        final Map<Thread, Long> stalledSince = new HashMap<>();
-        final Set<Thread> alreadyReported = new HashSet<>();
+        final Map<Long, Long> stalledSince = new HashMap<>();
+        final Set<Long> alreadyReported = new HashSet<>();
         while (watchdogThread == Thread.currentThread()) {
             try {
                 TimeUnit.MILLISECONDS.sleep(SAMPLE_INTERVAL_MILLIS);
@@ -113,37 +118,52 @@ class MockHttpServerStallWatchdog {
         }
     }
 
-    private void sample(Map<Thread, Long> stalledSince, Set<Thread> alreadyReported) {
+    private void sample(Map<Long, Long> stalledSince, Set<Long> alreadyReported) {
+        final ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+
+        // Names first, with no stack traces, so the common case costs almost nothing: capturing stacks for every thread
+        // in an integration test JVM on every tick would be far too expensive for a diagnostic that rarely has anything
+        // to say. Thread#getAllStackTraces is a forbidden API here in any case.
+        final List<Long> workerIds = new ArrayList<>();
+        for (ThreadInfo info : threadBean.getThreadInfo(threadBean.getAllThreadIds(), 0)) {
+            if (info != null && info.getThreadName().contains(workerThreadNameMarker)) {
+                workerIds.add(info.getThreadId());
+            }
+        }
+
+        stalledSince.keySet().retainAll(workerIds);
+        alreadyReported.retainAll(workerIds);
+
+        // A worker handling a request is busy, not stuck, so it needs no stack.
+        workerIds.removeIf(inFlightRequests::containsKey);
+        if (workerIds.isEmpty()) {
+            return;
+        }
+
         final long now = System.currentTimeMillis();
-        final Map<Thread, StackTraceElement[]> stacks = Thread.getAllStackTraces();
-
-        stalledSince.keySet().retainAll(stacks.keySet());
-        alreadyReported.retainAll(stacks.keySet());
-
-        for (Map.Entry<Thread, StackTraceElement[]> entry : stacks.entrySet()) {
-            final Thread thread = entry.getKey();
-            if (thread.getName().contains(workerThreadNameMarker) == false) {
+        final long[] idsNeedingStacks = workerIds.stream().mapToLong(Long::longValue).toArray();
+        for (ThreadInfo info : threadBean.getThreadInfo(idsNeedingStacks, Integer.MAX_VALUE)) {
+            if (info == null) {
                 continue;
             }
-            if (isStuckReadingRequest(thread, entry.getValue()) == false) {
-                stalledSince.remove(thread);
-                alreadyReported.remove(thread);
+            final long threadId = info.getThreadId();
+            if (isInsideJdkHttpServer(info) == false) {
+                // Idle in the executor's queue rather than parsing a request.
+                stalledSince.remove(threadId);
+                alreadyReported.remove(threadId);
                 continue;
             }
-            final long since = stalledSince.computeIfAbsent(thread, t -> now);
+            final long since = stalledSince.computeIfAbsent(threadId, id -> now);
             final long stalledForMillis = now - since;
-            if (stalledForMillis >= STALL_WARN_THRESHOLD_MILLIS && alreadyReported.add(thread)) {
-                warn(thread, entry.getValue(), stalledForMillis);
+            if (stalledForMillis >= STALL_WARN_THRESHOLD_MILLIS && alreadyReported.add(threadId)) {
+                warn(info, stalledForMillis);
             }
         }
     }
 
     /** A worker inside the JDK http server but not inside a handler is parsing a request that has not fully arrived. */
-    private boolean isStuckReadingRequest(Thread thread, StackTraceElement[] stack) {
-        if (inFlightRequests.containsKey(thread)) {
-            return false;
-        }
-        for (StackTraceElement frame : stack) {
+    private static boolean isInsideJdkHttpServer(ThreadInfo info) {
+        for (StackTraceElement frame : info.getStackTrace()) {
             if (frame.getClassName().startsWith(JDK_HTTP_SERVER_PACKAGE)) {
                 return true;
             }
@@ -151,19 +171,19 @@ class MockHttpServerStallWatchdog {
         return false;
     }
 
-    private void warn(Thread thread, StackTraceElement[] stack, long stalledForMillis) {
+    private void warn(ThreadInfo info, long stalledForMillis) {
         final StringBuilder message = new StringBuilder();
         message.append("mock http server worker [")
-            .append(thread.getName())
+            .append(info.getThreadName())
             .append("] has been reading an incomplete request for [")
             .append(stalledForMillis)
             .append("ms]; this connection cannot serve anything until sun.net.httpserver.maxReqTime closes it. ")
             .append("Last request completed by this worker was [")
-            .append(lastCompletedRequests.getOrDefault(thread, "none"))
+            .append(lastCompletedRequests.getOrDefault(info.getThreadId(), "none"))
             .append("]. Other workers are handling ")
             .append(inFlightRequests.values())
             .append(". See https://github.com/elastic/elasticsearch/issues/156468\n");
-        for (StackTraceElement frame : stack) {
+        for (StackTraceElement frame : info.getStackTrace()) {
             message.append("\tat ").append(frame).append('\n');
         }
         logger.warn(message.toString());

--- a/test/framework/src/test/java/org/elasticsearch/repositories/blobstore/MockHttpServerRequestTimeoutTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/repositories/blobstore/MockHttpServerRequestTimeoutTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Guards the {@code sun.net.httpserver.maxReqTime} system property that {@code ElasticsearchTestBasePlugin} sets for
+ * test JVMs.
+ *
+ * <p>Without it the property defaults to {@code -1}, so a {@code com.sun.net.httpserver} worker will block forever
+ * reading a request whose header block never terminates, making the mock HTTP servers used by the blob store repository
+ * tests unresponsive until the client's own read timeout fires. That is what failed
+ * {@code GoogleCloudStorageBlobStoreRepositoryTests#testSnapshotWithLargeSegmentFiles} in
+ * <a href="https://github.com/elastic/elasticsearch/issues/156468">156468</a>.
+ *
+ * <p>This deliberately asserts only that the property is configured, which is the realistic regression: someone
+ * removing or renaming the build setting. Asserting the <em>behaviour</em> — that the server really does close such a
+ * request — requires waiting out the timeout, which costs more wall clock than a guard of this value justifies. That
+ * behaviour was verified manually when the setting was introduced, and {@link MockHttpServerStallWatchdog} reports any
+ * occurrence at runtime.
+ */
+public class MockHttpServerRequestTimeoutTests extends ESTestCase {
+
+    public void testRequestReadTimeoutIsConfiguredForTestJvms() {
+        final String maxReqTime = System.getProperty("sun.net.httpserver.maxReqTime");
+        assertThat(
+            "sun.net.httpserver.maxReqTime should be set for test JVMs by ElasticsearchTestBasePlugin; "
+                + "without it a mock HTTP server worker can block forever on an incomplete request",
+            maxReqTime,
+            notNullValue()
+        );
+        assertThat("sun.net.httpserver.maxReqTime should be a positive number of seconds", Integer.parseInt(maxReqTime), greaterThan(0));
+    }
+}


### PR DESCRIPTION
The mock HTTP servers used by the blob store repository integration tests can stall
indefinitely, which is what fails `GoogleCloudStorageBlobStoreRepositoryTests` roughly
once in 29,000 runs.

### What happens

`com.sun.net.httpserver` hands a connection to a worker as soon as it becomes readable
and parses the request head on that worker. If the head never completes, the worker
blocks in `Request.headers` forever, because `sun.net.httpserver.maxReqTime` defaults to
`-1` and disables the watchdog that would otherwise close the connection. The server
also will not dispatch a second exchange for a connection that already has one in
flight, so that connection is dead until something else intervenes — and with the
2-thread executor these fixtures use, a couple of such requests make the whole fixture
unresponsive.

From the failing CI run: the last handler activity is at `18:31:47,529`, then nothing at
all for 60s, then the client gives up:

```
18:31:43,137 SnapshotsService      snapshot [...] started
18:32:47,862 SnapshotShardsService [[index-no-merges][0]] failed to snapshot shard
             com.google.cloud.storage.StorageException: Unknown Error
             ...at GoogleCloudStorageBlobStore.writeBlobResumable(...:572)
             Caused by: java.net.SocketTimeoutException: Read timed out
18:32:48,175 SnapshotsService      snapshot [...] completed with state [PARTIAL]
```

The shard snapshot fails, the snapshot goes `PARTIAL`, and
`assertSuccessfulSnapshot` fails on `successfulShards` being 0 — the
`Expected: a value greater than <0>` assertion in the issue.

### What this changes

- Set `sun.net.httpserver.maxReqTime=30` for test JVMs, so the server closes a request
  that never finishes arriving instead of stalling until the client's read timeout
  fires. It has to go on the JVM command line: `ServerConfig` reads this in its static
  initialiser, so setting it from test code is silently ignored once any `HttpServer`
  exists in the JVM.
- Add `MockHttpServerStallWatchdog`, which logs a `WARN` when a worker has been reading
  an incomplete request for more than 10s. It never fails a test. Since the fix makes
  the tests pass, this is what keeps the condition visible — see below.
- Unmute `testSnapshotWithLargeSegmentFiles`.

### This is a mitigation, not a root cause

It bounds the damage from a request that never finishes arriving; it does not explain
why one occurs. Two candidate mechanisms were tested and ruled out — an unread request
body (the server resynchronises correctly at every leftover size, and drops the
connection above `drainAmount` as documented) and request pipelining (buffered bytes
survive between exchanges correctly).

Worth noting for whoever picks up the cause: across 90 days, the identical fixture under
other clients shows no occurrences of this failure — `S3BlobStoreRepositoryTests` 0 in
622,190 runs, `AzureBlobStoreRepositoryTests` 0 in 645,618 runs (its single failure is an
unrelated Azure SDK assertion). So the shared test infrastructure alone is not
sufficient; something about the GCS client path appears necessary. That is not proof of a
client defect, since those clients use different HTTP stacks and do not exercise
resumable uploads the same way, but it means the trigger may not be in test code. This is
also why the watchdog logs rather than staying silent: production impact would be bounded
at occasional retried uploads, because real GCS enforces its own request timeouts, but we
should not lose the signal.

`testRequestStats` shares this root cause and was never muted — it accounts for 2 of the
3 recent failures, so the tracked failure count under-reported the problem. This fix
covers it too.

Closes #156468
Relates #151474, #152286, #146156
