### PR TITLE
Reduce Hollow TTL from 3d to 1d for regular indices

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/HollowShardsService.java
@@ -97,7 +97,7 @@ public class HollowShardsService extends AbstractLifecycleComponent implements M
      */
     public static final Setting<TimeValue> SETTING_HOLLOW_INGESTION_TTL = Setting.positiveTimeSetting(
         "stateless.hollow_index_shards.ingestion.ttl",
-        TimeValue.timeValueDays(3),
+        TimeValue.timeValueDays(1),
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
Inactive indices might not hit the 3d TTL if the shard moves between
nodes due to events such as autoscaling, pod recycling, etc. This
commit reduces the TTL to be more aggressive with hollowing and avoid
using prewarming resources for inactive shards.