### PR TITLE
[9.5] ES|QL: strip conflicted sub-fields before transport (#156326)

### DIFF
--- a/docs/changelog/156326.yaml
+++ b/docs/changelog/156326.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues: []
+pr: 156326
+summary: Fix ES|QL query failures when a multi-field sub-field has conflicting types across
+  indices
+type: bug

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ConflictedMultifieldTransportIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ConflictedMultifieldTransportIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * A keyword multi-field whose sub-field conflicts (text vs keyword) across indices must not crash when its healthy
+ * parent serializes to a remote data node.
+ */
+public class ConflictedMultifieldTransportIT extends AbstractEsqlIntegTestCase {
+
+    public void testConflictedMultifieldSerializesToRemoteDataNode() {
+        setupTwoPinnedConflictIndices("""
+            {
+              "properties": {
+                "my_field": { "type": "keyword", "fields": { "analyzed": { "type": "text" } } }
+              }
+            }""", """
+            {
+              "properties": {
+                "my_field": { "type": "keyword", "fields": { "analyzed": { "type": "keyword" } } }
+              }
+            }""");
+
+        // SORT keeps my_field in the plan, dragging its conflicted analyzed sub-field onto the wire pre-fix.
+        String query = "FROM conflict-a,conflict-b | SORT my_field | LIMIT 2";
+        try (var resp = run(query)) {
+            assertFalse("query should not be partial: " + resp.getExecutionInfo(), resp.isPartial());
+            assertThat(getValuesList(resp).size(), greaterThan(0));
+        }
+    }
+
+    /**
+     * A text field's only keyword sub-field conflicts across indices, so the field loses its "exact sub-field": pushdown of
+     * sort/equality/LIKE, which normally rewrites to the exact sub-field, must fall back to the compute engine and still be correct.
+     */
+    public void testExactSubfieldUnusableWhenConflicted() {
+        setupTwoPinnedConflictIndices("""
+            {
+              "properties": {
+                "my_field": { "type": "text", "fields": { "analyzed": { "type": "keyword" } } }
+              }
+            }""", """
+            {
+              "properties": {
+                "my_field": { "type": "text", "fields": { "analyzed": { "type": "text" } } }
+              }
+            }""");
+
+        try (var resp = run("FROM conflict-a,conflict-b | SORT my_field | KEEP my_field | LIMIT 2")) {
+            assertFalse("query should not be partial: " + resp.getExecutionInfo(), resp.isPartial());
+            assertThat(getValuesList(resp), equalTo(List.of(List.of("hello"), List.of("world"))));
+        }
+        try (var resp = run("FROM conflict-a,conflict-b | WHERE my_field == \"world\" | KEEP my_field | LIMIT 2")) {
+            assertFalse("query should not be partial: " + resp.getExecutionInfo(), resp.isPartial());
+            assertThat(getValuesList(resp), equalTo(List.of(List.of("world"))));
+        }
+        try (var resp = run("FROM conflict-a,conflict-b | WHERE my_field LIKE \"he*\" | KEEP my_field | LIMIT 2")) {
+            assertFalse("query should not be partial: " + resp.getExecutionInfo(), resp.isPartial());
+            assertThat(getValuesList(resp), equalTo(List.of(List.of("hello"))));
+        }
+    }
+
+    /** Creates conflict-a/conflict-b pinned to two different data nodes (guaranteeing cross-node transport) with one doc each. */
+    private void setupTwoPinnedConflictIndices(String mappingA, String mappingB) {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String nodeA = randomDataNode().getName();
+        String nodeB = randomValueOtherThan(nodeA, () -> randomDataNode().getName());
+        createPinnedIndex("conflict-a", nodeA, mappingA);
+        createPinnedIndex("conflict-b", nodeB, mappingB);
+
+        client().prepareIndex("conflict-a").setSource("my_field", "hello").get();
+        client().prepareIndex("conflict-b").setSource("my_field", "world").get();
+        refresh("conflict-a", "conflict-b");
+    }
+
+    private void createPinnedIndex(String index, String node, String mapping) {
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate(index)
+                .setSettings(
+                    Settings.builder()
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .put("index.routing.allocation.require._name", node)
+                )
+                .setMapping(mapping)
+        );
+    }
+
+    private DiscoveryNode randomDataNode() {
+        return randomFrom(clusterService().state().nodes().getDataNodes().values());
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TsConflictedDimensionSubfieldTransportIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TsConflictedDimensionSubfieldTransportIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * A conflicted sub-field ({@code dim.sub}: keyword vs long across two indices) nested under a healthy time-series dimension
+ * must not crash a {@code TS} query when the parent is serialized to a remote data node.
+ */
+public class TsConflictedDimensionSubfieldTransportIT extends AbstractEsqlIntegTestCase {
+
+    public void testTsConflictedDimensionSubfieldSerializesToRemoteDataNode() {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String nodeA = randomDataNode().getName();
+        String nodeB = randomValueOtherThan(nodeA, () -> randomDataNode().getName());
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("conflict-a")
+                .setSettings(
+                    Settings.builder()
+                        .put("mode", "time_series")
+                        .putList("routing_path", List.of("host"))
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .put("index.routing.allocation.require._name", nodeA)
+                )
+                .setMapping("""
+                    {
+                      "properties": {
+                        "@timestamp": { "type": "date" },
+                        "host":       { "type": "keyword", "time_series_dimension": true },
+                        "dim":        { "type": "keyword", "time_series_dimension": true,
+                                        "fields": { "sub": { "type": "keyword" } } },
+                        "metric":     { "type": "long", "time_series_metric": "gauge" },
+                        "req":        { "type": "long", "time_series_metric": "counter" }
+                      }
+                    }""")
+        );
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("conflict-b")
+                .setSettings(
+                    Settings.builder()
+                        .put("mode", "time_series")
+                        .putList("routing_path", List.of("host"))
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .put("index.routing.allocation.require._name", nodeB)
+                )
+                .setMapping("""
+                    {
+                      "properties": {
+                        "@timestamp": { "type": "date" },
+                        "host":       { "type": "keyword", "time_series_dimension": true },
+                        "dim":        { "type": "keyword", "time_series_dimension": true,
+                                        "fields": { "sub": { "type": "long" } } },
+                        "metric":     { "type": "long", "time_series_metric": "gauge" },
+                        "req":        { "type": "long", "time_series_metric": "counter" }
+                      }
+                    }""")
+        );
+
+        // time_series mode derives _id from the tsid + @timestamp, so it must not be set explicitly.
+        long now = System.currentTimeMillis();
+        // dim is copied into the dim.sub multi-field, which is long on conflict-b, so its value must parse as a long.
+        client().prepareIndex("conflict-a").setSource("@timestamp", now, "host", "h1", "dim", "1", "metric", 10, "req", 100).get();
+        client().prepareIndex("conflict-b").setSource("@timestamp", now, "host", "h2", "dim", "2", "metric", 20, "req", 200).get();
+        refresh("conflict-a", "conflict-b");
+
+        // Shapes that keep dim in the plan (WHERE/BY/KEEP/raw) exercise the crash; shapes that prune it are the contrast.
+        List<String> tsQueries = List.of(
+            "TS conflict-a,conflict-b | WHERE dim == \"1\" | STATS s = sum(metric) BY bucket(@timestamp, 1 minute) | LIMIT 10",
+            "TS conflict-a,conflict-b | STATS s = sum(rate(req)) BY bucket(@timestamp, 1 minute) | LIMIT 10",
+            "TS conflict-a,conflict-b | STATS s = sum(metric) BY bucket(@timestamp, 1 minute) | LIMIT 10",
+            "TS conflict-a,conflict-b | STATS s = sum(metric) BY host | LIMIT 10",
+            "TS conflict-a,conflict-b | STATS s = sum(metric) BY dim | LIMIT 10",
+            "TS conflict-a,conflict-b | KEEP dim, metric | LIMIT 10",
+            "TS conflict-a,conflict-b | LIMIT 10"
+        );
+        StringBuilder all = new StringBuilder();
+        boolean crashed = false;
+        for (String q : tsQueries) {
+            String outcome = describeOutcome(q);
+            all.append(outcome).append("----\n");
+            crashed |= tripsGuard(outcome);
+        }
+        // No TS shape may trip the coordinator-only serialization guard.
+        assertFalse("A TS query tripped the coordinator-only serialization guard. Outcomes:\n" + all, crashed);
+
+        // FROM does not force-resolve dim, so it never trips the guard.
+        assertFalse(tripsGuard(describeOutcome("FROM conflict-a,conflict-b | STATS s = sum(metric) BY host | LIMIT 10")));
+
+        // A kept-parent shape completes and returns rows.
+        try (
+            var resp = run(
+                "TS conflict-a,conflict-b | WHERE dim == \"1\" | STATS s = sum(metric) BY bucket(@timestamp, 1 minute) | LIMIT 10"
+            )
+        ) {
+            assertFalse("kept-parent TS query should not be partial", resp.isPartial());
+            assertThat(getValuesList(resp).size(), greaterThan(0));
+        }
+    }
+
+    /** Flattens a query's outcome (exception cause-chain, or partiality + execution-info) so one string can be asserted. */
+    private String describeOutcome(String query) {
+        StringBuilder sb = new StringBuilder("query: ").append(query).append('\n');
+        try (var resp = run(query)) {
+            sb.append("returned: isPartial=").append(resp.isPartial()).append('\n');
+            sb.append("executionInfo=").append(resp.getExecutionInfo()).append('\n');
+        } catch (Exception e) {
+            for (Throwable t = e; t != null; t = t.getCause()) {
+                sb.append("caused by: ").append(t.getClass().getName()).append(": ").append(t.getMessage()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /** A top-level dimension type conflict (keyword vs long) must not crash a {@code TS} query. */
+    public void testTsConflictedTopLevelDimensionSerializesToRemoteDataNode() {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+        String nodeA = randomDataNode().getName();
+        String nodeB = randomValueOtherThan(nodeA, () -> randomDataNode().getName());
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("tconflict-a")
+                .setSettings(
+                    Settings.builder()
+                        .put("mode", "time_series")
+                        .putList("routing_path", List.of("host"))
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .put("index.routing.allocation.require._name", nodeA)
+                )
+                .setMapping("""
+                    {
+                      "properties": {
+                        "@timestamp": { "type": "date" },
+                        "host":       { "type": "keyword", "time_series_dimension": true },
+                        "role":       { "type": "keyword", "time_series_dimension": true },
+                        "metric":     { "type": "long", "time_series_metric": "gauge" }
+                      }
+                    }""")
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("tconflict-b")
+                .setSettings(
+                    Settings.builder()
+                        .put("mode", "time_series")
+                        .putList("routing_path", List.of("host"))
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 0)
+                        .put("index.routing.allocation.require._name", nodeB)
+                )
+                .setMapping("""
+                    {
+                      "properties": {
+                        "@timestamp": { "type": "date" },
+                        "host":       { "type": "keyword", "time_series_dimension": true },
+                        "role":       { "type": "long", "time_series_dimension": true },
+                        "metric":     { "type": "long", "time_series_metric": "gauge" }
+                      }
+                    }""")
+        );
+
+        long now = System.currentTimeMillis();
+        client().prepareIndex("tconflict-a").setSource("@timestamp", now, "host", "h1", "role", "web", "metric", 10).get();
+        client().prepareIndex("tconflict-b").setSource("@timestamp", now, "host", "h2", "role", 7, "metric", 20).get();
+        refresh("tconflict-a", "tconflict-b");
+
+        List<String> tsQueries = List.of(
+            "TS tconflict-a,tconflict-b | STATS s = sum(metric) BY bucket(@timestamp, 1 minute) | LIMIT 10",
+            "TS tconflict-a,tconflict-b | STATS s = sum(metric) BY host | LIMIT 10",
+            "TS tconflict-a,tconflict-b | LIMIT 10"
+        );
+        StringBuilder all = new StringBuilder();
+        boolean crashed = false;
+        for (String q : tsQueries) {
+            String outcome = describeOutcome(q);
+            all.append(outcome).append("----\n");
+            crashed |= tripsGuard(outcome);
+        }
+        assertFalse("A top-level-dimension TS shape tripped the coordinator guard. Outcomes:\n" + all, crashed);
+    }
+
+    private static boolean tripsGuard(String outcome) {
+        return outcome.contains("must never leave the coordinator") || outcome.contains("shouldn't be transported");
+    }
+
+    private DiscoveryNode randomDataNode() {
+        return randomFrom(clusterService().state().nodes().getDataNodes().values());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -3397,13 +3397,58 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // unsupported / unresolved fields can be explicitly retained
             return cleanPlan.transformUp(
                 LogicalPlan.class,
-                p -> p.transformExpressionsOnly(
-                    FieldAttribute.class,
-                    fa -> fa.field() instanceof PotentiallyUnmappedSingleTypeEsField punk
-                        ? fallbackToMappedType(fa, punk)
-                        : fa.flagTypeConflicts()
-                )
+                p -> p.transformExpressionsOnly(FieldAttribute.class, UnionTypesCleanup::cleanTypeConflicts)
             );
+        }
+
+        private static Attribute cleanTypeConflicts(FieldAttribute fa) {
+            EsField field = fa.field();
+            FieldAttribute shipped;
+            if (field instanceof PotentiallyUnmappedSingleTypeEsField punk) {
+                // Falls back to its single mapped type; that mapped field may still carry a nested conflict to neutralize.
+                shipped = fallbackToMappedType(fa, punk);
+            } else if (field instanceof TypeConflictedField) {
+                // A top-level conflict is representable as an UnsupportedAttribute; its properties never ship.
+                return fa.flagTypeConflicts();
+            } else {
+                shipped = fa;
+            }
+            EsField cleaned = stripNestedConflicts(shipped.field());
+            return cleaned == shipped.field() ? shipped : shipped.withField(cleaned);
+        }
+
+        /**
+         * A conflict object nested in a healthy parent's {@code properties} throws when the parent serializes, so swap it for a
+         * transportable {@link UnsupportedEsField} instead of stripping the properties: a text parent resolves its exact keyword
+         * sub-field from this map on the data node ({@code TextEsField#getExactInfo}, used by Lucene pushdown), and the unsupported
+         * replacement keeps the conflict's original types for error messages. Healthy sub-fields are kept as-is (rebuilding the
+         * parent would downgrade an unsupported one and lose its original types), so the parent is rebuilt only when a nested
+         * conflict was actually replaced.
+         */
+        private static EsField stripNestedConflicts(EsField field) {
+            Map<String, EsField> properties = field.getProperties();
+            if (properties == null || properties.isEmpty()) {
+                return field;
+            }
+            Map<String, EsField> rewritten = new LinkedHashMap<>(properties.size());
+            boolean changed = false;
+            for (Map.Entry<String, EsField> entry : properties.entrySet()) {
+                EsField child = entry.getValue();
+                EsField cleanedChild = asTransportable(child);
+                rewritten.put(entry.getKey(), cleanedChild);
+                changed |= cleanedChild != child;
+            }
+            return changed ? field.withProperties(rewritten) : field;
+        }
+
+        private static EsField asTransportable(EsField field) {
+            if (field instanceof TypeConflictedField tcf) {
+                return new UnsupportedEsField(tcf.getName(), tcf.getTypesToIndices().keySet().stream().toList());
+            }
+            if (field instanceof InvalidMappedTsField imtf) {
+                return new UnsupportedEsField(imtf.getName(), List.of());
+            }
+            return stripNestedConflicts(field);
         }
 
         private static void warnObservedNonLoadablePunks(LogicalPlan plan, AnalyzerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/CompactInvalidMappedField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/CompactInvalidMappedField.java
@@ -62,7 +62,7 @@ public final class CompactInvalidMappedField extends TypeConflictedField {
 
     @Override
     public void writeContent(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("CompactInvalidMappedField shouldn't be transported");
+        throw new UnsupportedOperationException("CompactInvalidMappedField [" + getName() + "] shouldn't be transported");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
@@ -45,6 +45,11 @@ public class DateEsField extends EsField {
     }
 
     @Override
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        return dateEsField(getName(), newProperties, isAggregatable(), getTimeSeriesFieldType());
+    }
+
+    @Override
     public void writeContent(StreamOutput out) throws IOException {
         ((PlanStreamOutput) out).writeCachedString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -249,6 +249,14 @@ public class EsField implements Writeable {
     }
 
     /**
+     * Returns a copy with a different sub-field map, preserving the concrete field type. Subtypes with extra state must
+     * override this so that state (e.g. a keyword's {@code normalized} flag, which decides exact-match eligibility) is not lost.
+     */
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        return new EsField(name, esDataType, newProperties, aggregatable, isAlias, timeSeriesFieldType);
+    }
+
+    /**
      * This field is an alias to another field
      */
     public boolean isAlias() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedTsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedTsField.java
@@ -46,7 +46,7 @@ public class InvalidMappedTsField extends EsField {
 
     @Override
     public void writeContent(StreamOutput out) {
-        throw new UnsupportedOperationException("InvalidMappedTsField must never leave the coordinator");
+        throw new UnsupportedOperationException("InvalidMappedTsField [" + getName() + "] must never leave the coordinator");
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
@@ -67,6 +67,20 @@ public class KeywordEsField extends EsField {
     }
 
     @Override
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        return new KeywordEsField(
+            getName(),
+            getDataType(),
+            newProperties,
+            isAggregatable(),
+            precision,
+            normalized,
+            isAlias(),
+            getTimeSeriesFieldType()
+        );
+    }
+
+    @Override
     public void writeContent(StreamOutput out) throws IOException {
         ((PlanStreamOutput) out).writeCachedString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedKeywordEsField.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class is used as a marker for fields that may be unmapped, where an unmapped field is a field which exists in the _source but is not
@@ -21,11 +22,22 @@ public class PotentiallyUnmappedKeywordEsField extends KeywordEsField {
     public PotentiallyUnmappedKeywordEsField(String name) {
         // Use a mutable map: IndexResolver may add child fields into the properties when the keyword field
         // has multi-fields (e.g. "my_field.analyzed") that are also partially unmapped.
-        super(name, new HashMap<>(), true, Short.MAX_VALUE, false, false, TimeSeriesFieldType.UNKNOWN);
+        this(name, new HashMap<>());
+    }
+
+    // Visible for testing
+    public PotentiallyUnmappedKeywordEsField(String name, Map<String, EsField> properties) {
+        super(name, properties, true, Short.MAX_VALUE, false, false, TimeSeriesFieldType.UNKNOWN);
     }
 
     public PotentiallyUnmappedKeywordEsField(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        // Preserve the unmapped marker so data nodes still load this field from _source where it is unmapped.
+        return new PotentiallyUnmappedKeywordEsField(getName(), newProperties);
     }
 
     public String getWriteableName(TransportVersion transportVersion) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedSingleTypeEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/PotentiallyUnmappedSingleTypeEsField.java
@@ -51,7 +51,7 @@ public final class PotentiallyUnmappedSingleTypeEsField extends TypeConflictedFi
 
     @Override
     public void writeContent(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("PotentiallyUnmappedSingleTypeEsField shouldn't be transported");
+        throw new UnsupportedOperationException("PotentiallyUnmappedSingleTypeEsField [" + getName() + "] shouldn't be transported");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
@@ -47,6 +47,11 @@ public class TextEsField extends EsField {
     }
 
     @Override
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        return new TextEsField(getName(), newProperties, isAggregatable(), isAlias(), getTimeSeriesFieldType());
+    }
+
+    @Override
     public void writeContent(StreamOutput out) throws IOException {
         ((PlanStreamOutput) out).writeCachedString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/UnsupportedEsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/UnsupportedEsField.java
@@ -68,6 +68,12 @@ public class UnsupportedEsField extends EsField {
     }
 
     @Override
+    public EsField withProperties(Map<String, EsField> newProperties) {
+        // Preserve the original types (and inherited marker) so a rebuilt parent still reports as unsupported, not a plain field.
+        return new UnsupportedEsField(getName(), originalTypes, inherited, newProperties, getTimeSeriesFieldType());
+    }
+
+    @Override
     public void writeContent(StreamOutput out) throws IOException {
         ((PlanStreamOutput) out).writeCachedString(getName());
         if (out.getTransportVersion().supports(ESQL_REPORT_ORIGINAL_TYPES)) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -50,7 +50,12 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedTsField;
+import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
+import org.elasticsearch.xpack.esql.core.type.PotentiallyUnmappedSingleTypeEsField;
+import org.elasticsearch.xpack.esql.core.type.TextEsField;
+import org.elasticsearch.xpack.esql.core.type.TypeConflictedField;
 import org.elasticsearch.xpack.esql.core.type.UnionTypeEsField;
+import org.elasticsearch.xpack.esql.core.type.UnsupportedEsField;
 import org.elasticsearch.xpack.esql.enrich.ResolvedEnrichPolicy;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
@@ -176,6 +181,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -4633,6 +4639,203 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(fooAttr.dataType(), equalTo(KEYWORD));
         assertThat(idAttr.dataType(), equalTo(KEYWORD));
         assertThat(idAttr.name(), equalTo("id"));
+    }
+
+    /** Name of the conflicted sub-field under test; must match the key in the parent's properties map. */
+    private static final String CONFLICTED_SUBFIELD = "analyzed";
+
+    public void testTypeConflictedMultifieldIsCleanedAfterAnalysis() {
+        // A conflicted sub-field must be neutralized so its parent FieldAttribute is transportable.
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put(KEYWORD.typeName(), Set.of("conflict-a"));
+        typesToIndices.put(DataType.TEXT.typeName(), Set.of("conflict-b"));
+        assertConflictedMultifieldIsCleaned(new InvalidMappedField(CONFLICTED_SUBFIELD, typesToIndices));
+    }
+
+    public void testTsRoleConflictedMultifieldIsCleanedAfterAnalysis() {
+        // InvalidMappedTsField is not a TypeConflictedField but also throws on transport, so it must be neutralized too.
+        EsField cleanedParent = assertConflictedMultifieldIsCleaned(new InvalidMappedTsField(CONFLICTED_SUBFIELD, "role conflict"));
+        // The rebuilt parent keeps its keyword type so exact-match/sort still work.
+        assertThat(cleanedParent, instanceOf(KeywordEsField.class));
+    }
+
+    private static EsField assertConflictedMultifieldIsCleaned(EsField conflictedMultifield) {
+        EsField parent = new KeywordEsField(
+            "my_field",
+            Map.of(CONFLICTED_SUBFIELD, conflictedMultifield),
+            true,
+            256,
+            false,
+            false,
+            EsField.TimeSeriesFieldType.NONE
+        );
+        EsIndex index = new EsIndex(
+            "conflict-*",
+            Map.of("my_field", parent),
+            Map.of("conflict-a", new IndexProperties(IndexMode.STANDARD, 0), "conflict-b", new IndexProperties(IndexMode.STANDARD, 0)),
+            Map.of(),
+            Map.of()
+        );
+
+        LogicalPlan plan = analyzer().addIndex(IndexResolution.valid(index)).query("FROM conflict-* | SORT my_field | LIMIT 2");
+
+        List<FieldAttribute> parentAttributes = new ArrayList<>();
+        plan.forEachExpressionDown(FieldAttribute.class, fieldAttribute -> {
+            assertNoConflicts(fieldAttribute.field());
+            if (fieldAttribute.name().equals("my_field")) {
+                parentAttributes.add(fieldAttribute);
+            }
+        });
+        assertFalse(parentAttributes.isEmpty());
+        EsField cleanedParent = null;
+        for (FieldAttribute parentAttribute : parentAttributes) {
+            // The conflict is replaced by a transportable UnsupportedEsField, not dropped: the sub-field key stays.
+            assertThat(parentAttribute.field().getProperties(), hasKey(CONFLICTED_SUBFIELD));
+            assertThat(parentAttribute.field().getProperties().get(CONFLICTED_SUBFIELD), instanceOf(UnsupportedEsField.class));
+            cleanedParent = parentAttribute.field();
+        }
+        return cleanedParent;
+    }
+
+    /** Asserts no coordinator-only conflict field ({@link TypeConflictedField} or {@link InvalidMappedTsField}) survives anywhere. */
+    private static void assertNoConflicts(EsField field) {
+        assertThat(field, not(instanceOf(TypeConflictedField.class)));
+        assertThat(field, not(instanceOf(InvalidMappedTsField.class)));
+        if (field.getProperties() != null) {
+            field.getProperties().values().forEach(AnalyzerTests::assertNoConflicts);
+        }
+    }
+
+    public void testTextFieldKeepsHealthySubfields() {
+        // Healthy sub-fields are kept untouched - including a text field's exact keyword, which pushdown resolves on the data node.
+        EsField exact = new KeywordEsField("keyword", Map.of(), true, 256, false, false, EsField.TimeSeriesFieldType.NONE);
+        EsField normalized = new KeywordEsField("norm", Map.of(), true, 256, true, false, EsField.TimeSeriesFieldType.NONE);
+        EsField message = new TextEsField(
+            "message",
+            new LinkedHashMap<>(Map.of("keyword", exact, "norm", normalized)),
+            false,
+            false,
+            EsField.TimeSeriesFieldType.NONE
+        );
+
+        EsField parentField = shippedFieldAfterAnalysis("message", message, "FROM idx | SORT message | LIMIT 2");
+        assertThat(parentField, instanceOf(TextEsField.class));
+        assertThat(parentField.getProperties(), hasKey("keyword"));
+        assertThat(parentField.getProperties(), hasKey("norm"));
+        assertThat(parentField.getExactInfo().hasExact(), is(true));
+    }
+
+    public void testTextFieldWithConflictedExactSubfieldIsNeutralized() {
+        // The only keyword sub-field is itself type-conflicted: neutralize it to a transportable UnsupportedEsField (no exact left).
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put(KEYWORD.typeName(), Set.of("idx-a"));
+        typesToIndices.put(DataType.LONG.typeName(), Set.of("idx-b"));
+        EsField message = new TextEsField(
+            "message",
+            new LinkedHashMap<>(Map.of("keyword", new InvalidMappedField("keyword", typesToIndices))),
+            false,
+            false,
+            EsField.TimeSeriesFieldType.NONE
+        );
+
+        EsField parentField = shippedFieldAfterAnalysis("message", message, "FROM idx | LIMIT 2");
+        assertThat(parentField, instanceOf(TextEsField.class));
+        assertThat(parentField.getProperties().get("keyword"), instanceOf(UnsupportedEsField.class));
+        assertThat(parentField.getExactInfo().hasExact(), is(false));
+    }
+
+    public void testPunkFallbackStripsNestedConflictedSubfield() {
+        // A potentially-unmapped field falls back to its mapped type; that mapped field's conflicted sub-field must be neutralized.
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put(KEYWORD.typeName(), Set.of("idx-a"));
+        typesToIndices.put(DataType.LONG.typeName(), Set.of("idx-b"));
+        EsField mapped = new KeywordEsField(
+            "val",
+            new LinkedHashMap<>(Map.of("sub", new InvalidMappedField("sub", typesToIndices))),
+            true,
+            256,
+            false,
+            false,
+            EsField.TimeSeriesFieldType.NONE
+        );
+        EsField punk = new PotentiallyUnmappedSingleTypeEsField(mapped, Set.of("idx-a"));
+
+        EsField parentField = shippedFieldAfterAnalysis("val", punk, "FROM idx | LIMIT 2");
+        // The mapped keyword type is kept (not the PUNK marker) and its conflicted sub-field is neutralized to unsupported.
+        assertThat(parentField, instanceOf(KeywordEsField.class));
+        assertThat(parentField.getProperties().get("sub"), instanceOf(UnsupportedEsField.class));
+    }
+
+    public void testConflictedSubfieldNestedTwoLevelsDeepIsCleaned() {
+        // Not a reachable mapping shape today (https://github.com/elastic/elasticsearch/issues/144400 keeps multi-level sub-fields
+        // from resolving under a proper field attribute), but the cleaner already recurses, so guard the >1-level case.
+        LinkedHashMap<String, Set<String>> typesToIndices = new LinkedHashMap<>();
+        typesToIndices.put(KEYWORD.typeName(), Set.of("idx-a"));
+        typesToIndices.put(DataType.TEXT.typeName(), Set.of("idx-b"));
+        EsField sub = new KeywordEsField(
+            "sub",
+            Map.of(CONFLICTED_SUBFIELD, new InvalidMappedField(CONFLICTED_SUBFIELD, typesToIndices)),
+            true,
+            256,
+            false,
+            false,
+            EsField.TimeSeriesFieldType.NONE
+        );
+        EsField parent = new KeywordEsField("my_field", Map.of("sub", sub), true, 256, false, false, EsField.TimeSeriesFieldType.NONE);
+
+        EsField parentField = shippedFieldAfterAnalysis("my_field", parent, "FROM idx | SORT my_field | LIMIT 2");
+        EsField cleanedSub = parentField.getProperties().get("sub");
+        assertThat(cleanedSub, instanceOf(KeywordEsField.class));
+        assertThat(cleanedSub.getProperties().get(CONFLICTED_SUBFIELD), instanceOf(UnsupportedEsField.class));
+    }
+
+    public void testUnsupportedParentWithPropagatedSubfieldIsUntouched() {
+        // Regression (FieldExtractorIT): an unsupported parent with a healthy/inherited sub-field must not be downgraded - it must
+        // stay unsupported and keep its original types, otherwise it drops out of the Verifier and loses original_types.
+        EsField raw = new UnsupportedEsField("raw", List.of("ip_range"), "ip_range", Map.of());
+        EsField parent = new UnsupportedEsField("f", List.of("ip_range"), null, Map.of("raw", raw));
+        EsIndex index = new EsIndex(
+            "idx",
+            Map.of("f", parent),
+            Map.of("idx-a", new IndexProperties(IndexMode.STANDARD, 0)),
+            Map.of(),
+            Map.of()
+        );
+
+        LogicalPlan plan = analyzer().addIndex(IndexResolution.valid(index)).query("FROM idx | LIMIT 2");
+
+        List<UnsupportedAttribute> found = new ArrayList<>();
+        plan.forEachExpressionDown(UnsupportedAttribute.class, ua -> {
+            if (ua.name().equals("f")) {
+                found.add(ua);
+            }
+        });
+        assertFalse("expected [f] to remain an UnsupportedAttribute", found.isEmpty());
+        UnsupportedEsField cleaned = found.getLast().field();
+        assertThat(cleaned.getOriginalTypes(), contains("ip_range"));
+        assertThat(cleaned.getProperties(), hasKey("raw"));
+    }
+
+    /** Analyzes {@code query} over a single-field index and returns the last {@code fieldName} attribute's (cleaned) field. */
+    private static EsField shippedFieldAfterAnalysis(String fieldName, EsField field, String query) {
+        EsIndex index = new EsIndex(
+            "idx",
+            Map.of(fieldName, field),
+            Map.of("idx-a", new IndexProperties(IndexMode.STANDARD, 0), "idx-b", new IndexProperties(IndexMode.STANDARD, 0)),
+            Map.of(),
+            Map.of()
+        );
+        LogicalPlan plan = analyzer().addIndex(IndexResolution.valid(index)).query(query);
+
+        List<EsField> found = new ArrayList<>();
+        plan.forEachExpressionDown(FieldAttribute.class, fieldAttribute -> {
+            assertNoConflicts(fieldAttribute.field());
+            if (fieldAttribute.name().equals(fieldName)) {
+                found.add(fieldAttribute.field());
+            }
+        });
+        assertFalse("expected a [" + fieldName + "] field attribute", found.isEmpty());
+        return found.get(found.size() - 1);
     }
 
     public void testExplicitRetainOriginalFieldWithCast() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -4672,7 +4672,7 @@ public class AnalyzerTests extends ESTestCase {
         EsIndex index = new EsIndex(
             "conflict-*",
             Map.of("my_field", parent),
-            Map.of("conflict-a", new IndexProperties(IndexMode.STANDARD, 0), "conflict-b", new IndexProperties(IndexMode.STANDARD, 0)),
+            Map.of("conflict-a", IndexMode.STANDARD, "conflict-b", IndexMode.STANDARD),
             Map.of(),
             Map.of()
         );
@@ -4794,13 +4794,7 @@ public class AnalyzerTests extends ESTestCase {
         // stay unsupported and keep its original types, otherwise it drops out of the Verifier and loses original_types.
         EsField raw = new UnsupportedEsField("raw", List.of("ip_range"), "ip_range", Map.of());
         EsField parent = new UnsupportedEsField("f", List.of("ip_range"), null, Map.of("raw", raw));
-        EsIndex index = new EsIndex(
-            "idx",
-            Map.of("f", parent),
-            Map.of("idx-a", new IndexProperties(IndexMode.STANDARD, 0)),
-            Map.of(),
-            Map.of()
-        );
+        EsIndex index = new EsIndex("idx", Map.of("f", parent), Map.of("idx-a", IndexMode.STANDARD), Map.of(), Map.of());
 
         LogicalPlan plan = analyzer().addIndex(IndexResolution.valid(index)).query("FROM idx | LIMIT 2");
 
@@ -4821,7 +4815,7 @@ public class AnalyzerTests extends ESTestCase {
         EsIndex index = new EsIndex(
             "idx",
             Map.of(fieldName, field),
-            Map.of("idx-a", new IndexProperties(IndexMode.STANDARD, 0), "idx-b", new IndexProperties(IndexMode.STANDARD, 0)),
+            Map.of("idx-a", IndexMode.STANDARD, "idx-b", IndexMode.STANDARD),
             Map.of(),
             Map.of()
         );


### PR DESCRIPTION
This will backport the following commits from `main` to `9.5`:
 - [ES|QL: strip conflicted sub-fields before transport (#156326)](https://github.com/elastic/elasticsearch/pull/156326)