### PR TITLE
Introduce FailureStrategy to RecoveryListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -208,6 +208,7 @@ import static org.elasticsearch.cluster.metadata.DataStream.TIMESERIES_LEAF_READ
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
 import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
 
 public class IndexShard extends AbstractIndexShardComponent implements IndicesClusterStateService.Shard {
@@ -3855,7 +3856,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     recoveryTargetService.startRecovery(this, recoveryState.getSourceNode(), clusterStateVersion, recoveryListener);
                 } catch (Exception e) {
                     failShard("corrupted preexisting index", e);
-                    recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), true);
+                    recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), FAIL_SEND);
                 }
             }
             case SNAPSHOT -> {
@@ -3941,7 +3942,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             } else {
                 recoveryListener.onRecoveryAborted();
             }
-        }, e -> recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), true));
+        }, e -> recoveryListener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), FAIL_SEND));
         ActionListener.run(actionListener, action);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1230,7 +1230,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         }
 
         @Override
-        public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+        public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
             RecoveryClusterStateDelay.ensureClusterStateVersion(
                 creationClusterStateVersion,
                 clusterService,
@@ -1238,7 +1238,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 threadPool.getThreadContext(),
                 ActionListener.noop(),
                 listener -> {
-                    handleRecoveryFailure(shardRouting, sendShardFailure, primaryTerm, e);
+                    handleRecoveryFailure(shardRouting, failureStrategy.notifyMaster(), primaryTerm, e);
                     listener.onResponse(null);
                 }
             );

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1238,7 +1238,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 threadPool.getThreadContext(),
                 ActionListener.noop(),
                 listener -> {
-                    handleRecoveryFailure(shardRouting, failureStrategy.notifyMaster(), primaryTerm, e);
+                    handleRecoveryFailure(shardRouting, failureStrategy, primaryTerm, e);
                     listener.onResponse(null);
                 }
             );
@@ -1253,13 +1253,18 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     }
 
     // package-private for testing
-    synchronized void handleRecoveryFailure(ShardRouting shardRouting, boolean sendShardFailure, long primaryTerm, Exception failure) {
+    synchronized void handleRecoveryFailure(
+        ShardRouting shardRouting,
+        RecoveryListener.FailureStrategy failureStrategy,
+        long primaryTerm,
+        Exception failure
+    ) {
         try {
             CloseUtils.executeDirectly(
                 l -> failAndRemoveShard(
                     shardRouting,
                     primaryTerm,
-                    sendShardFailure,
+                    failureStrategy.notifyMaster(),
                     "failed recovery",
                     failure,
                     clusterService.state(),

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -70,6 +70,8 @@ import java.util.function.Consumer;
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.core.TimeValue.timeValueMillis;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
 
 /**
  * The recovery target handles recoveries of peer shards of the shard+node to recover to.
@@ -285,7 +287,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             onGoingRecoveries.failRecovery(
                 recoveryId,
                 new RecoveryFailedException(recoveryTarget.state(), "failed to prepare shard for recovery", e),
-                true
+                FAIL_SEND
             );
         }), recoveryRef::close));
 
@@ -332,18 +334,18 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                         @Override
                         public void onFailure(Exception e) {
                             final var cause = ExceptionsHelper.unwrapCause(e);
-                            final var sendShardFailure =
+                            final var failureStrategy =
                                 // these indicate the source shard has already failed, which will independently notify the master and fail
                                 // the target shard
-                                false == (cause instanceof ShardNotFoundException
+                                (cause instanceof ShardNotFoundException
                                     || cause instanceof IndexNotFoundException
-                                    || cause instanceof AlreadyClosedException);
+                                    || cause instanceof AlreadyClosedException) ? FAIL_SILENT : FAIL_SEND;
 
                             // TODO retries? See RecoveryResponseHandler#handleException
                             onGoingRecoveries.failRecovery(
                                 recoveryId,
                                 new RecoveryFailedException(recoveryState, null, e),
-                                sendShardFailure
+                                failureStrategy
                             );
                         }
                     }
@@ -719,7 +721,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     onGoingRecoveries.failRecovery(
                         recoveryId,
                         new RecoveryFailedException(recoveryRef.target().state(), "unexpected error", e),
-                        true // be safe
+                        FAIL_SEND // be safe
                     );
                 } else {
                     logger.debug(() -> "unexpected error during recovery, but recovery id [" + recoveryId + "] is finished", e);
@@ -802,7 +804,11 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (transportService.lifecycleState() != Lifecycle.State.STARTED) {
                 // the node is shutting down, we just fail the recovery to release resources
-                onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, "node is shutting down", cause), false);
+                onGoingRecoveries.failRecovery(
+                    recoveryId,
+                    new RecoveryFailedException(request, "node is shutting down", cause),
+                    FAIL_SILENT
+                );
                 return;
             }
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
@@ -810,7 +816,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 onGoingRecoveries.failRecovery(
                     recoveryId,
                     new RecoveryFailedException(request, "source has canceled the recovery", cause),
-                    false
+                    FAIL_SILENT
                 );
                 return;
             }
@@ -855,11 +861,15 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             }
 
             if (cause instanceof AlreadyClosedException) {
-                onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, "source shard is closed", cause), false);
+                onGoingRecoveries.failRecovery(
+                    recoveryId,
+                    new RecoveryFailedException(request, "source shard is closed", cause),
+                    FAIL_SILENT
+                );
                 return;
             }
 
-            onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, e), true);
+            onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(request, e), FAIL_SEND);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
+
 /**
  * This class holds a collection of all on going recoveries on the current node (i.e., the node is the target node
  * of those recoveries). The class is used to guarantee concurrent semantics such that once a recoveries was done/cancelled/failed
@@ -106,7 +108,7 @@ public class RecoveriesCollection {
             failRecovery(
                 newRecoveryTarget.recoveryId(),
                 new RecoveryFailedException(oldRecoveryTarget.state(), "failed to retry recovery", e),
-                true
+                FAIL_SEND
             );
             return null;
         }
@@ -183,11 +185,11 @@ public class RecoveriesCollection {
     /**
      * Fails the recovery with the given id (if found) and remove it from the recovery collection
      *
-     * @param id               id of the recovery to fail
-     * @param e                exception with reason for the failure
-     * @param sendShardFailure true a shard failed message should be sent to the master
+     * @param id              id of the recovery to fail
+     * @param e               exception with reason for the failure
+     * @param failureStrategy failure strategy decides if master should be notified
      */
-    public void failRecovery(long id, RecoveryFailedException e, boolean sendShardFailure) {
+    public void failRecovery(long id, RecoveryFailedException e, RecoveryListener.FailureStrategy failureStrategy) {
         RecoveryTarget removed = removeRecoveryTarget(id);
         if (removed != null) {
             logger.trace(
@@ -195,9 +197,9 @@ public class RecoveriesCollection {
                 removed.shardId(),
                 removed.sourceNode(),
                 removed.recoveryId(),
-                sendShardFailure
+                failureStrategy
             );
-            removed.fail(e, sendShardFailure);
+            removed.fail(e, failureStrategy);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryListener.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryListener.java
@@ -28,7 +28,7 @@ public interface RecoveryListener {
         ) {}
 
         @Override
-        public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {}
+        public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {}
 
         @Override
         public void onRecoveryAborted() {}
@@ -42,10 +42,25 @@ public interface RecoveryListener {
     );
 
     /// Called when recovery fails with an exception.
-    void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure);
+    void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy);
 
     /// Called when recovery has been internally aborted, usually due to shard closure or shard relocation
     void onRecoveryAborted();
+
+    enum FailureStrategy {
+        FAIL_SILENT(false),
+        FAIL_SEND(true);
+
+        private final boolean notifyMaster;
+
+        FailureStrategy(boolean notifyMaster) {
+            this.notifyMaster = notifyMaster;
+        }
+
+        public boolean notifyMaster() {
+            return notifyMaster;
+        }
+    }
 
     static RecoveryListener wrapPreservingContext(RecoveryListener listener, Supplier<ThreadContext.StoredContext> context) {
         return new RecoveryListener() {
@@ -61,9 +76,9 @@ public interface RecoveryListener {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try (ThreadContext.StoredContext ignore = context.get()) {
-                    listener.onRecoveryFailure(e, sendShardFailure);
+                    listener.onRecoveryFailure(e, failureStrategy);
                 }
             }
 
@@ -93,9 +108,9 @@ public interface RecoveryListener {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try {
-                    listener.onRecoveryFailure(e, sendShardFailure);
+                    listener.onRecoveryFailure(e, failureStrategy);
                 } finally {
                     runAfter.run();
                 }
@@ -129,11 +144,11 @@ public interface RecoveryListener {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try {
                     runBefore.run();
                 } finally {
-                    listener.onRecoveryFailure(e, sendShardFailure);
+                    listener.onRecoveryFailure(e, failureStrategy);
                 }
             }
 
@@ -166,8 +181,8 @@ public interface RecoveryListener {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
-                listener.onRecoveryFailure(e, sendShardFailure);
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
+                listener.onRecoveryFailure(e, failureStrategy);
             }
 
             @Override
@@ -191,11 +206,11 @@ public interface RecoveryListener {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 try {
                     beforeFailure.accept(e);
                 } finally {
-                    listener.onRecoveryFailure(e, sendShardFailure);
+                    listener.onRecoveryFailure(e, failureStrategy);
                 }
             }
 
@@ -236,10 +251,10 @@ public interface RecoveryListener {
                 }
 
                 @Override
-                public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+                public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                     assertFirstRun();
                     try {
-                        delegate.onRecoveryFailure(e, sendShardFailure);
+                        delegate.onRecoveryFailure(e, failureStrategy);
                     } catch (RuntimeException ex) {
                         if (e != null && ex != e) {
                             ex.addSuppressed(e);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadataVerifier.isReadOnlyVerified;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
 
 /**
  * Represents a recovery where the current node is the target node of the recovery. To track recoveries in a central place, instances of
@@ -269,13 +270,13 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     /**
      * fail the recovery and call listener
      *
-     * @param e                exception that encapsulating the failure
-     * @param sendShardFailure indicates whether to notify the master of the shard failure
+     * @param e               exception that encapsulating the failure
+     * @param failureStrategy failure strategy decides if master should be notified
      */
-    public void fail(RecoveryFailedException e, boolean sendShardFailure) {
+    public void fail(RecoveryFailedException e, RecoveryListener.FailureStrategy failureStrategy) {
         if (finished.compareAndSet(false, true)) {
             try {
-                listener.onRecoveryFailure(e, sendShardFailure);
+                listener.onRecoveryFailure(e, failureStrategy);
             } finally {
                 try {
                     cancellableThreads.cancel("failed recovery [" + ExceptionsHelper.stackTrace(e) + "]");
@@ -300,7 +301,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 @Override
                 public void onFailure(Exception e) {
                     logger.debug("recovery failed after being marked as done", e);
-                    listener.onRecoveryFailure(new RecoveryFailedException(state(), "Recovery failed on post recovery step", e), true);
+                    listener.onRecoveryFailure(new RecoveryFailedException(state(), "Recovery failed on post recovery step", e), FAIL_SEND);
                 }
             }, this::decRef));
         }
@@ -515,11 +516,11 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                     ex.addSuppressed(e);
                 }
                 RecoveryFailedException rfe = new RecoveryFailedException(state(), "failed to clean after recovery", ex);
-                fail(rfe, true);
+                fail(rfe, FAIL_SEND);
                 throw rfe;
             } catch (Exception ex) {
                 RecoveryFailedException rfe = new RecoveryFailedException(state(), "failed to clean after recovery", ex);
-                fail(rfe, true);
+                fail(rfe, FAIL_SEND);
                 throw rfe;
             }
             return null;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryService.java
@@ -46,6 +46,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
+
 /// Limit the number of concurrent recoveries. Slots are filled when dispatching a recovery task to the executor and
 /// released when the recovery's [RecoveryListener] completes.
 /// The max number of concurrent recovery slots is controlled by the [#INDICES_RECOVERY_MAX_CONCURRENT_RECOVERIES_SETTING]
@@ -194,7 +197,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
                                 recoveryState.getSourceNode(),
                                 recoveryState.getTargetNode()
                             ),
-                            true
+                            FAIL_SEND
                         );
                     schedulingListener.onRecoveryCancelledBeforeQueuingOnTarget(recoveryType);
                 });
@@ -239,7 +242,10 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
 
             logger.trace("cancelling recovery in queue: {}", state);
             RecoveryListener.wrapPreservingContext(pendingRecovery.listener, pendingRecovery.context)
-                .onRecoveryFailure(new RecoveryCancelledException(state.getShardId(), state.getSourceNode(), state.getTargetNode()), false);
+                .onRecoveryFailure(
+                    new RecoveryCancelledException(state.getShardId(), state.getSourceNode(), state.getTargetNode()),
+                    FAIL_SILENT
+                );
             schedulingListener.onQueuedRecoveryCancelledOnTarget(state.getRecoverySource().getType(), pendingRecovery.priorityGroup());
             cancelledInQueue.add(pendingRecovery.allocationId());
         }
@@ -290,7 +296,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
                 stale.listener()
                     .onRecoveryFailure(
                         new RecoveryCancelledException(state.getShardId(), state.getSourceNode(), state.getTargetNode()),
-                        false
+                        FAIL_SILENT
                     );
                 schedulingListener.onQueuedRecoveryDiscardedOnTarget(state.getRecoverySource().getType(), stale.priorityGroup());
             });
@@ -575,7 +581,7 @@ public final class ThrottlingRecoveryService extends AbstractLifecycleComponent 
 
         @Override
         public void onFailure(Exception e) {
-            listener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), true);
+            listener.onRecoveryFailure(new RecoveryFailedException(recoveryState, null, e), FAIL_SEND);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -6085,7 +6085,7 @@ public class IndexShardTests extends IndexShardTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 assert false : "Unexpected failure";
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -78,6 +78,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -304,10 +305,10 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         final long primaryTerm = localState.metadata().getProject().index(index).primaryTerm(shardId.id());
 
         // check that failing unrelated allocation does not remove shard
-        indicesCSSvc.handleRecoveryFailure(shardRouting.reinitializeReplicaShard(), false, primaryTerm, new Exception("dummy"));
+        indicesCSSvc.handleRecoveryFailure(shardRouting.reinitializeReplicaShard(), FAIL_SILENT, primaryTerm, new Exception("dummy"));
         assertNotNull(indicesCSSvc.indicesService.getShardOrNull(shardId));
 
-        indicesCSSvc.handleRecoveryFailure(shardRouting, false, primaryTerm, new Exception("dummy"));
+        indicesCSSvc.handleRecoveryFailure(shardRouting, FAIL_SILENT, primaryTerm, new Exception("dummy"));
         assertNull(indicesCSSvc.indicesService.getShardOrNull(shardId));
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -366,7 +366,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 future.onFailure(e);
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveriesCollectionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveriesCollectionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.MockLog;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RecoveriesCollectionTests extends ESIndexLevelReplicationTestCase {
@@ -109,7 +110,7 @@ public class RecoveriesCollectionTests extends ESIndexLevelReplicationTestCase {
                 (collection, shardId, recoveryId) -> () -> collection.failRecovery(
                     recoveryId,
                     new RecoveryFailedException(fakeRecoveryState(), "failed", new RuntimeException("cause")),
-                    false
+                    FAIL_SILENT
                 ),
                 " failing recovery from"
             );

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -456,7 +456,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
                     }
 
                     @Override
-                    public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+                    public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                         assertThat(ExceptionsHelper.unwrap(e, IOException.class).getMessage(), equalTo("simulated"));
                     }
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/ThrottlingRecoveryServiceTests.java
@@ -69,6 +69,8 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.indices.recovery.RecoveryGateMonitor.ENABLE_RECOVERY_GATES_SETTING;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SEND;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
 import static org.elasticsearch.indices.recovery.ThrottlingRecoveryService.INDICES_RECOVERY_MAX_CONCURRENT_RECOVERIES_SETTING;
 import static org.elasticsearch.indices.recovery.ThrottlingRecoveryService.INDICES_RECOVERY_MAX_CONCURRENT_RELOCATION_RECOVERIES_SETTING;
 import static org.hamcrest.Matchers.equalTo;
@@ -153,7 +155,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 assertThat(threadPool.getThreadContext().getHeader(Task.X_ELASTIC_PROJECT_ID_HTTP_HEADER), equalTo(projectId2.id()));
             }
 
@@ -847,7 +849,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                 // simulates cancellation of started recovery
                 taskQueue.scheduleAt(
                     taskQueue.getCurrentTimeMillis() + 100,
-                    () -> listener.onRecoveryFailure(new RecoveryCancelledException(shardId1, null, null), true)
+                    () -> listener.onRecoveryFailure(new RecoveryCancelledException(shardId1, null, null), FAIL_SEND)
                 );
             }
         );
@@ -947,7 +949,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                 // occupies the sole concurrency slot
                 taskQueue.scheduleAt(
                     taskQueue.getCurrentTimeMillis() + 100,
-                    () -> listener.onRecoveryFailure(new RecoveryCancelledException(blockerShardId, null, null), true)
+                    () -> listener.onRecoveryFailure(new RecoveryCancelledException(blockerShardId, null, null), FAIL_SEND)
                 );
             }
         );
@@ -1051,7 +1053,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 completed.incrementAndGet();
             }
 
@@ -1114,7 +1116,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                                                 null,
                                                 new RuntimeException("test recovery task injected failure")
                                             ),
-                                            false
+                                            FAIL_SILENT
                                         );
                                     }
                                 }
@@ -1179,7 +1181,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 runningOrPending.decrementAndGet();
                 tasksCompleted.incrementAndGet();
                 refCounted.decRef();
@@ -1267,7 +1269,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
                 } else {
                     schedulingListener.onRecoveryFailure(
                         new RecoveryFailedException(recoveryState, null, new RuntimeException("test recovery task injected failure")),
-                        randomBoolean()
+                        randomBoolean() ? FAIL_SEND : FAIL_SILENT
                     );
                 }
             }
@@ -1310,12 +1312,12 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
         }
 
         @Override
-        public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+        public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
             assert super.isDone() == false;
             switch (expectedOutcome) {
                 case FAILED -> super.onResponse(null);
                 case CANCELLED_IN_QUEUE, CANCELLED_STARTED -> {
-                    assert expectedOutcome == ExpectedRecoveryOutcome.CANCELLED_IN_QUEUE || sendShardFailure
+                    assert expectedOutcome == ExpectedRecoveryOutcome.CANCELLED_IN_QUEUE || failureStrategy.notifyMaster()
                         : "should notify the master solely when cancelling started recoveries";
                     if (e instanceof RecoveryCancelledException == false) {
                         throw new AssertionError("unexpected failure type", e);
@@ -1763,7 +1765,7 @@ public class ThrottlingRecoveryServiceTests extends ESTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 fail(e, "unexpected recovery failure");
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/TransportCancelRecoveriesActionTests.java
@@ -494,7 +494,7 @@ public class TransportCancelRecoveriesActionTests extends ESTestCase {
             }
 
             @Override
-            public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+            public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
                 cancelled.set(true);
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -120,6 +120,7 @@ import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
+import static org.elasticsearch.indices.recovery.RecoveryListener.FailureStrategy.FAIL_SILENT;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -155,7 +156,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         ) {}
 
         @Override
-        public void onRecoveryFailure(RecoveryFailedException e, boolean sendShardFailure) {
+        public void onRecoveryFailure(RecoveryFailedException e, FailureStrategy failureStrategy) {
             throw new AssertionError(e);
         }
 
@@ -1041,7 +1042,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
             future.actionGet();
             recoveryTarget.markAsDone();
         } catch (Exception e) {
-            recoveryTarget.fail(new RecoveryFailedException(request, e), false);
+            recoveryTarget.fail(new RecoveryFailedException(request, e), FAIL_SILENT);
             throw e;
         }
     }


### PR DESCRIPTION
Laying the foundation for extending the RecoveryListener with more strategies for how to handle failures during recovery.

Relates https://github.com/elastic/elasticsearch-team/issues/4351