### PR TITLE
[9.5] Fix SLM races that mis-record concurrent snapshot outcomes (#155934)

### DIFF
--- a/docs/changelog/155934.yaml
+++ b/docs/changelog/155934.yaml
@@ -1,0 +1,6 @@
+area: SLM
+issues:
+ - 155621
+pr: 155934
+summary: Fix SLM stats races that mis-record concurrent snapshot outcomes
+type: bug

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -51,7 +51,6 @@ import org.elasticsearch.xpack.slm.history.SnapshotHistoryStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -88,12 +87,12 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
     }
 
     /**
-     * Find {@link RegisteredPolicySnapshots} for the given policy that are no longer running.
+     * Find {@link SnapshotId}s for the given policy that are registered but no longer running.
      * @param projectState the current project state
      * @param policyId the policy id for which to find completed registered snapshots
-     * @return a list of snapshot names
+     * @return snapshot ids that are registered for {@code policyId} and not present in {@link SnapshotsInProgress}
      */
-    static List<String> findCompletedRegisteredSnapshotNames(ProjectState projectState, String policyId) {
+    static List<SnapshotId> findCompletedRegisteredSnapshotIds(ProjectState projectState, String policyId) {
         Set<SnapshotId> runningSnapshots = currentlyRunningSnapshots(projectState.cluster());
 
         RegisteredPolicySnapshots registeredSnapshots = projectState.metadata()
@@ -105,8 +104,40 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             .filter(policySnapshot -> policySnapshot.getPolicy().equals(policyId))
             // look for snapshots that are no longer running
             .filter(policySnapshot -> runningSnapshots.contains(policySnapshot.getSnapshotId()) == false)
-            .map(policySnapshot -> policySnapshot.getSnapshotId().getName())
+            .map(PolicySnapshot::getSnapshotId)
             .toList();
+    }
+
+    /**
+     * Snapshot infos retrieved for registered snapshots that were not running at lookup time, plus the ids that were queried.
+     * The queried ids are used by {@link WriteJobStatus} to distinguish "missing from the repository" (infer failure) from
+     * "was still running at lookup, so we never fetched it" (leave registered for a later cleanup).
+     * <p>
+     * Every {@link SnapshotInfo} should correspond to a queried id; infos are a subset of {@code queriedSnapshotIds}
+     * (some queried snapshots may be missing from the repository). {@code GetSnapshots} is keyed by snapshot name, while
+     * {@link SnapshotId} equality includes the uuid, so a deleted snapshot whose name was reused can yield info that is
+     * not in the queried set. That mismatch is ignored rather than thrown so SLM cleanup can continue.
+     */
+    record CompletedRegisteredSnapshotInfos(Set<SnapshotId> queriedSnapshotIds, List<SnapshotInfo> snapshotInfos) {
+        CompletedRegisteredSnapshotInfos {
+            queriedSnapshotIds = Set.copyOf(queriedSnapshotIds);
+            List<SnapshotInfo> matchedSnapshotInfos = new ArrayList<>(snapshotInfos.size());
+            for (SnapshotInfo snapshotInfo : snapshotInfos) {
+                if (queriedSnapshotIds.contains(snapshotInfo.snapshotId())) {
+                    matchedSnapshotInfos.add(snapshotInfo);
+                } else {
+                    // GetSnapshots is keyed by name, while SnapshotId equality includes uuid. Do not throw:
+                    // that would fail every subsequent SLM run while a stale registered name is reused.
+                    logger.debug(
+                        () -> "snapshot info for [" + snapshotInfo.snapshotId() + "] was not in the queried snapshot id set; ignoring it"
+                    );
+                    assert false : "snapshot info for [" + snapshotInfo.snapshotId() + "] was not in the queried snapshot id set";
+                }
+            }
+            snapshotInfos = List.copyOf(matchedSnapshotInfos);
+        }
+
+        static final CompletedRegisteredSnapshotInfos EMPTY = new CompletedRegisteredSnapshotInfos(Set.of(), List.of());
     }
 
     @Override
@@ -130,31 +161,37 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
     }
 
     /**
-     * Find {@link RegisteredPolicySnapshots} that are no longer running, and fetch their snapshot info. These snapshots should have been
-     * removed from the registered set by WriteJobStatus when they were completed. However, they were not removed likely due to the master
-     * being shutdown at the same time of a SLM run, causing WriteJobStatus to fail. These registered snapshots will be cleaned up in the
-     * next SLM run and their stats will be retroactively recorded in SLM cluster state based on their status.
+     * Find registered snapshots for {@code policyId} that are no longer running, and fetch their {@link SnapshotInfo}.
+     * <p>
+     * These entries should already have been removed from the registered set by {@link WriteJobStatus} when they completed. When they were
+     * not (for example because the master shut down during an SLM run and {@code WriteJobStatus} failed), the next SLM run cleans them up
+     * and retroactively records stats from their snapshot info.
+     * <p>
+     * The listener receives both the fetched infos and the set of snapshot ids that were queried. {@link WriteJobStatus} uses that queried
+     * set so that a snapshot still running at lookup time, which later finishes before the cluster-state update, is left registered instead
+     * of being inferred as a failure when its info was never fetched.
      */
     private static void findCompletedRegisteredSnapshotInfo(
         final ProjectState projectState,
         final String policyId,
         final Client client,
-        final ActionListener<List<SnapshotInfo>> listener
+        final ActionListener<CompletedRegisteredSnapshotInfos> listener
     ) {
-        var snapshotNames = findCompletedRegisteredSnapshotNames(projectState, policyId);
+        var completedSnapshotIds = findCompletedRegisteredSnapshotIds(projectState, policyId);
 
-        if (snapshotNames.isEmpty() == false) {
+        if (completedSnapshotIds.isEmpty() == false) {
             var policyMetadata = getSnapPolicyMetadataById(projectState.metadata(), policyId);
             if (policyMetadata.isPresent() == false) {
                 listener.onFailure(new IllegalStateException(format("snapshot lifecycle policy [%s] no longer exists", policyId)));
                 return;
             }
             SnapshotLifecyclePolicy policy = policyMetadata.get().getPolicy();
+            final Set<SnapshotId> queriedSnapshotIds = Set.copyOf(completedSnapshotIds);
 
             GetSnapshotsRequest request = new GetSnapshotsRequest(
                 TimeValue.MAX_VALUE,    // do not time out internal request in case of slow master node
                 new String[] { policy.getRepository() },
-                snapshotNames.toArray(new String[0])
+                completedSnapshotIds.stream().map(SnapshotId::getName).toArray(String[]::new)
             );
             request.ignoreUnavailable(true);
             request.includeIndexNames(false);
@@ -164,10 +201,13 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                 .execute(
                     TransportGetSnapshotsAction.TYPE,
                     request,
-                    ActionListener.wrap(response -> listener.onResponse(response.getSnapshots()), listener::onFailure)
+                    ActionListener.wrap(
+                        response -> listener.onResponse(new CompletedRegisteredSnapshotInfos(queriedSnapshotIds, response.getSnapshots())),
+                        listener::onFailure
+                    )
                 );
         } else {
-            listener.onResponse(Collections.emptyList());
+            listener.onResponse(CompletedRegisteredSnapshotInfos.EMPTY);
         }
     }
 
@@ -225,18 +265,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         ProjectState currentProjectState = clusterService.state().projectState(projectId);
                         findCompletedRegisteredSnapshotInfo(currentProjectState, policyId, client, new ActionListener<>() {
                             @Override
-                            public void onResponse(List<SnapshotInfo> snapshotInfo) {
-                                submitUnbatchedTask(
-                                    clusterService,
-                                    "slm-record-success-" + policyId,
-                                    WriteJobStatus.success(projectId, policyId, snapshotId, snapshotStartTime, timestamp, snapshotInfo)
-                                );
-                            }
-
-                            @Override
-                            public void onFailure(Exception e) {
-                                logger.warn(() -> format("failed to retrieve stale registered snapshots for job [%s]", jobId), e);
-                                // still record the successful snapshot
+                            public void onResponse(CompletedRegisteredSnapshotInfos completedRegisteredSnapshotInfos) {
                                 submitUnbatchedTask(
                                     clusterService,
                                     "slm-record-success-" + policyId,
@@ -246,7 +275,25 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                                         snapshotId,
                                         snapshotStartTime,
                                         timestamp,
-                                        Collections.emptyList()
+                                        completedRegisteredSnapshotInfos
+                                    )
+                                );
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                logger.warn(() -> format("failed to retrieve stale registered snapshots for job [%s]", jobId), e);
+                                // still record the successful snapshot; leave other registered snapshots for a later run
+                                submitUnbatchedTask(
+                                    clusterService,
+                                    "slm-record-success-" + policyId,
+                                    WriteJobStatus.success(
+                                        projectId,
+                                        policyId,
+                                        snapshotId,
+                                        snapshotStartTime,
+                                        timestamp,
+                                        CompletedRegisteredSnapshotInfos.EMPTY
                                     )
                                 );
                             }
@@ -259,13 +306,25 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                             request.snapshot(),
                             "failed to create snapshot successfully, " + failures + " out of " + total + " total shards failed"
                         );
-                        // Call the failure handler to register this as a failure and persist it
-                        onFailure(e);
+                        // SnapshotInfo means the snapshot was started and registered; never treat as never-registered.
+                        recordSnapshotFailure(e, false, clusterService.state().projectState(projectId));
                     }
                 }
 
                 @Override
                 public void onFailure(Exception e) {
+                    // Capture never-registered from the same cluster state used for the completed-snapshot lookup.
+                    // If it is registered now, a concurrent cleanup may remove it before WriteJobStatus runs; skip then.
+                    // SnapshotInfo failures pass recordFailureIfUnregistered=false so a peer cleanup is not confused
+                    // with a never-registered CreateSnapshot failure (#136759).
+                    ProjectState currentProjectState = clusterService.state().projectState(projectId);
+                    final boolean snapshotNeverRegistered = currentProjectState.metadata()
+                        .custom(RegisteredPolicySnapshots.TYPE, RegisteredPolicySnapshots.EMPTY)
+                        .contains(snapshotId) == false;
+                    recordSnapshotFailure(e, snapshotNeverRegistered, currentProjectState);
+                }
+
+                private void recordSnapshotFailure(Exception e, boolean recordFailureIfUnregistered, ProjectState currentProjectState) {
                     logger.warn(
                         () -> format("failed to create snapshot for snapshot lifecycle policy [%s]", policyMetadata.getPolicy().getId()),
                         e
@@ -292,11 +351,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         );
                     }
 
-                    // retrieve the current project state after snapshot is completed, since snapshotting can take a while
-                    ProjectState currentProjectState = clusterService.state().projectState(projectId);
                     findCompletedRegisteredSnapshotInfo(currentProjectState, policyId, client, new ActionListener<>() {
                         @Override
-                        public void onResponse(List<SnapshotInfo> snapshotInfo) {
+                        public void onResponse(CompletedRegisteredSnapshotInfos completedRegisteredSnapshotInfos) {
                             submitUnbatchedTask(
                                 clusterService,
                                 "slm-record-failure-" + policyMetadata.getPolicy().getId(),
@@ -305,16 +362,20 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                                     policyMetadata.getPolicy().getId(),
                                     snapshotId,
                                     timestamp,
-                                    snapshotInfo,
-                                    e
+                                    completedRegisteredSnapshotInfos,
+                                    e,
+                                    recordFailureIfUnregistered
                                 )
                             );
                         }
 
                         @Override
-                        public void onFailure(Exception e) {
-                            logger.warn(() -> format("failed to retrieve stale registered snapshots for job [%s]", jobId), e);
-                            // still record the failed snapshot
+                        public void onFailure(Exception getSnapshotsException) {
+                            logger.warn(
+                                () -> format("failed to retrieve stale registered snapshots for job [%s]", jobId),
+                                getSnapshotsException
+                            );
+                            // still record the failed snapshot; leave other registered snapshots for a later run
                             submitUnbatchedTask(
                                 clusterService,
                                 "slm-record-failure-" + policyMetadata.getPolicy().getId(),
@@ -323,8 +384,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                                     policyMetadata.getPolicy().getId(),
                                     snapshotId,
                                     timestamp,
-                                    Collections.emptyList(),
-                                    e
+                                    CompletedRegisteredSnapshotInfos.EMPTY,
+                                    e,
+                                    recordFailureIfUnregistered
                                 )
                             );
                         }
@@ -416,6 +478,20 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
         private final Optional<Exception> exception;
         // preloaded snapshot info for registered snapshots that are no longer running
         private final List<SnapshotInfo> registeredSnapshotInfo;
+        /**
+         * Snapshot ids that were not running when {@link SnapshotLifecycleTask#findCompletedRegisteredSnapshotInfo} ran and for which
+         * we attempted to load {@link SnapshotInfo}. Only these may be inferred as failures when their info is missing. Registered
+         * snapshots that finish between that lookup and this cluster state update are left registered for a later cleanup.
+         */
+        private final Set<SnapshotId> queriedSnapshotIds;
+        /**
+         * When true, this failure is for a snapshot that was never added to the registered set (e.g., CreateSnapshot failed before
+         * registration). WriteJobStatus must still record failure stats even though the snapshot is unregistered. When false, an
+         * unregistered initiating snapshot means another cleanup already recorded it - skip to avoid double-counting.
+         * Ignored when {@link #queriedSnapshotIds} contains this snapshot: lookup saw it registered, so a missing registered
+         * entry is a peer cleanup, not a never-registered failure.
+         */
+        private final boolean recordFailureIfUnregistered;
 
         private WriteJobStatus(
             ProjectId projectId,
@@ -423,8 +499,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             SnapshotId snapshotId,
             long snapshotStartTime,
             long snapshotFinishTime,
-            List<SnapshotInfo> registeredSnapshotInfo,
-            Optional<Exception> exception
+            CompletedRegisteredSnapshotInfos completedRegisteredSnapshotInfos,
+            Optional<Exception> exception,
+            boolean recordFailureIfUnregistered
         ) {
             this.projectId = projectId;
             this.policyName = policyName;
@@ -432,7 +509,11 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             this.exception = exception;
             this.snapshotStartTime = snapshotStartTime;
             this.snapshotFinishTime = snapshotFinishTime;
-            this.registeredSnapshotInfo = registeredSnapshotInfo;
+            this.registeredSnapshotInfo = completedRegisteredSnapshotInfos.snapshotInfos();
+            this.queriedSnapshotIds = completedRegisteredSnapshotInfos.queriedSnapshotIds();
+            this.recordFailureIfUnregistered = recordFailureIfUnregistered;
+            assert recordFailureIfUnregistered == false || queriedSnapshotIds.contains(snapshotId) == false
+                : "snapshot [" + snapshotId + "] was flagged as never registered but appeared in the queried set";
         }
 
         static WriteJobStatus success(
@@ -441,7 +522,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             SnapshotId snapshotId,
             long snapshotStartTime,
             long snapshotFinishTime,
-            List<SnapshotInfo> registeredSnapshotInfo
+            CompletedRegisteredSnapshotInfos completedRegisteredSnapshotInfos
         ) {
             return new WriteJobStatus(
                 projectId,
@@ -449,8 +530,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                 snapshotId,
                 snapshotStartTime,
                 snapshotFinishTime,
-                registeredSnapshotInfo,
-                Optional.empty()
+                completedRegisteredSnapshotInfos,
+                Optional.empty(),
+                false
             );
         }
 
@@ -459,8 +541,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             String policyId,
             SnapshotId snapshotId,
             long timestamp,
-            List<SnapshotInfo> registeredSnapshotInfo,
-            Exception exception
+            CompletedRegisteredSnapshotInfos completedRegisteredSnapshotInfos,
+            Exception exception,
+            boolean recordFailureIfUnregistered
         ) {
             return new WriteJobStatus(
                 projectId,
@@ -468,8 +551,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                 snapshotId,
                 timestamp,
                 timestamp,
-                registeredSnapshotInfo,
-                Optional.of(exception)
+                completedRegisteredSnapshotInfos,
+                Optional.of(exception),
+                recordFailureIfUnregistered
             );
         }
 
@@ -498,14 +582,6 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
             SnapshotLifecycleStats newStats = snapMeta.getStats();
 
             final boolean snapshotIsRegistered = registeredSnapshots.contains(snapshotId);
-            if (snapshotIsRegistered == false) {
-                logger.warn(
-                    "Snapshot [{}] not found in registered set after snapshot completion. This means snapshot was"
-                        + " recorded as a failure by another snapshot's cleanup run.",
-                    snapshotId.getName()
-                );
-            }
-
             final Set<SnapshotId> runningSnapshots = currentlyRunningSnapshots(currentState);
             final List<PolicySnapshot> newRegistered = new ArrayList<>();
 
@@ -544,18 +620,59 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                                     )
                                 );
                         }
-                    } else {
-                        // either the snapshot no longer exist in the repo or its info failed to be retrieved, assume failure to clean it up
+                    } else if (queriedSnapshotIds.contains(registeredSnapshotId)) {
+                        // we looked up this snapshot because it was already not running, and its info is unavailable - assume failure
                         // so it is not stuck in the registered set forever
                         newStats = newStats.withFailedIncremented(policyName);
                         newPolicyMetadata.incrementInvocationsSinceLastSuccess()
                             .setLastFailure(buildFailedSnapshotRecord(registeredSnapshotId));
+                    } else {
+                        // not running now, but we never fetched its info (it was still running at lookup time). Leave it registered
+                        // so a later SLM run can record the true outcome instead of inferring a failure.
+                        newRegistered.add(registeredSnapshot);
                     }
                 }
             }
 
-            // Add stats from the just completed snapshot execution
-            if (exception.isPresent()) {
+            // Add stats from the just completed snapshot execution, unless another cleanup already recorded it.
+            //
+            // CreateSnapshot can fail before registration (e.g. missing index). Those failures set
+            // recordFailureIfUnregistered so they are still counted, but only when lookup did not see this id.
+            // If queriedSnapshotIds contains this snapshot, it was registered at lookup time, so a missing
+            // registered entry means a peer cleanup already recorded it.
+            //
+            // Do not infer "already recorded" from lastSuccess/lastFailure. Those fields store only the most
+            // recent snapshot name. Example: snapshots A and B both fail; A's WriteJobStatus records B's failure
+            // (lastFailure=B) then A's own failure (lastFailure=A). When B's WriteJobStatus runs, lastFailure no
+            // longer names B, so matching on that name would count B a second time.
+            if (snapshotIsRegistered == false) {
+                // If lookup saw this id, it was registered then; a peer cleanup must not be treated as never-registered.
+                if (exception.isPresent() && recordFailureIfUnregistered && queriedSnapshotIds.contains(snapshotId) == false) {
+                    // Expected for CreateSnapshot failures that never reached registration (e.g. missing index).
+                    logger.debug(
+                        "Snapshot [{}] not found in registered set after snapshot failure. Recording failure stats"
+                            + " (snapshot failed before registration).",
+                        snapshotId.getName()
+                    );
+                    newStats = newStats.withFailedIncremented(policyName);
+                    newPolicyMetadata.setLastFailure(
+                        new SnapshotInvocationRecord(
+                            snapshotId.getName(),
+                            null,
+                            snapshotFinishTime,
+                            exception.map(SnapshotLifecycleTask::exceptionToString).orElse(null)
+                        )
+                    );
+                    newPolicyMetadata.incrementInvocationsSinceLastSuccess();
+                } else {
+                    logger.warn(
+                        "Snapshot [{}] not found in registered set after snapshot {}. This means snapshot was"
+                            + " already recorded by another snapshot's cleanup run.",
+                        snapshotId.getName(),
+                        exception.isPresent() ? "failure" : "completion"
+                    );
+                }
+            } else if (exception.isPresent()) {
                 newStats = newStats.withFailedIncremented(policyName);
                 newPolicyMetadata.setLastFailure(
                     new SnapshotInvocationRecord(
@@ -565,11 +682,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         exception.map(SnapshotLifecycleTask::exceptionToString).orElse(null)
                     )
                 );
-                // If the snapshot was not registered, it means it was already counted as a failure by another snapshot's cleanup run
-                // so we should not increment the invocationsSinceLastSuccess again.
-                if (snapshotIsRegistered) {
-                    newPolicyMetadata.incrementInvocationsSinceLastSuccess();
-                }
+                newPolicyMetadata.incrementInvocationsSinceLastSuccess();
             } else {
                 newStats = newStats.withTakenIncremented(policyName);
                 newPolicyMetadata.setLastSuccess(

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.scheduler.SchedulerEngine;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexVersion;
@@ -60,6 +61,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -352,15 +354,16 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                 initiatingSnap,
                 randomLong(),
                 randomLong(),
-                Collections.emptyList()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY
             )
             : SnapshotLifecycleTask.WriteJobStatus.failure(
                 projectId,
                 policyId,
                 initiatingSnap,
                 randomLong(),
-                Collections.emptyList(),
-                new RuntimeException()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY,
+                new RuntimeException(),
+                randomBoolean()
             );
 
         // deletedPolicy is no longer defined
@@ -393,15 +396,16 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                 initiatingSnap,
                 randomLong(),
                 randomLong(),
-                Collections.emptyList()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY
             )
             : SnapshotLifecycleTask.WriteJobStatus.failure(
                 projectId,
                 policyId,
                 initiatingSnap,
                 randomLong(),
-                Collections.emptyList(),
-                new RuntimeException()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY,
+                new RuntimeException(),
+                randomBoolean()
             );
 
         var definedSlmPolicies = List.of(policyId, otherPolicy);
@@ -429,15 +433,16 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                 initiatingSnap,
                 randomLong(),
                 randomLong(),
-                Collections.emptyList()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY
             )
             : SnapshotLifecycleTask.WriteJobStatus.failure(
                 projectId,
                 policyId,
                 initiatingSnap,
                 randomLong(),
-                Collections.emptyList(),
-                new RuntimeException()
+                SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY,
+                new RuntimeException(),
+                randomBoolean()
             );
 
         final SnapshotId stillRunning = randSnapshotId();
@@ -469,7 +474,13 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
         var definedSlmPolicies = List.of(policyId);
         var registeredSnapshots = Map.of(
             policyId,
-            List.of(stillRunning, inferredFailureSnapshot, snapshotInfoSuccess.snapshotId(), snapshotInfoFailure.snapshotId())
+            List.of(
+                stillRunning,
+                inferredFailureSnapshot,
+                snapshotInfoSuccess.snapshotId(),
+                snapshotInfoFailure.snapshotId(),
+                initiatingSnapshot
+            )
         );
         var inProgress = Map.of(policyId, List.of(stillRunning));
         ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
@@ -480,7 +491,10 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
             initiatingSnapshot,
             randomLong(),
             randomLong(),
-            List.of(snapshotInfoSuccess, snapshotInfoFailure)
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.of(inferredFailureSnapshot, snapshotInfoSuccess.snapshotId(), snapshotInfoFailure.snapshotId()),
+                List.of(snapshotInfoSuccess, snapshotInfoFailure)
+            )
         );
 
         ClusterState newClusterState = writeJobTask.execute(clusterState);
@@ -540,8 +554,18 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
             policyId,
             initiatingSnapshot,
             randomLong(),
-            List.of(snapshotInfoSuccess, snapshotInfoFailure1, snapshotInfoFailure2),
-            new RuntimeException()
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.of(
+                    inferredFailureSnapshot,
+                    snapshotInfoSuccess.snapshotId(),
+                    snapshotInfoFailure1.snapshotId(),
+                    snapshotInfoFailure2.snapshotId()
+                ),
+                List.of(snapshotInfoSuccess, snapshotInfoFailure1, snapshotInfoFailure2)
+            ),
+            new RuntimeException(),
+            // initiating snapshot is still registered, so this flag must not affect stats
+            randomBoolean()
         );
 
         ClusterState newClusterState = writeJobTask.execute(clusterState);
@@ -570,6 +594,703 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
             .custom(RegisteredPolicySnapshots.TYPE);
         List<SnapshotId> newRegisteredSnapIds = newRegisteredPolicySnapshots.getSnapshotsByPolicy(policyId);
         assertEquals(List.of(stillRunning), newRegisteredSnapIds);
+    }
+
+    /**
+     * Reproduces the race from #155621: snapshot B was still running when snapshot A's cleanup looked up completed registered
+     * snapshots (so B's SnapshotInfo was never fetched), but B finished before A's WriteJobStatus cluster-state update ran.
+     * B must stay registered rather than being inferred as a failure.
+     */
+    public void testDoesNotInferFailureForSnapshotThatFinishedAfterLookup() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(snapshotA, snapshotB));
+        // B has finished by the time WriteJobStatus runs (not in SnapshotsInProgress)
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        // Lookup saw A as already completed (queried) while B was still running (not queried). No SnapshotInfo for B.
+        var writeJobTask = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            snapshotA,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotA), List.of())
+        );
+
+        ClusterState newClusterState = writeJobTask.execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(1, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(0, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(snapshotA.getName(), newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertNull(newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure());
+        assertEquals(0, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+
+        RegisteredPolicySnapshots newRegisteredPolicySnapshots = newClusterState.metadata()
+            .getProject(projectId)
+            .custom(RegisteredPolicySnapshots.TYPE);
+        assertEquals(List.of(snapshotB), newRegisteredPolicySnapshots.getSnapshotsByPolicy(policyId));
+    }
+
+    /**
+     * Same TOCTOU as {@link #testDoesNotInferFailureForSnapshotThatFinishedAfterLookup}, but the initiating WriteJobStatus is a
+     * failure: snapshot B finished after lookup and must remain registered rather than being inferred as another failure.
+     */
+    public void testDoesNotInferFailureForSnapshotThatFinishedAfterLookupOnFailurePath() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(snapshotA, snapshotB));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState newClusterState = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            snapshotA,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotA), List.of()),
+            new RuntimeException("initiating snapshot failed"),
+            // initiating snapshot was queried as registered, so it cannot also be flagged never-registered
+            false
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(0, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(1, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(snapshotA.getName(), newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName());
+        assertNull(newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastSuccess());
+        assertEquals(1, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+
+        RegisteredPolicySnapshots newRegisteredPolicySnapshots = newClusterState.metadata()
+            .getProject(projectId)
+            .custom(RegisteredPolicySnapshots.TYPE);
+        assertEquals(List.of(snapshotB), newRegisteredPolicySnapshots.getSnapshotsByPolicy(policyId));
+    }
+
+    /**
+     * Two snapshots that finish around the same time can each discover the other as completed and fetch SnapshotInfo.
+     * Whichever WriteJobStatus runs first records both outcomes and clears the registered set; the second must not
+     * double-count stats or overwrite last success/failure, even when it still carries stale SnapshotInfo for the peer.
+     */
+    public void testDoesNotDoubleCountWhenAnotherCleanupAlreadyRecordedSnapshot() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+        final SnapshotInfo snapshotInfoA = snapshotInfoSuccess(projectId, snapshotA);
+        final SnapshotInfo snapshotInfoB = snapshotInfoSuccess(projectId, snapshotB);
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(snapshotA, snapshotB));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        // A's cleanup discovers B already completed and records B from SnapshotInfo, then records A's own success
+        ClusterState afterA = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            snapshotA,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotB), List.of(snapshotInfoB))
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata slmAfterA = afterA.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats statsAfterA = slmAfterA.getStats().getMetrics().get(policyId);
+        assertEquals(2, statsAfterA.getSnapshotTakenCount());
+        assertEquals(0, statsAfterA.getSnapshotFailedCount());
+        assertEquals(snapshotA.getName(), slmAfterA.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertEquals(0, slmAfterA.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        RegisteredPolicySnapshots registeredAfterA = afterA.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE);
+        assertEquals(List.of(), registeredAfterA.getSnapshotsByPolicy(policyId));
+        SnapshotLifecycleStats statsAfterASource = slmAfterA.getStats();
+        final long takenAfterA = statsAfterA.getSnapshotTakenCount();
+        final long failedAfterA = statsAfterA.getSnapshotFailedCount();
+
+        // B also discovered A at lookup time; A is already gone from the registered set so this must be a no-op for stats
+        ClusterState afterB = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            snapshotB,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotA, snapshotB), List.of(snapshotInfoA))
+        ).execute(afterA);
+
+        SnapshotLifecycleMetadata slmAfterB = afterB.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats statsAfterB = slmAfterB.getStats().getMetrics().get(policyId);
+        assertEquals(2, statsAfterB.getSnapshotTakenCount());
+        assertEquals(0, statsAfterB.getSnapshotFailedCount());
+        assertEquals(snapshotA.getName(), slmAfterB.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertEquals(0, slmAfterB.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+        assertStatsNotMutated(statsAfterASource, policyId, takenAfterA, failedAfterA);
+    }
+
+    /**
+     * CreateSnapshot can fail before the snapshot is added to the registered set (e.g. missing index). Failure stats
+     * must still be recorded so SLM does not appear stuck with empty policy metrics, including
+     * invocationsSinceLastSuccess.
+     */
+    public void testRecordsFailureEvenWhenSnapshotNeverRegistered() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId initiatingSnapshot = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.<SnapshotId>of());
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState newClusterState = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            initiatingSnapshot,
+            randomLong(),
+            SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY,
+            new RuntimeException("no such index"),
+            true
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(0, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(1, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(
+            initiatingSnapshot.getName(),
+            newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName()
+        );
+        assertEquals(1, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+    }
+
+    /**
+     * Like {@link #testDoesNotDoubleCountWhenAnotherCleanupAlreadyRecordedSnapshot}, but for failures: A's cleanup can record B
+     * from SnapshotInfo as a failure and clear the registered set; B's WriteJobStatus.failure must not double-count even when
+     * it still carries stale SnapshotInfo for A (concurrent lookup) and is no longer in the registered set. Pass
+     * {@code recordFailureIfUnregistered=false} because the snapshot was registered — a peer cleanup removing it must not be
+     * confused with a never-registered CreateSnapshot failure (#136759).
+     */
+    public void testDoesNotDoubleCountFailureWhenAnotherCleanupAlreadyRecordedSnapshot() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+        final SnapshotInfo snapshotInfoA = snapshotInfoSuccess(projectId, snapshotA);
+        final SnapshotInfo snapshotInfoB = snapshotInfoFailure(projectId, snapshotB);
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(snapshotA, snapshotB));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState afterA = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            snapshotA,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotB), List.of(snapshotInfoB))
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata slmAfterA = afterA.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats statsAfterA = slmAfterA.getStats().getMetrics().get(policyId);
+        assertEquals(1, statsAfterA.getSnapshotTakenCount());
+        assertEquals(1, statsAfterA.getSnapshotFailedCount());
+        assertEquals(snapshotA.getName(), slmAfterA.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertEquals(snapshotB.getName(), slmAfterA.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName());
+        // A's success resets invocations even though B's failure was recorded in the same cleanup
+        assertEquals(0, slmAfterA.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertTrue(policyAlreadyRecordsSnapshot(slmAfterA.getSnapshotConfigurations().get(policyId), snapshotB.getName()));
+        SnapshotLifecycleStats statsAfterASource = slmAfterA.getStats();
+        final long takenAfterA = statsAfterA.getSnapshotTakenCount();
+        final long failedAfterA = statsAfterA.getSnapshotFailedCount();
+
+        ClusterState afterB = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            snapshotB,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotA), List.of(snapshotInfoA)),
+            new RuntimeException("failed to create snapshot successfully"),
+            false
+        ).execute(afterA);
+
+        SnapshotLifecycleMetadata slmAfterB = afterB.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats statsAfterB = slmAfterB.getStats().getMetrics().get(policyId);
+        assertEquals(1, statsAfterB.getSnapshotTakenCount());
+        assertEquals(1, statsAfterB.getSnapshotFailedCount());
+        assertEquals(snapshotB.getName(), slmAfterB.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName());
+        assertEquals(snapshotA.getName(), slmAfterB.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertEquals(0, slmAfterB.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+        assertStatsNotMutated(statsAfterASource, policyId, takenAfterA, failedAfterA);
+    }
+
+    /**
+     * Companion to {@link #testDoesNotDoubleCountFailureWhenAnotherCleanupAlreadyRecordedSnapshot} with the initiating snapshot
+     * also failing. A's cleanup records B's failure and then A's own failure record overwrites {@code lastFailure}, so when B's
+     * WriteJobStatus runs the policy metadata no longer names B and B's outcome must not be recorded a second time (#136759).
+     */
+    public void testDoesNotDoubleCountWhenBothConcurrentSnapshotsFailed() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(snapshotA, snapshotB));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        // A's cleanup discovers B already completed and failed, records it, then records A's own failure
+        ClusterState afterA = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            snapshotA,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.of(snapshotB),
+                List.of(snapshotInfoFailure(projectId, snapshotB))
+            ),
+            new RuntimeException("snapshot A failed"),
+            false
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata slmAfterA = afterA.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyAfterA = slmAfterA.getSnapshotConfigurations().get(policyId);
+        SnapshotLifecycleStats statsAfterASource = slmAfterA.getStats();
+        final long takenAfterA = statsAfterASource.getMetrics().get(policyId).getSnapshotTakenCount();
+        final long failedAfterA = statsAfterASource.getMetrics().get(policyId).getSnapshotFailedCount();
+        assertEquals(0, takenAfterA);
+        assertEquals(2, failedAfterA);
+        assertEquals(2, policyAfterA.getInvocationsSinceLastSuccess());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) afterA.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+
+        // A's own failure record overwrote the one A's cleanup wrote for B, so the policy no longer names B.
+        // last success/failure cannot be used to skip already-recorded outcomes (#136759).
+        assertEquals(snapshotA.getName(), policyAfterA.getLastFailure().getSnapshotName());
+        assertFalse(policyAlreadyRecordsSnapshot(policyAfterA, snapshotB.getName()));
+
+        // B also discovered A at lookup time; B was already recorded by A's cleanup and must not be counted again
+        ClusterState afterB = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            snapshotB,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.of(snapshotA),
+                List.of(snapshotInfoFailure(projectId, snapshotA))
+            ),
+            new RuntimeException("snapshot B failed"),
+            false
+        ).execute(afterA);
+
+        SnapshotLifecycleMetadata slmAfterB = afterB.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyAfterB = slmAfterB.getSnapshotConfigurations().get(policyId);
+        assertEquals(0, slmAfterB.getStats().getMetrics().get(policyId).getSnapshotTakenCount());
+        assertEquals(2, slmAfterB.getStats().getMetrics().get(policyId).getSnapshotFailedCount());
+        assertEquals(2, policyAfterB.getInvocationsSinceLastSuccess());
+        assertEquals(snapshotA.getName(), policyAfterB.getLastFailure().getSnapshotName());
+        assertEquals(2, policyAfterA.getInvocationsSinceLastSuccess());
+        assertEquals(snapshotA.getName(), policyAfterA.getLastFailure().getSnapshotName());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) afterB.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        assertStatsNotMutated(statsBefore);
+        assertStatsNotMutated(statsAfterASource, policyId, takenAfterA, failedAfterA);
+    }
+
+    /**
+     * The scenario from #136759: three snapshots of the same policy fail at virtually the same time. The first cleanup run
+     * records all three, so the two later runs must not increment {@code invocationsSinceLastSuccess} or the failed count
+     * again - otherwise three failures are reported as more invocations and the SLM health indicator can turn yellow
+     * prematurely. Later runs still carry stale SnapshotInfo from concurrent lookup.
+     */
+    public void testThreeConcurrentFailuresCountedOnce() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+        final SnapshotId snapshotC = randSnapshotId();
+        final List<SnapshotId> allSnapshots = List.of(snapshotA, snapshotB, snapshotC);
+        final SnapshotId first = randomFrom(allSnapshots);
+        final List<SnapshotId> others = new ArrayList<>(allSnapshots);
+        others.remove(first);
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, allSnapshots);
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        // First cleanup sees the other two already completed and failed, records both, then records its own failure
+        ClusterState state = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            first,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.copyOf(allSnapshots),
+                others.stream().map(id -> snapshotInfoFailure(projectId, id)).toList()
+            ),
+            new RuntimeException("snapshot failed"),
+            false
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata slmAfterFirst = state.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyAfterFirst = slmAfterFirst.getSnapshotConfigurations().get(policyId);
+        SnapshotLifecycleStats statsAfterFirst = slmAfterFirst.getStats();
+        final long takenAfterFirst = statsAfterFirst.getMetrics().get(policyId).getSnapshotTakenCount();
+        final long failedAfterFirst = statsAfterFirst.getMetrics().get(policyId).getSnapshotFailedCount();
+        assertEquals(0, takenAfterFirst);
+        assertEquals(3, failedAfterFirst);
+        assertEquals(3, policyAfterFirst.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyAfterFirst.getLastFailure().getSnapshotName());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) state.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        for (SnapshotId other : others) {
+            assertFalse(policyAlreadyRecordsSnapshot(policyAfterFirst, other.getName()));
+        }
+
+        // Later listeners still carry stale SnapshotInfo for their peers from concurrent lookup
+        for (SnapshotId snapshotId : shuffledList(others)) {
+            List<SnapshotId> peers = new ArrayList<>(allSnapshots);
+            peers.remove(snapshotId);
+            state = SnapshotLifecycleTask.WriteJobStatus.failure(
+                projectId,
+                policyId,
+                snapshotId,
+                randomLong(),
+                new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                    Set.copyOf(allSnapshots),
+                    peers.stream().map(id -> snapshotInfoFailure(projectId, id)).toList()
+                ),
+                new RuntimeException("snapshot failed"),
+                false
+            ).execute(state);
+        }
+
+        SnapshotLifecycleMetadata slmMetadata = state.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyMetadata = slmMetadata.getSnapshotConfigurations().get(policyId);
+        assertEquals(0, slmMetadata.getStats().getMetrics().get(policyId).getSnapshotTakenCount());
+        assertEquals(3, slmMetadata.getStats().getMetrics().get(policyId).getSnapshotFailedCount());
+        assertEquals(3, policyMetadata.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyMetadata.getLastFailure().getSnapshotName());
+        assertEquals(3, policyAfterFirst.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyAfterFirst.getLastFailure().getSnapshotName());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) state.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        assertStatsNotMutated(statsBefore);
+        assertStatsNotMutated(statsAfterFirst, policyId, takenAfterFirst, failedAfterFirst);
+    }
+
+    /**
+     * Combines registered-set cleanup with the #155621 TOCTOU: a queried snapshot missing SnapshotInfo is inferred as a
+     * failure, while a snapshot that was still running at lookup (not queried) but finished before WriteJobStatus stays
+     * registered rather than being inferred.
+     */
+    public void testInfersFailureOnlyForQueriedSnapshotsWhenAnotherFinishedAfterLookup() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId initiatingSnapshot = randSnapshotId();
+        final SnapshotId inferredFailureSnapshot = randSnapshotId();
+        final SnapshotId finishedAfterLookup = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(finishedAfterLookup, inferredFailureSnapshot, initiatingSnapshot));
+        // finishedAfterLookup is no longer in SnapshotsInProgress, but was not queried (still running at lookup)
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState newClusterState = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            initiatingSnapshot,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(initiatingSnapshot, inferredFailureSnapshot), List.of())
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(1, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(1, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(
+            initiatingSnapshot.getName(),
+            newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName()
+        );
+        assertEquals(
+            inferredFailureSnapshot.getName(),
+            newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName()
+        );
+        assertEquals(0, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertStatsNotMutated(statsBefore);
+
+        RegisteredPolicySnapshots newRegisteredPolicySnapshots = newClusterState.metadata()
+            .getProject(projectId)
+            .custom(RegisteredPolicySnapshots.TYPE);
+        assertEquals(List.of(finishedAfterLookup), newRegisteredPolicySnapshots.getSnapshotsByPolicy(policyId));
+    }
+
+    /**
+     * CreateSnapshot can fail before registration while other registered snapshots still need cleanup. Own failure stats
+     * are recorded ({@code recordFailureIfUnregistered=true}) and peer SnapshotInfo is still applied.
+     */
+    public void testNeverRegisteredFailureStillCleansUpOtherRegisteredSnapshots() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId initiatingSnapshot = randSnapshotId();
+        final SnapshotId staleSuccess = randSnapshotId();
+        final SnapshotInfo staleSuccessInfo = snapshotInfoSuccess(projectId, staleSuccess);
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(staleSuccess));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState newClusterState = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            initiatingSnapshot,
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(staleSuccess), List.of(staleSuccessInfo)),
+            new RuntimeException("no such index"),
+            true
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(1, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(1, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(staleSuccess.getName(), newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastSuccess().getSnapshotName());
+        assertEquals(
+            initiatingSnapshot.getName(),
+            newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName()
+        );
+        assertEquals(1, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) newClusterState.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        assertStatsNotMutated(statsBefore);
+    }
+
+    /**
+     * GetSnapshots can fail independently of CreateSnapshot. A never-registered initiating failure must still be
+     * recorded, but other registered snapshots that were not queried must stay registered rather than being inferred
+     * as failures (same TOCTOU rule as #155621).
+     */
+    public void testNeverRegisteredFailureWithLookupFailureLeavesOtherSnapshotsRegistered() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId initiatingSnapshot = randSnapshotId();
+        final SnapshotId staleRegistered = randSnapshotId();
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, List.of(staleRegistered));
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState newClusterState = SnapshotLifecycleTask.WriteJobStatus.failure(
+            projectId,
+            policyId,
+            initiatingSnapshot,
+            randomLong(),
+            SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos.EMPTY,
+            new RuntimeException("no such index"),
+            true
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata newSlmMetadata = newClusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecycleStats.SnapshotPolicyStats snapshotPolicyStats = newSlmMetadata.getStats().getMetrics().get(policyId);
+        assertEquals(0, snapshotPolicyStats.getSnapshotTakenCount());
+        assertEquals(1, snapshotPolicyStats.getSnapshotFailedCount());
+        assertEquals(
+            initiatingSnapshot.getName(),
+            newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastFailure().getSnapshotName()
+        );
+        assertNull(newSlmMetadata.getSnapshotConfigurations().get(policyId).getLastSuccess());
+        assertEquals(1, newSlmMetadata.getSnapshotConfigurations().get(policyId).getInvocationsSinceLastSuccess());
+        assertEquals(
+            List.of(staleRegistered),
+            ((RegisteredPolicySnapshots) newClusterState.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        assertStatsNotMutated(statsBefore);
+    }
+
+    /**
+     * Success-path counterpart of {@link #testThreeConcurrentFailuresCountedOnce} (#136759): the first cleanup
+     * records all three successes; later runs must not increment the taken count or overwrite last success from stale
+     * SnapshotInfo.
+     */
+    public void testThreeConcurrentSuccessesCountedOnce() throws Exception {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId snapshotA = randSnapshotId();
+        final SnapshotId snapshotB = randSnapshotId();
+        final SnapshotId snapshotC = randSnapshotId();
+        final List<SnapshotId> allSnapshots = List.of(snapshotA, snapshotB, snapshotC);
+        final SnapshotId first = randomFrom(allSnapshots);
+        final List<SnapshotId> others = new ArrayList<>(allSnapshots);
+        others.remove(first);
+
+        var definedSlmPolicies = List.of(policyId);
+        var registeredSnapshots = Map.of(policyId, allSnapshots);
+        var inProgress = Map.of(policyId, List.<SnapshotId>of());
+        ClusterState clusterState = buildClusterState(projectId, definedSlmPolicies, registeredSnapshots, inProgress);
+        SnapshotLifecycleStats statsBefore = slmStats(clusterState);
+
+        ClusterState state = SnapshotLifecycleTask.WriteJobStatus.success(
+            projectId,
+            policyId,
+            first,
+            randomLong(),
+            randomLong(),
+            new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                Set.copyOf(allSnapshots),
+                others.stream().map(id -> snapshotInfoSuccess(projectId, id)).toList()
+            )
+        ).execute(clusterState);
+
+        SnapshotLifecycleMetadata slmAfterFirst = state.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyAfterFirst = slmAfterFirst.getSnapshotConfigurations().get(policyId);
+        SnapshotLifecycleStats statsAfterFirst = slmAfterFirst.getStats();
+        final long takenAfterFirst = statsAfterFirst.getMetrics().get(policyId).getSnapshotTakenCount();
+        final long failedAfterFirst = statsAfterFirst.getMetrics().get(policyId).getSnapshotFailedCount();
+        assertEquals(3, takenAfterFirst);
+        assertEquals(0, failedAfterFirst);
+        assertEquals(0, policyAfterFirst.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyAfterFirst.getLastSuccess().getSnapshotName());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) state.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        for (SnapshotId other : others) {
+            assertFalse(policyAlreadyRecordsSnapshot(policyAfterFirst, other.getName()));
+        }
+
+        for (SnapshotId snapshotId : shuffledList(others)) {
+            List<SnapshotId> peers = new ArrayList<>(allSnapshots);
+            peers.remove(snapshotId);
+            state = SnapshotLifecycleTask.WriteJobStatus.success(
+                projectId,
+                policyId,
+                snapshotId,
+                randomLong(),
+                randomLong(),
+                new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(
+                    Set.copyOf(allSnapshots),
+                    peers.stream().map(id -> snapshotInfoSuccess(projectId, id)).toList()
+                )
+            ).execute(state);
+        }
+
+        SnapshotLifecycleMetadata slmMetadata = state.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE);
+        SnapshotLifecyclePolicyMetadata policyMetadata = slmMetadata.getSnapshotConfigurations().get(policyId);
+        assertEquals(3, slmMetadata.getStats().getMetrics().get(policyId).getSnapshotTakenCount());
+        assertEquals(0, slmMetadata.getStats().getMetrics().get(policyId).getSnapshotFailedCount());
+        assertEquals(0, policyMetadata.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyMetadata.getLastSuccess().getSnapshotName());
+        assertEquals(
+            List.of(),
+            ((RegisteredPolicySnapshots) state.metadata().getProject(projectId).custom(RegisteredPolicySnapshots.TYPE))
+                .getSnapshotsByPolicy(policyId)
+        );
+        assertEquals(3, statsAfterFirst.getMetrics().get(policyId).getSnapshotTakenCount());
+        assertEquals(0, policyAfterFirst.getInvocationsSinceLastSuccess());
+        assertEquals(first.getName(), policyAfterFirst.getLastSuccess().getSnapshotName());
+        assertStatsNotMutated(statsBefore);
+        assertStatsNotMutated(statsAfterFirst, policyId, takenAfterFirst, failedAfterFirst);
+    }
+
+    /**
+     * {@code recordFailureIfUnregistered=true} means CreateSnapshot failed before registration, so lookup cannot have
+     * queried this snapshot id. The execute-path still ignores that combination if assertions are disabled.
+     */
+    public void testNeverRegisteredFlagRejectedWhenSnapshotWasQueried() {
+        assumeTrue("assertions enabled", Assertions.ENABLED);
+        final SnapshotId snapshotId = randSnapshotId();
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> SnapshotLifecycleTask.WriteJobStatus.failure(
+                projectId,
+                randomAlphaOfLength(10),
+                snapshotId,
+                randomLong(),
+                new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(snapshotId), List.of()),
+                new RuntimeException("failed"),
+                true
+            )
+        );
+        assertThat(error.getMessage(), containsString(snapshotId.toString()));
+    }
+
+    public void testCompletedRegisteredSnapshotInfosRejectsInfoOutsideQueriedSet() {
+        assumeTrue("assertions enabled", Assertions.ENABLED);
+        final SnapshotId queried = randSnapshotId();
+        final SnapshotId notQueried = randSnapshotId();
+        final SnapshotInfo info = snapshotInfoSuccess(projectId, notQueried);
+        AssertionError ex = expectThrows(
+            AssertionError.class,
+            () -> new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(Set.of(queried), List.of(info))
+        );
+        assertThat(ex.getMessage(), containsString(notQueried.toString()));
+    }
+
+    public void testCompletedRegisteredSnapshotInfosDefensivelyCopiesInputs() {
+        final SnapshotId snapshotId = randSnapshotId();
+        final SnapshotInfo info = snapshotInfoSuccess(projectId, snapshotId);
+        Set<SnapshotId> queried = new HashSet<>(Set.of(snapshotId));
+        List<SnapshotInfo> infos = new ArrayList<>(List.of(info));
+        var completed = new SnapshotLifecycleTask.CompletedRegisteredSnapshotInfos(queried, infos);
+        queried.clear();
+        infos.clear();
+        assertEquals(Set.of(snapshotId), completed.queriedSnapshotIds());
+        assertEquals(List.of(info), completed.snapshotInfos());
+    }
+
+    public void testFindCompletedRegisteredSnapshotIdsExcludesRunningSnapshots() {
+        final String policyId = randomAlphaOfLength(10);
+        final SnapshotId completed = randSnapshotId();
+        final SnapshotId running = randSnapshotId();
+        ClusterState clusterState = buildClusterState(
+            projectId,
+            List.of(policyId),
+            Map.of(policyId, List.of(completed, running)),
+            Map.of(policyId, List.of(running))
+        );
+        assertEquals(
+            List.of(completed),
+            SnapshotLifecycleTask.findCompletedRegisteredSnapshotIds(clusterState.projectState(projectId), policyId)
+        );
     }
 
     public void testGetCurrentlyRunningSnapshots() {
@@ -606,6 +1327,39 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
 
     private static SnapshotId randSnapshotId() {
         return new SnapshotId(randomAlphaOfLength(10), randomUUID());
+    }
+
+    private SnapshotLifecycleStats slmStats(ClusterState clusterState) {
+        return ((SnapshotLifecycleMetadata) clusterState.metadata().getProject(projectId).custom(SnapshotLifecycleMetadata.TYPE))
+            .getStats();
+    }
+
+    /**
+     * WriteJobStatus must copy-on-write stats (see {@code SLMStatsImmutableIT}): prior cluster-state stats instances and the
+     * {@link SnapshotLifecycleMetadata#EMPTY} singleton must remain untouched. Pin primitive counts rather than a shallow
+     * map copy of policy stats objects, which would not detect in-place mutation.
+     */
+    private static void assertStatsNotMutated(SnapshotLifecycleStats emptyStatsSource) {
+        assertThat(emptyStatsSource.getMetrics(), equalTo(Map.of()));
+        assertThat(SnapshotLifecycleMetadata.EMPTY.getStats().getMetrics(), equalTo(Map.of()));
+    }
+
+    private static void assertStatsNotMutated(SnapshotLifecycleStats statsSource, String policyId, long taken, long failed) {
+        SnapshotLifecycleStats.SnapshotPolicyStats policyStats = statsSource.getMetrics().get(policyId);
+        assertEquals(taken, policyStats.getSnapshotTakenCount());
+        assertEquals(failed, policyStats.getSnapshotFailedCount());
+        assertThat(SnapshotLifecycleMetadata.EMPTY.getStats().getMetrics(), equalTo(Map.of()));
+    }
+
+    /**
+     * Whether {@code policyMetadata} currently names {@code snapshotName} as last success or last failure.
+     * Concurrent cleanups overwrite these fields, so they must not be used to skip already-recorded outcomes.
+     */
+    private static boolean policyAlreadyRecordsSnapshot(SnapshotLifecyclePolicyMetadata policyMetadata, String snapshotName) {
+        var lastFailure = policyMetadata.getLastFailure();
+        var lastSuccess = policyMetadata.getLastSuccess();
+        return (lastFailure != null && snapshotName.equals(lastFailure.getSnapshotName()))
+            || (lastSuccess != null && snapshotName.equals(lastSuccess.getSnapshotName()));
     }
 
     private static ClusterState buildClusterState(
@@ -736,10 +1490,14 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
     }
 
     private static SnapshotInfo randomSnapshotInfoSuccess(ProjectId projectId) {
+        return snapshotInfoSuccess(projectId, randSnapshotId());
+    }
+
+    private static SnapshotInfo snapshotInfoSuccess(ProjectId projectId, SnapshotId snapshotId) {
         long startTime = randomNonNegativeLong();
         long endTime = randomLongBetween(startTime, Long.MAX_VALUE);
         return new SnapshotInfo(
-            new Snapshot(projectId, "repo", randSnapshotId()),
+            new Snapshot(projectId, "repo", snapshotId),
             List.of("index1", "index2"),
             List.of(),
             List.of(),
@@ -755,10 +1513,14 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
     }
 
     private static SnapshotInfo randomSnapshotInfoFailure(ProjectId projectId) {
+        return snapshotInfoFailure(projectId, randSnapshotId());
+    }
+
+    private static SnapshotInfo snapshotInfoFailure(ProjectId projectId, SnapshotId snapshotId) {
         long startTime = randomNonNegativeLong();
         long endTime = randomLongBetween(startTime, Long.MAX_VALUE);
         return new SnapshotInfo(
-            new Snapshot(projectId, "repo", randSnapshotId()),
+            new Snapshot(projectId, "repo", snapshotId),
             List.of("index1", "index2"),
             List.of(),
             List.of(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix SLM races that mis-record concurrent snapshot outcomes (#155934)](https://github.com/elastic/elasticsearch/pull/155934)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)