### PR TITLE
[9.5] ESQL: Solves CIDRMatch optimizer bug and unresolved ref after implicit casting bug in analyzer (#156162)

### DIFF
--- a/docs/changelog/156162.yaml
+++ b/docs/changelog/156162.yaml
@@ -1,0 +1,7 @@
+area: ES|QL
+issues:
+ - 155979
+pr: 156162
+summary: Solves CIDRMatch optimizer bug and unresolved ref after implicit casting
+  bug in analyzer
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -850,3 +850,77 @@ ROW x = null |  EVAL append_coalesce = MV_APPEND("2", COALESCE(null, "1"))
 x:null | append_coalesce:keyword
 null   | [2, 1]
 ;
+
+implicitCastingOfIPWithMultipleEvalsInterleaved
+required_capability: fix_missed_implicit_casting_inside_interleaved_evals
+
+FROM hosts
+| EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1", TO_STRING(ip0), null), field = CASE(ip IS NOT NULL, "a", "b")
+| keep ip0, ip, field
+;
+warning:Line 2:29: evaluation of [ip0] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:29: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+ignoreOrder:true
+                                    ip0:ip                                       | ip:keyword    |     field:keyword
+127.0.0.1                                                                        |127.0.0.1      |a              
+::1                                                                              |null           |b              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]|null           |b              
+null                                                                             |null           |b              
+[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0]                           |null           |b
+;
+
+explicitCastingOfIPWithMultipleEvalsInterleaved
+required_capability: fix_missed_implicit_casting_inside_interleaved_evals
+
+
+FROM hosts
+| EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1"::ip, TO_STRING(ip0), null), field = CASE(ip IS NOT NULL, "a", "b")
+| keep ip0, ip, field
+;
+warning:Line 2:29: evaluation of [ip0] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:29: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+ignoreOrder:true
+                                    ip0:ip                                       | ip:keyword    |     field:keyword
+127.0.0.1                                                                        |127.0.0.1      |a              
+::1                                                                              |null           |b              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]|null           |b              
+null                                                                             |null           |b              
+[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0]                           |null           |b
+;
+
+implicitCastingOfIPWithSeparateEvals
+required_capability: fix_missed_implicit_casting_inside_interleaved_evals
+
+FROM hosts
+| EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1", TO_STRING(ip0), null)
+| EVAL field = CASE(ip IS NOT NULL, "a", "b")
+| keep ip0, ip, field
+;
+warning:Line 2:29: evaluation of [ip0] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:29: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+ignoreOrder:true
+                                    ip0:ip                                       | ip:keyword    |     field:keyword
+127.0.0.1                                                                        |127.0.0.1      |a              
+::1                                                                              |null           |b              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+127.0.0.1                                                                        |127.0.0.1      |a              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+fe80::cae2:65ff:fece:feb9                                                        |null           |b              
+[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]|null           |b              
+null                                                                             |null           |b              
+[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0]                           |null           |b
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1139,6 +1139,13 @@ public class EsqlCapabilities {
         IMPLICIT_CASTING_STRING_LITERAL_TO_TEMPORAL_AMOUNT,
 
         /**
+         * When multiple aliases are defined in a single EVAL, an implicit CASTing is missed because of a premature exit due
+         * to failing to immediately resolve a field referenced in one of the EVALed aliases.
+         * See <a href="https://github.com/elastic/elasticsearch/issues/155979">#155979</a>.
+         */
+        FIX_MISSED_IMPLICIT_CASTING_INSIDE_INTERLEAVED_EVALS,
+
+        /**
          * LOOKUP JOIN
          */
         JOIN_LOOKUP_V12,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -2084,11 +2084,23 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private List<Alias> resolveFields(List<Alias> fields, List<Attribute> initialInputs) {
+            Set<String> evalFieldNames = new HashSet<>(fields.size());
+            for (Alias f : fields) {
+                evalFieldNames.add(f.name());
+            }
             List<Attribute> allResolvedInputs = new ArrayList<>(initialInputs);
             List<Alias> newFields = new ArrayList<>();
             boolean changed = false;
             for (Alias field : fields) {
-                Alias result = (Alias) field.transformUp(UnresolvedAttribute.class, ua -> resolveAttribute(ua, allResolvedInputs));
+                Alias result = (Alias) field.transformUp(UnresolvedAttribute.class, ua -> {
+                    Attribute resolved = resolveAttribute(ua, allResolvedInputs);
+                    // If the unresolved attribute references another EVAL field, give it another opportunity to resolve
+                    // in the next pass (after implicit casting has run). If we set customMessage() it won't try to resolve again
+                    if (resolved instanceof UnresolvedAttribute u && u.customMessage() && evalFieldNames.contains(ua.name())) {
+                        return ua;
+                    }
+                    return resolved;
+                });
 
                 changed |= result != field;
                 newFields.add(result);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineDisjunctions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineDisjunctions.java
@@ -87,9 +87,9 @@ public final class CombineDisjunctions extends OptimizerRules.OptimizerExpressio
                         // If the data type is IP, convert the internal IP format in Equals and IN to the format that is compatible with
                         // CIDRMatch, and store them in a separate map, so that they can be combined into existing CIDRMatch later.
                         if (value instanceof BytesRef bytesRef) {
-                            value = ipToString(bytesRef);
+                            value = new BytesRef(ipToString(bytesRef));
                         }
-                        ips.computeIfAbsent(eq.left(), k -> new LinkedHashSet<>()).add(new Literal(Source.EMPTY, value, DataType.IP));
+                        ips.computeIfAbsent(eq.left(), k -> new LinkedHashSet<>()).add(new Literal(Source.EMPTY, value, DataType.KEYWORD));
                     }
                 } else {
                     ors.add(exp);
@@ -105,9 +105,9 @@ public final class CombineDisjunctions extends OptimizerRules.OptimizerExpressio
                         Object value = i.fold(ctx.foldCtx());
                         // Same as Equals.
                         if (value instanceof BytesRef bytesRef) {
-                            value = ipToString(bytesRef);
+                            value = new BytesRef(ipToString(bytesRef));
                         }
-                        values.add(new Literal(Source.EMPTY, value, DataType.IP));
+                        values.add(new Literal(Source.EMPTY, value, DataType.KEYWORD));
                     }
                     ips.computeIfAbsent(in.value(), k -> new LinkedHashSet<>()).addAll(values);
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2516,6 +2516,33 @@ public class AnalyzerTests extends ESTestCase {
         );
     }
 
+    public void testEvalResolvesForwardReferenceWithImplicitCasting() {
+        analyzer().addIndex("hosts", "mapping-hosts.json").query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1", TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """);
+    }
+
+    public void testEvalResolvesForwardReferenceWithImplicitCasting2() {
+        analyzer().addIndex("hosts", "mapping-hosts.json").query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 IN ("127.0.0.1", "192.168.1.1"), TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """);
+    }
+
+    public void testEvalResolvesForwardReferenceWithImplicitCasting3() {
+        analyzer().addIndex("hosts", "mapping-hosts.json").query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 IN ("127.0.0.1", "192.168.1.1"::ip), TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """);
+    }
+
     public void testDenseVectorImplicitCastingKnn() {
         checkDenseVectorCastingHexKnn("float_vector");
         checkDenseVectorCastingKnn("float_vector");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -634,4 +634,78 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         assertThat(err, is("1:19: Unbounded SORT not supported yet [SORT emp_no + 1] please add a LIMIT"));
     }
+
+    /**
+     * Regression test for https://github.com/elastic/elasticsearch/issues/155979 where ip
+     * ended up as unresolved in the logical plan optimizations
+     */
+    public void testOrCidrMatchNotPruned() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1"::ip, TO_STRING(ip0), null)
+            """));
+    }
+
+    /**
+     * Regression test for https://github.com/elastic/elasticsearch/issues/155979 where ip
+     * disappeared from the plan in the logical optimizations
+     */
+    public void testOrCidrMatchNotPruned2() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1"::ip, TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """));
+    }
+
+    public void testOrCidrMatchWithInNotPruned() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 IN ("127.0.0.1"::ip, "192.168.1.1"::ip), TO_STRING(ip0), null)
+            """));
+    }
+
+    public void testOrCidrMatchWithInNotPruned2() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 IN ("127.0.0.1"::ip, "192.168.1.1"::ip), TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """));
+    }
+
+    public void testOrCidrMatchWithMixedTypeInNotPruned() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 IN ("127.0.0.1"::ip, "192.168.1.1"), TO_STRING(ip0), null)
+            """));
+    }
+
+    public void testIpInWithoutCidrMatchNotPruned() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(ip0 IN ("127.0.0.1"::ip, "192.168.1.1"::ip), TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """));
+    }
+
+    public void testIpEqualityAndInCombinedWithCidrMatchNotPruned() {
+        var testAnalyzer = analyzer().addIndex("hosts", "mapping-hosts.json");
+        optimize(testAnalyzer.query("""
+            FROM hosts
+            | EVAL ip = CASE(
+                CIDR_MATCH(ip0, "10.0.0.0/8") OR ip0 == "127.0.0.1"::ip OR ip0 IN ("192.168.1.1"::ip, "172.16.0.1"::ip),
+                TO_STRING(ip0), null),
+                   field = CASE(ip IS NOT NULL, "a", "b")
+            | STATS count = COUNT(*) BY field
+            """));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineDisjunctionsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineDisjunctionsTests.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -284,6 +287,162 @@ public class CombineDisjunctionsTests extends ESTestCase {
                 assertTrue(in1.list().size() == 2 && in1.list().containsAll(List.of(ONE, SIX)));
                 assertTrue(in2.list().size() == 4 && in2.list().containsAll(List.of(ONE, FOUR, FIVE, SIX)));
             }
+        }
+    }
+
+    public void testCombineIpEqualityIntoCidrMatchUsesKeywordType() {
+        FieldAttribute ipField = getFieldAttribute("ip_field", DataType.IP);
+
+        BytesRef cidrPattern = new BytesRef("10.0.0.0/8");
+        List<Expression> cidrPatterns = List.of(new Literal(EMPTY, cidrPattern, DataType.KEYWORD));
+
+        BytesRef encodedIp = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")));
+        Literal ipLiteral = new Literal(EMPTY, encodedIp, DataType.IP);
+        Equals ipEquals = new Equals(EMPTY, ipField, ipLiteral, null);
+
+        // CIDRMatch(ipField, "10.0.0.0/8") OR ipField == 127.0.0.1::ip
+        CIDRMatch cidrMatch = new CIDRMatch(EMPTY, ipField, cidrPatterns);
+        Or or = new Or(EMPTY, cidrMatch, ipEquals);
+
+        Expression result = combineDisjunctions(or);
+        assertEquals(CIDRMatch.class, result.getClass());
+        CIDRMatch combined = (CIDRMatch) result;
+        // CIDRMatch(ipField, "10.0.0.0/8", "127.0.0.1")
+        assertTrue(result.resolved());
+        assertEquals(ipField, combined.ipField());
+        assertEquals(2, combined.matches().size());
+
+        for (Expression match : combined.matches()) {
+            assertEquals(DataType.KEYWORD, match.dataType());
+        }
+    }
+
+    public void testCombineIpInIntoCidrMatchUsesKeywordType() {
+        FieldAttribute ipField = getFieldAttribute("ip_field", DataType.IP);
+
+        BytesRef cidrPattern = new BytesRef("10.0.0.0/8");
+        List<Expression> cidrPatterns = List.of(new Literal(EMPTY, cidrPattern, DataType.KEYWORD));
+
+        BytesRef encodedIp1 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")));
+        BytesRef encodedIp2 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.1.1")));
+        Literal ipLiteral1 = new Literal(EMPTY, encodedIp1, DataType.IP);
+        Literal ipLiteral2 = new Literal(EMPTY, encodedIp2, DataType.IP);
+        In ipIn = new In(EMPTY, ipField, List.of(ipLiteral1, ipLiteral2));
+
+        // CIDRMatch(ipField, "10.0.0.0/8") OR ipField IN (127.0.0.1::ip, 192.168.1.1::ip)
+        CIDRMatch cidrMatch = new CIDRMatch(EMPTY, ipField, cidrPatterns);
+        Or or = new Or(EMPTY, cidrMatch, ipIn);
+
+        Expression result = combineDisjunctions(or);
+        assertEquals(CIDRMatch.class, result.getClass());
+        CIDRMatch combined = (CIDRMatch) result;
+        // CIDRMatch(ipField, "10.0.0.0/8", "127.0.0.1", "192.168.1.1")
+        assertTrue(result.resolved());
+        assertEquals(ipField, combined.ipField());
+        assertEquals(3, combined.matches().size());
+
+        for (Expression match : combined.matches()) {
+            assertEquals(DataType.KEYWORD, match.dataType());
+        }
+    }
+
+    /**
+     * When there's no CIDRMatch at all, the IN should remain unchanged because
+     * the {@code ips} map is never consumed (the {@code cidrs.isEmpty()} guard prevents it).
+     */
+    public void testIpInWithoutCidrMatchRemainsAsIn() {
+        FieldAttribute ipField = getFieldAttribute("ip_field", DataType.IP);
+
+        BytesRef encodedIp1 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")));
+        BytesRef encodedIp2 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.1.1")));
+        Literal ipLiteral1 = new Literal(EMPTY, encodedIp1, DataType.IP);
+        Literal ipLiteral2 = new Literal(EMPTY, encodedIp2, DataType.IP);
+        In ipIn = new In(EMPTY, ipField, List.of(ipLiteral1, ipLiteral2));
+
+        // ipField IN (127.0.0.1::ip) OR ipField IN (192.168.1.1::ip) — no CIDRMatch present
+        In ipIn2 = new In(EMPTY, ipField, List.of(ipLiteral2));
+        Or or = new Or(EMPTY, ipIn, ipIn2);
+
+        Expression result = combineDisjunctions(or);
+        assertEquals(In.class, result.getClass());
+        In combined = (In) result;
+        assertEquals(ipField, combined.value());
+        assertEquals(2, combined.list().size());
+        for (Expression item : combined.list()) {
+            assertEquals(DataType.IP, item.dataType());
+        }
+    }
+
+    /**
+     * When a CIDRMatch exists on a different field, the IN's IP values still get
+     * merged into a new CIDRMatch for their own field (because {@code cidrs.isEmpty()} is false).
+     * Verify the resulting CIDRMatch literals are KEYWORD-typed.
+     */
+    public void testIpInPromotedToCidrMatchWhenCidrExistsOnDifferentField() {
+        FieldAttribute ipField1 = getFieldAttribute("ip_field_1", DataType.IP);
+        FieldAttribute ipField2 = getFieldAttribute("ip_field_2", DataType.IP);
+
+        BytesRef cidrPattern = new BytesRef("10.0.0.0/8");
+        List<Expression> cidrPatterns = List.of(new Literal(EMPTY, cidrPattern, DataType.KEYWORD));
+        CIDRMatch cidrMatch = new CIDRMatch(EMPTY, ipField1, cidrPatterns);
+
+        BytesRef encodedIp = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")));
+        Literal ipLiteral = new Literal(EMPTY, encodedIp, DataType.IP);
+        In ipIn = new In(EMPTY, ipField2, List.of(ipLiteral));
+
+        // CIDRMatch(ip_field_1, "10.0.0.0/8") OR ip_field_2 IN (127.0.0.1::ip)
+        Or or = new Or(EMPTY, cidrMatch, ipIn);
+
+        Expression result = combineDisjunctions(or);
+        // Should become: CIDRMatch(ip_field_1, "10.0.0.0/8") OR CIDRMatch(ip_field_2, "127.0.0.1")
+        assertEquals(Or.class, result.getClass());
+        Or resultOr = (Or) result;
+
+        CIDRMatch left = (CIDRMatch) resultOr.left();
+        assertEquals(ipField1, left.ipField());
+        assertEquals(1, left.matches().size());
+        assertEquals(DataType.KEYWORD, left.matches().get(0).dataType());
+
+        CIDRMatch right = (CIDRMatch) resultOr.right();
+        assertEquals(ipField2, right.ipField());
+        assertEquals(1, right.matches().size());
+        assertEquals(DataType.KEYWORD, right.matches().get(0).dataType());
+    }
+
+    /**
+     * An IP equality combined with an IP IN on the same field, with a CIDRMatch also on that field.
+     * All three should merge into a single CIDRMatch with KEYWORD-typed patterns.
+     */
+    public void testCombineIpEqualityAndInIntoCidrMatch() {
+        FieldAttribute ipField = getFieldAttribute("ip_field", DataType.IP);
+
+        BytesRef cidrPattern = new BytesRef("10.0.0.0/8");
+        List<Expression> cidrPatterns = List.of(new Literal(EMPTY, cidrPattern, DataType.KEYWORD));
+        CIDRMatch cidrMatch = new CIDRMatch(EMPTY, ipField, cidrPatterns);
+
+        BytesRef encodedIp1 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1")));
+        BytesRef encodedIp2 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.1.1")));
+        BytesRef encodedIp3 = new BytesRef(InetAddressPoint.encode(InetAddresses.forString("172.16.0.1")));
+        Literal ipLiteral1 = new Literal(EMPTY, encodedIp1, DataType.IP);
+        Literal ipLiteral2 = new Literal(EMPTY, encodedIp2, DataType.IP);
+        Literal ipLiteral3 = new Literal(EMPTY, encodedIp3, DataType.IP);
+
+        Equals ipEquals = new Equals(EMPTY, ipField, ipLiteral1, null);
+        In ipIn = new In(EMPTY, ipField, List.of(ipLiteral2, ipLiteral3));
+
+        // CIDRMatch(ipField, "10.0.0.0/8") OR ipField == 127.0.0.1::ip OR ipField IN (192.168.1.1::ip, 172.16.0.1::ip)
+        Or inner = new Or(EMPTY, cidrMatch, ipEquals);
+        Or or = new Or(EMPTY, inner, ipIn);
+
+        Expression result = combineDisjunctions(or);
+        assertEquals(CIDRMatch.class, result.getClass());
+        CIDRMatch combined = (CIDRMatch) result;
+        assertEquals(ipField, combined.ipField());
+        // "10.0.0.0/8" + "127.0.0.1" + "192.168.1.1" + "172.16.0.1"
+        assertEquals(4, combined.matches().size());
+
+        for (Expression match : combined.matches()) {
+            assertEquals(DataType.KEYWORD, match.dataType());
         }
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [ESQL: Solves CIDRMatch optimizer bug and unresolved ref after implicit casting bug in analyzer (#156162)](https://github.com/elastic/elasticsearch/pull/156162)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)