### PR TITLE
[DOCS] GPU vector indexing: update example Dockerfile for 9.5 (libcuvs 26.x from NVIDIA redist)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/_snippets/docker-gpu-indexing.md
+++ b/docs/reference/elasticsearch/mapping-reference/_snippets/docker-gpu-indexing.md
@@ -1,5 +1,5 @@
 ```plaintext
-FROM docker.elastic.co/elasticsearch/elasticsearch:9.3.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.5.1
 
 USER root
 
@@ -7,7 +7,11 @@ USER root
 # and https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.9.1/ubi9/devel/Dockerfile?ref_type=heads
 # We are installing nvidia/cuda drivers/libraries the same way that nvidia does in their images
 
-ENV CUVS_VERSION=25.12.0
+# libcuvs version. It must be at least the cuvs-java version bundled with this
+# Elasticsearch release (see modules/gpu/cuvs-java-<version>.jar); 26.04 is the
+# version Elasticsearch 9.5 is tested with. For 9.3.x and 9.4.x use 25.12 instead
+# (see the note below this Dockerfile).
+ENV CUVS_NATIVE_VERSION=26.04.00.194111
 
 ENV NVARCH=x86_64
 ENV NVIDIA_REQUIRE_CUDA="cuda>=12.9 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571"
@@ -71,17 +75,20 @@ RUN dnf install -y \
     && dnf clean all \
     && rm -rf /var/cache/yum/*
 
-# Grab the libcuvs library from Elastic's gcs archive
-# These are tarballs that contain only the libraries necessary from nvidia's libcuvs builds in conda
-# Note: this is temporary until nvidia begins publishing minimal libcuvs tarballs along with their releases
+# Grab libcuvs from NVIDIA's redistributable archives
+# (https://developer.download.nvidia.com/compute/cuvs/redist/). The archive
+# contains a single self-contained libcuvs_c shared library that only depends
+# on the CUDA libraries installed above.
+RUN dnf install -y xz && dnf clean all && rm -rf /var/cache/yum/*
 RUN mkdir -p "$LIBCUVS_DIR" && \
     chmod 775 "$LIBCUVS_DIR" && \
     cd "$LIBCUVS_DIR" && \
-    CUVS_ARCHIVE="libcuvs-$CUVS_VERSION.tar.gz" && \
-    curl -fO "https://storage.googleapis.com/elasticsearch-cuvs-snapshots/libcuvs/$CUVS_ARCHIVE" && \
-    tar -xzf "$CUVS_ARCHIVE" && \
-    rm -f "$CUVS_ARCHIVE" && \
-    if [[ -d "$CUVS_VERSION" ]]; then mv "$CUVS_VERSION/*" ./; fi
+    CUVS_ARCHIVE="libcuvs-linux-x86_64-${CUVS_NATIVE_VERSION}_cuda12-archive" && \
+    curl -fO "https://developer.download.nvidia.com/compute/cuvs/redist/libcuvs/linux-x86_64/${CUVS_ARCHIVE}.tar.xz" && \
+    tar -xJf "${CUVS_ARCHIVE}.tar.xz" && \
+    rm -f "${CUVS_ARCHIVE}.tar.xz" && \
+    mv "${CUVS_ARCHIVE}"/lib/libcuvs_c.so* ./ && \
+    rm -rf "${CUVS_ARCHIVE}"
 
 # Reset the user back to elasticsearch
 USER 1000:0

--- a/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
+++ b/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
@@ -61,7 +61,7 @@ bundle cuvs-java 26.02 and require libcuvs 26.02 or later (26.04 is the tested
 version, as in the Dockerfile above). {{es}} 9.3 and 9.4 bundle cuvs-java 25.12
 and require libcuvs 25.12, available from
 `https://storage.googleapis.com/elasticsearch-cuvs-snapshots/libcuvs/libcuvs-25.12.0.tar.gz`
-(replace the libcuvs step above with a download and extraction of that archive
+(replace the libcuvs download step in the example Dockerfile with a download and extraction of that archive
 into `$LIBCUVS_DIR`).
 ::::
 
@@ -144,7 +144,7 @@ indexing is not being used, such as an unsupported environment, missing
 libraries, or an incompatible GPU.
 
 
-### GPU indexing is disabled with a `Version mismatch: outdated libcuvs_c` warning
+### GPU indexing is unavailable with a `Version mismatch: outdated libcuvs_c` warning
 
 If the node logs a warning like:
 
@@ -157,7 +157,7 @@ the libcuvs library on `LD_LIBRARY_PATH` is older than the `cuvs-java`
 version bundled with {{es}}. Install a libcuvs version that is at least the
 bundled `cuvs-java` version (see the note under the example Dockerfile) and
 restart the node. With `vectors.indexing.use_gpu: auto` (the default) the node
-starts and silently falls back to CPU indexing in this case; use
+starts and silently falls back to CPU indexing in this case. Use
 `vectors.indexing.use_gpu: true` to make the node fail to start instead.
 
 ### Node fails to start with `vectors.indexing.use_gpu: true`

--- a/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
+++ b/docs/reference/elasticsearch/mapping-reference/gpu-vector-indexing.md
@@ -54,6 +54,17 @@ like our official Docker images.
 :::
 ::::
 
+::::{note}
+The libcuvs version must match the `cuvs-java` version bundled with your
+{{es}} release (`modules/gpu/cuvs-java-<version>.jar`): {{es}} 9.5 and later
+bundle cuvs-java 26.02 and require libcuvs 26.02 or later (26.04 is the tested
+version, as in the Dockerfile above). {{es}} 9.3 and 9.4 bundle cuvs-java 25.12
+and require libcuvs 25.12, available from
+`https://storage.googleapis.com/elasticsearch-cuvs-snapshots/libcuvs/libcuvs-25.12.0.tar.gz`
+(replace the libcuvs step above with a download and extraction of that archive
+into `$LIBCUVS_DIR`).
+::::
+
 ### Requirements
 
 The host machine running the Docker container needs
@@ -132,6 +143,22 @@ If you don't see this message, look for warning messages explaining why GPU
 indexing is not being used, such as an unsupported environment, missing
 libraries, or an incompatible GPU.
 
+
+### GPU indexing is disabled with a `Version mismatch: outdated libcuvs_c` warning
+
+If the node logs a warning like:
+
+```
+GPU based vector indexing is not supported on this platform; Cannot create JDKProvider:
+Version mismatch: outdated libcuvs_c (libcuvs_c [25.12.0], cuvs-java version [26.02.0])
+```
+
+the libcuvs library on `LD_LIBRARY_PATH` is older than the `cuvs-java`
+version bundled with {{es}}. Install a libcuvs version that is at least the
+bundled `cuvs-java` version (see the note under the example Dockerfile) and
+restart the node. With `vectors.indexing.use_gpu: auto` (the default) the node
+starts and silently falls back to CPU indexing in this case; use
+`vectors.indexing.use_gpu: true` to make the node fail to start instead.
 
 ### Node fails to start with `vectors.indexing.use_gpu: true`
 


### PR DESCRIPTION
Closes #157279

## Summary

The GPU vector indexing page's example Dockerfile still targets 9.3.0 with libcuvs 25.12.0 from the interim GCS repack. Elasticsearch **9.5.x bundles `cuvs-java-26.02.0`** and refuses that library:

```
GPU based vector indexing is not supported on this platform; Cannot create JDKProvider:
Version mismatch: outdated libcuvs_c (libcuvs_c [25.12.0], cuvs-java version [26.02.0])
```

Under `vectors.indexing.use_gpu: auto` (the default) this only logs a WARN and the node silently indexes on CPU, so users following the docs on 9.5 get no GPU acceleration and no error.

This PR:
- updates the example Dockerfile to `9.5.1` and fetches **libcuvs `26.04.00.194111`** from NVIDIA's redistributable archives (`developer.download.nvidia.com/compute/cuvs/redist/`) — the same source `.buildkite/scripts/cuvs-snapshot/configure.sh` uses via `cuvs_native` in `build-tools-internal/version.properties` — which also removes the "temporary until NVIDIA publishes minimal tarballs" GCS dependency;
- adds a note about the cuvs-java ↔ libcuvs pairing (9.3/9.4 → 25.12 from the GCS archive; 9.5+ → 26.02+);
- adds a troubleshooting entry for the version-mismatch warning.

The 9.5 line uses a single self-contained `libcuvs_c.so`, so the bundled `libstdc++`/`librmm`/`librapids_logger` from the old tarball are no longer needed; the stock UBI9 `libstdc++`, `libgomp` and the CUDA 12.9 packages already installed by the Dockerfile satisfy its dependencies.

## Verification

Built the updated Dockerfile as-is and ran it on an RTX PRO 6000 Blackwell (host driver 580.105.08 / CUDA 13.0, NVIDIA Container Toolkit 1.18.1, Ubuntu 24.04):

```
INFO Found compatible GPU [NVIDIA RTX PRO 6000 Blackwell Workstation Edition] (id: [0])
GET _xpack/usage → "gpu_vector_indexing": {"available": true, "enabled": true, ...}
```
Indexed and force-merged 200k × 1024-d `int8_hnsw` vectors with GPU builds observed (`index_build_count` incrementing, `nvidia-smi` activity).

## Not covered here (for the owners to decide)
- The [support matrix](https://www.elastic.co/support/matrix) currently lists cuVS 2025.12 for 9.3/9.4 only; 9.5 should say cuVS 26.02+ (tested 26.04).
- The `NVIDIA_REQUIRE_CUDA` string in the example enumerates driver ranges up to 570; the bare `cuda>=12.9` term still matches newer drivers (verified on 580), so left unchanged.
