### PR TITLE
[8.19] Harden old-ES fixture download and rebake image

### DIFF
--- a/test/fixtures/old-elasticsearch/build.gradle
+++ b/test/fixtures/old-elasticsearch/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'elasticsearch.deploy-test-fixtures'
 
 description = 'Testcontainers fixture for old Elasticsearch versions'
 
-def fixtureVersion = '1.3'
+def fixtureVersion = '1.4'
 def sharedDockerContext = project.file('src/main/resources/docker')
 
 // Elasticsearch only started publishing native linux-aarch64 distributions in 7.8.0. Earlier

--- a/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
@@ -32,7 +32,7 @@ public class OldElasticsearchContainer extends DockerEnvironmentAwareTestContain
 
     private static final int HTTP_PORT = 9200;
     // Keep in sync with `def fixtureVersion` in test/fixtures/old-elasticsearch/build.gradle.
-    private static final String FIXTURE_IMAGE_VERSION = "1.3";
+    private static final String FIXTURE_IMAGE_VERSION = "1.4";
     private static final Map<String, String> IMAGES = Map.of(
         "0.90.13",
         "docker.elastic.co/elasticsearch-dev/old-elasticsearch-0-90-13-fixture:" + FIXTURE_IMAGE_VERSION,

--- a/test/fixtures/old-elasticsearch/src/main/resources/docker/Dockerfile
+++ b/test/fixtures/old-elasticsearch/src/main/resources/docker/Dockerfile
@@ -13,6 +13,11 @@ WORKDIR /tmp
 # - 2.4.5 lives on download.elastic.co under a Maven-style release path.
 # - >=5.0, <7.9 are architecture-independent zips on artifacts.elastic.co.
 # - >=7.9 ship per-architecture archives that bundle their own JDK.
+# The curl download is retried because fetching the ES distribution from
+# artifacts.elastic.co/download.elastic.co occasionally hits transient network errors
+# (e.g. HTTP/2 stream errors, curl exit 92) that otherwise fail the whole image build and,
+# in turn, the dependent test suites (see #156120). This keeps the local fallback build
+# (used when the prebaked fixture image cannot be pulled) resilient.
 RUN set -e; \
  case "$ES_VERSION" in \
    0.90.13|1.7.6) \
@@ -29,7 +34,7 @@ RUN set -e; \
    *) \
      url="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip"; ext=zip ;; \
  esac; \
- curl -fsSL -o "elasticsearch.${ext}" "$url"; \
+ curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o "elasticsearch.${ext}" "$url"; \
  if [ "$ext" = "zip" ]; then unzip -q "elasticsearch.${ext}"; else tar -xzf "elasticsearch.${ext}"; fi; \
  rm -f "elasticsearch.${ext}"; \
  mv "elasticsearch-${ES_VERSION}" /usr/share/elasticsearch


### PR DESCRIPTION
ReindexFromRemote7xIT failed at @ClassRule container startup: the
prebaked old-ES fixture image could not be pulled, so PullOrBuildImage
fell back to the local Dockerfile build, whose curl of the 7.9.3/7.10.0
distribution from artifacts.elastic.co hit a transient HTTP/2 error
(exit 92) and failed the whole suite.

Add curl retries to the fallback build and bump the fixture image
version to 1.4 so a fresh prebaked image is published and pulled.

Closes #156120