### PR TITLE
[8.19] Fix/indices query cache null shard stats (#157050)

### DIFF
--- a/docs/changelog/157050.yaml
+++ b/docs/changelog/157050.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 157050
+summary: Fix/indices query cache null shard stats
+type: bug

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -125,6 +125,11 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         sharedRamBytesUsed = 0;
     }
 
+    // Visible for testing:
+    LRUQueryCache getCache() {
+        return cache;
+    }
+
     private static QueryCacheStats toQueryCacheStatsSafe(@Nullable Stats stats) {
         return stats == null ? new QueryCacheStats() : stats.toQueryCacheStats();
     }
@@ -369,7 +374,11 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         }
 
         private Stats getOrCreateStats(Object coreKey) {
-            return shardStats.computeIfAbsent(shardKeyMap.getShardId(coreKey), Stats::new);
+            final ShardId shardId = shardKeyMap.getShardId(coreKey);
+            if (shardId == null) {
+                return null;
+            }
+            return shardStats.computeIfAbsent(shardId, Stats::new);
         }
 
         // It's ok to not protect these callbacks by a lock since it is
@@ -402,6 +411,9 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         protected void onDocIdSetCache(Object readerCoreKey, long ramBytesUsed) {
             super.onDocIdSetCache(readerCoreKey, ramBytesUsed);
             final Stats shardStats = getOrCreateStats(readerCoreKey);
+            if (shardStats == null) {
+                return;
+            }
             shardStats.cacheSize += 1;
             shardStats.cacheCount += 1;
             shardStats.ramBytesUsed += ramBytesUsed;
@@ -423,6 +435,9 @@ public class IndicesQueryCache implements QueryCache, Closeable {
                 // we only evict when nothing is cached anymore on the segment
                 // instead of relying on close listeners
                 final StatsAndCount statsAndCount = stats2.get(readerCoreKey);
+                if (statsAndCount == null) {
+                    return;
+                }
                 final Stats shardStats = statsAndCount.stats;
                 shardStats.cacheSize -= numEntries;
                 shardStats.ramBytesUsed -= sumRamBytesUsed;
@@ -437,14 +452,18 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         protected void onHit(Object readerCoreKey, Query filter) {
             super.onHit(readerCoreKey, filter);
             final Stats shardStats = getStats(readerCoreKey);
-            shardStats.hitCount += 1;
+            if (shardStats != null) {
+                shardStats.hitCount += 1;
+            }
         }
 
         @Override
         protected void onMiss(Object readerCoreKey, Query filter) {
             super.onMiss(readerCoreKey, filter);
             final Stats shardStats = getOrCreateStats(readerCoreKey);
-            shardStats.missCount += 1;
+            if (shardStats != null) {
+                shardStats.missCount += 1;
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
@@ -356,6 +356,32 @@ public class IndicesQueryCacheTests extends ESTestCase {
         cache.close(); // this triggers some assertions
     }
 
+    public void testCallbacksTolerateUnresolvedShard() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+        w.addDocument(new Document());
+        DirectoryReader r = DirectoryReader.open(w);
+        w.close();
+
+        IndexSearcher s = new IndexSearcher(r);
+        s.setQueryCachingPolicy(TrivialQueryCachingPolicy.ALWAYS);
+
+        Settings settings = Settings.builder()
+            .put(IndicesQueryCache.INDICES_CACHE_QUERY_COUNT_SETTING.getKey(), 10)
+            .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
+            .build();
+        IndicesQueryCache cache = new IndicesQueryCache(settings);
+        s.setQueryCache(cache.getCache());
+
+        assertEquals(1, s.count(new DummyQuery(0)));
+        assertEquals(1, s.count(new DummyQuery(0)));
+
+        r.close();
+        dir.close();
+
+        cache.close(); // this triggers some assertions
+    }
+
     private static class DummyWeight extends Weight {
 
         private final Weight weight;


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix/indices query cache null shard stats (#157050)