### PR TITLE
Log non-default keep_alive on async search submit

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -89,7 +89,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
     @Override
     protected void doExecute(Task submitTask, SubmitAsyncSearchRequest request, ActionListener<AsyncSearchResponse> submitListener) {
         if (request.getKeepAlive().equals(SubmitAsyncSearchRequest.DEFAULT_KEEP_ALIVE) == false) {
-            logger.info("async search submitted with non-default keep_alive [{}]", request.getKeepAlive());
+            logger.debug("async search submitted with non-default keep_alive [{}]", request.getKeepAlive());
         }
         final SearchRequest searchRequest = createSearchRequest(request, submitTask, request.getKeepAlive());
         try (var ignored = threadContext.newTraceContext()) {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -39,6 +41,8 @@ import java.util.Map;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportSubmitAsyncSearchAction extends HandledTransportAction<SubmitAsyncSearchRequest, AsyncSearchResponse> {
+    private static final Logger logger = LogManager.getLogger(TransportSubmitAsyncSearchAction.class);
+
     private final ClusterService clusterService;
     private final NodeClient nodeClient;
     private final SearchService searchService;
@@ -84,6 +88,9 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
 
     @Override
     protected void doExecute(Task submitTask, SubmitAsyncSearchRequest request, ActionListener<AsyncSearchResponse> submitListener) {
+        if (request.getKeepAlive().equals(SubmitAsyncSearchRequest.DEFAULT_KEEP_ALIVE) == false) {
+            logger.info("async search submitted with non-default keep_alive [{}]", request.getKeepAlive());
+        }
         final SearchRequest searchRequest = createSearchRequest(request, submitTask, request.getKeepAlive());
         try (var ignored = threadContext.newTraceContext()) {
             AsyncSearchTask searchTask = (AsyncSearchTask) taskManager.register(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -30,10 +30,11 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class SubmitAsyncSearchRequest extends UntypedActionRequest {
     public static final long MIN_KEEP_ALIVE = TimeValue.timeValueSeconds(1).millis();
+    public static final TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueDays(5);
 
     private TimeValue waitForCompletionTimeout = TimeValue.timeValueSeconds(1);
     private boolean keepOnCompletion = false;
-    private TimeValue keepAlive = TimeValue.timeValueDays(5);
+    private TimeValue keepAlive = DEFAULT_KEEP_ALIVE;
 
     private final SearchRequest request;
 


### PR DESCRIPTION
Adds some logging around async search requests that use a non-default TTL. This information would be useful when considering changes to maximum TTL going forward.