### PR TITLE
[9.5] ES|QL|DS: Fix throttled reads giving up early on duration budget (#157132)

### DIFF
--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
@@ -133,8 +133,13 @@ public final class AzureStorageObject extends AbstractMeteredStorageObject {
     private Exception mapReadFailure(String context, Throwable cause) {
         if (cause instanceof BlobStorageException bse && ExternalUnavailableException.isRetryableStatus(bse.getStatusCode())) {
             boolean throttling = ExternalUnavailableException.isThrottlingStatus(bse.getStatusCode());
+            long retryAfterMs = 0L;
+            if (throttling && bse.getResponse() != null) {
+                retryAfterMs = ExternalUnavailableException.parseRetryAfterMs(bse.getResponse().getHeaderValue("Retry-After"));
+            }
             return new ExternalUnavailableException(
                 throttling,
+                retryAfterMs,
                 cause,
                 "Azure store unavailable reading [{}] (HTTP {})",
                 path,

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureTransientTypingInputStream.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureTransientTypingInputStream.java
@@ -61,12 +61,16 @@ final class AzureTransientTypingInputStream extends FilterInputStream {
         // rather than reading only the immediate cause. Absent a BlobStorageException, a mid-read transport fault
         // is still transient, just not throttling.
         boolean throttling = false;
+        long retryAfterMs = 0L;
         for (Throwable c = e.getCause(); c != null; c = c.getCause()) {
             if (c instanceof BlobStorageException bse) {
                 throttling = ExternalUnavailableException.isThrottlingStatus(bse.getStatusCode());
+                if (throttling && bse.getResponse() != null) {
+                    retryAfterMs = ExternalUnavailableException.parseRetryAfterMs(bse.getResponse().getHeaderValue("Retry-After"));
+                }
                 break;
             }
         }
-        return new ExternalUnavailableException(throttling, e, "transient read failure for [{}]", path);
+        return new ExternalUnavailableException(throttling, retryAfterMs, e, "transient read failure for [{}]", path);
     }
 }

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -143,8 +143,15 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
     private Exception mapReadFailure(String context, Throwable cause) {
         if (cause instanceof S3Exception s3 && ExternalUnavailableException.isRetryableStatus(s3.statusCode())) {
             boolean throttling = ExternalUnavailableException.isThrottlingStatus(s3.statusCode());
+            long retryAfterMs = 0L;
+            if (throttling && s3.awsErrorDetails() != null && s3.awsErrorDetails().sdkHttpResponse() != null) {
+                retryAfterMs = ExternalUnavailableException.parseRetryAfterMs(
+                    s3.awsErrorDetails().sdkHttpResponse().firstMatchingHeader("Retry-After").orElse(null)
+                );
+            }
             return new ExternalUnavailableException(
                 throttling,
+                retryAfterMs,
                 cause,
                 "S3 store unavailable reading [{}] (HTTP {})",
                 path,

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/TransientTypingInputStream.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/TransientTypingInputStream.java
@@ -62,8 +62,20 @@ final class TransientTypingInputStream extends FilterInputStream implements Abor
     private ExternalUnavailableException wrap(Exception e) {
         // A mid-body read fault is a transport fault (the request already succeeded), so it is always transient;
         // flag throttling for the rare 503/429 surfaced during the body read so it shares the throttle budget.
-        boolean throttling = e instanceof S3Exception s3e && ExternalUnavailableException.isThrottlingStatus(s3e.statusCode());
-        return new ExternalUnavailableException(throttling, e, "transient read failure for [{}]", path);
+        long retryAfterMs = 0L;
+        boolean throttling = false;
+        for (Throwable current = e; current != null; current = current.getCause()) {
+            if (current instanceof S3Exception s3e) {
+                throttling = ExternalUnavailableException.isThrottlingStatus(s3e.statusCode());
+                if (throttling && s3e.awsErrorDetails() != null && s3e.awsErrorDetails().sdkHttpResponse() != null) {
+                    retryAfterMs = ExternalUnavailableException.parseRetryAfterMs(
+                        s3e.awsErrorDetails().sdkHttpResponse().firstMatchingHeader("Retry-After").orElse(null)
+                    );
+                }
+                break;
+            }
+        }
+        return new ExternalUnavailableException(throttling, retryAfterMs, e, "transient read failure for [{}]", path);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryPolicy.java
@@ -20,21 +20,25 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.function.LongSupplier;
 
 /**
  * Retry policy with exponential backoff and jitter for transient storage failures.
- * Supports separate retry budgets for throttling errors (429/503/SlowDown) versus
+ * Supports separate retry semantics for throttling errors (429/503/SlowDown) versus
  * other transient errors (connection reset, socket timeout).
  * <p>
- * Throttling errors are expected under high parallelism and are always transient,
- * so they get a higher retry budget (default 10) with longer backoff delays.
- * Non-throttle transient errors use the standard budget (default 3).
+ * <b>Throttle arm:</b> governed by a wall-clock time budget
+ * ({@code esql.external.throttle_max_retry_duration}, default 30 s). Within the budget the
+ * delay is either the server-supplied {@code Retry-After} hint (when the exception carries one) or the
+ * computed exponential backoff, truncated to the remaining budget so the sleep never overshoots.
+ * The attempt count ({@link #THROTTLE_RETRIES_SANITY_CAP}) acts only as a backstop against a broken clock,
+ * not as the primary bound.
  * <p>
- * Optionally integrates with {@link AdaptiveBackoff} to scale throttle retry delays
- * based on the global throttling pressure observed across all requests on the same provider.
+ * <b>Non-throttle transient arm:</b> bounded by attempt count (default {@link #DEFAULT_MAX_RETRIES})
+ * with an optional secondary time budget check — semantics unchanged from the original design.
  * <p>
- * A total duration budget can also be applied to cap the cumulative time spent retrying,
- * regardless of remaining attempt count.
+ * Optionally integrates with {@link AdaptiveBackoff} to scale throttle retry delays based on
+ * the global throttling pressure observed across all requests on the same provider.
  */
 class RetryPolicy {
 
@@ -44,7 +48,13 @@ class RetryPolicy {
     static final long DEFAULT_INITIAL_DELAY_MS = 200;
     static final long DEFAULT_MAX_DELAY_MS = 5000;
 
-    static final int DEFAULT_THROTTLE_MAX_RETRIES = 10;
+    /**
+     * Sanity backstop on the number of throttle retries — guards against an infinite loop when
+     * the budget is zero or the clock is broken. The effective throttle bound is the time budget
+     * ({@code esql.external.throttle_max_retry_duration}), which is always reached first under
+     * any realistic configuration.
+     */
+    static final int THROTTLE_RETRIES_SANITY_CAP = 10;
     static final long DEFAULT_THROTTLE_INITIAL_DELAY_MS = 500;
     static final long DEFAULT_THROTTLE_MAX_DELAY_MS = 30_000;
 
@@ -56,7 +66,7 @@ class RetryPolicy {
         DEFAULT_MAX_RETRIES,
         DEFAULT_INITIAL_DELAY_MS,
         DEFAULT_MAX_DELAY_MS,
-        DEFAULT_THROTTLE_MAX_RETRIES,
+        THROTTLE_RETRIES_SANITY_CAP,
         DEFAULT_THROTTLE_INITIAL_DELAY_MS,
         DEFAULT_THROTTLE_MAX_DELAY_MS,
         NO_BUDGET,
@@ -71,6 +81,7 @@ class RetryPolicy {
     private final long throttleMaxDelayMs;
     private final long maxTotalDurationMs;
     private final AdaptiveBackoff adaptiveBackoff;
+    private final LongSupplier clockNanos;
 
     RetryPolicy(
         int maxRetries,
@@ -82,6 +93,30 @@ class RetryPolicy {
         long maxTotalDurationMs,
         AdaptiveBackoff adaptiveBackoff
     ) {
+        this(
+            maxRetries,
+            initialDelayMs,
+            maxDelayMs,
+            throttleMaxRetries,
+            throttleInitialDelayMs,
+            throttleMaxDelayMs,
+            maxTotalDurationMs,
+            adaptiveBackoff,
+            null
+        );
+    }
+
+    private RetryPolicy(
+        int maxRetries,
+        long initialDelayMs,
+        long maxDelayMs,
+        int throttleMaxRetries,
+        long throttleInitialDelayMs,
+        long throttleMaxDelayMs,
+        long maxTotalDurationMs,
+        AdaptiveBackoff adaptiveBackoff,
+        LongSupplier clockNanos
+    ) {
         this.maxRetries = maxRetries;
         this.initialDelayMs = initialDelayMs;
         this.maxDelayMs = maxDelayMs;
@@ -90,6 +125,7 @@ class RetryPolicy {
         this.throttleMaxDelayMs = throttleMaxDelayMs;
         this.maxTotalDurationMs = maxTotalDurationMs;
         this.adaptiveBackoff = adaptiveBackoff;
+        this.clockNanos = clockNanos != null ? clockNanos : System::nanoTime;
     }
 
     RetryPolicy(int maxRetries, long initialDelayMs, long maxDelayMs) {
@@ -102,8 +138,8 @@ class RetryPolicy {
 
     /**
      * Returns a new policy with the same retry parameters but constrained by a total duration budget.
-     * When the elapsed time plus the next delay would exceed the budget, the operation fails immediately
-     * rather than sleeping and retrying.
+     * For the throttle arm the budget is the primary bound: the delay is truncated to the remaining budget
+     * rather than causing a refusal, so the budget is genuinely spent before giving up.
      */
     RetryPolicy withTotalDurationBudget(long budgetMs) {
         return new RetryPolicy(
@@ -114,7 +150,8 @@ class RetryPolicy {
             throttleInitialDelayMs,
             throttleMaxDelayMs,
             budgetMs,
-            adaptiveBackoff
+            adaptiveBackoff,
+            clockNanos
         );
     }
 
@@ -127,7 +164,8 @@ class RetryPolicy {
             throttleInitialDelayMs,
             throttleMaxDelayMs,
             maxTotalDurationMs,
-            backoff
+            backoff,
+            clockNanos
         );
     }
 
@@ -140,7 +178,23 @@ class RetryPolicy {
             throttleInitialMs,
             throttleMaxMs,
             maxTotalDurationMs,
-            adaptiveBackoff
+            adaptiveBackoff,
+            clockNanos
+        );
+    }
+
+    /** Returns a new policy that uses the given clock supplier instead of {@code System::nanoTime}. For testing only. */
+    RetryPolicy withClock(LongSupplier clock) {
+        return new RetryPolicy(
+            maxRetries,
+            initialDelayMs,
+            maxDelayMs,
+            throttleMaxRetries,
+            throttleInitialDelayMs,
+            throttleMaxDelayMs,
+            maxTotalDurationMs,
+            adaptiveBackoff,
+            clock
         );
     }
 
@@ -209,29 +263,78 @@ class RetryPolicy {
 
     /**
      * The shared retry decision used by every retry driver — sync {@link #execute}, async reads, and the
-     * mid-read resume. Classifies the fault, applies the throttle-vs-normal budget against {@code attempt}
-     * (retries already made), feeds the adaptive backoff on a throttle, and checks the total-time budget against
-     * {@code startNanos}. Returns the backoff to wait before retrying, or {@link RetryDecision#GIVE_UP}. Having
-     * one decision point keeps every driver's classification/budget/backoff identical (the throttle signal that
-     * used to drift between hand-rolled loops cannot diverge here).
+     * mid-read resume. Classifies the fault, applies the appropriate bound against {@code attempt}
+     * (retries already made), feeds the adaptive backoff on a throttle, and checks the time budget against
+     * {@code startNanos}. Returns the backoff to wait before retrying, or {@link RetryDecision#GIVE_UP}.
+     * Having one decision point keeps every driver's classification/budget/backoff identical.
+     * <p>
+     * <b>Throttle arm:</b> the time budget is the primary bound. The delay is truncated to the remaining
+     * budget rather than causing a refusal, so the budget is genuinely spent before giving up. When the
+     * exception carries a server-supplied {@code Retry-After} hint, that hint is used as the delay; if it
+     * exceeds the remaining budget the operation gives up immediately (retrying before the store's stated
+     * wait is spam, not resilience). {@link #throttleMaxRetries} acts as a sanity cap only.
+     * <p>
+     * <b>Non-throttle arm:</b> attempt count is the primary bound; the time budget is a secondary check.
      */
     RetryDecision decide(Throwable e, int attempt, long startNanos) {
         boolean isThrottle = isThrottlingError(e);
         boolean isTransient = isThrottle || isTransientStorageError(e);
-        int effectiveMaxRetries = isThrottle ? throttleMaxRetries : maxRetries;
-        if (isTransient == false || attempt >= effectiveMaxRetries) {
+        if (isTransient == false) {
             return RetryDecision.GIVE_UP;
         }
-        long delay = delayMillis(attempt, isThrottle);
-        if (maxTotalDurationMs > 0 && (System.nanoTime() - startNanos) / 1_000_000 + delay > maxTotalDurationMs) {
-            return RetryDecision.GIVE_UP;
+
+        if (isThrottle) {
+            // Throttle arm: budget-governed; attempt count is a sanity backstop only.
+            if (attempt >= throttleMaxRetries) {
+                return RetryDecision.GIVE_UP;
+            }
+            long retryAfterMs = retryAfterMsFromChain(e);
+            long elapsedMs = (clockNanos.getAsLong() - startNanos) / 1_000_000;
+
+            long delay;
+            if (retryAfterMs > 0) {
+                // Honor the server's hint, capped at our maximum configured delay so a broken server cannot
+                // cause an unbounded sleep. If the capped hint still exceeds the remaining budget, give up:
+                // retrying before the store's stated wait is spam, not resilience.
+                long cappedHint = Math.min(retryAfterMs, throttleMaxDelayMs);
+                if (maxTotalDurationMs > 0 && elapsedMs + cappedHint > maxTotalDurationMs) {
+                    return RetryDecision.GIVE_UP;
+                }
+                delay = cappedHint;
+            } else {
+                long computed = delayMillis(attempt, true);
+                if (maxTotalDurationMs > 0) {
+                    long remainingMs = maxTotalDurationMs - elapsedMs;
+                    if (remainingMs < throttleInitialDelayMs) {
+                        // Remaining budget is less than the minimum meaningful retry sleep. Starting
+                        // another attempt only to truncate the delay to near-zero is wasteful; treat the
+                        // budget as spent. The hint path uses a tighter test (hint > remaining) because
+                        // the server told us exactly how long to wait — a partial hint is useless.
+                        return RetryDecision.GIVE_UP;
+                    }
+                    // Truncate to remaining budget so the sleep never overshoots.
+                    delay = Math.min(computed, remainingMs);
+                } else {
+                    delay = computed;
+                }
+            }
+
+            // Feed the cross-request adaptive backoff only once we've committed to retrying.
+            if (adaptiveBackoff != null) {
+                adaptiveBackoff.onThrottled();
+            }
+            return new RetryDecision(true, delay);
+        } else {
+            // Non-throttle transient arm: attempt count is the effective bound.
+            if (attempt >= maxRetries) {
+                return RetryDecision.GIVE_UP;
+            }
+            long delay = delayMillis(attempt, false);
+            if (maxTotalDurationMs > 0 && (clockNanos.getAsLong() - startNanos) / 1_000_000 + delay > maxTotalDurationMs) {
+                return RetryDecision.GIVE_UP;
+            }
+            return new RetryDecision(true, delay);
         }
-        // Feed the cross-request adaptive backoff only once we've committed to retrying — no point ramping it
-        // when we're about to give up on the budget or the time limit.
-        if (isThrottle && adaptiveBackoff != null) {
-            adaptiveBackoff.onThrottled();
-        }
-        return new RetryDecision(true, delay);
     }
 
     <T> T execute(IOSupplier<T> operation, String operationName, StoragePath path) throws IOException {
@@ -271,7 +374,7 @@ class RetryPolicy {
                 throw e;
             }
         }
-        long startNanos = System.nanoTime();
+        long startNanos = clockNanos.getAsLong();
         long totalBackoffMillis = 0;
         int maxAttempts = Math.max(maxRetries, throttleMaxRetries);
         for (int attempt = 0; attempt <= maxAttempts; attempt++) {
@@ -321,6 +424,16 @@ class RetryPolicy {
         if (adaptiveBackoff != null) {
             adaptiveBackoff.onSuccess();
         }
+    }
+
+    /** Walks the cause chain to extract a server-supplied {@code Retry-After} hint, mirroring {@link #isThrottlingError}. */
+    private static long retryAfterMsFromChain(Throwable e) {
+        for (Throwable current = e; current != null; current = current.getCause()) {
+            if (current instanceof ExternalUnavailableException eue && eue.retryAfterMs() > 0) {
+                return eue.retryAfterMs();
+            }
+        }
+        return 0L;
     }
 
     static boolean isThrottlingError(Throwable t) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalUnavailableException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalUnavailableException.java
@@ -28,30 +28,66 @@ import org.elasticsearch.rest.RestStatus;
 public final class ExternalUnavailableException extends ExternalException {
 
     private final boolean throttling;
+    /** Server-supplied wait hint in milliseconds; 0 means absent. */
+    private final long retryAfterMs;
 
     public ExternalUnavailableException(String message, Throwable cause) {
         super(message, cause);
         this.throttling = false;
+        this.retryAfterMs = 0L;
     }
 
     public ExternalUnavailableException(Throwable cause, String message, Object... args) {
         super(cause, message, args);
         this.throttling = false;
+        this.retryAfterMs = 0L;
     }
 
     public ExternalUnavailableException(String message, Object... args) {
         super(message, args);
         this.throttling = false;
+        this.retryAfterMs = 0L;
     }
 
     public ExternalUnavailableException(boolean throttling, Throwable cause, String message, Object... args) {
         super(cause, message, args);
         this.throttling = throttling;
+        this.retryAfterMs = 0L;
     }
 
     public ExternalUnavailableException(boolean throttling, String message, Object... args) {
         super(message, args);
         this.throttling = throttling;
+        this.retryAfterMs = 0L;
+    }
+
+    /**
+     * Constructs a throttle exception carrying an explicit server-supplied retry-after hint.
+     *
+     * @param throttling     {@code true} for a 429/503 throttle signal
+     * @param retryAfterMs   server-suggested wait in milliseconds; 0 means absent
+     * @param cause          underlying cause
+     * @param message        format string
+     * @param args           format arguments
+     */
+    public ExternalUnavailableException(boolean throttling, long retryAfterMs, Throwable cause, String message, Object... args) {
+        super(cause, message, args);
+        this.throttling = throttling;
+        this.retryAfterMs = retryAfterMs > 0 ? retryAfterMs : 0L;
+    }
+
+    /**
+     * Constructs a throttle exception carrying an explicit server-supplied retry-after hint (no cause).
+     *
+     * @param throttling     {@code true} for a 429/503 throttle signal
+     * @param retryAfterMs   server-suggested wait in milliseconds; 0 means absent
+     * @param message        format string
+     * @param args           format arguments
+     */
+    public ExternalUnavailableException(boolean throttling, long retryAfterMs, String message, Object... args) {
+        super(message, args);
+        this.throttling = throttling;
+        this.retryAfterMs = retryAfterMs > 0 ? retryAfterMs : 0L;
     }
 
     @Override
@@ -65,6 +101,36 @@ public final class ExternalUnavailableException extends ExternalException {
      */
     public boolean throttling() {
         return throttling;
+    }
+
+    /**
+     * Server-supplied retry-after hint in milliseconds, or {@code 0} if the server sent no hint.
+     * When non-zero, the retry policy uses this as the backoff delay instead of its computed value,
+     * provided the hint fits within the remaining time budget.
+     */
+    public long retryAfterMs() {
+        return retryAfterMs;
+    }
+
+    /**
+     * Parses a {@code Retry-After} HTTP header value (integer seconds as sent by S3, Azure, and GCS)
+     * to milliseconds. Returns {@code 0} if the value is absent, blank, non-positive, or unparseable
+     * (the HTTP-date form is not supported — cloud stores use integer seconds in practice).
+     */
+    public static long parseRetryAfterMs(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return 0L;
+        }
+        try {
+            long seconds = Long.parseLong(headerValue.strip());
+            if (seconds <= 0) {
+                return 0L;
+            }
+            // Cap before multiplying to avoid overflow; no real server sends more than a day.
+            return Math.min(seconds, 86_400L) * 1000L;
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryPolicyTests.java
@@ -25,8 +25,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class RetryPolicyTests extends ESTestCase {
 
@@ -356,16 +358,17 @@ public class RetryPolicyTests extends ESTestCase {
     }
 
     public void testDecideDoesNotRampAdaptiveBackoffWhenGivingUp() {
-        // The onThrottled() feed sits AFTER the give-up + time-budget checks in decide(), so abandoning a
-        // throttle must not ramp the cross-request multiplier. Pins that ordering.
+        // The onThrottled() feed sits AFTER the give-up checks in decide(), so abandoning a throttle
+        // must not ramp the cross-request multiplier. Pins that ordering.
         AtomicLong clock = new AtomicLong(0);
         AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, clock::get);
         RetryPolicy policy = RetryPolicy.DEFAULT.withAdaptiveBackoff(backoff);
         ExternalUnavailableException throttle = new ExternalUnavailableException(true, (Throwable) null, "throttled (HTTP 503)");
 
-        // Budget exhausted (attempt == throttleMaxRetries) -> GIVE_UP, and the backoff must stay at baseline.
+        // Sanity cap reached (attempt == throttleMaxRetries / THROTTLE_RETRIES_SANITY_CAP) -> GIVE_UP,
+        // and the backoff must stay at baseline.
         RetryPolicy.RetryDecision giveUp = policy.decide(throttle, policy.throttleMaxRetries(), System.nanoTime());
-        assertFalse("an exhausted-budget throttle must give up", giveUp.retry());
+        assertFalse("sanity-cap throttle must give up", giveUp.retry());
         assertEquals("giving up must not ramp the adaptive backoff", 1, backoff.currentMultiplier());
 
         // Positive control: a within-budget throttle commits to a retry and DOES ramp the backoff.
@@ -376,7 +379,7 @@ public class RetryPolicyTests extends ESTestCase {
 
     public void testThrottleMaxRetriesAccessor() {
         RetryPolicy policy = RetryPolicy.DEFAULT;
-        assertEquals(RetryPolicy.DEFAULT_THROTTLE_MAX_RETRIES, policy.throttleMaxRetries());
+        assertEquals(RetryPolicy.THROTTLE_RETRIES_SANITY_CAP, policy.throttleMaxRetries());
     }
 
     public void testWithThrottleConfig() {
@@ -491,5 +494,187 @@ public class RetryPolicyTests extends ESTestCase {
 
         assertEquals("ok", result);
         assertEquals(3, calls.get());
+    }
+
+    // --- Budget-governed throttle arm tests ---
+
+    public void testThrottleRetriesAreNotTruncatedByTheDurationBudget() {
+        // Acceptance test: esql-planning#1658.
+        // Production config: RetryPolicy.DEFAULT + 30s budget (what StorageProviderRegistry.buildRetryPolicy
+        // produces from esql.external.throttle_max_retry_duration). A fast injected clock lets the test run
+        // without real sleeps. The loop advances the clock by each decision's delay and counts retries until
+        // GIVE_UP; the budget must be genuinely spent, not truncated by an attempt-count limit.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(30_000).withClock(clockNanos::get);
+        long startNanos = 0L;
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, "throttled");
+        int retries = 0;
+        RetryPolicy.RetryDecision decision;
+        do {
+            decision = policy.decide(throttle, retries, startNanos);
+            if (decision.retry()) {
+                clockNanos.addAndGet(decision.delayMillis() * 1_000_000L);
+                retries++;
+            }
+        } while (decision.retry());
+
+        long elapsedMs = clockNanos.get() / 1_000_000L;
+        // Must exceed the old attempt-count limit of 5 — budget, not attempt count, is the governing bound.
+        assertThat("retries should be budget-governed, not attempt-count-limited", retries, greaterThan(5));
+        // Must not overshoot the budget.
+        assertThat("clock must not exceed the budget", elapsedMs, lessThanOrEqualTo(30_000L));
+        // Budget must be nearly spent (within one initial delay of exhaustion).
+        assertThat(
+            "budget must be nearly spent before giving up",
+            elapsedMs,
+            greaterThan(30_000L - RetryPolicy.DEFAULT_THROTTLE_INITIAL_DELAY_MS)
+        );
+    }
+
+    public void testRetryAfterHintIsUsedAsDelay() {
+        // When the exception carries a Retry-After hint, that hint must be used as the delay.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(30_000).withClock(clockNanos::get);
+        long hint = 5_000L;
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, hint, "throttled with hint");
+
+        RetryPolicy.RetryDecision decision = policy.decide(throttle, 0, 0L);
+
+        assertTrue("must retry within budget", decision.retry());
+        assertEquals("delay must equal the server hint", hint, decision.delayMillis());
+    }
+
+    public void testRetryAfterHintExceedingBudgetGivesUp() {
+        // When the (capped) hint exceeds the remaining budget, retrying before the stated wait is spam;
+        // the policy must give up immediately rather than use a shorter delay.
+        // Use a hint of 20s against a 10s budget (hint stays under throttleMaxDelayMs=30s so it is not capped).
+        AtomicLong clockNanos = new AtomicLong(0L);
+        long budget = 10_000L;
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(budget).withClock(clockNanos::get);
+        long hint = 20_000L;
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, hint, "throttled with large hint");
+
+        RetryPolicy.RetryDecision decision = policy.decide(throttle, 0, 0L);
+
+        assertFalse("hint exceeds budget — must give up", decision.retry());
+    }
+
+    public void testRetryAfterHintCappedAtMaxThrottleDelay() {
+        // A pathological server returning Retry-After: 86400 (one day) must not cause an unbounded sleep;
+        // the hint is capped at throttleMaxDelayMs.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withClock(clockNanos::get);
+        long hint = 86_400_000L;
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, hint, "throttled with huge hint");
+
+        RetryPolicy.RetryDecision decision = policy.decide(throttle, 0, 0L);
+
+        assertTrue("must retry", decision.retry());
+        assertThat(
+            "delay must be capped at throttleMaxDelayMs",
+            decision.delayMillis(),
+            lessThanOrEqualTo(RetryPolicy.DEFAULT_THROTTLE_MAX_DELAY_MS)
+        );
+    }
+
+    public void testRetryAfterHintFromWrappedException() {
+        // isThrottlingError() walks the cause chain; retryAfterMs must too — a hint on a wrapped
+        // ExternalUnavailableException must not be silently discarded.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(30_000).withClock(clockNanos::get);
+        long hint = 5_000L;
+        ExternalUnavailableException inner = new ExternalUnavailableException(true, hint, "throttled");
+        RuntimeException wrapper = new RuntimeException("outer wrapper", inner);
+
+        RetryPolicy.RetryDecision decision = policy.decide(wrapper, 0, 0L);
+
+        assertTrue("wrapped throttle must retry", decision.retry());
+        assertEquals("hint must be extracted from cause chain", hint, decision.delayMillis());
+    }
+
+    public void testComputedThrottleDelayTruncatesToRemainingBudget() {
+        // When the computed backoff exceeds the remaining budget, the delay is truncated (not refused),
+        // so the last retry sleeps out the remaining budget rather than giving up with time left.
+        long budget = 30_000L;
+        long elapsed = 29_000L;  // 1s remaining
+        AtomicLong clockNanos = new AtomicLong(elapsed * 1_000_000L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(budget).withClock(clockNanos::get);
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, "throttled");
+
+        // At attempt 5, the computed delay would be ~16s — far beyond the 1s remaining.
+        RetryPolicy.RetryDecision decision = policy.decide(throttle, 5, 0L);
+
+        assertTrue("should still retry with truncated delay", decision.retry());
+        assertThat("delay must be capped at remaining budget", decision.delayMillis(), lessThanOrEqualTo(budget - elapsed));
+    }
+
+    public void testAdaptiveMultiplierAt16xStillYieldsFullBudget() {
+        // Before the fix, a 16x adaptive multiplier caused the budget check to refuse retry 3 of 5 because
+        // the inflated delay exceeded the remaining budget. With truncation, the multiplier changes pacing
+        // within the budget but cannot convert pressure into early give-up.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        AdaptiveBackoff backoff = new AdaptiveBackoff(AdaptiveBackoff.MAX_MULTIPLIER, () -> 0L);
+        // Ramp to the 16x cap.
+        for (int i = 0; i < 8; i++) {
+            backoff.onThrottled();
+        }
+        assertEquals("backoff must be at the cap for this test", AdaptiveBackoff.MAX_MULTIPLIER, backoff.currentMultiplier());
+
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(30_000).withAdaptiveBackoff(backoff).withClock(clockNanos::get);
+        ExternalUnavailableException throttle = new ExternalUnavailableException(true, "throttled");
+        int retries = 0;
+        RetryPolicy.RetryDecision decision;
+        do {
+            decision = policy.decide(throttle, retries, 0L);
+            if (decision.retry()) {
+                clockNanos.addAndGet(decision.delayMillis() * 1_000_000L);
+                retries++;
+            }
+        } while (decision.retry());
+
+        // At 16x the first computed delay is 8000ms (500ms * 16); jitter can make the first two delays consume
+        // most of the 30s budget, so the retry count is not deterministic. The invariant is that the budget is
+        // genuinely exhausted: remaining < throttleInitialDelayMs triggers give-up, so elapsed >= 29_500ms.
+        // Before the fix, the clock stopped at ~24_000ms because the inflated delay was refused rather than truncated.
+        assertThat(
+            "16x multiplier must not cause early give-up (pre-fix clock stopped at ~24000ms)",
+            clockNanos.get() / 1_000_000L,
+            greaterThan(29_000L)
+        );
+        assertThat("clock must not exceed budget", clockNanos.get() / 1_000_000L, lessThanOrEqualTo(30_000L));
+    }
+
+    public void testRetryAfterHintZeroFallsBackToComputedDelay() {
+        // retryAfterMs == 0 means absent — must use the computed exponential backoff.
+        AtomicLong clockNanos = new AtomicLong(0L);
+        RetryPolicy policy = RetryPolicy.DEFAULT.withTotalDurationBudget(30_000).withClock(clockNanos::get);
+        ExternalUnavailableException noHint = new ExternalUnavailableException(true, 0L, "throttled no hint");
+
+        RetryPolicy.RetryDecision decision = policy.decide(noHint, 0, 0L);
+
+        assertTrue("must retry", decision.retry());
+        // Computed delay for attempt 0 is 500ms + jitter; it must be at least the initial delay.
+        assertThat(
+            "delay must be at least the initial delay",
+            decision.delayMillis(),
+            greaterThan(RetryPolicy.DEFAULT_THROTTLE_INITIAL_DELAY_MS / 2)
+        );
+    }
+
+    public void testParseRetryAfterMs() {
+        assertEquals(5_000L, ExternalUnavailableException.parseRetryAfterMs("5"));
+        assertEquals(60_000L, ExternalUnavailableException.parseRetryAfterMs("60"));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs(null));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs(""));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs("  "));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs("abc"));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs("0"));
+        assertEquals(0L, ExternalUnavailableException.parseRetryAfterMs("-1"));
+        assertEquals(1_000L, ExternalUnavailableException.parseRetryAfterMs(" 1 "));
+        // Values above 86400s (1 day) are capped to prevent overflow on multiplication.
+        assertEquals(86_400_000L, ExternalUnavailableException.parseRetryAfterMs("99999999999999999"));
+        assertEquals(86_400_000L, ExternalUnavailableException.parseRetryAfterMs("86401"));
+        assertEquals(86_400_000L, ExternalUnavailableException.parseRetryAfterMs("86400"));
+        assertEquals(86_399_000L, ExternalUnavailableException.parseRetryAfterMs("86399"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ES|QL|DS: Fix throttled reads giving up early on duration budget (#157132)