### PR TITLE
Disable Log4j shutdown hook in test JVMs

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -219,6 +219,9 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
             // JVMs and are unaffected.
             test.systemProperty("es.queryable_built_in_roles_enabled", "false");
 
+            // Logging is shut down explicitly, so disable Log4j's own shutdown hook as we do in jvm.options
+            test.systemProperty("log4j.shutdownHookEnabled", "false");
+
             // Set netty system properties to the properties we configure in jvm.options
             test.systemProperty("io.netty.noUnsafe", "true");
             test.systemProperty("io.netty.noKeySetOptimization", "true");

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -458,7 +458,6 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @SuppressForbidden(reason = "force log4j and netty sysprops")
     private static void setTestSysProps(Random random) {
-        System.setProperty("log4j.shutdownHookEnabled", "false");
         System.setProperty("log4j2.disable.jmx", "true");
 
         // Enable Netty leak detection and monitor logger for logged leak errors


### PR DESCRIPTION
`ESTestCase` registers a shutdown hook that shuts logging down when the test JVM exits, and sets `log4j.shutdownHookEnabled=false` so that Log4j doesn't register a competing one of its own.

That `System.setProperty` call has been a no-op since #157016. `Log4jContextFactory` snapshots the property into a `static final` when the class is first loaded, and #157016 added a `STATIC_LOGGER` field to `ESTestCase` above the static block, so Log4j is now initialized before `setTestSysProps` gets a chance to run.

With both hooks registered they race at JVM exit:

1. Log4j's hook stops the `LoggerContext`. `ClassLoaderContextSelector`, registered as a shutdown listener, removes it from `CONTEXT_MAP`.
2. `ESTestCase`'s hook calls `LogManager.getContext(false)`. With no entry in the map, the selector builds a fresh context in state `INITIALIZED`, so `Log4jContextFactory` calls `start()` on it.
3. `start()` tries to register a shutdown hook on a registry that is already `STOPPING` and throws `IllegalStateException`. `LogManager.getContext` catches that and falls back to a `SimpleLoggerContext`.
4. The cast in `ESTestCase`'s hook fails:

```
Exception in thread "Thread-3" java.lang.ClassCastException: class org.apache.logging.log4j.simple.SimpleLoggerContext cannot be cast to class org.apache.logging.log4j.core.LoggerContext
    at org.elasticsearch.test.ESTestCase.lambda$static$0(ESTestCase.java:367)
    at java.base/java.lang.Thread.run(Thread.java:1516)
```

It is intermittent because if `ESTestCase`'s hook wins the race the context is still `STARTED`, or `STOPPING` and still in the map, so `start()` is never called and the cast succeeds.

Pass the property as a JVM argument from `ElasticsearchTestBasePlugin` instead, the way `jvm.options` does for the server, so that class initialization order cannot defeat it. This restores the behaviour we had before #157016: Log4j registers no hook of its own, and `ESTestCase`'s hook is the only thing that shuts logging down.
