### PR TITLE
[9.5] Soving concurrency and timeout in OTel tests (#153961)

### DIFF
--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractMetricsIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/AbstractMetricsIT.java
@@ -17,8 +17,8 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -52,7 +52,7 @@ public abstract class AbstractMetricsIT extends AbstractTelemetryIT {
     }
 
     public void testExplicitMetrics() throws Exception {
-        Map<String, Predicate<Number>> valueAssertions = new HashMap<>(
+        Map<String, Predicate<Number>> valueAssertions = new ConcurrentHashMap<>(
             Map.ofEntries(
                 entry("es.test.long_counter.total", n -> closeTo(1.0, 0.001).matches(n.doubleValue())),
                 entry("es.test.double_counter.total", n -> closeTo(1.0, 0.001).matches(n.doubleValue())),
@@ -63,7 +63,7 @@ public abstract class AbstractMetricsIT extends AbstractTelemetryIT {
             )
         );
 
-        Map<String, Integer> histogramAssertions = new HashMap<>(
+        Map<String, Integer> histogramAssertions = new ConcurrentHashMap<>(
             Map.ofEntries(entry("es.test.double_histogram.histogram", 2), entry("es.test.long_histogram.histogram", 2))
         );
 
@@ -127,7 +127,8 @@ public abstract class AbstractMetricsIT extends AbstractTelemetryIT {
     }
 
     public void testJvmMetrics() throws Exception {
-        Map<String, Predicate<Number>> valueAssertions = new HashMap<>(
+        // Concurrent because the RecordingApmServer consumer thread mutates this map while the main thread reads it.
+        Map<String, Predicate<Number>> valueAssertions = new ConcurrentHashMap<>(
             Map.ofEntries(
                 entry("system.cpu.total.norm.pct", n -> closeTo(0.0, 1.0).matches(n.doubleValue())),
                 entry("system.process.cpu.total.norm.pct", n -> closeTo(0.0, 1.0).matches(n.doubleValue())),

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelMetricsIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/OtelMetricsIT.java
@@ -40,7 +40,7 @@ public class OtelMetricsIT extends AbstractMetricsIT {
         .systemProperty("telemetry.metrics.otel_jvm.enabled", "true")
         .setting("telemetry.export.endpoint", () -> recordingApmServer.getGrpcEndpoint())
         .setting("telemetry.export.interval", "1000ms")
-        .setting("telemetry.export.send_timeout", "200ms")
+        .setting("telemetry.export.send_timeout", "600ms")
         .setting("telemetry.metrics.buffer.disk_size", "0b")
         // Mirrors the three labels ServerlessServerCli writes via telemetry.agent.global_labels.* on the APM-agent path,
         // bridged here to the OTel resource via the telemetry.resource.* affix.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Soving concurrency and timeout in OTel tests (#153961)](https://github.com/elastic/elasticsearch/pull/153961)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #157343