### PR TITLE
[ESQL] Reuse parquet page decompress buffers

### DIFF
--- a/docs/changelog/157375.yaml
+++ b/docs/changelog/157375.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157375
+summary: Reuse parquet page decompress buffers
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -45,8 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * released on {@link #close()}. Heap-backed compressed input still copies through a per-page
  * scratch buffer; production prefetch already yields direct slices, so that path is idle.
  * Returned {@link DataPage}s and {@link BytesInput}s alias the current buffer and must not be
- * used after the next {@link #readPage()} or {@link #close()}. Equal-size reuse overwrites in
- * place (no poison); a stale alias sees the new page, not a crash.
+ * used after the next {@link #readPage()} or {@link #close()}.
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -38,15 +38,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * original page type ({@link DataPageV1} stays V1, {@link DataPageV2} stays V2 with only the
  * data portion decompressed). Encryption and CRC verification are not supported.
  *
- * <p>Decompression buffers are allocated as {@link ArrowBuf}s from the supplied
- * {@link BufferAllocator}, exposed to the codec via {@link ArrowBuf#nioBuffer(long, int)} to
- * preserve the direct-to-direct JNI fast path. The reader owns one reusable decompress buffer:
- * {@link #readPage()} overwrites it instead of malloc/free per page (glibc otherwise retains
- * the freed arenas and RSS climbs across queries). Live decompressed bytes stay O(one page)
- * per (column, reader); the buffer grows only when a later page needs more capacity, and
- * {@link #close()} releases it. The {@link DataPage}s and {@link BytesInput}s returned from
- * {@link #readPage()} alias the current page's buffer and must not be used after the next
- * {@link #readPage()} call or after the reader is closed.
+ * <p>Decompression uses one reusable {@link ArrowBuf} from the supplied {@link BufferAllocator},
+ * exposed via {@link ArrowBuf#nioBuffer(long, int)} for the direct-to-direct JNI fast path.
+ * {@link #readPage()} overwrites that buffer. It grows only when a later page needs more
+ * capacity — breaker residency is the high-water-mark page, not the current page — and is
+ * released on {@link #close()}. Heap-backed compressed input still copies through a per-page
+ * scratch buffer; production prefetch already yields direct slices, so that path is idle.
+ * Returned {@link DataPage}s and {@link BytesInput}s alias the current buffer and must not be
+ * used after the next {@link #readPage()} or {@link #close()}. Equal-size reuse overwrites in
+ * place (no poison); a stale alias sees the new page, not a crash.
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
 
@@ -306,11 +306,6 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
     }
 
-    /**
-     * Direct {@link ByteBuffer} of {@code size} bytes, backed by this reader's reusable
-     * {@link ArrowBuf}. Reuses the existing buffer when it is large enough; otherwise closes it
-     * and allocates a larger one. Released on {@link #close()}.
-     */
     private ByteBuffer allocateDirect(int size) {
         if (reusableDecompBuf == null || reusableDecompBuf.capacity() < size) {
             closeReusableDecompBuf();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -18,13 +18,11 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectMemoryDebug;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,11 +40,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Decompression buffers are allocated as {@link ArrowBuf}s from the supplied
  * {@link BufferAllocator}, exposed to the codec via {@link ArrowBuf#nioBuffer(long, int)} to
- * preserve the direct-to-direct JNI fast path. The reader owns these buffers. A page's buffer is
- * released back to the allocator (which routes the accounting through the circuit breaker) as soon
- * as the consumer asks for the next page — see {@link #readPage()} — so only ONE page's
- * decompressed bytes are live per (column, reader) at a time; {@link #close()} releases whatever
- * remains (the tail page). The {@link DataPage}s and {@link BytesInput}s returned from
+ * preserve the direct-to-direct JNI fast path. The reader owns one reusable decompress buffer:
+ * {@link #readPage()} overwrites it instead of malloc/free per page (glibc otherwise retains
+ * the freed arenas and RSS climbs across queries). Live decompressed bytes stay O(one page)
+ * per (column, reader); the buffer grows only when a later page needs more capacity, and
+ * {@link #close()} releases it. The {@link DataPage}s and {@link BytesInput}s returned from
  * {@link #readPage()} alias the current page's buffer and must not be used after the next
  * {@link #readPage()} call or after the reader is closed.
  */
@@ -66,11 +64,10 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
-    // Decompress-output buffer(s) of the page returned by the most recent readPage() call. Bounded
-    // to one page: readPage() releases the previous page's buffers before decoding the next, and
-    // close() releases the tail page. Named for that lifetime rather than "owned for the reader's
-    // life" — parking every page's buffer until close() was the native-memory leak this reader had.
-    private final List<Releasable> livePageBuffers = new ArrayList<>();
+    // Reusable decompress-output buffer. Grown when a page needs more capacity; released on
+    // close(). Overwritten in place across pages so we do not malloc/free per page — that churn
+    // is what retained glibc arenas after the allocator balance had already returned to baseline.
+    private ArrowBuf reusableDecompBuf;
 
     private DictionaryPage cachedDictionaryPage;
     private boolean dictionaryDecompressed;
@@ -102,11 +99,11 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         CompressedPage entry = compressedPages.poll();
         if (entry == null) {
             // Queue drained. The last page returned stays live (the consumer may still be decoding
-            // it) until close() releases it; there is no new page to decode, so nothing to release.
+            // it) until close() releases the reusable buffer; there is no new page to decode.
             return null;
         }
-        // Per-page release. Both consumers of this reader ask for pages strictly sequentially and
-        // are done with the current page's bytes before they ask for the next one:
+        // Previous page is dead. Both consumers of this reader ask for pages strictly sequentially
+        // and are done with the current page's bytes before they ask for the next one:
         // - PageColumnReader#loadNextPage (flat columns) runs its remainder-skip off the current
         // value/def-level buffers BEFORE calling readPage(), and reassigns those buffers to the
         // new page immediately after;
@@ -115,13 +112,10 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // its level/value readers from the new page before any further read, and its consumers
         // (ParquetColumnDecoding#readListRow) copy each value to the heap before the consume()
         // that can cross a page boundary.
-        // So the previously returned page's decompress buffer is dead the moment the consumer asks
-        // for the next page. Release it now rather than parking every page's buffer until close(): otherwise
-        // the live decompressed working set per (column, reader) is O(uncompressed column chunk)
-        // instead of O(one page), and — one such reader per projected column, up to 48 concurrent
-        // read streams — the accumulation climbs until the OS OOM-killer takes the node, invisible
-        // to every heap-only circuit breaker.
-        releaseLivePageBuffers();
+        // Overwrite the reusable decompress buffer rather than free+malloc: per-page free fed
+        // glibc arena retention even when the allocator balance returned to baseline. Live
+        // working set stays O(one page); parking a new buffer per page until close() is the
+        // accumulation the OOM-killer saw.
         DataPage page = entry.page();
         if (page instanceof DataPageV1 v1) {
             return decompressV1(v1);
@@ -291,8 +285,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
         // Scratch buffer used only when the input is on the heap and must be copied to direct
         // memory to take the codec's direct-to-direct JNI fast path. decompress() consumes it
-        // synchronously, so it is released in the finally below rather than registered with the
-        // reader — otherwise it would sit in livePageBuffers until the next page is decoded.
+        // synchronously, so it is released in the finally below rather than held on the reader.
         ArrowBuf scratch = null;
         try {
             if (input.isDirect() == false) {
@@ -314,41 +307,30 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     }
 
     /**
-     * Allocate a direct {@link ByteBuffer} of the requested size, backed by an {@link ArrowBuf}
-     * owned by this reader. The buffer is breaker-accounted via the allocator's listener and is
-     * released when the consumer asks for the next page (see {@link #readPage()}) or, for the tail
-     * page, on {@link #close()} — whichever comes first.
+     * Direct {@link ByteBuffer} of {@code size} bytes, backed by this reader's reusable
+     * {@link ArrowBuf}. Reuses the existing buffer when it is large enough; otherwise closes it
+     * and allocates a larger one. Released on {@link #close()}.
      */
     private ByteBuffer allocateDirect(int size) {
-        ArrowBuf buf = allocator.buffer(size);
-        // Use the explicit (index, length) overload: ArrowBuf may round capacity up, but the
-        // codec's size sanity check expects remaining() == declared decompressed size.
-        ByteBuffer view = buf.nioBuffer(0, size);
-        // Poison the region just before release (assertions only) so a decompressed-page BytesInput
-        // that aliases this buffer and is read after the buffer is released (next readPage() /
-        // close()) fails deterministically.
-        livePageBuffers.add(() -> {
-            DirectMemoryDebug.poison(view);
-            buf.close();
-        });
-        return view;
+        if (reusableDecompBuf == null || reusableDecompBuf.capacity() < size) {
+            closeReusableDecompBuf();
+            reusableDecompBuf = allocator.buffer(size);
+        }
+        // Explicit (index, length): ArrowBuf may round capacity up, but the codec's size sanity
+        // check expects remaining() == declared decompressed size.
+        return reusableDecompBuf.nioBuffer(0, size);
     }
 
-    /**
-     * Release the decompress-output buffer(s) of the page returned by the previous
-     * {@link #readPage()} call back to the allocator. Called at the top of {@link #readPage()}
-     * before decoding the next page, and by {@link #close()} for the tail page. Idempotent and a
-     * no-op when nothing is live (e.g. the uncompressed short-circuit that aliases the caller's
-     * input buffer without allocating).
-     */
-    private void releaseLivePageBuffers() {
-        if (livePageBuffers.isEmpty()) {
+    private void closeReusableDecompBuf() {
+        if (reusableDecompBuf == null) {
             return;
         }
+        ArrowBuf buf = reusableDecompBuf;
+        reusableDecompBuf = null;
         try {
-            Releasables.close(livePageBuffers);
+            DirectMemoryDebug.poison(buf.nioBuffer(0, Math.toIntExact(buf.capacity())));
         } finally {
-            livePageBuffers.clear();
+            buf.close();
         }
     }
 
@@ -358,11 +340,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             return;
         }
         // Drop the cached dictionary page reference. It is deliberately heap-backed (see
-        // readDictionaryPage), so this is reference hygiene, not a buffer-lifetime requirement —
-        // in particular it is NOT in livePageBuffers and is never touched by the per-page release.
+        // readDictionaryPage), so this is reference hygiene, not a buffer-lifetime requirement.
         cachedDictionaryPage = null;
-        // Release the tail page's buffer(s). Every earlier page was already released by the
-        // readPage() call that superseded it, so at most one page's buffer remains here.
-        releaseLivePageBuffers();
+        closeReusableDecompBuf();
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.greaterThan;
@@ -29,22 +30,20 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
- * Pins the per-(column, reader) decompressed working-set bound on {@link PrefetchedPageReader}:
- * live native memory stays O(one page), not O(uncompressed column chunk). The reader reuses one
- * decompress buffer across pages (grown only when a later page needs more capacity) and releases
- * it on {@link PrefetchedPageReader#close()}.
+ * Pins two contracts on {@link PrefetchedPageReader}: live native memory stays O(high-water-mark
+ * page), not O(uncompressed column chunk); and equal-sized direct pages malloc the decompress
+ * buffer once, not once per page. The reader reuses one buffer (grown only when a later page
+ * needs more capacity) and releases it on {@link PrefetchedPageReader#close()}.
  *
  * <p>Before per-page bounding, every {@code decompressToDirectBuffer} output was parked until
- * {@link PrefetchedPageReader#close()} at row-group rollover — the whole column chunk's
- * decompressed bytes were held live simultaneously and, multiplied across projected columns and
- * concurrent read streams, climbed until the OS OOM-killer took the node (invisible to every
- * heap-only circuit breaker). These tests FAIL on that accumulation: the allocator balance grows
- * by one page per {@code readPage()}. They PASS when live memory stays bounded by one page.
+ * {@link PrefetchedPageReader#close()} at row-group rollover. The live-bound tests FAIL on that
+ * accumulation. Reuse failures (malloc per page with live still O(one page)) still pass those
+ * tests — {@link #testBufferReuseReducesAllocationCount} is the malloc pin.
  *
  * <p>Both a zstd {@link DataPageV2} (the canonical bench case, direct-to-direct JNI fast path) and
  * a gzip {@link DataPageV1} (the codec-uniformity twin, heap-staged, no native-library dependency)
- * are covered — the direct decompress-output buffer is allocated by {@code decompressToDirectBuffer}
- * identically for every codec, so the fix must bound the working set uniformly.
+ * are covered for the live bound. Allocation-count tests use direct compressed input so the
+ * heap-to-direct scratch path cannot hide output-buffer reuse.
  */
 public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
 
@@ -76,26 +75,38 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
      * not used here: that path allocates a scratch buffer per page and would hide reuse.
      */
     public void testBufferReuseReducesAllocationCount() throws IOException {
+        int[] sizes = new int[PAGES];
+        Arrays.fill(sizes, PAGE_PAYLOAD_BYTES);
         CountingListener listener = new CountingListener();
-        PagesFixture fixture = buildDirectZstdV2Pages(PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES);
+        DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(fixture.codec),
+                fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                 allocator,
                 fixture.pages,
                 null,
-                (long) PAGE_PAYLOAD_BYTES * PAGES
+                valueCount(sizes)
             );
             try {
                 int baseline = listener.allocations;
-                for (int p = 0; p < PAGES; p++) {
-                    assertNotNull(reader.readPage());
+                DataPageV2 first = (DataPageV2) reader.readPage();
+                assertNotNull(first);
+                BytesInput firstData = first.getData();
+                assertArrayEquals(fixture.payloads.get(0), firstData.toByteArray());
+
+                DataPageV2 second = (DataPageV2) reader.readPage();
+                assertNotNull(second);
+                assertArrayEquals(fixture.payloads.get(1), second.getData().toByteArray());
+                // Stale alias of page 1 now sees page 2 — reuse overwrites in place.
+                assertArrayEquals(fixture.payloads.get(1), firstData.toByteArray());
+
+                for (int p = 2; p < PAGES; p++) {
+                    DataPageV2 page = (DataPageV2) reader.readPage();
+                    assertNotNull(page);
+                    assertArrayEquals(fixture.payloads.get(p), page.getData().toByteArray());
                 }
                 assertNull(reader.readPage());
-                int allocated = listener.allocations - baseline;
-                assertThat("must allocate the decompress buffer at least once", allocated, greaterThanOrEqualTo(1));
-                assertThat("equal-sized pages must reuse one decompress buffer, not malloc per page", allocated, lessThanOrEqualTo(2));
-                assertThat(allocated, lessThan(PAGES));
+                assertEquals("equal-sized direct pages must malloc the decompress buffer once", 1, listener.allocations - baseline);
             } finally {
                 reader.close();
             }
@@ -106,77 +117,49 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
     }
 
     /**
-     * Reused buffer stays live after the queue is drained and is released only on {@code close()}.
-     */
-    public void testReusedBufferReleasedOnClose() throws IOException {
-        PagesFixture fixture = buildZstdV2Pages();
-        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
-            PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(fixture.codec),
-                allocator,
-                fixture.pages,
-                null,
-                (long) PAGE_PAYLOAD_BYTES * PAGES
-            );
-            try {
-                for (int p = 0; p < PAGES; p++) {
-                    assertNotNull(reader.readPage());
-                }
-                assertNull(reader.readPage());
-                assertThat(
-                    "reusable decompress buffer must stay live after the last readPage()",
-                    allocator.getAllocatedMemory(),
-                    greaterThan(0L)
-                );
-            } finally {
-                reader.close();
-            }
-            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
-        } finally {
-            fixture.codecFactory.release();
-        }
-    }
-
-    /**
-     * Growing pages realloc; a later smaller page reuses the large buffer. Live memory never
-     * accumulates across pages.
+     * Growing pages realloc and free the previous buffer; a later smaller page reuses the large
+     * buffer. Live memory never becomes the sum of grown sizes.
      */
     public void testBufferReuseHandlesVaryingPageSizes() throws IOException {
         int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
         CountingListener listener = new CountingListener();
-        PagesFixture fixture = buildDirectZstdV2Pages(sizes);
-        long totalValues = 0;
-        for (int size : sizes) {
-            totalValues += size / 4;
-        }
+        DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(fixture.codec),
+                fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                 allocator,
                 fixture.pages,
                 null,
-                totalValues
+                valueCount(sizes)
             );
             try {
+                long cap = 0L;
                 long peakLive = 0L;
                 for (int i = 0; i < sizes.length; i++) {
                     long liveBefore = allocator.getAllocatedMemory();
                     int allocationsBefore = listener.allocations;
-                    assertNotNull(reader.readPage());
-                    if (sizes[i] > liveBefore) {
+                    DataPageV2 page = (DataPageV2) reader.readPage();
+                    assertNotNull(page);
+                    assertArrayEquals(fixture.payloads.get(i), page.getData().toByteArray());
+                    long live = allocator.getAllocatedMemory();
+                    if (sizes[i] > cap) {
                         assertThat(
                             "page larger than the reusable buffer must allocate",
                             listener.allocations,
                             greaterThan(allocationsBefore)
                         );
+                        if (liveBefore > 0L) {
+                            // Leak-on-grow would keep the old buf: live ≈ liveBefore + sizes[i].
+                            assertThat("grow must free the previous decompress buffer", live, lessThan(liveBefore + sizes[i]));
+                        }
+                        cap = sizes[i];
                     } else {
                         assertEquals("page that fits in the reusable buffer must not allocate", allocationsBefore, listener.allocations);
+                        assertEquals("smaller page must keep the high-water buffer", peakLive, live);
                     }
-                    long live = allocator.getAllocatedMemory();
                     peakLive = Math.max(peakLive, live);
-                    assertEquals("live memory must not accumulate across pages", peakLive, live);
                 }
-                assertThat("must not malloc once per page", listener.allocations, lessThan(sizes.length));
+                assertEquals("three grows, then one reuse", 3, listener.allocations);
                 assertThat(allocator.getAllocatedMemory(), greaterThan(0L));
             } finally {
                 reader.close();
@@ -218,6 +201,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
                 }
                 // Reader drained: the tail page stays live until close().
                 assertNull(reader.readPage());
+                assertThat("decompress buffer must stay live after the last readPage()", allocator.getAllocatedMemory(), greaterThan(0L));
             } finally {
                 reader.close();
             }
@@ -278,12 +262,14 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
      * Zstd V2 pages whose compressed bytes are already direct, matching the production S3 path
      * so {@code decompressToDirectBuffer} skips the heap-to-direct scratch allocation.
      */
-    private PagesFixture buildDirectZstdV2Pages(int... payloadBytes) throws IOException {
+    private DirectPagesFixture buildDirectZstdV2Pages(int... payloadBytes) throws IOException {
         PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
         BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
         List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(payloadBytes.length);
+        List<byte[]> payloads = new ArrayList<>(payloadBytes.length);
         for (int payloadSize : payloadBytes) {
             byte[] data = randomByteArrayOfLength(payloadSize);
+            payloads.add(data);
             byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
             ByteBuffer direct = ByteBuffer.allocateDirect(compressedData.length);
             direct.put(compressedData).flip();
@@ -301,13 +287,27 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             );
             pages.add(new PrefetchedPageReader.CompressedPage(v2, -1L));
         }
-        return new PagesFixture(codecFactory, CompressionCodecName.ZSTD, pages);
+        return new DirectPagesFixture(codecFactory, pages, payloads);
+    }
+
+    private static long valueCount(int[] payloadBytes) {
+        long values = 0;
+        for (int size : payloadBytes) {
+            values += size / 4;
+        }
+        return values;
     }
 
     private record PagesFixture(
         PlainCompressionCodecFactory codecFactory,
         CompressionCodecName codec,
         List<PrefetchedPageReader.CompressedPage> pages
+    ) {}
+
+    private record DirectPagesFixture(
+        PlainCompressionCodecFactory codecFactory,
+        List<PrefetchedPageReader.CompressedPage> pages,
+        List<byte[]> payloads
     ) {}
 
     private static final class CountingListener implements AllocationListener {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.arrow.memory.AllocationListener;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
@@ -18,25 +19,27 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
- * Pins the per-page release bound on {@link PrefetchedPageReader}: the native memory backing a
- * decompressed page must be returned to the allocator no later than the next
- * {@link PrefetchedPageReader#readPage()} call, so the live decompressed working set per
- * (column, reader) is O(one page), not O(uncompressed column chunk).
+ * Pins the per-(column, reader) decompressed working-set bound on {@link PrefetchedPageReader}:
+ * live native memory stays O(one page), not O(uncompressed column chunk). The reader reuses one
+ * decompress buffer across pages (grown only when a later page needs more capacity) and releases
+ * it on {@link PrefetchedPageReader#close()}.
  *
- * <p>Before the fix, every {@code decompressToDirectBuffer} output was parked until
+ * <p>Before per-page bounding, every {@code decompressToDirectBuffer} output was parked until
  * {@link PrefetchedPageReader#close()} at row-group rollover — the whole column chunk's
  * decompressed bytes were held live simultaneously and, multiplied across projected columns and
  * concurrent read streams, climbed until the OS OOM-killer took the node (invisible to every
- * heap-only circuit breaker). These tests FAIL on that behavior: the allocator balance grows by
- * one page per {@code readPage()}. They PASS once {@code readPage()} releases the previous page's
- * buffer before decompressing the next.
+ * heap-only circuit breaker). These tests FAIL on that accumulation: the allocator balance grows
+ * by one page per {@code readPage()}. They PASS when live memory stays bounded by one page.
  *
  * <p>Both a zstd {@link DataPageV2} (the canonical bench case, direct-to-direct JNI fast path) and
  * a gzip {@link DataPageV1} (the codec-uniformity twin, heap-staged, no native-library dependency)
@@ -65,6 +68,123 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
      */
     public void testGzipV1DecompressBufferReleasedPerPageAndOnClose() throws IOException {
         assertPerPageReleaseAndZeroOnClose(buildGzipV1Pages());
+    }
+
+    /**
+     * Equal-sized zstd V2 pages with direct compressed input (the production S3 path) must
+     * malloc the decompress buffer once, not once per page. Heap-backed compressed input is
+     * not used here: that path allocates a scratch buffer per page and would hide reuse.
+     */
+    public void testBufferReuseReducesAllocationCount() throws IOException {
+        CountingListener listener = new CountingListener();
+        PagesFixture fixture = buildDirectZstdV2Pages(PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES);
+        try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
+            PrefetchedPageReader reader = new PrefetchedPageReader(
+                fixture.codecFactory.getDecompressor(fixture.codec),
+                allocator,
+                fixture.pages,
+                null,
+                (long) PAGE_PAYLOAD_BYTES * PAGES
+            );
+            try {
+                int baseline = listener.allocations;
+                for (int p = 0; p < PAGES; p++) {
+                    assertNotNull(reader.readPage());
+                }
+                assertNull(reader.readPage());
+                int allocated = listener.allocations - baseline;
+                assertThat("must allocate the decompress buffer at least once", allocated, greaterThanOrEqualTo(1));
+                assertThat("equal-sized pages must reuse one decompress buffer, not malloc per page", allocated, lessThanOrEqualTo(2));
+                assertThat(allocated, lessThan(PAGES));
+            } finally {
+                reader.close();
+            }
+            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
+        } finally {
+            fixture.codecFactory.release();
+        }
+    }
+
+    /**
+     * Reused buffer stays live after the queue is drained and is released only on {@code close()}.
+     */
+    public void testReusedBufferReleasedOnClose() throws IOException {
+        PagesFixture fixture = buildZstdV2Pages();
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            PrefetchedPageReader reader = new PrefetchedPageReader(
+                fixture.codecFactory.getDecompressor(fixture.codec),
+                allocator,
+                fixture.pages,
+                null,
+                (long) PAGE_PAYLOAD_BYTES * PAGES
+            );
+            try {
+                for (int p = 0; p < PAGES; p++) {
+                    assertNotNull(reader.readPage());
+                }
+                assertNull(reader.readPage());
+                assertThat(
+                    "reusable decompress buffer must stay live after the last readPage()",
+                    allocator.getAllocatedMemory(),
+                    greaterThan(0L)
+                );
+            } finally {
+                reader.close();
+            }
+            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
+        } finally {
+            fixture.codecFactory.release();
+        }
+    }
+
+    /**
+     * Growing pages realloc; a later smaller page reuses the large buffer. Live memory never
+     * accumulates across pages.
+     */
+    public void testBufferReuseHandlesVaryingPageSizes() throws IOException {
+        int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
+        CountingListener listener = new CountingListener();
+        PagesFixture fixture = buildDirectZstdV2Pages(sizes);
+        long totalValues = 0;
+        for (int size : sizes) {
+            totalValues += size / 4;
+        }
+        try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
+            PrefetchedPageReader reader = new PrefetchedPageReader(
+                fixture.codecFactory.getDecompressor(fixture.codec),
+                allocator,
+                fixture.pages,
+                null,
+                totalValues
+            );
+            try {
+                long peakLive = 0L;
+                for (int i = 0; i < sizes.length; i++) {
+                    long liveBefore = allocator.getAllocatedMemory();
+                    int allocationsBefore = listener.allocations;
+                    assertNotNull(reader.readPage());
+                    if (sizes[i] > liveBefore) {
+                        assertThat(
+                            "page larger than the reusable buffer must allocate",
+                            listener.allocations,
+                            greaterThan(allocationsBefore)
+                        );
+                    } else {
+                        assertEquals("page that fits in the reusable buffer must not allocate", allocationsBefore, listener.allocations);
+                    }
+                    long live = allocator.getAllocatedMemory();
+                    peakLive = Math.max(peakLive, live);
+                    assertEquals("live memory must not accumulate across pages", peakLive, live);
+                }
+                assertThat("must not malloc once per page", listener.allocations, lessThan(sizes.length));
+                assertThat(allocator.getAllocatedMemory(), greaterThan(0L));
+            } finally {
+                reader.close();
+            }
+            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
+        } finally {
+            fixture.codecFactory.release();
+        }
     }
 
     private void assertPerPageReleaseAndZeroOnClose(PagesFixture fixture) {
@@ -154,9 +274,48 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         return new PagesFixture(codecFactory, CompressionCodecName.GZIP, pages);
     }
 
+    /**
+     * Zstd V2 pages whose compressed bytes are already direct, matching the production S3 path
+     * so {@code decompressToDirectBuffer} skips the heap-to-direct scratch allocation.
+     */
+    private PagesFixture buildDirectZstdV2Pages(int... payloadBytes) throws IOException {
+        PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
+        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
+        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(payloadBytes.length);
+        for (int payloadSize : payloadBytes) {
+            byte[] data = randomByteArrayOfLength(payloadSize);
+            byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
+            ByteBuffer direct = ByteBuffer.allocateDirect(compressedData.length);
+            direct.put(compressedData).flip();
+            DataPageV2 v2 = new DataPageV2(
+                payloadSize / 4,
+                0,
+                payloadSize / 4,
+                BytesInput.empty(),
+                BytesInput.empty(),
+                Encoding.PLAIN,
+                BytesInput.from(direct),
+                payloadSize,
+                new IntStatistics(),
+                true
+            );
+            pages.add(new PrefetchedPageReader.CompressedPage(v2, -1L));
+        }
+        return new PagesFixture(codecFactory, CompressionCodecName.ZSTD, pages);
+    }
+
     private record PagesFixture(
         PlainCompressionCodecFactory codecFactory,
         CompressionCodecName codec,
         List<PrefetchedPageReader.CompressedPage> pages
     ) {}
+
+    private static final class CountingListener implements AllocationListener {
+        private int allocations;
+
+        @Override
+        public void onAllocation(long size) {
+            allocations++;
+        }
+    }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -89,18 +89,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             );
             try {
                 int baseline = listener.allocations;
-                DataPageV2 first = (DataPageV2) reader.readPage();
-                assertNotNull(first);
-                BytesInput firstData = first.getData();
-                assertArrayEquals(fixture.payloads.get(0), firstData.toByteArray());
-
-                DataPageV2 second = (DataPageV2) reader.readPage();
-                assertNotNull(second);
-                assertArrayEquals(fixture.payloads.get(1), second.getData().toByteArray());
-                // Stale alias of page 1 now sees page 2 — reuse overwrites in place.
-                assertArrayEquals(fixture.payloads.get(1), firstData.toByteArray());
-
-                for (int p = 2; p < PAGES; p++) {
+                for (int p = 0; p < PAGES; p++) {
                     DataPageV2 page = (DataPageV2) reader.readPage();
                     assertNotNull(page);
                     assertArrayEquals(fixture.payloads.get(p), page.getData().toByteArray());


### PR DESCRIPTION
PrefetchedPageReader allocated a new ArrowBuf per page and freed it on the next read. That malloc/free churn left glibc arenas retained, so RSS climbed across queries even when allocator accounting returned to baseline.

Keep one reusable buffer per reader, grown only when a later page needs more capacity, and release it on close.