### PR TITLE
[ESQL] Charge Arrow pages against MaxDirectMemorySize

### DIFF
--- a/docs/changelog/157281.yaml
+++ b/docs/changelog/157281.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157281
+summary: Charge Arrow pages against `MaxDirectMemorySize`
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -503,6 +503,10 @@ public class JvmInfo implements ReportingService.Info {
             return ByteSizeValue.ofBytes(heapMax);
         }
 
+        public ByteSizeValue getDirectMemoryMax() {
+            return ByteSizeValue.ofBytes(directMemoryMax);
+        }
+
         public ByteSizeValue getTotalMax() {
             return ByteSizeValue.ofBytes(heapMax + nonHeapMax + directMemoryMax);
         }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
@@ -12,6 +12,8 @@ package org.elasticsearch.monitor.jvm;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
 public class JvmInfoTests extends ESTestCase {
 
     public void testUseG1GC() {
@@ -23,6 +25,10 @@ public class JvmInfoTests extends ESTestCase {
         } else {
             assertEquals("unknown", JvmInfo.jvmInfo().useG1GC());
         }
+    }
+
+    public void testDirectMemoryMax() {
+        assertThat(JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes(), greaterThanOrEqualTo(0L));
     }
 
     private boolean isG1GCEnabled() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -18,6 +16,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.compute.data.Block.MvOrdering;
 import org.elasticsearch.compute.data.arrow.CircuitBreakerAllocationListener;
+import org.elasticsearch.compute.data.arrow.DirectBufferAllocationManager;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -41,15 +40,6 @@ public class BlockFactory {
     public static final ByteSizeValue DEFAULT_BYTES_REF_RAM_OVERESTIMATE_THRESHOLD = ByteSizeValue.ofMb(1);
     // The same as PlannerSettings.BYTES_REF_RAM_OVERESTIMATE_FACTOR
     public static final double DEFAULT_BYTES_REF_RAM_OVERESTIMATE_FACTOR = 2.5;
-
-    /**
-     * Exact-fit rounding policy for the Arrow root allocator. We use {@code arrow-memory-unsafe},
-     * whose {@code UnsafeAllocationManager} is a straight malloc/free with no free list or size
-     * classes. The default power-of-two rounding exists to feed a pooled allocator
-     * ({@code arrow-memory-netty}); without that pool, it only wastes memory (up to 2x for
-     * sub-16 MiB allocations). Pass this policy to let the OS allocator handle alignment.
-     */
-    private static final RoundingPolicy EXACT_FIT_ROUNDING_POLICY = requestSize -> requestSize;
 
     private static final Logger log = LogManager.getLogger(BlockFactory.class);
 
@@ -100,9 +90,13 @@ public class BlockFactory {
             synchronized (this) {
                 if (arrowAllocator == null) {
                     if (this.parent == null) {
-                        // Root block factory
+                        // Root block factory. DirectByteBuffer backing so Arrow is visible to
+                        // MaxDirectMemorySize; cap is MaxDirect minus a small NIO reserve.
                         var listener = new CircuitBreakerAllocationListener(breaker);
-                        var allocator = new RootAllocator(listener, Long.MAX_VALUE, EXACT_FIT_ROUNDING_POLICY);
+                        var allocator = DirectBufferAllocationManager.createRootAllocator(
+                            listener,
+                            DirectBufferAllocationManager.arrowDirectMemoryLimit()
+                        );
                         cleaner.register(this, () -> {
                             try {
                                 allocator.close();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListener.java
@@ -8,10 +8,16 @@
 package org.elasticsearch.compute.data.arrow;
 
 import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationOutcome;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
 /**
  * Arrow allocation listener that uses a circuit breaker to track memory usage.
+ * <p>
+ * Arrow's {@code BaseAllocator} charges {@link #onPreAllocation} before checking
+ * {@code maxAllocation}. When that cap fails, {@link #onFailedAllocation} undoes
+ * the breaker charge and throws {@link org.elasticsearch.common.breaker.CircuitBreakingException}
+ * so the query returns 429 rather than Arrow's {@code OutOfMemoryException} (HTTP 500).
  */
 
 // Note: it would more naturally fit in the :libs:arrow module, but would require a dependency
@@ -27,5 +33,23 @@ public record CircuitBreakerAllocationListener(CircuitBreaker circuitBreaker) im
     @Override
     public void onRelease(long size) {
         circuitBreaker.addWithoutBreaking(-size);
+    }
+
+    @Override
+    public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
+        circuitBreaker.addWithoutBreaking(-size);
+        throw DirectBufferAllocationManager.circuitBreakingException(size, failedAllocatorLimit(outcome), null);
+    }
+
+    private static long failedAllocatorLimit(AllocationOutcome outcome) {
+        if (outcome == null) {
+            return 0L;
+        }
+        var details = outcome.getDetails();
+        if (details.isEmpty()) {
+            return 0L;
+        }
+        var failed = details.get().getFailedAllocator();
+        return failed == null ? 0L : failed.getLimit();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManager.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManager.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationManager;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.rounding.RoundingPolicy;
+import org.apache.arrow.memory.util.MemoryUtil;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Arrow {@link AllocationManager} backed by {@link ByteBuffer#allocateDirect}.
+ * <p>
+ * That is the only off-heap API HotSpot charges to {@code MaxDirectMemorySize}.
+ * {@code UnsafeAllocationManager} mallocs outside that budget (SIGKILL on a
+ * cgroup-hard container). Request-breaker accounting stays on
+ * {@link CircuitBreakerAllocationListener}. Allocation failure becomes
+ * {@link CircuitBreakingException} (429). RootAllocator max is MaxDirect minus
+ * {@link #NIO_RESERVE_BYTES}. Arrow's config builder is package-private, so
+ * {@link #createRootAllocator} reaches it reflectively.
+ */
+public final class DirectBufferAllocationManager extends AllocationManager {
+
+    public static final long NIO_RESERVE_BYTES = ByteSizeValue.ofMb(32).getBytes();
+
+    static final RoundingPolicy EXACT_FIT_ROUNDING_POLICY = requestSize -> requestSize;
+
+    private static final MethodHandle INVOKE_CLEANER = bindInvokeCleaner();
+    private static final ArrowConfigApi ARROW_CONFIG = bindArrowConfigApi();
+
+    // Process-lifetime 0-size sentinel. UnsafeAllocationManager does the same
+    // (allocateMemory(0) + NO_OP). Must not free: allocator.getEmpty() is shared.
+    private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP, null, 0, MemoryUtil.allocateMemory(0));
+
+    public static final Factory FACTORY = new Factory() {
+        @Override
+        public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+            // Allocate before super(): AllocationManager's ctor associates a BufferLedger.
+            return new DirectBufferAllocationManager(accountingAllocator, allocateDirect(accountingAllocator, size));
+        }
+
+        @Override
+        public ArrowBuf empty() {
+            return EMPTY;
+        }
+    };
+
+    private ByteBuffer buffer;
+    private final long size;
+    private final long address;
+
+    private DirectBufferAllocationManager(BufferAllocator accountingAllocator, ByteBuffer buffer) {
+        super(accountingAllocator);
+        this.buffer = buffer;
+        this.size = buffer.capacity();
+        this.address = MemoryUtil.getByteBufferAddress(buffer);
+    }
+
+    public static RootAllocator createRootAllocator(AllocationListener listener, long maxAllocation) {
+        return createRootAllocator(listener, maxAllocation, FACTORY);
+    }
+
+    // Test-only Factory injection. Production always uses FACTORY. Needed so
+    // buffer() can throw CBE without filling MaxDirect (hostile in a unit JVM).
+    static RootAllocator createRootAllocator(AllocationListener listener, long maxAllocation, Factory factory) {
+        return ARROW_CONFIG.newRootAllocator(listener, maxAllocation, factory);
+    }
+
+    public static long arrowDirectMemoryLimit() {
+        long maxDirect = JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes();
+        // MXBean 0 = unset flag or non-HotSpot; treat as unknown and do not cap here.
+        return maxDirect <= 0L ? Long.MAX_VALUE : Math.max(0L, maxDirect - NIO_RESERVE_BYTES);
+    }
+
+    static CircuitBreakingException circuitBreakingException(long bytesWanted, long byteLimit, Throwable cause) {
+        CircuitBreakingException cbe = new CircuitBreakingException(
+            Strings.format("Unable to allocate [%d] bytes of direct memory for Arrow; limit is [%d] bytes", bytesWanted, byteLimit),
+            bytesWanted,
+            byteLimit,
+            CircuitBreaker.Durability.TRANSIENT
+        );
+        if (cause != null) {
+            cbe.initCause(cause);
+        }
+        return cbe;
+    }
+
+    private static ByteBuffer allocateDirect(BufferAllocator accountingAllocator, long size) {
+        if (size > Integer.MAX_VALUE) {
+            undoPreAllocation(accountingAllocator, size);
+            throw circuitBreakingException(size, Integer.MAX_VALUE, null);
+        }
+        try {
+            return ByteBuffer.allocateDirect((int) size);
+        } catch (OutOfMemoryError e) {
+            throw failedDirectAllocation(accountingAllocator, size, e);
+        }
+    }
+
+    private static void undoPreAllocation(BufferAllocator accountingAllocator, long size) {
+        accountingAllocator.getListener().onRelease(size);
+    }
+
+    static CircuitBreakingException failedDirectAllocation(BufferAllocator accountingAllocator, long size, OutOfMemoryError error) {
+        undoPreAllocation(accountingAllocator, size);
+        return circuitBreakingException(size, arrowDirectMemoryLimit(), error);
+    }
+
+    private record ArrowConfigApi(
+        Method configBuilder,
+        Method setListener,
+        Method setMaxAllocation,
+        Method setRoundingPolicy,
+        Method setFactory,
+        Method build,
+        Constructor<RootAllocator> ctor
+    ) {
+        RootAllocator newRootAllocator(AllocationListener listener, long maxAllocation, Factory factory) {
+            try {
+                Object builder = configBuilder.invoke(null);
+                setListener.invoke(builder, listener);
+                setMaxAllocation.invoke(builder, maxAllocation);
+                setRoundingPolicy.invoke(builder, EXACT_FIT_ROUNDING_POLICY);
+                setFactory.invoke(builder, factory);
+                return ctor.newInstance(build.invoke(builder));
+            } catch (InvocationTargetException e) {
+                throw rethrow(e.getCause());
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError("Arrow RootAllocator config API is not accessible", e);
+            }
+        }
+    }
+
+    @SuppressForbidden(reason = "Arrow hid RootAllocator config behind package-private BaseAllocator")
+    private static ArrowConfigApi bindArrowConfigApi() {
+        try {
+            Method configBuilder = Class.forName("org.apache.arrow.memory.BaseAllocator").getMethod("configBuilder");
+            configBuilder.setAccessible(true);
+            Class<?> builderType = configBuilder.invoke(null).getClass();
+            Constructor<RootAllocator> ctor = RootAllocator.class.getConstructor(
+                Class.forName("org.apache.arrow.memory.BaseAllocator$Config")
+            );
+            ctor.setAccessible(true);
+            return new ArrowConfigApi(
+                configBuilder,
+                builderType.getMethod("listener", AllocationListener.class),
+                builderType.getMethod("maxAllocation", long.class),
+                builderType.getMethod("roundingPolicy", RoundingPolicy.class),
+                builderType.getMethod("allocationManagerFactory", Factory.class),
+                builderType.getMethod("build"),
+                ctor
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @SuppressForbidden(reason = "need jdk.internal.misc.Unsafe.invokeCleaner to free DirectByteBuffer immediately")
+    private static MethodHandle bindInvokeCleaner() {
+        try {
+            Class<?> unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+            Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            return MethodHandles.lookup()
+                .findVirtual(unsafeClass, "invokeCleaner", MethodType.methodType(void.class, ByteBuffer.class))
+                .bindTo(theUnsafe.get(null));
+        } catch (Throwable e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static void freeDirectBuffer(ByteBuffer buffer) {
+        try {
+            INVOKE_CLEANER.invokeExact(buffer);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    private static RuntimeException rethrow(Throwable t) {
+        if (t instanceof RuntimeException re) {
+            return re;
+        }
+        if (t instanceof Error err) {
+            throw err;
+        }
+        throw new AssertionError(t);
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    protected long memoryAddress() {
+        return address;
+    }
+
+    @Override
+    protected void release0() {
+        ByteBuffer toFree = buffer;
+        if (toFree == null) {
+            return;
+        }
+        buffer = null;
+        freeDirectBuffer(toFree);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListenerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListenerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.data.arrow;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -27,7 +26,7 @@ public class CircuitBreakerAllocationListenerTests extends ESTestCase {
     }
 
     private BufferAllocator allocator(CircuitBreaker breaker) {
-        return new RootAllocator(new CircuitBreakerAllocationListener(breaker), Long.MAX_VALUE, requestSize -> requestSize);
+        return DirectBufferAllocationManager.createRootAllocator(new CircuitBreakerAllocationListener(breaker), Long.MAX_VALUE);
     }
 
     public void testAllocationWithinLimitSucceeds() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManagerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManagerTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationManager;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.test.ESTestCase;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class DirectBufferAllocationManagerTests extends ESTestCase {
+
+    private static final long FOUR_MB = 4L << 20;
+
+    public void testAllocateAddressAndRoundTrip() {
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try (ArrowBuf buf = allocator.buffer(64)) {
+                assertThat(buf.memoryAddress(), greaterThan(0L));
+                buf.setByte(0, (byte) 42);
+                buf.setByte(63, (byte) 7);
+                assertEquals(42, buf.getByte(0));
+                assertEquals(7, buf.getByte(63));
+                assertTrue(buf.nioBuffer().isDirect());
+            }
+        }
+    }
+
+    public void testReleaseDropsDirectBufferPoolUsage() {
+        long before = directMemoryUsedBytes();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            ArrowBuf buf = allocator.buffer(FOUR_MB);
+            long held = directMemoryUsedBytes();
+            assertThat("allocateDirect must show up on the direct BufferPoolMXBean", held - before, greaterThanOrEqualTo(FOUR_MB));
+            buf.close();
+            long after = directMemoryUsedBytes();
+            assertThat(
+                "cleaner must return direct memory without waiting for GC; grew " + (after - before) + " after close",
+                after - before,
+                lessThanOrEqualTo(1L << 20)
+            );
+        }
+    }
+
+    public void testOverAllocatorMaxThrowsCircuitBreakingException() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(new CircuitBreakerAllocationListener(breaker), 1024)) {
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(2048));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    public void testFactoryOutOfMemoryErrorUndoesBreaker() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        AllocationManager.Factory oomFactory = new AllocationManager.Factory() {
+            @Override
+            public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+                throw DirectBufferAllocationManager.failedDirectAllocation(
+                    accountingAllocator,
+                    size,
+                    new OutOfMemoryError("Direct buffer memory")
+                );
+            }
+
+            @Override
+            public ArrowBuf empty() {
+                return DirectBufferAllocationManager.FACTORY.empty();
+            }
+        };
+        try (
+            RootAllocator allocator = DirectBufferAllocationManager.createRootAllocator(
+                new CircuitBreakerAllocationListener(breaker),
+                Long.MAX_VALUE,
+                oomFactory
+            )
+        ) {
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(64));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertThat(e.getCause(), instanceOf(OutOfMemoryError.class));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    public void testSizeAboveIntegerMaxThrowsCircuitBreakingException() {
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            long tooBig = Integer.MAX_VALUE + 1L;
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(tooBig));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertThat(e.getBytesWanted(), equalTo(tooBig));
+            assertThat(e.getByteLimit(), equalTo((long) Integer.MAX_VALUE));
+        }
+    }
+
+    public void testArrowDirectMemoryLimitMatchesJvmInfo() {
+        long maxDirect = JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes();
+        long limit = DirectBufferAllocationManager.arrowDirectMemoryLimit();
+        if (maxDirect <= 0L) {
+            assertEquals(Long.MAX_VALUE, limit);
+        } else {
+            assertEquals(Math.max(0L, maxDirect - DirectBufferAllocationManager.NIO_RESERVE_BYTES), limit);
+        }
+    }
+
+    public void testRequestBreakerTripsBeforeDirectCap() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(1024));
+        try (
+            var allocator = DirectBufferAllocationManager.createRootAllocator(
+                new CircuitBreakerAllocationListener(breaker),
+                DirectBufferAllocationManager.arrowDirectMemoryLimit()
+            )
+        ) {
+            expectThrows(CircuitBreakingException.class, () -> allocator.buffer(2048));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    private static long directMemoryUsedBytes() {
+        for (BufferPoolMXBean p : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
+            if ("direct".equals(p.getName())) {
+                return p.getMemoryUsed();
+            }
+        }
+        fail("JVM has no 'direct' BufferPoolMXBean");
+        return 0;
+    }
+}


### PR DESCRIPTION
Unsafe malloc is invisible to the JVM direct-memory cap, so
cgroup-hard nodes SIGKILL instead of 429. Back Arrow with
DirectByteBuffer and convert allocation failure to a circuit break.

Relates to elastic/esql-planning#1761