### PR TITLE
[8.19] Migrate ml-with-security to JUnit rule-based yaml rest test (#157080)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -49,7 +49,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:ccs-rolling-upgrade");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:basic-multi-node");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:ml-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:multi-cluster-tests-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:native-multi-node-tests");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:single-node-tests");

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
   yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
@@ -16,6 +16,7 @@ restResources {
 }
 
 tasks.named("yamlRestTest").configure {
+  usesDefaultDistribution("ML with security requires x-pack trial license and security")
   systemProperty 'tests.rest.blacklist', [
     // Remove these tests because they don't call an ML endpoint and we don't want
     // to grant extra permissions to the users used in this test suite
@@ -248,16 +249,4 @@ tasks.named("yamlRestTest").configure {
     'ml/set_upgrade_mode/Test setting upgrade_mode to false when it is already false',
     'ml/update_trained_model_deployment/Test with unknown model id'
   ].join(',')
-}
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  rolesFile file('roles.yml')
-  user username: "x_pack_rest_user", password: "x-pack-test-password"
-  user username: "ml_admin", password: "x-pack-test-password", role: "minimal,machine_learning_admin,ingest_admin"
-  user username: "ml_user", password: "x-pack-test-password", role: "minimal,machine_learning_user"
-  user username: "no_ml", password: "x-pack-test-password", role: "minimal"
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'xpack.security.enabled', 'true'
-  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
 }

--- a/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/Clusters.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/Clusters.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.smoketest;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+
+class Clusters {
+
+    private Clusters() {}
+
+    static ElasticsearchCluster create() {
+        return ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .rolesFile(Resource.fromClasspath("roles.yml"))
+            .user("x_pack_rest_user", "x-pack-test-password")
+            .user("ml_admin", "x-pack-test-password", "minimal,machine_learning_admin,ingest_admin", false)
+            .user("ml_user", "x-pack-test-password", "minimal,machine_learning_user", false)
+            .user("no_ml", "x-pack-test-password", "minimal", false)
+            .setting("xpack.license.self_generated.type", "trial")
+            .setting("xpack.security.enabled", "true")
+            .systemProperty("es.queryable_built_in_roles_enabled", "false")
+            .build();
+    }
+}

--- a/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityIT.java
@@ -12,8 +12,10 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.xpack.test.rest.AbstractXPackRestTest;
+import org.junit.ClassRule;
 
 import java.util.Collections;
 import java.util.Map;
@@ -22,8 +24,16 @@ public class MlWithSecurityIT extends AbstractXPackRestTest {
 
     private static final String TEST_ADMIN_USERNAME = "x_pack_rest_user";
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.create();
+
     public MlWithSecurityIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
     protected String[] getCredentials() {

--- a/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityInsufficientRoleIT.java
@@ -8,9 +8,11 @@ package org.elasticsearch.smoketest;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,6 +23,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
 
 public class MlWithSecurityInsufficientRoleIT extends MlWithSecurityIT {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.create();
 
     private final ClientYamlTestCandidate testCandidate;
 
@@ -78,6 +83,11 @@ public class MlWithSecurityInsufficientRoleIT extends MlWithSecurityIT {
                 );
             }
         }
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/java/org/elasticsearch/smoketest/MlWithSecurityUserRoleIT.java
@@ -8,9 +8,11 @@ package org.elasticsearch.smoketest;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.section.DoSection;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,6 +23,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
 
 public class MlWithSecurityUserRoleIT extends MlWithSecurityIT {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.create();
 
     /**
      * These are actions that require the monitor role and/or access to the relevant source index.
@@ -71,6 +76,11 @@ public class MlWithSecurityUserRoleIT extends MlWithSecurityIT {
             }
         }
         return false;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/resources/roles.yml
+++ b/x-pack/plugin/ml/qa/ml-with-security/src/yamlRestTest/resources/roles.yml
@@ -7,7 +7,7 @@ minimal:
     # Give all users involved in these tests access to the indices where the data to
     # be analyzed is stored, because the ML roles alone do not provide access to
     # non-ML indices
-    - names: [ 'airline-data', 'index-*', 'unavailable-data', 'utopia', 'store', 'store-flattened' ]
+    - names: [ 'airline-data', 'index-*', 'unavailable-data', 'utopia', 'store', 'store-flattened', 'sparse_vector*', 'test-sparse-vector*' ]
       privileges:
         - create_index
         - indices:admin/refresh


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate ml-with-security to JUnit rule-based yaml rest test (#157080)](https://github.com/elastic/elasticsearch/pull/157080)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)