### PR TITLE
[9.5] Fix percentiles reduce using a closed preallocated breaker (#157254)

### DIFF
--- a/docs/changelog/157254.yaml
+++ b/docs/changelog/157254.yaml
@@ -1,0 +1,6 @@
+area: Aggregations
+issues:
+ - 157206
+pr: 157254
+summary: Fix percentiles reduce using a closed preallocated breaker
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesReduceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesReduceIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.closeTo;
+
+/**
+ * Coordinator-side reduction of tdigest percentiles, over a shard layout that mixes partially reduced
+ * results with shard results the coordinator never received over the wire.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class TDigestPercentilesReduceIT extends ESIntegTestCase {
+
+    /**
+     * A shard result that stays on the coordinating node is never serialized, so its state still holds the
+     * aggregation context's {@code PreallocatedCircuitBreaker}, which is closed once the shard is done. Reduction
+     * used to accumulate into whichever state had the larger compression, so such a result could become the
+     * accumulator and charge that closed breaker as it grew.
+     * <p>
+     * The layout below fixes the order the reducer sees. Partially reduced results are consumed ahead of raw shard
+     * results, and the two empty shards sit alone on a node, so that node reduces them into a partial carrying an
+     * empty state, whose compression is a hard-coded 1.0 and therefore always below the request's. The raw results
+     * follow in shard index order, which orders these single-shard indices by name: the coordinator's own result
+     * used to be adopted as the accumulator, and merging the remaining, wire-received result into it grew it.
+     */
+    public void testReduceOverEmptyPartialAndCoordinatorLocalShardResult() throws Exception {
+        List<String> nodes = internalCluster().startNodes(3);
+        String coordinator = nodes.get(0);
+
+        createPinnedIndex("a_local", 1, coordinator);
+        createPinnedIndex("m_empty", 2, nodes.get(2));
+        createPinnedIndex("z_remote", 1, nodes.get(1));
+
+        // Each data shard holds fewer values than the HybridDigest threshold at which it switches from sorting to
+        // merging (20 * the default compression of 100), which their combined size crosses, so that the switch, and
+        // the allocation it needs, happens while the shard results are merged during reduction rather than while a
+        // single shard collects them.
+        List<IndexRequestBuilder> docs = new ArrayList<>();
+        for (int i = 0; i < 1500; i++) {
+            docs.add(prepareIndex("a_local").setSource("value", i));
+            docs.add(prepareIndex("z_remote").setSource("value", i));
+        }
+        indexRandom(true, docs);
+        ensureGreen("a_local", "m_empty", "z_remote");
+
+        assertResponse(
+            internalCluster().client(coordinator)
+                .prepareSearch("a_local", "m_empty", "z_remote")
+                .setSize(0)
+                .addAggregation(percentiles("percentiles").field("value").percentiles(50.0)),
+            response -> {
+                Percentiles result = response.getAggregations().get("percentiles");
+                assertThat(result.percentile(50.0), closeTo(749.5, 30.0));
+            }
+        );
+    }
+
+    private void createPinnedIndex(String name, int shards, String node) {
+        assertAcked(
+            prepareCreate(name).setSettings(indexSettings(shards, 0).put("index.routing.allocation.require._name", node))
+                .setMapping("value", "type=long")
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -141,11 +141,24 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
             public void accept(InternalAggregation aggregation) {
                 final AbstractInternalTDigestPercentiles percentiles = (AbstractInternalTDigestPercentiles) aggregation;
                 if (percentiles.state != null) {
-                    if (merged == null) {
-                        // Shard results use NOOP_BREAKER after deserialization; the accumulator matches.
+                    // Accumulate into a state we own and that is backed by NOOP_BREAKER. Only the accumulator grows
+                    // here, and growing an incoming shard result instead would charge its own breaker, which for a
+                    // result that stayed on the coordinating node, and so was never serialized, is a
+                    // PreallocatedCircuitBreaker the aggregation context has already closed. Re-seeding on higher
+                    // compression keeps the smaller-compression data merged into the larger-compression state, so the
+                    // result does not lose precision.
+                    if (merged == null || percentiles.state.compression() > merged.compression()) {
+                        HistogramUnionState previous = merged;
                         merged = HistogramUnionState.createUsingParamsFrom(percentiles.state, HistogramUnionState.NOOP_BREAKER);
+                        if (previous != null) {
+                            try {
+                                merged.add(previous);
+                            } finally {
+                                previous.close();
+                            }
+                        }
                     }
-                    merged = merge(merged, percentiles.state);
+                    merged.add(percentiles.state);
                 }
             }
 
@@ -154,26 +167,6 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
                 return createReduced(getName(), keys, merged == null ? HistogramUnionState.EMPTY : merged, keyed, getMetadata());
             }
         };
-    }
-
-    /**
-     * Merges two {@link HistogramUnionState}s such that we always merge the one with smaller
-     * compression into the one with larger compression.
-     * This prevents producing a result that has lower than expected precision.
-     *
-     * @param digest1 The first histogram to merge
-     * @param digest2 The second histogram to merge
-     * @return One of the input histograms such that the one with larger compression is used as the one for merging
-     */
-    private static HistogramUnionState merge(final HistogramUnionState digest1, final HistogramUnionState digest2) {
-        HistogramUnionState largerCompression = digest1;
-        HistogramUnionState smallerCompression = digest2;
-        if (digest2.compression() > digest1.compression()) {
-            largerCompression = digest2;
-            smallerCompression = digest1;
-        }
-        largerCompression.add(smallerCompression);
-        return largerCompression;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
@@ -22,15 +22,21 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.indices.breaker.CircuitBreakerMetrics;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
@@ -45,9 +51,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.percentiles;
 import static org.elasticsearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
+
+    private static final double DEFAULT_COMPRESSION = 100.0;
 
     @Override
     protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
@@ -251,6 +260,98 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             expectThrows(CircuitBreakingException.class, () -> collectWithBreaker(reader, breakerService, aggBuilder, fieldType));
             assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
         });
+    }
+
+    public void testReduceAfterAggregationContextClosed() throws IOException {
+        HierarchyCircuitBreakerService breakerService = requestBreakerService("100mb");
+        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
+        PercentilesAggregationBuilder aggBuilder = percentilesBuilder(DEFAULT_COMPRESSION);
+
+        // A partial reduce over shard results that collected nothing emits HistogramUnionState.EMPTY, whose compression
+        // is hard-coded to 1.0 and therefore always below the request's. The coordinator consumes partials ahead of raw
+        // shard results, so such a partial used to make the reducer adopt the first data-bearing result as its
+        // accumulator. Both shard results read the same 1500 document index, which keeps each below the HybridDigest
+        // sorting-to-merging threshold of 20 * 100 = 2000 that their combined 3000 values cross, so the allocating
+        // transition happens during reduction, against the already-closed preallocated breaker of the aggregation
+        // context that built the adopted result.
+        withSequentialIndex(1500, reader -> {
+            InternalAggregations emptyPartial = InternalAggregations.topLevelReduce(
+                List.of(InternalAggregations.from(List.of(emptyShardResult())), InternalAggregations.from(List.of(emptyShardResult()))),
+                partialReduceContext(aggBuilder)
+            );
+            assertThat(((InternalTDigestPercentiles) emptyPartial.copyResults().get(0)).state.compression(), equalTo(1.0));
+
+            InternalAggregation first = buildPreallocatedShardResult(reader, breakerService, fieldType, DEFAULT_COMPRESSION);
+            InternalAggregation second = buildPreallocatedShardResult(reader, breakerService, fieldType, DEFAULT_COMPRESSION);
+
+            InternalAggregations reduced = InternalAggregations.topLevelReduce(
+                List.of(emptyPartial, InternalAggregations.from(List.of(first)), InternalAggregations.from(List.of(second))),
+                finalReduceContext(aggBuilder)
+            );
+
+            InternalTDigestPercentiles result = (InternalTDigestPercentiles) reduced.copyResults().get(0);
+            assertThat(result.state.size(), equalTo(3000L));
+            assertThat(result.percentile(50), closeTo(749.5, 30.0));
+        });
+        assertThat(breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+    }
+
+    private static InternalAggregation emptyShardResult() {
+        return InternalTDigestPercentiles.empty("p", new double[] { 50 }, false, DocValueFormat.RAW, null);
+    }
+
+    private InternalAggregation buildPreallocatedShardResult(
+        DirectoryReader reader,
+        CircuitBreakerService breakerService,
+        MappedFieldType fieldType,
+        double compression
+    ) throws IOException {
+        PercentilesAggregationBuilder aggBuilder = percentilesBuilder(compression);
+        try (
+            AggregationContext context = createAggregationContext(
+                reader,
+                createIndexSettings(),
+                Queries.ALL_DOCS_INSTANCE,
+                breakerService,
+                AggregationBuilder.DEFAULT_PREALLOCATION,
+                DEFAULT_MAX_BUCKETS,
+                false,
+                false,
+                fieldType
+            )
+        ) {
+            Aggregator aggregator = createAggregator(aggBuilder, context);
+            aggregator.preCollection();
+            context.searcher().search(Queries.ALL_DOCS_INSTANCE, aggregator.asCollector());
+            aggregator.postCollection();
+            return aggregator.buildTopLevel();
+        }
+    }
+
+    private static PercentilesAggregationBuilder percentilesBuilder(double compression) {
+        return new PercentilesAggregationBuilder("p").field("number").percentilesConfig(new PercentilesConfig.TDigest(compression));
+    }
+
+    private static AggregationReduceContext finalReduceContext(AggregationBuilder builder) {
+        return new AggregationReduceContext.ForFinal(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            null,
+            () -> false,
+            new AggregatorFactories.Builder().addAggregator(builder),
+            bucketCount -> {},
+            null
+        );
+    }
+
+    private static AggregationReduceContext partialReduceContext(AggregationBuilder builder) {
+        return new AggregationReduceContext.ForPartial(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            null,
+            () -> false,
+            new AggregatorFactories.Builder().addAggregator(builder),
+            bucketCount -> {},
+            null
+        );
     }
 
     private static void withSequentialIndex(int docCount, CheckedConsumer<DirectoryReader, IOException> body) throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix percentiles reduce using a closed preallocated breaker (#157254)