### PR TITLE
Fix YAML syntax in trigger-test-analysis workflow

### DIFF
--- a/.github/workflows/trigger-test-analysis.yml
+++ b/.github/workflows/trigger-test-analysis.yml
@@ -117,7 +117,7 @@ jobs:
             --header "Content-Type: application/json" \
             --data "$BODY"
 
-      - name: Mark issue as processed (:eyes: reaction)
+      - name: "Mark issue as processed (:eyes: reaction)"
         if: steps.check-processed.outputs.alreadyProcessed != 'true'
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
The step name contained an unquoted ":eyes: " sequence, which YAML
parses as a mapping value. This made the workflow file invalid and
produced a startup failure on push. Quote the step name so the colons
are treated as literal text.