### PR TITLE
[9.4] [Build] Fix pom path for custom archives names (#157349)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
@@ -45,7 +45,6 @@ import org.w3c.dom.Element;
 
 import java.io.File;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
@@ -136,16 +135,14 @@ public class PublishPlugin implements Plugin<Project> {
         var archivesBaseName = providerFactory.provider(() -> getArchivesBaseName(extensions));
         var projectVersion = providerFactory.provider(() -> project.getVersion());
         var generateMavenPoms = project.getTasks().withType(GenerateMavenPom.class);
-        generateMavenPoms.configureEach(pomTask -> {
-            pomTask.setDestination(
-                (Callable<String>) () -> String.format(
-                    "%s/distributions/%s-%s.pom",
-                    projectLayout.getBuildDirectory().get().getAsFile().getPath(),
-                    archivesBaseName.get(),
-                    projectVersion.get()
-                )
-            );
-        });
+        // Use the lazy destinationFile property rather than the eager setDestination(Object) bridge. The eager
+        // variant resolves its value at an unspecified point relative to afterEvaluate, so projects overriding
+        // base.archivesName ended up with a pom whose file name did not match the configured archives name.
+        var pomFile = archivesBaseName.zip(
+            projectVersion,
+            (baseName, version) -> String.format("distributions/%s-%s.pom", baseName, version)
+        );
+        generateMavenPoms.configureEach(pomTask -> pomTask.getDestinationFile().set(projectLayout.getBuildDirectory().file(pomFile)));
 
         var publishing = extensions.getByType(PublishingExtension.class);
         final var mavenPublications = publishing.getPublications().withType(MavenPublication.class);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [Build] Fix pom path for custom archives names (#157349)