### PR TITLE
Fix NPE in nvidia inference service when similarity is set and dimensions are unknown

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaService.java
@@ -56,6 +56,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.inference.TaskType.CHAT_COMPLETION;
@@ -175,7 +176,7 @@ public class NvidiaService extends SenderService<NvidiaModel> implements Reranki
             var similarityFromModel = serviceSettings.similarity();
             var similarityToUse = similarityFromModel == null ? SimilarityMeasure.DOT_PRODUCT : similarityFromModel;
 
-            if (similarityToUse.equals(similarityFromModel) && embeddingSize == serviceSettings.dimensions()) {
+            if (similarityToUse.equals(similarityFromModel) && Objects.equals(embeddingSize, serviceSettings.dimensions())) {
                 // Avoid creating a new model if similarity and embedding size are unchanged
                 return model;
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/NvidiaServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
@@ -53,6 +54,7 @@ import org.elasticsearch.xpack.inference.services.nvidia.embeddings.NvidiaEmbedd
 import org.elasticsearch.xpack.inference.services.nvidia.embeddings.NvidiaEmbeddingsTaskSettings;
 import org.elasticsearch.xpack.inference.services.nvidia.rerank.NvidiaRerankModel;
 import org.elasticsearch.xpack.inference.services.nvidia.rerank.NvidiaRerankModelTests;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
@@ -570,6 +572,48 @@ public class NvidiaServiceTests extends InferenceServiceTestCase {
             assertThat(requestMap.get(MODEL_FIELD_NAME), is(MODEL_VALUE));
             assertThat(requestMap.get(INPUT_TYPE_FIELD_NAME), is(INPUT_TYPE_NVIDIA_DEFAULT_VALUE));
         }
+    }
+
+    public void testUpdateModelWithEmbeddingDetails_NullDimensionsAndExplicitSimilarity_DoesNotThrow() throws IOException {
+        // Users cannot set dimensions when creating an nvidia endpoint, so dimensions is null until the first embedding is seen.
+        // When similarity is set explicitly this used to unbox the null Integer and throw a NullPointerException.
+        try (var service = createInferenceService()) {
+            var similarity = randomFrom(SimilarityMeasure.values());
+            var model = createEmbeddingsModelWithDimensionsAndSimilarity(null, similarity);
+            var embeddingSize = randomIntBetween(1, 4096);
+
+            var updatedModel = service.updateModelWithEmbeddingDetails(model, embeddingSize);
+
+            assertThat(updatedModel, instanceOf(NvidiaEmbeddingsModel.class));
+            assertThat(updatedModel.getServiceSettings().dimensions(), is(embeddingSize));
+            assertThat(updatedModel.getServiceSettings().similarity(), is(similarity));
+        }
+    }
+
+    public void testUpdateModelWithEmbeddingDetails_UnchangedSimilarityAndDimensions_ReturnsSameModel() throws IOException {
+        try (var service = createInferenceService()) {
+            var embeddingSize = randomIntBetween(1, 4096);
+            var model = createEmbeddingsModelWithDimensionsAndSimilarity(embeddingSize, SimilarityMeasure.DOT_PRODUCT);
+
+            var updatedModel = service.updateModelWithEmbeddingDetails(model, embeddingSize);
+
+            assertThat(updatedModel, CoreMatchers.sameInstance(model));
+        }
+    }
+
+    private static NvidiaEmbeddingsModel createEmbeddingsModelWithDimensionsAndSimilarity(
+        Integer dimensions,
+        SimilarityMeasure similarity
+    ) {
+        return new NvidiaEmbeddingsModel(
+            INFERENCE_ID_VALUE,
+            TEXT_EMBEDDING,
+            NvidiaService.NAME,
+            new NvidiaEmbeddingsServiceSettings(MODEL_VALUE, URL_VALUE, dimensions, similarity, null, null),
+            NvidiaEmbeddingsTaskSettings.EMPTY_SETTINGS,
+            null,
+            new DefaultSecretSettings(new SecureString(API_KEY_VALUE.toCharArray()))
+        );
     }
 
     public void testGetConfiguration() throws Exception {


### PR DESCRIPTION
Closes #157288

## Summary
`NvidiaService.updateModelWithEmbeddingDetails` compared `int embeddingSize == serviceSettings.dimensions()` where `dimensions()` is a nullable `Integer`. The nvidia service does not accept `dimensions` in the request config, so it is always `null` before the first embedding response; whenever the user set `similarity` explicitly (so it equals the resolved similarity) the `&&` reached the comparison and unboxed `null` → `NullPointerException` → HTTP 500 on `PUT _inference/text_embedding/<id>`. Net effect: `similarity` could never be set on nvidia text-embedding endpoints.

This PR:
- uses `Objects.equals(embeddingSize, serviceSettings.dimensions())` so a null `dimensions` means "changed" and a new model with the detected size is returned;
- adds `NvidiaServiceTests.testUpdateModelWithEmbeddingDetails_NullDimensionsAndExplicitSimilarity_DoesNotThrow` (fails with NPE before the fix) and `..._UnchangedSimilarityAndDimensions_ReturnsSameModel` to pin the short-circuit branch.

The shared `InferenceServiceTestCase` harness did not catch this because its nvidia model is built with a non-null random `dimensions`.

## Verification
Reproduced on 9.5.1 with a self-hosted NIM (`PUT` with `"similarity": "dot_product"` → 500 NPE; without → 200). New unit tests pass locally with `./gradlew :x-pack:plugin:inference:test --tests "*NvidiaServiceTests"`.
