### PR TITLE
ESQL: Unmute csv-union-by-name LOCAL glob spec test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -151,9 +151,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
   method: testRightClosedBucketIsNotSubstituted
   issue: https://github.com/elastic/elasticsearch/issues/149133
-- class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
-  method: test {csv-spec:csv-union-by-name.* [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/149482
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/147383


### PR DESCRIPTION
Unmutes `CsvFormatSpecIT test {csv-spec:csv-union-by-name.* [LOCAL]}`.

**Why:** the Windows glob-path failure (`Illegal char <*>` from `Path.resolve` on `multifile_ubn/*.csv`) was fixed in #149469 (`resolveLocalUri` splits the glob off before resolving). The mechanism-identical parquet sibling was unmuted in #149566 and has been green since; this csv entry was simply left behind. (Windows-only failure; other platforms never hit it.)

Closes #149482