### PR TITLE
ESQL: Makes FlattenedFieldExtractBenchmark quicker

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/FlattenedFieldExtractBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/FlattenedFieldExtractBenchmark.java
@@ -221,8 +221,8 @@ import java.util.stream.IntStream;
  * ./gradlew -p benchmarks run --args 'FlattenedFieldExtractBenchmark -f 3'
  * }</pre>
  */
-@Warmup(iterations = 5)
-@Measurement(iterations = 7)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 7, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)


### PR DESCRIPTION
Uses a similar trick to the one in https://github.com/elastic/elasticsearch/pull/157035. That benchmark takes 22 minutes at the moment. With this it should take a 10th of the time (I think).