### PR TITLE
[9.5] Migrate ml basic-multi-node to JUnit rule cluster (#157293)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -28,14 +28,13 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
     private static ListMultimap<Class<?>, String> createLegacyRestTestBasePluginUsage() {
         ListMultimap<Class<?>, String> map = ArrayListMultimap.create(1, 200);
         // Projects that apply LegacyRestTestBasePlugin directly via the legacy-yaml-rest-test or legacy-java-rest-test plugins.
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:basic-multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-based-recoveries:qa:license-enforcing");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-repo-test-kit:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:text-structure:qa:text-structure-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:multi-node-tests");
+        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
 
         // Projects that apply LegacyRestTestBasePlugin transitively via the standalone-rest-test plugin.
         map.put(LegacyRestTestBasePlugin.class, ":qa:mixed-cluster");

--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -5,22 +5,21 @@
  * 2.0.
  */
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation(project(':modules:lang-mustache'))
 }
 
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 3
-  setting 'xpack.security.enabled', 'false'
-  setting 'xpack.monitoring.elasticsearch.collection.enabled', 'false'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.ml.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'indices.lifecycle.history_index_enabled', 'false'
-  setting 'slm.history_index_enabled', 'false'
+tasks.named("javaRestTest").configure {
+  // Verified by experiment, not assumed: on INTEG_TEST the nodes fail to boot on the unregistered
+  // xpack.monitoring / slm / indices.lifecycle settings, and once those are dropped the master hits
+  // "expected [index.lifecycle.name] to be private" while installing the ML index templates.
+  usesDefaultDistribution("ML index templates need ILM, and the cluster sets monitoring/SLM/ILM settings")
+
+  // Both IT classes share one 3-node cluster (see Clusters#CLUSTER). Sharing is per-JVM, so parallel forks
+  // would each start their own cluster and negate the saving; measured 71s serial+shared vs 85-91s parallel.
+  maxParallelForks = 1
 }
 
 if (buildParams.inFipsJvm){

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/Clusters.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/Clusters.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+
+/**
+ * The single 3-node cluster shared by every IT class in this project.
+ * <p>
+ * The legacy {@code testClusters} configuration created one cluster per {@code javaRestTest} task, so all IT
+ * classes ran against the same nodes. {@code shared(true)} preserves that behaviour rather than starting a
+ * fresh 3-node cluster per class. Test isolation still holds because {@code ESRestTestCase} wipes cluster
+ * content after every test method, including a {@code POST /_features/_reset} that clears ML jobs, datafeeds
+ * and trained models.
+ * <p>
+ * Two consequences of sharing, both wired up deliberately:
+ * <ul>
+ *     <li>Every class using this cluster must carry
+ *     {@code @ThreadLeakFilters(filters = TestClustersThreadFilter.class)}; the framework asserts this because a
+ *     shared cluster outlives the suite that started it, so its threads would be reported as suite-level leaks.</li>
+ *     <li>{@code javaRestTest} pins {@code maxParallelForks = 1} in {@code build.gradle}. Sharing is per-JVM, so
+ *     parallel forks would each start their own 3-node cluster and negate the benefit.</li>
+ * </ul>
+ * The default distribution is required, not merely convenient: {@code xpack.monitoring.*}, {@code slm.*} and
+ * {@code indices.lifecycle.*} settings below are only registered when those modules are present, and the ML
+ * index templates reference the ILM-owned {@code index.lifecycle.name} setting.
+ */
+public final class Clusters {
+
+    public static final ElasticsearchCluster CLUSTER = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .nodes(3)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.monitoring.elasticsearch.collection.enabled", "false")
+        .setting("xpack.watcher.enabled", "false")
+        .setting("xpack.ml.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("indices.lifecycle.history_index_enabled", "false")
+        .setting("slm.history_index_enabled", "false")
+        .shared(true)
+        .build();
+
+    private Clusters() {}
+}

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.client.Request;
@@ -13,8 +15,11 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -28,7 +33,16 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class MlBasicMultiNodeIT extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = Clusters.CLUSTER;
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     private static final String BASE_PATH = "/_ml/";
 

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlLearningToRankRescorerIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlLearningToRankRescorerIT.java
@@ -6,12 +6,17 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.Before;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +26,16 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class MlLearningToRankRescorerIT extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = Clusters.CLUSTER;
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     private static final String MODEL_ID = "basic-ltr-model";
     private static final String INDEX_NAME = "store";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Migrate ml basic-multi-node to JUnit rule cluster (#157293)](https://github.com/elastic/elasticsearch/pull/157293)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)