### PR TITLE
[9.5] Fix shared score accumulator amongst segments for ivf search (#157229)

### DIFF
--- a/docs/changelog/157229.yaml
+++ b/docs/changelog/157229.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 157229
+summary: Fix shared score accumulator amongst segments for ivf search
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
@@ -136,6 +136,9 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         // When providedVisitRatio is 0.0f (dynamic), the codec computes the visit ratio
         // per-segment using the Two-Signal model with segment-size awareness.
         final float visitRatio = providedVisitRatio;
+        final LongAccumulator longAccumulator = indexSearcher.getIndexReader().leaves().size() > 1
+            ? new LongAccumulator(Long::max, LEAST_COMPETITIVE)
+            : null;
 
         List<Callable<TopDocs>> tasks = new ArrayList<>(leafReaderContexts.size());
         float maxRescoreOversampleAcrossLeaves = 1f;
@@ -152,7 +155,7 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
 
             IVFCollectorManager knnCollectorManagerForSegment = getKnnCollectorManager(
                 IvfSegmentConfig.leafCollectorBudget(k, segmentOversample),
-                indexSearcher
+                longAccumulator
             );
 
             // Preconditioning might differ per segment when they are calibrated, so, potentially,
@@ -249,8 +252,8 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         boolean usePrecondition
     ) throws IOException;
 
-    protected IVFCollectorManager getKnnCollectorManager(int k, IndexSearcher searcher) {
-        return new IVFCollectorManager(k, searcher);
+    protected IVFCollectorManager getKnnCollectorManager(int k, LongAccumulator longAccumulator) {
+        return new IVFCollectorManager(k, longAccumulator);
     }
 
     @Override
@@ -262,9 +265,9 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         private final int k;
         final LongAccumulator longAccumulator;
 
-        IVFCollectorManager(int k, IndexSearcher searcher) {
+        IVFCollectorManager(int k, LongAccumulator longAccumulator) {
             this.k = k;
-            longAccumulator = searcher.getIndexReader().leaves().size() > 1 ? new LongAccumulator(Long::max, LEAST_COMPETITIVE) : null;
+            this.longAccumulator = longAccumulator;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifiedIVFKnnCollectorManager.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifiedIVFKnnCollectorManager.java
@@ -10,19 +10,19 @@
 package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.BitSet;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.LongAccumulator;
 
 public class DiversifiedIVFKnnCollectorManager extends AbstractIVFKnnVectorQuery.IVFCollectorManager {
     private final int k;
     private final BitSetProducer parentsFilter;
 
-    DiversifiedIVFKnnCollectorManager(int k, IndexSearcher searcher, BitSetProducer parentsFilter) {
-        super(k, searcher);
+    DiversifiedIVFKnnCollectorManager(int k, LongAccumulator longAccumulator, BitSetProducer parentsFilter) {
+        super(k, longAccumulator);
         this.k = k;
         this.parentsFilter = parentsFilter;
     }

--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatSlicedVectorQuery.java
@@ -9,13 +9,13 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.codec.vectors.diskbbq.IvfQueryConfigResolver;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.LongAccumulator;
 
 /**
  * IVF kNN search over a slice of an index, with nested (block-join) diversification so at most one
@@ -53,8 +53,8 @@ public class DiversifyingChildrenIVFKnnFloatSlicedVectorQuery extends IVFKnnFloa
     }
 
     @Override
-    protected IVFCollectorManager getKnnCollectorManager(int k, IndexSearcher searcher) {
-        return new DiversifiedIVFKnnCollectorManager(k, searcher, parentsFilter);
+    protected IVFCollectorManager getKnnCollectorManager(int k, LongAccumulator longAccumulator) {
+        return new DiversifiedIVFKnnCollectorManager(k, longAccumulator, parentsFilter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DiversifyingChildrenIVFKnnFloatVectorQuery.java
@@ -9,12 +9,12 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.elasticsearch.index.codec.vectors.diskbbq.IvfQueryConfigResolver;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.LongAccumulator;
 
 public class DiversifyingChildrenIVFKnnFloatVectorQuery extends IVFKnnFloatVectorQuery {
 
@@ -46,8 +46,8 @@ public class DiversifyingChildrenIVFKnnFloatVectorQuery extends IVFKnnFloatVecto
     }
 
     @Override
-    protected IVFCollectorManager getKnnCollectorManager(int k, IndexSearcher searcher) {
-        return new DiversifiedIVFKnnCollectorManager(k, searcher, parentsFilter);
+    protected IVFCollectorManager getKnnCollectorManager(int k, LongAccumulator longAccumulator) {
+        return new DiversifiedIVFKnnCollectorManager(k, longAccumulator, parentsFilter);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQueryTestCase.java
@@ -78,9 +78,14 @@ import org.elasticsearch.index.codec.vectors.diskbbq.TestIvfQueryConfigResolver;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAccumulator;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.frequently;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
@@ -882,6 +887,114 @@ public abstract class AbstractIVFKnnVectorQueryTestCase extends LuceneTestCase {
                     () -> searcher.search(getKnnVectorQuery("vector", randomVector(dim), 10, filter), numDocs)
                 );
             }
+        }
+    }
+
+    /**
+     * The cross-leaf min-competitive {@link LongAccumulator} must be a single instance shared by every
+     * per-leaf collector manager; otherwise each leaf accumulates in isolation and cross-leaf pruning is
+     * inert. Wiring regression: fails if the accumulator is (re)created per collector manager.
+     */
+    public void testAccumulatorSharedAcrossLeaves() throws IOException {
+        try (Directory dir = buildMultiSegmentIndex(); IndexReader reader = DirectoryReader.open(dir)) {
+            assertTrue("test requires multiple segments", reader.leaves().size() > 1);
+            List<LongAccumulator> captured = Collections.synchronizedList(new ArrayList<>());
+            new AccumulatorCapturingQuery("field", 3, testResolver(), captured).rewrite(newSearcher(reader));
+
+            assertEquals("one collector manager per leaf", reader.leaves().size(), captured.size());
+            Set<LongAccumulator> distinct = Collections.newSetFromMap(new IdentityHashMap<>());
+            distinct.addAll(captured);
+            assertEquals("all leaves must share a single accumulator instance", 1, distinct.size());
+            assertNotNull("multi-leaf accumulator must be non-null", captured.get(0));
+        }
+    }
+
+    /** With a single leaf there is nothing to share, so the accumulator is left null (no atomic churn). */
+    public void testAccumulatorNullForSingleLeaf() throws IOException {
+        int dim = randomIntBetween(4, 64);
+        int numDocs = randomIntBetween(10, 100);
+        try (Directory dir = newDirectoryForTest()) {
+            IndexWriterConfig iwc = new IndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format));
+            decorateIWC(iwc);
+            try (IndexWriter w = new IndexWriter(dir, iwc)) {
+                for (int i = 0; i < numDocs; i++) {
+                    Document doc = getDocumentToIndex();
+                    doc.add(getKnnVectorField("field", randomVector(dim)));
+                    w.addDocument(doc);
+                }
+                w.forceMerge(1);
+            }
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                assertEquals(1, reader.leaves().size());
+                List<LongAccumulator> captured = Collections.synchronizedList(new ArrayList<>());
+                new AccumulatorCapturingQuery("field", 3, testResolver(), captured).rewrite(newSearcher(reader));
+                assertEquals(1, captured.size());
+                assertNull("single-leaf accumulator must be null", captured.get(0));
+            }
+        }
+    }
+
+    private Directory buildMultiSegmentIndex() throws IOException {
+        int numSegments = randomIntBetween(2, 10);
+        int dim = randomIntBetween(4, 64);
+        Directory dir = newDirectoryForTest();
+        IndexWriterConfig iwc = new IndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format));
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        decorateIWC(iwc);
+        try (IndexWriter w = new IndexWriter(dir, iwc)) {
+            for (int s = 0; s < numSegments; s++) {
+                int docsPerSegment = randomIntBetween(1, 20);
+                for (int i = 0; i < docsPerSegment; i++) {
+                    Document doc = getDocumentToIndex();
+                    doc.add(getKnnVectorField("field", randomVector(dim)));
+                    w.addDocument(doc);
+                }
+                w.commit(); // new segment per commit (merges disabled)
+            }
+        }
+        return dir;
+    }
+
+    /**
+     * Minimal {@link AbstractIVFKnnVectorQuery} that records the {@link LongAccumulator} handed to each
+     * per-leaf collector manager during {@code rewrite()}. {@code getLeafResults} is stubbed out: the wiring
+     * under test — that {@code rewrite()} threads a single shared accumulator into every leaf's collector
+     * manager — is established in the task-setup loop before any leaf search runs, so no real vector scoring
+     * (and hence no per-variant query type) is needed to observe it.
+     */
+    private static class AccumulatorCapturingQuery extends AbstractIVFKnnVectorQuery {
+        private final List<LongAccumulator> captured;
+
+        AccumulatorCapturingQuery(String field, int k, TestIvfQueryConfigResolver resolver, List<LongAccumulator> captured) {
+            super(field, 0f, k, k, null, resolver);
+            this.captured = captured;
+        }
+
+        @Override
+        protected IVFCollectorManager getKnnCollectorManager(int k, LongAccumulator longAccumulator) {
+            captured.add(longAccumulator);
+            return super.getKnnCollectorManager(k, longAccumulator);
+        }
+
+        @Override
+        TopDocs getLeafResults(
+            LeafReaderContext ctx,
+            Weight filterWeight,
+            IVFCollectorManager knnCollectorManager,
+            float visitRatio,
+            boolean usePrecondition
+        ) {
+            return NO_RESULTS;
+        }
+
+        @Override
+        Query getAutoRescoreQuery(IndexSearcher indexSearcher, TopDocs topOversampled, int effectiveK) {
+            return null;
+        }
+
+        @Override
+        public String toString(String field) {
+            return "AccumulatorCapturingQuery[" + field + "]";
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix shared score accumulator amongst segments for ivf search (#157229)](https://github.com/elastic/elasticsearch/pull/157229)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)