### PR TITLE
Completes health/10_basic

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -36,9 +36,12 @@
   - exists: indicators.shards_availability.details.started_primaries
   - exists: indicators.shards_availability.details.unassigned_replicas
 
-  # The shards_availability indicator is dependent on HealthMetadata being present in the cluster state, which we can't guarantee.
+  # The shards_capacity indicator is dependent on HealthMetadata being present in the cluster state, which we can't guarantee.
   - is_true: indicators.shards_capacity.status
   - is_true: indicators.shards_capacity.symptom
 
   - is_true: indicators.data_stream_lifecycle.status
   - is_true: indicators.data_stream_lifecycle.symptom
+
+  - is_true: indicators.file_settings.status
+  - is_true: indicators.file_settings.symptom


### PR DESCRIPTION
Completes the `health/10_basic` test to assert on the `file_settings` indicator. This test now asserts on all core indicators

Relates: https://github.com/elastic/elasticsearch-team/issues/4925

