### PR TITLE
[DO NOT MERGE] Probe: full test-compile timing on CI

### DIFF
--- a/.buildkite/pipelines/pull-request/full-test-compile-timing-probe.yml
+++ b/.buildkite/pipelines/pull-request/full-test-compile-timing-probe.yml
@@ -1,0 +1,36 @@
+# Temporary timing probe - DO NOT MERGE.
+# Measures full test-source-set compile time on CI with and without
+# the remote Gradle build cache. Delete this file once measurements
+# are collected.
+config:
+  auto-retry: false
+  allow-labels: "compile-timing-probe"
+steps:
+  - label: part-compile-all-tests-cache-on
+    command: |
+      .ci/scripts/run-gradle.sh \
+        compileTestJava \
+        compileInternalClusterTestJava \
+        compileJavaRestTestJava \
+        compileYamlRestTestJava
+    timeout_in_minutes: 45
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk
+  - label: part-compile-all-tests-cache-off
+    command: |
+      .ci/scripts/run-gradle.sh --no-build-cache \
+        compileTestJava \
+        compileInternalClusterTestJava \
+        compileJavaRestTestJava \
+        compileYamlRestTestJava
+    timeout_in_minutes: 45
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-custom-32-98304
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// compile-timing-probe: cache-invalidation marker (no behaviour change)
 package org.elasticsearch;
 
 import org.elasticsearch.common.io.FileSystemUtils;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/AbstractLocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/AbstractLocalStateSecurity.java
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+// compile-timing-probe: cache-invalidation marker (no behaviour change)
 package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.common.settings.Settings;


### PR DESCRIPTION
## What this PR measures

This is a **temporary, throwaway probe** that must not be merged.
It exists solely to measure how long it takes to compile all test
source sets across the entire Elasticsearch repo on a real
Buildkite CI agent, under two conditions:

- **cache-on** (`part-compile-all-tests-cache-on`): remote Gradle
  build cache enabled (the CI default, configured via
  `org.elasticsearch.build.cache.url` in `.ci/init.gradle`).
- **cache-off** (`part-compile-all-tests-cache-off`): same tasks,
  with `--no-build-cache` so Gradle skips the cache entirely.

Both steps run on the same machine type (`n4-custom-32-98304`)
with the RAM-disk build directory (`/dev/shm/bk`) so the
numbers are directly comparable.

Two test files have a one-line inert comment added to seed a
real cache miss in the cache-on arm while the rest of the
build exercises cache hits.

## Pipeline trigger

The pipeline is gated behind the label `compile-timing-probe`.
Add that label to this PR to trigger the two compile steps.

## Cleanup

Delete this PR and the branch once the timing data is collected.
Do not merge.