### PR TITLE
[Build] Fix pom path for custom archives names

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
@@ -45,7 +45,6 @@ import org.w3c.dom.Element;
 
 import java.io.File;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
@@ -136,16 +135,14 @@ public class PublishPlugin implements Plugin<Project> {
         var archivesBaseName = providerFactory.provider(() -> getArchivesBaseName(extensions));
         var projectVersion = providerFactory.provider(() -> project.getVersion());
         var generateMavenPoms = project.getTasks().withType(GenerateMavenPom.class);
-        generateMavenPoms.configureEach(pomTask -> {
-            pomTask.setDestination(
-                (Callable<String>) () -> String.format(
-                    "%s/distributions/%s-%s.pom",
-                    projectLayout.getBuildDirectory().get().getAsFile().getPath(),
-                    archivesBaseName.get(),
-                    projectVersion.get()
-                )
-            );
-        });
+        // Use the lazy destinationFile property rather than the eager setDestination(Object) bridge. The eager
+        // variant resolves its value at an unspecified point relative to afterEvaluate, so projects overriding
+        // base.archivesName ended up with a pom whose file name did not match the configured archives name.
+        var pomFile = archivesBaseName.zip(
+            projectVersion,
+            (baseName, version) -> String.format("distributions/%s-%s.pom", baseName, version)
+        );
+        generateMavenPoms.configureEach(pomTask -> pomTask.getDestinationFile().set(projectLayout.getBuildDirectory().file(pomFile)));
 
         var publishing = extensions.getByType(PublishingExtension.class);
         final var mavenPublications = publishing.getPublications().withType(MavenPublication.class);


### PR DESCRIPTION
The generated maven pom destination was configured through the eager
GenerateMavenPom.setDestination(Object) bridge with a Callable. Gradle
9.7 introduced a lazy getDestinationFile() RegularFileProperty and kept
the eager setter as a backwards compatible bridge, which changed when
the Callable is resolved relative to afterEvaluate.

Projects that override base.archivesName resolved the archives name
before it was set, so the pom was written under a file name that did not
match the configured archives name. The DRA release-manager derives the
expected pom file name from its own artifact config and failed with
"An input file was expected to be present but it doesnt exist" for
build-tools, integ-test-zip, lang-painless spi, x-pack-core and
x-pack-template-resources.

Set the lazy destinationFile property instead so the archives name and
version are only resolved when the task runs.