### PR TITLE
[ESQL] Stop wrapping Parquet I/O as HTTP 400 IAE

### DIFF
--- a/docs/changelog/157247.yaml
+++ b/docs/changelog/157247.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157247
+summary: Stop wrapping Parquet I/O as HTTP 400 IAE
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1016,9 +1016,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         try {
             return advanceRowGroup();
         } catch (IOException e) {
-            throw new IllegalArgumentException(
-                "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]: " + e.getMessage(),
-                e
+            throw ParquetReadFailures.wrap(
+                e,
+                "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]"
             );
         }
     }
@@ -1543,14 +1543,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             // No manual breaker accounting here: the Arrow allocator that backs the
             // prefetch's direct memory automatically releases the reservation when the
             // failed future is drained by the caller's cleanup path.
-            throw new IllegalArgumentException(
-                "Trivially-passes Phase-2 fetch failed for row group ["
-                    + rowGroupOrdinal
-                    + "] in ["
-                    + fileLocation
-                    + "]: "
-                    + e.getMessage(),
-                e
+            throw ParquetReadFailures.wrap(
+                e,
+                "Trivially-passes Phase-2 fetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]"
             );
         }
         // Merge the two chunk maps. Both phases prefetched disjoint columns (predicate vs.
@@ -1616,10 +1611,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             // No manual breaker accounting here: the Arrow allocator that backs the
             // prefetch's direct memory automatically releases the reservation when the
             // failed future is drained by the caller's cleanup path.
-            throw new IllegalArgumentException(
-                "Phase 2 prefetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]: " + e.getMessage(),
-                e
-            );
+            throw ParquetReadFailures.wrap(e, "Phase 2 prefetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]");
         }
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = result != null ? result.chunks() : null;
         // The Phase-2 chunks' allocator-backed memory is the sole breaker accounting for this row
@@ -2060,16 +2052,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         } catch (RuntimeException e) {
             Releasables.closeExpectNoException(blocks);
             Releasables.closeExpectNoException(predicateBlocks);
-            throw new IllegalArgumentException(
+            throw ParquetReadFailures.wrap(
+                e,
                 "Failed to emit two-phase Page at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] batch ["
                     + state.nextBatchIndex()
                     + "] in file ["
                     + fileLocation
-                    + "]: "
-                    + e.getMessage(),
-                e
+                    + "]"
             );
         }
 
@@ -2159,26 +2150,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 } catch (CircuitBreakingException e) {
                     // Let breaker exceptions flow through unwrapped: callers (and tests) match
                     // on the exact type to distinguish memory-pressure failures from data errors.
-                    Releasables.closeExpectNoException(blocks);
                     throw e;
                 } catch (Exception e) {
-                    Releasables.closeExpectNoException(blocks);
-                    Attribute attr = attributes.get(col);
-                    throw new IllegalArgumentException(
-                        "Failed to read Parquet column ["
-                            + attr.name()
-                            + "] (type "
-                            + attr.dataType()
-                            + ") at row group ["
-                            + (rowGroupOrdinal + 1)
-                            + "] page batch ["
-                            + pageBatchIndexInRowGroup
-                            + "] in file ["
-                            + fileLocation
-                            + "]: "
-                            + e.getMessage(),
-                        e
-                    );
+                    throw wrapColumnReadException(col, e);
                 }
             }
             if (producedRows < 0) {
@@ -2189,20 +2163,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     blocks[col] = blockFactory.newConstantNullBlock(producedRows);
                 }
             }
-        } catch (IllegalArgumentException | CircuitBreakingException e) {
+        } catch (CircuitBreakingException e) {
+            Releasables.closeExpectNoException(blocks);
             throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
-            throw new IllegalArgumentException(
+            throw ParquetReadFailures.wrap(
+                e,
                 "Failed to create Page batch at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] page batch ["
                     + pageBatchIndexInRowGroup
                     + "] in file ["
                     + fileLocation
-                    + "]: "
-                    + e.getMessage(),
-                e
+                    + "]"
             );
         }
         counters.addRowsEmitted(rowsToRead);
@@ -2295,21 +2269,20 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
             counters.addRowsEmitted(survivorCount);
             return new Page(blocks);
-        } catch (IllegalArgumentException | CircuitBreakingException e) {
+        } catch (CircuitBreakingException e) {
             Releasables.closeExpectNoException(blocks);
             throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
-            throw new IllegalArgumentException(
+            throw ParquetReadFailures.wrap(
+                e,
                 "Failed to create late-materialized Page at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] page batch ["
                     + pageBatchIndexInRowGroup
                     + "] in file ["
                     + fileLocation
-                    + "]: "
-                    + e.getMessage(),
-                e
+                    + "]"
             );
         }
     }
@@ -2368,9 +2341,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
     }
 
-    private IllegalArgumentException wrapColumnReadException(int colIndex, Exception e) {
+    private RuntimeException wrapColumnReadException(int colIndex, Exception e) {
         Attribute attr = attributes.get(colIndex);
-        return new IllegalArgumentException(
+        return ParquetReadFailures.wrap(
+            e,
             "Failed to read Parquet column ["
                 + attr.name()
                 + "] (type "
@@ -2381,9 +2355,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 + pageBatchIndexInRowGroup
                 + "] in file ["
                 + fileLocation
-                + "]: "
-                + e.getMessage(),
-            e
+                + "]"
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -510,7 +510,7 @@ final class PageColumnReader implements Releasable {
                 currentValueBytes = pageBytes;
             }
         } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to read V1 page bytes: " + e.getMessage(), e);
+            throw ParquetReadFailures.wrap(e, "Failed to read V1 page bytes");
         }
     }
 
@@ -524,7 +524,7 @@ final class PageColumnReader implements Releasable {
             }
             currentValueBytes = v2.getData().toByteBuffer();
         } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to read V2 page bytes: " + e.getMessage(), e);
+            throw ParquetReadFailures.wrap(e, "Failed to read V2 page bytes");
         }
     }
 
@@ -549,10 +549,7 @@ final class PageColumnReader implements Releasable {
                 currentValueBytes.duplicate().get(bytes);
                 fallbackReader.initFromPage(currentPageValueCount, bytes, 0);
             } catch (IOException e) {
-                throw new IllegalArgumentException(
-                    "Failed to init fallback decoder for encoding " + currentEncoding + ": " + e.getMessage(),
-                    e
-                );
+                throw ParquetReadFailures.wrap(e, "Failed to init fallback decoder for encoding " + currentEncoding);
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -529,9 +529,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     }
 
     /**
-     * Opens a Parquet reader, mapping parquet-mr failures (checked and unchecked) to an
-     * {@link IllegalArgumentException} that includes the storage object URI. This ensures
-     * invalid/corrupt Parquet files produce HTTP 400 rather than 500.
+     * Opens a Parquet reader. I/O is routed through {@link ParquetReadFailures#wrap} so a closed
+     * storage client stays {@code ExternalUnavailableException} (503) rather than becoming an IAE.
+     * parquet-mr {@link RuntimeException}s (corrupt footer/magic) become {@link IllegalArgumentException}
+     * so invalid files stay HTTP 400; {@link CircuitBreakingException} and other
+     * {@link ElasticsearchException}s pass through.
      */
     private static ParquetFileReader openParquetFile(
         StorageObject object,
@@ -543,7 +545,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         try {
             return ParquetFileReader.open(inputFile, cachedFooter, options, inputFile.newStream());
         } catch (IOException e) {
-            throw newInvalidParquetFileException(uri, e);
+            throw ParquetReadFailures.wrap(e, "Could not read [" + uri + "] as a Parquet file");
         } catch (RuntimeException e) {
             if (e instanceof CircuitBreakingException) {
                 throw e;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -2879,9 +2879,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             try {
                 return advanceRowGroup();
             } catch (IOException e) {
-                throw new IllegalArgumentException(
-                    "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]: " + e.getMessage(),
-                    e
+                throw ParquetReadFailures.wrap(
+                    e,
+                    "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]"
                 );
             }
         }
@@ -3001,12 +3001,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                                     blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead, col);
                                 }
                             } catch (CircuitBreakingException e) {
-                                Releasables.closeExpectNoException(blocks);
                                 throw e;
                             } catch (Exception e) {
-                                Releasables.closeExpectNoException(blocks);
                                 Attribute attr = attributes.get(col);
-                                throw new IllegalArgumentException(
+                                throw ParquetReadFailures.wrap(
+                                    e,
                                     "Failed to read Parquet column ["
                                         + attr.name()
                                         + "] (type "
@@ -3017,27 +3016,25 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                                         + pageBatchIndexInRowGroup
                                         + "] in file ["
                                         + fileLocation
-                                        + "]: "
-                                        + e.getMessage(),
-                                    e
+                                        + "]"
                                 );
                             }
                         }
                     }
-                } catch (IllegalArgumentException | CircuitBreakingException e) {
+                } catch (CircuitBreakingException e) {
+                    Releasables.closeExpectNoException(blocks);
                     throw e;
                 } catch (Exception e) {
                     Releasables.closeExpectNoException(blocks);
-                    throw new IllegalArgumentException(
+                    throw ParquetReadFailures.wrap(
+                        e,
                         "Failed to create Page batch at row group ["
                             + (rowGroupOrdinal + 1)
                             + "] page batch ["
                             + pageBatchIndexInRowGroup
                             + "] in file ["
                             + fileLocation
-                            + "]: "
-                            + e.getMessage(),
-                        e
+                            + "]"
                     );
                 }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailures.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailures.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Maps a failure on the Parquet read path to the exception the iterator should throw, without
+ * recasting I/O or typed Elasticsearch failures as {@link IllegalArgumentException}.
+ * <p>
+ * Blanket IAE recasts made every storage fault look like bad input (HTTP 400) and hid
+ * {@code ExternalUnavailableException} (503) and bug-class {@code IllegalStateException} (500)
+ * from {@link ExternalFailures#classify}. Callers replace {@code catch (Exception) → new IAE}
+ * with {@code throw ParquetReadFailures.wrap(t, context)}. {@code Future.join()}/{@code get()}
+ * wrap the raw cause in {@link java.util.concurrent.CompletionException}/
+ * {@link java.util.concurrent.ExecutionException}; those are peeled here because
+ * {@code ExceptionsHelper.unwrapCause} does not.
+ */
+final class ParquetReadFailures {
+
+    private ParquetReadFailures() {}
+
+    static RuntimeException wrap(Throwable t, String context) {
+        Throwable cause = unwrapJoin(t);
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        if (cause instanceof ElasticsearchException ese) {
+            return ese;
+        }
+        if (cause instanceof IOException || cause instanceof UncheckedIOException) {
+            return ExternalFailures.surface(cause, context);
+        }
+        if (cause instanceof RuntimeException re) {
+            return re;
+        }
+        return ExternalFailures.surface(cause, context);
+    }
+
+    private static Throwable unwrapJoin(Throwable t) {
+        Throwable current = t;
+        while (current instanceof CompletionException || current instanceof ExecutionException) {
+            Throwable next = current.getCause();
+            if (next == null || next == current) {
+                break;
+            }
+            current = next;
+        }
+        return current;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailures.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailures.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
 
 import java.io.IOException;
@@ -26,6 +25,11 @@ import java.util.concurrent.ExecutionException;
  * wrap the raw cause in {@link java.util.concurrent.CompletionException}/
  * {@link java.util.concurrent.ExecutionException}; those are peeled here because
  * {@code ExceptionsHelper.unwrapCause} does not.
+ * <p>
+ * {@code context} is applied to I/O and to {@link IllegalArgumentException} (malformed pages)
+ * so call-site column/file strings show up in the 400 message. Other {@link RuntimeException}s
+ * (typed ES failures, {@code ParquetDecodingException}, bug-class ISE) pass through so
+ * {@link ExternalFailures#classify} still sees the original type.
  */
 final class ParquetReadFailures {
 
@@ -36,11 +40,15 @@ final class ParquetReadFailures {
         if (cause instanceof Error error) {
             throw error;
         }
-        if (cause instanceof ElasticsearchException ese) {
-            return ese;
-        }
         if (cause instanceof IOException || cause instanceof UncheckedIOException) {
             return ExternalFailures.surface(cause, context);
+        }
+        if (cause instanceof IllegalArgumentException iae) {
+            String detail = iae.getMessage();
+            if (detail == null || detail.isEmpty()) {
+                detail = iae.getClass().getSimpleName();
+            }
+            return new IllegalArgumentException(context + ": " + detail, iae);
         }
         if (cause instanceof RuntimeException re) {
             return re;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -37,7 +37,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -284,9 +283,9 @@ final class PrefetchedRowGroupBuilder {
             }
             return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
         } catch (IOException e) {
-            throw new IllegalArgumentException(
-                "Failed to read column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]: " + e.getMessage(),
-                e
+            throw ParquetReadFailures.wrap(
+                e,
+                "Failed to read column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]"
             );
         }
     }
@@ -334,13 +333,9 @@ final class PrefetchedRowGroupBuilder {
             }
             return makeDictionaryPage(header, payload);
         } catch (IOException e) {
-            throw new UncheckedIOException(
-                "Failed to parse dictionary page for column ["
-                    + column.getPath().toDotString()
-                    + "] in row group ["
-                    + rowGroupOrdinal
-                    + "]",
-                e
+            throw ParquetReadFailures.wrap(
+                e,
+                "Failed to parse dictionary page for column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]"
             );
         }
     }
@@ -362,9 +357,9 @@ final class PrefetchedRowGroupBuilder {
             ByteBuffer payload = sliceFromBuffer(pageSlice, headerLen, compressedPageSize);
             return makeDataPage(header, payload, primitiveType, firstRowIndex, indexRowCount);
         } catch (IOException e) {
-            throw new UncheckedIOException(
-                "Failed to parse page header for column [" + path + "] in row group [" + rowGroupOrdinal + "]: " + e.getMessage(),
-                e
+            throw ParquetReadFailures.wrap(
+                e,
+                "Failed to parse page header for column [" + path + "] in row group [" + rowGroupOrdinal + "]"
             );
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -675,7 +675,7 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         assertThat("explicit no-late-mat returns all rows (no row-level filtering)", rowsNoLateMat, equalTo(totalRows));
     }
 
-    public void testCorruptDataPageOptimizedReaderProducesIllegalArgumentException() throws Exception {
+    public void testCorruptDataPageOptimizedReaderIsClient400() throws Exception {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
         byte[] parquetData = createParquetFile(schema, factory -> {
             List<Group> groups = new ArrayList<>();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -19,6 +19,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -29,12 +30,14 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -692,13 +695,14 @@ public class OptimizedParquetReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+        Exception ex = expectThrows(Exception.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(storageObject, FormatReadContext.of(null, 100))) {
                 while (iterator.hasNext()) {
                     iterator.next().releaseBlocks();
                 }
             }
         });
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(ex)));
         assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("id"));
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -35,6 +35,7 @@ import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -52,13 +53,16 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
 import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
 import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
@@ -3536,14 +3540,15 @@ public class ParquetFormatReaderTests extends ESTestCase {
         // metadata() should still succeed (footer is intact)
         SourceMetadata metadata = reader.metadata(storageObject);
         assertNotNull(metadata);
-        // read() should fail with IllegalArgumentException (not ElasticsearchException/500)
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+        // read() should fail as a client-class 400 (I/O / malformed page), not a server 500
+        Exception ex = expectThrows(Exception.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 100)) {
                 while (iterator.hasNext()) {
                     iterator.next().releaseBlocks();
                 }
             }
         });
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(ex)));
         assertThat(ex.getMessage(), containsString("id"));
     }
 
@@ -4100,7 +4105,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 new RangeReadContext(List.of("x"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
-            expectThrows(IllegalArgumentException.class, () -> {
+            expectThrows(InvalidArgumentException.class, () -> {
                 while (it.hasNext()) {
                     it.next().releaseBlocks();
                 }
@@ -4325,7 +4330,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
                     new RangeReadContext(List.of("ts"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
                 )
             ) {
-                expectThrows(IllegalArgumentException.class, () -> {
+                expectThrows(InvalidArgumentException.class, () -> {
                     while (it.hasNext()) {
                         it.next().releaseBlocks();
                     }
@@ -4429,7 +4434,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 new RangeReadContext(List.of("vals"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
-            expectThrows(IllegalArgumentException.class, () -> {
+            expectThrows(InvalidArgumentException.class, () -> {
                 while (it.hasNext()) {
                     it.next().releaseBlocks();
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -3514,7 +3514,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertTrue(ex.getMessage(), ex.getMessage().contains("https://host/obj.parquet"));
     }
 
-    public void testCorruptDataPageProducesIllegalArgumentException() throws Exception {
+    public void testCorruptDataPageIsClient400() throws Exception {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
         byte[] parquetData = createParquetFile(schema, factory -> {
             List<Group> groups = new ArrayList<>();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailuresTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailuresTests.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class ParquetReadFailuresTests extends ESTestCase {
@@ -84,10 +85,12 @@ public class ParquetReadFailuresTests extends ESTestCase {
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(classified));
     }
 
-    public void testIaeIdentity400() {
+    public void testIaeKeepsContext400() {
         IllegalArgumentException iae = new IllegalArgumentException("bad page");
         RuntimeException wrapped = ParquetReadFailures.wrap(iae, "ctx");
-        assertSame(iae, wrapped);
+        assertThat(wrapped, instanceOf(IllegalArgumentException.class));
+        assertSame(iae, wrapped.getCause());
+        assertThat(wrapped.getMessage(), containsString("ctx"));
         assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(wrapped)));
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailuresTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReadFailuresTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalServerException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class ParquetReadFailuresTests extends ESTestCase {
+
+    public void testIoExceptionBecomesExternalClient400() {
+        IOException io = new IOException("truncated");
+        RuntimeException wrapped = ParquetReadFailures.wrap(io, "Failed to read column [id]");
+        assertThat(wrapped, instanceOf(ExternalClientException.class));
+        assertSame(io, wrapped.getCause());
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(wrapped));
+        assertSame(wrapped, ExternalFailures.classify(wrapped));
+    }
+
+    public void testUncheckedIoExceptionBecomesExternalClient400() {
+        IOException cause = new IOException("upstream");
+        UncheckedIOException uioe = new UncheckedIOException("wrapped", cause);
+        RuntimeException wrapped = ParquetReadFailures.wrap(uioe, "Failed to parse page header");
+        assertThat(wrapped, instanceOf(ExternalClientException.class));
+        assertSame(uioe, wrapped.getCause());
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(wrapped));
+        assertSame(wrapped, ExternalFailures.classify(wrapped));
+    }
+
+    public void testExternalUnavailableIdentityAnd503() {
+        ExternalUnavailableException unavailable = new ExternalUnavailableException("store 503", new IOException());
+        RuntimeException wrapped = ParquetReadFailures.wrap(unavailable, "ctx");
+        assertSame(unavailable, wrapped);
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(ExternalFailures.classify(wrapped)));
+    }
+
+    public void testCircuitBreakingIdentity() {
+        CircuitBreakingException breaking = new CircuitBreakingException("over", 10, 5, CircuitBreaker.Durability.TRANSIENT);
+        assertSame(breaking, ParquetReadFailures.wrap(breaking, "ctx"));
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(ExternalFailures.classify(breaking)));
+    }
+
+    public void testCompletionExceptionUnwrapsExternalUnavailableTo503() {
+        ExternalUnavailableException unavailable = new ExternalUnavailableException("store 503", new IOException());
+        RuntimeException wrapped = ParquetReadFailures.wrap(new CompletionException(unavailable), "Phase 2 prefetch failed");
+        assertSame(unavailable, wrapped);
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(ExternalFailures.classify(wrapped)));
+    }
+
+    public void testExecutionExceptionUnwrapsIoExceptionTo400() {
+        IOException io = new IOException("truncated");
+        RuntimeException wrapped = ParquetReadFailures.wrap(new ExecutionException(io), "Failed to read column");
+        assertThat(wrapped, instanceOf(ExternalClientException.class));
+        assertSame(io, wrapped.getCause());
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(wrapped));
+    }
+
+    public void testIllegalStateExceptionIsNotIaeAndClassifies500() {
+        IllegalStateException ise = new IllegalStateException("broken invariant");
+        RuntimeException wrapped = ParquetReadFailures.wrap(ise, "ctx");
+        assertSame(ise, wrapped);
+        assertFalse(wrapped instanceof IllegalArgumentException);
+        RuntimeException classified = ExternalFailures.classify(wrapped);
+        assertThat(classified, instanceOf(ExternalServerException.class));
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(classified));
+    }
+
+    public void testIaeIdentity400() {
+        IllegalArgumentException iae = new IllegalArgumentException("bad page");
+        RuntimeException wrapped = ParquetReadFailures.wrap(iae, "ctx");
+        assertSame(iae, wrapped);
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(wrapped)));
+    }
+
+    public void testInvalidArgumentExceptionIdentity400() {
+        InvalidArgumentException invalid = new InvalidArgumentException("cannot coerce");
+        RuntimeException wrapped = ParquetReadFailures.wrap(invalid, "ctx");
+        assertSame(invalid, wrapped);
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(wrapped)));
+    }
+
+    public void testErrorIsRethrown() {
+        AssertionError error = new AssertionError("boom");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> ParquetReadFailures.wrap(error, "ctx"));
+        assertSame(error, thrown);
+    }
+
+    public void testErrorBuriedUnderCompletionExceptionIsRethrown() {
+        AssertionError error = new AssertionError("boom");
+        AssertionError thrown = expectThrows(AssertionError.class, () -> ParquetReadFailures.wrap(new CompletionException(error), "ctx"));
+        assertSame(error, thrown);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -23,14 +23,19 @@ import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.ExternalFailures;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.junit.After;
@@ -46,6 +51,8 @@ import java.util.List;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.instanceOf;
 
 public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
 
@@ -111,6 +118,60 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
 
     public void testV2NoDictionary() throws IOException {
         assertParity(WriterVersion.PARQUET_2_0, CompressionCodecName.SNAPPY, false);
+    }
+
+    public void testSequentialOpenStreamIoExceptionIsClient400NotIae() throws Exception {
+        byte[] file = writeIntFile(WriterVersion.PARQUET_1_0, CompressionCodecName.UNCOMPRESSED, false, true);
+        try (ParquetFileReader reader = openReader(file)) {
+            BlockMetaData block = reader.getRowGroups().getFirst();
+            MessageType schema = reader.getFileMetaData().getSchema();
+            IOException injected = new IOException("injected storage read failure");
+            RuntimeException ex = expectThrows(
+                RuntimeException.class,
+                () -> PrefetchedRowGroupBuilder.build(
+                    block,
+                    0,
+                    schema,
+                    Set.of("id"),
+                    null,
+                    PreloadedRowGroupMetadata.empty(),
+                    null,
+                    throwingOnStream(injected),
+                    codecFactory,
+                    blockFactory.arrowAllocator()
+                )
+            );
+            assertThat(ex, instanceOf(ExternalClientException.class));
+            assertFalse(ex instanceof IllegalArgumentException);
+            assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(ExternalFailures.classify(ex)));
+            assertSame(injected, ex.getCause());
+        }
+    }
+
+    public void testSequentialOpenStreamExternalUnavailableStays503() throws Exception {
+        byte[] file = writeIntFile(WriterVersion.PARQUET_1_0, CompressionCodecName.UNCOMPRESSED, false, true);
+        try (ParquetFileReader reader = openReader(file)) {
+            BlockMetaData block = reader.getRowGroups().getFirst();
+            MessageType schema = reader.getFileMetaData().getSchema();
+            ExternalUnavailableException injected = new ExternalUnavailableException("store 503", new IOException("pool"));
+            ExternalUnavailableException ex = expectThrows(
+                ExternalUnavailableException.class,
+                () -> PrefetchedRowGroupBuilder.build(
+                    block,
+                    0,
+                    schema,
+                    Set.of("id"),
+                    null,
+                    PreloadedRowGroupMetadata.empty(),
+                    null,
+                    throwingOnStream(injected),
+                    codecFactory,
+                    blockFactory.arrowAllocator()
+                )
+            );
+            assertSame(injected, ex);
+            assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(ex));
+        }
     }
 
     /**
@@ -545,6 +606,41 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
             public void write(byte[] b, int off, int len) {
                 outputStream.write(b, off, len);
                 pos += len;
+            }
+        };
+    }
+
+    private static StorageObject throwingOnStream(Exception failure) {
+        return new StorageObject() {
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://throwing.parquet");
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public long length() {
+                return 1L;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                if (failure instanceof IOException io) {
+                    throw io;
+                }
+                if (failure instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new IOException(failure);
             }
         };
     }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.logging.LogManager;
@@ -33,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.utils.ContentRangeParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.concurrent.Executor;
 
 /**
@@ -41,6 +41,9 @@ import java.util.concurrent.Executor;
  */
 public final class S3StorageObject extends AbstractMeteredStorageObject {
     private static final Logger logger = LogManager.getLogger(S3StorageObject.class);
+
+    // Real SDK chains here are 2-4 deep; this only stops a pathological one.
+    private static final int MAX_CAUSE_DEPTH = 12;
 
     private final S3Client s3Client;
     private final S3AsyncClient s3AsyncClient;
@@ -137,9 +140,11 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
     /**
      * Maps a failure from the S3 client into the exception to surface to ES|QL. A retryable transport
      * status (5xx/429) becomes an {@link ExternalUnavailableException} (503 — the read may succeed on
-     * retry). An {@link IllegalStateException} in the cause chain (typically Apache
-     * {@code Connection pool shut down} after the SDK client is closed) is the same 503: the client
-     * is gone, not the object. A missing object or any other failure becomes an {@link IOException},
+     * retry). A closed HTTP client ({@code Connection pool shut down} / client-closed
+     * {@link IllegalStateException}) is the same 503: the client is gone, not the object. Other
+     * {@link IllegalStateException}s are returned as-is (HTTP 500 via classify) so a programming
+     * error is not retried and is not disguised as a client 400. A missing object or any other
+     * failure becomes an {@link IOException},
      * which the external source operator classifies as a client-class 400. Returns the exception
      * (never throws) so both the synchronous and async read paths can route it.
      */
@@ -157,7 +162,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
         if (cause instanceof NoSuchKeyException) {
             return new IOException("Object not found: " + path, cause);
         }
-        if (ExceptionsHelper.unwrap(cause, IllegalStateException.class) != null) {
+        if (isClosedClient(cause)) {
             return new ExternalUnavailableException(
                 false,
                 cause,
@@ -166,7 +171,31 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
                 S3FailureDetail.of(cause)
             );
         }
+        if (cause instanceof IllegalStateException ise) {
+            return ise;
+        }
         return new IOException(context + " " + path + ": " + S3FailureDetail.of(cause), cause);
+    }
+
+    private static boolean isClosedClient(Throwable cause) {
+        Throwable current = cause;
+        for (int depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth++) {
+            if (current instanceof IllegalStateException) {
+                String message = current.getMessage();
+                if (message != null) {
+                    String lower = message.toLowerCase(Locale.ROOT);
+                    if (lower.contains("pool shut down") || lower.contains("client is closed")) {
+                        return true;
+                    }
+                }
+            }
+            Throwable next = current.getCause();
+            if (next == null || next == current) {
+                break;
+            }
+            current = next;
+        }
+        return false;
     }
 
     /**
@@ -309,6 +338,8 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             } else {
                 fetchMetadataViaHead();
             }
+        } catch (Exception e) {
+            throw throwReadFailure("Failed to read object metadata for", e);
         }
     }
 
@@ -326,7 +357,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             if (e instanceof S3Exception s3e && s3e.statusCode() == 403) {
                 fetchMetadataViaRangeGet();
             } else {
-                throw new IOException("HeadObject request failed for " + path + ": " + S3FailureDetail.of(e), e);
+                throw throwReadFailure("HeadObject request failed for", e);
             }
         }
     }
@@ -352,10 +383,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             if (e instanceof NoSuchKeyException) {
                 setNotFound();
             } else {
-                throw new IOException(
-                    "Failed to get metadata for " + path + " (HEAD denied, range GET also failed): " + S3FailureDetail.of(e),
-                    e
-                );
+                throw throwReadFailure("Failed to get metadata for", e);
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.logging.LogManager;
@@ -136,9 +137,11 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
     /**
      * Maps a failure from the S3 client into the exception to surface to ES|QL. A retryable transport
      * status (5xx/429) becomes an {@link ExternalUnavailableException} (503 — the read may succeed on
-     * retry); a missing object or any other failure becomes an {@link IOException}, which the external
-     * source operator classifies as a client-class 400. Returns the exception (never throws) so both
-     * the synchronous and async read paths can route it.
+     * retry). An {@link IllegalStateException} in the cause chain (typically Apache
+     * {@code Connection pool shut down} after the SDK client is closed) is the same 503: the client
+     * is gone, not the object. A missing object or any other failure becomes an {@link IOException},
+     * which the external source operator classifies as a client-class 400. Returns the exception
+     * (never throws) so both the synchronous and async read paths can route it.
      */
     private Exception mapReadFailure(String context, Throwable cause) {
         if (cause instanceof S3Exception s3 && ExternalUnavailableException.isRetryableStatus(s3.statusCode())) {
@@ -153,6 +156,15 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
         }
         if (cause instanceof NoSuchKeyException) {
             return new IOException("Object not found: " + path, cause);
+        }
+        if (ExceptionsHelper.unwrap(cause, IllegalStateException.class) != null) {
+            return new ExternalUnavailableException(
+                false,
+                cause,
+                "S3 client unavailable reading [{}]: {}",
+                path,
+                S3FailureDetail.of(cause)
+            );
         }
         return new IOException(context + " " + path + ": " + S3FailureDetail.of(cause), cause);
     }

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
@@ -16,7 +16,10 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.ByteArrayInputStream;
@@ -90,7 +93,8 @@ public class S3AnonymousAccessTests extends ESTestCase {
 
     /**
      * When the suffix-range GET fails with a non-403 S3 error, falls back to HEAD.
-     * If HEAD also fails, the error propagates as IOException.
+     * A retryable HEAD status (500) maps like a retryable GET: {@link ExternalUnavailableException}
+     * (HTTP 503), not a client-class {@link IOException}.
      */
     public void testHeadNon403ErrorPropagates() {
         when(mockS3Client.getObject(any(GetObjectRequest.class))).thenThrow(
@@ -102,8 +106,10 @@ public class S3AnonymousAccessTests extends ESTestCase {
 
         S3StorageObject obj = new S3StorageObject(mockS3Client, BUCKET, KEY, PATH);
 
-        IOException e = expectThrows(IOException.class, obj::length);
-        assertThat(e.getMessage(), containsString("HeadObject request failed"));
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::length);
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
+        assertThat(eue.getMessage(), containsString("HTTP 500"));
+        assertFalse(eue.throttling());
     }
 
     /**
@@ -126,8 +132,8 @@ public class S3AnonymousAccessTests extends ESTestCase {
     }
 
     /**
-     * When HeadObject returns 403 and the range GET also fails (non-404), the error
-     * should propagate with a descriptive message.
+     * When suffix-range GET and the bytes=0-0 fallback both return 403, the error
+     * is a client-class {@link IOException} (not retryable).
      */
     public void testHeadFallbackRangeGetAlsoFails() {
         when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(
@@ -140,7 +146,8 @@ public class S3AnonymousAccessTests extends ESTestCase {
         S3StorageObject obj = new S3StorageObject(mockS3Client, BUCKET, KEY, PATH);
 
         IOException e = expectThrows(IOException.class, obj::length);
-        assertThat(e.getMessage(), containsString("HEAD denied, range GET also failed"));
+        assertThat(e.getMessage(), containsString("Failed to get metadata for"));
+        assertThat(e.getMessage(), containsString("HTTP 403"));
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectReadFailureTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectReadFailureTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class S3StorageObjectReadFailureTests extends ESTestCase {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String KEY = "data/file.parquet";
+    private static final StoragePath PATH = StoragePath.of("s3://" + BUCKET + "/" + KEY);
+
+    public void testBareIllegalStateExceptionIsUnavailable503() {
+        S3Client mockS3 = mock(S3Client.class);
+        IllegalStateException ise = new IllegalStateException("Connection pool shut down");
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(ise);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::newStream);
+        assertSame(ise, eue.getCause());
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
+        assertFalse(eue.throttling());
+    }
+
+    public void testSdkClientExceptionWrappingIllegalStateExceptionIsUnavailable503() {
+        S3Client mockS3 = mock(S3Client.class);
+        IllegalStateException ise = new IllegalStateException("Connection pool shut down");
+        SdkClientException wrapped = SdkClientException.create("Unable to execute HTTP request", ise);
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(wrapped);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::newStream);
+        assertSame(wrapped, eue.getCause());
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
+        assertNotNull(ExceptionsHelper.unwrap(eue, IllegalStateException.class));
+    }
+
+    public void testNoSuchKeyStaysIoException() {
+        S3Client mockS3 = mock(S3Client.class);
+        NoSuchKeyException missing = NoSuchKeyException.builder().statusCode(404).message("Not Found").build();
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(missing);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        IOException io = expectThrows(IOException.class, obj::newStream);
+        assertEquals("Object not found: " + PATH, io.getMessage());
+        assertSame(missing, io.getCause());
+    }
+}

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectReadFailureTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectReadFailureTests.java
@@ -10,7 +10,9 @@ package org.elasticsearch.xpack.esql.datasource.s3;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.rest.RestStatus;
@@ -64,5 +66,41 @@ public class S3StorageObjectReadFailureTests extends ESTestCase {
         IOException io = expectThrows(IOException.class, obj::newStream);
         assertEquals("Object not found: " + PATH, io.getMessage());
         assertSame(missing, io.getCause());
+    }
+
+    public void testProgrammingIllegalStateExceptionStays500() {
+        S3Client mockS3 = mock(S3Client.class);
+        IllegalStateException ise = new IllegalStateException("broken invariant");
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(ise);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        IllegalStateException thrown = expectThrows(IllegalStateException.class, obj::newStream);
+        assertSame(ise, thrown);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(thrown));
+    }
+
+    public void testClosedClientOnLengthIsUnavailable503() {
+        S3Client mockS3 = mock(S3Client.class);
+        IllegalStateException ise = new IllegalStateException("Connection pool shut down");
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(ise);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::length);
+        assertSame(ise, eue.getCause());
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
+        assertFalse(eue.throttling());
+    }
+
+    public void testClosedClientOnHeadFallbackIsUnavailable503() {
+        S3Client mockS3 = mock(S3Client.class);
+        S3Exception serverError = (S3Exception) S3Exception.builder().statusCode(500).message("Internal Error").build();
+        IllegalStateException ise = new IllegalStateException("Connection pool shut down");
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(serverError);
+        when(mockS3.headObject(any(HeadObjectRequest.class))).thenThrow(ise);
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::length);
+        assertSame(ise, eue.getCause());
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
     }
 }


### PR DESCRIPTION
Parquet recast storage failures as IllegalArgumentException, so a closed S3 client looked like a bad request. Route read-path I/O through ParquetReadFailures and map client IllegalStateException to 503.