### PR TITLE
Align ColumNAR terminology: doc id, rank, value address

### DIFF
--- a/libs/columnar/README.md
+++ b/libs/columnar/README.md
@@ -8,6 +8,41 @@ depends on `lucene-core` plus `libs:simdvec` (vectorized range scan).
 **NAR** — Native Adaptive Representation. Values live in a binary substrate; each block is encoded by
 a pipeline that picks transforms from the data.
 
+## Terms
+
+Reading a value walks **three** distinct positions, and most confusion in this codec comes from
+conflating two of them:
+
+```
+doc id  ──presence──▶  rank  ──value-address table──▶  value address  ──block──▶  bytes
+```
+
+| Term | Means | Range |
+| --- | --- | --- |
+| **doc id** | Lucene's document number within the segment. | `[0, maxDoc)` |
+| **rank** | Where a document sits among the documents that *have* a value. Identifies a **document**, not a value — two documents with identical bytes have different ranks. | `[0, numDocsWithField)` |
+| **value address** | Where a value sits in the column's value store, in write order. | `[0, numValues)` |
+| **ordinal** | A term id assigned by a dictionary, as in Lucene. **Reserved**: no shipped layout has a dictionary, so nothing is an ordinal yet. Never use it for a rank or a value address. | — |
+
+A single-valued column maps a rank straight to a value address, so the middle arrow is identity and
+the two are numerically equal — which is exactly why they need different names. A multi-valued column
+resolves a rank to a *range* of value addresses through the value-address table.
+
+Vocabulary for the storage layer:
+
+| Term | Means |
+| --- | --- |
+| **block** | The **encoding** quantum, counted in **values**. 128 for bit-packed longs, because the `ForUtil` kernels unroll over it and FOR needs the group's min/max. One entry in the offset table per block. |
+| **chunk** | The **compression** unit, counted in **bytes**. Independent of what it holds; a chunk closes only on a block boundary, so no value spans two. |
+| **layout** | How a column encodes its values, recorded as a frozen id in metadata so a later layout arrives without a format bump. |
+| **presence** | Which documents have a value — dense (every document) or sparse (an `IndexedDISI`). Turns a doc id into a rank. |
+| **offset table** | A `DirectMonotonic` table (block offsets, value addresses, chunk starts), built through a temp file and read off-heap. |
+| **pipeline** | A numeric column's encoding chain: ordered **transforms** (delta, offset, GCD) then one **terminal** (FOR bit-packing). |
+| **skip index** | Per-interval min/max held *inside* the column, since a `BINARY` field cannot carry a Lucene skipper. |
+
+Blocks and chunks address **values**, not documents: sparsity is absorbed one level up, in
+doc id → rank.
+
 ## Surface
 
 Every field is a `BinaryDocValues` field tagged with a `ColumnarFieldType` (the `columnar.type`
@@ -18,11 +53,12 @@ Every field is a `BinaryDocValues` field tagged with a `ColumnarFieldType` (the 
   - `ColumnarNumericRangeQuery` — a self-contained Lucene range query, vectorized and skipper-aware;
   - `ColumnarNumericBinaryDocValues.bulkLongs` — column-at-a-time reads for aggregation/block loading;
   - `binaryValue()` — re-emits the payload for a classic binary consumer.
-- **`STRING` (keyword)** — values stored plain in blocks, read back through `binaryValue()`, which re-emits
-  them as a `StringBinaryPayload`. Single-valued for now (a document with more than one value is rejected at
-  write time). An ordinal layout is planned as a second layout id, decided at merge from statistics a flush
-  emits rather than from a per-segment probe; ordinals will stay internal, so the read API stays binary
-  either way. See `docs/PLAN.md`.
+- **`STRING` (keyword)** — values stored plain in blocks, read back through `binaryValue()`, which hands
+  back the bytes the mapper wrote (a keyword field writes a lone value raw, so nothing wraps it).
+  Single-valued for now (a document with more than one value is rejected at write time). A dictionary
+  layout is planned as a second layout id, decided at merge from statistics a flush emits rather than
+  from a per-segment probe; its ordinals stay internal, so the read API stays binary either way. See
+  `docs/PLAN.md`.
 
 The typed shapes (`Numeric`, `SortedNumeric`, `Sorted`, `SortedSet`) are **not** this library's
 surface: they throw. There is no delegate format — a type it can't handle is an error. A typed view,
@@ -48,9 +84,9 @@ the ids it was written with, older data lists only old ids and a newer reader re
 
 ## Storage
 
-- **Presence.** Which documents hold a value, and a document's value ordinal. A dense column stores
-  nothing per document (doc id == ordinal); a sparse column reuses Lucene `IndexedDISI`. Supplies the
-  `intoBitSet` fast path and is shared by every column type.
+- **Presence.** Which documents hold a value, and a document's rank. A dense column stores nothing per
+  document (doc id == rank); a sparse column reuses Lucene `IndexedDISI`. Supplies the `intoBitSet`
+  fast path and is shared by every column type.
 - **Numeric column.** Single- and multi-valued in one store: values in written order (never
   reordered) in configurable fixed-size blocks (default 128), a block offset table, and — only when multi-valued — a
   per-document value-address table. A block decodes whole into a reused buffer with a single-block
@@ -59,7 +95,7 @@ the ids it was written with, older data lists only old ids and a newer reader re
   `DirectMonotonic` table holds each block's byte offset. Per block rather than per value, so the table costs a
   fraction of the column and a scan pays one bulk read per block instead of one read per value; a block decodes
   whole into a reused buffer with a single-block cache, as the numeric column does. The layout id is the
-  extension point a later ordinal layout arrives on. No skip index yet.
+  extension point a later dictionary layout arrives on. No skip index yet.
 - **Skip index.** Range pushdown lives inside the column (a `BINARY` field can't carry a Lucene
   skipper): a multi-level per-interval min/max index the range query consults.
 

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumNARDocValuesConsumer.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/ColumNARDocValuesConsumer.java
@@ -340,7 +340,7 @@ final class ColumNARDocValuesConsumer extends DocValuesConsumer {
         for (int doc = counter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = counter.nextDoc()) {
             numDocsWithField++;
             // One value per document: that is what this surface carries, and what lets the reader take a
-            // document's rank as its value's index rather than keeping an address for every document.
+            // document's rank as its value's address rather than keeping one for every document.
             assert counter.valueCount() == 1 : "document [" + doc + "] of field [" + field.name + "] has " + counter.valueCount();
             numValues++;
         }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/ColumnarNumericBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/ColumnarNumericBinaryDocValues.java
@@ -36,7 +36,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
     private final NumericColumnReader reader;
     private final ColumnIterator iterator;
     private final int maxDoc;
-    /** Single-valued: a rank is its own value ordinal, so a run of ranks is a contiguous slice of a block. */
+    /** Single-valued: a rank is its own value address, so a run of ranks is a contiguous slice of a block. */
     private final boolean singleValued;
     private final int blockShift;
     private final int blockMask;
@@ -68,13 +68,13 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
     @Override
     public BytesRef binaryValue() throws IOException {
         final int rank = iterator.rank();
-        final long first = reader.firstOrdinal(rank);
+        final long first = reader.firstValueAddress(rank);
         final long count = reader.valueCount(rank);
         if (values.length < count) {
             values = new long[ArrayUtil.oversize((int) count, Long.BYTES)];
         }
         for (int i = 0; i < count; i++) {
-            values[i] = reader.valueForOrdinal(first + i);
+            values[i] = reader.valueAt(first + i);
         }
         return NumericBinaryPayload.encode(values, (int) count, payload);
     }
@@ -126,7 +126,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
 
             @Override
             public long nextValue() throws IOException {
-                return reader.valueForOrdinal(first + upto++);
+                return reader.valueAt(first + upto++);
             }
 
             @Override
@@ -152,7 +152,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
             private int position(int doc) {
                 if (doc != DocIdSetIterator.NO_MORE_DOCS) {
                     int rank = iterator.rank();
-                    first = reader.firstOrdinal(rank);
+                    first = reader.firstValueAddress(rank);
                     count = reader.valueCount(rank);
                     upto = 0;
                 }
@@ -163,8 +163,8 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
 
     /**
      * Reads the values of {@code docs[offset..offset+count)} (ascending doc ids) into {@code sink}, one
-     * value per document, as runs sliced out of a decoded block. Documents are resolved to value ordinals
-     * through {@link ColumnIterator#ranks}, and the run detection compares ordinals rather than document
+     * value per document, as runs sliced out of a decoded block. Documents are resolved to value addresses
+     * through {@link ColumnIterator#ranks}, and the run detection compares value addresses rather than document
      * ids, so the column may be dense or sparse.
      *
      * <p>Returns {@code false} without touching the sink when the column is multi-valued, when any
@@ -185,14 +185,14 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
             }
         }
         for (int i = 0; i < count;) {
-            final int ordinal = ranks[i]; // single-valued: rank == value ordinal
-            final long[] block = reader.block(ordinal >>> blockShift);
-            final int inBlock = ordinal & blockMask;
+            final int valueAddress = ranks[i]; // single-valued: rank == value address
+            final long[] block = reader.block(valueAddress >>> blockShift);
+            final int inBlock = valueAddress & blockMask;
             final int remaining = Math.min(blockMask + 1 - inBlock, count - i);
             int length = 1;
             for (int candidate = remaining; candidate > 1; candidate >>= 1) {
-                // A run is contiguous when its last ordinal is exactly candidate-1 above the first.
-                if (ranks[i + candidate - 1] - ordinal == candidate - 1) {
+                // A run is contiguous when its last value address is exactly candidate-1 above the first.
+                if (ranks[i + candidate - 1] - valueAddress == candidate - 1) {
                     length = candidate;
                     break;
                 }
@@ -208,7 +208,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
      * {@code null} when the column is multi-valued. Consults the skip index when present.
      *
      * <p>The approximation is the column's own iterator, so only documents that have a value are visited,
-     * and the block work is keyed on value ordinals. The column may be dense or sparse.
+     * and the block work is keyed on value addresses. The column may be dense or sparse.
      */
     public DocIdSetIterator rangeIterator(long lowerValue, long upperValue) throws IOException {
         if (singleValued == false) {
@@ -228,33 +228,33 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
      * iterator on the first document at or after {@code upTo}.
      *
      * <p>Proceeds in runs of documents known present ({@link ColumnIterator#docIDRunEnd()}). Within a run
-     * document ids and ordinals advance in lockstep, so a position in a decoded block maps back to a
+     * document ids and value addresses advance in lockstep, so a position in a decoded block maps back to a
      * document id by a constant offset, and one {@code forEach} per block fills that stretch.
      */
     private void maskIntoBitSet(ColumnIterator column, BlockMask mask, int upTo, FixedBitSet bitSet, int offset) throws IOException {
         int doc = column.docID();
         while (doc < upTo) {
-            final int ordinal = column.rank();
+            final int valueAddress = column.rank();
             final int runEnd = Math.min(column.docIDRunEnd(), upTo);
             if (runEnd - doc == 1) {
                 // A single document: setting the bit directly is cheaper than the block-at-a-time path.
-                mask.load(ordinal >>> blockShift);
-                if (mask.matches.get(ordinal & blockMask)) {
+                mask.load(valueAddress >>> blockShift);
+                if (mask.matches.get(valueAddress & blockMask)) {
                     bitSet.set(doc - offset);
                 }
                 doc = column.nextDoc();
                 continue;
             }
-            final int ordinalToDoc = doc - ordinal; // constant for as long as the run lasts
-            final int firstOrdinal = ordinal;
-            final int lastOrdinal = ordinal + (runEnd - doc) - 1;
-            final int firstBlock = firstOrdinal >>> blockShift;
-            final int lastBlock = lastOrdinal >>> blockShift;
+            final int valueAddressToDoc = doc - valueAddress; // constant for as long as the run lasts
+            final int firstValueAddress = valueAddress;
+            final int lastValueAddress = valueAddress + (runEnd - doc) - 1;
+            final int firstBlock = firstValueAddress >>> blockShift;
+            final int lastBlock = lastValueAddress >>> blockShift;
             for (int blockId = firstBlock; blockId <= lastBlock; blockId++) {
                 mask.load(blockId);
-                final int firstInBlock = blockId == firstBlock ? firstOrdinal & blockMask : 0;
-                final int lastInBlock = blockId == lastBlock ? lastOrdinal & blockMask : blockMask;
-                mask.matches.forEach(firstInBlock, lastInBlock + 1, (blockId << blockShift) + ordinalToDoc - offset, bitSet::set);
+                final int firstInBlock = blockId == firstBlock ? firstValueAddress & blockMask : 0;
+                final int lastInBlock = blockId == lastBlock ? lastValueAddress & blockMask : blockMask;
+                mask.matches.forEach(firstInBlock, lastInBlock + 1, (blockId << blockShift) + valueAddressToDoc - offset, bitSet::set);
             }
             doc = column.advance(runEnd);
         }
@@ -265,9 +265,9 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
         return new TwoPhaseIterator(column) {
             @Override
             public boolean matches() throws IOException {
-                final int ordinal = column.rank();
-                mask.load(ordinal >>> blockShift);
-                return mask.matches.get(ordinal & blockMask);
+                final int valueAddress = column.rank();
+                mask.load(valueAddress >>> blockShift);
+                return mask.matches.get(valueAddress & blockMask);
             }
 
             @Override
@@ -311,9 +311,9 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
                 if (minVal > upperValue || maxVal < lowerValue) {
                     return false; // no overlap
                 }
-                final int ordinal = column.rank();
-                mask.load(ordinal >>> blockShift);
-                return mask.matches.get(ordinal & blockMask);
+                final int valueAddress = column.rank();
+                mask.load(valueAddress >>> blockShift);
+                return mask.matches.get(valueAddress & blockMask);
             }
 
             @Override
@@ -391,27 +391,27 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
             }
         }
 
-        /** The first ordinal at or after {@code ordinal} that does not match, in ordinal space. */
-        int runEnd(int ordinal) {
-            final int blockId = ordinal >>> blockShift;
+        /** The first value address at or after {@code valueAddress} that does not match, in value-address space. */
+        int runEnd(int valueAddress) {
+            final int blockId = valueAddress >>> blockShift;
             // docIDRunEnd may be called on an unconfirmed candidate, so never claim a run from a non-match.
-            if (maskBlock == blockId && matches.get(ordinal & blockMask)) {
-                return (blockId << blockShift) + nextClearBit((ordinal & blockMask) + 1, matches);
+            if (maskBlock == blockId && matches.get(valueAddress & blockMask)) {
+                return (blockId << blockShift) + nextClearBit((valueAddress & blockMask) + 1, matches);
             }
-            return ordinal;
+            return valueAddress;
         }
     }
 
     /**
      * The end of the run of matching documents at the iterator's current position: the lesser of how far
-     * the values keep matching, from the block mask in ordinal space, and how far the documents stay
+     * the values keep matching, from the block mask in value-address space, and how far the documents stay
      * present, from the iterator in document space.
      */
     private int matchingRunEnd(ColumnIterator column, BlockMask mask) throws IOException {
         final int doc = column.docID();
-        final int ordinal = column.rank();
-        final int matchingOrdinals = mask.runEnd(ordinal) - ordinal;
-        return Math.min(column.docIDRunEnd(), Math.min(doc + matchingOrdinals, maxDoc));
+        final int valueAddress = column.rank();
+        final int matchingValueAddresses = mask.runEnd(valueAddress) - valueAddress;
+        return Math.min(column.docIDRunEnd(), Math.min(doc + matchingValueAddresses, maxDoc));
     }
 
     /** First clear (0) bit at or after {@code from}; {@code matches.length()} if none. */

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/ColumnarNumericBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/ColumnarNumericBinaryDocValues.java
@@ -67,7 +67,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
 
     @Override
     public BytesRef binaryValue() throws IOException {
-        final int rank = iterator.index();
+        final int rank = iterator.rank();
         final long first = reader.firstOrdinal(rank);
         final long count = reader.valueCount(rank);
         if (values.length < count) {
@@ -151,7 +151,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
 
             private int position(int doc) {
                 if (doc != DocIdSetIterator.NO_MORE_DOCS) {
-                    int rank = iterator.index();
+                    int rank = iterator.rank();
                     first = reader.firstOrdinal(rank);
                     count = reader.valueCount(rank);
                     upto = 0;
@@ -234,7 +234,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
     private void maskIntoBitSet(ColumnIterator column, BlockMask mask, int upTo, FixedBitSet bitSet, int offset) throws IOException {
         int doc = column.docID();
         while (doc < upTo) {
-            final int ordinal = column.index();
+            final int ordinal = column.rank();
             final int runEnd = Math.min(column.docIDRunEnd(), upTo);
             if (runEnd - doc == 1) {
                 // A single document: setting the bit directly is cheaper than the block-at-a-time path.
@@ -265,7 +265,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
         return new TwoPhaseIterator(column) {
             @Override
             public boolean matches() throws IOException {
-                final int ordinal = column.index();
+                final int ordinal = column.rank();
                 mask.load(ordinal >>> blockShift);
                 return mask.matches.get(ordinal & blockMask);
             }
@@ -311,7 +311,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
                 if (minVal > upperValue || maxVal < lowerValue) {
                     return false; // no overlap
                 }
-                final int ordinal = column.index();
+                final int ordinal = column.rank();
                 mask.load(ordinal >>> blockShift);
                 return mask.matches.get(ordinal & blockMask);
             }
@@ -409,7 +409,7 @@ public final class ColumnarNumericBinaryDocValues extends BinaryDocValues {
      */
     private int matchingRunEnd(ColumnIterator column, BlockMask mask) throws IOException {
         final int doc = column.docID();
-        final int ordinal = column.index();
+        final int ordinal = column.rank();
         final int matchingOrdinals = mask.runEnd(ordinal) - ordinal;
         return Math.min(column.docIDRunEnd(), Math.min(doc + matchingOrdinals, maxDoc));
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/NumericColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/NumericColumnReader.java
@@ -77,7 +77,7 @@ public final class NumericColumnReader {
         this.blockBuffer = new long[meta.blockSize()];
     }
 
-    /** A fresh iterator over the documents that have a value; {@link ColumnIterator#index()} is the rank. */
+    /** A fresh iterator over the documents that have a value; {@link ColumnIterator#rank()} is the rank. */
     public ColumnIterator iterator() throws IOException {
         return iteratorReader.iterator();
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/NumericColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/numeric/NumericColumnReader.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 /**
  * Reads a numeric column written by {@link NumericColumnWriter}, single- or multi-valued.
  *
- * <p>Values are addressed by ordinal within one block-encoded store. A document maps to its value
- * ordinals through {@link #iterator()}: single-valued columns map a document's rank
- * straight to its ordinal, while multi-valued columns look the range up in the value-address table.
- * A block is decoded whole into a reusable buffer with a single-block cache; nothing
+ * <p>Values are addressed by <b>value address</b> — a value's 0-based position in the block-encoded store, in
+ * {@code [0, numValues)}. A document maps to its value addresses through {@link #iterator()}: a single-valued
+ * column maps a document's rank straight to its value address, while a multi-valued one looks the range up in
+ * the value-address table. A block is decoded whole into a reusable buffer with a single-block cache; nothing
  * column-proportional is held on the heap (offset tables are read on demand from the mapped input).
  */
 public final class NumericColumnReader {
@@ -77,21 +77,21 @@ public final class NumericColumnReader {
         this.blockBuffer = new long[meta.blockSize()];
     }
 
-    /** A fresh iterator over the documents that have a value; {@link ColumnIterator#rank()} is the rank. */
+    /** A fresh iterator over the documents that have a value; positioned by {@link ColumnIterator#rank()}. */
     public ColumnIterator iterator() throws IOException {
         return iteratorReader.iterator();
     }
 
     /**
-     * Whether any document holds more than one value. A single-valued column maps a rank straight to an
-     * ordinal.
+     * Whether any document holds more than one value. A single-valued column maps a rank straight to a value
+     * address.
      */
     public boolean multiValued() {
         return valueAddresses != null;
     }
 
-    /** The ordinal of a document's first value, given its rank. */
-    public long firstOrdinal(int rank) {
+    /** The value address of a document's first value, given its rank. */
+    public long firstValueAddress(int rank) {
         return valueAddresses == null ? rank : valueAddresses.get(rank);
     }
 
@@ -100,11 +100,11 @@ public final class NumericColumnReader {
         return valueAddresses == null ? 1 : valueAddresses.get(rank + 1) - valueAddresses.get(rank);
     }
 
-    /** The value at {@code ordinal} in {@code [0, numValues)}. */
-    public long valueForOrdinal(long ordinal) throws IOException {
-        long block = ordinal / meta.blockSize();
+    /** The value at {@code valueAddress} in {@code [0, numValues)}. */
+    public long valueAt(long valueAddress) throws IOException {
+        long block = valueAddress / meta.blockSize();
         ensureBlock(block);
-        return blockBuffer[(int) (ordinal - block * meta.blockSize())];
+        return blockBuffer[(int) (valueAddress - block * meta.blockSize())];
     }
 
     /** Values per encoding block. */

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -43,12 +43,12 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues {
      */
     @Override
     public BytesRef binaryValue() throws IOException {
-        final int index = iterator.rank();
-        assert reader.valueCount(index) == 1
+        final int rank = iterator.rank();
+        assert reader.valueCount(rank) == 1
             : "multi-valued string column reached binaryValue with "
-                + reader.valueCount(index)
+                + reader.valueCount(rank)
                 + " values; this surface carries one value per document";
-        return reader.valueAt(reader.firstValueAddress(index));
+        return reader.valueAt(reader.firstValueAddress(rank));
     }
 
     @Override
@@ -123,9 +123,9 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues {
 
             private int position(int doc) {
                 if (doc != DocIdSetIterator.NO_MORE_DOCS) {
-                    int index = iterator.rank();
-                    first = reader.firstValueAddress(index);
-                    count = reader.valueCount(index);
+                    int rank = iterator.rank();
+                    first = reader.firstValueAddress(rank);
+                    count = reader.valueCount(rank);
                     upto = 0;
                 }
                 return doc;

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ColumnarStringBinaryDocValues.java
@@ -43,7 +43,7 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues {
      */
     @Override
     public BytesRef binaryValue() throws IOException {
-        final int index = iterator.index();
+        final int index = iterator.rank();
         assert reader.valueCount(index) == 1
             : "multi-valued string column reached binaryValue with "
                 + reader.valueCount(index)
@@ -123,7 +123,7 @@ public final class ColumnarStringBinaryDocValues extends BinaryDocValues {
 
             private int position(int doc) {
                 if (doc != DocIdSetIterator.NO_MORE_DOCS) {
-                    int index = iterator.index();
+                    int index = iterator.rank();
                     first = reader.firstValueAddress(index);
                     count = reader.valueCount(index);
                     upto = 0;

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/StringColumnReader.java
@@ -44,7 +44,7 @@ public final class StringColumnReader {
         this.values = meta.numDocsWithField() == 0 ? null : meta.values().open(data);
     }
 
-    /** A fresh iterator over the documents that have a value; positioned by {@link ColumnIterator#index()}. */
+    /** A fresh iterator over the documents that have a value; positioned by {@link ColumnIterator#rank()}. */
     public ColumnIterator iterator() throws IOException {
         return iteratorReader.iterator();
     }

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ValueStream.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/string/ValueStream.java
@@ -243,7 +243,7 @@ public final class ValueStream {
         }
     }
 
-    /** Random access by index; a block is decoded once and its value bounds kept for the next lookup. */
+    /** Random access by value address; a block is decoded once and its value bounds kept for the next lookup. */
     public static final class Reader {
 
         private final ChunkedBytesReader chunks;
@@ -269,12 +269,12 @@ public final class ValueStream {
             return numValues;
         }
 
-        /** Points {@code dst} at value {@code index}; the bytes are valid until the next call. */
-        public void get(long index, BytesRef dst) throws IOException {
-            assert index >= 0 && index < numValues : index + " out of [0, " + numValues + ")";
-            final long blockIndex = index / valuesPerBlock;
+        /** Points {@code dst} at the value at {@code valueAddress}; the bytes are valid until the next call. */
+        public void get(long valueAddress, BytesRef dst) throws IOException {
+            assert valueAddress >= 0 && valueAddress < numValues : valueAddress + " out of [0, " + numValues + ")";
+            final long blockIndex = valueAddress / valuesPerBlock;
             ensureBlock(blockIndex);
-            final int within = (int) (index - blockIndex * valuesPerBlock);
+            final int within = (int) (valueAddress - blockIndex * valuesPerBlock);
             dst.bytes = block.bytes;
             dst.offset = starts[within];
             dst.length = lengths[within];

--- a/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/ColumnIterator.java
+++ b/libs/columnar/src/main/java/org/elasticsearch/columnar/substrate/ColumnIterator.java
@@ -18,8 +18,14 @@ import java.util.Arrays;
 
 /**
  * Iterates the documents that have a value for a field, and for the current document exposes its
- * value ordinal via {@link #index()} — the 0-based position among all documents that have a value.
- * The value layer uses that ordinal to locate the document's bytes in the substrate.
+ * <b>rank</b> via {@link #rank()} — the 0-based position of that document among the documents that have a
+ * value. The value layer turns a rank into a value address to locate the document's bytes in the substrate.
+ *
+ * <p>A rank identifies a <em>document</em>, not a value: it is a position in the sequence of documents that
+ * have one. Two documents holding identical bytes have different ranks, and a rank says nothing about what its
+ * document's value is. That is why it is not a "value ordinal" — the substrate does not look at values at all.
+ * Secondarily, <em>ordinal</em> is already the term id a dictionary assigns, following Lucene, so a dictionary
+ * layout would otherwise put two unrelated numbers under one name.
  *
  * <p>This is a {@link DocIdSetIterator}, so range and dense-loading code paths (including
  * {@link #intoBitSet}) consume it directly. Concrete shapes are chosen by the reader from
@@ -30,11 +36,11 @@ public abstract class ColumnIterator extends DocIdSetIterator {
     /** Written by {@link #ranks} for a document that has no value. */
     public static final int NO_RANK = -1;
 
-    /** The current document's value ordinal. */
-    public abstract int index();
+    /** The current document's rank. */
+    public abstract int rank();
 
     /**
-     * Resolves {@code docs[offset..offset + count)} to their value ordinals, writing them to
+     * Resolves {@code docs[offset..offset + count)} to their ranks, writing them to
      * {@code ranks[0..count)}. Document ids must be ascending with no duplicates; a document with no
      * value gets {@link #NO_RANK}.
      *
@@ -44,12 +50,12 @@ public abstract class ColumnIterator extends DocIdSetIterator {
      */
     public void ranks(int[] docs, int offset, int count, int[] ranks) throws IOException {
         for (int i = 0; i < count; i++) {
-            ranks[i] = advanceExact(docs[offset + i]) ? index() : NO_RANK;
+            ranks[i] = advanceExact(docs[offset + i]) ? rank() : NO_RANK;
         }
     }
 
     /**
-     * Whether every document has a value, so a document id equals its own value ordinal. The
+     * Whether every document has a value, so a document id equals its own rank. The
      * vectorized range and bulk-read fast paths gate on this: only a dense column maps a value block
      * directly onto a contiguous doc-id window.
      */
@@ -80,7 +86,7 @@ public abstract class ColumnIterator extends DocIdSetIterator {
         private int doc = -1;
 
         @Override
-        public int index() {
+        public int rank() {
             return -1;
         }
 
@@ -116,7 +122,7 @@ public abstract class ColumnIterator extends DocIdSetIterator {
     }
 
     /**
-     * Every document has a value, so the document id is its own value ordinal and no per-document
+     * Every document has a value, so the document id is its own rank and no per-document
      * data is stored. {@link #intoBitSet} fills the requested range in one shot.
      */
     private static final class Dense extends ColumnIterator {
@@ -133,11 +139,11 @@ public abstract class ColumnIterator extends DocIdSetIterator {
         }
 
         @Override
-        public int index() {
+        public int rank() {
             return doc;
         }
 
-        /** A document id is its own ordinal, so the batch resolves with no I/O and no iterator state. */
+        /** A document id is its own rank, so the batch resolves with no I/O and no iterator state. */
         @Override
         public void ranks(int[] docs, int offset, int count, int[] ranks) {
             for (int i = 0; i < count; i++) {
@@ -199,13 +205,13 @@ public abstract class ColumnIterator extends DocIdSetIterator {
         }
 
         @Override
-        public int index() {
+        public int rank() {
             return disi.index();
         }
 
         /**
          * Resolves a run of documents per {@link IndexedDISI#advanceExact} rather than one each: every
-         * document in {@code [docID(), runEnd)} is present, so their ordinals are consecutive from the one
+         * document in {@code [docID(), runEnd)} is present, so their ranks are consecutive from the one
          * just read and follow by arithmetic.
          */
         @Override
@@ -219,7 +225,7 @@ public abstract class ColumnIterator extends DocIdSetIterator {
                 }
                 final int rank = disi.index();
                 ranks[i++] = rank;
-                // Documents up to runEnd are known present, so their ordinals need no further advancing.
+                // Documents up to runEnd are known present, so their ranks need no further advancing.
                 final int runEnd = disi.docIDRunEnd();
                 while (i < count && docs[offset + i] < runEnd) {
                     ranks[i] = rank + (docs[offset + i] - doc);

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericColumnTests.java
@@ -199,7 +199,7 @@ public class NumericColumnTests extends ESTestCase {
 
                 ColumnIterator iterator = reader.iterator();
                 for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
-                    int rank = iterator.index();
+                    int rank = iterator.rank();
                     long first = reader.firstOrdinal(rank);
                     long count = reader.valueCount(rank);
                     assertEquals("value count at doc " + doc, docValues[doc].length, count);

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericColumnTests.java
@@ -200,12 +200,12 @@ public class NumericColumnTests extends ESTestCase {
                 ColumnIterator iterator = reader.iterator();
                 for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
                     int rank = iterator.rank();
-                    long first = reader.firstOrdinal(rank);
+                    long first = reader.firstValueAddress(rank);
                     long count = reader.valueCount(rank);
                     assertEquals("value count at doc " + doc, docValues[doc].length, count);
                     for (int i = 0; i < count; i++) {
                         // exact written order, never sorted
-                        assertEquals("doc " + doc + " value " + i, docValues[doc][i], reader.valueForOrdinal(first + i));
+                        assertEquals("doc " + doc + " value " + i, docValues[doc][i], reader.valueAt(first + i));
                     }
                 }
             }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericPipelineSelectorTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericPipelineSelectorTests.java
@@ -192,7 +192,7 @@ public class NumericPipelineSelectorTests extends ESTestCase {
                 final ColumnIterator iterator = reader.iterator();
                 int idx = 0;
                 for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
-                    assertEquals(values[idx++], reader.valueForOrdinal(reader.firstOrdinal(iterator.index())));
+                    assertEquals(values[idx++], reader.valueForOrdinal(reader.firstOrdinal(iterator.rank())));
                 }
             }
             return read;

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericPipelineSelectorTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/numeric/NumericPipelineSelectorTests.java
@@ -192,7 +192,7 @@ public class NumericPipelineSelectorTests extends ESTestCase {
                 final ColumnIterator iterator = reader.iterator();
                 int idx = 0;
                 for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
-                    assertEquals(values[idx++], reader.valueForOrdinal(reader.firstOrdinal(iterator.rank())));
+                    assertEquals(values[idx++], reader.valueAt(reader.firstValueAddress(iterator.rank())));
                 }
             }
             return read;

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
@@ -247,7 +247,7 @@ public class StringColumnTests extends ColumnarStringTestCase {
             int seenDocs = 0;
             ColumnIterator iterator = reader.iterator();
             for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
-                int index = iterator.index();
+                int index = iterator.rank();
                 assertEquals("value count at doc " + doc, 1, reader.valueCount(index));
                 BytesRef actual = reader.valueAt(reader.firstValueAddress(index));
                 assertEquals("doc " + doc, docValues[doc], actual);

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/string/StringColumnTests.java
@@ -157,7 +157,6 @@ public class StringColumnTests extends ColumnarStringTestCase {
         assertColumn(docs);
     }
 
-    /** Writes {@code docValues} as a string column, reads it back, and asserts every value round-trips in order. */
     /**
      * A value larger than the bytes a chunk is meant to hold. A chunk closes only on a block boundary, so it
      * has to grow past its target rather than split the value across two chunks.
@@ -229,6 +228,7 @@ public class StringColumnTests extends ColumnarStringTestCase {
         assertColumn(mixed);
     }
 
+    /** Writes {@code docValues} as a string column, reads it back, and asserts every value round-trips in order. */
     private void assertColumn(BytesRef[] docValues) throws IOException {
         assertColumn(docValues, randomValidBlockSize());
     }

--- a/libs/columnar/src/test/java/org/elasticsearch/columnar/substrate/ColumnIteratorTests.java
+++ b/libs/columnar/src/test/java/org/elasticsearch/columnar/substrate/ColumnIteratorTests.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 /**
  * Round-trips the column iterator through a real {@link Directory} for the empty, dense, and sparse
- * shapes, checking that iteration, value ordinals ({@link ColumnIterator#index()}),
+ * shapes, checking that iteration, ranks ({@link ColumnIterator#rank()}),
  * {@link ColumnIterator#advanceExact}, and {@link ColumnIterator#intoBitSet} all agree with a
  * reference {@link FixedBitSet} of the documents that have a value.
  */
@@ -160,7 +160,7 @@ public class ColumnIteratorTests extends ESTestCase {
         BitSetIterator reference = new BitSetIterator(expected, cardinality);
         for (int doc = reference.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = reference.nextDoc()) {
             assertEquals(doc, iterator.nextDoc());
-            assertEquals("value ordinal at doc " + doc, rank, iterator.index());
+            assertEquals("rank at doc " + doc, rank, iterator.rank());
             rank++;
         }
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
@@ -174,17 +174,17 @@ public class ColumnIteratorTests extends ESTestCase {
             boolean present = expected.get(doc);
             assertEquals("iterator at doc " + doc, present, iterator.advanceExact(doc));
             if (present) {
-                assertEquals("value ordinal at doc " + doc, seen, iterator.index());
+                assertEquals("rank at doc " + doc, seen, iterator.rank());
                 seen++;
             }
         }
     }
 
     /**
-     * Bulk {@link ColumnIterator#ranks} agrees with the per-document {@code advanceExact}/{@code index()}
+     * Bulk {@link ColumnIterator#ranks} agrees with the per-document {@code advanceExact}/{@code rank()}
      * pair it replaces, over batches that mix present and absent documents. The sparse shape is the one
      * that can disagree: it resolves whole runs arithmetically from {@code docIDRunEnd()} rather than
-     * advancing to each document, so a run reported too long would silently hand back wrong ordinals.
+     * advancing to each document, so a run reported too long would silently hand back wrong ranks.
      */
     private void assertRanks(ColumnIteratorReader reader, FixedBitSet expected, int maxDoc) throws IOException {
         final int[] expectedRank = new int[maxDoc];
@@ -212,7 +212,7 @@ public class ColumnIteratorTests extends ESTestCase {
             final int[] ranks = new int[length];
             reader.iterator().ranks(docs, offset, length, ranks);
             for (int i = 0; i < length; i++) {
-                assertEquals("ordinal of doc " + docs[offset + i], expectedRank[docs[offset + i]], ranks[i]);
+                assertEquals("rank of doc " + docs[offset + i], expectedRank[docs[offset + i]], ranks[i]);
             }
         }
     }
@@ -227,7 +227,7 @@ public class ColumnIteratorTests extends ESTestCase {
         for (int doc = 0; doc < maxDoc; doc++) {
             if (expected.get(doc)) {
                 assertTrue("doc " + doc + " has a value but advanceExact says otherwise", iterator.advanceExact(doc));
-                assertEquals("ordinal at doc " + doc, rank, iterator.index());
+                assertEquals("rank at doc " + doc, rank, iterator.rank());
                 rank++;
             }
         }


### PR DESCRIPTION
Reading a value in `libs/columnar` walks three distinct positions, and each was going by more than one name:

```
doc id  ──presence──▶  rank  ──value-address table──▶  value address  ──block──▶  bytes
```

Renames only — no behaviour change, no format change.

### `rank`, not `index`

`ColumnIterator.index()` is back to `rank()`, matching the four other places the class already used that word: the bulk method `ranks`, the sentinel `NO_RANK`, and `Sparse`'s own local. Its javadocs called the value a "value ordinal", which is wrong rather than merely inconsistent — a rank identifies a **document**, not a value. Two documents holding identical bytes get different ranks, and a rank says nothing about what its document's value is; the substrate never looks at values at all.

### `value address`, not `ordinal`

`NumericColumnReader.firstOrdinal`/`valueForOrdinal` are now `firstValueAddress`/`valueAt`, matching `StringColumnReader`, which already had both names. The metadata field they read was already called `valueAddresses`, so the accessors were the outliers. `ColumnarNumericBinaryDocValues` carried the same word through its locals and its run-detection comments, down to reasoning in "ordinal space" about a mask indexed by value address.

`ordinal` is left meaning only what Lucene means by it — a term id a dictionary assigns — which is why `NumericBlockEncoder.encodeOrdinals` keeps its name. Nothing is an ordinal today, since no shipped layout has a dictionary.

Also swept up: the string binary surface named a rank `index`, and `ValueStream.get` took an `index` that is a value address. Both had a caller passing `rank()` into a parameter called `index`, which is the mechanism by which this spreads.

### Glossary

`README.md` gains a terms table, because the root cause is structural rather than careless: in a single-valued column a rank and a value address are **numerically equal**, so nothing goes wrong until a multi-valued or dictionary layout makes them diverge — which is exactly when it becomes expensive to untangle. The table gives each position its range, and lists `ordinal` as *reserved* rather than omitting it, since it is the word a reader reaches for first.

It also covers the storage vocabulary that had the same problem: `block` (values, an encoding quantum) against `chunk` (bytes, a compression unit).

Two things the glossary contradicted, corrected here: "Presence" was documented as giving a document its "value ordinal", which is a rank; and the `STRING` bullet described `binaryValue()` as re-emitting a `StringBinaryPayload`, which no longer exists — a lone keyword value is handed back as the bytes the mapper wrote.
