### PR TITLE
Add full name and email to audit MapMessage

### DIFF
--- a/docs/changelog/157439.yaml
+++ b/docs/changelog/157439.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 157439
+summary: Add full name and email to audit `MapMessage`
+type: enhancement

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -184,6 +184,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     public static final String EVENT_TYPE_FIELD_NAME = "event.type";
     public static final String EVENT_ACTION_FIELD_NAME = "event.action";
     public static final String PRINCIPAL_FIELD_NAME = "user.name";
+    public static final String PRINCIPAL_FULL_NAME_FIELD_NAME = "user.full_name";
+    public static final String PRINCIPAL_EMAIL_FIELD_NAME = "user.email";
     public static final String PRINCIPAL_RUN_BY_FIELD_NAME = "user.run_by.name";
     public static final String PRINCIPAL_RUN_AS_FIELD_NAME = "user.run_as.name";
     public static final String PRINCIPAL_REALM_FIELD_NAME = "user.realm";
@@ -1647,9 +1649,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         }
 
         LogEntryBuilder withRunAsSubject(Authentication authentication) {
-            logEntry.with(PRINCIPAL_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
+            final User authenticatingUser = authentication.getAuthenticatingSubject().getUser();
+            logEntry.with(PRINCIPAL_FIELD_NAME, authenticatingUser.principal())
                 .with(PRINCIPAL_REALM_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getName())
                 .with(PRINCIPAL_RUN_AS_FIELD_NAME, authentication.getEffectiveSubject().getUser().principal());
+            addUserFullNameAndEmail(logEntry, authenticatingUser);
             if (authentication.getAuthenticatingSubject().getRealm().getDomain() != null) {
                 logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getDomain().name());
             }
@@ -1729,7 +1733,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
 
         static void addAuthenticationFieldsToLogEntry(StringMapMessage logEntry, Authentication authentication) {
             assert false == authentication.isCloudApiKey() : "audit logging for Cloud API keys is not supported";
-            logEntry.with(PRINCIPAL_FIELD_NAME, authentication.getEffectiveSubject().getUser().principal());
+            final User effectiveUser = authentication.getEffectiveSubject().getUser();
+            logEntry.with(PRINCIPAL_FIELD_NAME, effectiveUser.principal());
+            addUserFullNameAndEmail(logEntry, effectiveUser);
             logEntry.with(AUTHENTICATION_TYPE_FIELD_NAME, authentication.getAuthenticationType().toString());
             if (authentication.isApiKey() || authentication.isCrossClusterAccess()) {
                 logEntry.with(
@@ -1802,6 +1808,19 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                             + "_"
                             + authentication.getAuthenticatingSubject().getMetadata().get(TOKEN_SOURCE_FIELD)
                     );
+            }
+        }
+
+        /**
+         * Emits ECS/OTel {@code user.full_name} and {@code user.email} for the user already recorded as {@code user.name}.
+         * Not included in the PatternLayout or the final logfile output.
+         */
+        private static void addUserFullNameAndEmail(StringMapMessage logEntry, User user) {
+            if (user.fullName() != null) {
+                logEntry.with(PRINCIPAL_FULL_NAME_FIELD_NAME, user.fullName());
+            }
+            if (user.email() != null) {
+                logEntry.with(PRINCIPAL_EMAIL_FIELD_NAME, user.email());
             }
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -169,6 +169,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -2068,6 +2069,36 @@ public class LoggingAuditTrailTests extends ESTestCase {
         updateLoggerSettings(Settings.builder().put(settings).put("xpack.security.audit.logfile.events.exclude", "access_granted").build());
         auditTrail.accessGranted(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
+    }
+
+    public void testCustomizerSeesUserFullNameAndEmail() throws Exception {
+        final User user = new User("u1", new String[] { "r1" }, "Ada Lovelace", "ada@example.com", Map.of(), true);
+        final Authentication authentication = AuthenticationTestHelper.builder().user(user).build(false);
+        final AtomicBoolean rewriteRan = new AtomicBoolean();
+        final LoggingAuditTrail auditTrail = new LoggingAuditTrail(
+            settings,
+            clusterService,
+            logger,
+            threadContext,
+            new AuditLogCustomizer() {
+                @Override
+                public Message rewrite(AuditEventContext ctx, MapMessage<?, ?> entry) {
+                    assertThat(entry.get(LoggingAuditTrail.PRINCIPAL_FULL_NAME_FIELD_NAME), equalTo(user.fullName()));
+                    assertThat(entry.get(LoggingAuditTrail.PRINCIPAL_EMAIL_FIELD_NAME), equalTo(user.email()));
+                    rewriteRan.set(true);
+                    return entry;
+                }
+            }
+        );
+
+        auditTrail.accessGranted(
+            randomRequestId(),
+            authentication,
+            "_action",
+            new MockRequest(threadContext),
+            () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, user.roles())
+        );
+        assertTrue(rewriteRan.get());
     }
 
     public void testCustomizerCanSuppressAuditEntry() throws Exception {


### PR DESCRIPTION
Audit entries already carry `user.name` from the `User` on the authentication. Serverless (and any `AuditLogCustomizer`) also needs the human-readable name and email that already live on that `User`.

Emit `user.full_name` and `user.email` on the `MapMessage` only. They are not in the default `PatternLayout`, so the stateful logfile is unchanged.
