### PR TITLE
Optimize bitmap_terms on sorted index for point fields

### DIFF
--- a/docs/changelog/157211.yaml
+++ b/docs/changelog/157211.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 157211
+summary: Optimize `bitmap_terms` on sorted index for point fields
+type: enhancement

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQuery.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQuery.java
@@ -9,10 +9,13 @@
 
 package org.elasticsearch.index.query.bitmapterms;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
+import org.apache.lucene.index.PointValues.PointTree;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
@@ -28,6 +31,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.RamUsageEstimator;
 
 import java.io.IOException;
@@ -40,6 +44,11 @@ import java.util.Objects;
  * The bitmap values are streamed in sorted order and merged with the BKD tree leaves, giving
  * O(N_index_leaves + N_bitmap_values) total work across the entire tree.
  * Based on {@link org.apache.lucene.search.PointInSetQuery}.
+ * <p>
+ * On a segment sorted by this field the merge's matches come out already in doc order, so they are
+ * streamed rather than collected; see {@link StreamingDocIdIterator}. Otherwise they are collected into a
+ * {@link DocIdSetBuilder} first, which is what puts them in order &mdash; and what stops a top-N consumer
+ * from finishing early, since it cannot reach its limit until the whole match set has been built.
  * <p>
  * The field's width lives entirely in the {@link BitmapValues}, so this handles {@code integer} and
  * {@code long} fields with one implementation: every comparison here is over the sortable-bytes
@@ -97,6 +106,32 @@ public class BitmapBKDQuery extends Query implements Accountable {
                     return null;
                 }
 
+                if (streams(reader, pointValues)) {
+                    // Both members below need it: cost() returns it, and the scan reports it as its own
+                    // DocIdSetIterator cost. Computing it inside cost() would only compute it twice.
+                    final long estimatedCost = estimateCost(pointValues.getDocCount(), segmentMin, segmentMax);
+                    return new ScorerSupplier() {
+                        @Override
+                        public Scorer get(long leadCost) throws IOException {
+                            // Opened here rather than per supplier, so a supplier asked only for its cost
+                            // reads neither structure and each scorer gets its own cursor over both.
+                            NumericDocValues docValues = DocValues.unwrapSingleton(DocValues.getSortedNumeric(reader, field));
+                            StreamingDocIdIterator scan = new StreamingDocIdIterator(
+                                pointValues.getPointTree(),
+                                docValues,
+                                reader.maxDoc(),
+                                estimatedCost
+                            );
+                            return new ConstantScoreScorer(score(), scoreMode, scan);
+                        }
+
+                        @Override
+                        public long cost() {
+                            return estimatedCost;
+                        }
+                    };
+                }
+
                 return new ScorerSupplier() {
                     long cost = -1;
 
@@ -119,11 +154,68 @@ public class BitmapBKDQuery extends Query implements Accountable {
                 };
             }
 
+            /**
+             * Only the streaming path reads doc values, to skip with, and those are updatable; the collecting
+             * path reads points alone, which cannot change under a cached entry. Testing the same predicate
+             * the scorer chooses with keeps a segment that collects from being withheld from the cache on the
+             * strength of a dependency it does not have.
+             */
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                return true;
+                PointValues pointValues;
+                try {
+                    pointValues = ctx.reader().getPointValues(field);
+                } catch (IOException e) {
+                    // This method cannot throw, and a segment whose points will not read is in no state to
+                    // have its results cached either.
+                    return false;
+                }
+                return pointValues == null || streams(ctx.reader(), pointValues) == false || DocValues.isCacheable(ctx, field);
             }
         };
+    }
+
+    /**
+     * Whether this segment's matches come out of the tree walk in doc order, so they can be streamed rather
+     * than collected. Under an ascending index sort they do; single-valued only, which is what
+     * {@code size() == getDocCount()} says, since index sort places a multi-valued document by one of its
+     * values and another of them can sit in a far later cell while the document sits early.
+     */
+    private boolean streams(LeafReader reader, PointValues pointValues) {
+        return SegmentSort.ascendingBy(reader, field) && pointValues.size() == pointValues.getDocCount();
+    }
+
+    /**
+     * Rough per-segment cost for the streaming path, from segment metadata alone: the bitmap's cardinality
+     * scaled by the average documents per distinct value, clamped to the segment's doc count. That factor is
+     * not 1 just because the field is single-valued &mdash; that bounds values per document, not documents
+     * per value, and many documents may share one. Spreading the documents evenly across the segment's value
+     * span is the only way to get it without reading the tree, since BKD records no distinct-value count.
+     * <p>
+     * {@link PointValues#estimateDocCount} is more accurate and is what the collecting path uses, but it
+     * walks the tree, and a bitmap of scattered values crosses most cells so that walk reaches nearly
+     * every leaf. The collecting path can afford it because it is about to traverse the tree anyway; the
+     * streaming path is built not to, and the built {@code DocIdSet} that would go on to report the true
+     * cost never exists.
+     * <p>
+     * Even spread is a crude assumption. A field holding dense ids plus one distant outlier has a span far
+     * wider than its populated range, which flattens the average to one document per value and makes the
+     * bitmap look more selective than it is.
+     */
+    private long estimateCost(int docCount, byte[] segmentMin, byte[] segmentMax) {
+        long lowest = values.decode(segmentMin, 0);
+        long highest = values.decode(segmentMax, 0);
+        // Inclusive bounds, hence the +1, and in floating point because a long field's span can exceed
+        // Long.MAX_VALUE -- Long.MIN_VALUE to Long.MAX_VALUE wraps to -1 in long arithmetic.
+        double span = (double) highest - (double) lowest + 1.0;
+        // Floored at one document per value, since a value the segment holds is carried by at least one.
+        // A sparser field than that divides below 1, and a zero would report the query as matching
+        // nothing -- which is the reading that makes a conjunction lead with this clause.
+        double avgDocsPerValue = Math.max(1.0, docCount / span);
+        // Clamped before multiplying, so neither factor exceeds the doc count and the product cannot
+        // overflow whatever cardinality the bitmap reports.
+        long cardinality = Math.min(values.cardinality(), docCount);
+        return Math.min(docCount, (long) (cardinality * avgDocsPerValue));
     }
 
     /**
@@ -134,14 +226,17 @@ public class BitmapBKDQuery extends Query implements Accountable {
      * <p>
      * This half decides <em>which cells match</em> and collects nothing, which is all
      * {@link PointValues#estimateDocCount} needs — it calls only {@link #compare}. Collecting the
-     * matched documents costs a {@link DocIdSetBuilder}, so that lives in
-     * {@link CollectingMergePointVisitor} and the cost estimate does not pay for it.
+     * matched documents costs somewhere to put them, so that lives in the subclasses:
+     * {@link CollectingMergePointVisitor} for the whole match set, and
+     * {@link BufferingMergePointVisitor} for one cell of it at a time.
      */
     private class MergePointVisitor implements IntersectVisitor {
         private final BitmapValues.PeekableIterator iterator;
         private final ArrayUtil.ByteArrayComparator comparator;
         /** The bitmap value being merged, encoded. Owned here, so nothing else can recycle it. */
         private final byte[] queryPoint;
+        /** {@link #queryPoint} decoded, so that a skip target can be compared without decoding it. */
+        private long queryValue;
         private boolean hasQueryPoint;
 
         MergePointVisitor() {
@@ -155,6 +250,7 @@ public class BitmapBKDQuery extends Query implements Accountable {
         private void takeQueryPoint() {
             hasQueryPoint = iterator.hasNext();
             if (hasQueryPoint) {
+                queryValue = iterator.peek();
                 iterator.encodePeek(queryPoint);
                 iterator.next();
             }
@@ -170,14 +266,28 @@ public class BitmapBKDQuery extends Query implements Accountable {
             takeQueryPoint();
         }
 
+        /**
+         * Jumps the bitmap cursor to {@code value}, so that every cell below it is then rejected by a
+         * single {@link #compare} rather than descended into. Unlike {@link #skipTo(byte[])} this is
+         * reached from outside the merge, where the cursor may already be at or past the target, so it
+         * checks before consuming — a blind {@code takeQueryPoint} would drop a value that still matches.
+         */
+        void skipTo(long value) {
+            if (hasQueryPoint == false || value <= queryValue) {
+                return;
+            }
+            iterator.advanceTo(value);
+            takeQueryPoint();
+        }
+
         @Override
         public void visit(int docID) {
-            throw new UnsupportedOperationException("this visitor does not collect; use " + CollectingMergePointVisitor.class);
+            throw new UnsupportedOperationException("this visitor does not collect; use one of its subclasses");
         }
 
         @Override
         public void visit(int docID, byte[] packedValue) {
-            throw new UnsupportedOperationException("this visitor does not collect; use " + CollectingMergePointVisitor.class);
+            throw new UnsupportedOperationException("this visitor does not collect; use one of its subclasses");
         }
 
         protected boolean matches(byte[] packedValue) {
@@ -266,6 +376,219 @@ public class BitmapBKDQuery extends Query implements Accountable {
             if (matches(packedValue)) {
                 adder.add(docIdSetIterator);
             }
+        }
+    }
+
+    /**
+     * Holds one cell's matching doc ids for {@link StreamingDocIdIterator} to hand out. Separate from
+     * {@link CollectingMergePointVisitor} because that one accumulates the whole match set before any of
+     * it is returned, which is precisely what the streaming path must not do; this one is emptied and
+     * refilled per cell, so its footprint stays a leaf's worth of points however large the match set
+     * grows.
+     */
+    private final class BufferingMergePointVisitor extends MergePointVisitor {
+        private int[] docs = new int[64];
+        private int size;
+        private int position;
+
+        /** Empties the buffer, so it only ever holds the cell currently being visited. */
+        void reset() {
+            size = 0;
+            position = 0;
+        }
+
+        boolean isEmpty() {
+            return position == size;
+        }
+
+        int next() {
+            return docs[position++];
+        }
+
+        /** The first buffered doc at or after {@code target}, or -1 once the buffer is drained. */
+        int advanceTo(int target) {
+            while (position < size) {
+                int doc = docs[position++];
+                if (doc >= target) {
+                    return doc;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public void grow(int count) {
+            docs = ArrayUtil.grow(docs, size + count);
+        }
+
+        @Override
+        public void visit(int docID) {
+            if (size == docs.length) {
+                docs = ArrayUtil.grow(docs, size + 1);
+            }
+            docs[size++] = docID;
+        }
+
+        @Override
+        public void visit(IntsRef ref) {
+            grow(ref.length);
+            System.arraycopy(ref.ints, ref.offset, docs, size, ref.length);
+            size += ref.length;
+        }
+
+        @Override
+        public void visit(DocIdSetIterator docIdSetIterator) throws IOException {
+            for (int docID = docIdSetIterator.nextDoc(); docID != DocIdSetIterator.NO_MORE_DOCS; docID = docIdSetIterator.nextDoc()) {
+                visit(docID);
+            }
+        }
+
+        @Override
+        public void visit(int docID, byte[] packedValue) {
+            if (matches(packedValue)) {
+                visit(docID);
+            }
+        }
+
+        @Override
+        public void visit(DocIdSetIterator docIdSetIterator, byte[] packedValue) throws IOException {
+            if (matches(packedValue)) {
+                visit(docIdSetIterator);
+            }
+        }
+    }
+
+    /**
+     * Streams the merge's matches, for a segment whose values increase with its doc ids &mdash; the
+     * ascending index sort the caller checked for, which is what makes the walk emit doc ids in order.
+     * <p>
+     * The tree is walked through a {@link PointTree} cursor rather than
+     * {@link PointValues#intersect(IntersectVisitor)}, because that recurses and a recursion cannot be
+     * suspended between two documents; here the cursor's position in the tree <em>is</em> the resume point.
+     * Each step compares the current cell against the bitmap and does one of three things: steps over a
+     * cell the bitmap misses entirely, descends into an inner cell, or reads a leaf's matching doc ids into
+     * a buffer that {@link #nextDoc()} then hands out one at a time. Descending as far as the leaves rather
+     * than bulk-reading an inner cell that matches in full is what keeps that buffer to one leaf's points,
+     * however many documents an inner cell covers.
+     */
+    private final class StreamingDocIdIterator extends DocIdSetIterator {
+        private final PointTree tree;
+        private final BufferingMergePointVisitor visitor = new BufferingMergePointVisitor();
+        private final NumericDocValues docValues;
+        private final int maxDoc;
+        private final long cost;
+        /** Whether the walk has climbed back out of the root, leaving no cell left to visit. */
+        private boolean finished;
+        private int doc = -1;
+
+        StreamingDocIdIterator(PointTree tree, NumericDocValues docValues, int maxDoc, long cost) {
+            this.tree = tree;
+            this.docValues = docValues;
+            this.maxDoc = maxDoc;
+            this.cost = cost;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            if (visitor.isEmpty() && nextCellWithMatches() == false) {
+                return doc = NO_MORE_DOCS;
+            }
+            return emit(visitor.next());
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            if (target >= maxDoc) {
+                // No document can satisfy this, and the doc values read below would be out of bounds.
+                return doc = NO_MORE_DOCS;
+            }
+            int buffered = visitor.advanceTo(target);
+            if (buffered != -1) {
+                return emit(buffered);
+            }
+            // The tree positions on a value quickly, but advance() is given a doc id and the tree holds no
+            // doc-id index to translate it with. Doc values do: the value this document carries, which under
+            // the index sort is a lower bound on every match from here on. Jumping the bitmap cursor there
+            // lets a single compare() reject each cell in between. Read forward only, since advance targets
+            // increase monotonically; a document with no value declines the jump and the walk proceeds.
+            if (docValues != null && docValues.advanceExact(target)) {
+                visitor.skipTo(docValues.longValue());
+            }
+            while (nextCellWithMatches()) {
+                buffered = visitor.advanceTo(target);
+                if (buffered != -1) {
+                    return emit(buffered);
+                }
+            }
+            return doc = NO_MORE_DOCS;
+        }
+
+        /**
+         * The one place a doc id leaves this iterator, so the ascending order the whole strategy rests on
+         * is asserted once rather than argued about per call site.
+         */
+        private int emit(int next) {
+            assert next > doc : "doc ids out of order: [" + next + "] after [" + doc + "]";
+            return doc = next;
+        }
+
+        /**
+         * Advances the walk to the next cell holding matches and buffers them. False once the tree is
+         * exhausted.
+         */
+        private boolean nextCellWithMatches() throws IOException {
+            while (finished == false) {
+                Relation relation = visitor.compare(tree.getMinPackedValue(), tree.getMaxPackedValue());
+                if (relation == Relation.CELL_OUTSIDE_QUERY) {
+                    moveToNextCell();
+                    continue;
+                }
+                if (tree.moveToChild()) {
+                    // Descend even when the whole cell matches, so that what is buffered is bounded by a
+                    // leaf's points rather than by however many documents an inner cell holds. The extra
+                    // comparisons are free: a child of a cell whose min equals its max has the same min
+                    // and max, so it takes the same branch without moving the bitmap cursor.
+                    continue;
+                }
+                visitor.reset();
+                if (relation == Relation.CELL_INSIDE_QUERY) {
+                    // Every point in the leaf matches, so its values need not be read back at all.
+                    tree.visitDocIDs(visitor);
+                } else {
+                    tree.visitDocValues(visitor);
+                }
+                // Stepped past now rather than on the next call, so the cursor always rests on work still
+                // to do and the buffer is never tied to where the cursor sits.
+                moveToNextCell();
+                if (visitor.isEmpty() == false) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Steps the pre-order walk past the current cell without descending into it, climbing to a parent
+         * whenever a cell has no further sibling. Skipping a whole subtree therefore costs no more than
+         * the one {@link MergePointVisitor#compare} that rejected it.
+         */
+        private void moveToNextCell() throws IOException {
+            while (tree.moveToSibling() == false) {
+                if (tree.moveToParent() == false) {
+                    finished = true;
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public long cost() {
+            return cost;
         }
     }
 

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQuery.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQuery.java
@@ -26,8 +26,6 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
@@ -47,7 +45,7 @@ import java.util.Objects;
  * everything below.
  * <p>
  * On a segment sorted by this field the matches come out of that scan already in doc order, so they
- * are streamed rather than collected; see {@link StreamingScan}. Otherwise they are collected into a
+ * are streamed rather than collected; see {@link StreamingDocIdIterator}. Otherwise they are collected into a
  * {@link DocIdSetBuilder} first, which is what puts them in order.
  * <p>
  * The field's width lives entirely in the {@link BitmapValues}, so this handles {@code integer} and
@@ -92,9 +90,9 @@ public class BitmapTermsQuery extends Query implements Accountable {
                         public Scorer get(long leadCost) throws IOException {
                             // Opened here rather than per supplier, so a supplier asked only for its cost
                             // does not read doc values and each scorer gets its own cursor over them.
-                            NumericDocValues skipValues = DocValues.unwrapSingleton(DocValues.getSortedNumeric(reader, field));
+                            NumericDocValues docValues = DocValues.unwrapSingleton(DocValues.getSortedNumeric(reader, field));
                             TermMerge merge = new TermMerge(terms.iterator());
-                            StreamingScan scan = new StreamingScan(merge, skipValues, reader.maxDoc(), estimatedCost);
+                            StreamingDocIdIterator scan = new StreamingDocIdIterator(merge, docValues, reader.maxDoc(), estimatedCost);
                             return new ConstantScoreScorer(score(), scoreMode, scan);
                         }
 
@@ -159,7 +157,7 @@ public class BitmapTermsQuery extends Query implements Accountable {
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
                 // Only the streaming path reads doc values, to skip with, and those are updatable.
-                return sortedByField(ctx.reader(), field) == false || DocValues.isCacheable(ctx, field);
+                return SegmentSort.ascendingBy(ctx.reader(), field) == false || DocValues.isCacheable(ctx, field);
             }
         };
     }
@@ -175,27 +173,17 @@ public class BitmapTermsQuery extends Query implements Accountable {
      * Documents missing a value are fine, and where the sort's missing value places them does not matter.
      * They carry no term, so they can only leave gaps in the doc ids a term's postings cover; two
      * documents with values V1 &lt; V2 still sort in that order, so {@code term(V1)}'s postings still
-     * precede {@code term(V2)}'s. Nor is the missing value visible to {@link StreamingScan#skipTo}, which
+     * precede {@code term(V2)}'s. Nor is the missing value visible to {@link StreamingDocIdIterator#skipTo}, which
      * reads doc values rather than the sort key: {@link NumericDocValues#advanceExact} simply reports
      * false for such a document and the skip is declined.
      */
     private boolean canStream(LeafReader reader, Terms terms) throws IOException {
-        return sortedByField(reader, field) && singleValued(terms);
+        return SegmentSort.ascendingBy(reader, field) && singleValued(terms);
     }
 
     /** Every document with this field carries exactly one value, so no document repeats across terms. */
     private static boolean singleValued(Terms terms) throws IOException {
         return terms.getSumDocFreq() == terms.getDocCount();
-    }
-
-    /** Whether the segment's primary sort is an ascending sort on {@code field}. */
-    private static boolean sortedByField(LeafReader reader, String field) {
-        Sort sort = reader.getMetaData().sort();
-        if (sort == null || sort.getSort().length == 0) {
-            return false;
-        }
-        SortField primary = sort.getSort()[0];
-        return field.equals(primary.getField()) && primary.getReverse() == false;
     }
 
     /**
@@ -340,9 +328,9 @@ public class BitmapTermsQuery extends Query implements Accountable {
      * paying it up front is what stops a consumer from finishing early: a top-N collector cannot reach
      * its limit until the whole match set has been built.
      */
-    private static final class StreamingScan extends DocIdSetIterator {
+    private static final class StreamingDocIdIterator extends DocIdSetIterator {
         private final TermMerge merge;
-        private final NumericDocValues skipValues;
+        private final NumericDocValues docValues;
         private final int maxDoc;
         private final long cost;
         /** Kept across terms so each one recycles the last one's enum rather than allocating. */
@@ -351,9 +339,9 @@ public class BitmapTermsQuery extends Query implements Accountable {
         private boolean draining;
         private int doc = -1;
 
-        StreamingScan(TermMerge merge, NumericDocValues skipValues, int maxDoc, long cost) {
+        StreamingDocIdIterator(TermMerge merge, NumericDocValues docValues, int maxDoc, long cost) {
             this.merge = merge;
-            this.skipValues = skipValues;
+            this.docValues = docValues;
             this.maxDoc = maxDoc;
             this.cost = cost;
         }
@@ -412,10 +400,10 @@ public class BitmapTermsQuery extends Query implements Accountable {
          * because advance targets increase monotonically.
          */
         private void skipTo(int targetDoc) throws IOException {
-            if (skipValues == null || skipValues.advanceExact(targetDoc) == false) {
+            if (docValues == null || docValues.advanceExact(targetDoc) == false) {
                 return;
             }
-            merge.skipTo(skipValues.longValue());
+            merge.skipTo(docValues.longValue());
         }
 
         @Override

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/IntBitmap.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/IntBitmap.java
@@ -30,9 +30,14 @@ public final class IntBitmap implements BitmapValues {
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(IntBitmap.class);
 
     private final RoaringBitmap bitmap;
+    private final long cardinality;
 
     IntBitmap(RoaringBitmap bitmap) {
         this.bitmap = bitmap;
+        // Frozen at construction as LongBitmap freezes its own: getLongCardinality() sums every
+        // container, and every run within a run container, while the queries ask for it once per
+        // segment to size their cost estimate.
+        this.cardinality = bitmap.getLongCardinality();
     }
 
     /**
@@ -72,7 +77,7 @@ public final class IntBitmap implements BitmapValues {
 
     @Override
     public long cardinality() {
-        return bitmap.getLongCardinality();
+        return cardinality;
     }
 
     @Override

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/SegmentSort.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/SegmentSort.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.query.bitmapterms;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+
+/**
+ * The index-sort precondition both bitmap queries share. Under an ascending sort on the queried field
+ * doc order follows value order, which is what lets {@link BitmapTermsQuery} and {@link BitmapBKDQuery}
+ * stream their matches instead of collecting them into a
+ * {@link org.apache.lucene.util.DocIdSetBuilder} to put them in order.
+ */
+final class SegmentSort {
+
+    private SegmentSort() {}
+
+    /** Whether the segment's primary sort is an ascending sort on {@code field}. */
+    static boolean ascendingBy(LeafReader reader, String field) {
+        Sort sort = reader.getMetaData().sort();
+        if (sort == null || sort.getSort().length == 0) {
+            return false;
+        }
+        SortField primary = sort.getSort()[0];
+        return field.equals(primary.getField()) && primary.getReverse() == false;
+    }
+}

--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
@@ -12,13 +12,23 @@ package org.elasticsearch.index.query.bitmapterms;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
@@ -31,9 +41,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
 /**
@@ -48,7 +61,7 @@ public class BitmapBKDQueryTests extends ESTestCase {
     /** Beyond the 32-bit range, so a long bitmap spreads across several high-32-bit buckets. */
     private static final long BEYOND_INT = 1L << 40;
 
-    private enum Width {
+    private enum NumberType {
         INT {
             @Override
             BitmapValues bitmapOf(long... valuesIn) {
@@ -72,6 +85,16 @@ public class BitmapBKDQueryTests extends ESTestCase {
                 }
                 return IntPoint.newSetQuery(FIELD, ints);
             }
+
+            @Override
+            SortField.Type sortType() {
+                return SortField.Type.INT;
+            }
+
+            @Override
+            Object missingValue(long value) {
+                return (int) value;
+            }
         },
         LONG {
             @Override
@@ -88,6 +111,16 @@ public class BitmapBKDQueryTests extends ESTestCase {
             Query pointSetQuery(long... valuesIn) {
                 return LongPoint.newSetQuery(FIELD, valuesIn);
             }
+
+            @Override
+            SortField.Type sortType() {
+                return SortField.Type.LONG;
+            }
+
+            @Override
+            Object missingValue(long value) {
+                return value;
+            }
         };
 
         abstract BitmapValues bitmapOf(long... valuesIn);
@@ -96,35 +129,46 @@ public class BitmapBKDQueryTests extends ESTestCase {
 
         abstract Query pointSetQuery(long... valuesIn);
 
+        abstract SortField.Type sortType();
+
+        /** Boxed as the type {@link SortField#setMissingValue} demands for this type. */
+        abstract Object missingValue(long value);
+
+        /** Adds the point plus the doc values the index sort and the streaming scan's skip both read. */
+        void addSortableField(Document doc, long value) {
+            addField(doc, value);
+            doc.add(new SortedNumericDocValuesField(FIELD, value));
+        }
+
         BitmapValues empty() {
             return bitmapOf();
         }
     }
 
-    private static Query query(Width width, long... valuesIn) {
-        return new BitmapBKDQuery(FIELD, width.bitmapOf(valuesIn));
+    private static Query query(NumberType type, long... valuesIn) {
+        return new BitmapBKDQuery(FIELD, type.bitmapOf(valuesIn));
     }
 
     public void testEqualsAndHashCode() {
-        for (Width width : Width.values()) {
-            Query a = query(width, 1, 2, 3);
-            Query b = query(width, 1, 2, 3);
-            Query c = query(width, 1, 2);
+        for (NumberType type : NumberType.values()) {
+            Query a = query(type, 1, 2, 3);
+            Query b = query(type, 1, 2, 3);
+            Query c = query(type, 1, 2);
             QueryUtils.check(a);
             QueryUtils.checkEqual(a, b);
             QueryUtils.checkUnequal(a, c);
-            QueryUtils.checkUnequal(a, new BitmapBKDQuery("g", width.bitmapOf(1, 2, 3)));
+            QueryUtils.checkUnequal(a, new BitmapBKDQuery("g", type.bitmapOf(1, 2, 3)));
         }
         // An int bitmap and a long bitmap holding the same values are different queries, because they
         // merge against differently encoded points.
-        QueryUtils.checkUnequal(query(Width.INT, 1, 2, 3), query(Width.LONG, 1, 2, 3));
+        QueryUtils.checkUnequal(query(NumberType.INT, 1, 2, 3), query(NumberType.LONG, 1, 2, 3));
     }
 
     public void testToString() {
-        for (Width width : Width.values()) {
-            assertThat(new BitmapBKDQuery(FIELD, width.empty()).toString(FIELD), containsString("cardinality=0"));
+        for (NumberType type : NumberType.values()) {
+            assertThat(new BitmapBKDQuery(FIELD, type.empty()).toString(FIELD), containsString("cardinality=0"));
 
-            String description = query(width, 1, 100, 1000).toString(FIELD);
+            String description = query(type, 1, 100, 1000).toString(FIELD);
             assertThat(description, containsString("cardinality=3"));
             assertThat(description, containsString("first=1"));
             assertThat(description, containsString("last=1000"));
@@ -132,24 +176,24 @@ public class BitmapBKDQueryTests extends ESTestCase {
     }
 
     public void testNoIndexedField() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 w.addDocument(new Document());
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertThat(searcher.count(query(width, 1)), equalTo(0));
+                    assertThat(searcher.count(query(type, 1)), equalTo(0));
                 }
             }
         }
     }
 
     public void testSearch() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             for (boolean splitIntoSegments : new boolean[] { false, true }) {
                 try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                     for (int i = 0; i < 10; i++) {
                         Document doc = new Document();
-                        width.addField(doc, i);
+                        type.addField(doc, i);
                         w.addDocument(doc);
                         if (splitIntoSegments && i < 9 && randomBoolean()) {
                             w.commit();
@@ -160,13 +204,13 @@ public class BitmapBKDQueryTests extends ESTestCase {
 
                     try (IndexReader reader = w.getReader()) {
                         IndexSearcher searcher = newSearcher(reader);
-                        String message = "width=" + width + " splitIntoSegments=" + splitIntoSegments;
-                        assertThat(message, searcher.count(query(width, 1, 3, 5)), equalTo(3));
-                        assertThat(message, searcher.count(query(width, 100)), equalTo(0));
-                        assertThat(message, searcher.count(query(width, 0, 5, 9)), equalTo(3));
-                        assertThat(message, searcher.count(query(width, 0)), equalTo(1));
-                        assertThat(message, searcher.count(query(width, 9)), equalTo(1));
-                        assertThat(message, searcher.count(query(width, 3, 100)), equalTo(1));
+                        String message = "type=" + type + " splitIntoSegments=" + splitIntoSegments;
+                        assertThat(message, searcher.count(query(type, 1, 3, 5)), equalTo(3));
+                        assertThat(message, searcher.count(query(type, 100)), equalTo(0));
+                        assertThat(message, searcher.count(query(type, 0, 5, 9)), equalTo(3));
+                        assertThat(message, searcher.count(query(type, 0)), equalTo(1));
+                        assertThat(message, searcher.count(query(type, 9)), equalTo(1));
+                        assertThat(message, searcher.count(query(type, 3, 100)), equalTo(1));
                     }
                 }
             }
@@ -180,17 +224,17 @@ public class BitmapBKDQueryTests extends ESTestCase {
      * guaranteed. What is asserted either way is that heavy duplication matches every document once.
      */
     public void testManyDocsWithSameValue() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 for (int i = 0; i < 600; i++) {
                     Document doc = new Document();
-                    width.addField(doc, 42);
+                    type.addField(doc, 42);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertThat(searcher.count(query(width, 42)), equalTo(600));
-                    assertThat(searcher.count(query(width, 1)), equalTo(0));
+                    assertThat(searcher.count(query(type, 42)), equalTo(600));
+                    assertThat(searcher.count(query(type, 1)), equalTo(0));
                 }
             }
         }
@@ -203,22 +247,22 @@ public class BitmapBKDQueryTests extends ESTestCase {
      * merge scan finding nothing.
      */
     public void testRangeSkipping() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 for (int i = 1; i <= 100; i++) {
                     Document doc = new Document();
-                    width.addField(doc, i);
+                    type.addField(doc, i);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // Entirely above the indexed range, and entirely below it
-                    for (Query nonOverlapping : List.of(query(width, 200, 300), query(width, 0))) {
+                    for (Query nonOverlapping : List.of(query(type, 200, 300), query(type, 0))) {
                         assertThat(searcher.count(nonOverlapping), equalTo(0));
 
                         Weight weight = searcher.createWeight(searcher.rewrite(nonOverlapping), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
                         for (LeafReaderContext leaf : searcher.getIndexReader().leaves()) {
-                            assertNull("width=" + width + " query=" + nonOverlapping, weight.scorerSupplier(leaf));
+                            assertNull("type=" + type + " query=" + nonOverlapping, weight.scorerSupplier(leaf));
                         }
                     }
                 }
@@ -232,17 +276,17 @@ public class BitmapBKDQueryTests extends ESTestCase {
      * no negatives, which the query builder enforces.
      */
     public void testNegativeDocumentValuesAreNotMatched() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 for (long value : new long[] { Integer.MIN_VALUE, -100, -1, 0, 1, 42 }) {
                     Document doc = new Document();
-                    width.addField(doc, value);
+                    type.addField(doc, value);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertThat(searcher.count(query(width, 0, 1, 42)), equalTo(3));
-                    assertThat(searcher.count(query(width, 0)), equalTo(1));
+                    assertThat(searcher.count(query(type, 0, 1, 42)), equalTo(3));
+                    assertThat(searcher.count(query(type, 0)), equalTo(1));
                 }
             }
         }
@@ -257,8 +301,8 @@ public class BitmapBKDQueryTests extends ESTestCase {
      * count while disagreeing on which documents, and that would be a silent correctness bug.
      */
     public void testAgreesWithPointSetQuery() throws IOException {
-        for (Width width : Width.values()) {
-            long bound = width == Width.INT ? Integer.MAX_VALUE : Long.MAX_VALUE;
+        for (NumberType type : NumberType.values()) {
+            long bound = type == NumberType.INT ? Integer.MAX_VALUE : Long.MAX_VALUE;
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 int docCount = randomIntBetween(50, 300);
                 long[] indexed = new long[docCount];
@@ -267,7 +311,7 @@ public class BitmapBKDQueryTests extends ESTestCase {
                     // value, exercising the bulk-add and CELL_INSIDE_QUERY paths.
                     indexed[i] = randomLongBetween(0, randomBoolean() ? 50 : bound);
                     Document doc = new Document();
-                    width.addField(doc, indexed[i]);
+                    type.addField(doc, indexed[i]);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
@@ -275,9 +319,9 @@ public class BitmapBKDQueryTests extends ESTestCase {
                     for (int nTerms : TERM_COUNTS) {
                         long[] queried = randomQueryValues(nTerms, indexed, bound);
                         assertThat(
-                            "width=" + width + " nTerms=" + nTerms + " values=" + Arrays.toString(queried),
-                            matchingDocs(searcher, query(width, queried), docCount),
-                            equalTo(matchingDocs(searcher, width.pointSetQuery(queried), docCount))
+                            "type=" + type + " nTerms=" + nTerms + " values=" + Arrays.toString(queried),
+                            matchingDocs(searcher, query(type, queried), docCount),
+                            equalTo(matchingDocs(searcher, type.pointSetQuery(queried), docCount))
                         );
                     }
                 }
@@ -317,31 +361,237 @@ public class BitmapBKDQueryTests extends ESTestCase {
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (long value : indexed) {
                 Document doc = new Document();
-                Width.LONG.addField(doc, value);
+                NumberType.LONG.addField(doc, value);
                 w.addDocument(doc);
             }
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(searcher.count(query(Width.LONG, indexed)), equalTo(indexed.length));
-                assertThat(searcher.count(query(Width.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
-                assertThat(searcher.count(query(Width.LONG, 1L << 32, 1L << 34)), equalTo(1));
+                assertThat(searcher.count(query(NumberType.LONG, indexed)), equalTo(indexed.length));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, 1L << 34)), equalTo(1));
                 // Shares a bucket with an indexed value but is not itself indexed
-                assertThat(searcher.count(query(Width.LONG, (1L << 32) + 5)), equalTo(0));
+                assertThat(searcher.count(query(NumberType.LONG, (1L << 32) + 5)), equalTo(0));
             }
         }
     }
 
     public void testEmptyBitmapRewritesToMatchNoDocs() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 Document doc = new Document();
-                width.addField(doc, 1);
+                type.addField(doc, 1);
                 w.addDocument(doc);
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query rewritten = searcher.rewrite(new BitmapBKDQuery(FIELD, width.empty()));
+                    Query rewritten = searcher.rewrite(new BitmapBKDQuery(FIELD, type.empty()));
                     assertThat(rewritten, instanceOf(MatchNoDocsQuery.class));
                 }
+            }
+        }
+    }
+
+    private static RandomIndexWriter sortedWriter(NumberType type, Directory dir) throws IOException {
+        return sortedWriter(type, dir, null);
+    }
+
+    /**
+     * @param missingValue where the sort places a document carrying no value, or null for the default
+     */
+    private static RandomIndexWriter sortedWriter(NumberType type, Directory dir, Long missingValue) throws IOException {
+        IndexWriterConfig config = newIndexWriterConfig();
+        SortedNumericSortField sortField = new SortedNumericSortField(FIELD, type.sortType());
+        if (missingValue != null) {
+            sortField.setMissingValue(type.missingValue(missingValue));
+        }
+        config.setIndexSort(new Sort(sortField));
+        return new RandomIndexWriter(random(), dir, config);
+    }
+
+    /**
+     * Asserts that every leaf carrying the field qualifies for the sorted-index optimization, so a test written to
+     * cover it cannot quietly fall back to collecting into a builder and still pass.
+     * <p>
+     * A leaf holding only documents without a value contributes no points at all, and the query skips such
+     * a segment outright rather than streaming it. {@link RandomIndexWriter} flushes where it likes, so a
+     * test that indexes valueless documents cannot pin down whether one exists.
+     */
+    private static void assertSortingOptimizationApplies(IndexReader reader) throws IOException {
+        int streamed = 0;
+        for (LeafReaderContext context : reader.leaves()) {
+            PointValues points = context.reader().getPointValues(FIELD);
+            if (points == null) {
+                continue;
+            }
+            Sort sort = context.reader().getMetaData().sort();
+            assertNotNull("index sort did not survive to the leaf", sort);
+            assertThat(sort.getSort()[0].getField(), equalTo(FIELD));
+            assertThat("field must be single-valued", points.size(), equalTo((long) points.getDocCount()));
+            streamed++;
+        }
+        assertThat("no leaf carried the field, so nothing exercised the sorted-index optimization", streamed, greaterThan(0));
+    }
+
+    /**
+     * Scattered singletons plus a few runs. The streaming walk treats both the same way, so the shape
+     * that matters is only that some values are absent from the index and some are shared by several
+     * documents.
+     */
+    private long[] randomQueriedValues(int maxValue) {
+        SortedSet<Long> chosen = new TreeSet<>();
+        for (int singletons = randomIntBetween(5, 60); singletons > 0; singletons--) {
+            chosen.add((long) randomIntBetween(0, maxValue));
+        }
+        for (int runs = randomIntBetween(0, 3); runs > 0; runs--) {
+            long start = randomIntBetween(0, maxValue);
+            for (int i = 0, length = randomIntBetween(2, 50); i < length && start + i <= maxValue; i++) {
+                chosen.add(start + i);
+            }
+        }
+        // Above everything indexed, so the walk running off the end of the tree is covered.
+        if (randomBoolean()) {
+            chosen.add(maxValue + 1000L);
+        }
+        return chosen.stream().mapToLong(Long::longValue).toArray();
+    }
+
+    /**
+     * The matched documents' field values, sorted. An index sort reorders documents, so doc ids cannot
+     * be compared across a sorted and an unsorted copy of the same data, but the values they carry can.
+     */
+    private static List<Long> matchedValues(IndexSearcher searcher, Query query) throws IOException {
+        Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        List<Long> matched = new ArrayList<>();
+        for (LeafReaderContext context : searcher.getIndexReader().leaves()) {
+            ScorerSupplier supplier = weight.scorerSupplier(context);
+            if (supplier == null) {
+                continue;
+            }
+            SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), FIELD);
+            DocIdSetIterator docs = supplier.get(Long.MAX_VALUE).iterator();
+            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                assertTrue("doc " + doc + " has no value", values.advanceExact(doc));
+                for (int i = 0; i < values.docValueCount(); i++) {
+                    matched.add(values.nextValue());
+                }
+            }
+        }
+        Collections.sort(matched);
+        return matched;
+    }
+
+    /**
+     * The sorted index must match the unsorted one over identical data, which pins correctness because
+     * {@link #testAgreesWithPointSetQuery} already holds the unsorted path to {@code newSetQuery}. Then
+     * {@link QueryUtils#check} must find {@code advance()} and {@code nextDoc()} in agreement &mdash; the only
+     * check here that catches doc ids emitted out of order.
+     * <p>
+     * Layouts are randomised: all documents valued, some valueless, some valueless placed by the sort in the
+     * middle of the range the rest span, and multi-valued, which must fall back to collecting.
+     */
+    public void testSortedAndUnsortedAgree() throws IOException {
+        for (NumberType type : NumberType.values()) {
+            int numDocs = atLeast(300);
+            int maxValue = randomIntBetween(50, 300);
+            // Index sort permits a multi-valued field (index.sort.mode picks min or max), so the fallback is
+            // a configuration users can reach, not a theoretical one.
+            boolean multiValued = randomBoolean();
+            boolean someValueless = multiValued == false && randomBoolean();
+            Long missingValue = someValueless && randomBoolean() ? (long) randomIntBetween(0, maxValue) : null;
+            String layout = multiValued ? "multi-valued"
+                : someValueless == false ? "all valued"
+                : "valueless sorted at " + (missingValue == null ? "the default" : missingValue);
+
+            long[] indexed = new long[numDocs];
+            for (int i = 0; i < numDocs; i++) {
+                // -1 marks a document indexed without a value at all.
+                indexed[i] = someValueless && randomInt(2) == 0 ? -1 : randomIntBetween(0, maxValue);
+            }
+            try (
+                Directory sortedDir = newDirectory();
+                RandomIndexWriter sorted = sortedWriter(type, sortedDir, missingValue);
+                Directory plainDir = newDirectory();
+                RandomIndexWriter plain = new RandomIndexWriter(random(), plainDir)
+            ) {
+                for (long value : indexed) {
+                    Document doc = new Document();
+                    Document copy = new Document();
+                    if (value >= 0) {
+                        type.addSortableField(doc, value);
+                        type.addSortableField(copy, value);
+                        if (multiValued) {
+                            // Far above the first, so value order and doc order disagree as widely as possible.
+                            type.addSortableField(doc, value + 1000);
+                            type.addSortableField(copy, value + 1000);
+                        }
+                    }
+                    sorted.addDocument(doc);
+                    plain.addDocument(copy);
+                }
+                try (IndexReader sortedReader = sorted.getReader(); IndexReader plainReader = plain.getReader()) {
+                    IndexSearcher sortedSearcher = newSearcher(sortedReader);
+                    IndexSearcher plainSearcher = newSearcher(plainReader);
+                    if (multiValued == false) {
+                        assertSortingOptimizationApplies(sortedSearcher.getIndexReader());
+                    }
+                    for (int iter = 0; iter < 10; iter++) {
+                        Query query = query(type, randomQueriedValues(maxValue));
+                        String message = "type=" + type + " layout=" + layout;
+                        assertThat(message, matchedValues(sortedSearcher, query), equalTo(matchedValues(plainSearcher, query)));
+                        QueryUtils.check(random(), query, sortedSearcher);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Enough documents per value that a whole cell holds one value, which is the {@code CELL_INSIDE_QUERY}
+     * branch. On a sorted segment those documents are also a contiguous doc-id range, so the leaf's ids
+     * reach the buffer through the bulk {@code visit} overloads rather than one at a time — the paths a
+     * per-document test never touches.
+     */
+    public void testSortedIndexManyDocsPerValue() throws IOException {
+        for (NumberType type : NumberType.values()) {
+            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(type, dir)) {
+                for (int value = 0; value < 5; value++) {
+                    for (int i = 0; i < 600; i++) {
+                        Document doc = new Document();
+                        type.addSortableField(doc, value);
+                        w.addDocument(doc);
+                    }
+                }
+                try (IndexReader reader = w.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    assertSortingOptimizationApplies(searcher.getIndexReader());
+                    assertThat(searcher.count(query(type, 2)), equalTo(600));
+                    assertThat(searcher.count(query(type, 0, 4)), equalTo(1200));
+                    assertThat(searcher.count(query(type, 7)), equalTo(0));
+                    QueryUtils.check(random(), query(type, 1, 3), searcher);
+                }
+            }
+        }
+    }
+
+    /**
+     * Every other test draws values that fit in an {@code int}, even those running over a {@code long} field.
+     * This is the one that uses genuinely 64-bit values, so the bitmap has to cross the high-32-bit bucket
+     * boundaries the portable format splits on.
+     */
+    public void testSortedIndexLongValuesBeyondIntRange() throws IOException {
+        long[] indexed = { 0L, 1L, Integer.MAX_VALUE, 1L << 32, (1L << 32) + 1, 1L << 33, BEYOND_INT, Long.MAX_VALUE };
+        try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(NumberType.LONG, dir)) {
+            for (long value : indexed) {
+                Document doc = new Document();
+                NumberType.LONG.addSortableField(doc, value);
+                w.addDocument(doc);
+            }
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = newSearcher(reader);
+                assertSortingOptimizationApplies(searcher.getIndexReader());
+                assertThat(searcher.count(query(NumberType.LONG, indexed)), equalTo(indexed.length));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
+                assertThat(searcher.count(query(NumberType.LONG, (1L << 32) + 5)), equalTo(0));
+                QueryUtils.check(random(), query(NumberType.LONG, indexed), searcher);
             }
         }
     }

--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQueryTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapTermsQueryTests.java
@@ -80,7 +80,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
     }
 
     /** Mirrors {@code NumberFieldMapper}'s {@code encodeIntIndexTerm}/{@code encodeLongIndexTerm}. */
-    private enum Width {
+    private enum NumberType {
         INT {
             @Override
             BitmapValues bitmapOf(long... valuesIn) {
@@ -138,7 +138,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
 
         abstract SortField.Type sortType();
 
-        /** Boxed as the type {@link SortField#setMissingValue} demands for this width. */
+        /** Boxed as the type {@link SortField#setMissingValue} demands for this type. */
         abstract Object missingValue(long value);
 
         void addField(Document doc, long value) {
@@ -164,30 +164,30 @@ public class BitmapTermsQueryTests extends ESTestCase {
         }
     }
 
-    private static Query query(Width width, long... valuesIn) {
-        return new BitmapTermsQuery(FIELD, width.bitmapOf(valuesIn));
+    private static Query query(NumberType type, long... valuesIn) {
+        return new BitmapTermsQuery(FIELD, type.bitmapOf(valuesIn));
     }
 
     public void testEqualsAndHashCode() {
-        for (Width width : Width.values()) {
-            Query a = query(width, 1, 2, 3);
-            Query b = query(width, 1, 2, 3);
-            Query c = query(width, 1, 2);
+        for (NumberType type : NumberType.values()) {
+            Query a = query(type, 1, 2, 3);
+            Query b = query(type, 1, 2, 3);
+            Query c = query(type, 1, 2);
             QueryUtils.check(a);
             QueryUtils.checkEqual(a, b);
             QueryUtils.checkUnequal(a, c);
-            QueryUtils.checkUnequal(a, new BitmapTermsQuery("g", width.bitmapOf(1, 2, 3)));
+            QueryUtils.checkUnequal(a, new BitmapTermsQuery("g", type.bitmapOf(1, 2, 3)));
         }
         // An int bitmap and a long bitmap holding the same values are different queries, because their
         // terms are encoded at different widths.
-        QueryUtils.checkUnequal(query(Width.INT, 1, 2, 3), query(Width.LONG, 1, 2, 3));
+        QueryUtils.checkUnequal(query(NumberType.INT, 1, 2, 3), query(NumberType.LONG, 1, 2, 3));
     }
 
     public void testToString() {
-        for (Width width : Width.values()) {
-            assertThat(new BitmapTermsQuery(FIELD, width.empty()).toString(FIELD), containsString("cardinality=0"));
+        for (NumberType type : NumberType.values()) {
+            assertThat(new BitmapTermsQuery(FIELD, type.empty()).toString(FIELD), containsString("cardinality=0"));
 
-            String description = query(width, 1, 100, 1000).toString(FIELD);
+            String description = query(type, 1, 100, 1000).toString(FIELD);
             assertThat(description, containsString("cardinality=3"));
             assertThat(description, containsString("first=1"));
             assertThat(description, containsString("last=1000"));
@@ -195,24 +195,24 @@ public class BitmapTermsQueryTests extends ESTestCase {
     }
 
     public void testNoIndexedField() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 w.addDocument(new Document());
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertThat(searcher.count(query(width, 1)), equalTo(0));
+                    assertThat(searcher.count(query(type, 1)), equalTo(0));
                 }
             }
         }
     }
 
     public void testSearch() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             for (boolean splitIntoSegments : new boolean[] { false, true }) {
                 try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                     for (int i = 0; i < 10; i++) {
                         Document doc = new Document();
-                        width.addField(doc, i);
+                        type.addField(doc, i);
                         w.addDocument(doc);
                         if (splitIntoSegments && i < 9 && randomBoolean()) {
                             w.commit();
@@ -223,13 +223,13 @@ public class BitmapTermsQueryTests extends ESTestCase {
 
                     try (IndexReader reader = w.getReader()) {
                         IndexSearcher searcher = newSearcher(reader);
-                        String message = "width=" + width + " splitIntoSegments=" + splitIntoSegments;
-                        assertThat(message, searcher.count(query(width, 1, 3, 5)), equalTo(3));
-                        assertThat(message, searcher.count(query(width, 100)), equalTo(0));
-                        assertThat(message, searcher.count(query(width, 0, 5, 9)), equalTo(3));
-                        assertThat(message, searcher.count(query(width, 0)), equalTo(1));
-                        assertThat(message, searcher.count(query(width, 9)), equalTo(1));
-                        assertThat(message, searcher.count(query(width, 3, 100)), equalTo(1));
+                        String message = "type=" + type + " splitIntoSegments=" + splitIntoSegments;
+                        assertThat(message, searcher.count(query(type, 1, 3, 5)), equalTo(3));
+                        assertThat(message, searcher.count(query(type, 100)), equalTo(0));
+                        assertThat(message, searcher.count(query(type, 0, 5, 9)), equalTo(3));
+                        assertThat(message, searcher.count(query(type, 0)), equalTo(1));
+                        assertThat(message, searcher.count(query(type, 9)), equalTo(1));
+                        assertThat(message, searcher.count(query(type, 3, 100)), equalTo(1));
                     }
                 }
             }
@@ -241,12 +241,12 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * which then has to skip a long run of values to catch up.
      */
     public void testBitmapSkipsManyValuesBetweenTerms() throws IOException {
-        for (Width width : Width.values()) {
-            long[] indexedValues = width == Width.INT ? new long[] { 0L, 1L << 20, 1L << 28 } : new long[] { 0L, 1L << 32, BEYOND_INT };
+        for (NumberType type : NumberType.values()) {
+            long[] indexedValues = type == NumberType.INT ? new long[] { 0L, 1L << 20, 1L << 28 } : new long[] { 0L, 1L << 32, BEYOND_INT };
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 for (long value : indexedValues) {
                     Document doc = new Document();
-                    width.addField(doc, value);
+                    type.addField(doc, value);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
@@ -259,7 +259,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
                             queried[at++] = base + offset;
                         }
                     }
-                    assertThat(searcher.count(query(width, queried)), equalTo(indexedValues.length));
+                    assertThat(searcher.count(query(type, queried)), equalTo(indexedValues.length));
                 }
             }
         }
@@ -271,17 +271,17 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * because the bitmap holds no negatives, which the query builder enforces.
      */
     public void testNegativeDocumentValuesAreNotMatched() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 for (long value : new long[] { Integer.MIN_VALUE, -100, -1, 0, 1, 42 }) {
                     Document doc = new Document();
-                    width.addField(doc, value);
+                    type.addField(doc, value);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertThat(searcher.count(query(width, 0, 1, 42)), equalTo(3));
-                    assertThat(searcher.count(query(width, 0)), equalTo(1));
+                    assertThat(searcher.count(query(type, 0, 1, 42)), equalTo(3));
+                    assertThat(searcher.count(query(type, 0)), equalTo(1));
                 }
             }
         }
@@ -296,8 +296,8 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * count while disagreeing on which documents, and that would be a silent correctness bug.
      */
     public void testAgreesWithTermInSetQuery() throws IOException {
-        for (Width width : Width.values()) {
-            long bound = width == Width.INT ? Integer.MAX_VALUE : Long.MAX_VALUE;
+        for (NumberType type : NumberType.values()) {
+            long bound = type == NumberType.INT ? Integer.MAX_VALUE : Long.MAX_VALUE;
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 int docCount = randomIntBetween(50, 300);
                 long[] indexed = new long[docCount];
@@ -306,7 +306,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
                     // term, exercising the postings bulk-add path.
                     indexed[i] = randomLongBetween(0, randomBoolean() ? 50 : bound);
                     Document doc = new Document();
-                    width.addField(doc, indexed[i]);
+                    type.addField(doc, indexed[i]);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
@@ -314,9 +314,9 @@ public class BitmapTermsQueryTests extends ESTestCase {
                     for (int nTerms : TERM_COUNTS) {
                         long[] queried = randomQueryValues(nTerms, indexed, bound);
                         assertThat(
-                            "width=" + width + " nTerms=" + nTerms + " values=" + Arrays.toString(queried),
-                            matchingDocs(searcher, query(width, queried), docCount),
-                            equalTo(matchingDocs(searcher, width.termInSetQuery(queried), docCount))
+                            "type=" + type + " nTerms=" + nTerms + " values=" + Arrays.toString(queried),
+                            matchingDocs(searcher, query(type, queried), docCount),
+                            equalTo(matchingDocs(searcher, type.termInSetQuery(queried), docCount))
                         );
                     }
                 }
@@ -353,54 +353,62 @@ public class BitmapTermsQueryTests extends ESTestCase {
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             for (long value : indexed) {
                 Document doc = new Document();
-                Width.LONG.addField(doc, value);
+                NumberType.LONG.addField(doc, value);
                 w.addDocument(doc);
             }
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertThat(searcher.count(query(Width.LONG, indexed)), equalTo(indexed.length));
-                assertThat(searcher.count(query(Width.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
-                assertThat(searcher.count(query(Width.LONG, 1L << 32, 1L << 34)), equalTo(1));
-                assertThat(searcher.count(query(Width.LONG, (1L << 32) + 5)), equalTo(0));
+                assertThat(searcher.count(query(NumberType.LONG, indexed)), equalTo(indexed.length));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, 1L << 34)), equalTo(1));
+                assertThat(searcher.count(query(NumberType.LONG, (1L << 32) + 5)), equalTo(0));
             }
         }
     }
 
     public void testEmptyBitmapRewritesToMatchNoDocs() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 Document doc = new Document();
-                width.addField(doc, 1);
+                type.addField(doc, 1);
                 w.addDocument(doc);
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query rewritten = searcher.rewrite(new BitmapTermsQuery(FIELD, width.empty()));
+                    Query rewritten = searcher.rewrite(new BitmapTermsQuery(FIELD, type.empty()));
                     assertThat(rewritten, instanceOf(MatchNoDocsQuery.class));
                 }
             }
         }
     }
 
-    private static RandomIndexWriter sortedWriter(Width width, Directory dir) throws IOException {
+    private static RandomIndexWriter sortedWriter(NumberType type, Directory dir) throws IOException {
         IndexWriterConfig config = newIndexWriterConfig();
-        config.setIndexSort(new Sort(new SortedNumericSortField(FIELD, width.sortType())));
+        config.setIndexSort(new Sort(new SortedNumericSortField(FIELD, type.sortType())));
         return new RandomIndexWriter(random(), dir, config);
     }
 
     /**
-     * Asserts every leaf qualifies for the streaming scan, so a test written to cover it cannot quietly
-     * fall back to collecting into a builder and still pass.
+     * Asserts that every leaf carrying the field qualifies for the sorted-index optimization, so a test written to
+     * cover it cannot quietly fall back to collecting into a builder and still pass.
+     * <p>
+     * A leaf holding only documents without a value has no terms for the field at all, and the query skips
+     * such a segment outright rather than streaming it. {@link RandomIndexWriter} flushes where it likes,
+     * so a test that indexes valueless documents cannot pin down whether one exists.
      */
-    private static void assertStreamingApplies(IndexReader reader) throws IOException {
-        assertFalse("expected at least one leaf", reader.leaves().isEmpty());
+    private static void assertSortingOptimizationApplies(IndexReader reader) throws IOException {
+        int streamed = 0;
         for (LeafReaderContext context : reader.leaves()) {
+            Terms terms = context.reader().terms(FIELD);
+            if (terms == null) {
+                continue;
+            }
             Sort sort = context.reader().getMetaData().sort();
             assertNotNull("index sort did not survive to the leaf", sort);
             assertThat(sort.getSort()[0].getField(), equalTo(FIELD));
-            Terms terms = context.reader().terms(FIELD);
-            assertNotNull(terms);
             assertThat("field must be single-valued", terms.getSumDocFreq(), equalTo((long) terms.getDocCount()));
+            streamed++;
         }
+        assertThat("no leaf carried the field, so nothing exercised the sorted-index optimization", streamed, greaterThan(0));
     }
 
     /**
@@ -431,20 +439,20 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * {@code advance()} is verified against {@code nextDoc()} rather than only exhaustive iteration.
      */
     public void testSortedIndexAgainstBruteForce() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             int numDocs = atLeast(500);
             int maxValue = randomIntBetween(50, 500);
             long[] indexed = new long[numDocs];
-            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(width, dir)) {
+            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(type, dir)) {
                 for (int i = 0; i < numDocs; i++) {
                     indexed[i] = randomIntBetween(0, maxValue);
                     Document doc = new Document();
-                    width.addSortableField(doc, indexed[i]);
+                    type.addSortableField(doc, indexed[i]);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertStreamingApplies(searcher.getIndexReader());
+                    assertSortingOptimizationApplies(searcher.getIndexReader());
                     for (int iter = 0; iter < 15; iter++) {
                         long[] queried = randomQueriedValues(maxValue);
                         Set<Long> wanted = Arrays.stream(queried).boxed().collect(Collectors.toSet());
@@ -454,8 +462,8 @@ public class BitmapTermsQueryTests extends ESTestCase {
                                 expected++;
                             }
                         }
-                        Query query = query(width, queried);
-                        assertThat("width=" + width, searcher.count(query), equalTo(expected));
+                        Query query = query(type, queried);
+                        assertThat("type=" + type, searcher.count(query), equalTo(expected));
                         QueryUtils.check(random(), query, searcher);
                     }
                 }
@@ -491,7 +499,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * identical data isolates the strategy from the data, which a brute-force oracle alone cannot do.
      */
     public void testSortedAndUnsortedAgree() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             int numDocs = atLeast(300);
             int maxValue = randomIntBetween(50, 300);
             long[] indexed = new long[numDocs];
@@ -500,25 +508,25 @@ public class BitmapTermsQueryTests extends ESTestCase {
             }
             try (
                 Directory sortedDir = newDirectory();
-                RandomIndexWriter sorted = sortedWriter(width, sortedDir);
+                RandomIndexWriter sorted = sortedWriter(type, sortedDir);
                 Directory plainDir = newDirectory();
                 RandomIndexWriter plain = new RandomIndexWriter(random(), plainDir)
             ) {
                 for (long value : indexed) {
                     Document doc = new Document();
-                    width.addSortableField(doc, value);
+                    type.addSortableField(doc, value);
                     sorted.addDocument(doc);
                     Document copy = new Document();
-                    width.addSortableField(copy, value);
+                    type.addSortableField(copy, value);
                     plain.addDocument(copy);
                 }
                 try (IndexReader sortedReader = sorted.getReader(); IndexReader plainReader = plain.getReader()) {
                     IndexSearcher sortedSearcher = newSearcher(sortedReader);
                     IndexSearcher plainSearcher = newSearcher(plainReader);
-                    assertStreamingApplies(sortedSearcher.getIndexReader());
+                    assertSortingOptimizationApplies(sortedSearcher.getIndexReader());
                     for (int iter = 0; iter < 10; iter++) {
-                        Query query = query(width, randomQueriedValues(maxValue));
-                        assertThat("width=" + width, matchedValues(sortedSearcher, query), equalTo(matchedValues(plainSearcher, query)));
+                        Query query = query(type, randomQueriedValues(maxValue));
+                        assertThat("type=" + type, matchedValues(sortedSearcher, query), equalTo(matchedValues(plainSearcher, query)));
                     }
                 }
             }
@@ -531,23 +539,23 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * exclude and this one does not.
      */
     public void testSortedIndexWithMissingValues() throws IOException {
-        for (Width width : Width.values()) {
-            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(width, dir)) {
+        for (NumberType type : NumberType.values()) {
+            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(type, dir)) {
                 int withValue = 0;
                 for (int i = 0; i < 200; i++) {
                     Document doc = new Document();
                     // Roughly a third of the documents carry no value at all.
                     if (i % 3 != 0) {
-                        width.addSortableField(doc, i);
+                        type.addSortableField(doc, i);
                         withValue++;
                     }
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertStreamingApplies(searcher.getIndexReader());
+                    assertSortingOptimizationApplies(searcher.getIndexReader());
                     long[] all = LongStream.range(0, 200).toArray();
-                    assertThat(searcher.count(query(width, all)), equalTo(withValue));
+                    assertThat(searcher.count(query(type, all)), equalTo(withValue));
                 }
             }
         }
@@ -565,26 +573,26 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * would expose the assumption if it were wrong.
      */
     public void testSortedIndexWithInterleavedMissingValues() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             IndexWriterConfig config = newIndexWriterConfig();
-            SortedNumericSortField sortField = new SortedNumericSortField(FIELD, width.sortType());
-            sortField.setMissingValue(width.missingValue(100));
+            SortedNumericSortField sortField = new SortedNumericSortField(FIELD, type.sortType());
+            sortField.setMissingValue(type.missingValue(100));
             config.setIndexSort(new Sort(sortField));
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir, config)) {
                 int withValue = 0;
                 for (int i = 0; i < 200; i++) {
                     Document doc = new Document();
                     if (i % 3 != 0) {
-                        width.addSortableField(doc, i);
+                        type.addSortableField(doc, i);
                         withValue++;
                     }
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertStreamingApplies(searcher.getIndexReader());
-                    Query query = query(width, LongStream.range(0, 200).toArray());
-                    assertThat("width=" + width, searcher.count(query), equalTo(withValue));
+                    assertSortingOptimizationApplies(searcher.getIndexReader());
+                    Query query = query(type, LongStream.range(0, 200).toArray());
+                    assertThat("type=" + type, searcher.count(query), equalTo(withValue));
                     // Emitting doc ids out of order would fail the iterator contract here.
                     QueryUtils.check(random(), query, searcher);
                 }
@@ -599,14 +607,14 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * the iterator contract that streaming out of order would break.
      */
     public void testMultiValuedFieldIsNotStreamed() throws IOException {
-        for (Width width : Width.values()) {
-            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(width, dir)) {
+        for (NumberType type : NumberType.values()) {
+            try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(type, dir)) {
                 for (int i = 0; i < 100; i++) {
                     Document doc = new Document();
-                    width.addSortableField(doc, i);
+                    type.addSortableField(doc, i);
                     // A second, far higher value on every document, so the terms order and the doc order
                     // disagree as widely as possible.
-                    width.addSortableField(doc, 1000 + i);
+                    type.addSortableField(doc, 1000 + i);
                     w.addDocument(doc);
                 }
                 try (IndexReader reader = w.getReader()) {
@@ -615,7 +623,7 @@ public class BitmapTermsQueryTests extends ESTestCase {
                         Terms terms = context.reader().terms(FIELD);
                         assertThat("expected multi-valued", terms.getSumDocFreq(), greaterThan((long) terms.getDocCount()));
                     }
-                    Query query = query(width, 5, 1005, 40, 1040);
+                    Query query = query(type, 5, 1005, 40, 1040);
                     assertThat(searcher.count(query), equalTo(2));
                     QueryUtils.check(random(), query, searcher);
                 }
@@ -628,22 +636,22 @@ public class BitmapTermsQueryTests extends ESTestCase {
      * back to counting by iteration.
      */
     public void testCountWithDeletions() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             for (boolean sorted : new boolean[] { true, false }) {
                 try (
                     Directory dir = newDirectory();
-                    RandomIndexWriter w = sorted ? sortedWriter(width, dir) : new RandomIndexWriter(random(), dir)
+                    RandomIndexWriter w = sorted ? sortedWriter(type, dir) : new RandomIndexWriter(random(), dir)
                 ) {
                     for (int i = 0; i < 200; i++) {
                         Document doc = new Document();
-                        width.addSortableField(doc, i);
+                        type.addSortableField(doc, i);
                         w.addDocument(doc);
                     }
-                    w.deleteDocuments(new Term(FIELD, width.encodeTerm(100)));
+                    w.deleteDocuments(new Term(FIELD, type.encodeTerm(100)));
                     try (IndexReader reader = w.getReader()) {
                         IndexSearcher searcher = newSearcher(reader);
                         // 150 values queried, one of them deleted.
-                        assertThat(searcher.count(query(width, LongStream.range(0, 150).toArray())), equalTo(149));
+                        assertThat(searcher.count(query(type, LongStream.range(0, 150).toArray())), equalTo(149));
                     }
                 }
             }
@@ -652,24 +660,24 @@ public class BitmapTermsQueryTests extends ESTestCase {
 
     /** The docFreq count path needs no index sort, so it must agree with iteration on either layout. */
     public void testCountAgreesWithIteration() throws IOException {
-        for (Width width : Width.values()) {
+        for (NumberType type : NumberType.values()) {
             for (boolean sorted : new boolean[] { true, false }) {
                 int maxValue = 200;
                 try (
                     Directory dir = newDirectory();
-                    RandomIndexWriter w = sorted ? sortedWriter(width, dir) : new RandomIndexWriter(random(), dir)
+                    RandomIndexWriter w = sorted ? sortedWriter(type, dir) : new RandomIndexWriter(random(), dir)
                 ) {
                     for (int i = 0; i < 400; i++) {
                         Document doc = new Document();
-                        width.addSortableField(doc, randomIntBetween(0, maxValue));
+                        type.addSortableField(doc, randomIntBetween(0, maxValue));
                         w.addDocument(doc);
                     }
                     try (IndexReader reader = w.getReader()) {
                         IndexSearcher searcher = newSearcher(reader);
                         for (int iter = 0; iter < 10; iter++) {
-                            Query query = query(width, randomQueriedValues(maxValue));
+                            Query query = query(type, randomQueriedValues(maxValue));
                             assertThat(
-                                "width=" + width + " sorted=" + sorted,
+                                "type=" + type + " sorted=" + sorted,
                                 searcher.count(query),
                                 equalTo(matchedValues(searcher, query).size())
                             );
@@ -683,19 +691,19 @@ public class BitmapTermsQueryTests extends ESTestCase {
     /** Long-only: streaming must hold across high-32-bit bucket boundaries, not just within one. */
     public void testSortedIndexLongValuesBeyondIntRange() throws IOException {
         long[] indexed = { 0L, 1L, Integer.MAX_VALUE, 1L << 32, (1L << 32) + 1, 1L << 33, BEYOND_INT, Long.MAX_VALUE };
-        try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(Width.LONG, dir)) {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = sortedWriter(NumberType.LONG, dir)) {
             for (long value : indexed) {
                 Document doc = new Document();
-                Width.LONG.addSortableField(doc, value);
+                NumberType.LONG.addSortableField(doc, value);
                 w.addDocument(doc);
             }
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
-                assertStreamingApplies(searcher.getIndexReader());
-                assertThat(searcher.count(query(Width.LONG, indexed)), equalTo(indexed.length));
-                assertThat(searcher.count(query(Width.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
-                assertThat(searcher.count(query(Width.LONG, (1L << 32) + 5)), equalTo(0));
-                QueryUtils.check(random(), query(Width.LONG, indexed), searcher);
+                assertSortingOptimizationApplies(searcher.getIndexReader());
+                assertThat(searcher.count(query(NumberType.LONG, indexed)), equalTo(indexed.length));
+                assertThat(searcher.count(query(NumberType.LONG, 1L << 32, Long.MAX_VALUE)), equalTo(2));
+                assertThat(searcher.count(query(NumberType.LONG, (1L << 32) + 5)), equalTo(0));
+                QueryUtils.check(random(), query(NumberType.LONG, indexed), searcher);
             }
         }
     }


### PR DESCRIPTION
Brings the sorted-index optimization of #156212 to the BKD points path, which that change deliberately left alone. Applies to `integer` and `long` fields on the default mapping, where the query merges the bitmap against the field's point tree rather than a terms dictionary.

### What it does

Points of a one-dimensional field are written in (value, doc id) order — the ordering `BKDWriter#valueInOrder` asserts as it writes, that the 1-D merge's priority queue tie-breaks on, and that `IntersectVisitor#visit(int, byte[])` documents. Under an ascending index sort on the field, value order **is** doc order, so the merge's matches already come out ascending and the `DocIdSetBuilder` that exists to sort them is pure overhead. Building it up front is also what prevented early termination: a top-N collector cannot reach its limit until the whole match set has been built.

Matches are now streamed. `PointValues#intersect` recurses, and a recursion cannot be suspended between two documents, so the walk is written out as an explicit pre-order traversal over a `PointTree` cursor whose position in the tree *is* the iterator's resume point. The buffering visitor descends to leaves even for a cell that matches in full, so what is held is bounded by one leaf's points however many documents an inner cell covers.

`advance()` reads the target document's value from doc values and jumps the bitmap cursor there. The tree can position on a value quickly, but `advance()` is given a doc id and the tree holds no doc-id index to translate it with; doc values supply that, and under the index sort the value is a lower bound on every match from there on, so a subtree between the cursor and the target dies on the single `compare()` that rejects it. This is an optimization only — with no doc values the scan simply walks.

`cost()` answers from segment metadata rather than `PointValues#estimateDocCount`, whose traversal is the very work the lazy walk exists to defer.

### Preconditions

The segment must be sorted ascending on the field **and** the field must be single-valued, since index sort places a multi-valued document by one of its values and another of them can sit in a far later cell while the document itself sits early. Documents missing a value are fine — they contribute no point, so they can only leave gaps in the doc ids a cell covers. A segment failing either precondition keeps the existing eager sweep.

### Measurements

10M docs, single segment, cardinality 10000, BKD points path, `integer` field. Before → after, µs/op:

| cell | before | after | |
|---|---|---|---|
| dpv=100 scattered, topN `track_total_hits: false` | 4959 | **1.95** | **2548×** |
| dpv=1 scattered, topN `track_total_hits: false` | 30601 | **27.2** | **1125×** |
| dpv=100 run=4096, topN `track_total_hits: false` | 2880 | **2.82** | **1021×** |
| dpv=1 run=4096, topN `track_total_hits: false` | 134 | 8.59 | 16× |
| dpv=100 scattered, topN default (10000) | 4985 | 74.8 | **67×** |
| dpv=100 run=4096, topN default (10000) | 2903 | 65.2 | **45×** |
| dpv=100 run=4096, leadFilter | 3122 | 982 | 3.2× |
| dpv=1 run=4096, leadFilter | 197 | 80.4 | 2.5× |
| dpv=100 scattered, leadFilter | 6053 | 4137 | 1.5× |
| dpv=100 run=4096, count | 5722 | 4360 | 1.3× |
| dpv=100 scattered, collectAll | 8301 | 7071 | 1.2× |

How much `topN` gains depends on `track_total_hits`, since a lazy scan still has to produce `max(size, track_total_hits)` documents. At `docsPerValue=1` the whole match set fits inside the 10000 default, so there is nothing left to skip and that cell is unchanged — as on the `index_terms` path, the setting was previously inert for this query and now is not.

**No measured cell regressed.** The regression canary — 10000 singleton values over 10M distinct values, drained in full — was re-measured at 10 iterations of 3s per side and is level: `collectAll` 29179 ± 355 → 29580 ± 822, `count` 27897 ± 476 → 27689 ± 959.

The `leadFilter` figures are on an `integer` field. `LongBitmap#advanceTo` walks values one at a time (`Roaring64NavigableMap` exposes no positionable iterator — see its javadoc), so the `advance()` skip is weaker on `long` fields. Streaming and early termination apply to both.

### Also here

- `SegmentSort` extracts the index-sort precondition the terms and points queries now share, rather than leaving each with its own copy.
- `IntBitmap` freezes its cardinality at construction as `LongBitmap` already does, since `getLongCardinality()` sums every container — and every run within a run container — while both queries ask for it once per segment to size their cost estimate.
- `assertSortingOptimizationApplies` in both test classes now skips leaves carrying no value for the field instead of requiring every leaf to have one, and asserts that at least one leaf did. `RandomIndexWriter` flushes where it likes, so a test indexing valueless documents can produce a segment holding only those, whose terms or points are absent — a segment the queries skip outright rather than streaming. **This fixes a pre-existing flake in `BitmapTermsQueryTests`**, reproducible on `main` with `-Dtests.seed=17D7E3885FF97E79 -Dtests.iters=10`.

### Testing

`BitmapBKDQueryTests` gains sorted-index coverage over both number types. `testSortedAndUnsortedAgree` compares the streaming and collecting paths by matched *values* — an index sort reorders documents, so doc ids cannot be compared across the two — and runs `QueryUtils.check` on each so `advance()` is held against `nextDoc()`. Since `testAgreesWithPointSetQuery` already pins the collecting path to `newSetQuery`, that comparison anchors the walk to Lucene's answer rather than to a second implementation of ours.

Its layouts are randomised over all-valued, valueless, valueless placed by the sort in the *middle* of the range the rest span (which `index.sort.missing` cannot express, taking only `_first`/`_last`, but Lucene permits), and multi-valued, which must fall back to collecting. That last one was verified by deleting the single-valued clause from the gate: 8 of 25 seeds fail.

Separately, `testSortedIndexManyDocsPerValue` covers `CELL_INSIDE_QUERY` and the bulk `visit` overloads, and `testSortedIndexLongValuesBeyondIntRange` is the one test using genuinely 64-bit values, so the bitmap crosses the high-32-bit bucket boundaries the portable format splits on.

The measurements come from a JMH harness (`SortedIntegerBitmapQueryBenchmark`) which is deliberately **not** included here, as in #156212, to keep the diff to the change itself. Happy to add it if reviewers would rather have it in-tree.
