### PR TITLE
[9.5] Add more logging and re-enable flappy test (#157344)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -397,9 +397,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardingPitSearchIT
   method: testLongLivedPitRelocation
   issue: https://github.com/elastic/elasticsearch/issues/155740
-- class: org.elasticsearch.xpack.stateless.StatelessComponentsOrderIT
-  method: testClosingNodeShouldWaitForOngoingMerge
-  issue: https://github.com/elastic/elasticsearch/issues/155780
 - class: org.elasticsearch.gateway.GatewayServiceIT
   method: testSettingsAppliedBeforeReroute
   issue: https://github.com/elastic/elasticsearch/issues/155802

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessComponentsOrderIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessComponentsOrderIT.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.stateless.cache.StatelessSharedBlobCacheService;
@@ -55,43 +57,50 @@ public class StatelessComponentsOrderIT extends AbstractStatelessPluginIntegTest
         final TestStatelessPlugin plugin = findPlugin(indexNode, TestStatelessPlugin.class);
         final var indicesService = internalCluster().getInstance(IndicesService.class, indexNode);
         final var indexShard = findIndexShard(indexName);
+        final Thread shuttingDownThread;
 
-        logger.info("--> indexing and flush docs to trigger background merge");
-        for (int i = 0; i < 11; i++) {
-            indexDocs(indexName, 10);
-            flush(indexName);
-        }
-
-        // Wait for merge to trigger and evict cache so that merge will attempt to fill the cache
-        safeAwait(plugin.mergeReadStartedLatch);
-        logger.info("--> evict cache after merge read started");
-        final var blobStoreCacheDirectory = BlobStoreCacheDirectory.unwrapDirectory(indexShard.store().directory());
-        getCacheService(blobStoreCacheDirectory).forceEvict((key) -> true);
-
-        logger.info("--> deleting index to remove the shard from IndicesService");
-        safeGet(indicesAdmin().prepareDelete(indexName).execute());
-        assertNull(indicesService.indexService(indexShard.shardId().getIndex()));
-
-        logger.info("--> shutting down the index node");
-        final Thread shuttingDownThread = new Thread(() -> {
-            try {
-                internalCluster().stopNode(indexNode);
-            } catch (IOException e) {
-                fail(e);
+        try {
+            logger.info("--> indexing and flush docs to trigger background merge");
+            for (int i = 0; i < 11; i++) {
+                indexDocs(indexName, 10);
+                logger.info("--> indexed {} docs", (i + 1) * 10);
+                flush(indexName);
             }
-        });
-        shuttingDownThread.start();
 
-        safeAwait(plugin.statelessCloseCalledLatch);
-        // Let merge continue, and it should not run into exceptions such as ClosedChannelException or EsRejectedExecutionException
-        logger.info("--> resume the merge thread");
-        plugin.cacheEvictedLatch.countDown();
+            // Wait for merge to trigger and evict cache so that merge will attempt to fill the cache
+            safeAwait(plugin.mergeReadStartedLatch);
+            logger.info("--> evict cache after merge read started");
+            final var blobStoreCacheDirectory = BlobStoreCacheDirectory.unwrapDirectory(indexShard.store().directory());
+            getCacheService(blobStoreCacheDirectory).forceEvict((key) -> true);
+
+            logger.info("--> deleting index to remove the shard from IndicesService");
+            safeGet(indicesAdmin().prepareDelete(indexName).execute());
+            assertNull(indicesService.indexService(indexShard.shardId().getIndex()));
+
+            logger.info("--> shutting down the index node");
+            shuttingDownThread = new Thread(() -> {
+                try {
+                    internalCluster().stopNode(indexNode);
+                } catch (IOException e) {
+                    fail(e);
+                }
+            });
+            shuttingDownThread.start();
+
+            safeAwait(plugin.statelessCloseCalledLatch);
+        } finally {
+            // Let merge continue, and it should not run into exceptions such as ClosedChannelException or EsRejectedExecutionException
+            logger.info("--> resume the merge thread");
+            plugin.cacheEvictedLatch.countDown();
+        }
 
         shuttingDownThread.join(30000);
         assertFalse(shuttingDownThread.isAlive());
     }
 
     public static class TestStatelessPlugin extends TestUtils.StatelessPluginWithTrialLicense {
+
+        private static final Logger logger = LogManager.getLogger(TestStatelessPlugin.class);
 
         private final CountDownLatch mergeReadStartedLatch = new CountDownLatch(1);
         private final CountDownLatch cacheEvictedLatch = new CountDownLatch(1);
@@ -111,6 +120,7 @@ public class StatelessComponentsOrderIT extends AbstractStatelessPluginIntegTest
                 protected IndexInput doOpenInput(String name, IOContext context, BlobFileRanges blobFileRanges) {
                     if (ThreadPool.Names.MERGE.equals(EsExecutors.executorName(Thread.currentThread()))) {
                         mergeReadStartedLatch.countDown();
+                        logger.info("--> merge thread blocked");
                         safeAwait(cacheEvictedLatch);
                     }
                     return super.doOpenInput(name, context, blobFileRanges);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Add more logging and re-enable flappy test (#157344)