### PR TITLE
ESQL:DS: Harden Utf8AscTopNEncoder lead-byte table against

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
@@ -133,7 +133,7 @@ final class Utf8AscTopNEncoder extends SortableAscTopNEncoder {
                 { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
                 { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
                 { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
-                { 4, 4, 4, 4, 4, 4, 4, 4 /* , 5, 5, 5, 5, 6, 6, 0, 0 */ } }
+                { 4, 4, 4, 4, 4, 4, 4, 4, v, v, v, v, v, v, v, v } }
         ).flatMapToInt(Arrays::stream).toArray();
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoderTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator.topn;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import static org.hamcrest.Matchers.lessThan;
@@ -24,5 +25,24 @@ public class Utf8AscTopNEncoderTests extends AbstractUtf8TopNEncoderTests {
     @Override
     protected void assertMinMax(BreakingBytesRefBuilder min, BreakingBytesRefBuilder max) {
         assertThat(min.bytesRefView(), lessThan(max.bytesRefView()));
+    }
+
+    /**
+     * Bytes 0xF8–0xFF are outside the original 248-entry lead-byte table.
+     * The decoder must throw a controlled IllegalArgumentException rather than
+     * an ArrayIndexOutOfBoundsException (defense-in-depth; no current reachable path).
+     */
+    public void testDecodeHighLeadBytesThrowsIllegalArgument() {
+        for (int b = 0xF8; b <= 0xFF; b++) {
+            // Construct an encoded stream: [highByte, NUL-terminator]
+            byte[] encoded = { (byte) b, Utf8AscTopNEncoder.TERMINATOR };
+            BytesRef ref = new BytesRef(encoded, 0, encoded.length);
+            int finalB = b;
+            assertThrows(
+                "expected IllegalArgumentException for byte 0x" + Integer.toHexString(finalB),
+                IllegalArgumentException.class,
+                () -> TopNEncoder.UTF8.decodeBytesRef(ref, new BytesRef())
+            );
+        }
     }
 }


### PR DESCRIPTION
Extends the utf8CodeLength table from 248 to 256 entries by filling in the eight previously-commented-out slots (0xF8–0xFF) with the invalid-byte marker v (Integer.MIN_VALUE). Bytes in that range previously caused an unchecked ArrayIndexOutOfBoundsException in decodeBytesRef.
They now hit the existing default branch and throw a controlled IllegalArgumentException instead.

Closes https://github.com/elastic/esql-planning/issues/1066