### PR TITLE
[9.4] Fix smart-retry gap in lucene-index-compatibility (#157165)

### DIFF
--- a/qa/lucene-index-compatibility/build.gradle
+++ b/qa/lucene-index-compatibility/build.gradle
@@ -10,6 +10,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
+// Each suite shares one cluster and upgrades it one version per parameter, so a parameter that passed must still run
+// when a later one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 buildParams.bwcVersions.withLatestReadOnlyIndexCompatible { bwcVersion ->
   tasks.named("javaRestTest").configure {
     systemProperty("tests.minimum.index.compatible", bwcVersion)

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/FullClusterRestartIndexCompatibilityTestCase.java
@@ -26,6 +26,10 @@ import static org.hamcrest.Matchers.equalTo;
  * Test suite for Lucene indices backward compatibility with N-2 versions after full cluster restart upgrades. The test suite creates a
  * cluster in N-2 version, then upgrades it to N-1 version and finally upgrades it to the current version. Test methods are executed after
  * each upgrade.
+ * <p>
+ * A project hosting this suite must opt out of smart retry's individual test pruning in its {@code build.gradle}, otherwise a parameter
+ * that passed in an earlier build attempt is skipped on retry and the later hop fails:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
  */
 @TestCaseOrdering(FullClusterRestartIndexCompatibilityTestCase.TestCaseOrdering.class)
 public abstract class FullClusterRestartIndexCompatibilityTestCase extends AbstractIndexCompatibilityTestCase {

--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/RollingUpgradeIndexCompatibilityTestCase.java
@@ -42,6 +42,10 @@ import static org.hamcrest.Matchers.notNullValue;
  * Test suite for Lucene indices backward compatibility with N-2 versions during rolling upgrades. The test suite creates a cluster in N-2
  * version, then upgrades each node sequentially to N-1 version and finally upgrades each node sequentially to the current version. Test
  * methods are executed after each node upgrade.
+ * <p>
+ * A project hosting this suite must opt out of smart retry's individual test pruning in its {@code build.gradle}, otherwise a phase that
+ * passed in an earlier build attempt is skipped on retry and a later phase fails:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
  */
 @TestCaseOrdering(RollingUpgradeIndexCompatibilityTestCase.TestCaseOrdering.class)
 public abstract class RollingUpgradeIndexCompatibilityTestCase extends AbstractIndexCompatibilityTestCase {

--- a/x-pack/qa/repository-old-versions-compatibility/build.gradle
+++ b/x-pack/qa/repository-old-versions-compatibility/build.gradle
@@ -10,6 +10,10 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
 
+// Each suite shares one cluster and upgrades it one version per parameter, so a parameter that passed must still run
+// when a later one is retried.
+smartRetry.pruneIndividualTests.set(false)
+
 buildParams.bwcVersions.withLatestReadOnlyIndexCompatible { bwcVersion ->
   tasks.named("javaRestTest").configure {
     systemProperty("tests.minimum.index.compatible", bwcVersion)

--- a/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/AbstractUpgradeCompatibilityTestCase.java
+++ b/x-pack/qa/repository-old-versions-compatibility/src/javaRestTest/java/org/elasticsearch/oldrepos/AbstractUpgradeCompatibilityTestCase.java
@@ -53,6 +53,13 @@ import static org.elasticsearch.test.rest.ObjectPath.createFromResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
+/**
+ * Upgrade suites that share one cluster and hop it forward one version per parameter.
+ * <p>
+ * A project hosting this suite must opt out of smart retry's individual test pruning in its {@code build.gradle}, otherwise a parameter
+ * that passed in an earlier build attempt is skipped on retry and the later hop fails:
+ * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
+ */
 @TestCaseOrdering(AbstractUpgradeCompatibilityTestCase.TestCaseOrdering.class)
 public class AbstractUpgradeCompatibilityTestCase extends ESRestTestCase {
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix smart-retry gap in lucene-index-compatibility (#157165)