### PR TITLE
[SecuritySolution] Add bulk API key grant for rule install

### DIFF
--- a/docs/reference/elasticsearch/elasticsearch-audit-events.md
+++ b/docs/reference/elasticsearch/elasticsearch-audit-events.md
@@ -261,6 +261,14 @@ $$$event-create-apikey$$$
     ::::
 
 
+$$$event-create-apikeys$$$
+
+`create_apikeys`
+:   Logged when the bulk grant API key API is invoked to create multiple API keys on behalf of another user.
+
+    You must include the `security_config_change` event type to audit the related event action.
+
+
 $$$event-change-apikey$$$
 
 `change_apikey`
@@ -628,7 +636,7 @@ The following list shows attributes that are common to all audit event types:
 `event.action`
 :   The type of event that occurred: `anonymous_access_denied`, `authentication_failed`, `authentication_success`, `realm_authentication_failed`, `access_denied`, `access_granted`, `connection_denied`, `connection_granted`, `tampered_request`, `run_as_denied`, or `run_as_granted`.
 
-    In addition, if `event.type` equals [`security_config_change`](#security-config-change), the `event.action` attribute takes one of the following values: `put_user`, `change_password`, `put_role`, `put_role_mapping`, `change_enable_user`, `change_disable_user`, `put_privileges`, `create_apikey`, `delete_user`, `delete_role`, `delete_role_mapping`, `invalidate_apikeys`, `delete_privileges`, `change_apikey`, or `change_apikeys`.
+    In addition, if `event.type` equals [`security_config_change`](#security-config-change), the `event.action` attribute takes one of the following values: `put_user`, `change_password`, `put_role`, `put_role_mapping`, `change_enable_user`, `change_disable_user`, `put_privileges`, `create_apikey`, `create_apikeys`, `delete_user`, `delete_role`, `delete_role_mapping`, `invalidate_apikeys`, `delete_privileges`, `change_apikey`, or `change_apikeys`.
 
 
 `request.id`
@@ -695,7 +703,7 @@ The events with `event.type` equal to `ip_filter` have one of the following `eve
 
 ### Audit event attributes of the `security_config_change` event type [security-config-change]
 
-The events with the `event.type` attribute equal to `security_config_change` have one of the following `event.action` attribute values: `put_user`, `change_password`, `put_role`, `put_role_mapping`, `change_enable_user`, `change_disable_user`, `put_privileges`, `create_apikey`, `delete_user`, `delete_role`, `delete_role_mapping`, `invalidate_apikeys`, `delete_privileges`, `change_apikey`, or `change_apikeys`.
+The events with the `event.type` attribute equal to `security_config_change` have one of the following `event.action` attribute values: `put_user`, `change_password`, `put_role`, `put_role_mapping`, `change_enable_user`, `change_disable_user`, `put_privileges`, `create_apikey`, `create_apikeys`, `delete_user`, `delete_role`, `delete_role_mapping`, `invalidate_apikeys`, `delete_privileges`, `change_apikey`, or `change_apikeys`.
 
 These events also have **one** of the following extra attributes (in addition to the common ones), which is specific to the `event.type` attribute. The attribute’s value is a nested JSON object:
 
@@ -709,7 +717,7 @@ These events also have **one** of the following extra attributes (in addition to
 :   The object representation of the security config that is being changed. It can be the `password`, `enable` or `disable`, config object for native or built-in users. If an API key is updated, the config object will be an `apikey`.
 
 `create`
-:   The object representation of the new security config that is being created. This is currently only used for API keys auditing. If the API key is created using the [create API key API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key) it only contains an `apikey` config object. If the API key is created using the [grant API key API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-grant-api-key) it also contains a `grant` config object.
+:   The object representation of the new security config that is being created. This is currently only used for API keys auditing. If the API key is created using the [create API key API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key) it only contains an `apikey` config object. If the API key is created using the [grant API key API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-grant-api-key) it also contains a `grant` config object. If multiple keys are created using the bulk grant API key API, it contains an `apikeys` array and a `grant` config object.
 
 `invalidate`
 :   The object representation of the security configuration that is being invalidated. The only config that currently supports invalidation is `apikeys`, through the [invalidate API key API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-invalidate-api-key).

--- a/docs/reference/elasticsearch/security-privileges.md
+++ b/docs/reference/elasticsearch/security-privileges.md
@@ -61,7 +61,7 @@ When creating roles, refer to this page for a complete list of available privile
 
 
 `grant_api_key` {applies_to}`serverless: unavailable`
-:   Privileges to create {{es}} API keys on behalf of other users.
+:   Privileges to create {{es}} API keys on behalf of other users, including bulk grant.
 
 
 `clone_api_key` {applies_to}`stack: ga 9.4+` {applies_to}`serverless: unavailable`

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.bulk_grant_api_key.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.bulk_grant_api_key.json
@@ -1,0 +1,44 @@
+{
+  "security.bulk_grant_api_key": {
+    "documentation": {
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-bulk-grant-api-key",
+      "description": "Bulk grant API keys"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_security/api_key/_bulk_grant",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    },
+    "params": {
+      "refresh": {
+        "type": "enum",
+        "options": [
+          "true",
+          "false",
+          "wait_for"
+        ],
+        "default": "false",
+        "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
+      }
+    },
+    "body": {
+      "description": "The grant credentials (shared) and the API keys to create",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyAction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.action.ActionType;
+
+/**
+ * ActionType for creating multiple API keys on behalf of another user in a single request.
+ * Nested under {@link GrantApiKeyAction#NAME} so the existing {@code grant_api_key} cluster privilege
+ * authorizes this action without a separate privilege.
+ */
+public final class BulkGrantApiKeyAction extends ActionType<BulkGrantApiKeyResponse> {
+
+    public static final String NAME = GrantApiKeyAction.NAME + "/bulk";
+    public static final BulkGrantApiKeyAction INSTANCE = new BulkGrantApiKeyAction();
+
+    private BulkGrantApiKeyAction() {
+        super(NAME);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.xpack.core.security.action.GrantRequest;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+/**
+ * Request class used to create multiple API keys on behalf of another user.
+ * Grant credentials apply to the whole request; each item in {@code api_keys} is a
+ * {@link CreateApiKeyRequest} (name, optional expiration, role descriptors, and metadata).
+ */
+public final class BulkGrantApiKeyRequest extends GrantRequest {
+
+    private List<CreateApiKeyRequest> apiKeyRequests = List.of();
+
+    public BulkGrantApiKeyRequest() {
+        super();
+    }
+
+    public List<CreateApiKeyRequest> getApiKeyRequests() {
+        return apiKeyRequests;
+    }
+
+    public void setApiKeyRequests(List<CreateApiKeyRequest> apiKeyRequests) {
+        this.apiKeyRequests = List.copyOf(Objects.requireNonNull(apiKeyRequests, "Cannot set a null api_keys"));
+    }
+
+    public WriteRequest.RefreshPolicy getRefreshPolicy() {
+        return apiKeyRequests.isEmpty() ? null : apiKeyRequests.get(0).getRefreshPolicy();
+    }
+
+    public void setRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {
+        for (CreateApiKeyRequest apiKeyRequest : apiKeyRequests) {
+            apiKeyRequest.setRefreshPolicy(refreshPolicy);
+        }
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (apiKeyRequests.isEmpty()) {
+            validationException = addValidationError("[api_keys] must not be empty", validationException);
+        } else {
+            for (CreateApiKeyRequest apiKeyRequest : apiKeyRequests) {
+                ActionRequestValidationException keyException = apiKeyRequest.validate();
+                if (keyException != null) {
+                    for (String error : keyException.validationErrors()) {
+                        validationException = addValidationError(error, validationException);
+                    }
+                }
+            }
+        }
+        return grant.validate(validationException);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyResponse.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.security.xcontent.XContentUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Response for bulk grant of API keys. Successfully created keys (including the secret, returned once)
+ * are listed under {@code created}. Per-key failures are listed under {@code errors}, keyed by the
+ * pre-generated API key id.
+ */
+public final class BulkGrantApiKeyResponse extends ActionResponse implements ToXContentObject, Writeable {
+
+    private final List<CreateApiKeyResponse> created;
+    private final Map<String, Exception> errorDetails;
+
+    public BulkGrantApiKeyResponse(final List<CreateApiKeyResponse> created, final Map<String, Exception> errorDetails) {
+        this.created = created;
+        this.errorDetails = errorDetails;
+    }
+
+    public BulkGrantApiKeyResponse(StreamInput in) throws IOException {
+        this.created = in.readCollectionAsList(CreateApiKeyResponse::new);
+        this.errorDetails = in.readMap(StreamInput::readException);
+    }
+
+    public List<CreateApiKeyResponse> getCreated() {
+        return created;
+    }
+
+    public Map<String, Exception> getErrorDetails() {
+        return errorDetails;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startArray("created");
+        for (CreateApiKeyResponse createdKey : created) {
+            createdKey.toXContent(builder, params);
+        }
+        builder.endArray();
+        XContentUtils.maybeAddErrorDetails(builder, errorDetails);
+        return builder.endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeCollection(created);
+        out.writeMap(errorDetails, StreamOutput::writeException);
+    }
+
+    @Override
+    public String toString() {
+        return "BulkGrantApiKeyResponse{created=" + created + ", errorDetails=" + errorDetails + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final List<CreateApiKeyResponse> created;
+        private final Map<String, Exception> errorDetails;
+
+        public Builder() {
+            created = new ArrayList<>();
+            errorDetails = new HashMap<>();
+        }
+
+        public Builder created(final CreateApiKeyResponse response) {
+            created.add(response);
+            return this;
+        }
+
+        public Builder error(final String id, final Exception ex) {
+            errorDetails.put(id, ex);
+            return this;
+        }
+
+        public Map<String, Exception> getErrorDetails() {
+            return errorDetails;
+        }
+
+        public BulkGrantApiKeyResponse build() {
+            return new BulkGrantApiKeyResponse(created, errorDetails);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
@@ -114,8 +114,8 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
             } else if (request instanceof GrantApiKeyRequest
                 || request instanceof BulkGrantApiKeyRequest
                 || request instanceof CloneApiKeyRequest) {
-                return false;
-            }
+                    return false;
+                }
             String message = "manage own api key privilege only supports API key requests (not " + request.getClass().getName() + ")";
             assert false : message;
             throw new IllegalArgumentException(message);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CloneApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
@@ -110,7 +111,9 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                     return false;
                 }
                 return queryApiKeyRequest.isFilterForCurrentUser();
-            } else if (request instanceof GrantApiKeyRequest || request instanceof CloneApiKeyRequest) {
+            } else if (request instanceof GrantApiKeyRequest
+                || request instanceof BulkGrantApiKeyRequest
+                || request instanceof CloneApiKeyRequest) {
                 return false;
             }
             String message = "manage own api key privilege only supports API key requests (not " + request.getClass().getName() + ")";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyRequestTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class BulkGrantApiKeyRequestTests extends ESTestCase {
+
+    public void testEmptyApiKeysNotValid() {
+        final var request = new BulkGrantApiKeyRequest();
+        request.getGrant().setType("password");
+        request.getGrant().setUsername("user");
+        request.getGrant().setPassword(new SecureString("password".toCharArray()));
+        final ActionRequestValidationException ve = request.validate();
+        assertNotNull(ve);
+        assertThat(ve.validationErrors().get(0), containsString("[api_keys] must not be empty"));
+    }
+
+    public void testValidRequest() {
+        final var request = new BulkGrantApiKeyRequest();
+        request.getGrant().setType("password");
+        request.getGrant().setUsername("user");
+        request.getGrant().setPassword(new SecureString("password".toCharArray()));
+        final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest("key-1", List.of(), null);
+        createApiKeyRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.NONE);
+        request.setApiKeyRequests(List.of(createApiKeyRequest));
+        assertThat(request.validate(), nullValue());
+        assertThat(request.getApiKeyRequests().size(), equalTo(1));
+        assertThat(request.getApiKeyRequests().get(0).getName(), equalTo("key-1"));
+    }
+
+    public void testSetRefreshPolicyAppliesToAllKeys() {
+        final var request = new BulkGrantApiKeyRequest();
+        final CreateApiKeyRequest first = new CreateApiKeyRequest("key-1", List.of(), null);
+        final CreateApiKeyRequest second = new CreateApiKeyRequest("key-2", List.of(), null);
+        request.setApiKeyRequests(List.of(first, second));
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        assertThat(first.getRefreshPolicy(), equalTo(WriteRequest.RefreshPolicy.IMMEDIATE));
+        assertThat(second.getRefreshPolicy(), equalTo(WriteRequest.RefreshPolicy.IMMEDIATE));
+        assertThat(request.getRefreshPolicy(), equalTo(WriteRequest.RefreshPolicy.IMMEDIATE));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkGrantApiKeyResponseTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BulkGrantApiKeyResponseTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        final CreateApiKeyResponse created = new CreateApiKeyResponse(
+            "key-1",
+            "id-1",
+            new SecureString("secret".toCharArray()),
+            Instant.ofEpochMilli(1_700_000_000_000L)
+        );
+        final var response = new BulkGrantApiKeyResponse(
+            List.of(created),
+            Map.of("id-2", new IllegalArgumentException("bad role descriptors"))
+        );
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            response.writeTo(output);
+            try (StreamInput input = output.bytes().streamInput()) {
+                final var serialized = new BulkGrantApiKeyResponse(input);
+                assertThat(serialized.getCreated().size(), equalTo(1));
+                assertThat(serialized.getCreated().get(0).getId(), equalTo("id-1"));
+                assertThat(serialized.getCreated().get(0).getName(), equalTo("key-1"));
+                assertThat(serialized.getCreated().get(0).getKey().toString(), equalTo("secret"));
+                assertThat(serialized.getErrorDetails().size(), equalTo(1));
+                assertThat(serialized.getErrorDetails().get("id-2").toString(), containsString("bad role descriptors"));
+            }
+        }
+    }
+
+    public void testToXContent() throws IOException {
+        final CreateApiKeyResponse created = new CreateApiKeyResponse(
+            "key-1",
+            "id-1",
+            new SecureString("secret".toCharArray()),
+            Instant.ofEpochMilli(1_700_000_000_000L)
+        );
+        final SortedMap<String, Exception> errorDetails = new TreeMap<>();
+        errorDetails.put("id-2", new ElasticsearchException("failed to create"));
+        final var response = new BulkGrantApiKeyResponse(List.of(created), errorDetails);
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final String json = Strings.toString(builder);
+        assertThat(json, containsString("\"created\""));
+        assertThat(json, containsString("\"id\":\"id-1\""));
+        assertThat(json, containsString("\"name\":\"key-1\""));
+        assertThat(json, containsString("\"api_key\":\"secret\""));
+        assertThat(json, containsString("\"errors\""));
+        assertThat(json, containsString("\"count\":1"));
+        assertThat(json, containsString("\"id-2\""));
+    }
+
+    public void testToXContentOmitsErrorsSectionIfNoErrors() throws IOException {
+        final CreateApiKeyResponse created = new CreateApiKeyResponse("key-1", "id-1", new SecureString("secret".toCharArray()), null);
+        final var response = new BulkGrantApiKeyResponse(List.of(created), Map.of());
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertThat(Strings.toString(builder), equalTo(XContentHelper.stripWhitespace("""
+            {
+              "created": [
+                {
+                  "id": "id-1",
+                  "name": "key-1",
+                  "api_key": "secret",
+                  "encoded": "aWQtMTpzZWNyZXQ="
+                }
+              ]
+            }""")));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -134,6 +134,7 @@ import org.elasticsearch.xpack.core.security.action.ActionTypes;
 import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyRequestTranslator;
 import org.elasticsearch.xpack.core.security.action.apikey.CloneApiKeyAction;
@@ -237,6 +238,7 @@ import org.elasticsearch.xpack.core.ssl.action.TransportGetCertificateInfoAction
 import org.elasticsearch.xpack.core.ssl.rest.RestGetCertificateInfoAction;
 import org.elasticsearch.xpack.security.action.TransportClearSecurityCacheAction;
 import org.elasticsearch.xpack.security.action.TransportDelegatePkiAuthenticationAction;
+import org.elasticsearch.xpack.security.action.apikey.TransportBulkGrantApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportBulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportCloneApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportCreateApiKeyAction;
@@ -362,6 +364,7 @@ import org.elasticsearch.xpack.security.rest.RemoteHostHeader;
 import org.elasticsearch.xpack.security.rest.SecurityRestFilter;
 import org.elasticsearch.xpack.security.rest.action.RestAuthenticateAction;
 import org.elasticsearch.xpack.security.rest.action.RestDelegatePkiAuthenticationAction;
+import org.elasticsearch.xpack.security.rest.action.apikey.RestBulkGrantApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestBulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestClearApiKeyCacheAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestCloneApiKeyAction;
@@ -633,6 +636,7 @@ public class Security extends Plugin
     private final SetOnce<UpdateApiKeyRequestTranslator> updateApiKeyRequestTranslator = new SetOnce<>();
     private final SetOnce<BulkUpdateApiKeyRequestTranslator> bulkUpdateApiKeyRequestTranslator = new SetOnce<>();
     private final SetOnce<RestGrantApiKeyAction.RequestTranslator> grantApiKeyRequestTranslator = new SetOnce<>();
+    private final SetOnce<RestBulkGrantApiKeyAction.RequestTranslator> bulkGrantApiKeyRequestTranslator = new SetOnce<>();
     private final SetOnce<GetBuiltinPrivilegesResponseTranslator> getBuiltinPrivilegesResponseTranslator = new SetOnce<>();
     private final SetOnce<HasPrivilegesRequestBuilderFactory> hasPrivilegesRequestBuilderFactory = new SetOnce<>();
 
@@ -976,6 +980,9 @@ public class Security extends Plugin
         }
         if (grantApiKeyRequestTranslator.get() == null) {
             grantApiKeyRequestTranslator.set(new RestGrantApiKeyAction.RequestTranslator.Default());
+        }
+        if (bulkGrantApiKeyRequestTranslator.get() == null) {
+            bulkGrantApiKeyRequestTranslator.set(new RestBulkGrantApiKeyAction.RequestTranslator.Default());
         }
         if (hasPrivilegesRequestBuilderFactory.get() == null) {
             hasPrivilegesRequestBuilderFactory.trySet(new HasPrivilegesRequestBuilderFactory.Default());
@@ -1821,6 +1828,7 @@ public class Security extends Plugin
             new ActionHandler(CreateApiKeyAction.INSTANCE, TransportCreateApiKeyAction.class),
             new ActionHandler(CreateCrossClusterApiKeyAction.INSTANCE, TransportCreateCrossClusterApiKeyAction.class),
             new ActionHandler(GrantApiKeyAction.INSTANCE, TransportGrantApiKeyAction.class),
+            new ActionHandler(BulkGrantApiKeyAction.INSTANCE, TransportBulkGrantApiKeyAction.class),
             new ActionHandler(CloneApiKeyAction.INSTANCE, TransportCloneApiKeyAction.class),
             new ActionHandler(InvalidateApiKeyAction.INSTANCE, TransportInvalidateApiKeyAction.class),
             new ActionHandler(GetApiKeyAction.INSTANCE, TransportGetApiKeyAction.class),
@@ -1921,6 +1929,7 @@ public class Security extends Plugin
             new RestBulkUpdateApiKeyAction(settings, getLicenseState(), bulkUpdateApiKeyRequestTranslator.get()),
             new RestUpdateCrossClusterApiKeyAction(settings, getLicenseState()),
             new RestGrantApiKeyAction(settings, getLicenseState(), grantApiKeyRequestTranslator.get()),
+            new RestBulkGrantApiKeyAction(settings, getLicenseState(), bulkGrantApiKeyRequestTranslator.get()),
             new RestCloneApiKeyAction(settings, getLicenseState()),
             new RestInvalidateApiKeyAction(settings, getLicenseState()),
             new RestGetApiKeyAction(settings, getLicenseState()),
@@ -2596,6 +2605,7 @@ public class Security extends Plugin
         loadSingletonExtensionAndSetOnce(loader, authorizationDenialMessages, AuthorizationDenialMessages.class);
         loadSingletonExtensionAndSetOnce(loader, reservedRoleNameCheckerFactory, ReservedRoleNameChecker.Factory.class);
         loadSingletonExtensionAndSetOnce(loader, grantApiKeyRequestTranslator, RestGrantApiKeyAction.RequestTranslator.class);
+        loadSingletonExtensionAndSetOnce(loader, bulkGrantApiKeyRequestTranslator, RestBulkGrantApiKeyAction.RequestTranslator.class);
         loadSingletonExtensionAndSetOnce(loader, fileRoleValidator, FileRoleValidator.class);
         loadSingletonExtensionAndSetOnce(loader, secondaryAuthActions, SecondaryAuthActions.class);
         loadSingletonExtensionAndSetOnce(loader, queryableRolesProviderFactory, QueryableBuiltInRolesProviderFactory.class);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkGrantApiKeyAction.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.apikey;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.security.action.Grant;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyResponse;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.CustomTokenAuthenticator;
+import org.elasticsearch.xpack.security.action.TransportGrantAction;
+import org.elasticsearch.xpack.security.authc.ApiKeyService;
+import org.elasticsearch.xpack.security.authc.AuthenticationService;
+import org.elasticsearch.xpack.security.authc.PluggableAuthenticatorChain;
+import org.elasticsearch.xpack.security.authc.support.ApiKeyUserRoleDescriptorResolver;
+import org.elasticsearch.xpack.security.authz.AuthorizationService;
+import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
+
+import java.util.List;
+
+/**
+ * Implementation of the action needed to create multiple API keys on behalf of another user (using an OAuth style "grant").
+ * Grant credentials are authenticated once; all keys are created under that authentication.
+ */
+public final class TransportBulkGrantApiKeyAction extends TransportGrantAction<BulkGrantApiKeyRequest, BulkGrantApiKeyResponse> {
+
+    private final ApiKeyService apiKeyService;
+    private final ApiKeyUserRoleDescriptorResolver resolver;
+    private final List<CustomTokenAuthenticator> customTokenAuthenticators;
+
+    @Inject
+    public TransportBulkGrantApiKeyAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        AuthenticationService authenticationService,
+        AuthorizationService authorizationService,
+        ApiKeyService apiKeyService,
+        CompositeRolesStore rolesStore,
+        NamedXContentRegistry xContentRegistry,
+        PluggableAuthenticatorChain pluggableAuthenticatorChain
+    ) {
+        this(
+            transportService,
+            actionFilters,
+            threadPool.getThreadContext(),
+            authenticationService,
+            authorizationService,
+            apiKeyService,
+            new ApiKeyUserRoleDescriptorResolver(rolesStore, xContentRegistry),
+            pluggableAuthenticatorChain
+        );
+
+    }
+
+    TransportBulkGrantApiKeyAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadContext threadContext,
+        AuthenticationService authenticationService,
+        AuthorizationService authorizationService,
+        ApiKeyService apiKeyService,
+        ApiKeyUserRoleDescriptorResolver resolver,
+        PluggableAuthenticatorChain pluggableAuthenticatorChain
+    ) {
+        super(BulkGrantApiKeyAction.NAME, transportService, actionFilters, authenticationService, authorizationService, threadContext);
+        this.apiKeyService = apiKeyService;
+        this.resolver = resolver;
+        this.customTokenAuthenticators = pluggableAuthenticatorChain.getCustomAuthenticators()
+            .stream()
+            .filter(CustomTokenAuthenticator.class::isInstance)
+            .map(CustomTokenAuthenticator.class::cast)
+            .toList();
+    }
+
+    @Override
+    protected void doExecuteWithGrantAuthentication(
+        Task task,
+        BulkGrantApiKeyRequest request,
+        Authentication authentication,
+        ActionListener<BulkGrantApiKeyResponse> listener
+    ) {
+        resolver.resolveUserRoleDescriptors(
+            authentication,
+            ActionListener.wrap(
+                roleDescriptors -> apiKeyService.bulkCreateApiKeys(authentication, request.getApiKeyRequests(), roleDescriptors, listener),
+                listener::onFailure
+            )
+        );
+    }
+
+    @Override
+    protected AuthenticationToken extractAccessToken(Grant grant) {
+        for (CustomTokenAuthenticator customTokenAuthenticator : customTokenAuthenticators) {
+            AuthenticationToken token = customTokenAuthenticator.extractGrantAccessToken(grant);
+            if (token != null) {
+                return token;
+            }
+        }
+        return super.extractAccessToken(grant);
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -50,6 +50,8 @@ import org.elasticsearch.xpack.core.security.action.apikey.AbstractCreateApiKeyR
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKeyCredentials;
 import org.elasticsearch.xpack.core.security.action.apikey.BaseSingleUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.BaseUpdateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CloneApiKeyAction;
@@ -754,6 +756,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 } else if (msg instanceof GrantApiKeyRequest) {
                     assert GrantApiKeyAction.NAME.equals(action);
                     securityChangeLogEntryBuilder(requestId).withRequestBody((GrantApiKeyRequest) msg).build();
+                } else if (msg instanceof BulkGrantApiKeyRequest bulkGrantApiKeyRequest) {
+                    assert BulkGrantApiKeyAction.NAME.equals(action);
+                    securityChangeLogEntryBuilder(requestId).withRequestBody(bulkGrantApiKeyRequest).build();
                 } else if (msg instanceof CloneApiKeyRequest cloneApiKeyRequest) {
                     assert CloneApiKeyAction.NAME.equals(action);
                     securityChangeLogEntryBuilder(requestId).withRequestBody(cloneApiKeyRequest).build();
@@ -1296,6 +1301,35 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             withRequestBody(builder, grantApiKeyRequest.getApiKeyRequest());
             Grant grant = grantApiKeyRequest.getGrant();
             withGrant(builder, grant);
+            builder.endObject();
+            logEntry.with(CREATE_CONFIG_FIELD_NAME, Strings.toString(builder));
+            return this;
+        }
+
+        LogEntryBuilder withRequestBody(BulkGrantApiKeyRequest bulkGrantApiKeyRequest) throws IOException {
+            logEntry.with(EVENT_ACTION_FIELD_NAME, "create_apikeys");
+            XContentBuilder builder = JsonXContent.contentBuilder().humanReadable(true);
+            builder.startObject();
+            builder.startArray("apikeys");
+            for (CreateApiKeyRequest apiKeyRequest : bulkGrantApiKeyRequest.getApiKeyRequests()) {
+                builder.startObject();
+                TimeValue expiration = apiKeyRequest.getExpiration();
+                builder.field("id", apiKeyRequest.getId())
+                    .field("name", apiKeyRequest.getName())
+                    .field("type", apiKeyRequest.getType().value())
+                    .field("expiration", expiration != null ? expiration.toString() : null)
+                    .startArray("role_descriptors");
+                for (RoleDescriptor roleDescriptor : apiKeyRequest.getRoleDescriptors()) {
+                    withRoleDescriptor(builder, roleDescriptor);
+                }
+                builder.endArray();
+                if (apiKeyRequest.getMetadata() != null && apiKeyRequest.getMetadata().isEmpty() == false) {
+                    builder.field("metadata", apiKeyRequest.getMetadata());
+                }
+                builder.endObject();
+            }
+            builder.endArray();
+            withGrant(builder, bulkGrantApiKeyRequest.getGrant());
             builder.endObject();
             logEntry.with(CREATE_CONFIG_FIELD_NAME, Strings.toString(builder));
             return this;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -90,9 +90,11 @@ import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKeyCredentials;
 import org.elasticsearch.xpack.core.security.action.apikey.BaseBulkUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.BaseUpdateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.apikey.CertificateIdentity;
 import org.elasticsearch.xpack.core.security.action.apikey.CloneApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.InvalidateApiKeyResponse;
@@ -133,8 +135,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
@@ -439,49 +444,50 @@ public class ApiKeyService implements Closeable {
         final List<RoleDescriptor> roleDescriptors,
         final TransportVersion transportVersion
     ) {
-        if (transportVersion.supports(Authentication.VERSION_CROSS_CLUSTER_ACCESS) == false && hasRemoteIndices(roleDescriptors)) {
-            // API keys with roles which define remote indices privileges is not allowed in a mixed cluster.
-            listener.onFailure(
-                new IllegalArgumentException(
-                    "all nodes must have version ["
-                        + Authentication.VERSION_CROSS_CLUSTER_ACCESS.toReleaseVersion()
-                        + "] or higher to support remote indices privileges for API keys"
-                )
-            );
-            return false;
-        }
-        if (transportVersion.supports(ROLE_REMOTE_CLUSTER_PRIVS) == false && hasRemoteCluster(roleDescriptors)) {
-            // API keys with roles which define remote cluster privileges is not allowed in a mixed cluster.
-            listener.onFailure(
-                new IllegalArgumentException(
-                    "all nodes must have version ["
-                        + ROLE_REMOTE_CLUSTER_PRIVS.toReleaseVersion()
-                        + "] or higher to support remote cluster privileges for API keys"
-                )
-            );
-            return false;
-        }
-        if (transportVersion.supports(MANAGE_ROLES_PRIVILEGE) == false && hasGlobalManageRolesPrivilege(roleDescriptors)) {
-            listener.onFailure(
-                new IllegalArgumentException(
-                    "all nodes must have version ["
-                        + MANAGE_ROLES_PRIVILEGE.toReleaseVersion()
-                        + "] or higher to support the manage roles privilege for API keys"
-                )
-            );
-            return false;
-        }
-        if (transportVersion.supports(ESQL_DATASOURCE_PRIVILEGE) == false && hasGlobalDatasourcePrivilege(roleDescriptors)) {
-            listener.onFailure(
-                new IllegalArgumentException(
-                    "all nodes must have version ["
-                        + ESQL_DATASOURCE_PRIVILEGE.toReleaseVersion()
-                        + "] or higher to support the datasource privilege for API keys"
-                )
-            );
+        Exception exception = checkRoleDescriptorsForMixedCluster(roleDescriptors, transportVersion);
+        if (exception != null) {
+            listener.onFailure(exception);
             return false;
         }
         return true;
+    }
+
+    @Nullable
+    private Exception checkRoleDescriptorsForMixedCluster(
+        final List<RoleDescriptor> roleDescriptors,
+        final TransportVersion transportVersion
+    ) {
+        if (transportVersion.supports(Authentication.VERSION_CROSS_CLUSTER_ACCESS) == false && hasRemoteIndices(roleDescriptors)) {
+            // API keys with roles which define remote indices privileges is not allowed in a mixed cluster.
+            return new IllegalArgumentException(
+                "all nodes must have version ["
+                    + Authentication.VERSION_CROSS_CLUSTER_ACCESS.toReleaseVersion()
+                    + "] or higher to support remote indices privileges for API keys"
+            );
+        }
+        if (transportVersion.supports(ROLE_REMOTE_CLUSTER_PRIVS) == false && hasRemoteCluster(roleDescriptors)) {
+            // API keys with roles which define remote cluster privileges is not allowed in a mixed cluster.
+            return new IllegalArgumentException(
+                "all nodes must have version ["
+                    + ROLE_REMOTE_CLUSTER_PRIVS.toReleaseVersion()
+                    + "] or higher to support remote cluster privileges for API keys"
+            );
+        }
+        if (transportVersion.supports(MANAGE_ROLES_PRIVILEGE) == false && hasGlobalManageRolesPrivilege(roleDescriptors)) {
+            return new IllegalArgumentException(
+                "all nodes must have version ["
+                    + MANAGE_ROLES_PRIVILEGE.toReleaseVersion()
+                    + "] or higher to support the manage roles privilege for API keys"
+            );
+        }
+        if (transportVersion.supports(ESQL_DATASOURCE_PRIVILEGE) == false && hasGlobalDatasourcePrivilege(roleDescriptors)) {
+            return new IllegalArgumentException(
+                "all nodes must have version ["
+                    + ESQL_DATASOURCE_PRIVILEGE.toReleaseVersion()
+                    + "] or higher to support the datasource privilege for API keys"
+            );
+        }
+        return null;
     }
 
     /**
@@ -650,6 +656,196 @@ public class ApiKeyService implements Closeable {
             }
         }));
     }
+
+    /**
+     * Creates multiple REST API keys for the same owning authentication in a single bulk index request.
+     * Per-key failures (validation or indexing) are returned in {@link BulkGrantApiKeyResponse} rather
+     * than failing the whole request. Grant credentials and limited-by roles are resolved by the caller.
+     */
+    public void bulkCreateApiKeys(
+        Authentication authentication,
+        List<CreateApiKeyRequest> requests,
+        Set<RoleDescriptor> userRoleDescriptors,
+        ActionListener<BulkGrantApiKeyResponse> listener
+    ) {
+        ensureEnabled();
+        if (authentication == null) {
+            listener.onFailure(new IllegalArgumentException("authentication must be provided"));
+            return;
+        }
+        if (requests == null || requests.isEmpty()) {
+            listener.onFailure(new IllegalArgumentException("[api_keys] must not be empty"));
+            return;
+        }
+
+        final TransportVersion transportVersion = getMinTransportVersion();
+        final Set<RoleDescriptor> filteredRoleDescriptors = removeUserRoleDescriptorDescriptions(userRoleDescriptors);
+        final Map<String, Exception> errorDetails = new ConcurrentHashMap<>();
+        final List<CreateApiKeyRequest> toCreate = new ArrayList<>(requests.size());
+        for (CreateApiKeyRequest request : requests) {
+            assert request.getType() == ApiKey.Type.REST : "bulk grant only supports REST API keys";
+            Exception mixedClusterException = checkRoleDescriptorsForMixedCluster(request.getRoleDescriptors(), transportVersion);
+            if (mixedClusterException != null) {
+                errorDetails.put(request.getId(), mixedClusterException);
+                continue;
+            }
+            final IllegalArgumentException workflowsValidationException = validateWorkflowsRestrictionConstraints(
+                transportVersion,
+                request.getRoleDescriptors(),
+                userRoleDescriptors
+            );
+            if (workflowsValidationException != null) {
+                errorDetails.put(request.getId(), workflowsValidationException);
+                continue;
+            }
+            toCreate.add(request);
+        }
+        hashAndIndexApiKeys(authentication, requests, toCreate, filteredRoleDescriptors, errorDetails, listener);
+    }
+
+    private void hashAndIndexApiKeys(
+        Authentication authentication,
+        List<CreateApiKeyRequest> originalOrder,
+        List<CreateApiKeyRequest> toCreate,
+        Set<RoleDescriptor> userRoleDescriptors,
+        Map<String, Exception> errorDetails,
+        ActionListener<BulkGrantApiKeyResponse> listener
+    ) {
+        if (toCreate.isEmpty()) {
+            listener.onResponse(new BulkGrantApiKeyResponse(List.of(), Map.copyOf(errorDetails)));
+            return;
+        }
+        final List<PendingApiKey> pending = new CopyOnWriteArrayList<>();
+        final AtomicInteger remaining = new AtomicInteger(toCreate.size());
+        for (CreateApiKeyRequest request : toCreate) {
+            final Instant created = clock.instant();
+            final Instant expiration = getApiKeyExpiration(created, request.getExpiration());
+            final SecureString apiKey = getBase64SecureRandomString(API_KEY_SECRET_NUM_BYTES);
+            computeHashForApiKey(apiKey, ActionListener.wrap(apiKeyHashChars -> {
+                pending.add(new PendingApiKey(request, apiKey, apiKeyHashChars, created, expiration));
+                if (remaining.decrementAndGet() == 0) {
+                    indexPendingApiKeys(authentication, originalOrder, userRoleDescriptors, pending, errorDetails, listener);
+                }
+            }, ex -> {
+                errorDetails.put(request.getId(), ex);
+                if (remaining.decrementAndGet() == 0) {
+                    indexPendingApiKeys(authentication, originalOrder, userRoleDescriptors, pending, errorDetails, listener);
+                }
+            }));
+        }
+    }
+
+    private void indexPendingApiKeys(
+        Authentication authentication,
+        List<CreateApiKeyRequest> originalOrder,
+        Set<RoleDescriptor> userRoleDescriptors,
+        List<PendingApiKey> pending,
+        Map<String, Exception> errorDetails,
+        ActionListener<BulkGrantApiKeyResponse> listener
+    ) {
+        if (pending.isEmpty()) {
+            listener.onResponse(new BulkGrantApiKeyResponse(List.of(), Map.copyOf(errorDetails)));
+            return;
+        }
+        final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+        final Map<String, PendingApiKey> pendingById = new HashMap<>(pending.size());
+        for (PendingApiKey pendingApiKey : pending) {
+            pendingById.put(pendingApiKey.request().getId(), pendingApiKey);
+            try (
+                XContentBuilder builder = newDocument(
+                    pendingApiKey.apiKeyHashChars(),
+                    pendingApiKey.request().getName(),
+                    authentication,
+                    userRoleDescriptors,
+                    pendingApiKey.created(),
+                    pendingApiKey.expiration(),
+                    pendingApiKey.request().getRoleDescriptors(),
+                    pendingApiKey.request().getType(),
+                    ApiKey.CURRENT_API_KEY_VERSION,
+                    pendingApiKey.request().getMetadata(),
+                    getCertificateIdentityFromCreateRequest(pendingApiKey.request())
+                )
+            ) {
+                bulkRequestBuilder.add(
+                    client.prepareIndex(SECURITY_MAIN_ALIAS)
+                        .setSource(builder)
+                        .setId(pendingApiKey.request().getId())
+                        .setOpType(DocWriteRequest.OpType.CREATE)
+                        .request()
+                );
+            } catch (Exception e) {
+                errorDetails.put(pendingApiKey.request().getId(), e);
+            } finally {
+                Arrays.fill(pendingApiKey.apiKeyHashChars(), (char) 0);
+            }
+        }
+        if (bulkRequestBuilder.numberOfActions() == 0) {
+            listener.onResponse(new BulkGrantApiKeyResponse(List.of(), Map.copyOf(errorDetails)));
+            return;
+        }
+        bulkRequestBuilder.setRefreshPolicy(pending.get(0).request().getRefreshPolicy());
+        final BulkRequest bulkRequest = bulkRequestBuilder.request();
+        securityIndex.forCurrentProject()
+            .prepareIndexIfNeededThenExecute(
+                listener::onFailure,
+                () -> executeAsyncWithOrigin(
+                    client,
+                    SECURITY_ORIGIN,
+                    TransportBulkAction.TYPE,
+                    bulkRequest,
+                    ActionListener.<BulkResponse>wrap(bulkResponse -> {
+                        final Map<String, CreateApiKeyResponse> createdById = new HashMap<>();
+                        for (BulkItemResponse bulkItemResponse : bulkResponse.getItems()) {
+                            final String apiKeyId = bulkItemResponse.getId();
+                            if (bulkItemResponse.isFailed()) {
+                                errorDetails.put(
+                                    apiKeyId,
+                                    new ElasticsearchException(
+                                        "bulk request execution failure",
+                                        bulkItemResponse.getFailure().getCause()
+                                    )
+                                );
+                            } else {
+                                assert bulkItemResponse.getResponse().getResult() == DocWriteResponse.Result.CREATED
+                                    : "Index response was [" + bulkItemResponse.getResponse().getResult() + "]";
+                                final PendingApiKey pendingApiKey = pendingById.get(apiKeyId);
+                                assert pendingApiKey != null : "missing pending API key for id [" + apiKeyId + "]";
+                                if (apiKeyAuthCache != null) {
+                                    final ListenableFuture<CachedApiKeyHashResult> listenableFuture = new ListenableFuture<>();
+                                    listenableFuture.onResponse(new CachedApiKeyHashResult(true, pendingApiKey.apiKey()));
+                                    apiKeyAuthCache.put(apiKeyId, listenableFuture);
+                                }
+                                createdById.put(
+                                    apiKeyId,
+                                    new CreateApiKeyResponse(
+                                        pendingApiKey.request().getName(),
+                                        apiKeyId,
+                                        pendingApiKey.apiKey(),
+                                        pendingApiKey.expiration()
+                                    )
+                                );
+                            }
+                        }
+                        final List<CreateApiKeyResponse> created = new ArrayList<>(createdById.size());
+                        for (CreateApiKeyRequest request : originalOrder) {
+                            final CreateApiKeyResponse createdKey = createdById.get(request.getId());
+                            if (createdKey != null) {
+                                created.add(createdKey);
+                            }
+                        }
+                        listener.onResponse(new BulkGrantApiKeyResponse(created, Map.copyOf(errorDetails)));
+                    }, listener::onFailure)
+                )
+            );
+    }
+
+    private record PendingApiKey(
+        CreateApiKeyRequest request,
+        SecureString apiKey,
+        char[] apiKeyHashChars,
+        Instant created,
+        Instant expiration
+    ) {}
 
     /**
      * Clones an API key: validates the source credential, then creates a new key with the source's role descriptors

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -800,10 +800,7 @@ public class ApiKeyService implements Closeable {
                             if (bulkItemResponse.isFailed()) {
                                 errorDetails.put(
                                     apiKeyId,
-                                    new ElasticsearchException(
-                                        "bulk request execution failure",
-                                        bulkItemResponse.getFailure().getCause()
-                                    )
+                                    new ElasticsearchException("bulk request execution failure", bulkItemResponse.getFailure().getCause())
                                 );
                             } else {
                                 assert bulkItemResponse.getResponse().getResult() == DocWriteResponse.Result.CREATED

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestBulkGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestBulkGrantApiKeyAction.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.apikey;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestRequestFilter;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyResponse;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequestBuilder;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.security.authc.ApiKeyService;
+import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+/**
+ * Rest action to create multiple API keys on behalf of another user in a single request.
+ * Grant credentials are shared across all keys; each element of {@code api_keys} matches
+ * the {@code api_key} object of {@link RestGrantApiKeyAction}.
+ */
+@ServerlessScope(Scope.INTERNAL)
+public final class RestBulkGrantApiKeyAction extends ApiKeyBaseRestHandler implements RestRequestFilter {
+    public interface RequestTranslator {
+        BulkGrantApiKeyRequest translate(RestRequest request) throws IOException;
+
+        class Default implements RequestTranslator {
+            private static final RoleDescriptor.Parser ROLE_DESCRIPTOR_PARSER = RoleDescriptor.parserBuilder()
+                .allowRestriction(true)
+                .build();
+            private static final ObjectParser<BulkGrantApiKeyRequest, Void> PARSER = createParser(ROLE_DESCRIPTOR_PARSER::parse);
+
+            protected static ObjectParser<BulkGrantApiKeyRequest, Void> createParser(
+                CheckedBiFunction<String, XContentParser, RoleDescriptor, IOException> roleDescriptorParser
+            ) {
+                final ConstructingObjectParser<CreateApiKeyRequest, Void> apiKeyParser = CreateApiKeyRequestBuilder.createParser(
+                    roleDescriptorParser
+                );
+                final ObjectParser<BulkGrantApiKeyRequest, Void> parser = new ObjectParser<>(
+                    "bulk_grant_api_key_request",
+                    BulkGrantApiKeyRequest::new
+                );
+                parser.declareString((req, str) -> req.getGrant().setType(str), new ParseField("grant_type"));
+                parser.declareString((req, str) -> req.getGrant().setUsername(str), new ParseField("username"));
+                parser.declareField(
+                    (req, secStr) -> req.getGrant().setPassword(secStr),
+                    SecurityBaseRestHandler::getSecureString,
+                    new ParseField("password"),
+                    ObjectParser.ValueType.STRING
+                );
+                parser.declareField(
+                    (req, secStr) -> req.getGrant().setAccessToken(secStr),
+                    SecurityBaseRestHandler::getSecureString,
+                    new ParseField("access_token"),
+                    ObjectParser.ValueType.STRING
+                );
+                parser.declareString((req, str) -> req.getGrant().setRunAsUsername(str), new ParseField("run_as"));
+                parser.declareObject(
+                    (req, clientAuthentication) -> req.getGrant().setClientAuthentication(clientAuthentication),
+                    CLIENT_AUTHENTICATION_PARSER,
+                    new ParseField("client_authentication")
+                );
+                parser.declareObjectArray(
+                    BulkGrantApiKeyRequest::setApiKeyRequests,
+                    (p, ignore) -> apiKeyParser.parse(p, null),
+                    new ParseField("api_keys")
+                );
+                return parser;
+            }
+
+            @Override
+            public BulkGrantApiKeyRequest translate(RestRequest request) throws IOException {
+                try (XContentParser parser = request.contentParser()) {
+                    return fromXContent(parser);
+                }
+            }
+
+            public static BulkGrantApiKeyRequest fromXContent(XContentParser parser) throws IOException {
+                return PARSER.parse(parser, null);
+            }
+        }
+    }
+
+    private final RequestTranslator requestTranslator;
+
+    public RestBulkGrantApiKeyAction(Settings settings, XPackLicenseState licenseState, RequestTranslator requestTranslator) {
+        super(settings, licenseState);
+        this.requestTranslator = requestTranslator;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_security/api_key/_bulk_grant"));
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_security_bulk_grant_api_key";
+    }
+
+    @Override
+    protected RestChannelConsumer innerPrepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final BulkGrantApiKeyRequest grantRequest = requestTranslator.translate(request);
+        final String refresh = request.param("refresh");
+        if (refresh != null) {
+            grantRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.parse(refresh));
+        } else {
+            grantRequest.setRefreshPolicy(ApiKeyService.defaultCreateDocRefreshPolicy(settings));
+        }
+        return channel -> client.execute(
+            BulkGrantApiKeyAction.INSTANCE,
+            grantRequest,
+            new RestToXContentListener<BulkGrantApiKeyResponse>(channel).delegateResponse((listener, ex) -> {
+                RestStatus status = ExceptionsHelper.status(ex);
+                if (status == RestStatus.UNAUTHORIZED) {
+                    listener.onFailure(
+                        new ElasticsearchSecurityException("Failed to authenticate api key grant", RestStatus.FORBIDDEN, ex)
+                    );
+                } else {
+                    listener.onFailure(ex);
+                }
+            })
+        );
+    }
+
+    @Override
+    public Set<String> getFilteredFields() {
+        return Set.of("password", "access_token", "client_authentication.value");
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkGrantApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkGrantApiKeyActionTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.apikey;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyResponse;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyResponse;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.ApiKeyService;
+import org.elasticsearch.xpack.security.authc.AuthenticationService;
+import org.elasticsearch.xpack.security.authc.PluggableAuthenticatorChain;
+import org.elasticsearch.xpack.security.authc.support.ApiKeyUserRoleDescriptorResolver;
+import org.elasticsearch.xpack.security.authz.AuthorizationService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportBulkGrantApiKeyActionTests extends ESTestCase {
+
+    private TransportBulkGrantApiKeyAction action;
+    private ApiKeyService apiKeyService;
+    private ApiKeyUserRoleDescriptorResolver resolver;
+    private AuthenticationService authenticationService;
+    private ThreadPool threadPool;
+    private AuthorizationService authorizationService;
+
+    @Before
+    public void setupMocks() {
+        apiKeyService = mock(ApiKeyService.class);
+        resolver = mock(ApiKeyUserRoleDescriptorResolver.class);
+        authenticationService = mock(AuthenticationService.class);
+        authorizationService = mock(AuthorizationService.class);
+
+        threadPool = new TestThreadPool("TP-" + getTestName());
+        final ThreadContext threadContext = threadPool.getThreadContext();
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+
+        PluggableAuthenticatorChain pluggableAuthenticatorChain = mock(PluggableAuthenticatorChain.class);
+        when(pluggableAuthenticatorChain.getCustomAuthenticators()).thenReturn(List.of());
+
+        action = new TransportBulkGrantApiKeyAction(
+            transportService,
+            ActionFilters.EMPTY,
+            threadContext,
+            authenticationService,
+            authorizationService,
+            apiKeyService,
+            resolver,
+            pluggableAuthenticatorChain
+        );
+    }
+
+    @After
+    public void cleanup() {
+        threadPool.shutdown();
+    }
+
+    public void testBulkGrantApiKeyWithUsernamePassword() {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        final SecureString password = new SecureString(randomAlphaOfLengthBetween(8, 24).toCharArray());
+        final Authentication authentication = AuthenticationTestHelper.builder()
+            .user(new User(username))
+            .realmRef(new Authentication.RealmRef("realm_name", "realm_type", "node_name"))
+            .build(false);
+
+        final BulkGrantApiKeyRequest request = mockRequest();
+        request.getGrant().setType("password");
+        request.getGrant().setUsername(username);
+        request.getGrant().setPassword(password);
+
+        final BulkGrantApiKeyResponse response = new BulkGrantApiKeyResponse(
+            List.of(
+                new CreateApiKeyResponse(
+                    request.getApiKeyRequests().get(0).getName(),
+                    randomAlphaOfLength(12),
+                    new SecureString(randomAlphaOfLength(18).toCharArray()),
+                    null
+                )
+            ),
+            Map.of()
+        );
+
+        doAnswer(inv -> {
+            final Object[] args = inv.getArguments();
+            assertThat(args, arrayWithSize(4));
+            assertThat(args[0], equalTo(BulkGrantApiKeyAction.NAME));
+            assertThat(args[1], sameInstance(request));
+            assertThat(args[2], instanceOf(UsernamePasswordToken.class));
+            UsernamePasswordToken token = (UsernamePasswordToken) args[2];
+            assertThat(token.principal(), equalTo(username));
+            assertThat(token.credentials(), equalTo(password));
+
+            @SuppressWarnings("unchecked")
+            ActionListener<Authentication> listener = (ActionListener<Authentication>) args[args.length - 1];
+            listener.onResponse(authentication);
+            return null;
+        }).when(authenticationService)
+            .authenticate(eq(BulkGrantApiKeyAction.NAME), same(request), any(UsernamePasswordToken.class), anyActionListener());
+
+        final Set<RoleDescriptor> roleDescriptors = Set.of();
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<Set<RoleDescriptor>> listener = (ActionListener<Set<RoleDescriptor>>) inv.getArguments()[1];
+            listener.onResponse(roleDescriptors);
+            return null;
+        }).when(resolver).resolveUserRoleDescriptors(any(Authentication.class), anyActionListener());
+
+        doAnswer(inv -> {
+            assertThat(inv.getArguments()[0], equalTo(authentication));
+            assertThat(inv.getArguments()[1], sameInstance(request.getApiKeyRequests()));
+            assertThat(inv.getArguments()[2], sameInstance(roleDescriptors));
+            @SuppressWarnings("unchecked")
+            ActionListener<BulkGrantApiKeyResponse> listener = (ActionListener<BulkGrantApiKeyResponse>) inv.getArguments()[3];
+            listener.onResponse(response);
+            return null;
+        }).when(apiKeyService).bulkCreateApiKeys(any(Authentication.class), any(), any(), anyActionListener());
+
+        final PlainActionFuture<BulkGrantApiKeyResponse> future = new PlainActionFuture<>();
+        action.execute(null, request, future);
+
+        assertThat(future.actionGet(), sameInstance(response));
+        verify(authorizationService, never()).authorize(any(), any(), any(), anyActionListener());
+    }
+
+    private BulkGrantApiKeyRequest mockRequest() {
+        final BulkGrantApiKeyRequest request = new BulkGrantApiKeyRequest();
+        CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(randomAlphaOfLengthBetween(6, 32), List.of(), null);
+        createApiKeyRequest.setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values()));
+        request.setApiKeyRequests(List.of(createApiKeyRequest));
+        return request;
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -53,6 +53,8 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.action.ActionTypes;
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKeyTests;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CloneApiKeyAction;
@@ -2237,6 +2239,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
             new Tuple<>(TransportChangePasswordAction.TYPE.name(), new ChangePasswordRequest()),
             new Tuple<>(CreateApiKeyAction.NAME, new CreateApiKeyRequest()),
             new Tuple<>(GrantApiKeyAction.NAME, new GrantApiKeyRequest()),
+            new Tuple<>(BulkGrantApiKeyAction.NAME, new BulkGrantApiKeyRequest()),
             new Tuple<>(PutPrivilegesAction.NAME, new PutPrivilegesRequest()),
             new Tuple<>(DeleteUserAction.NAME, new DeleteUserRequest()),
             new Tuple<>(DeleteRoleAction.NAME, new DeleteRoleRequest()),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestBulkGrantApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestBulkGrantApiKeyActionTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.apikey;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.security.action.apikey.BulkGrantApiKeyRequest;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class RestBulkGrantApiKeyActionTests extends ESTestCase {
+
+    public void testParseXContentForBulkGrantApiKeyRequest() throws Exception {
+        final String grantType = randomAlphaOfLength(8);
+        final String username = randomAlphaOfLength(8);
+        final String password = randomAlphaOfLength(8);
+        final String apiKeyName1 = randomAlphaOfLength(8);
+        final String apiKeyName2 = randomAlphaOfLength(8);
+        final var apiKeyExpiration = randomTimeValue();
+        try (
+            XContentParser content = createParser(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("grant_type", grantType)
+                    .field("username", username)
+                    .field("password", password)
+                    .startArray("api_keys")
+                    .startObject()
+                    .field("name", apiKeyName1)
+                    .field("expiration", apiKeyExpiration.getStringRep())
+                    .endObject()
+                    .startObject()
+                    .field("name", apiKeyName2)
+                    .endObject()
+                    .endArray()
+                    .endObject()
+            )
+        ) {
+            BulkGrantApiKeyRequest request = RestBulkGrantApiKeyAction.RequestTranslator.Default.fromXContent(content);
+            assertThat(request.getGrant().getType(), is(grantType));
+            assertThat(request.getGrant().getUsername(), is(username));
+            assertThat(request.getGrant().getPassword(), is(new SecureString(password.toCharArray())));
+            assertThat(request.getApiKeyRequests().size(), equalTo(2));
+            assertThat(request.getApiKeyRequests().get(0).getName(), is(apiKeyName1));
+            assertThat(request.getApiKeyRequests().get(0).getExpiration(), is(apiKeyExpiration));
+            assertThat(request.getApiKeyRequests().get(1).getName(), is(apiKeyName2));
+        }
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/13_bulk_grant.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/13_bulk_grant.yml
@@ -1,0 +1,149 @@
+---
+setup:
+  - skip:
+      features: [headers, transform_and_set]
+
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+  - do:
+      security.put_role:
+        name: "api_key_granter_role"
+        body:  >
+            {
+              "cluster": ["grant_api_key"]
+            }
+  - do:
+      security.put_role:
+        name: "api_key_grant_target_role"
+        body: >
+          {
+            "cluster": ["manage_token"],
+            "indices": [
+              {
+                "names": "index",
+                "privileges": ["all"]
+              }
+            ]
+          }
+
+  - do:
+      security.put_user:
+        username: "api_key_granter"
+        body:  >
+          {
+            "password" : "x-pack-test-password",
+            "roles" : [ "api_key_granter_role" ],
+            "full_name" : "API key granter"
+          }
+
+  - do:
+      security.put_user:
+        username: "api_key_grant_target_user"
+        body: >
+          {
+            "password" : "x-pack-test-password-2",
+            "roles" : [ "api_key_grant_target_role" ],
+            "full_name" : "API key grant target user"
+          }
+
+---
+teardown:
+  - do:
+      security.delete_role:
+        name: "api_key_granter_role"
+        ignore: 404
+
+  - do:
+      security.delete_role:
+        name: "api_key_grant_target_role"
+        ignore: 404
+
+  - do:
+      security.delete_user:
+        username: "api_key_granter"
+        ignore: 404
+
+  - do:
+      security.delete_user:
+        username: "api_key_grant_target_user"
+        ignore: 404
+
+---
+"Test bulk grant api keys with password":
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV9ncmFudGVyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_granter
+      security.bulk_grant_api_key:
+        body:  >
+          {
+            "grant_type": "password",
+            "username": "api_key_grant_target_user",
+            "password": "x-pack-test-password-2",
+            "api_keys": [
+              {
+                "name": "bulk-key-1",
+                "expiration": "1d",
+                "metadata": { "managed": true }
+              },
+              {
+                "name": "bulk-key-2"
+              }
+            ]
+          }
+  - length: { created: 2 }
+  - match: { created.0.name: "bulk-key-1" }
+  - is_true: created.0.id
+  - is_true: created.0.api_key
+  - is_true: created.0.expiration
+  - match: { created.1.name: "bulk-key-2" }
+  - is_true: created.1.id
+  - is_true: created.1.api_key
+  - transform_and_set: { login_creds: "#base64EncodeCredentials(created.0.id,created.0.api_key)" }
+  - match: { created.0.encoded: $login_creds }
+
+  - do:
+      headers:
+        Authorization: ApiKey ${login_creds}
+      security.authenticate: {}
+
+  - match: { username: "api_key_grant_target_user" }
+  - match: { authentication_realm.name: "_es_api_key" }
+  - match: { api_key.name: "bulk-key-1" }
+
+---
+"Test bulk grant api key forbidden":
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV9ncmFudF90YXJnZXRfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZC0y" # api_key_grant_target_user
+      catch: forbidden
+      security.bulk_grant_api_key:
+        body:  >
+          {
+            "grant_type": "password",
+            "username": "api_key_granter",
+            "password": "x-pack-test-password",
+            "api_keys": [
+              { "name": "bulk-key-forbidden" }
+            ]
+          }
+  - match: { "error.type": "security_exception" }
+  - match:
+      "error.reason": "action [cluster:admin/xpack/security/api_key/grant/bulk] is unauthorized for user [api_key_grant_target_user] with effective roles [api_key_grant_target_role], this action is granted by the cluster privileges [grant_api_key,manage_api_key,manage_security,all]"
+
+---
+"Test bulk grant api keys requires api_keys":
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV9ncmFudGVyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_granter
+      catch: bad_request
+      security.bulk_grant_api_key:
+        body:  >
+          {
+            "grant_type": "password",
+            "username": "api_key_grant_target_user",
+            "password": "x-pack-test-password-2"
+          }
+  - match: { "error.type": "action_request_validation_exception" }
+  - match: { "error.reason": "Validation Failed: 1: [api_keys] must not be empty;" }


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/273675**

## Summary
- Adds `POST /_security/api_key/_bulk_grant` so callers can create many API keys under one grant in a single HTTP request.
- Grant credentials are authenticated once; keys are hashed and written in one `.security` bulk index. Existing `grant_api_key` covers the action (`cluster:admin/xpack/security/api_key/grant/bulk`).
- Motivated by current push to [improve performance](https://github.com/elastic/security-team/issues/16958) of SIEM endpoints for AI scalability: [elastic/kibana#273675](https://github.com/elastic/kibana/issues/273675) showed per-key grant is ~70% of the time delta when bulk-creating enabled vs disabled detection rules.

## Test plan

Tested in localhost manually using `yarn es source` during https://github.com/elastic/kibana/pull/284946, which showed a ~2x performance improvement on kibana `rules/_import` (`overwrite=true`) from `42s` -> `20s`. Instead of 1000x calls to generate API keys only 5 calls were made.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/ecd6bc46-d69e-443a-a3a5-b56bf88a10e8" />

#### Unit tests

- [x] `:x-pack:plugin:core:test` — `BulkGrantApiKeyRequestTests`, `BulkGrantApiKeyResponseTests`
- [x] `:x-pack:plugin:security:test` — `RestBulkGrantApiKeyActionTests`, `TransportBulkGrantApiKeyActionTests`
- [x] `:x-pack:plugin:yamlRestTest` — `api_key/13_bulk_grant/*`
