### PR TITLE
[9.4] Skip and stop publishing old-ES fixtures on aarch64 below 7.8 (#157358)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureDeployment.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureDeployment.java
@@ -37,5 +37,13 @@ public abstract class TestFixtureDeployment implements Named {
 
     public abstract ListProperty<String> getBaseImages();
 
+    /**
+     * Docker platforms (e.g. {@code linux/amd64}, {@code linux/arm64}) to build and publish this
+     * fixture image for. When left empty the fixture is built for every supported architecture.
+     * Restrict this for images that are known not to work on a given architecture, so we neither
+     * build nor publish a manifest that cannot run there.
+     */
+    public abstract ListProperty<String> getPlatforms();
+
     public abstract MapProperty<String, String> getBuildArgs();
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesDeployPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesDeployPlugin.java
@@ -57,7 +57,13 @@ public class TestFixturesDeployPlugin implements Plugin<Project> {
                             resolveTargetDockerRegistry(fixture) + "/" + fixture.getName() + "-fixture:" + fixture.getVersion().get() }
                     );
                     task.getPush().set(isCi);
-                    task.getPlatforms().addAll(Arrays.stream(Architecture.values()).map(a -> a.dockerPlatform).toList());
+                    // A fixture may restrict the platforms it is built/published for (e.g. images that do not run
+                    // on aarch64); otherwise default to every supported architecture.
+                    List<String> platforms = fixture.getPlatforms().get();
+                    if (platforms.isEmpty()) {
+                        platforms = Arrays.stream(Architecture.values()).map(a -> a.dockerPlatform).toList();
+                    }
+                    task.getPlatforms().addAll(platforms);
                     task.setGroup("Deploy TestFixtures");
                     task.setDescription("Deploys the " + fixture.getName() + " test fixture");
                 })

--- a/test/fixtures/old-elasticsearch/build.gradle
+++ b/test/fixtures/old-elasticsearch/build.gradle
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import org.elasticsearch.gradle.Architecture
+
 apply plugin: 'elasticsearch.java'
 apply plugin: 'elasticsearch.cache-test-fixtures'
 apply plugin: 'elasticsearch.deploy-test-fixtures'
@@ -16,48 +18,61 @@ description = 'Testcontainers fixture for old Elasticsearch versions'
 def fixtureVersion = '1.3'
 def sharedDockerContext = project.file('src/main/resources/docker')
 
+// Elasticsearch only started publishing native linux-aarch64 distributions in 7.8.0. Earlier
+// majors ship x86-oriented distributions that do not start under aarch64 (see
+// OldElasticsearchContainer#start), so we build and publish their fixture images for amd64 only
+// rather than baking and pushing an arm64 manifest that cannot run.
+def amd64Only = [Architecture.X64.dockerPlatform]
+
 dockerFixtures {
   create('old-elasticsearch-0-90-13') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '0.90.13']
+    platforms = amd64Only
   }
   create('old-elasticsearch-1-7-6') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '1.7.6']
+    platforms = amd64Only
   }
   create('old-elasticsearch-2-4-5') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '2.4.5']
+    platforms = amd64Only
   }
   create('old-elasticsearch-5-0-0') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '5.0.0']
+    platforms = amd64Only
   }
   create('old-elasticsearch-5-6-16') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '5.6.16']
+    platforms = amd64Only
   }
   create('old-elasticsearch-6-0-0') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '6.0.0']
+    platforms = amd64Only
   }
   create('old-elasticsearch-6-8-20') {
     dockerContext = sharedDockerContext
     version = fixtureVersion
     baseImages = ['eclipse-temurin:8-jdk']
     buildArgs = ['ES_VERSION': '6.8.20']
+    platforms = amd64Only
   }
   create('old-elasticsearch-7-9-3') {
     dockerContext = sharedDockerContext

--- a/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
@@ -11,6 +11,7 @@ package org.elasticsearch.test.fixtures.oldelasticsearch;
 
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
 import org.elasticsearch.test.fixtures.testcontainers.PullOrBuildImage;
+import org.junit.Assume;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
@@ -67,8 +68,11 @@ public class OldElasticsearchContainer extends DockerEnvironmentAwareTestContain
         "xpack.ml.enabled: false\nxpack.security.enabled: false\ndiscovery.type: single-node"
     );
 
+    private final String version;
+
     public OldElasticsearchContainer(String version, String repoLocation) {
         super(new PullOrBuildImage(resolveImage(version), localImage(version)));
+        this.version = version;
         addExposedPort(HTTP_PORT);
         withFileSystemBind(repoLocation, repoLocation);
         withEnv("ES_PATH_REPO", repoLocation);
@@ -77,6 +81,41 @@ public class OldElasticsearchContainer extends DockerEnvironmentAwareTestContain
             withEnv("ES_EXTRA_CONFIG", extraConfig);
         }
         setWaitStrategy(Wait.forHttp("/_cluster/health").forPort(HTTP_PORT).forStatusCode(200).withStartupTimeout(Duration.ofMinutes(2)));
+    }
+
+    /**
+     * Skips the fixture on aarch64 for Elasticsearch versions that predate native aarch64 support.
+     *
+     * <p>Elasticsearch first published {@code linux-aarch64} distributions in 7.8.0. Earlier majors
+     * ship only x86-oriented distributions whose bundled JVM options and launch scripts do not run
+     * under aarch64: the containerised old ES process exits immediately (code 1) and the fixture's
+     * {@link Wait} strategy then times out waiting for {@code /_cluster/health}. Rather than let
+     * these suites fail on the aarch64 periodic pipelines, we raise a JUnit assumption so the
+     * dependent tests are skipped there while continuing to run on x86_64. Versions that do have a
+     * native aarch64 distribution (7.8.0+, e.g. 7.9.3/7.10.0) still run on both architectures.
+     */
+    @Override
+    public void start() {
+        Assume.assumeTrue(
+            "Elasticsearch [" + version + "] has no native aarch64 distribution and does not run on aarch64; skipping",
+            isAarch64() == false || hasNativeAarch64Distribution(version)
+        );
+        super.start();
+    }
+
+    private static boolean isAarch64() {
+        return "aarch64".equals(System.getProperty("os.arch"));
+    }
+
+    /**
+     * Whether the given Elasticsearch version ships a native {@code linux-aarch64} distribution,
+     * which was first available in 7.8.0.
+     */
+    static boolean hasNativeAarch64Distribution(String version) {
+        String[] parts = version.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+        return major > 7 || (major == 7 && minor >= 8);
     }
 
     private static String resolveImage(String version) {

--- a/test/fixtures/old-elasticsearch/src/test/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainerTests.java
+++ b/test/fixtures/old-elasticsearch/src/test/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainerTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.fixtures.oldelasticsearch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the version boundary used to decide whether an old Elasticsearch fixture can run on
+ * aarch64. Elasticsearch first published native {@code linux-aarch64} distributions in 7.8.0, so
+ * everything below that must be skipped on aarch64 (see {@link OldElasticsearchContainer#start()}).
+ */
+public class OldElasticsearchContainerTests {
+
+    @Test
+    public void testPre78VersionsHaveNoNativeAarch64Distribution() {
+        for (String version : new String[] { "0.90.13", "1.7.6", "2.4.5", "5.0.0", "5.6.16", "6.0.0", "6.8.20", "7.7.1" }) {
+            assertFalse(version, OldElasticsearchContainer.hasNativeAarch64Distribution(version));
+        }
+    }
+
+    @Test
+    public void testVersionsFrom78OnwardsHaveNativeAarch64Distribution() {
+        for (String version : new String[] { "7.8.0", "7.9.3", "7.10.0", "8.0.0", "9.2.0" }) {
+            assertTrue(version, OldElasticsearchContainer.hasNativeAarch64Distribution(version));
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Skip and stop publishing old-ES fixtures on aarch64 below 7.8 (#157358)