### PR TITLE
ESQL: Unmute streaming coordinator wrapper deadlock test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -295,9 +295,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testColumnarBadDateTokenNullsCellEagerAndDeferred
   issue: https://github.com/elastic/elasticsearch/issues/153187
-- class: org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinatorTests
-  method: testConcurrentProducerLoopsThroughStatsCapturingWrapperDoNotDeadlock
-  issue: https://github.com/elastic/elasticsearch/issues/153210
 - class: org.elasticsearch.xpack.stateless.commits.StatelessClusterIntegrityStressIT
   method: testRandomActivities
   issue: https://github.com/elastic/elasticsearch/issues/147841


### PR DESCRIPTION
Unmutes `testConcurrentProducerLoopsThroughStatsCapturingWrapperDoNotDeadlock`.

**Why:** the drain deadlock was fixed in #153253 (non-blocking `tryAdvance()`, forwarded through `StatsCapturingIterator`), which unmuted this test — but it was then accidentally re-muted by an un-rebased `muted-tests.yml` region rewrite in #153321. No failures in ~3.5k runs since the fix, and its sibling test is already unmuted.

Closes #153210