### PR TITLE
CCS: change error message to be ESQL-friendly

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
@@ -73,8 +73,9 @@ public final class QueryBuilderResolver {
             System.currentTimeMillis()
         );
 
-        // Set the cluster alias to the local cluster and CCS minimize round-trips to false since ES|QL does not perform a remote cluster
-        // coordinator node rewrite
+        // Set the cluster alias to the local cluster. CCS minimize round-trips is left unset rather than false: ES|QL does
+        // not perform a remote cluster coordinator node rewrite, and has no request option to do otherwise, so the setting
+        // does not apply here. Consumers treat unset the same as false, but can tell not to suggest changing it.
         return services.searchService()
             .getRewriteContext(
                 System::currentTimeMillis,
@@ -82,7 +83,7 @@ public final class QueryBuilderResolver {
                 RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
                 resolvedIndices,
                 null,
-                false
+                null
             );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InferenceQueryUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/InferenceQueryUtils.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.MlDenseEmbeddingResults
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.inference.InferenceException;
+import org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -176,7 +177,7 @@ public final class InferenceQueryUtils {
             ActionListener<InferenceInfo> localInferenceInfoListener = refs.acquire(localInferenceInfoSupplier::set);
             getLocalInferenceInfo(queryRewriteContext, inferenceInfoRequest, localInferenceInfoListener);
 
-            if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false && queryRewriteContext.isCcsMinimizeRoundTrips() == false) {
+            if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false && minimizesRoundTrips(queryRewriteContext) == false) {
                 ActionListener<
                     Map<String, Tuple<GetInferenceFieldsInternalAction.Response, TransportVersion>>> remoteInferenceInfoListener = refs
                         .acquire(remoteInferenceInfoSupplier::set);
@@ -219,16 +220,34 @@ public final class InferenceQueryUtils {
         if (inferenceInfo.minTransportVersion().supports(GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV) == false
             && inferenceInfo.inferenceFieldCount() > 0
             && resolvedIndices.getRemoteClusterIndices().isEmpty() == false
-            && queryRewriteContext.isCcsMinimizeRoundTrips() == false) {
+            && minimizesRoundTrips(queryRewriteContext) == false) {
+
+            // Only mention the search parameter to a caller that has one. ES|QL always resolves inference across
+            // clusters and exposes no such option, so telling it about [ccs_minimize_roundtrips] sends it looking
+            // for a setting it cannot change.
+            String remedy = queryRewriteContext.isCcsMinimizeRoundTrips() == null
+                ? ""
+                : " Alternatively, set [ccs_minimize_roundtrips] to true.";
 
             throw new IllegalArgumentException(
                 "One or more remote clusters do not support "
                     + queryName
-                    + " query cross-cluster search when"
-                    + " [ccs_minimize_roundtrips] is false. Please update all clusters to at least "
+                    + " against a ["
+                    + SemanticTextFieldMapper.CONTENT_TYPE
+                    + "] field in cross-cluster search. Please update all clusters to at least "
                     + GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV.toReleaseVersion()
+                    + "."
+                    + remedy
             );
         }
+    }
+
+    /**
+     * null-safe version of {@link QueryRewriteContext#isCcsMinimizeRoundTrips()}, where unset means not minimizing
+     */
+    private static boolean minimizesRoundTrips(QueryRewriteContext queryRewriteContext) {
+        final Boolean isMinimized = queryRewriteContext.isCcsMinimizeRoundTrips();
+        return isMinimized != null && isMinimized;
     }
 
     private static void getLocalInferenceInfo(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
@@ -266,19 +266,34 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
             false,
             Map.of(preCcsRemoteClusterAlias, preCcsRemoteClusterConfig)
         );
+        String unsupportedRemote = "One or more remote clusters do not support "
+            + queryName
+            + " against a [semantic_text] field in cross-cluster search. Please update all clusters to at least "
+            + GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV.toReleaseVersion()
+            + ".";
+
         assertRewriteAndSerializeOnInferenceField(
             inferenceFieldQuery,
             preCcsRemoteClusterContext,
-            new IllegalArgumentException(
-                "One or more remote clusters do not support "
-                    + queryName
-                    + " query cross-cluster search when"
-                    + " [ccs_minimize_roundtrips] is false. Please update all clusters to at least "
-                    + GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV.toReleaseVersion()
-            ),
+            // A search request can turn the setting back on, so it is offered the alternative.
+            new IllegalArgumentException(unsupportedRemote + " Alternatively, set [ccs_minimize_roundtrips] to true."),
             null
         );
         assertRewriteAndSerializeOnNonInferenceField(nonInferenceFieldQuery, preCcsRemoteClusterContext);
+
+        // A caller that leaves the setting unset - ES|QL - has no such alternative and is not offered one.
+        QueryRewriteContext esqlStyleContext = createQueryRewriteContext(
+            localIndexInferenceFields,
+            TransportVersion.current(),
+            null,
+            Map.of(preCcsRemoteClusterAlias, preCcsRemoteClusterConfig)
+        );
+        assertRewriteAndSerializeOnInferenceField(
+            inferenceFieldQuery,
+            esqlStyleContext,
+            new IllegalArgumentException(unsupportedRemote),
+            null
+        );
     }
 
     public void testCcsBwCSerialization() throws Exception {


### PR DESCRIPTION
The error told the client their remote clusters were too old "when [ccs_minimize_roundtrips] is false". That is a _search request parameter, and it defaults to true, so the check only fires for a search that opted out. ES|QL always resolves inference across clusters and has no such option, which meant that users were being pointed at a setting they cannot change.
