### PR TITLE
[9.5] fix(mapper): order keyword binary ranges by bytes (#156920)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/395_binary_doc_values_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/395_binary_doc_values_search.yml
@@ -174,6 +174,88 @@ setup:
   - match: { hits.hits.0.sort.0: key2 }
   - match: { hits.hits.1.sort.0: key1 }
 
+---
+"Test keyword range uses indexed byte ordering for binary doc values":
+
+  - do:
+      indices.create:
+        index: keyword_range_indexed
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              keyword:
+                type: keyword
+
+  - do:
+      indices.create:
+        index: keyword_range_binary
+        body:
+          settings:
+            index:
+              mode: columnar
+          mappings:
+            dynamic: false
+            properties:
+              keyword:
+                type: keyword
+                index: false
+
+  - do:
+      index:
+        index: keyword_range_indexed
+        id: "1"
+        body:
+          keyword: "\U0001F600"
+
+  - do:
+      index:
+        index: keyword_range_binary
+        id: "1"
+        body:
+          keyword: "\U0001F600"
+
+  - do:
+      index:
+        index: keyword_range_indexed
+        id: "2"
+        body:
+          keyword: "\uF000"
+
+  - do:
+      index:
+        index: keyword_range_binary
+        id: "2"
+        body:
+          keyword: "\uF000"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: keyword_range_indexed
+        body:
+          size: 0
+          track_total_hits: true
+          query:
+            range:
+              keyword:
+                gte: "\uE000"
+  - match: { hits.total.value: 2 }
+
+  - do:
+      search:
+        index: keyword_range_binary
+        body:
+          size: 0
+          track_total_hits: true
+          query:
+            range:
+              keyword:
+                gte: "\uE000"
+  - match: { hits.total.value: 2 }
+
 
 ---
 "Test match query on ip field where only doc values are enabled":
@@ -201,4 +283,3 @@ setup:
         index: test
         body: { query: { range: { ip: { gte: "192.168.0.1" } } } }
   - length:   { hits.hits: 2  }
-

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -76,6 +76,7 @@ import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
@@ -92,7 +93,6 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldFuzzyQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
-import org.elasticsearch.search.runtime.StringScriptFieldRangeQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldTermQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 import org.elasticsearch.xcontent.Text;
@@ -797,14 +797,13 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
             } else if (usesBinaryDocValues) {
-                return new StringScriptFieldRangeQuery(
-                    new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
+                return new ScanningBinaryDocValuesRangeQuery(
                     name(),
-                    lowerTerm == null ? null : indexedValueForSearch(lowerTerm).utf8ToString(),
-                    upperTerm == null ? null : indexedValueForSearch(upperTerm).utf8ToString(),
+                    lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
+                    upperTerm == null ? null : indexedValueForSearch(upperTerm),
                     includeLower,
-                    includeUpper
+                    includeUpper,
+                    useArrayOrderBinaryDocValues
                 );
             } else {
                 return SortedSetDocValuesField.newSlowRangeQuery(

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQuery.java
@@ -32,21 +32,51 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
 
     private final BytesRef lower;
     private final BytesRef upper;
+    private final boolean includeLower;
+    private final boolean includeUpper;
 
     public ScanningBinaryDocValuesRangeQuery(String fieldName, BytesRef lower, BytesRef upper, boolean arrayOrderInlineNull) {
-        super(fieldName, rangeMatcher(Objects.requireNonNull(lower), Objects.requireNonNull(upper)), arrayOrderInlineNull);
-        assert lower.compareTo(upper) <= 0;
-        this.lower = lower;
-        this.upper = upper;
+        this(fieldName, lower, upper, true, true, arrayOrderInlineNull);
     }
 
-    private static Predicate<BytesRef> rangeMatcher(BytesRef lower, BytesRef upper) {
-        return value -> lower.compareTo(value) <= 0 && upper.compareTo(value) >= 0;
+    public ScanningBinaryDocValuesRangeQuery(
+        String fieldName,
+        BytesRef lower,
+        BytesRef upper,
+        boolean includeLower,
+        boolean includeUpper,
+        boolean arrayOrderInlineNull
+    ) {
+        super(fieldName, rangeMatcher(lower, upper, includeLower, includeUpper), arrayOrderInlineNull);
+        this.lower = lower;
+        this.upper = upper;
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
+    }
+
+    private static Predicate<BytesRef> rangeMatcher(BytesRef lower, BytesRef upper, boolean includeLower, boolean includeUpper) {
+        return value -> isAboveLowerBound(value, lower, includeLower) && isBelowUpperBound(value, upper, includeUpper);
+    }
+
+    private static boolean isAboveLowerBound(BytesRef value, BytesRef lower, boolean includeLower) {
+        if (lower == null) {
+            return true;
+        }
+        int cmp = value.compareTo(lower);
+        return includeLower ? cmp >= 0 : cmp > 0;
+    }
+
+    private static boolean isBelowUpperBound(BytesRef value, BytesRef upper, boolean includeUpper) {
+        if (upper == null) {
+            return true;
+        }
+        int cmp = value.compareTo(upper);
+        return includeUpper ? cmp <= 0 : cmp < 0;
     }
 
     @Override
     public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-        if (lower.bytesEquals(upper)) {
+        if (lower != null && upper != null && includeLower && includeUpper && lower.bytesEquals(upper)) {
             return new ScanningBinaryDocValuesTermQuery(fieldName, lower, arrayOrderInlineNull);
         }
         return super.rewrite(indexSearcher);
@@ -54,12 +84,12 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
 
     @Override
     protected float matchCost() {
-        return 20; // two comparisons per candidate value
+        return 20;
     }
 
     @Override
     public String toString(String field) {
-        return "ScanningBinaryDocValuesRangeQuery(fieldName=" + field + ",lower=" + lower.toString() + ",upper=" + upper.toString() + ")";
+        return "ScanningBinaryDocValuesRangeQuery(fieldName=" + fieldName + ",lower=" + lower + ",upper=" + upper + ")";
     }
 
     @Override
@@ -71,11 +101,16 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
             return false;
         }
         ScanningBinaryDocValuesRangeQuery that = (ScanningBinaryDocValuesRangeQuery) o;
-        return Objects.equals(fieldName, that.fieldName) && lower.bytesEquals(that.lower) && upper.bytesEquals(that.upper);
+        return Objects.equals(fieldName, that.fieldName)
+            && Objects.equals(lower, that.lower)
+            && Objects.equals(upper, that.upper)
+            && includeLower == that.includeLower
+            && includeUpper == that.includeUpper
+            && arrayOrderInlineNull == that.arrayOrderInlineNull;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, lower, upper);
+        return Objects.hash(classHash(), fieldName, lower, upper, includeLower, includeUpper, arrayOrderInlineNull);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -59,6 +59,7 @@ import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
@@ -321,6 +322,23 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         assertEquals(
             "[range] queries on [text] or [keyword] fields cannot be executed when " + "'search.allow_expensive_queries' is set to false.",
             ee.getMessage()
+        );
+    }
+
+    public void testRangeQueryUsesBinaryDocValuesQuery() {
+        KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("field", defaultIndexSettings());
+        builder.docValues(FieldMapper.DocValuesParameter.Values.Cardinality.HIGH);
+        MappedFieldType ft = new KeywordFieldType(
+            "field",
+            IndexType.docValuesOnly(),
+            TextSearchInfo.SIMPLE_MATCH_ONLY,
+            null,
+            builder,
+            true
+        );
+        assertEquals(
+            new ScanningBinaryDocValuesRangeQuery("field", BytesRefs.toBytesRef("bar"), BytesRefs.toBytesRef("foo"), true, false, false),
+            ft.rangeQuery("bar", "foo", true, false, null, null, null, MOCK_CONTEXT)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQueryTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.lucene.queries;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -24,6 +25,50 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 
 public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
+
+    public void testRangeUsesBytesRefOrdering() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(docWithValue(fieldName, new String(Character.toChars(0x1F600))));
+                writer.addDocument(docWithValue(fieldName, "\uF000"));
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("\uE000"), null, true, true, false);
+                    assertEquals(2, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testRangeSupportsOpenAndExclusiveBounds() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(docWithValue(fieldName, "alpha"));
+                writer.addDocument(docWithValue(fieldName, "beta"));
+                writer.addDocument(docWithValue(fieldName, "gamma"));
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query closed = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("alpha"),
+                        new BytesRef("gamma"),
+                        true,
+                        true,
+                        false
+                    );
+                    assertEquals(3, searcher.count(closed));
+
+                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, null, new BytesRef("gamma"), true, false, false);
+                    assertEquals(2, searcher.count(lowerOpen));
+
+                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("alpha"), null, false, true, false);
+                    assertEquals(2, searcher.count(upperOpen));
+                }
+            }
+        }
+    }
 
     public void testArrayOrderInlineNull() throws Exception {
         String fieldName = "field";
@@ -52,6 +97,12 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
         return new BytesRef(InetAddressPoint.encode(InetAddresses.forString(ip)));
     }
 
+    private static Document docWithValue(String fieldName, String value) {
+        Document document = new Document();
+        document.add(new BinaryDocValuesField(fieldName, new BytesRef(value)));
+        return document;
+    }
+
     private static Document docWithIps(String... ips) {
         Document document = new Document();
         var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE);
@@ -60,6 +111,20 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
         }
         document.add(field);
         document.add(new NumericDocValuesField("field.counts", field.count()));
+        return document;
+    }
+
+    private static Document docWithValues(String fieldName, String... values) {
+        Document document = new Document();
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount(
+            fieldName,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+        );
+        for (String value : values) {
+            field.add(new BytesRef(value));
+        }
+        document.add(field);
+        document.add(new NumericDocValuesField(fieldName + ".counts", field.count()));
         return document;
     }
 
@@ -77,6 +142,36 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, false);
                     assertEquals(2, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testOpenRangeMatchesMultiValued() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(docWithValues(fieldName, "gamma"));
+                writer.addDocument(docWithValues(fieldName, "alpha"));
+                writer.addDocument(docWithValues(fieldName, "alpha", "beta"));
+                writer.addDocument(docWithValues(fieldName, "delta", "epsilon"));
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query closed = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("beta"),
+                        new BytesRef("delta"),
+                        true,
+                        true,
+                        false
+                    );
+                    assertEquals(2, searcher.count(closed));
+
+                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, null, new BytesRef("beta"), true, true, false);
+                    assertEquals(2, searcher.count(lowerOpen));
+
+                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("delta"), null, true, true, false);
+                    assertEquals(2, searcher.count(upperOpen));
                 }
             }
         }
@@ -112,13 +207,26 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
     }
 
     public void testRewriteToTermQueryWhenBoundsEqual() throws Exception {
-        BytesRef term = encodeIp("192.168.1.1");
+        BytesRef term = new BytesRef("alpha");
         ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, false);
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     assertEquals(new ScanningBinaryDocValuesTermQuery("field", term, false), range.rewrite(searcher));
+                }
+            }
+        }
+    }
+
+    public void testRewriteKeepsExclusiveEqualBoundsRange() throws Exception {
+        BytesRef term = new BytesRef("alpha");
+        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, false, true, false);
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    assertSame(range, range.rewrite(searcher));
                 }
             }
         }

--- a/x-pack/qa/runtime-fields/core-with-mapped/build.gradle
+++ b/x-pack/qa/runtime-fields/core-with-mapped/build.gradle
@@ -81,6 +81,8 @@ tasks.named("yamlRestTest").configure {
       'aggregations/time_series/*',
       // columnar index modes reject mapping-level runtime fields
       'search/400_columnar_default_field/*',
+      // runtime keyword fields compare range bounds as Java strings, not indexed UTF-8 bytes
+      'search/395_binary_doc_values_search/Test keyword range uses indexed byte ordering for binary doc values',
       // The error messages are different
       'search/330_fetch_fields/error includes field name',
       'search/330_fetch_fields/error includes glob pattern',

--- a/x-pack/qa/runtime-fields/core-with-search/build.gradle
+++ b/x-pack/qa/runtime-fields/core-with-search/build.gradle
@@ -76,6 +76,8 @@ tasks.named("yamlRestTest").configure {
       'aggregations/time_series/*',
       // columnar index modes reject mapping-level runtime fields
       'search/400_columnar_default_field/*',
+      // runtime keyword fields compare range bounds as Java strings, not indexed UTF-8 bytes
+      'search/395_binary_doc_values_search/Test keyword range uses indexed byte ordering for binary doc values',
       // The error messages are different
       'search/330_fetch_fields/error includes field name',
       'search/330_fetch_fields/error includes glob pattern',


### PR DESCRIPTION
Backports the following commits to 9.5:
 - fix(mapper): order keyword binary ranges by bytes (#156920)