### PR TITLE
Experiment with ordinal map at sorted (set) doc values merge time 

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/MergeOrdinalMap.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/MergeOrdinalMap.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.InPlaceMergeSorter;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.lucene.util.packed.PackedLongValues;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A merge-only, forward-scan ordinal map for SORTED and SORTED_SET doc-values fields.
+ *
+ * <p>Compared to Lucene's full {@code OrdinalMap}, this class omits the {@code globalOrdDeltas}
+ * and {@code firstSegments} packed arrays that together account for roughly 81% of the allocation
+ * cost during a large merge (≈ 185 MB + 166 MB of a 430 MB peak observed in a 32-segment,
+ * ~1.9e8-ordinal production merge). Those arrays exist solely to allow the merged
+ * {@link TermsEnum} to jump to any global ordinal in O(1) time. During a merge every unique term
+ * is always visited in strictly ascending global-ord order, so random access is never needed.
+ *
+ * <p>The merged {@link TermsEnum} is instead produced by re-running a priority-queue merge over
+ * fresh per-segment {@code TermsEnum} iterators on each call to {@link #mergedTermsEnum}. This is
+ * I/O-neutral — the same iterators are opened regardless — and costs O(log N) comparisons per
+ * term rather than a packed-array lookup (N = number of segments, typically ≤ 32).
+ *
+ * <p><b>This class is strictly merge-time.</b> It must never be used in search-time global-ordinal
+ * code paths ({@code GlobalOrdinalsBuilder}, {@code GlobalOrdinalsIndexFieldData},
+ * {@code FlattenedFieldMapper}, etc.) because it does not implement
+ * {@code getFirstSegmentNumber}/{@code getFirstSegmentOrd}. The naming is intentionally
+ * <em>not</em> {@code XOrdinalMap}: the {@code X}-prefix convention in this package denotes
+ * verbatim Lucene forks that are drop-in substitutes for their Lucene counterparts; this class is
+ * a strict subset and is not substitutable.
+ *
+ * <p>Only wired in from the {@code MergeStats.supported()} optimised-merge path, which already
+ * requires {@code needsIndexSort == true} and no live-doc bitmaps — the same pre-conditions that
+ * guarantee per-segment ordinals are compact (no gaps, so the inner gap-filling loop in the
+ * constructor runs exactly once per segment ordinal).
+ */
+final class MergeOrdinalMap {
+
+    // -------------------------------------------------------------------------
+    // SegmentMap
+    //
+    // Verbatim copy of org.apache.lucene.index.OrdinalMap.SegmentMap (Lucene 10.5.1).
+    // Sorts segments by descending weight so the highest-weight segment's per-segment
+    // ordinal deltas are most likely to be all-zero, enabling LongValues.IDENTITY.
+    // -------------------------------------------------------------------------
+
+    private static final class SegmentMap {
+        final int[] newToOld;
+        final int[] oldToNew;
+
+        SegmentMap(long[] weights) {
+            newToOld = buildNewToOld(weights);
+            oldToNew = inverse(newToOld);
+        }
+
+        private static int[] buildNewToOld(final long[] weights) {
+            final int[] result = new int[weights.length];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = i;
+            }
+            new InPlaceMergeSorter() {
+                @Override
+                protected void swap(int i, int j) {
+                    int tmp = result[i];
+                    result[i] = result[j];
+                    result[j] = tmp;
+                }
+
+                @Override
+                protected int compare(int i, int j) {
+                    // j first: larger weights get smaller new-indices
+                    return Long.compare(weights[result[j]], weights[result[i]]);
+                }
+            }.sort(0, weights.length);
+            return result;
+        }
+
+        private static int[] inverse(int[] map) {
+            int[] inv = new int[map.length];
+            for (int i = 0; i < map.length; i++) {
+                inv[map[i]] = i;
+            }
+            return inv;
+        }
+
+        int newToOld(int newIdx) {
+            return newToOld[newIdx];
+        }
+
+        int oldToNew(int origIdx) {
+            return oldToNew[origIdx];
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // SubTermsEnum
+    //
+    // Adapted from org.apache.lucene.index.TermsEnumIndex (Lucene 10.5.1, package-private).
+    // Cannot be re-used directly: this repo has no org/apache/lucene/** source directory
+    // from which a same-package class could access the package-private original.
+    // The 8-byte prefix cache is kept; it significantly speeds up comparisons between
+    // enums with long shared prefixes (e.g. _tsid values).
+    // -------------------------------------------------------------------------
+
+    private static final class SubTermsEnum {
+        /** The original (un-remapped) segment index in the merge. */
+        final int origSegIdx;
+        final TermsEnum termsEnum;
+        private BytesRef currentTerm;
+        private long currentPrefix8;
+
+        SubTermsEnum(TermsEnum termsEnum, int origSegIdx) {
+            this.termsEnum = termsEnum;
+            this.origSegIdx = origSegIdx;
+        }
+
+        BytesRef term() {
+            return currentTerm;
+        }
+
+        BytesRef next() throws IOException {
+            currentTerm = termsEnum.next();
+            currentPrefix8 = (currentTerm == null) ? 0L : prefix8(currentTerm);
+            return currentTerm;
+        }
+
+        int compareTermTo(SubTermsEnum other) {
+            if (currentPrefix8 != other.currentPrefix8) {
+                return Long.compareUnsigned(currentPrefix8, other.currentPrefix8);
+            }
+            return Arrays.compareUnsigned(
+                currentTerm.bytes,
+                currentTerm.offset,
+                currentTerm.offset + currentTerm.length,
+                other.currentTerm.bytes,
+                other.currentTerm.offset,
+                other.currentTerm.offset + other.currentTerm.length
+            );
+        }
+
+        void copyStateTo(TermSnap snap) {
+            snap.term.copyBytes(currentTerm);
+            snap.prefix8 = currentPrefix8;
+        }
+
+        boolean termEquals(TermSnap snap) {
+            if (currentPrefix8 != snap.prefix8) {
+                return false;
+            }
+            return Arrays.equals(
+                currentTerm.bytes,
+                currentTerm.offset,
+                currentTerm.offset + currentTerm.length,
+                snap.term.bytes(),
+                0,
+                snap.term.length()
+            );
+        }
+
+        /** Lightweight snapshot of the current term to avoid heap allocation in the hot loop. */
+        static final class TermSnap {
+            final BytesRefBuilder term = new BytesRefBuilder();
+            long prefix8;
+        }
+
+        private static long prefix8(BytesRef t) {
+            if (t.length >= Long.BYTES) {
+                return (long) BitUtil.VH_BE_LONG.get(t.bytes, t.offset);
+            }
+            long l;
+            int o;
+            if (Integer.BYTES <= t.length) {
+                l = (int) BitUtil.VH_BE_INT.get(t.bytes, t.offset);
+                o = Integer.BYTES;
+            } else {
+                l = 0;
+                o = 0;
+            }
+            if (o + Short.BYTES <= t.length) {
+                l = (l << Short.SIZE) | Short.toUnsignedLong((short) BitUtil.VH_BE_SHORT.get(t.bytes, t.offset + o));
+                o += Short.BYTES;
+            }
+            if (o < t.length) {
+                l = (l << Byte.SIZE) | Byte.toUnsignedLong(t.bytes[t.offset + o]);
+            }
+            l <<= (Long.BYTES - t.length) << 3;
+            return l;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Priority queue
+    // -------------------------------------------------------------------------
+
+    private static final class SubTermsEnumPQ extends PriorityQueue<SubTermsEnum> {
+        SubTermsEnumPQ(int maxSize) {
+            super(maxSize);
+        }
+
+        @Override
+        protected boolean lessThan(SubTermsEnum a, SubTermsEnum b) {
+            return a.compareTermTo(b) < 0;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    private final long valueCount;
+    /**
+     * Indexed by <em>new</em> (weight-sorted) segment index. Use
+     * {@link #getGlobalOrds(int)} with the original segment index.
+     */
+    private final LongValues[] segmentToGlobalOrds;
+    private final SegmentMap segmentMap;
+    private final int numSubs;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a merge ordinal map from the provided sub-enumerators.
+     *
+     * <p>This is the equivalent of {@code OrdinalMap.build(null, subs, weights, PackedInts.COMPACT)}
+     * with the {@code globalOrdDeltas} and {@code firstSegments} builders removed. The
+     * {@code segmentToGlobalOrds} arrays are built identically to the original.
+     *
+     * @param subs    one {@link TermsEnum} per segment, in <em>original</em> segment order;
+     *                each must support {@link TermsEnum#ord()}
+     * @param weights number of unique values in each sub (used to order segments by weight)
+     * @throws IOException if any {@link TermsEnum#next()} call throws
+     */
+    MergeOrdinalMap(TermsEnum[] subs, long[] weights) throws IOException {
+        if (subs.length != weights.length) {
+            throw new IllegalArgumentException("subs and weights must have the same length");
+        }
+        numSubs = subs.length;
+        segmentMap = new SegmentMap(weights);
+
+        // One builder per weight-sorted segment index (same indexing as segmentToGlobalOrds)
+        final PackedLongValues.Builder[] deltaBuilders = new PackedLongValues.Builder[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            deltaBuilders[i] = PackedLongValues.monotonicBuilder(PackedInts.COMPACT);
+        }
+        final long[] ordDeltaBits = new long[numSubs];
+        final long[] segmentOrds = new long[numSubs];
+
+        // Populate the PQ in weight-sorted (newToOld) order — same as OrdinalMap
+        final SubTermsEnumPQ queue = new SubTermsEnumPQ(numSubs);
+        for (int newIdx = 0; newIdx < numSubs; newIdx++) {
+            int origIdx = segmentMap.newToOld(newIdx);
+            SubTermsEnum sub = new SubTermsEnum(subs[origIdx], origIdx);
+            if (sub.next() != null) {
+                queue.add(sub);
+            }
+        }
+
+        final SubTermsEnum.TermSnap topSnap = new SubTermsEnum.TermSnap();
+        long globalOrd = 0;
+
+        while (queue.size() != 0) {
+            SubTermsEnum top = queue.top();
+            top.copyStateTo(topSnap);
+
+            // Advance past all sub-enums sharing the same term, recording per-segment deltas
+            while (true) {
+                long segmentOrd = top.termsEnum.ord();
+                long delta = globalOrd - segmentOrd;
+                int segNewIdx = segmentMap.oldToNew(top.origSegIdx);
+                ordDeltaBits[segNewIdx] |= delta;
+
+                assert segmentOrds[segNewIdx] <= segmentOrd;
+                // Gap-filling inner loop: mirrors OrdinalMap exactly. On the deletion-free
+                // optimised-merge path the loop body runs exactly once per iteration.
+                do {
+                    deltaBuilders[segNewIdx].add(delta);
+                    segmentOrds[segNewIdx]++;
+                } while (segmentOrds[segNewIdx] <= segmentOrd);
+
+                if (top.next() == null) {
+                    queue.pop();
+                    if (queue.size() == 0) {
+                        break;
+                    }
+                    top = queue.top();
+                } else {
+                    top = queue.updateTop();
+                }
+                if (top.termEquals(topSnap) == false) {
+                    break;
+                }
+            }
+            globalOrd++;
+        }
+
+        valueCount = globalOrd;
+
+        // Build segmentToGlobalOrds — identical logic to OrdinalMap (PackedInts.COMPACT overhead)
+        segmentToGlobalOrds = new LongValues[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            final PackedLongValues deltas = deltaBuilders[i].build();
+            if (ordDeltaBits[i] == 0L) {
+                // Segment ords == global ords for this segment (typically the heaviest segment)
+                segmentToGlobalOrds[i] = LongValues.IDENTITY;
+            } else {
+                final int bitsRequired = ordDeltaBits[i] < 0 ? 64 : PackedInts.bitsRequired(ordDeltaBits[i]);
+                final long monotonicBits = deltas.ramBytesUsed() * 8;
+                final long packedBits = bitsRequired * deltas.size();
+                // Use plain packed ints if no larger than monotonic encoding (COMPACT ratio = 0)
+                if (deltas.size() <= Integer.MAX_VALUE && packedBits <= monotonicBits) {
+                    final int size = (int) deltas.size();
+                    final PackedInts.Mutable packed = PackedInts.getMutable(size, bitsRequired, PackedInts.COMPACT);
+                    final PackedLongValues.Iterator it = deltas.iterator();
+                    for (int ord = 0; ord < size; ord++) {
+                        packed.set(ord, it.next());
+                    }
+                    assert it.hasNext() == false;
+                    segmentToGlobalOrds[i] = new LongValues() {
+                        @Override
+                        public long get(long ord) {
+                            return ord + packed.get((int) ord);
+                        }
+                    };
+                } else {
+                    segmentToGlobalOrds[i] = new LongValues() {
+                        @Override
+                        public long get(long ord) {
+                            return ord + deltas.get(ord);
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Total number of unique terms across all segments (= the global ordinal space size).
+     */
+    long getValueCount() {
+        return valueCount;
+    }
+
+    /**
+     * Returns a {@link LongValues} that maps per-segment ordinals to global ordinals for the
+     * segment at {@code originalSegmentIndex} (0-based, in the original merge order).
+     */
+    LongValues getGlobalOrds(int originalSegmentIndex) {
+        return segmentToGlobalOrds[segmentMap.oldToNew(originalSegmentIndex)];
+    }
+
+    /**
+     * Returns a forward-only {@link TermsEnum} that yields all unique terms in ascending
+     * global-ordinal order by re-running a priority-queue merge over the provided sub-enumerators.
+     *
+     * <p>Each call produces an independent iterator: callers may invoke this method multiple times
+     * (e.g. for the terms-dict pass and the reverse-index pass in
+     * {@link AbstractTSDBDocValuesConsumer}) and each returned iterator advances independently.
+     *
+     * <p>The returned enum supports:
+     * <ul>
+     *   <li>{@link TermsEnum#next()} — advance to the next unique term</li>
+     *   <li>{@link TermsEnum#term()} — the current term</li>
+     *   <li>{@link TermsEnum#ord()} — the current global ordinal (0-based)</li>
+     *   <li>{@link TermsEnum#seekExact(long)} — forward-only; throws
+     *       {@link UnsupportedOperationException} for backward seeks</li>
+     * </ul>
+     * All other operations throw {@link UnsupportedOperationException} so that a stray binary
+     * search cannot silently degrade to O(G · log G) complexity.
+     *
+     * @param freshSubs one fresh {@link TermsEnum} per segment, in <em>original</em> segment order
+     * @throws IOException if any initial {@link TermsEnum#next()} call throws during PQ setup
+     */
+    TermsEnum mergedTermsEnum(TermsEnum[] freshSubs) throws IOException {
+        if (freshSubs.length != numSubs) {
+            throw new IllegalArgumentException("freshSubs.length=" + freshSubs.length + " != numSubs=" + numSubs);
+        }
+
+        // Populate the PQ in the same weight-sorted order as the constructor so that global ord
+        // assignment is deterministic and matches segmentToGlobalOrds
+        final SubTermsEnumPQ queue = new SubTermsEnumPQ(numSubs);
+        for (int newIdx = 0; newIdx < numSubs; newIdx++) {
+            int origIdx = segmentMap.newToOld(newIdx);
+            SubTermsEnum sub = new SubTermsEnum(freshSubs[origIdx], origIdx);
+            if (sub.next() != null) {
+                queue.add(sub);
+            }
+        }
+
+        return new BaseTermsEnum() {
+            private long currentOrd = -1;
+            private BytesRef currentTerm;
+            private final SubTermsEnum.TermSnap topSnap = new SubTermsEnum.TermSnap();
+            private final BytesRefBuilder termCopy = new BytesRefBuilder();
+
+            @Override
+            public BytesRef next() throws IOException {
+                if (queue.size() == 0) {
+                    currentTerm = null;
+                    return null;
+                }
+                SubTermsEnum top = queue.top();
+                top.copyStateTo(topSnap);
+                // Save a copy of the term before the PQ advances past it
+                termCopy.copyBytes(top.term());
+                currentTerm = termCopy.get();
+                currentOrd++;
+
+                // Drain all sub-enums sharing this term from the PQ
+                while (true) {
+                    if (top.next() == null) {
+                        queue.pop();
+                        if (queue.size() == 0) {
+                            break;
+                        }
+                        top = queue.top();
+                    } else {
+                        top = queue.updateTop();
+                    }
+                    if (top.termEquals(topSnap) == false) {
+                        break;
+                    }
+                }
+                return currentTerm;
+            }
+
+            @Override
+            public BytesRef term() {
+                return currentTerm;
+            }
+
+            @Override
+            public long ord() {
+                return currentOrd;
+            }
+
+            @Override
+            public void seekExact(long targetOrd) throws IOException {
+                if (targetOrd < currentOrd) {
+                    throw new UnsupportedOperationException("seekExact backward: targetOrd=" + targetOrd + " < currentOrd=" + currentOrd);
+                }
+                while (currentOrd < targetOrd) {
+                    if (next() == null) {
+                        throw new IOException("seekExact past end of enum: targetOrd=" + targetOrd + " valueCount=" + valueCount);
+                    }
+                }
+            }
+
+            @Override
+            public TermsEnum.SeekStatus seekCeil(BytesRef text) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int docFreq() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long totalTermFreq() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public PostingsEnum postings(PostingsEnum reuse, int flags) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ImpactsEnum impacts(int flags) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public TermState termState() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/XDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/XDocValuesConsumer.java
@@ -9,26 +9,106 @@
 package org.elasticsearch.index.codec.tsdb;
 
 import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
 import org.elasticsearch.index.codec.tsdb.DocValuesConsumerUtil.MergeStats;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Base subclass that allows pushing down {@link TsdbDocValuesProducer} instance so that subclasses can perform optimized merge.
+ *
+ * <p>The {@link #mergeSortedField} and {@link #mergeSortedSetField} overloads that accept a
+ * {@link MergeStats} use a {@link MergeOrdinalMap} instead of Lucene's full
+ * {@code OrdinalMap}. This eliminates the {@code globalOrdDeltas} and {@code firstSegments}
+ * packed arrays (≈81% of the ordinal-map peak allocation) by re-running a PQ merge over fresh
+ * sub-{@link TermsEnum}s on each term-dictionary pass instead of materialising a random-access
+ * structure. See {@link MergeOrdinalMap} for the full rationale.
+ *
+ * <p>These overloads are only reached from the {@code MergeStats.supported()} path (index-sorted,
+ * deletion-free), so the {@code BitsFilteredTermsEnum} / live-doc handling in Lucene's
+ * {@code createOrdinalMapForSortedSetDV} is intentionally absent here.
  */
 public abstract class XDocValuesConsumer extends DocValuesConsumer {
 
     /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
     protected XDocValuesConsumer() {}
+
+    // -------------------------------------------------------------------------
+    // Helper sub-classes (private copies of Lucene's package-private inner classes)
+    // -------------------------------------------------------------------------
+
+    /** Tracks state of one SORTED sub-reader during a merge doc pass. */
+    private static final class SortedDocValuesSub extends DocIDMerger.Sub {
+        final SortedDocValues values;
+        final LongValues map;
+
+        SortedDocValuesSub(MergeState.DocMap docMap, SortedDocValues values, LongValues map) {
+            super(docMap);
+            this.values = values;
+            this.map = map;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return values.nextDoc();
+        }
+    }
+
+    /** Tracks state of one SORTED_SET sub-reader during a merge doc pass. */
+    private static final class SortedSetDocValuesSub extends DocIDMerger.Sub {
+        final SortedSetDocValues values;
+        final LongValues map;
+
+        SortedSetDocValuesSub(MergeState.DocMap docMap, SortedSetDocValues values, LongValues map) {
+            super(docMap);
+            this.values = values;
+            this.map = map;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return values.nextDoc();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: open fresh TermsEnums for mergedTermsEnum / lookupOrd cursor
+    // -------------------------------------------------------------------------
+
+    private static TermsEnum[] freshSortedSubs(SortedDocValues[] dvs) throws IOException {
+        TermsEnum[] subs = new TermsEnum[dvs.length];
+        for (int i = 0; i < dvs.length; i++) {
+            subs[i] = dvs[i].termsEnum();
+        }
+        return subs;
+    }
+
+    private static TermsEnum[] freshSortedSetSubs(List<SortedSetDocValues> list) throws IOException {
+        TermsEnum[] subs = new TermsEnum[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            subs[i] = list.get(i).termsEnum();
+        }
+        return subs;
+    }
+
+    // -------------------------------------------------------------------------
+    // Numeric / binary / sorted-numeric (unchanged from the original)
+    // -------------------------------------------------------------------------
 
     /**
      * Merges the numeric docvalues from <code>MergeState</code>.
@@ -84,49 +164,310 @@ public abstract class XDocValuesConsumer extends DocValuesConsumer {
         });
     }
 
+    // -------------------------------------------------------------------------
+    // mergeSortedField — ES-local, uses MergeOrdinalMap
+    // -------------------------------------------------------------------------
+
     /**
      * Merges the sorted docvalues from <code>toMerge</code>.
      *
-     * <p>The default implementation calls {@link #addSortedField}, passing an Iterable that merges
-     * ordinals and values and filters deleted documents .
+     * <p>Uses {@link MergeOrdinalMap} instead of Lucene's {@code OrdinalMap} to avoid building
+     * the {@code globalOrdDeltas} and {@code firstSegments} packed arrays (~81% of peak memory).
+     * The merged {@link TermsEnum} is produced by re-running a PQ merge over fresh sub-enumerators
+     * on each call, which is I/O-neutral since the same iterators would be opened anyway.
+     *
+     * <p>Only called from the {@code MergeStats.supported()} path (deletion-free, index-sorted).
      */
     public void mergeSortedField(MergeStats mergeStats, FieldInfo fieldInfo, final MergeState mergeState) throws IOException {
-        // step 1: iterate thru each sub and mark terms still in use
-        // step 2: create ordinal map (this conceptually does the "merging")
-        final OrdinalMap map = createOrdinalMapForSortedDV(fieldInfo, mergeState);
-        // step 3: add field
+        // Collect SortedDocValues for each segment (no liveDocs filter: supported() guarantees
+        // deletion-free, so no BitsFilteredTermsEnum is needed)
+        final SortedDocValues[] sortedDvs = new SortedDocValues[mergeState.docValuesProducers.length];
+        final long[] weights = new long[sortedDvs.length];
+        for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
+            SortedDocValues dv = null;
+            DocValuesProducer dvProducer = mergeState.docValuesProducers[i];
+            if (dvProducer != null) {
+                FieldInfo readerField = mergeState.fieldInfos[i].fieldInfo(fieldInfo.name);
+                if (readerField != null && readerField.getDocValuesType() == DocValuesType.SORTED) {
+                    dv = dvProducer.getSorted(readerField);
+                }
+            }
+            sortedDvs[i] = (dv != null) ? dv : DocValues.emptySorted();
+            weights[i] = sortedDvs[i].getValueCount();
+        }
+
+        // Build MergeOrdinalMap — opens one TermsEnum per sub (I/O-neutral)
+        final TermsEnum[] mapSubs = freshSortedSubs(sortedDvs);
+        final MergeOrdinalMap map = new MergeOrdinalMap(mapSubs, weights);
+
         addSortedField(fieldInfo, new TsdbDocValuesProducer(mergeStats) {
             @Override
             public SortedDocValues getSorted(FieldInfo fieldInfoIn) throws IOException {
                 if (fieldInfoIn != fieldInfo) {
                     throw new IllegalArgumentException("wrong FieldInfo");
                 }
-                return getMergedSortedSetDocValues(fieldInfo, mergeState, map);
+                return buildMergedSortedDocValues(fieldInfo, mergeState, map, sortedDvs);
             }
         });
     }
 
     /**
+     * Builds the merged {@link SortedDocValues} for one field.
+     *
+     * <p>Opens fresh sub doc-value instances from {@code mergeState.docValuesProducers} for the
+     * doc-pass (so callers may invoke {@link DocValuesProducer#getSorted} multiple times to obtain
+     * independent iterators). The {@code sortedDvsForTerms} array is used only for
+     * {@link TermsEnum} and {@link SortedDocValues#lookupOrd} access, which is independent of
+     * doc-iteration state.
+     */
+    private SortedDocValues buildMergedSortedDocValues(
+        FieldInfo fieldInfo,
+        MergeState mergeState,
+        MergeOrdinalMap map,
+        SortedDocValues[] sortedDvsForTerms
+    ) throws IOException {
+        // Fresh doc-pass sub instances (independent of sortedDvsForTerms)
+        final List<SortedDocValuesSub> subs = new ArrayList<>();
+        long cost = 0;
+        for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
+            SortedDocValues dv = null;
+            DocValuesProducer dvProducer = mergeState.docValuesProducers[i];
+            if (dvProducer != null) {
+                FieldInfo readerField = mergeState.fieldInfos[i].fieldInfo(fieldInfo.name);
+                if (readerField != null && readerField.getDocValuesType() == DocValuesType.SORTED) {
+                    dv = dvProducer.getSorted(readerField);
+                }
+            }
+            if (dv == null) {
+                dv = DocValues.emptySorted();
+            }
+            cost += dv.cost();
+            subs.add(new SortedDocValuesSub(mergeState.docMaps[i], dv, map.getGlobalOrds(i)));
+        }
+        final long finalCost = cost;
+        final DocIDMerger<SortedDocValuesSub> docIDMerger = DocIDMerger.of(subs, mergeState.needsIndexSort);
+
+        return new SortedDocValues() {
+            private int docID = -1;
+            private SortedDocValuesSub current;
+
+            @Override
+            public int docID() {
+                return docID;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                current = docIDMerger.next();
+                docID = (current == null) ? NO_MORE_DOCS : current.mappedDocID;
+                return docID;
+            }
+
+            @Override
+            public int ordValue() throws IOException {
+                return (int) current.map.get(current.values.ordValue());
+            }
+
+            @Override
+            public int advance(int target) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean advanceExact(int target) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long cost() {
+                return finalCost;
+            }
+
+            @Override
+            public int getValueCount() {
+                return (int) map.getValueCount();
+            }
+
+            // Forward-only cursor for lookupOrd. Restarts from ord 0 on backward access
+            // (expected once per merge in the single-valued SortedSetDV path).
+            private TermsEnum lookupCursor = map.mergedTermsEnum(freshSortedSubs(sortedDvsForTerms));
+            private long cursorOrd = 0;
+
+            @Override
+            public BytesRef lookupOrd(int ord) throws IOException {
+                if (cursorOrd == map.getValueCount()) {
+                    cursorOrd = 0;
+                    lookupCursor = map.mergedTermsEnum(freshSortedSubs(sortedDvsForTerms));
+                }
+                assert cursorOrd == ord;
+
+                cursorOrd++;
+                return lookupCursor.next();
+            }
+
+            /**
+             * Returns a fresh PQ-based terms enumeration, bypassing the {@code lookupOrd} cursor.
+             * Called twice per sorted-DV merge: once by {@code addTermsDict} and once by
+             * {@code writeTermsIndex}; each call gets an independent iterator.
+             */
+            @Override
+            public TermsEnum termsEnum() throws IOException {
+                return map.mergedTermsEnum(freshSortedSubs(sortedDvsForTerms));
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // mergeSortedSetField — ES-local, uses MergeOrdinalMap
+    // -------------------------------------------------------------------------
+
+    /**
      * Merges the sortedset docvalues from <code>toMerge</code>.
      *
-     * <p>The default implementation calls {@link #addSortedSetField}, passing an Iterable that merges
-     * ordinals and values and filters deleted documents .
+     * <p>Uses {@link MergeOrdinalMap} instead of Lucene's {@code OrdinalMap} to avoid building
+     * the {@code globalOrdDeltas} and {@code firstSegments} packed arrays (~81% of peak memory).
+     * The merged {@link TermsEnum} is produced by re-running a PQ merge over fresh sub-enumerators
+     * on each call, which is I/O-neutral since the same iterators would be opened anyway.
+     *
+     * <p>Only called from the {@code MergeStats.supported()} path (deletion-free, index-sorted).
      */
     public void mergeSortedSetField(MergeStats mergeStats, FieldInfo mergeFieldInfo, final MergeState mergeState) throws IOException {
-        // step 1: iterate thru each sub and mark terms still in use
-        // step 2: create ordinal map (this conceptually does the "merging")
-        List<SortedSetDocValues> toMerge = selectLeavesToMerge(mergeFieldInfo, mergeState);
-        OrdinalMap map = createOrdinalMapForSortedSetDV(toMerge, mergeState);
-        // step 3: add field
+        // selectLeavesToMerge is protected-static in DocValuesConsumer and handles absent fields
+        final List<SortedSetDocValues> toMerge = selectLeavesToMerge(mergeFieldInfo, mergeState);
+
+        // Build MergeOrdinalMap — no liveDocs filter: supported() guarantees deletion-free
+        final TermsEnum[] mapSubs = freshSortedSetSubs(toMerge);
+        final long[] weights = new long[toMerge.size()];
+        for (int i = 0; i < toMerge.size(); i++) {
+            weights[i] = toMerge.get(i).getValueCount();
+        }
+        final MergeOrdinalMap map = new MergeOrdinalMap(mapSubs, weights);
+
         addSortedSetField(mergeFieldInfo, new TsdbDocValuesProducer(mergeStats) {
             @Override
             public SortedSetDocValues getSortedSet(FieldInfo fieldInfo) throws IOException {
                 if (fieldInfo != mergeFieldInfo) {
                     throw new IllegalArgumentException("wrong FieldInfo");
                 }
-                return getMergedSortedSetDocValues(mergeFieldInfo, mergeState, map, toMerge);
+                return buildMergedSortedSetDocValues(mergeFieldInfo, mergeState, map, toMerge);
             }
         });
+    }
+
+    /**
+     * Builds the merged {@link SortedSetDocValues} for one field.
+     *
+     * <p>Opens fresh sub doc-value instances from {@code mergeState.docValuesProducers} for the
+     * doc-pass (so callers may invoke {@link DocValuesProducer#getSortedSet} multiple times to
+     * obtain independent iterators). The {@code toMerge} list is used only for {@link TermsEnum}
+     * and {@link SortedSetDocValues#lookupOrd} access, which is independent of doc-iteration state.
+     *
+     * <p>The {@code lookupOrd} implementation uses a forward-only cursor over a PQ-merged
+     * {@link TermsEnum}. The cursor restarts on backward access, which occurs exactly once per
+     * merge in the single-valued field path (between {@code addTermsDict} and
+     * {@code writeTermsIndex}): the restart is logged at DEBUG and costs one additional forward
+     * scan through the term dictionary (O(G), the same as one terms-dict pass).
+     */
+    private SortedSetDocValues buildMergedSortedSetDocValues(
+        FieldInfo mergeFieldInfo,
+        MergeState mergeState,
+        MergeOrdinalMap map,
+        List<SortedSetDocValues> toMerge
+    ) throws IOException {
+        // Fresh doc-pass sub instances
+        final List<SortedSetDocValuesSub> subs = new ArrayList<>();
+        long cost = 0;
+        for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
+            SortedSetDocValues values = null;
+            DocValuesProducer dvProducer = mergeState.docValuesProducers[i];
+            if (dvProducer != null) {
+                FieldInfo readerField = mergeState.fieldInfos[i].fieldInfo(mergeFieldInfo.name);
+                if (readerField != null && readerField.getDocValuesType() == DocValuesType.SORTED_SET) {
+                    values = dvProducer.getSortedSet(readerField);
+                }
+            }
+            if (values == null) {
+                values = DocValues.emptySortedSet();
+            }
+            cost += values.cost();
+            subs.add(new SortedSetDocValuesSub(mergeState.docMaps[i], values, map.getGlobalOrds(i)));
+        }
+        final long finalCost = cost;
+        final DocIDMerger<SortedSetDocValuesSub> docIDMerger = DocIDMerger.of(subs, mergeState.needsIndexSort);
+
+        return new SortedSetDocValues() {
+            private int docID = -1;
+            private SortedSetDocValuesSub currentSub;
+
+            @Override
+            public int docID() {
+                return docID;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                currentSub = docIDMerger.next();
+                docID = (currentSub == null) ? NO_MORE_DOCS : currentSub.mappedDocID;
+                return docID;
+            }
+
+            @Override
+            public int advance(int target) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean advanceExact(int target) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long nextOrd() throws IOException {
+                return currentSub.map.get(currentSub.values.nextOrd());
+            }
+
+            @Override
+            public int docValueCount() {
+                return currentSub.values.docValueCount();
+            }
+
+            @Override
+            public long cost() {
+                return finalCost;
+            }
+
+            @Override
+            public long getValueCount() {
+                return map.getValueCount();
+            }
+
+            // Forward-only cursor for lookupOrd. Restarts from ord 0 on backward access
+            // (expected once per single-valued merge: between addTermsDict and writeTermsIndex).
+            private TermsEnum lookupCursor = map.mergedTermsEnum(freshSortedSetSubs(toMerge));
+            private long cursorOrd = 0;
+
+            @Override
+            public BytesRef lookupOrd(long ord) throws IOException {
+                if (cursorOrd == map.getValueCount()) {
+                    cursorOrd = 0;
+                    lookupCursor = map.mergedTermsEnum(freshSortedSetSubs(toMerge));
+                }
+                assert cursorOrd == ord;
+
+                cursorOrd++;
+                return lookupCursor.next();
+            }
+
+            /**
+             * Returns a fresh PQ-based terms enumeration independent of the {@code lookupOrd}
+             * cursor. Called up to twice per sorted-set-DV merge: once by {@code addTermsDict}
+             * and once by {@code writeTermsIndex}; each call gets an independent iterator.
+             */
+            @Override
+            public TermsEnum termsEnum() throws IOException {
+                return map.mergedTermsEnum(freshSortedSetSubs(toMerge));
+            }
+        };
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/MergeOrdinalMapTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/MergeOrdinalMapTests.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermState;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.packed.PackedInts;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.TreeSet;
+
+/**
+ * Unit tests for {@link MergeOrdinalMap}.
+ *
+ * <p>Each test builds a {@link MergeOrdinalMap} and an equivalent Lucene {@link OrdinalMap}
+ * from the same per-segment term arrays, then asserts that:
+ * <ul>
+ *   <li>{@link MergeOrdinalMap#getValueCount()} equals {@code OrdinalMap.getValueCount()}</li>
+ *   <li>{@link MergeOrdinalMap#getGlobalOrds(int)} maps every segment ordinal identically</li>
+ *   <li>{@link MergeOrdinalMap#mergedTermsEnum} yields the same terms in the same order</li>
+ * </ul>
+ */
+public class MergeOrdinalMapTests extends ESTestCase {
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * A minimal {@link TermsEnum} over a pre-sorted {@link BytesRef} array that supports
+     * {@code ord()} — required by both {@link OrdinalMap#build} and {@link MergeOrdinalMap}.
+     */
+    private static TermsEnum arrayTermsEnum(BytesRef[] sortedTerms) {
+        return new BaseTermsEnum() {
+            int pos = -1;
+
+            @Override
+            public BytesRef next() {
+                pos++;
+                return pos < sortedTerms.length ? sortedTerms[pos] : null;
+            }
+
+            @Override
+            public BytesRef term() {
+                return sortedTerms[pos];
+            }
+
+            @Override
+            public long ord() {
+                return pos;
+            }
+
+            @Override
+            public TermsEnum.SeekStatus seekCeil(BytesRef text) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void seekExact(long ord) {
+                pos = (int) ord;
+            }
+
+            @Override
+            public int docFreq() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long totalTermFreq() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public PostingsEnum postings(PostingsEnum reuse, int flags) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ImpactsEnum impacts(int flags) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public TermState termState() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    /** Converts a string array to a sorted {@link BytesRef} array. */
+    private static BytesRef[] toSortedBytes(String... terms) {
+        BytesRef[] refs = Arrays.stream(terms).map(BytesRef::new).toArray(BytesRef[]::new);
+        Arrays.sort(refs);
+        return refs;
+    }
+
+    /**
+     * Builds both a {@link MergeOrdinalMap} and a reference {@link OrdinalMap} from the given
+     * term arrays (one per segment), then asserts they are equivalent on all observable outputs.
+     */
+    private void assertEquivalent(BytesRef[][] segmentTerms) throws IOException {
+        int numSubs = segmentTerms.length;
+        long[] weights = new long[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            weights[i] = segmentTerms[i].length;
+        }
+
+        // Build MergeOrdinalMap
+        TermsEnum[] mapSubs = new TermsEnum[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            mapSubs[i] = arrayTermsEnum(segmentTerms[i]);
+        }
+        MergeOrdinalMap mergeMap = new MergeOrdinalMap(mapSubs, weights);
+
+        // Build reference OrdinalMap from identical subs
+        TermsEnum[] refSubs = new TermsEnum[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            refSubs[i] = arrayTermsEnum(segmentTerms[i]);
+        }
+        OrdinalMap refMap = OrdinalMap.build(null, refSubs, weights, PackedInts.COMPACT);
+
+        // valueCount must match
+        assertEquals("getValueCount", refMap.getValueCount(), mergeMap.getValueCount());
+
+        // getGlobalOrds must match for every segment and every segment ordinal
+        for (int seg = 0; seg < numSubs; seg++) {
+            LongValues refGO = refMap.getGlobalOrds(seg);
+            LongValues mergeGO = mergeMap.getGlobalOrds(seg);
+            for (int segOrd = 0; segOrd < segmentTerms[seg].length; segOrd++) {
+                assertEquals("seg=" + seg + " segOrd=" + segOrd, refGO.get(segOrd), mergeGO.get(segOrd));
+            }
+        }
+
+        // mergedTermsEnum must yield the same terms in the same global-ord order
+        TermsEnum[] enumSubs = new TermsEnum[numSubs];
+        for (int i = 0; i < numSubs; i++) {
+            enumSubs[i] = arrayTermsEnum(segmentTerms[i]);
+        }
+        TermsEnum merged = mergeMap.mergedTermsEnum(enumSubs);
+        long expectedOrd = 0;
+        for (BytesRef term = merged.next(); term != null; term = merged.next()) {
+            assertEquals("ord", expectedOrd, merged.ord());
+            expectedOrd++;
+        }
+        assertEquals("valueCount from enum", mergeMap.getValueCount(), expectedOrd);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    public void testSingleSegmentAllTermsDistinct() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("apple", "banana", "cherry") };
+        assertEquivalent(segs);
+    }
+
+    public void testTwoSegmentsNoOverlap() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("aaa", "bbb"), toSortedBytes("ccc", "ddd") };
+        assertEquivalent(segs);
+    }
+
+    public void testTwoSegmentsFullOverlap() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("foo", "bar"), toSortedBytes("foo", "bar") };
+        assertEquivalent(segs);
+    }
+
+    public void testTwoSegmentsPartialOverlap() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("apple", "cherry", "elderberry"), toSortedBytes("banana", "cherry", "fig") };
+        assertEquivalent(segs);
+    }
+
+    public void testThreeSegmentsMixedOverlap() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("a", "b", "c", "d"), toSortedBytes("b", "c", "e"), toSortedBytes("a", "c", "f") };
+        assertEquivalent(segs);
+    }
+
+    /**
+     * Simulates a realistic scenario: many segments with partial overlap on a high-cardinality
+     * field (e.g. a {@code keyword} or {@code _tsid} field). Verifies equivalence across a
+     * 32-segment merge to mirror the incident configuration (N=32).
+     */
+    public void testThirtyTwoSegmentsMerge() throws IOException {
+        int numSegs = 32;
+        int termsPerSeg = 1000;
+        int totalDistinct = 5000; // ~20% overlap between segments
+
+        // Generate all distinct terms
+        String[] allTerms = new String[totalDistinct];
+        for (int i = 0; i < totalDistinct; i++) {
+            allTerms[i] = String.format(Locale.ROOT, "term%08d", i);
+        }
+
+        BytesRef[][] segs = new BytesRef[numSegs][];
+        for (int seg = 0; seg < numSegs; seg++) {
+            // Each segment gets a random subset of terms; reproducible via randomLong()
+            TreeSet<String> chosen = new TreeSet<>();
+            int offset = seg * (totalDistinct / numSegs);
+            for (int t = 0; t < termsPerSeg; t++) {
+                chosen.add(allTerms[(offset + t) % totalDistinct]);
+            }
+            segs[seg] = chosen.stream().map(BytesRef::new).toArray(BytesRef[]::new);
+        }
+        assertEquivalent(segs);
+    }
+
+    /** An empty segment contributes no terms and must not disturb the global ord sequence. */
+    public void testEmptySegment() throws IOException {
+        BytesRef[][] segs = { toSortedBytes("alpha", "beta"), new BytesRef[0], toSortedBytes("beta", "gamma") };
+        assertEquivalent(segs);
+    }
+
+    /** All segments are empty — value count must be 0. */
+    public void testAllSegmentsEmpty() throws IOException {
+        BytesRef[][] segs = { new BytesRef[0], new BytesRef[0] };
+        assertEquivalent(segs);
+        MergeOrdinalMap m = new MergeOrdinalMap(
+            new TermsEnum[] { arrayTermsEnum(new BytesRef[0]), arrayTermsEnum(new BytesRef[0]) },
+            new long[] { 0, 0 }
+        );
+        assertEquals(0L, m.getValueCount());
+    }
+
+    /** A single segment with zero terms. */
+    public void testSingleEmptySegment() throws IOException {
+        BytesRef[][] segs = { new BytesRef[0] };
+        assertEquivalent(segs);
+    }
+
+    /**
+     * Verifies that {@link MergeOrdinalMap#mergedTermsEnum} can be called multiple times on the
+     * same map and that each call returns an independent iterator.
+     */
+    public void testMultipleMergedTermsEnumCallsAreIndependent() throws IOException {
+        BytesRef[] terms = toSortedBytes("aaa", "bbb", "ccc");
+        BytesRef[][] segs = { terms, toSortedBytes("aaa", "ddd") };
+        long[] weights = { terms.length, 2 };
+
+        TermsEnum[] mapSubs = { arrayTermsEnum(segs[0]), arrayTermsEnum(segs[1]) };
+        MergeOrdinalMap map = new MergeOrdinalMap(mapSubs, weights);
+
+        // First enum: advance to the end
+        TermsEnum e1 = map.mergedTermsEnum(new TermsEnum[] { arrayTermsEnum(segs[0]), arrayTermsEnum(segs[1]) });
+        while (e1.next() != null) {
+            /* drain */ }
+
+        // Second enum: must start fresh at ord 0
+        TermsEnum e2 = map.mergedTermsEnum(new TermsEnum[] { arrayTermsEnum(segs[0]), arrayTermsEnum(segs[1]) });
+        BytesRef first = e2.next();
+        assertNotNull("second enum should start fresh", first);
+        assertEquals(0L, e2.ord());
+        assertEquals(new BytesRef("aaa"), first);
+    }
+
+    /** Randomized stress test: random number of segments, random terms with random overlap. */
+    public void testRandomized() throws IOException {
+        int numSegs = randomIntBetween(1, 16);
+        int distinctCount = randomIntBetween(1, 500);
+
+        // Generate a pool of distinct terms
+        String[] pool = new String[distinctCount];
+        for (int i = 0; i < distinctCount; i++) {
+            pool[i] = randomAlphaOfLengthBetween(1, 20) + i; // suffix ensures uniqueness
+        }
+        Arrays.sort(pool);
+
+        BytesRef[][] segs = new BytesRef[numSegs][];
+        for (int seg = 0; seg < numSegs; seg++) {
+            int segSize = randomIntBetween(0, distinctCount);
+            TreeSet<String> chosen = new TreeSet<>();
+            for (int t = 0; t < segSize; t++) {
+                chosen.add(pool[randomIntBetween(0, distinctCount - 1)]);
+            }
+            segs[seg] = chosen.stream().map(BytesRef::new).toArray(BytesRef[]::new);
+        }
+        assertEquivalent(segs);
+    }
+}


### PR DESCRIPTION
that is more memory efficient at the expense of more expensive ordinal to term lookup.