### PR TITLE
Mute EsqlSecurityLogsdb LOAD_ALL FLS tests (#157326)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -794,7 +794,7 @@ tests:
 - class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbColumnarIT
   method: testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll
   issue: https://github.com/elastic/elasticsearch/issues/157326
-- class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbColumnarIT
+- class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbIT
   method: testFromDatasetDeniedWithoutReadOnName
   issue: https://github.com/elastic/elasticsearch/issues/157335
 - class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbIT

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -788,3 +788,9 @@ tests:
 - class: org.elasticsearch.xpack.inference.services.ai21.Ai21ServiceTests
   method: testUnifiedCompletionInfer
   issue: https://github.com/elastic/elasticsearch/issues/157322
+- class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbIT
+  method: testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll
+  issue: https://github.com/elastic/elasticsearch/issues/157326
+- class: org.elasticsearch.xpack.esql.EsqlSecurityLogsdbColumnarIT
+  method: testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll
+  issue: https://github.com/elastic/elasticsearch/issues/157326


### PR DESCRIPTION
Mutes two release-test failures that are currently red on `main` and block every PR that has merged `main` since #156828 landed (2026-08-20).

`EsqlSecurityLogsdbIT` / `EsqlSecurityLogsdbColumnarIT`.`testFieldLevelSecurityFieldDeniedWithUnmappedFieldsLoadAll` exercise `SET unmapped_fields="LOAD_ALL"`, which is snapshot-only. Release-tests run with `-Dbuild.snapshot=false`, and the tests' `assumeTrue(hasCapabilities(OPTIONAL_FIELDS_LOAD_ALL))` guard is not skipping them in that harness, so they hit a `400 … requires a snapshot build`.

Tracked in #157326. The real fix is to gate these tests off for non-snapshot builds (see #144741 for the analogous `unmapped_fields="load"` fix).
