### PR TITLE
Add more logging for StatelessComponentsOrderIT test failure

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessComponentsOrderIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessComponentsOrderIT.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService;
@@ -55,43 +57,50 @@ public class StatelessComponentsOrderIT extends AbstractStatelessPluginIntegTest
         final TestStatelessPlugin plugin = findPlugin(indexNode, TestStatelessPlugin.class);
         final var indicesService = internalCluster().getInstance(IndicesService.class, indexNode);
         final var indexShard = findIndexShard(indexName);
+        final Thread shuttingDownThread;
 
-        logger.info("--> indexing and flush docs to trigger background merge");
-        for (int i = 0; i < 11; i++) {
-            indexDocs(indexName, 10);
-            flush(indexName);
-        }
-
-        // Wait for merge to trigger and evict cache so that merge will attempt to fill the cache
-        safeAwait(plugin.mergeReadStartedLatch);
-        logger.info("--> evict cache after merge read started");
-        final var blobStoreCacheDirectory = BlobStoreCacheDirectory.unwrapDirectory(indexShard.store().directory());
-        getCacheService(blobStoreCacheDirectory).forceEvict((key) -> true);
-
-        logger.info("--> deleting index to remove the shard from IndicesService");
-        safeGet(indicesAdmin().prepareDelete(indexName).execute());
-        assertNull(indicesService.indexService(indexShard.shardId().getIndex()));
-
-        logger.info("--> shutting down the index node");
-        final Thread shuttingDownThread = new Thread(() -> {
-            try {
-                internalCluster().stopNode(indexNode);
-            } catch (IOException e) {
-                fail(e);
+        try {
+            logger.info("--> indexing and flush docs to trigger background merge");
+            for (int i = 0; i < 11; i++) {
+                indexDocs(indexName, 10);
+                logger.info("--> indexed {} docs", (i + 1) * 10);
+                flush(indexName);
             }
-        });
-        shuttingDownThread.start();
 
-        safeAwait(plugin.statelessCloseCalledLatch);
-        // Let merge continue, and it should not run into exceptions such as ClosedChannelException or EsRejectedExecutionException
-        logger.info("--> resume the merge thread");
-        plugin.cacheEvictedLatch.countDown();
+            // Wait for merge to trigger and evict cache so that merge will attempt to fill the cache
+            safeAwait(plugin.mergeReadStartedLatch);
+            logger.info("--> evict cache after merge read started");
+            final var blobStoreCacheDirectory = BlobStoreCacheDirectory.unwrapDirectory(indexShard.store().directory());
+            getCacheService(blobStoreCacheDirectory).forceEvict((key) -> true);
+
+            logger.info("--> deleting index to remove the shard from IndicesService");
+            safeGet(indicesAdmin().prepareDelete(indexName).execute());
+            assertNull(indicesService.indexService(indexShard.shardId().getIndex()));
+
+            logger.info("--> shutting down the index node");
+            shuttingDownThread = new Thread(() -> {
+                try {
+                    internalCluster().stopNode(indexNode);
+                } catch (IOException e) {
+                    fail(e);
+                }
+            });
+            shuttingDownThread.start();
+
+            safeAwait(plugin.statelessCloseCalledLatch);
+        } finally {
+            // Let merge continue, and it should not run into exceptions such as ClosedChannelException or EsRejectedExecutionException
+            logger.info("--> resume the merge thread");
+            plugin.cacheEvictedLatch.countDown();
+        }
 
         shuttingDownThread.join(30000);
         assertFalse(shuttingDownThread.isAlive());
     }
 
     public static class TestStatelessPlugin extends TestUtils.StatelessPluginWithTrialLicense {
+
+        private static final Logger logger = LogManager.getLogger(TestStatelessPlugin.class);
 
         private final CountDownLatch mergeReadStartedLatch = new CountDownLatch(1);
         private final CountDownLatch cacheEvictedLatch = new CountDownLatch(1);
@@ -111,6 +120,7 @@ public class StatelessComponentsOrderIT extends AbstractStatelessPluginIntegTest
                 protected IndexInput doOpenInput(String name, IOContext context, BlobFileRanges blobFileRanges) {
                     if (ThreadPool.Names.MERGE.equals(EsExecutors.executorName(Thread.currentThread()))) {
                         mergeReadStartedLatch.countDown();
+                        logger.info("--> merge thread blocked");
                         safeAwait(cacheEvictedLatch);
                     }
                     return super.doOpenInput(name, context, blobFileRanges);


### PR DESCRIPTION
This test failure is very hard to reproduce.

What we know

- The merge thread was blocked, it had attempted to open the input, but timed out waiting for the test thread to unblock it
- The test thread was blocked in `indexDocs`. This suggests it was either very slowly indexing additional docs or blocked somehow by the blocked merge
- There's no server thread that's blocked by the merge thread in the thread dump, so it's unclear what (if anything) is blocking the test thread

The latch used to block the merge thread is never released which caused something to get blocked in teardown and triggered a test timeout. This PR puts the merge thread latch countdown in a finally block to prevent that happening.

The PR also adds log lines for when the merge thread is blocked and when the indexing thread proceeds, it should allow us to see whether the indexing thread was in fact blocked or just slow.

The test is muted on 9.5, I'll backport this there as well and remove the mute from the backport PR

Closes #155780