### PR TITLE
[CI] Support ARCHIMEDES_REF for testing archimedes branches on the agentic pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -127,28 +127,52 @@ if [[ "${USE_ARCHIMEDES:-}" == "true" ]]; then
   export GH_TOKEN="${GH_ADMIN_TOKEN}"
   unset GH_ADMIN_TOKEN
 
-  # Bootstrap archimedes, upgrading if the installed version is behind the
-  # latest release. bootstrap.sh is fetched from the same release tag so the
-  # installer and the binary are always in sync.
+  # Bootstrap archimedes. Two paths:
+  #
+  # 1. ARCHIMEDES_REF is set → install directly from that branch/tag/sha of
+  #    ARCHIMEDES_REPO, bypassing the release lookup entirely. Used for testing
+  #    unreleased archimedes changes end to end against this pipeline; the
+  #    version-cache gate is deliberately bypassed so a warm agent that still
+  #    has "latest" cached is reinstalled from the requested ref instead. Also
+  #    fetches bootstrap.sh itself from that ref (not from the latest release
+  #    tag) so an ARCHIMEDES_REF-only change lands without needing a release
+  #    cut first. ARCHIMEDES_REF is exported here so the piped bootstrap.sh
+  #    sees it and takes its own ARCHIMEDES_REF install path (which is where
+  #    the ref-under-test guardrail — routing obs docs to a per-ref experiment
+  #    index — lives).
+  #
+  # 2. otherwise → resolve the latest release tag and install it, upgrading if
+  #    the installed version is behind. bootstrap.sh is fetched from that same
+  #    tag ref so the installer and the binary are always in sync.
   ARCHIMEDES_REPO="${ARCHIMEDES_REPO:-elastic/elasticsearch-infra}"
-  _archimedes_latest_tag=$(gh api "repos/${ARCHIMEDES_REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
-  if [ -z "${_archimedes_latest_tag:-}" ] || [ "${_archimedes_latest_tag}" = "null" ]; then
-    _archimedes_latest_tag=$(gh api "repos/${ARCHIMEDES_REPO}/releases" \
-      --jq '[.[] | select(.tag_name | startswith("archimedes-"))] | sort_by(.created_at) | last | .tag_name' 2>/dev/null || echo "")
-  fi
-  _archimedes_latest_ver="${_archimedes_latest_tag#archimedes-v}"
-  _archimedes_installed_ver=$(archimedes version 2>/dev/null || echo "none")
-  if [[ "${_archimedes_installed_ver}" != "${_archimedes_latest_ver}" ]]; then
-    echo "--- Bootstrapping archimedes (latest release: ${_archimedes_latest_tag:-unknown}, installed: ${_archimedes_installed_ver})"
-    if ! gh api "repos/${ARCHIMEDES_REPO}/contents/archimedes/bootstrap.sh?ref=${_archimedes_latest_tag}" \
+  if [[ -n "${ARCHIMEDES_REF:-}" ]]; then
+    export ARCHIMEDES_REF
+    echo "--- Bootstrapping archimedes from ref ${ARCHIMEDES_REF} (ARCHIMEDES_REPO=${ARCHIMEDES_REPO})"
+    if ! gh api "repos/${ARCHIMEDES_REPO}/contents/archimedes/bootstrap.sh?ref=${ARCHIMEDES_REF}" \
            -H "Accept: application/vnd.github.raw+json" | bash -s; then
-      echo "archimedes bootstrap failed" >&2
+      echo "archimedes bootstrap from ref '${ARCHIMEDES_REF}' failed" >&2
       exit 1
     fi
   else
-    echo "archimedes ${_archimedes_installed_ver} already up to date"
+    _archimedes_latest_tag=$(gh api "repos/${ARCHIMEDES_REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+    if [ -z "${_archimedes_latest_tag:-}" ] || [ "${_archimedes_latest_tag}" = "null" ]; then
+      _archimedes_latest_tag=$(gh api "repos/${ARCHIMEDES_REPO}/releases" \
+        --jq '[.[] | select(.tag_name | startswith("archimedes-"))] | sort_by(.created_at) | last | .tag_name' 2>/dev/null || echo "")
+    fi
+    _archimedes_latest_ver="${_archimedes_latest_tag#archimedes-v}"
+    _archimedes_installed_ver=$(archimedes version 2>/dev/null || echo "none")
+    if [[ "${_archimedes_installed_ver}" != "${_archimedes_latest_ver}" ]]; then
+      echo "--- Bootstrapping archimedes (latest release: ${_archimedes_latest_tag:-unknown}, installed: ${_archimedes_installed_ver})"
+      if ! gh api "repos/${ARCHIMEDES_REPO}/contents/archimedes/bootstrap.sh?ref=${_archimedes_latest_tag}" \
+             -H "Accept: application/vnd.github.raw+json" | bash -s; then
+        echo "archimedes bootstrap failed" >&2
+        exit 1
+      fi
+    else
+      echo "archimedes ${_archimedes_installed_ver} already up to date"
+    fi
+    unset _archimedes_latest_tag _archimedes_latest_ver _archimedes_installed_ver
   fi
-  unset _archimedes_latest_tag _archimedes_latest_ver _archimedes_installed_ver
 
   # No external nono CLI bootstrap needed: archimedes sandboxes itself in-process
   # via the bundled nono-ts SDK. The `archimedes ci` entry point applies the

--- a/.buildkite/pipelines/agentic-workflow.yml
+++ b/.buildkite/pipelines/agentic-workflow.yml
@@ -20,13 +20,20 @@
 #     -d '{"branch":"main","env":{
 #            "WORKFLOW":"test-analysis",
 #            "ISSUE_URL":"https://github.com/elastic/elasticsearch/issues/150989"}}'
+#
+# To test an unreleased archimedes branch/tag/sha against this pipeline, add
+# ARCHIMEDES_REF=<ref> to the env block. The pre-command hook installs
+# archimedes from that ref (bypassing the release lookup + agent cache) and
+# archimedes auto-routes observability off the production dashboards. Any ref
+# the GH contents API accepts works — branch, tag, or commit SHA.
 
 # Surface trigger vars at pipeline level so env() in step `if` conditions can
 # see them on API-triggered builds.
 env:
-  WORKFLOW:  "${WORKFLOW:-}"
-  ISSUE_URL: "${ISSUE_URL:-}"
-  PR_URL:    "${PR_URL:-}"
+  WORKFLOW:       "${WORKFLOW:-}"
+  ISSUE_URL:      "${ISSUE_URL:-}"
+  PR_URL:         "${PR_URL:-}"
+  ARCHIMEDES_REF: "${ARCHIMEDES_REF:-}"
 
 steps:
   # ── Run archimedes ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Companion to [elastic/elasticsearch-infra#613](https://github.com/elastic/elasticsearch-infra/pull/613) — makes it possible to run the real `elasticsearch-agentic-workflow` pipeline against an unreleased archimedes branch/tag/sha via a single build-env var, without cutting a release or editing hooks per test.

**`.buildkite/hooks/pre-command`** — when `ARCHIMEDES_REF` is set, install archimedes directly from that ref of `ARCHIMEDES_REPO`. `bootstrap.sh` itself is fetched from the same ref (not from the latest release tag) so an `ARCHIMEDES_REF`-only change lands without a release cut. The version-cache gate is deliberately bypassed on this path so a warm agent that still has "latest" cached is reinstalled from the requested ref instead. `ARCHIMEDES_REF` is exported here so the piped `bootstrap.sh` sees it and takes its own `ARCHIMEDES_REF` install path — that's where the ref-under-test observability-index guardrail lives (see the paired archimedes PR).

Latest-release path (unset `ARCHIMEDES_REF`) is unchanged.

**`.buildkite/pipelines/agentic-workflow.yml`** — surface `ARCHIMEDES_REF` at pipeline level so API-triggered builds can pass it through alongside `WORKFLOW` / `ISSUE_URL` / `PR_URL`. Adds a doc block on how to trigger a ref-under-test run.

## Trigger a ref-under-test run

```bash
curl -X POST ".../pipelines/elasticsearch-agentic-workflow/builds" \
  -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
  -d '{
    "branch": "main",
    "env": {
      "WORKFLOW":        "test-analysis",
      "ISSUE_URL":       "https://github.com/elastic/elasticsearch/issues/N",
      "ARCHIMEDES_REF":  "my-feature-branch"
    }
  }'
```

archimedes will detect the ref, log `Ref build detected (ARCHIMEDES_REF=...)`, route the run doc to `archimedes-ref-<sanitized>-runs` (not the production `archimedes-workflow-runs` index), and stamp `run.archimedes_ref` for filtering in Kibana. The production dashboards stay uncontaminated.

## Test plan

- [x] `bash -n .buildkite/hooks/pre-command` — syntax clean
- [x] YAML validates against the buildkite pipeline schema (yaml-language-server directive already present)
- [ ] E2E: trigger `elasticsearch-agentic-workflow` with `ARCHIMEDES_REF` pointing at [elastic/elasticsearch-infra#613](https://github.com/elastic/elasticsearch-infra/pull/613)'s head, confirm:
  - `--- Bootstrapping archimedes from ref <sha>` appears in the hook log
  - `archimedes ci` runs from the branch's code (version reports `0.0.0-dev`)
  - obs run doc lands in `archimedes-ref-<sanitized>-runs`, not the production index
- [ ] Sanity: an ordinary build without `ARCHIMEDES_REF` still resolves + installs the latest release exactly as before.

Made with [Cursor](https://cursor.com)