### PR TITLE
[9.5] Unmute ReservedRealmAuthIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -450,9 +450,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/156861
 - class: org.elasticsearch.xpack.sql.qa.security.JdbcSecurityIT
   issue: https://github.com/elastic/elasticsearch/issues/156863
-- class: org.elasticsearch.xpack.security.authc.ReservedRealmAuthIT
-  method: testAuthenticationUsingReservedRealm
-  issue: https://github.com/elastic/elasticsearch/issues/156884
 - class: org.elasticsearch.search.aggregations.metrics.TDigestPercentilesIT
   method: testMultiValuedField
   issue: https://github.com/elastic/elasticsearch/issues/157040


### PR DESCRIPTION
## Summary
- Unmute `ReservedRealmAuthIT.testAuthenticationUsingReservedRealm` on 9.5.

Relates to #156884