### PR TITLE
[9.5] [Inference API] Fix inference/_update to allow rotating secrets (#157214)

### DIFF
--- a/docs/changelog/157214.yaml
+++ b/docs/changelog/157214.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 157214
+summary: "[Inference API] Fix inference/_update to allow rotating secrets"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionServiceSettings.java
@@ -134,5 +134,4 @@ public class Ai21ChatCompletionServiceSettings extends FilteredXContentObject im
     public int hashCode() {
         return Objects.hash(modelId, rateLimitSettings);
     }
-
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereCommonServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereCommonServiceSettings.java
@@ -298,6 +298,9 @@ public class CohereCommonServiceSettings extends FilteredXContentObject implemen
             (p, c) -> RateLimitSettings.createParser(false, null).apply(p, null),
             new ParseField(RateLimitSettings.FIELD_NAME)
         );
+        // api_key appears in the same JSON block as service settings in update requests; DefaultSecretSettings extracts it separately.
+        // Declare it here as a no-op so the strict update parser does not reject it as an unknown field.
+        parser.declareString((u, v) -> {}, new ParseField(DefaultSecretSettings.API_KEY));
     }
 
     public static class CommonUpdate {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/LlamaServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/LlamaServiceSettings.java
@@ -197,6 +197,9 @@ public abstract class LlamaServiceSettings extends FilteredXContentObject implem
             new ParseField(RateLimitSettings.FIELD_NAME),
             ObjectParser.ValueType.OBJECT_OR_NULL
         );
+        // api_key appears in the same JSON block as service settings in update requests; DefaultSecretSettings extracts it separately.
+        // Declare it here as a no-op so the strict update parser does not reject it as an unknown field.
+        parser.declareString((u, v) -> {}, new ParseField(DefaultSecretSettings.API_KEY));
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/SecretRotationTestCases.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/SecretRotationTestCases.java
@@ -172,7 +172,9 @@ public class SecretRotationTestCases {
                         AmazonBedrockConstants.MODEL_FIELD,
                         "amazon.titan-embed-text-v2:0",
                         AmazonBedrockConstants.PROVIDER_FIELD,
-                        "amazontitan"
+                        "amazontitan",
+                        ServiceFields.DIMENSIONS_SET_BY_USER,
+                        false
                     )
                 ),
                 new HashMap<>(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/SecretRotationTestCases.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/SecretRotationTestCases.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
+import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
+import org.elasticsearch.xpack.inference.services.SenderService;
+import org.elasticsearch.xpack.inference.services.ServiceFields;
+import org.elasticsearch.xpack.inference.services.ai21.Ai21Service;
+import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchService;
+import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchServiceSettings;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockService;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockMockRequestSender;
+import org.elasticsearch.xpack.inference.services.cohere.CohereCommonServiceSettings;
+import org.elasticsearch.xpack.inference.services.cohere.CohereService;
+import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingType;
+import org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxService;
+import org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields;
+import org.elasticsearch.xpack.inference.services.llama.LlamaService;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.elasticsearch.common.settings.Settings.EMPTY;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
+import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
+import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithSettings;
+
+/**
+ * Per-service, per-task-type descriptors for {@link TransportUpdateInferenceModelActionSecretRotationTests}.
+ *
+ * <p>When to add a new entry here:
+ * <ul>
+ *   <li>A <em>new</em> service is added that has secrets.</li>
+ *   <li>A <em>new task type</em> is added to an existing service — each task type has its own {@code ServiceSettings}
+ *       class and therefore its own update parser, so a new task type needs its own row.</li>
+ * </ul>
+ *
+ * <p>When you do <em>not</em> need to add an entry: converting an already-listed service to
+ * {@link org.elasticsearch.xcontent.ObjectParser}-based settings.  The existing rows already exercise whatever
+ * parsing implementation that settings class uses at test time, so if you forget to allow secret fields in the
+ * new parser the existing rows will fail.
+ *
+ * <p>The failure mode being guarded: secret fields (e.g. {@code api_key}, {@code access_key}) arrive
+ * inside the {@code service_settings} JSON block of an update request.  A strict {@code ObjectParser}
+ * that has not declared them via {@code allowSecretFields} rejects them as unknown fields, breaking
+ * secret rotation.
+ */
+public class SecretRotationTestCases {
+
+    private static final String INITIAL_API_KEY = "initial-api-key";
+    private static final String ROTATED_API_KEY = "rotated-api-key";
+    private static final String INITIAL_ACCESS_KEY = "initial-access-key";
+    private static final String ROTATED_ACCESS_KEY = "rotated-access-key";
+    private static final String INITIAL_SECRET_KEY = "initial-secret-key";
+    private static final String ROTATED_SECRET_KEY = "rotated-secret-key";
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> cohereCases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> new CohereService(
+            HttpRequestSenderTests.createSenderFactory(tp, cm),
+            createWithEmptySettings(tp),
+            mockClusterServiceEmpty()
+        );
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                CohereService.NAME,
+                TaskType.TEXT_EMBEDDING,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        ServiceFields.MODEL_ID,
+                        "embed-v4.0",
+                        ServiceFields.EMBEDDING_TYPE,
+                        CohereEmbeddingType.FLOAT.toString(),
+                        CohereCommonServiceSettings.API_VERSION,
+                        CohereCommonServiceSettings.CohereApiVersion.V2.toString()
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+            )
+        );
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                CohereService.NAME,
+                TaskType.COMPLETION,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        ServiceFields.MODEL_ID,
+                        "command-r-plus",
+                        CohereCommonServiceSettings.API_VERSION,
+                        CohereCommonServiceSettings.CohereApiVersion.V1.toString()
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+            )
+        );
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                CohereService.NAME,
+                TaskType.RERANK,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        ServiceFields.MODEL_ID,
+                        "rerank-english-v3.0",
+                        CohereCommonServiceSettings.API_VERSION,
+                        CohereCommonServiceSettings.CohereApiVersion.V2.toString()
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+            )
+        );
+
+        return cases;
+    }
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> amazonBedrockCases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> {
+            var bedrockFactory = new AmazonBedrockMockRequestSender.Factory(createWithSettings(tp, EMPTY), mockClusterServiceEmpty());
+            return new AmazonBedrockService(
+                HttpRequestSenderTests.createSenderFactory(tp, cm),
+                bedrockFactory,
+                createWithEmptySettings(tp),
+                mockClusterServiceEmpty()
+            );
+        };
+
+        // Two secret fields: access_key and secret_key
+        var region = "us-east-1";
+        var initialSecrets = new HashMap<String, Object>(
+            Map.of(AmazonBedrockConstants.ACCESS_KEY_FIELD, INITIAL_ACCESS_KEY, AmazonBedrockConstants.SECRET_KEY_FIELD, INITIAL_SECRET_KEY)
+        );
+        var rotatedSecrets = new HashMap<String, Object>(
+            Map.of(AmazonBedrockConstants.ACCESS_KEY_FIELD, ROTATED_ACCESS_KEY, AmazonBedrockConstants.SECRET_KEY_FIELD, ROTATED_SECRET_KEY)
+        );
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                AmazonBedrockService.NAME,
+                TaskType.TEXT_EMBEDDING,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        AmazonBedrockConstants.REGION_FIELD,
+                        region,
+                        AmazonBedrockConstants.MODEL_FIELD,
+                        "amazon.titan-embed-text-v2:0",
+                        AmazonBedrockConstants.PROVIDER_FIELD,
+                        "amazontitan"
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(initialSecrets),
+                new HashMap<>(rotatedSecrets)
+            )
+        );
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                AmazonBedrockService.NAME,
+                TaskType.COMPLETION,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        AmazonBedrockConstants.REGION_FIELD,
+                        region,
+                        AmazonBedrockConstants.MODEL_FIELD,
+                        "anthropic.claude-3-sonnet-20240229-v1:0",
+                        AmazonBedrockConstants.PROVIDER_FIELD,
+                        "anthropic"
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(initialSecrets),
+                new HashMap<>(rotatedSecrets)
+            )
+        );
+
+        cases.add(
+            new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                AmazonBedrockService.NAME,
+                TaskType.CHAT_COMPLETION,
+                factory,
+                new HashMap<>(
+                    Map.of(
+                        AmazonBedrockConstants.REGION_FIELD,
+                        region,
+                        AmazonBedrockConstants.MODEL_FIELD,
+                        "amazon.nova-lite-v1:0",
+                        AmazonBedrockConstants.PROVIDER_FIELD,
+                        "amazontitan"
+                    )
+                ),
+                new HashMap<>(),
+                new HashMap<>(initialSecrets),
+                new HashMap<>(rotatedSecrets)
+            )
+        );
+
+        return cases;
+    }
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> alibabaCloudSearchCases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> new AlibabaCloudSearchService(
+            HttpRequestSenderTests.createSenderFactory(tp, cm),
+            createWithEmptySettings(tp),
+            mockClusterServiceEmpty()
+        );
+
+        // Common service settings for all Alibaba task types
+        var baseServiceSettings = Map.of(
+            AlibabaCloudSearchServiceSettings.SERVICE_ID,
+            "ops-text-embedding-001",
+            AlibabaCloudSearchServiceSettings.HOST,
+            "dashscope.aliyuncs.com",
+            AlibabaCloudSearchServiceSettings.WORKSPACE_NAME,
+            "default"
+        );
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        for (var taskType : List.of(TaskType.TEXT_EMBEDDING, TaskType.SPARSE_EMBEDDING, TaskType.RERANK, TaskType.COMPLETION)) {
+            cases.add(
+                new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                    AlibabaCloudSearchService.NAME,
+                    taskType,
+                    factory,
+                    new HashMap<>(baseServiceSettings),
+                    new HashMap<>(),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+                )
+            );
+        }
+
+        return cases;
+    }
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> ibmWatsonxCases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> new IbmWatsonxService(
+            HttpRequestSenderTests.createSenderFactory(tp, cm),
+            createWithEmptySettings(tp),
+            mockClusterServiceEmpty()
+        );
+
+        var baseServiceSettings = Map.of(
+            ServiceFields.URL,
+            "https://us-south.ml.cloud.ibm.com",
+            ServiceFields.MODEL_ID,
+            "ibm/granite-13b-instruct-v2",
+            IbmWatsonxServiceFields.PROJECT_ID,
+            "my-project-id",
+            IbmWatsonxServiceFields.API_VERSION,
+            "2024-03-14"
+        );
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        for (var taskType : List.of(TaskType.TEXT_EMBEDDING, TaskType.RERANK, TaskType.COMPLETION, TaskType.CHAT_COMPLETION)) {
+            cases.add(
+                new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                    IbmWatsonxService.NAME,
+                    taskType,
+                    factory,
+                    new HashMap<>(baseServiceSettings),
+                    new HashMap<>(),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+                )
+            );
+        }
+
+        return cases;
+    }
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> ai21Cases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> new Ai21Service(
+            HttpRequestSenderTests.createSenderFactory(tp, cm),
+            createWithEmptySettings(tp),
+            mockClusterServiceEmpty()
+        );
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        for (var taskType : List.of(TaskType.COMPLETION, TaskType.CHAT_COMPLETION)) {
+            cases.add(
+                new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                    Ai21Service.NAME,
+                    taskType,
+                    factory,
+                    new HashMap<>(Map.of(ServiceFields.MODEL_ID, "jamba-1.5-mini")),
+                    new HashMap<>(),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+                )
+            );
+        }
+
+        return cases;
+    }
+
+    private static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> llamaCases() {
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> factory = (tp, cm) -> new LlamaService(
+            HttpRequestSenderTests.createSenderFactory(tp, cm),
+            createWithEmptySettings(tp),
+            mockClusterServiceEmpty()
+        );
+
+        var baseServiceSettings = Map.of(ServiceFields.URL, "http://localhost:11434", ServiceFields.MODEL_ID, "llama3.2");
+
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+
+        for (var taskType : List.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION, TaskType.CHAT_COMPLETION)) {
+            cases.add(
+                new TransportUpdateInferenceModelActionSecretRotationTests.TestCase(
+                    LlamaService.NAME,
+                    taskType,
+                    factory,
+                    new HashMap<>(baseServiceSettings),
+                    new HashMap<>(),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, INITIAL_API_KEY)),
+                    new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, ROTATED_API_KEY))
+                )
+            );
+        }
+
+        return cases;
+    }
+
+    /**
+     * Returns all parameterized test cases.  Cases are ordered: Wave 1 (services with
+     * {@code usesParserForServiceSettings() == true}) first, so regressions in the fix itself show up at
+     * the top of the test run.
+     */
+    public static List<TransportUpdateInferenceModelActionSecretRotationTests.TestCase> all() {
+        var cases = new ArrayList<TransportUpdateInferenceModelActionSecretRotationTests.TestCase>();
+        cases.addAll(cohereCases());
+        cases.addAll(amazonBedrockCases());
+        cases.addAll(alibabaCloudSearchCases());
+        cases.addAll(ibmWatsonxCases());
+        cases.addAll(ai21Cases());
+        cases.addAll(llamaCases());
+        return cases;
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionSecretRotationTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionSecretRotationTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.breaker.TestCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.inference.InferenceServiceRegistry;
@@ -141,13 +140,7 @@ public class TransportUpdateInferenceModelActionSecretRotationTests extends ESTe
     public void startHttpClient() throws Exception {
         super.setUp();
         threadPool = createThreadPool(inferenceUtilityExecutors());
-        clientManager = HttpClientManager.create(
-            Settings.EMPTY,
-            threadPool,
-            mockClusterServiceEmpty(),
-            mock(ThrottlerManager.class),
-            new TestCircuitBreaker()
-        );
+        clientManager = HttpClientManager.create(Settings.EMPTY, threadPool, mockClusterServiceEmpty(), mock(ThrottlerManager.class));
     }
 
     @After

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionSecretRotationTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelActionSecretRotationTests.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.TestCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.UnparsedModel;
+import org.elasticsearch.license.LicensedFeature;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
+import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
+import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
+import org.elasticsearch.xpack.inference.common.amazon.AwsSecretSettings;
+import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
+import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.services.SenderService;
+import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Transport-level secret-rotation tests for {@link TransportUpdateInferenceModelAction}.
+ *
+ * <p>Each parameterized case builds a real service instance, registers a persisted model, then calls
+ * {@code masterOperation} with an update body that contains only rotated secret fields inside
+ * {@code service_settings}.  The test asserts that:
+ * <ol>
+ *   <li>The request succeeds (no {@code unknown field} exception).</li>
+ *   <li>{@code modelRegistry.updateModelTransaction} is invoked with the rotated secrets.</li>
+ * </ol>
+ *
+ * <p>Before the fix in this PR, services converted to {@code ObjectParser}-based settings would reject
+ * secret keys as unknown fields and the future would complete with an exception.
+ *
+ * <h2>When to add a new entry in {@link SecretRotationTestCases}</h2>
+ * <ul>
+ *   <li>A <em>new service</em> is added that has secrets.</li>
+ *   <li>A <em>new task type</em> is added to an existing service — each task type has its own
+ *       {@code ServiceSettings} class and therefore its own update parser.</li>
+ * </ul>
+ * Converting an already-listed service to {@code ObjectParser} does <em>not</em> require a new entry:
+ * the existing rows already drive the new parser and will fail if secrets are not declared.
+ */
+public class TransportUpdateInferenceModelActionSecretRotationTests extends ESTestCase {
+
+    /**
+     * Descriptor for one parameterized test case.
+     *
+     * @param serviceName        value returned by {@link org.elasticsearch.inference.InferenceService#name()}
+     * @param taskType           the task type of the endpoint being updated
+     * @param serviceFactory     creates a real service (may be spied upon in the harness)
+     * @param persistedServiceSettings non-secret service settings stored in {@code .inference}
+     * @param persistedTaskSettings    task settings stored in {@code .inference}
+     * @param initialSecretSettings    secret settings stored in {@code .inference-secrets} (the "old" credential)
+     * @param rotatedSecretSettings    the new credential supplied in the update body's {@code service_settings}
+     */
+    public record TestCase(
+        String serviceName,
+        TaskType taskType,
+        BiFunction<ThreadPool, HttpClientManager, SenderService<?>> serviceFactory,
+        Map<String, Object> persistedServiceSettings,
+        Map<String, Object> persistedTaskSettings,
+        Map<String, Object> initialSecretSettings,
+        Map<String, Object> rotatedSecretSettings
+    ) {
+        @Override
+        public String toString() {
+            return serviceName + "/" + taskType;
+        }
+    }
+
+    private static final String INFERENCE_ENTITY_ID = "test-inference-entity-id";
+
+    private ThreadPool threadPool;
+    private HttpClientManager clientManager;
+    private final TestCase testCase;
+
+    public TransportUpdateInferenceModelActionSecretRotationTests(TestCase testCase) {
+        this.testCase = testCase;
+    }
+
+    @ParametersFactory(shuffle = false)
+    public static Iterable<Object[]> parameters() {
+        return SecretRotationTestCases.all().stream().map(tc -> new Object[] { tc }).toList();
+    }
+
+    @Before
+    public void startHttpClient() throws Exception {
+        super.setUp();
+        threadPool = createThreadPool(inferenceUtilityExecutors());
+        clientManager = HttpClientManager.create(
+            Settings.EMPTY,
+            threadPool,
+            mockClusterServiceEmpty(),
+            mock(ThrottlerManager.class),
+            new TestCircuitBreaker()
+        );
+    }
+
+    @After
+    public void shutdownHttpClient() throws Exception {
+        clientManager.close();
+        terminate(threadPool);
+    }
+
+    public void testMasterOperation_SecretRotation_Succeeds() throws Exception {
+        // Build a real service and spy on it so we can stub the network-touching validation entry
+        // points while keeping all parsing/building logic real.
+        var realService = testCase.serviceFactory().apply(threadPool, clientManager);
+        var spyService = spy(realService);
+        stubValidationEntryPoints(spyService);
+
+        var mockModelRegistry = mock(ModelRegistry.class);
+        // SenderService.parsePersistedConfig mutates the config and secrets maps (removes service_settings,
+        // secret_settings, and individual secret keys). Return fresh UnparsedModel instances built from
+        // independent copies of the leaf-level maps on every call.
+        mockGetModelWithSecrets(
+            mockModelRegistry,
+            testCase.taskType(),
+            testCase.serviceName(),
+            testCase.persistedServiceSettings(),
+            testCase.persistedTaskSettings(),
+            testCase.initialSecretSettings()
+        );
+        mockGetModel(
+            mockModelRegistry,
+            testCase.taskType(),
+            testCase.serviceName(),
+            testCase.persistedServiceSettings(),
+            testCase.persistedTaskSettings(),
+            testCase.initialSecretSettings()
+        );
+
+        // Capture the model passed to updateModelTransaction so we can assert on its secrets.
+        var capturedNewModel = ArgumentCaptor.forClass(Model.class);
+        doAnswer(inv -> {
+            ActionListener<Boolean> listener = inv.getArgument(2);
+            listener.onResponse(true);
+            return null;
+        }).when(mockModelRegistry).updateModelTransaction(capturedNewModel.capture(), any(), any());
+
+        var mockServiceRegistry = mock(InferenceServiceRegistry.class);
+        when(mockServiceRegistry.getService(testCase.serviceName())).thenReturn(Optional.of(spyService));
+
+        var licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(any(LicensedFeature.class))).thenReturn(true);
+
+        var action = buildAction(licenseState, mockModelRegistry, mockServiceRegistry);
+
+        var updateBody = buildUpdateBody(testCase.rotatedSecretSettings());
+        var future = callMasterOperation(action, testCase.taskType(), updateBody);
+
+        future.actionGet(TEST_REQUEST_TIMEOUT);
+
+        verify(mockModelRegistry).updateModelTransaction(any(), any(), any());
+        var persistedModel = capturedNewModel.getValue();
+        // The secret settings must reflect the rotated credential.
+        assertSecretSettingsRotated(persistedModel, testCase.rotatedSecretSettings());
+        // The service settings must be unchanged (rotating a secret must not perturb config).
+        assertThat(persistedModel.getConfigurations().getService(), is(testCase.serviceName()));
+        assertThat(persistedModel.getConfigurations().getTaskType(), is(testCase.taskType()));
+    }
+
+    public void testMasterOperation_GenuinelyUnknownServiceSetting_IsRejected() throws IOException {
+        var realService = testCase.serviceFactory().apply(threadPool, clientManager);
+        var spyService = spy(realService);
+        stubValidationEntryPoints(spyService);
+
+        var mockModelRegistry = mock(ModelRegistry.class);
+        mockGetModelWithSecrets(
+            mockModelRegistry,
+            testCase.taskType(),
+            testCase.serviceName(),
+            testCase.persistedServiceSettings(),
+            testCase.persistedTaskSettings(),
+            testCase.initialSecretSettings()
+        );
+        mockGetModel(
+            mockModelRegistry,
+            testCase.taskType(),
+            testCase.serviceName(),
+            testCase.persistedServiceSettings(),
+            testCase.persistedTaskSettings(),
+            testCase.initialSecretSettings()
+        );
+        doAnswer(inv -> {
+            ActionListener<Boolean> listener = inv.getArgument(2);
+            listener.onResponse(true);
+            return null;
+        }).when(mockModelRegistry).updateModelTransaction(any(), any(), any());
+
+        var mockServiceRegistry = mock(InferenceServiceRegistry.class);
+        when(mockServiceRegistry.getService(testCase.serviceName())).thenReturn(Optional.of(spyService));
+
+        var licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(any(LicensedFeature.class))).thenReturn(true);
+
+        var action = buildAction(licenseState, mockModelRegistry, mockServiceRegistry);
+
+        // A field that no service declares — this must still be rejected.
+        var updateBody = buildUpdateBody(Map.of("this_field_absolutely_does_not_exist", "value"));
+        var future = callMasterOperation(action, testCase.taskType(), updateBody);
+
+        var ex = expectThrows(Exception.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(ex.getMessage(), containsString("this_field_absolutely_does_not_exist"));
+    }
+
+    private TransportUpdateInferenceModelAction buildAction(
+        MockLicenseState licenseState,
+        ModelRegistry modelRegistry,
+        InferenceServiceRegistry serviceRegistry
+    ) {
+        return new TransportUpdateInferenceModelAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            licenseState,
+            modelRegistry,
+            serviceRegistry,
+            mock(Client.class),
+            TestProjectResolvers.DEFAULT_PROJECT_ONLY
+        );
+    }
+
+    private static String buildUpdateBody(Map<String, Object> serviceSettingsFields) throws IOException {
+        try (var builder = XContentFactory.jsonBuilder()) {
+            builder.startObject();
+            builder.field(ModelConfigurations.SERVICE_SETTINGS, serviceSettingsFields);
+            builder.endObject();
+            return Strings.toString(builder);
+        }
+    }
+
+    private TestPlainActionFuture<UpdateInferenceModelAction.Response> callMasterOperation(
+        TransportUpdateInferenceModelAction action,
+        TaskType taskType,
+        String requestBody
+    ) {
+        var future = new TestPlainActionFuture<UpdateInferenceModelAction.Response>();
+        action.masterOperation(
+            mock(Task.class),
+            new UpdateInferenceModelAction.Request(
+                INFERENCE_ENTITY_ID,
+                new BytesArray(requestBody),
+                XContentType.JSON,
+                taskType,
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            ),
+            ClusterState.EMPTY_STATE,
+            future
+        );
+        return future;
+    }
+
+    /**
+     * Stubs all service methods that contact external systems, so the update validation step does not
+     * actually make HTTP calls.  Every entry point returns a minimal but valid result for its task type.
+     */
+    private static void stubValidationEntryPoints(SenderService<?> spyService) {
+        // Stub onModelUpdated — Mockito does not invoke interface default methods.
+        doAnswer(inv -> {
+            ActionListener<Void> listener = inv.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(spyService).onModelUpdated(any(), any(), any());
+
+        // Stub the infer/unifiedCompletionInfer/rerankInfer/embeddingInfer entry points.
+        // Each validator routes to exactly one of these; we stub all so the test is robust to
+        // service-level getServiceIntegrationValidator() overrides.
+        doAnswer(inv -> {
+            ActionListener<InferenceServiceResults> listener = inv.getArgument(6);
+            listener.onResponse(
+                new DenseEmbeddingFloatResults(List.of(new EmbeddingFloatResults.Embedding(new float[] { 0.1f, 0.2f, 0.3f })))
+            );
+            return null;
+        }).when(spyService).infer(any(), any(), any(Boolean.class), any(), any(), any(), any());
+
+        doAnswer(inv -> {
+            ActionListener<InferenceServiceResults> listener = inv.getArgument(3);
+            listener.onResponse(
+                new DenseEmbeddingFloatResults(List.of(new EmbeddingFloatResults.Embedding(new float[] { 0.1f, 0.2f, 0.3f })))
+            );
+            return null;
+        }).when(spyService).embeddingInfer(any(), any(), any(), any());
+
+        doAnswer(inv -> {
+            ActionListener<InferenceServiceResults> listener = inv.getArgument(3);
+            listener.onResponse(new RankedDocsResults(List.of(new RankedDocsResults.RankedDoc(0, 1.0f, "test"))));
+            return null;
+        }).when(spyService).rerankInfer(any(), any(), any(), any());
+
+        doAnswer(inv -> {
+            ActionListener<InferenceServiceResults> listener = inv.getArgument(3);
+            listener.onResponse(new ChatCompletionResults(List.of(new ChatCompletionResults.Result("hello"))));
+            return null;
+        }).when(spyService).unifiedCompletionInfer(any(), any(), any(), any());
+
+        // updateModelWithEmbeddingDetails: return the model unchanged so we can assert on its secrets.
+        // Use doAnswer (not when/thenAnswer) because spying calls the real method before the stub takes effect.
+        doAnswer(inv -> inv.getArgument(0)).when(spyService).updateModelWithEmbeddingDetails(any(), any(Integer.class));
+    }
+
+    /**
+     * Stubs {@code getModelWithSecrets} and {@code getModel} to each return a fresh {@link UnparsedModel} on
+     * every call, built from independent copies of the leaf-level maps.
+     *
+     * <p>{@link org.elasticsearch.xpack.inference.services.SenderService#parsePersistedConfig} mutates both the
+     * top-level config/secrets maps (removes {@code service_settings} and {@code secret_settings}) and the
+     * nested maps (removes individual setting keys such as {@code api_key}).  Reusing the same object across
+     * calls would therefore cause the second parse to see empty maps.
+     */
+    private static void mockGetModelWithSecrets(
+        ModelRegistry registry,
+        TaskType taskType,
+        String serviceName,
+        Map<String, Object> serviceSettings,
+        Map<String, Object> taskSettings,
+        Map<String, Object> secretSettings
+    ) {
+        doAnswer(inv -> {
+            ActionListener<UnparsedModel> listener = inv.getArgument(1);
+            var freshConfig = getPersistedConfigMap(
+                new HashMap<>(serviceSettings),
+                new HashMap<>(taskSettings),
+                new HashMap<>(secretSettings)
+            );
+            listener.onResponse(new UnparsedModel(INFERENCE_ENTITY_ID, taskType, serviceName, freshConfig.config(), freshConfig.secrets()));
+            return null;
+        }).when(registry).getModelWithSecrets(eq(INFERENCE_ENTITY_ID), any());
+    }
+
+    /**
+     * Stubs {@code getModel} (re-fetch after persist) to return a fresh {@link UnparsedModel} built from the
+     * original persisted config maps.  The re-fetch result is parsed again to produce the response, so it must
+     * contain the full config.
+     */
+    private static void mockGetModel(
+        ModelRegistry registry,
+        TaskType taskType,
+        String serviceName,
+        Map<String, Object> serviceSettings,
+        Map<String, Object> taskSettings,
+        Map<String, Object> secretSettings
+    ) {
+        doAnswer(inv -> {
+            ActionListener<UnparsedModel> listener = inv.getArgument(1);
+            var freshConfig = getPersistedConfigMap(
+                new HashMap<>(serviceSettings),
+                new HashMap<>(taskSettings),
+                new HashMap<>(secretSettings)
+            );
+            listener.onResponse(new UnparsedModel(INFERENCE_ENTITY_ID, taskType, serviceName, freshConfig.config(), freshConfig.secrets()));
+            return null;
+        }).when(registry).getModel(eq(INFERENCE_ENTITY_ID), any());
+    }
+
+    /**
+     * Asserts that the persisted model's secret settings reflect the rotated values.
+     *
+     * <p>We match by checking that the string representation of each secret field equals the value
+     * in the rotation map.  This avoids coupling the assertion to a specific {@code SecretSettings}
+     * implementation while still exercising the full parse+equality path.
+     */
+    private static void assertSecretSettingsRotated(Model model, Map<String, Object> rotatedSecretSettings) {
+        var secretSettings = model.getSecretSettings();
+        assertNotNull(secretSettings);
+
+        // For DefaultSecretSettings (api_key): the model must carry the rotated api_key.
+        if (rotatedSecretSettings.containsKey(DefaultSecretSettings.API_KEY)) {
+            assertThat(secretSettings, instanceOf(DefaultSecretSettings.class));
+            var rotated = (DefaultSecretSettings) secretSettings;
+            assertThat(rotated.apiKey().toString(), is(rotatedSecretSettings.get(DefaultSecretSettings.API_KEY).toString()));
+        }
+
+        // For AwsSecretSettings (access_key + secret_key):
+        if (rotatedSecretSettings.containsKey(AmazonBedrockConstants.ACCESS_KEY_FIELD)) {
+            var rotated = (AwsSecretSettings) secretSettings;
+            assertThat(rotated.accessKey().toString(), is(rotatedSecretSettings.get(AmazonBedrockConstants.ACCESS_KEY_FIELD).toString()));
+            assertThat(rotated.secretKey().toString(), is(rotatedSecretSettings.get(AmazonBedrockConstants.SECRET_KEY_FIELD).toString()));
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionServiceSettingsTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
 
@@ -55,6 +56,18 @@ public class Ai21ChatCompletionServiceSettingsTests extends AbstractBWCWireSeria
             new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
         );
         var updatedServiceSettings = originalServiceSettings.updateServiceSettings(new HashMap<>());
+
+        assertThat(updatedServiceSettings, is(originalServiceSettings));
+    }
+
+    public void testUpdateServiceSettings_ApiKey_IsIgnored() {
+        var originalServiceSettings = new Ai21ChatCompletionServiceSettings(
+            INITIAL_TEST_MODEL_ID,
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, "secret-key"))
+        );
 
         assertThat(updatedServiceSettings, is(originalServiceSettings));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/AbstractCohereServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/AbstractCohereServiceSettingsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.cohere.CohereCommonServiceSettings.CohereApiVersion;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
@@ -289,6 +290,19 @@ public abstract class AbstractCohereServiceSettingsTests<T extends CohereService
         String xContentResult = Strings.toString(builder);
 
         assertThat(xContentResult, containsString(CohereCommonServiceSettings.API_VERSION));
+    }
+
+    public void testUpdateServiceSettings_ApiKey_IsIgnored() {
+        var serviceSettings = createGivenCommonSettings(
+            new HashMap<>(Map.of(ServiceFields.MODEL_ID, TEST_MODEL_ID)),
+            ConfigurationParseContext.REQUEST
+        );
+
+        var updatedServiceSettings = serviceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, "secret-key"))
+        );
+
+        assertThat(updatedServiceSettings, is(serviceSettings));
     }
 
     public void testUpdateServiceSettings_GivenImmutableFields_ShouldThrow() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/AbstractLlamaServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/AbstractLlamaServiceSettingsTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.net.URI;
@@ -177,6 +178,19 @@ public abstract class AbstractLlamaServiceSettingsTests<T extends LlamaServiceSe
             originalServiceSettings.updateServiceSettings(settingsMap),
             is(createServiceSettings(INITIAL_TEST_MODEL_ID, INITIAL_TEST_URI, new RateLimitSettings(DEFAULT_RATE_LIMIT)))
         );
+    }
+
+    public void testUpdateServiceSettings_ApiKey_IsIgnored() {
+        var originalServiceSettings = createServiceSettings(
+            INITIAL_TEST_MODEL_ID,
+            INITIAL_TEST_URI,
+            new RateLimitSettings(INITIAL_TEST_RATE_LIMIT)
+        );
+        var updatedServiceSettings = originalServiceSettings.updateServiceSettings(
+            new HashMap<>(Map.of(DefaultSecretSettings.API_KEY, "secret-key"))
+        );
+
+        assertThat(updatedServiceSettings, is(originalServiceSettings));
     }
 
     public void testUpdateServiceSettings_GivenImmutableFields_ThrowsException() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [[Inference API] Fix inference/_update to allow rotating secrets (#157214)](https://github.com/elastic/elasticsearch/pull/157214)

<!--- Backport version: 12.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)