### PR TITLE
POC: wider binary DV blocks + zstd-3 for large non-indexed text

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDVCompressionMode.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDVCompressionMode.java
@@ -15,7 +15,8 @@ import org.elasticsearch.index.codec.zstd.ZstdCompressionMode;
 public enum BinaryDVCompressionMode {
 
     NO_COMPRESS((byte) 0, null),
-    COMPRESSED_ZSTD_LEVEL_1((byte) 1, new ZstdCompressionMode(1));
+    COMPRESSED_ZSTD_LEVEL_1((byte) 1, new ZstdCompressionMode(1)),
+    COMPRESSED_ZSTD_LEVEL_3((byte) 2, new ZstdCompressionMode(3));
 
     public final byte code;
     private final CompressionMode compressionMode;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819Version3TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819Version3TSDBDocValuesFormat.java
@@ -72,4 +72,31 @@ public class ES819Version3TSDBDocValuesFormat extends ES819TSDBDocValuesFormat {
             writePrefixPartition
         );
     }
+
+    /**
+     * Test-only constructor that, unlike the other constructors above, does not hardcode the binary doc values block
+     * thresholds to {@link #BINARY_DV_BLOCK_BYTES_THRESHOLD_DEFAULT} / {@link #BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT}. This
+     * allows tests to explore how the block size threshold interacts with the {@link BinaryDVCompressionMode}, e.g. whether a
+     * larger compression window combined with a higher zstd level meaningfully improves compression of large, mutually similar
+     * binary doc values (such as JSON blobs sharing a common structure).
+     */
+    public ES819Version3TSDBDocValuesFormat(
+        BinaryDVCompressionMode binaryDVCompressionMode,
+        int blockBytesThreshold,
+        int blockCountThreshold
+    ) {
+        super(
+            CODEC_NAME,
+            DEFAULT_SKIP_INDEX_INTERVAL_SIZE,
+            ORDINAL_RANGE_ENCODING_MIN_DOC_PER_ORDINAL,
+            OPTIMIZED_MERGE_ENABLE_DEFAULT,
+            binaryDVCompressionMode,
+            true,
+            NUMERIC_BLOCK_SHIFT,
+            DocOffsetsCodec.BITPACKING,
+            blockBytesThreshold,
+            blockCountThreshold,
+            false
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -26,12 +26,14 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -725,6 +727,232 @@ public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTe
         assertThat(message, (double) sizes.windowOnlyBytes(), closeTo(sizes.todayBytes(), sizes.todayBytes() * 0.15));
         // Combining the larger window with zstd level 3 should meaningfully shrink storage.
         assertThat(message, sizes.windowPlusLevelBytes(), lessThan((long) (sizes.todayBytes() * 0.75)));
+    }
+
+    /**
+     * The other half of the trade-off measured by {@link #testLargeBinaryBlobZstdWindow}: what a wider
+     * compression block costs on the read and write side. A reader instance caches exactly one decompressed
+     * block, so the cost of a read depends entirely on the access pattern:
+     *
+     * <ul>
+     *   <li><b>full scan</b> — every block is decompressed once and fully consumed, so a wider block is
+     *       amortized and should be roughly neutral.</li>
+     *   <li><b>one session</b> — with an index sort on the session key a session's blobs are contiguous, so
+     *       they share blocks and behave like a small scan. This is the session-replay access pattern.</li>
+     *   <li><b>random single doc</b> — a cold reader per lookup pays a full block decompression to return one
+     *       ~256 KB value, so a 4 MB block is the worst case (~16x read amplification).</li>
+     * </ul>
+     *
+     * This is a measurement, not a pass/fail assertion: timings are logged and only correctness (bytes
+     * actually returned) is asserted, since wall-clock in a parallel test run is far too noisy to gate on.
+     */
+    public void testLargeBinaryBlobZstdWindowReadAndWriteCost() throws IOException {
+        final String binaryField = "body.text._original";
+        final String sessionField = "session";
+        final String idField = "id";
+        final int targetBlobBytes = 256 * 1024;
+        // Fixed rather than randomized: these numbers are compared across configurations, so the corpus has
+        // to be identical for all three.
+        final int numDocs = 256;
+        final int numSessions = 16;
+        final int randomLookups = 256;
+        final int repeats = 3;
+
+        final Random random = random();
+        final String[] vocabulary = buildJsonSkeletonVocabulary(1200, random);
+        final byte[][] blobs = new byte[numDocs][];
+        final String[] sessions = new String[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            sessions[i] = "session-" + (i % numSessions);
+            blobs[i] = buildSessionReplayBlob(vocabulary, random, targetBlobBytes, sessions[i], i);
+        }
+
+        final int[] lookupDocs = new int[randomLookups];
+        for (int i = 0; i < randomLookups; i++) {
+            lookupDocs[i] = random.nextInt(numDocs);
+        }
+
+        record Config(String label, BinaryDVCompressionMode mode, int blockBytes) {}
+        final List<Config> configs = List.of(
+            new Config("today       (zstd-1, 512KB)", BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1, 512 * 1024),
+            new Config("window-only (zstd-1,   4MB)", BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1, 4 * 1024 * 1024),
+            new Config("window+lvl  (zstd-3,   4MB)", BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_3, 4 * 1024 * 1024)
+        );
+
+        // Two passes over every configuration, logging only the second. Indexing and merging happen once per
+        // configuration, so without a warm-up the first configuration measured absorbs all the JIT cost and
+        // looks artificially slow on the write path.
+        for (int pass = 0; pass < 2; pass++) {
+            final boolean measured = pass == 1;
+            for (Config config : configs) {
+                measureReadAndWriteCost(
+                    config.label(),
+                    config.mode(),
+                    config.blockBytes(),
+                    binaryField,
+                    sessionField,
+                    idField,
+                    blobs,
+                    sessions,
+                    lookupDocs,
+                    targetBlobBytes,
+                    repeats,
+                    measured
+                );
+            }
+        }
+    }
+
+    /**
+     * One configuration's worth of {@link #testLargeBinaryBlobZstdWindowReadAndWriteCost}. Logs nothing unless
+     * {@code measured} is set, so the caller can run a discarded warm-up pass first.
+     */
+    private void measureReadAndWriteCost(
+        String label,
+        BinaryDVCompressionMode mode,
+        int blockBytes,
+        String binaryField,
+        String sessionField,
+        String idField,
+        byte[][] blobs,
+        String[] sessions,
+        int[] lookupDocs,
+        int targetBlobBytes,
+        int repeats,
+        boolean measured
+    ) throws IOException {
+        final int numDocs = blobs.length;
+        final int randomLookups = lookupDocs.length;
+        {
+            var dvFormat = new ES819Version3TSDBDocValuesFormat(
+                mode,
+                blockBytes,
+                ES819Version3TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT
+            );
+            var writerConfig = new IndexWriterConfig();
+            writerConfig.setIndexSort(new Sort(new SortField(sessionField, SortField.Type.STRING, false)));
+            writerConfig.setMergePolicy(new LogByteSizeMergePolicy());
+            writerConfig.setCodec(TestUtil.alwaysDocValuesFormat(dvFormat));
+
+            // A plain on-disk directory, not newDirectory(): the randomized mock wrappers add enough
+            // overhead and variance to swamp the differences being measured here.
+            try (Directory dir = new MMapDirectory(createTempDir())) {
+                long writeNanos = System.nanoTime();
+                try (IndexWriter writer = new IndexWriter(dir, writerConfig)) {
+                    for (int i = 0; i < numDocs; i++) {
+                        Document d = new Document();
+                        d.add(new NumericDocValuesField(idField, i));
+                        d.add(new SortedDocValuesField(sessionField, new BytesRef(sessions[i])));
+                        d.add(new BinaryDocValuesField(binaryField, new BytesRef(blobs[i])));
+                        writer.addDocument(d);
+                    }
+                    writer.commit();
+                    writeNanos = System.nanoTime() - writeNanos;
+
+                    long mergeNanos = System.nanoTime();
+                    writer.forceMerge(1);
+                    writer.commit();
+                    mergeNanos = System.nanoTime() - mergeNanos;
+
+                    long dataBytes = 0;
+                    for (String name : dir.listAll()) {
+                        if (name.endsWith("." + ES819TSDBDocValuesFormat.DATA_EXTENSION)) {
+                            dataBytes += dir.fileLength(name);
+                        }
+                    }
+
+                    try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                        var leaf = reader.leaves().get(0).reader();
+
+                        // Full scan: one reader walked in doc order, so each block is decompressed once.
+                        long scanNanos = Long.MAX_VALUE;
+                        long scanBytes = 0;
+                        for (int r = 0; r < repeats; r++) {
+                            long start = System.nanoTime();
+                            long bytes = 0;
+                            BinaryDocValues dv = leaf.getBinaryDocValues(binaryField);
+                            for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+                                assertTrue(dv.advanceExact(doc));
+                                bytes += dv.binaryValue().length;
+                            }
+                            scanNanos = Math.min(scanNanos, System.nanoTime() - start);
+                            scanBytes = bytes;
+                        }
+                        assertEquals("full scan should return the whole corpus", (long) numDocs * targetBlobBytes, scanBytes);
+
+                        // One session: contiguous under the index sort, read with a single cold reader —
+                        // the replay playback pattern.
+                        long sessionRuns = 0;
+                        long sessionNanos = Long.MAX_VALUE;
+                        for (int r = 0; r < repeats; r++) {
+                            long start = System.nanoTime();
+                            long runs = 0;
+                            SortedDocValues sessionDV = leaf.getSortedDocValues(sessionField);
+                            int doc = 0;
+                            while (doc < leaf.maxDoc()) {
+                                assertTrue(sessionDV.advanceExact(doc));
+                                int ord = sessionDV.ordValue();
+                                int runEnd = doc + 1;
+                                while (runEnd < leaf.maxDoc()) {
+                                    assertTrue(sessionDV.advanceExact(runEnd));
+                                    if (sessionDV.ordValue() != ord) {
+                                        break;
+                                    }
+                                    runEnd++;
+                                }
+                                // Fresh reader per session: nothing is cached from a previous session.
+                                BinaryDocValues dv = leaf.getBinaryDocValues(binaryField);
+                                for (int d = doc; d < runEnd; d++) {
+                                    assertTrue(dv.advanceExact(d));
+                                    assertTrue(dv.binaryValue().length > 0);
+                                }
+                                runs++;
+                                doc = runEnd;
+                            }
+                            sessionNanos = Math.min(sessionNanos, System.nanoTime() - start);
+                            sessionRuns = runs;
+                        }
+
+                        // Random single-doc fetch: a fresh reader each time, so every lookup pays a full
+                        // cold block decompression. This is the pattern a wider block penalises.
+                        long randomNanos = Long.MAX_VALUE;
+                        for (int r = 0; r < repeats; r++) {
+                            long start = System.nanoTime();
+                            long bytes = 0;
+                            for (int lookupDoc : lookupDocs) {
+                                BinaryDocValues dv = leaf.getBinaryDocValues(binaryField);
+                                assertTrue(dv.advanceExact(lookupDoc));
+                                bytes += dv.binaryValue().length;
+                            }
+                            randomNanos = Math.min(randomNanos, System.nanoTime() - start);
+                            assertEquals((long) randomLookups * targetBlobBytes, bytes);
+                        }
+
+                        if (measured) {
+                            logger.info(
+                                Strings.format(
+                                    "%s dvd=%d bytes | write=%d ms merge=%d ms | scan(%d docs)=%.1f ms "
+                                        + "session(%d sessions)=%.1f ms per-session=%.2f ms random(%d cold lookups)=%.1f ms "
+                                        + "per-lookup=%.3f ms",
+                                    label,
+                                    dataBytes,
+                                    writeNanos / 1_000_000,
+                                    mergeNanos / 1_000_000,
+                                    numDocs,
+                                    scanNanos / 1_000_000.0,
+                                    sessionRuns,
+                                    sessionNanos / 1_000_000.0,
+                                    sessionNanos / 1_000_000.0 / sessionRuns,
+                                    randomLookups,
+                                    randomNanos / 1_000_000.0,
+                                    randomNanos / 1_000_000.0 / randomLookups
+                                )
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private record ZstdWindowSizes(long todayBytes, long windowOnlyBytes, long windowPlusLevelBytes) {}

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -18,11 +18,13 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Sort;
@@ -34,6 +36,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.codec.Elasticsearch93Lucene104Codec;
 import org.elasticsearch.index.codec.tsdb.AbstractTSDBDocValuesFormatTests;
@@ -44,15 +47,20 @@ import org.elasticsearch.index.codec.tsdb.TSDBDocValuesTestUtil;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockLoader.OptionalColumnAtATimeReader;
 import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.NUMERIC_BLOCK_SHIFT;
@@ -61,9 +69,13 @@ import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomUnicodeOfCodepointLengthBetween;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 
 public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTests {
+
+    private static final Logger logger = LogManager.getLogger(ES819TSDBDocValuesFormatTests.class);
 
     private final Codec codec = new Elasticsearch93Lucene104Codec() {
 
@@ -666,5 +678,237 @@ public class ES819TSDBDocValuesFormatTests extends AbstractTSDBDocValuesFormatTe
                 );
             }
         }
+    }
+
+    /**
+     * POC for whether combining a larger binary doc values compression block ("window") with a higher zstd
+     * level meaningfully shrinks storage for large (~256 KB), mostly-unique-but-structurally-similar JSON blobs
+     * — the shape of session-replay {@code body.text._original} values written through LogsDB's text fallback
+     * field. The corpus reuses a shared vocabulary of small JSON fragments (mimicking the repeated
+     * tag/class-name/key "skeleton" of an rrweb/Kibana-like DOM snapshot) in a different random order per blob,
+     * plus a small unique tail (session, id, nonce), so most of the redundancy only becomes visible once a
+     * compression window spans many documents. Neither a bigger window at today's zstd level 1, nor today's
+     * small window at a higher zstd level, is expected to unlock that shared structure — only combining both.
+     */
+    public void testLargeBinaryBlobZstdWindow() throws IOException {
+        final String binaryField = "body.text._original";
+        final String sessionField = "session";
+        final String idField = "id";
+        final int targetBlobBytes = 256 * 1024;
+        final int vocabularySize = 1200;
+        final int numDocs = randomIntBetween(200, 320);
+        final int numSessions = Math.max(1, numDocs / 8);
+
+        final Random random = random();
+        final String[] vocabulary = buildJsonSkeletonVocabulary(vocabularySize, random);
+        final byte[][] blobs = new byte[numDocs][];
+        final String[] sessions = new String[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            sessions[i] = "session-" + (i % numSessions);
+            blobs[i] = buildSessionReplayBlob(vocabulary, random, targetBlobBytes, sessions[i], i);
+        }
+
+        final ZstdWindowSizes sizes = measureZstdWindowSizes(binaryField, sessionField, idField, blobs, sessions);
+
+        final String message = Strings.format(
+            "docs=%d blobBytes=%d today(zstd-1,512KB)=%d bytes window-only(zstd-1,4MB)=%d bytes " + "window+level(zstd-3,4MB)=%d bytes",
+            numDocs,
+            targetBlobBytes,
+            sizes.todayBytes(),
+            sizes.windowOnlyBytes(),
+            sizes.windowPlusLevelBytes()
+        );
+        logger.info(message);
+
+        // A bigger compression block without a higher zstd level should not meaningfully help: confirms the
+        // block-size threshold alone is not the lever.
+        assertThat(message, (double) sizes.windowOnlyBytes(), closeTo(sizes.todayBytes(), sizes.todayBytes() * 0.15));
+        // Combining the larger window with zstd level 3 should meaningfully shrink storage.
+        assertThat(message, sizes.windowPlusLevelBytes(), lessThan((long) (sizes.todayBytes() * 0.75)));
+    }
+
+    private record ZstdWindowSizes(long todayBytes, long windowOnlyBytes, long windowPlusLevelBytes) {}
+
+    /**
+     * Measures on-disk binary doc values size for {@code blobs} under today's format (zstd level 1, 512 KB
+     * blocks), a larger 4 MB block window at the same zstd level, and that same larger window at zstd level 3.
+     */
+    private ZstdWindowSizes measureZstdWindowSizes(
+        String binaryField,
+        String sessionField,
+        String idField,
+        byte[][] blobs,
+        String[] sessions
+    ) throws IOException {
+        final long todayBytes = indexAndMeasureBinaryDVSize(
+            new ES819Version3TSDBDocValuesFormat(
+                BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+                512 * 1024,
+                ES819Version3TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT
+            ),
+            binaryField,
+            sessionField,
+            idField,
+            blobs,
+            sessions
+        );
+        final long windowOnlyBytes = indexAndMeasureBinaryDVSize(
+            new ES819Version3TSDBDocValuesFormat(
+                BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_1,
+                4 * 1024 * 1024,
+                ES819Version3TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT
+            ),
+            binaryField,
+            sessionField,
+            idField,
+            blobs,
+            sessions
+        );
+        final long windowPlusLevelBytes = indexAndMeasureBinaryDVSize(
+            new ES819Version3TSDBDocValuesFormat(
+                BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_3,
+                4 * 1024 * 1024,
+                ES819Version3TSDBDocValuesFormat.BINARY_DV_BLOCK_COUNT_THRESHOLD_DEFAULT
+            ),
+            binaryField,
+            sessionField,
+            idField,
+            blobs,
+            sessions
+        );
+        return new ZstdWindowSizes(todayBytes, windowOnlyBytes, windowPlusLevelBytes);
+    }
+
+    /**
+     * Indexes {@code blobs} as binary doc values under the given format, force-merges to a single segment, then
+     * verifies every value round-trips before summing the on-disk size of the binary doc values data files.
+     */
+    private long indexAndMeasureBinaryDVSize(
+        ES819Version3TSDBDocValuesFormat dvFormat,
+        String binaryField,
+        String sessionField,
+        String idField,
+        byte[][] blobs,
+        String[] sessions
+    ) throws IOException {
+        var config = new IndexWriterConfig();
+        config.setIndexSort(new Sort(new SortField(sessionField, SortField.Type.STRING, false)));
+        config.setMergePolicy(new LogByteSizeMergePolicy());
+        config.setCodec(TestUtil.alwaysDocValuesFormat(dvFormat));
+
+        List<Integer> writeOrder = new ArrayList<>(blobs.length);
+        for (int i = 0; i < blobs.length; i++) {
+            writeOrder.add(i);
+        }
+        Randomness.shuffle(writeOrder);
+
+        try (Directory dir = newDirectory()) {
+            try (IndexWriter writer = new IndexWriter(dir, config)) {
+                for (int i : writeOrder) {
+                    Document d = new Document();
+                    d.add(new NumericDocValuesField(idField, i));
+                    d.add(new SortedDocValuesField(sessionField, new BytesRef(sessions[i])));
+                    d.add(new BinaryDocValuesField(binaryField, new BytesRef(blobs[i])));
+                    writer.addDocument(d);
+                }
+                writer.forceMerge(1);
+                writer.commit();
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals("forceMerge(1) should leave a single segment", 1, reader.leaves().size());
+                LeafReaderContext leafContext = reader.leaves().get(0);
+                var leaf = leafContext.reader();
+                NumericDocValues idDV = leaf.getNumericDocValues(idField);
+                BinaryDocValues binaryDV = leaf.getBinaryDocValues(binaryField);
+                assertEquals(blobs.length, leaf.maxDoc());
+                for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+                    assertTrue(idDV.advanceExact(doc));
+                    assertTrue(binaryDV.advanceExact(doc));
+                    int originalId = (int) idDV.longValue();
+                    assertEquals("round-trip mismatch for doc id " + originalId, new BytesRef(blobs[originalId]), binaryDV.binaryValue());
+                }
+            }
+
+            long totalBytes = 0;
+            for (String name : dir.listAll()) {
+                if (name.endsWith("." + ES819TSDBDocValuesFormat.DATA_EXTENSION)) {
+                    totalBytes += dir.fileLength(name);
+                }
+            }
+            return totalBytes;
+        }
+    }
+
+    /**
+     * Builds a vocabulary of small JSON fragments mimicking the repeated tag/class-name/key "skeleton" of an
+     * rrweb/Kibana-like DOM snapshot. Each {@link #buildSessionReplayBlob} call reuses this same vocabulary in a
+     * different random order, so the redundancy that matters lives mostly *across* documents rather than within
+     * a single one — matching why concatenating many real session-replay blobs into a wide zstd window (rather
+     * than compressing them individually) is what unlocks compression on the real data.
+     */
+    private static String[] buildJsonSkeletonVocabulary(int vocabularySize, Random random) {
+        final String[] tagNames = { "div", "span", "section", "button" };
+        // Most of each vocabulary entry is a sizeable "payload" that is fixed once per entry (e.g. a
+        // component's serialized attributes/inline styles/text run) so that, unlike the handful of short JSON
+        // keys wrapping it, it cannot be dedupe'd via trivial short-range matches within a single document —
+        // the only way to compress it away is for the exact same entry to recur elsewhere within reach of the
+        // compression window.
+        final int payloadLength = 1100;
+        String[] vocabulary = new String[vocabularySize];
+        for (int i = 0; i < vocabularySize; i++) {
+            String tag = tagNames[i % tagNames.length];
+            String payload = randomHex(random, payloadLength);
+            vocabulary[i] = "{\"type\":2,\"tagName\":\""
+                + tag
+                + "\",\"attributes\":{\"class\":\"euiFlexItem\",\"data-node-id\":\"n"
+                + i
+                + "\",\"payload\":\""
+                + payload
+                + "\"}},";
+        }
+        return vocabulary;
+    }
+
+    /**
+     * Builds a single ~{@code targetBytes} JSON blob out of a random ordering of {@code vocabulary} entries
+     * (simulating a session-replay DOM snapshot chunk), followed by a small unique tail (session, doc id, random
+     * nonce) so every blob is unique overall — matching how a real {@code body.text._original} value is a mostly
+     * shared skeleton plus session-specific bits.
+     */
+    private static byte[] buildSessionReplayBlob(String[] vocabulary, Random random, int targetBytes, String session, int id) {
+        List<Integer> order = new ArrayList<>(vocabulary.length);
+        for (int i = 0; i < vocabulary.length; i++) {
+            order.add(i);
+        }
+        Collections.shuffle(order, random);
+
+        StringBuilder sb = new StringBuilder(targetBytes + 256);
+        sb.append("{\"data\":{\"node\":[");
+        for (int idx : order) {
+            if (sb.length() >= targetBytes) {
+                break;
+            }
+            sb.append(vocabulary[idx]);
+        }
+
+        String tail = "],\"session\":\"" + session + "\",\"id\":" + id + ",\"nonce\":\"" + randomHex(random, 12) + "\"}}";
+        sb.setLength(Math.min(sb.length(), Math.max(0, targetBytes - tail.length())));
+        sb.append(tail);
+        while (sb.length() < targetBytes) {
+            sb.append('0');
+        }
+
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.US_ASCII);
+        assert bytes.length == targetBytes : bytes.length;
+        return bytes;
+    }
+
+    private static String randomHex(Random random, int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(Integer.toHexString(random.nextInt(16)));
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
**🚧 Draft / POC — not for merge.** Exists to put a number on a hypothesis and give #157245 something concrete to argue with. Changes **no production default**.

## 🎯 TL;DR

Widening the LogsDB binary DV block **and** raising zstd to level 3 halves a large non-indexed `text` payload on disk. Neither lever does anything alone.

The read cost is **not** uniform: a full scan and a session-at-a-time read are neutral, while a random single-document fetch is ~7× slower. For a payload read a whole session at a time that's the cheap side of the trade — but it *is* a real regression for point lookups, and it comes from the block size, not the zstd level.

## 🔍 Why

A non-indexed `text` field under LogsDB lives in binary doc values as `<field>._original`. For session replay (rrweb DOM, ~256 KB/doc) that field is **~96% of on-disk bytes**. It's individually near-unique (so per-doc compression finds little — ~4.5× measured) but *collectively* very redundant (same tag soup and JSON keys across docs; many real ~256 KB chunks were byte-identical).

Today's codec can't see that: ES819 `Version3` uses **zstd-1 / 512 KB blocks**, and `CompressedBinaryBlockWriter.addDoc` flushes *after* appending → with ~256 KB values a block holds **at most 2 docs**. The window never spans enough documents, and level 1 isn't hunting long-range matches anyway.

## 🔧 What changed

Two additive pieces, enough to measure and nothing more:

- **`BinaryDVCompressionMode.COMPRESSED_ZSTD_LEVEL_3`**, code `2`. Appended, so codes stay dense `0..n-1` for `fromMode()`; `NO_COMPRESS`/`LEVEL_1` untouched. New on-disk code, not a reinterpretation of an existing one.
- **Test-only `ES819Version3TSDBDocValuesFormat` ctor** passing `blockBytesThreshold`/`blockCountThreshold` through, instead of hardcoding 512 KB/8096 like the production ctors. Keeps `CODEC_NAME` and `DocOffsetsCodec.BITPACKING`, so readers are unaffected.

Both format factories and every production default are **deliberately untouched**.

## 📊 Storage

`testLargeBinaryBlobZstdWindow` — Lucene `Directory` + `IndexWriter`, no node, `forceMerge(1)`, byte-for-byte round-trip asserted on every value, summed `.dvd` size:

| Config | Mode | Block | Size | vs today |
|---|---|---|---:|---:|
| today | zstd-1 | 512 KB | 30,397,784 B | — |
| window only | zstd-1 | 4 MB | 28,892,103 B | −5.0% (wash) |
| **window + level** | **zstd-3** | **4 MB** | **15,353,655 B** | **−49.5% (~1.98×)** |

Stable across seeds and 200–320 docs. Cross-checked against two real corpora, neither committed (internal telemetry) — the test in this PR is synthetic and self-contained:

| Real corpus | Docs | Sessions | window-only | window+level |
|---|---:|---:|---:|---:|
| CCS cluster, random sample | 198 | n/a (recycled) | 89% | 58% (~1.73×) |
| **Kibana PR-cloud, sorted by real `session.id`** | **710** | **86** | 91.8% | **44.8% (~2.23×)** |

The second run is the stronger check: real per-session grouping (not a recycled/synthetic session assignment), 3.6× the docs, and a natural size distribution (196 B–2.26 MB, median still 262,144 B — a session's FullSnapshot splits into SDK chunks and the last one is a remainder). It came out **better** than the synthetic result, not worse — real successive snapshots of the same evolving DOM apparently share more structure than a hand-built vocabulary does.

⚠️ Helps **disk** only. Ingest-metered billing meters enriched `_source` *before* compression, so this does nothing there.

## ⚖️ Read & write cost

Fair challenge on the first version of this PR: storage is only half the trade. `testLargeBinaryBlobZstdWindowReadAndWriteCost` measures the rest.

A reader caches exactly **one** decompressed block and `findAndUpdateBlock` searches forward only, so read cost follows the access pattern rather than the block size alone. 256 docs × 256 KB, best of three, after a discarded warm-up pass:

| Config | full scan | one session | random single doc |
|---|---:|---:|---:|
| today (zstd-1, 512 KB) | 23.4 ms | 1.46 ms | **0.195 ms** |
| window-only (zstd-1, 4 MB) | 22.3 ms | 1.44 ms | 1.454 ms |
| window+level (zstd-3, 4 MB) | 21.8 ms | 1.40 ms | **1.372 ms** |

- **Scan and session-at-a-time: neutral** (marginally faster — fewer compressed bytes to fault in). Under an index sort a session's blobs are contiguous, so they share blocks and each is decompressed once.
- **Random single-doc fetch: ~7× slower.** Tracks the ~8× more uncompressed bytes per cold lookup (512 KB holding 2 values → 4 MB holding 16). Honest worst case.
- **Write: no measurable penalty** at this size — indexing and merge varied more between repeats of one config than between configs.
- **The level is not what costs.** At an equal 4 MB block, zstd-3 reads *marginally faster* than zstd-1 (fewer compressed bytes). The read trade-off is entirely block size; the compression level is free on the read side.

That last point is the useful decomposition: **block size buys storage and costs point-lookup latency; zstd level buys storage for free.**

## 🧪 Review the corpus first 👀

The most attackable part of the claim. A first design built docs from near-identical templates, which packed so much redundancy *inside* each doc that all three configs already hit ~15× and there was no headroom to show anything — a false negative. This version samples a 1200-entry vocabulary of ~1180-byte fragments **without replacement** per doc, so nothing repeats within a doc and every exploitable match is genuinely cross-document. Poke a hole in that and the number goes with it.

## 🚧 Why it's not mergeable

Full list in #157245:

1. **BWC** — old nodes can't read `code = 2`. Needs an index version bump.
2. **Scoping** — one binary DV format serves *every* field, and the numbers above show why a global flip would be wrong: fields read by point lookup would pay the ~7×. `libs/columnar`'s `BlockBytesCodec` (per-column, id frozen in metadata, identity-only today) looks like the natural home for this knob.
3. **Locality is load-bearing twice** — it's what makes the compression reachable *and* what keeps reads neutral. One real replay stream already sorts on `session.id` in its index template (that's where the 710-doc/2.23× result above came from), but not every replay stream does yet — where the sort is still `host.name`/`@timestamp`, this would pay the ~7× read penalty without the compression win. The sort has to land first, wherever it hasn't.
4. **Block-size safety** — #137139 avoided multi-MB blocks (a *fixed* 32-values/block OOMs on large values). Variable blocks allow 1 doc/block so 4 MB is bounded here, but shouldn't be raised blindly.
5. **The measurement harness itself** would move to `benchmarks/` (JMH) or be dropped before any real merge — it writes ~400 MB of temp data and asserts almost nothing.

## ✅ Testing

- Full `ES819TSDBDocValuesFormatTests` class green on current `main` — **179 tests, 0 failures**.
- Also ran `index.codec.tsdb.*`, `...tsdb.es95.*`, `TsdbDocValueBwcTests` — confirms the new enum value doesn't disturb anything iterating `BinaryDVCompressionMode.values()`.
- `:server:spotlessJavaCheck` clean.

No changelog entry — nothing user-visible changes.

