### PR TITLE
[ESQL] Cap Parquet LIMIT native hold

### DIFF
--- a/docs/changelog/157282.yaml
+++ b/docs/changelog/157282.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157282
+summary: Cap Parquet LIMIT native hold
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -119,7 +119,17 @@ final class ColumnChunkPrefetcher {
         Set<String> projectedColumns,
         BufferAllocator allocator
     ) {
-        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        return prefetchAsync(storageObject, block, projectedColumns, allocator, Long.MAX_VALUE);
+    }
+
+    static CompletableFuture<PrefetchedChunks> prefetchAsync(
+        StorageObject storageObject,
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        BufferAllocator allocator,
+        long maxBytesPerColumn
+    ) {
+        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns, maxBytesPerColumn);
         if (ranges.isEmpty()) {
             return CompletableFuture.completedFuture(new PrefetchedChunks(new TreeMap<>(), () -> {}));
         }
@@ -176,7 +186,11 @@ final class ColumnChunkPrefetcher {
      * what {@link CoalescedRangeReader#readCoalesced} will allocate.
      */
     static long computePrefetchBytes(BlockMetaData block, Set<String> projectedColumns) {
-        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        return computePrefetchBytes(block, projectedColumns, Long.MAX_VALUE);
+    }
+
+    static long computePrefetchBytes(BlockMetaData block, Set<String> projectedColumns, long maxBytesPerColumn) {
+        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns, maxBytesPerColumn);
         if (ranges.isEmpty()) {
             return 0;
         }
@@ -196,6 +210,14 @@ final class ColumnChunkPrefetcher {
      * starting position and total size in the file metadata.
      */
     static List<CoalescedRangeReader.ByteRange> computeColumnChunkRanges(BlockMetaData block, Set<String> projectedColumns) {
+        return computeColumnChunkRanges(block, projectedColumns, Long.MAX_VALUE);
+    }
+
+    static List<CoalescedRangeReader.ByteRange> computeColumnChunkRanges(
+        BlockMetaData block,
+        Set<String> projectedColumns,
+        long maxBytesPerColumn
+    ) {
         List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
         for (ColumnChunkMetaData col : block.getColumns()) {
             if (projectedColumns != null && projectedColumns.contains(col.getPath().toDotString()) == false) {
@@ -204,7 +226,8 @@ final class ColumnChunkPrefetcher {
             long startPos = col.getStartingPos();
             long totalSize = col.getTotalSize();
             if (totalSize > 0) {
-                ranges.add(new CoalescedRangeReader.ByteRange(startPos, totalSize));
+                long length = maxBytesPerColumn > 0 ? Math.min(totalSize, maxBytesPerColumn) : totalSize;
+                ranges.add(new CoalescedRangeReader.ByteRange(startPos, length));
             }
         }
         return ranges;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -227,16 +227,17 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private final CompressionCodecFactory codecFactory;
     private int rowBudget;
     /**
-     * Async prefetches allowed ahead of the consumed row group. Initialized from
-     * {@link #computePrefetchDepth} based on projected column size (1-3), then adapted
-     * at runtime: grows by {@link #PREFETCH_DEPTH_GROWTH} on stall detection (the
-     * prefetch future was not ready when consumed), shrinks by 1 after
-     * {@link #SHRINK_AFTER_NO_STALLS} consecutive no-stall row groups. Growth is
-     * suppressed when the circuit breaker exceeds {@link #BREAKER_GROWTH_THRESHOLD}
-     * utilization. Bounded by [{@link #prefetchDepthFloor}, {@link #MAX_PREFETCH_DEPTH}].
+     * Async prefetches allowed ahead of the consumed row group. Starts at
+     * {@link #prefetchDepthFloor} (1), grows by {@link #PREFETCH_DEPTH_GROWTH} on stall,
+     * shrinks after {@link #SHRINK_AFTER_NO_STALLS} consecutive no-stalls. Growth is
+     * suppressed when the circuit breaker exceeds {@link #BREAKER_GROWTH_THRESHOLD} and
+     * is capped at {@link #prefetchDepthCeiling} so queued compressed bytes stay within
+     * {@link #heldBytesCap}.
      */
     private int prefetchDepth;
     private final int prefetchDepthFloor;
+    private final int prefetchDepthCeiling;
+    private final long heldBytesCap;
     private int consecutiveNoStalls;
     private final ArrayDeque<PendingPrefetch> pendingPrefetches = new ArrayDeque<>();
     /**
@@ -373,7 +374,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         ColumnDescriptor sortColumnDescriptor,
         ParquetReaderCounters counters,
         ErrorPolicy errorPolicy,
-        @Nullable Consumer<String> warningSink
+        @Nullable Consumer<String> warningSink,
+        long heldBytesCap
     ) {
         this.errorPolicy = errorPolicy;
         this.warningSink = warningSink;
@@ -437,7 +439,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             projectionOnlyColumnPaths,
             fileLocation
         );
-        this.prefetchDepthFloor = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
+        this.heldBytesCap = heldBytesCap;
+        long projectedBytes = projectedColumnBytes(reader.getRowGroups(), this.projectedColumnPaths);
+        this.prefetchDepthFloor = 1;
+        this.prefetchDepthCeiling = computePrefetchDepthCeiling(projectedBytes, heldBytesCap);
         this.prefetchDepth = this.prefetchDepthFloor;
 
         reader.setRequestedSchema(projectedSchema);
@@ -454,6 +459,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             return;
         }
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+            return;
+        }
+        if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             return;
         }
         int startOrdinal = nextSurvivingRowGroupOrdinal(0);
@@ -477,6 +485,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
         int nextOrdinal = fromOrdinal;
         while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
+            if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+                break;
+            }
+            if (limitPrefetchCovered()) {
+                break;
+            }
             if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
                 break;
             }
@@ -485,7 +499,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
             }
-            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns);
+            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns, prefetchMaxBytesPerColumn());
             if (prefetchBytes <= 0) {
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
@@ -519,7 +533,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         blockFactory.arrowAllocator()
                     );
                 } else {
-                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns, blockFactory.arrowAllocator());
+                    future = ColumnChunkPrefetcher.prefetchAsync(
+                        storageObject,
+                        nextBlock,
+                        phaseColumns,
+                        blockFactory.arrowAllocator(),
+                        prefetchMaxBytesPerColumn()
+                    );
                 }
                 pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future));
             } catch (Exception e) {
@@ -528,6 +548,28 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
             nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
         }
+    }
+
+    private boolean unfilteredLimit() {
+        return rowBudget != FormatReader.NO_LIMIT && lateMaterialization == false;
+    }
+
+    private long prefetchMaxBytesPerColumn() {
+        return unfilteredLimit() ? heldBytesCap : Long.MAX_VALUE;
+    }
+
+    private boolean limitPrefetchCovered() {
+        if (unfilteredLimit() == false) {
+            return false;
+        }
+        long rows = 0;
+        if (rowGroupOrdinal >= 0) {
+            rows += rowsRemainingInGroup;
+        }
+        for (PendingPrefetch pending : pendingPrefetches) {
+            rows += reader.getRowGroups().get(pending.ordinal()).getRowCount();
+        }
+        return rows >= rowBudget;
     }
 
     private boolean rowGroupDominatedByThreshold(BlockMetaData block) {
@@ -740,22 +782,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         return ParquetColumnDecoding.isUnsignedInt64(sortColumnPrimitiveType) ? ParquetColumnDecoding.encodeUnsignedLong(raw) : null;
     }
 
-    private static final long DEEPER_PREFETCH_BYTES = 32_000_000L;
-    private static final long SHALLOW_PREFETCH_BYTES = 8_000_000L;
+    static final long DEFAULT_HELD_BYTES_CAP = 32L * 1024 * 1024;
     private static final int MAX_PREFETCH_DEPTH = 8;
     private static final int PREFETCH_DEPTH_GROWTH = 2;
     private static final int SHRINK_AFTER_NO_STALLS = 3;
     private static final double BREAKER_GROWTH_THRESHOLD = 0.75;
 
-    /**
-     * Computes the initial (floor) prefetch depth from the projected byte footprint of the
-     * first row group. This value serves as the floor for the adaptive depth — the runtime
-     * stall detector may increase depth up to {@link #MAX_PREFETCH_DEPTH} but never below
-     * this byte-based result.
-     */
-    private static int computePrefetchDepth(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
+    static long projectedColumnBytes(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
         if (rowGroups.isEmpty()) {
-            return 1;
+            return 0L;
         }
         BlockMetaData block = rowGroups.get(0);
         long projectedBytes = 0;
@@ -764,22 +799,18 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 projectedBytes += col.getTotalSize();
             }
         }
-        // Larger projected sizes need deeper prefetch: an S3 GET for a 20MB string column takes
-        // ~200ms while decode takes ~10ms, so single-ahead can't hide the latency. The circuit
-        // breaker caps actual memory regardless of depth.
-        //
-        // Two-phase note: under two-phase the queued prefetches carry only predicate columns, so
-        // the actual queued bytes are a fraction of {@code projectedBytes}. We intentionally keep
-        // the depth sized on the full projection footprint because the synchronous Phase-2 fetch
-        // we issue inside {@code advanceRowGroup} is what dominates per-row-group latency under
-        // two-phase, and a deeper queue lets Phase 1 of the next row group overlap that wait.
-        if (projectedBytes > DEEPER_PREFETCH_BYTES) {
-            return 3;
+        return projectedBytes;
+    }
+
+    static int computePrefetchDepthCeiling(long projectedBytes, long heldBytesCap) {
+        if (projectedBytes <= 0) {
+            return MAX_PREFETCH_DEPTH;
         }
-        if (projectedBytes > SHALLOW_PREFETCH_BYTES) {
-            return 2;
+        long fit = heldBytesCap / projectedBytes;
+        if (fit < 1) {
+            return 1;
         }
-        return 1;
+        return (int) Math.min(MAX_PREFETCH_DEPTH, fit);
     }
 
     /**
@@ -981,6 +1012,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
         if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             exhausted = true;
+            releaseHeldIo();
             return false;
         }
         // Under two-phase, drain leading fully-filtered batches before deciding: the source-row
@@ -1010,7 +1042,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
             exhausted = true;
-            cancelPendingPrefetch();
+            releaseHeldIo();
             return false;
         }
         try {
@@ -1083,8 +1115,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 int nextOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
                 if (nextOrdinal >= reader.getRowGroups().size()) {
                     exhausted = true;
-                    cancelPendingPrefetch();
-                    releaseCurrentReservation();
+                    releaseHeldIo();
                     logIteratorDiagnostics();
                     return false;
                 }
@@ -1344,6 +1375,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         long rowsConsumed = 0;
         try {
             while (rowsConsumed < rowGroupRowCount) {
+                if (rowBudget != FormatReader.NO_LIMIT && totalSurvivors >= rowBudget) {
+                    break;
+                }
                 int rowsToRead = (int) Math.min(batchSize, rowGroupRowCount - rowsConsumed);
                 BatchPredicateResult batch = decodePredicateBatch(rowsToRead, (int) rowsConsumed, globalSurvivors);
                 predicateBatches.add(batch.compactedPredicateBlocks);
@@ -1788,9 +1822,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * Adjusts {@link #prefetchDepth} based on whether the consumed prefetch future was already
      * complete. A stall ({@code wasReady == false}) means the consumer outpaced the producer —
-     * grow depth by {@link #PREFETCH_DEPTH_GROWTH} unless the circuit breaker is under pressure.
-     * Sustained no-stalls mean the queue is deep enough — shrink by 1 after
-     * {@link #SHRINK_AFTER_NO_STALLS} consecutive hits.
+     * grow depth by {@link #PREFETCH_DEPTH_GROWTH} unless the circuit breaker is under pressure
+     * or {@link #prefetchDepthCeiling} is already reached. Sustained no-stalls mean the queue is
+     * deep enough — shrink by 1 after {@link #SHRINK_AFTER_NO_STALLS} consecutive hits.
      */
     // Package-private for testing
     void adaptPrefetchDepth(boolean wasReady) {
@@ -1801,7 +1835,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
         } else {
             if (breakerPressure() < BREAKER_GROWTH_THRESHOLD) {
-                prefetchDepth = Math.min(prefetchDepth + PREFETCH_DEPTH_GROWTH, MAX_PREFETCH_DEPTH);
+                prefetchDepth = Math.min(prefetchDepth + PREFETCH_DEPTH_GROWTH, prefetchDepthCeiling);
             }
             consecutiveNoStalls = 0;
         }
@@ -1820,6 +1854,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     // Visible for testing
     int prefetchDepth() {
         return prefetchDepth;
+    }
+
+    // Visible for testing
+    int prefetchDepthCeiling() {
+        return prefetchDepthCeiling;
     }
 
     /**
@@ -2480,16 +2519,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
     @Override
     public void close() throws IOException {
-        cancelPendingPrefetch();
         try {
-            closeTwoPhaseState();
-            closePageColumnReaders();
-            if (rowGroup != null) {
-                rowGroup.close();
-                rowGroup = null;
-            }
+            releaseHeldIo();
         } finally {
-            releaseCurrentReservation();
             try {
                 if (preloadedMetadata != null) {
                     preloadedMetadata.close();
@@ -2497,6 +2529,24 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             } finally {
                 reader.close();
             }
+        }
+    }
+
+    private void releaseHeldIo() {
+        try {
+            closeTwoPhaseState();
+            closePageColumnReaders();
+            if (rowGroup != null) {
+                try {
+                    rowGroup.close();
+                } catch (Exception e) {
+                    logger.warn("Failed to close row-group store for [{}] in [{}]", rowGroupOrdinal, fileLocation, e);
+                }
+                rowGroup = null;
+            }
+        } finally {
+            cancelPendingPrefetch();
+            releaseCurrentReservation();
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -139,6 +139,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     private final Map<String, String> declaredDateFormats;
     /** Physical names of declared-type columns (licensed to narrow toward their target); see {@link #withDeclaredTypeColumns}. */
     private final Set<String> declaredTypeColumns;
+    /**
+     * Live compressed-bytes budget for one prefetch granule (first window per column under LIMIT,
+     * and the byte-based prefetch-depth ceiling). Independent of the row-group macro-split target
+     * even though the number currently matches.
+     */
+    private final long heldBytesCap;
     // Shared across all iterators created by this reader: holds lazy decompressor instances and
     // pays the per-codec init cost once. The factory is stateless across files/row groups.
     private final PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
@@ -269,11 +275,33 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     }
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false, true, true, null, Map.of(), Set.of());
+        this(
+            blockFactory,
+            FilterCompat.NOOP,
+            null,
+            false,
+            true,
+            true,
+            null,
+            Map.of(),
+            Set.of(),
+            OptimizedParquetColumnIterator.DEFAULT_HELD_BYTES_CAP
+        );
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
-        this(blockFactory, FilterCompat.NOOP, null, false, optimizedReader, true, null, Map.of(), Set.of());
+        this(
+            blockFactory,
+            FilterCompat.NOOP,
+            null,
+            false,
+            optimizedReader,
+            true,
+            null,
+            Map.of(),
+            Set.of(),
+            OptimizedParquetColumnIterator.DEFAULT_HELD_BYTES_CAP
+        );
     }
 
     private ParquetFormatReader(
@@ -285,7 +313,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         boolean lateMaterializationEnabled,
         DynamicThreshold dynamicThreshold,
         Map<String, String> declaredDateFormats,
-        Set<String> declaredTypeColumns
+        Set<String> declaredTypeColumns,
+        long heldBytesCap
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
@@ -296,6 +325,25 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         this.dynamicThreshold = dynamicThreshold;
         this.declaredDateFormats = declaredDateFormats;
         this.declaredTypeColumns = declaredTypeColumns;
+        this.heldBytesCap = heldBytesCap;
+    }
+
+    ParquetFormatReader withHeldBytesCap(long heldBytesCap) {
+        if (heldBytesCap <= 0) {
+            throw new IllegalArgumentException("heldBytesCap must be positive, got [" + heldBytesCap + "]");
+        }
+        return new ParquetFormatReader(
+            blockFactory,
+            pushedFilter,
+            pushedExpressions,
+            forceBaselinePath,
+            optimizedReader,
+            lateMaterializationEnabled,
+            dynamicThreshold,
+            declaredDateFormats,
+            declaredTypeColumns,
+            heldBytesCap
+        );
     }
 
     /**
@@ -313,7 +361,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             lateMaterializationEnabled,
             dynamicThreshold,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            heldBytesCap
         );
     }
 
@@ -329,7 +378,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 lateMaterializationEnabled,
                 dynamicThreshold,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                heldBytesCap
             );
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
@@ -342,7 +392,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 lateMaterializationEnabled,
                 dynamicThreshold,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                heldBytesCap
             );
         }
         return this;
@@ -359,7 +410,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             lateMaterializationEnabled,
             threshold,
             declaredDateFormats,
-            declaredTypeColumns
+            declaredTypeColumns,
+            heldBytesCap
         );
     }
 
@@ -384,7 +436,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             lateMaterializationEnabled,
             dynamicThreshold,
             Map.copyOf(physicalNameToPattern),
-            declaredTypeColumns
+            declaredTypeColumns,
+            heldBytesCap
         );
     }
 
@@ -410,7 +463,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             lateMaterializationEnabled,
             dynamicThreshold,
             declaredDateFormats,
-            Set.copyOf(physicalDeclaredColumns)
+            Set.copyOf(physicalDeclaredColumns),
+            heldBytesCap
         );
     }
 
@@ -432,7 +486,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 newLateMat,
                 dynamicThreshold,
                 declaredDateFormats,
-                declaredTypeColumns
+                declaredTypeColumns,
+                heldBytesCap
             );
         return Configured.fromKnownSubset(result, config, RECOGNIZED_KEYS);
     }
@@ -1651,7 +1706,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 reader,
                 context.projectedColumns(),
                 context.batchSize(),
-                NO_LIMIT,
+                context.rowLimit(),
                 context.resolvedAttributes(),
                 // The deferred extractor scopes itself to the file's full footer rather than the
                 // range-filtered subset, so the produced extractor can resolve any file-global
@@ -1991,7 +2046,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 resolveDynamicThresholdColumn(fileSchema, dynamicThreshold),
                 counters,
                 errorPolicy,
-                warningSink
+                warningSink,
+                heldBytesCap
             );
             // Constructor succeeded — iterator now owns preloadedMetadata. Set the flag after
             // construction so that a throw inside the constructor does not suppress cleanup.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -257,8 +257,22 @@ final class PrefetchedRowGroupBuilder {
             // byte-based loop can spuriously continue into bytes that belong to the next column.
             // parquet-mr uses the same value-count termination in ColumnChunkPageReadStore.
             while (valueCount < totalValues) {
-                PageHeader header = Util.readPageHeader(stream);
+                if (stream.available() <= 0) {
+                    break;
+                }
+                PageHeader header;
+                try {
+                    header = Util.readPageHeader(stream);
+                } catch (IOException e) {
+                    if (valueCount > 0) {
+                        break;
+                    }
+                    throw e;
+                }
                 int compressedPageSize = header.getCompressed_page_size();
+                if (stream.available() < compressedPageSize) {
+                    break;
+                }
                 ByteBuffer payload = stream.readPayload(compressedPageSize);
 
                 if (header.type == PageType.DICTIONARY_PAGE) {
@@ -281,6 +295,15 @@ final class PrefetchedRowGroupBuilder {
                     pages.add(new PrefetchedPageReader.CompressedPage(page, -1L));
                     valueCount += page.getValueCount();
                 }
+            }
+            if (valueCount == 0 && totalValues > 0) {
+                throw new IllegalArgumentException(
+                    "Truncated column chunk for ["
+                        + column.getPath().toDotString()
+                        + "] in row group ["
+                        + rowGroupOrdinal
+                        + "] contained no data pages"
+                );
             }
             return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
         } catch (IOException e) {
@@ -527,8 +550,22 @@ final class PrefetchedRowGroupBuilder {
 
         @Override
         public PageHeaderStream openStream(long fileOffset, long totalLength, String columnPath) {
-            ByteBuffer slice = slice(fileOffset, (int) totalLength, columnPath, -1);
-            return new ByteBufferPageHeaderStream(slice);
+            Map.Entry<Long, ColumnChunkPrefetcher.PrefetchedChunk> entry = chunks.floorEntry(fileOffset);
+            ColumnChunkPrefetcher.PrefetchedChunk chunk = entry == null ? null : entry.getValue();
+            if (chunk == null || fileOffset < chunk.offset() || fileOffset >= chunk.offset() + chunk.length()) {
+                throw new IllegalStateException(
+                    "prefetched data does not cover offset="
+                        + fileOffset
+                        + " length="
+                        + totalLength
+                        + " column="
+                        + columnPath
+                        + " rowGroup="
+                        + rowGroupOrdinal
+                );
+            }
+            long available = chunk.offset() + chunk.length() - fileOffset;
+            return new ByteBufferPageHeaderStream(slice(fileOffset, (int) Math.min(totalLength, available), columnPath, -1));
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
@@ -71,6 +71,16 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
         assertThat(ranges.get(2), equalTo(new CoalescedRangeReader.ByteRange(1100, 200)));
     }
 
+    public void testComputeColumnChunkRangesCapsFirstWindow() {
+        BlockMetaData block = createBlockWithColumns(new ColMeta("tall", 100, 50_000), new ColMeta("small", 50_200, 100));
+
+        List<CoalescedRangeReader.ByteRange> ranges = ColumnChunkPrefetcher.computeColumnChunkRanges(block, null, 4096);
+
+        assertThat(ranges.size(), equalTo(2));
+        assertThat(ranges.get(0), equalTo(new CoalescedRangeReader.ByteRange(100, 4096)));
+        assertThat(ranges.get(1), equalTo(new CoalescedRangeReader.ByteRange(50_200, 100)));
+    }
+
     public void testComputeColumnChunkRangesWithProjection() {
         BlockMetaData block = createBlockWithColumns(
             new ColMeta("col_a", 100, 500),

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetHeldBytesCapTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetHeldBytesCapTests.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * Stage 1 held-bytes cap: LIMIT clips I/O and releases compressed buffers when the
+ * row budget is exhausted, without waiting for iterator close.
+ */
+public class ParquetHeldBytesCapTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void initBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
+    }
+
+    public void testPrefetchDepthCeilingInvertsFatRowGroups() {
+        long cap = OptimizedParquetColumnIterator.DEFAULT_HELD_BYTES_CAP;
+        assertThat(OptimizedParquetColumnIterator.computePrefetchDepthCeiling(cap * 2, cap), equalTo(1));
+        assertThat(OptimizedParquetColumnIterator.computePrefetchDepthCeiling(cap / 2 + 1, cap), equalTo(1));
+        assertThat(OptimizedParquetColumnIterator.computePrefetchDepthCeiling(1024, cap), equalTo(8));
+        assertThat(OptimizedParquetColumnIterator.computePrefetchDepthCeiling(0, cap), equalTo(8));
+    }
+
+    public void testRangeReadContextDefaultsToNoLimit() {
+        RangeReadContext ctx = new RangeReadContext(List.of("id"), 10, 0, 100, List.of(), ErrorPolicy.STRICT);
+        assertThat(ctx.rowLimit(), equalTo(FormatReader.NO_LIMIT));
+    }
+
+    public void testReadRangeHonorsRowLimit() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(2000, 2048);
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        try (
+            CloseableIterator<Page> iter = reader.readRange(
+                storage,
+                new RangeReadContext(List.of("id"), 64, 0, parquetData.length, List.of(), ErrorPolicy.STRICT, null, 1)
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    public void testLimitDoesNotPrefetchLaterRowGroups() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(4000, 2048);
+        RecordingStorageObject fullScan = new RecordingStorageObject(parquetData);
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(fullScan, FormatReadContext.of(List.of("id"), 256))
+        ) {
+            while (iter.hasNext()) {
+                iter.next().releaseBlocks();
+            }
+        }
+        long fullDataGets = dataGetCount(fullScan, parquetData.length);
+        assertThat("full scan should touch more than one row group's data", fullDataGets, greaterThan(1L));
+
+        RecordingStorageObject limited = new RecordingStorageObject(parquetData);
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                limited,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(256).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            iter.next().releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+        long limitDataGets = dataGetCount(limited, parquetData.length);
+        assertThat(limitDataGets, greaterThan(0L));
+        assertThat(limitDataGets, lessThanOrEqualTo(fullDataGets - 1));
+    }
+
+    public void testLimitReleasesPrefetchBuffersBeforeClose() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(3000, 2048);
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        CloseableIterator<Page> iter = reader.read(
+            storage,
+            FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(64).rowLimit(1).build()
+        );
+        try {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+            assertThat("prefetch buffers must drop when LIMIT is exhausted, before close()", storage.liveAsyncBytes.get(), equalTo(0));
+        } finally {
+            iter.close();
+        }
+        assertThat(storage.liveAsyncBytes.get(), equalTo(0));
+    }
+
+    public void testLimitFirstWindowMissesTallChunkTail() throws Exception {
+        byte[] parquetData = createTallFile(800, 64);
+        assertThat(parquetData.length, greaterThan(16 * 1024));
+        long cap = 16 * 1024;
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory).withHeldBytesCap(cap);
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                storage,
+                FormatReadContext.builder().projectedColumns(List.of("payload")).batchSize(32).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+
+        long dataBytes = 0;
+        for (long[] get : storage.gets) {
+            if (isLikelyFooterGet(get[0], get[1], parquetData.length)) {
+                continue;
+            }
+            assertThat("column-chunk GET exceeded held-bytes cap", get[1], lessThanOrEqualTo(cap));
+            dataBytes += get[1];
+        }
+        assertThat(dataBytes, greaterThan(0L));
+        assertThat("first-window GETs must not download the whole tall file", dataBytes, lessThanOrEqualTo(parquetData.length / 2L));
+        assertThat(parquetData.length, greaterThan((int) cap * 2));
+    }
+
+    public void testLimitFirstRowMatchesFullScan() throws Exception {
+        byte[] parquetData = createTallFile(80, 32);
+        long fullFirst;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                new RecordingStorageObject(parquetData),
+                FormatReadContext.of(List.of("id", "payload"), 64)
+            )
+        ) {
+            Page page = iter.next();
+            fullFirst = ((LongBlock) page.getBlock(0)).getLong(0);
+            page.releaseBlocks();
+        }
+        long limitFirst;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                new RecordingStorageObject(parquetData),
+                FormatReadContext.builder().projectedColumns(List.of("id", "payload")).batchSize(64).rowLimit(1).build()
+            )
+        ) {
+            Page page = iter.next();
+            limitFirst = ((LongBlock) page.getBlock(0)).getLong(0);
+            page.releaseBlocks();
+        }
+        assertThat(limitFirst, equalTo(fullFirst));
+    }
+
+    private static long dataGetCount(RecordingStorageObject storage, int fileLength) {
+        long count = 0;
+        for (long[] get : storage.gets) {
+            if (isLikelyFooterGet(get[0], get[1], fileLength) == false) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isLikelyFooterGet(long offset, long length, int fileLength) {
+        return offset + length >= fileLength;
+    }
+
+    private byte[] createMultiRowGroupFile(int rowCount, int rowGroupSize) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(outputStream))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(256)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private byte[] createTallFile(int rowCount, int payloadBytes) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("payload")
+            .named("test_schema");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        String payload = "x".repeat(payloadBytes);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(outputStream))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(false)
+                .withRowGroupSize(8 * 1024 * 1024L)
+                .withPageSize(1024)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                g.add("payload", i + payload);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    @Override
+                    public long getPos() {
+                        return outputStream.size();
+                    }
+
+                    @Override
+                    public void write(int b) {
+                        outputStream.write(b);
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) {
+                        outputStream.write(b, off, len);
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    private static final class RecordingStorageObject implements StorageObject {
+        private final byte[] data;
+        final List<long[]> gets = new ArrayList<>();
+        final AtomicInteger liveAsyncBytes = new AtomicInteger();
+
+        RecordingStorageObject(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://held-bytes-cap.parquet");
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return true;
+        }
+
+        @Override
+        public void readBytesAsync(
+            long position,
+            long length,
+            DirectBufferFactory factory,
+            Executor executor,
+            ActionListener<DirectReadBuffer> listener
+        ) {
+            gets.add(new long[] { position, length });
+            executor.execute(() -> {
+                try {
+                    int pos = (int) position;
+                    int len = (int) Math.min(length, data.length - position);
+                    DirectReadBuffer allocated = factory.allocate(len);
+                    ByteBuffer buffer = allocated.buffer();
+                    buffer.put(data, pos, len);
+                    buffer.flip();
+                    liveAsyncBytes.addAndGet(len);
+                    listener.onResponse(new DirectReadBuffer(buffer, () -> {
+                        liveAsyncBytes.addAndGet(-len);
+                        allocated.close();
+                    }));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1987,7 +1987,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     rangeEnd,
                     PhysicalNames.translateSchema(perFileResolvedAttributes, renames),
                     errorPolicy,
-                    bufferedInformationalWarningSink(state.buffer)
+                    bufferedInformationalWarningSink(state.buffer),
+                    state.rowsRemaining
                 );
                 if (fileContext != null) {
                     rangeCtx.setFileContext(fileContext);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
@@ -29,6 +29,12 @@ public final class RangeReadContext {
     @Nullable
     private final Consumer<String> informationalWarningSink;
     /**
+     * Remaining row budget for this split ({@link FormatReader#NO_LIMIT} when unbounded).
+     * Threaded from the producer so range-aware readers can clip prefetch the same way
+     * whole-file {@link FormatReadContext#rowLimit()} already does.
+     */
+    private final int rowLimit;
+    /**
      * Opaque file-level context, single-writer/single-reader, carried by the owning producer across successive readRange calls.
      */
     @Nullable
@@ -59,6 +65,28 @@ public final class RangeReadContext {
         ErrorPolicy errorPolicy,
         @Nullable Consumer<String> informationalWarningSink
     ) {
+        this(
+            projectedColumns,
+            batchSize,
+            rangeStart,
+            rangeEnd,
+            resolvedAttributes,
+            errorPolicy,
+            informationalWarningSink,
+            FormatReader.NO_LIMIT
+        );
+    }
+
+    public RangeReadContext(
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> informationalWarningSink,
+        int rowLimit
+    ) {
         this.projectedColumns = projectedColumns;
         this.batchSize = batchSize;
         this.rangeStart = rangeStart;
@@ -66,6 +94,7 @@ public final class RangeReadContext {
         this.resolvedAttributes = resolvedAttributes;
         this.errorPolicy = errorPolicy;
         this.informationalWarningSink = informationalWarningSink;
+        this.rowLimit = rowLimit;
     }
 
     public List<String> projectedColumns() {
@@ -104,6 +133,10 @@ public final class RangeReadContext {
     @Nullable
     public Consumer<String> informationalWarningSink() {
         return informationalWarningSink;
+    }
+
+    public int rowLimit() {
+        return rowLimit;
     }
 
     @Nullable


### PR DESCRIPTION
Range splits ignored LIMIT so a fat row group still prefetched every projected chunk and held native buffers until close. Clip first-window I/O, release on budget exhaust, and stop queueing later groups once remaining rows are covered.

elastic/esql-planning#1762