### PR TITLE
Docs: document index_terms and bitmap_terms

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-parameters.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-parameters.md
@@ -27,6 +27,7 @@ The following mapping parameters are common to some or all field data types:
 * [`index_options`](/reference/elasticsearch/mapping-reference/index-options.md)
 * [`index_phrases`](/reference/elasticsearch/mapping-reference/index-phrases.md)
 * [`index_prefixes`](/reference/elasticsearch/mapping-reference/index-prefixes.md)
+* [`index_terms`](/reference/elasticsearch/mapping-reference/number.md#index-terms-mapping-param)
 * [`index`](/reference/elasticsearch/mapping-reference/mapping-index.md)
 * [`meta`](/reference/elasticsearch/mapping-reference/mapping-field-meta.md)
 * [`normalizer`](/reference/elasticsearch/mapping-reference/normalizer.md)

--- a/docs/reference/elasticsearch/mapping-reference/number.md
+++ b/docs/reference/elasticsearch/mapping-reference/number.md
@@ -116,6 +116,9 @@ The following parameters are accepted by numeric types:
 [`index`](/reference/elasticsearch/mapping-reference/mapping-index.md)
 :   Should the field be quickly searchable? Accepts `true` (default) and `false`. Numeric fields that only have [`doc_values`](/reference/elasticsearch/mapping-reference/doc-values.md) enabled can also be queried, albeit slower.
 
+`index_terms` {applies_to}`stack: ga 9.6` {applies_to}`serverless: ga`
+:   Index the field's values in an inverted index instead of a BKD tree. Accepts `true` or `false` (default). Only supported on `integer` and `long` fields. See [`index_terms`](#index-terms-mapping-param).
+
 [`meta`](/reference/elasticsearch/mapping-reference/mapping-field-meta.md)
 :   Metadata about the field.
 
@@ -163,6 +166,44 @@ The following parameters are accepted by numeric types:
 
     For a numeric time series metric, the `doc_values` parameter must be `true`. A numeric field can’t be both a time series dimension and a time series metric.
 
+
+
+## `index_terms` mapping parameter [index-terms-mapping-param]
+
+```{applies_to}
+stack: ga 9.6
+serverless: ga
+```
+
+By default, `integer` and `long` fields are indexed in a BKD tree, a structure optimized for [`range`](/reference/query-languages/query-dsl/query-dsl-range-query.md) queries. Setting `index_terms` to `true` indexes the values in an inverted index instead, which is optimized for matching documents against a set of exact values.
+
+Enable it on fields that are mostly used for set membership filtering rather than range filtering, such as identifiers that you filter against large lists of permitted values. Matching a large set of values against an inverted index requires a single pass over the terms dictionary, whereas a BKD tree has to be traversed repeatedly. `index_terms` is also what makes the [`bitmap_terms`](/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md) query most efficient, which matches against a set of values encoded as a [roaring bitmap](https://roaringbitmap.org) and is designed for exactly this pattern.
+
+```console
+PUT my-index-000002
+{
+  "mappings": {
+    "properties": {
+      "customer_id": {
+        "type": "long",
+        "index_terms": true
+      }
+    }
+  }
+}
+```
+
+All queries that work on a regular numeric field keep working, over the full signed range of the type, negative values included:
+
+* [`term`](/reference/query-languages/query-dsl/query-dsl-term-query.md) and [`terms`](/reference/query-languages/query-dsl/query-dsl-terms-query.md) queries look the values up in the terms dictionary.
+* [`range`](/reference/query-languages/query-dsl/query-dsl-range-query.md) queries scan the terms dictionary rather than the BKD tree. Because the terms are encoded so that their byte order matches their numeric order, ranges still resolve correctly, but wide ranges are typically slower than they would be on a BKD tree.
+* Sorting, aggregations, and scripts read [`doc_values`](/reference/elasticsearch/mapping-reference/doc-values.md) and are unaffected.
+
+The following restrictions apply:
+
+* `index_terms` is only supported on `integer` and `long` fields.
+* It requires [`index`](/reference/elasticsearch/mapping-reference/mapping-index.md) to be `true`.
+* It cannot be changed after the field is created. To turn it on or off for an existing field, reindex into a new index.
 
 
 ## Parameters for `scaled_float` [scaled-float-params]

--- a/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
@@ -1,0 +1,226 @@
+---
+applies_to:
+  stack: ga 9.6
+  serverless: ga
+navigation_title: "Bitmap terms"
+---
+
+# Bitmap terms query [query-dsl-bitmap-terms-query]
+
+Returns documents whose `integer` or `long` field value is contained in a [roaring bitmap](https://roaringbitmap.org) that you provide as a base64-encoded string.
+
+Bitmap values must be non-negative: `0` to `2^31 - 1` for `integer` fields, and `0` to `2^63 - 1` for `long` fields. {{es}} rejects a bitmap that contains a negative value. The field itself can still hold negative values; they simply can never be matched by a `bitmap_terms` query.
+
+`bitmap_terms` is the counterpart of the [`terms` query](/reference/query-languages/query-dsl/query-dsl-terms-query.md) for very large sets of numeric values. Rather than listing the values in a JSON array, you build a roaring bitmap on the client, serialize it, and send it as a single compact string.
+
+A common use case is filtering by an externally maintained set of identifiers, such as the product or document IDs a given user is entitled to see.
+
+::::{tip}
+For the best performance, map the field with [`index_terms: true`](/reference/elasticsearch/mapping-reference/number.md#index-terms-mapping-param). The query also works on the default BKD-indexed numeric fields.
+::::
+
+
+## Example request [bitmap-terms-query-ex-request]
+
+1. Create an index with a `long` field mapped for set membership filtering.
+
+    ```console
+    PUT my-index-000001
+    {
+      "mappings": {
+        "properties": {
+          "product_id": {
+            "type": "long",
+            "index_terms": true
+          }
+        }
+      }
+    }
+    ```
+
+2. Index a few documents.
+
+    ```console
+    POST my-index-000001/_bulk?refresh=true
+    { "index": {} }
+    { "product_id": 1 }
+    { "index": {} }
+    { "product_id": 2 }
+    { "index": {} }
+    { "product_id": 3 }
+    { "index": {} }
+    { "product_id": 4 }
+    { "index": {} }
+    { "product_id": 5 }
+    ```
+    % TEST[continued]
+
+3. Search with a bitmap holding the values `1`, `3`, and `5`. The query returns the three matching documents.
+
+    ```console
+    GET my-index-000001/_search
+    {
+      "query": {
+        "bitmap_terms": {
+          "field": "product_id",
+          "value": "AQAAAAAAAAAAAAAAOjAAAAEAAAAAAAIAEAAAAAEAAwAFAA=="
+        }
+      }
+    }
+    ```
+    % TEST[continued]
+
+
+## Top-level parameters for `bitmap_terms` [bitmap-terms-top-level-params]
+
+`field`
+:   (Required, string) Field you wish to search. Must be an `integer` or `long` field with [`index`](/reference/elasticsearch/mapping-reference/mapping-index.md) enabled.
+
+`value`
+:   (Required, string) Base64-encoded serialized roaring bitmap holding the values to match. The expected bitmap width depends on the type of `field`. See [Bitmap format](#bitmap-terms-format).
+
+`boost`
+:   (Optional, float) Floating point number used to decrease or increase the [relevance scores](/reference/query-languages/query-dsl/query-filter-context.md#relevance-scores) of a query. Defaults to `1.0`. Matching documents all receive the same constant score.
+
+`_name`
+:   (Optional, string) Name to identify the query for [named queries](/reference/query-languages/query-dsl/query-dsl-bool-query.md).
+
+
+## Bitmap format [bitmap-terms-format]
+
+The field type determines which roaring bitmap width {{es}} expects:
+
+| Field type | Expected bitmap |
+| --- | --- |
+| `integer` | 32-bit roaring bitmap |
+| `long` | 64-bit roaring bitmap, in the **portable** format |
+
+Sending a bitmap of the wrong width is rejected rather than silently mismatched: a 32-bit bitmap on a `long` field, or a 64-bit bitmap on an `integer` field, returns an error.
+
+### Generating the bitmap [bitmap-terms-generating-the-bitmap]
+
+Build the bitmap in your client, serialize it, then base64-encode the resulting bytes.
+
+For `long` fields, the portable format is what CRoaring's `roaring64_bitmap_portable_serialize`, Go's `roaring64.Bitmap#WriteTo`, and pyroaring's `BitMap64#serialize` all emit, so clients in those languages need no special handling:
+
+```python
+from pyroaring import BitMap64
+import base64
+
+bm = BitMap64([1_000_000_000_001, 4_000_000_000_004])
+value = base64.b64encode(bm.serialize()).decode()
+```
+
+In Java, `Roaring64NavigableMap` defaults to a different layout, so you have to ask for the portable one explicitly:
+
+```java
+Roaring64NavigableMap bitmap = new Roaring64NavigableMap();
+bitmap.addLong(1_000_000_000_001L);
+bitmap.addLong(4_000_000_000_004L);
+
+ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+bitmap.serializePortable(new DataOutputStream(bytes));  // not serialize()
+String value = Base64.getEncoder().encodeToString(bytes.toByteArray());
+```
+
+::::{warning}
+For `long` fields, Java's `Roaring64NavigableMap#serialize` writes a non-portable layout that {{es}} cannot read. Use `serializePortable` instead.
+::::
+
+For `integer` fields, build a 32-bit bitmap instead. There is only one serialization format at this width, so no special handling is needed in any language:
+
+```python
+from pyroaring import BitMap
+import base64
+
+bm = BitMap([1, 3, 5])
+value = base64.b64encode(bm.serialize()).decode()
+```
+
+```java
+RoaringBitmap bitmap = RoaringBitmap.bitmapOf(1, 3, 5);
+ByteBuffer buffer = ByteBuffer.allocate(bitmap.serializedSizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
+bitmap.serialize(buffer);
+String value = Base64.getEncoder().encodeToString(buffer.array());
+```
+
+
+## Advantages over the `terms` query [bitmap-terms-advantages]
+
+Both queries match documents against a set of exact values. On `integer` and `long` fields, `bitmap_terms` is the better choice once that set gets large:
+
+**No cap on the number of values**
+:   A `terms` query is limited to [`index.max_terms_count`](/reference/elasticsearch/index-settings/index-modules.md#index-max-terms-count) values, 65,536 by default. A bitmap has no such limit.
+
+**Smaller requests**
+:   Roaring bitmaps compress dense integer sets aggressively, so millions of values travel as a compact base64 string instead of a multi-megabyte JSON array.
+
+**Query construction is effectively free**
+:   A `terms` query has to parse, sort, and encode every value on every request, and that cost grows with the size of the set — at 100,000 values it alone accounts for several milliseconds per request. A bitmap is deserialized once and the query wraps it directly, so construction cost barely moves as the set grows.
+
+**Faster search**
+:   The bitmap is intersected with the index in a single ordered pass, instead of looking up each value separately.
+
+**Lower heap usage**
+:   The values stay in the bitmap's compressed form rather than being expanded into a list of boxed numbers, and matches are streamed lazily out of the bitmap during execution, so the full set is never materialized into an intermediate structure.
+
+For a set of 100,000 terms, `bitmap_terms` can be several times faster than an equivalent `terms` query, and its advantage grows with the number of terms.
+
+
+## Optimization on a sorted index [bitmap-terms-sorted-index]
+
+`bitmap_terms` is especially fast when the index is [sorted](/reference/elasticsearch/index-settings/sorting.md) in ascending order on the field being queried. This holds for both index structures: fields on the default BKD mapping and fields mapped with `index_terms: true`.
+
+Under such a sort, value order is document order, so matches come out already ordered as the query walks the bitmap. {{es}} can then stream them and stop as soon as it has collected enough hits, instead of building the complete set of matching documents up front.
+
+The optimization applies when:
+
+* The index is sorted in ascending order on the queried field.
+* The field is single-valued. Documents that have no value at all are fine.
+
+If either condition does not hold, the query falls back to collecting all matches first. Results are the same either way.
+
+```console
+PUT my-index-000002
+{
+  "settings": {
+    "index": {
+      "sort.field": "product_id",
+      "sort.order": "asc"
+    }
+  },
+  "mappings": {
+    "properties": {
+      "product_id": {
+        "type": "integer",
+        "index_terms": true
+      }
+    }
+  }
+}
+```
+
+### Lower `track_total_hits` to get the full benefit [bitmap-terms-track-total-hits]
+
+Early termination only helps if the search does not need a full hit count. By default {{es}} counts matches up to 10,000, so the scan has to produce that many documents before it can stop, which leaves most of the gain on the table.
+
+Set `track_total_hits` to `false` so the query can terminate as soon as `size` hits have been collected:
+
+```console
+GET my-index-000002/_search
+{
+  "size": 10,
+  "track_total_hits": false,
+  "query": {
+    "bitmap_terms": {
+      "field": "product_id",
+      "value": "OjAAAAEAAAAAAAIAEAAAAAEAAwAFAA=="
+    }
+  }
+}
+```
+% TEST[continued]
+
+A small number, such as `"track_total_hits": 10`, works too if you still want a lower bound on the count.
+
+On an unsorted index this setting makes no difference to `bitmap_terms`, because the full set of matches is built before any hits are collected.

--- a/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
@@ -165,7 +165,7 @@ Both queries match documents against a set of exact values. On `integer` and `lo
 **Lower heap usage**
 :   The values stay in the bitmap's compressed form rather than being expanded into a list of boxed numbers, and matches are streamed lazily out of the bitmap during execution, so the full set is never materialized into an intermediate structure.
 
-For a set of 100,000 terms, `bitmap_terms` can be several times faster than an equivalent `terms` query, and its advantage grows with the number of terms.
+For a set of 100,000 values, `bitmap_terms` can be several times faster than an equivalent `terms` query, and its advantage grows with the number of values.
 
 
 ## Optimization on a sorted index [bitmap-terms-sorted-index]
@@ -203,7 +203,7 @@ PUT my-index-000002
 
 ### Lower `track_total_hits` to get the full benefit [bitmap-terms-track-total-hits]
 
-Early termination only helps if the search does not need a full hit count. By default {{es}} counts matches up to 10,000, so the scan has to produce that many documents before it can stop, which leaves most of the gain on the table.
+Early termination only helps if the search does not need a full hit count. By default {{es}} counts matches up to 10,000, so the scan has to produce that many documents before it can stop, which means the full early-termination benefit is not realized.
 
 Set `track_total_hits` to `false` so the query can terminate as soon as `size` hits have been collected:
 

--- a/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
@@ -3,7 +3,7 @@ applies_to:
   stack: ga 9.6
   serverless: ga
 navigation_title: "Bitmap terms"
-Use the `bitmap_terms` query to match documents whose integer or long field value is contained in a roaring bitmap provided as a base64-encoded string.
+description: "Use the `bitmap_terms` query to match documents whose integer or long field value is contained in a roaring bitmap provided as a base64-encoded string."
 ---
 
 # Bitmap terms query [query-dsl-bitmap-terms-query]

--- a/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md
@@ -3,6 +3,7 @@ applies_to:
   stack: ga 9.6
   serverless: ga
 navigation_title: "Bitmap terms"
+Use the `bitmap_terms` query to match documents whose integer or long field value is contained in a roaring bitmap provided as a base64-encoded string.
 ---
 
 # Bitmap terms query [query-dsl-bitmap-terms-query]
@@ -95,7 +96,7 @@ The field type determines which roaring bitmap width {{es}} expects:
 | `integer` | 32-bit roaring bitmap |
 | `long` | 64-bit roaring bitmap, in the **portable** format |
 
-Sending a bitmap of the wrong width is rejected rather than silently mismatched: a 32-bit bitmap on a `long` field, or a 64-bit bitmap on an `integer` field, returns an error.
+Elasticsearch rejects a bitmap of the wrong width rather than silently mismatching it: a 32-bit bitmap on a `long` field, or a 64-bit bitmap on an `integer` field, returns an error.
 
 ### Generating the bitmap [bitmap-terms-generating-the-bitmap]
 
@@ -156,7 +157,7 @@ Both queries match documents against a set of exact values. On `integer` and `lo
 :   Roaring bitmaps compress dense integer sets aggressively, so millions of values travel as a compact base64 string instead of a multi-megabyte JSON array.
 
 **Query construction is effectively free**
-:   A `terms` query has to parse, sort, and encode every value on every request, and that cost grows with the size of the set — at 100,000 values it alone accounts for several milliseconds per request. A bitmap is deserialized once and the query wraps it directly, so construction cost barely moves as the set grows.
+:   A `terms` query has to parse, sort, and encode every value on every request, and that cost grows with the size of the set, at 100,000 values that overhead alone can account for several milliseconds per request. A bitmap is deserialized once and the query wraps it directly, so construction cost barely moves as the set grows.
 
 **Faster search**
 :   The bitmap is intersected with the index in a single ordered pass, instead of looking up each value separately.
@@ -169,7 +170,7 @@ For a set of 100,000 terms, `bitmap_terms` can be several times faster than an e
 
 ## Optimization on a sorted index [bitmap-terms-sorted-index]
 
-`bitmap_terms` is especially fast when the index is [sorted](/reference/elasticsearch/index-settings/sorting.md) in ascending order on the field being queried. This holds for both index structures: fields on the default BKD mapping and fields mapped with `index_terms: true`.
+`bitmap_terms` is especially fast when the index is [sorted](/reference/elasticsearch/index-settings/sorting.md) in ascending order on the field being queried. This applies to both index structures: fields on the default BKD mapping and fields mapped with `index_terms: true`.
 
 Under such a sort, value order is document order, so matches come out already ordered as the query walks the bitmap. {{es}} can then stream them and stop as soon as it has collected enough hits, instead of building the complete set of matching documents up front.
 
@@ -178,7 +179,7 @@ The optimization applies when:
 * The index is sorted in ascending order on the queried field.
 * The field is single-valued. Documents that have no value at all are fine.
 
-If either condition does not hold, the query falls back to collecting all matches first. Results are the same either way.
+If either condition does not hold, the query falls back to collecting all matches first, but results are the same either way.
 
 ```console
 PUT my-index-000002
@@ -221,6 +222,6 @@ GET my-index-000002/_search
 ```
 % TEST[continued]
 
-A small number, such as `"track_total_hits": 10`, works too if you still want a lower bound on the count.
+A small number, such as `"track_total_hits": 10`, also works if you want a lower bound on the count.
 
 On an unsorted index this setting makes no difference to `bitmap_terms`, because the full set of matches is built before any hits are collected.

--- a/docs/reference/query-languages/query-dsl/query-dsl-terms-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-terms-query.md
@@ -37,6 +37,11 @@ The value of this parameter is an array of terms you wish to find in the provide
 
 By default, {{es}} limits the `terms` query to a maximum of 65,536 terms. You can change this limit using the [`index.max_terms_count`](/reference/elasticsearch/index-settings/index-modules.md#index-max-terms-count) setting.
 
+::::{tip}
+To match against a much larger set of values on an `integer` or `long` field, use the [`bitmap_terms` query](/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md) {applies_to}`stack: ga 9.6` {applies_to}`serverless: ga`, which takes the values as a compact roaring bitmap and is not subject to this limit.
+::::
+
+
 ::::{note}
 To use the field values of an existing document as search terms, use the [terms lookup](#query-dsl-terms-lookup) parameters.
 ::::

--- a/docs/reference/query-languages/query-dsl/term-level-queries.md
+++ b/docs/reference/query-languages/query-dsl/term-level-queries.md
@@ -18,6 +18,9 @@ Term-level queries still normalize search terms for `keyword` fields with the `n
 
 ## Types of term-level queries [term-level-query-types]
 
+[`bitmap_terms` query](/reference/query-languages/query-dsl/query-dsl-bitmap-terms-query.md) {applies_to}`stack: ga 9.6` {applies_to}`serverless: ga`
+:   Returns documents whose `integer` or `long` field value is contained in a roaring bitmap. Use it in place of a `terms` query when the set of values is very large.
+
 [`exists` query](/reference/query-languages/query-dsl/query-dsl-exists-query.md)
 :   Returns documents that contain any indexed value for a field.
 

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -72,6 +72,7 @@ toc:
           - file: query-dsl/query-dsl-rule-query.md
       - file: query-dsl/term-level-queries.md
         children:
+          - file: query-dsl/query-dsl-bitmap-terms-query.md
           - file: query-dsl/query-dsl-exists-query.md
           - file: query-dsl/query-dsl-fuzzy-query.md
           - file: query-dsl/query-dsl-ids-query.md


### PR DESCRIPTION
Documents roaring bitmap support on numeric fields: the `index_terms`
mapping parameter (#155545, #155649) and the `bitmap_terms` query
(#153885, #155649, #156212, #157211).

### `index_terms`

Documented inline on the numeric field types page rather than as a
separate mapping-parameter page, since it is short and only applies to
`integer` and `long`:

- a one-line entry in **Parameters for numeric fields**
- an `index_terms` section covering what it changes (inverted index
  instead of a BKD tree), when to enable it, how `term` / `terms` /
  `range` and aggregations behave, and the restrictions
- indexed from **Mapping parameters** via an anchor, following the
  existing `fielddata` → `text.md#fielddata-mapping-param` pattern

### `bitmap_terms`

A new term-level query page covering:

- the non-negative value restriction, up front
- a worked example
- top-level parameters
- **Bitmap format** — 32-bit for `integer`, 64-bit portable for `long`,
  with client snippets for pyroaring and Java, and a warning that Java's
  `Roaring64NavigableMap#serialize` writes a layout Elasticsearch cannot
  read
- **Advantages over the `terms` query** — no `max_terms_count` cap,
  smaller requests, near-free query construction, faster search, lower
  heap usage
- **Optimization on a sorted index** — streaming and early termination on
  a segment sorted ascending on the queried field, on both the BKD and
  `index_terms` paths, and why `track_total_hits` should be lowered to
  collect the benefit


