### PR TITLE
[ESQL] Pool parquet decompress buffers

### DIFF
--- a/docs/changelog/157281.yaml
+++ b/docs/changelog/157281.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157281
+summary: Charge Arrow pages against `MaxDirectMemorySize`
+type: enhancement

--- a/docs/changelog/157441.yaml
+++ b/docs/changelog/157441.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157441
+summary: Pool parquet decompress buffers
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -503,6 +503,10 @@ public class JvmInfo implements ReportingService.Info {
             return ByteSizeValue.ofBytes(heapMax);
         }
 
+        public ByteSizeValue getDirectMemoryMax() {
+            return ByteSizeValue.ofBytes(directMemoryMax);
+        }
+
         public ByteSizeValue getTotalMax() {
             return ByteSizeValue.ofBytes(heapMax + nonHeapMax + directMemoryMax);
         }

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmInfoTests.java
@@ -12,6 +12,8 @@ package org.elasticsearch.monitor.jvm;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
 public class JvmInfoTests extends ESTestCase {
 
     public void testUseG1GC() {
@@ -23,6 +25,10 @@ public class JvmInfoTests extends ESTestCase {
         } else {
             assertEquals("unknown", JvmInfo.jvmInfo().useG1GC());
         }
+    }
+
+    public void testDirectMemoryMax() {
+        assertThat(JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes(), greaterThanOrEqualTo(0L));
     }
 
     private boolean isG1GCEnabled() {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1152,7 +1152,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         chunks,
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator()
+                        blockFactory.arrowAllocator(),
+                        blockFactory.directBufferPool()
                     );
                     rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
                     triggerNextRowGroupPrefetch();
@@ -1326,7 +1327,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             phase1Chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.arrowAllocator(),
+            blockFactory.directBufferPool()
         );
         rowGroup = predicateStore;
         initPredicateColumnReaders();
@@ -1579,7 +1581,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             merged,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.arrowAllocator(),
+            blockFactory.directBufferPool()
         );
         rowsRemainingInGroup = rowGroup.getRowCount();
         initColumnReaders(null);
@@ -1639,7 +1642,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.arrowAllocator(),
+            blockFactory.directBufferPool()
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1152,8 +1152,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         chunks,
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator(),
-                        blockFactory.directBufferPool()
+                        blockFactory.directBuffers()
                     );
                     rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
                     triggerNextRowGroupPrefetch();
@@ -1327,8 +1326,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             phase1Chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator(),
-            blockFactory.directBufferPool()
+            blockFactory.directBuffers()
         );
         rowGroup = predicateStore;
         initPredicateColumnReaders();
@@ -1581,8 +1579,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             merged,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator(),
-            blockFactory.directBufferPool()
+            blockFactory.directBuffers()
         );
         rowsRemainingInGroup = rowGroup.getRowCount();
         initColumnReaders(null);
@@ -1642,8 +1639,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator(),
-            blockFactory.directBufferPool()
+            blockFactory.directBuffers()
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -720,8 +720,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                 prefetched,
                 storageObject,
                 reader.codecFactory(),
-                blockFactory.arrowAllocator(),
-                blockFactory.directBufferPool()
+                blockFactory.directBuffers()
             )
         ) {
             if (info.maxRepLevel() == 0) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -720,7 +720,8 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                 prefetched,
                 storageObject,
                 reader.codecFactory(),
-                blockFactory.arrowAllocator()
+                blockFactory.arrowAllocator(),
+                blockFactory.directBufferPool()
             )
         ) {
             if (info.maxRepLevel() == 0) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
@@ -17,7 +16,7 @@ import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.io.ParquetDecodingException;
-import org.elasticsearch.compute.data.arrow.DirectBufferPool;
+import org.elasticsearch.compute.data.arrow.DirectBuffers;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
@@ -40,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * data portion decompressed). Encryption and CRC verification are not supported.
  *
  * <p>Decompression uses one reusable {@link ArrowBuf} borrowed from the supplied
- * {@link DirectBufferPool}, exposed via {@link ArrowBuf#nioBuffer(long, int)} for the
+ * {@link DirectBuffers}, exposed via {@link ArrowBuf#nioBuffer(long, int)} for the
  * direct-to-direct JNI fast path. {@link #readPage()} overwrites that buffer. It grows only
  * when a later page needs more capacity — breaker residency is the high-water-mark page, not
  * the current page — and is returned to the pool on {@link #close()} so the next query can
@@ -61,13 +60,12 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     record CompressedPage(DataPage page, long firstRowIndex) {}
 
     private final BytesInputDecompressor decompressor;
-    private final BufferAllocator allocator;
-    private final DirectBufferPool decompBufferPool;
+    private final DirectBuffers buffers;
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
     // Reusable decompress-output buffer. Grown when a page needs more capacity; returned to
-    // decompBufferPool on close() so the next query reuses it. Overwritten in place across pages
+    // buffers.pool() on close() so the next query reuses it. Overwritten in place across pages
     // so we do not malloc/free per page — that churn is what retained glibc arenas after the
     // allocator balance had already returned to baseline.
     private ArrowBuf reusableDecompBuf;
@@ -80,15 +78,13 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     PrefetchedPageReader(
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
-        DirectBufferPool decompBufferPool,
+        DirectBuffers buffers,
         List<CompressedPage> compressedPages,
         DictionaryPage compressedDictionaryPage,
         long valueCount
     ) {
         this.decompressor = decompressor;
-        this.allocator = allocator;
-        this.decompBufferPool = Objects.requireNonNull(decompBufferPool, "decompBufferPool");
+        this.buffers = Objects.requireNonNull(buffers, "buffers");
         this.compressedPages = new ArrayDeque<>(compressedPages);
         this.compressedDictionaryPage = compressedDictionaryPage;
         this.valueCount = valueCount;
@@ -294,7 +290,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         ArrowBuf scratch = null;
         try {
             if (input.isDirect() == false) {
-                scratch = allocator.buffer(input.remaining());
+                scratch = buffers.buffer(input.remaining());
                 ByteBuffer directInput = scratch.nioBuffer(0, input.remaining());
                 directInput.put(input);
                 directInput.flip();
@@ -327,7 +323,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             // idle undersized buffers still useful to other columns.
             current.close();
         }
-        reusableDecompBuf = decompBufferPool.borrow(allocator, size);
+        reusableDecompBuf = buffers.borrow(size);
         return reusableDecompBuf.nioBuffer(0, size);
     }
 
@@ -341,6 +337,6 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         cachedDictionaryPage = null;
         ArrowBuf buf = reusableDecompBuf;
         reusableDecompBuf = null;
-        decompBufferPool.returnBuf(buf);
+        buffers.returnBuf(buf);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -17,14 +17,15 @@ import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.xpack.esql.datasources.spi.DirectMemoryDebug;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -38,11 +39,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * original page type ({@link DataPageV1} stays V1, {@link DataPageV2} stays V2 with only the
  * data portion decompressed). Encryption and CRC verification are not supported.
  *
- * <p>Decompression uses one reusable {@link ArrowBuf} from the supplied {@link BufferAllocator},
- * exposed via {@link ArrowBuf#nioBuffer(long, int)} for the direct-to-direct JNI fast path.
- * {@link #readPage()} overwrites that buffer. It grows only when a later page needs more
- * capacity — breaker residency is the high-water-mark page, not the current page — and is
- * released on {@link #close()}. Heap-backed compressed input still copies through a per-page
+ * <p>Decompression uses one reusable {@link ArrowBuf} borrowed from the supplied
+ * {@link DirectBufferPool}, exposed via {@link ArrowBuf#nioBuffer(long, int)} for the
+ * direct-to-direct JNI fast path. {@link #readPage()} overwrites that buffer. It grows only
+ * when a later page needs more capacity — breaker residency is the high-water-mark page, not
+ * the current page — and is returned to the pool on {@link #close()} so the next query can
+ * reuse it without a malloc. Heap-backed compressed input still copies through a per-page
  * scratch buffer; production prefetch already yields direct slices, so that path is idle.
  * Returned {@link DataPage}s and {@link BytesInput}s alias the current buffer and must not be
  * used after the next {@link #readPage()} or {@link #close()}.
@@ -60,12 +62,14 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     private final BytesInputDecompressor decompressor;
     private final BufferAllocator allocator;
+    private final DirectBufferPool decompBufferPool;
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
-    // Reusable decompress-output buffer. Grown when a page needs more capacity; released on
-    // close(). Overwritten in place across pages so we do not malloc/free per page — that churn
-    // is what retained glibc arenas after the allocator balance had already returned to baseline.
+    // Reusable decompress-output buffer. Grown when a page needs more capacity; returned to
+    // decompBufferPool on close() so the next query reuses it. Overwritten in place across pages
+    // so we do not malloc/free per page — that churn is what retained glibc arenas after the
+    // allocator balance had already returned to baseline.
     private ArrowBuf reusableDecompBuf;
 
     private DictionaryPage cachedDictionaryPage;
@@ -77,12 +81,14 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     PrefetchedPageReader(
         BytesInputDecompressor decompressor,
         BufferAllocator allocator,
+        DirectBufferPool decompBufferPool,
         List<CompressedPage> compressedPages,
         DictionaryPage compressedDictionaryPage,
         long valueCount
     ) {
         this.decompressor = decompressor;
         this.allocator = allocator;
+        this.decompBufferPool = Objects.requireNonNull(decompBufferPool, "decompBufferPool");
         this.compressedPages = new ArrayDeque<>(compressedPages);
         this.compressedDictionaryPage = compressedDictionaryPage;
         this.valueCount = valueCount;
@@ -305,27 +311,24 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
     }
 
+    /**
+     * Direct decompress output. Explicit {@code (index, length)}: ArrowBuf may round capacity up,
+     * but the codec's size sanity check expects {@code remaining() ==} declared decompressed size.
+     */
     private ByteBuffer allocateDirect(int size) {
-        if (reusableDecompBuf == null || reusableDecompBuf.capacity() < size) {
-            closeReusableDecompBuf();
-            reusableDecompBuf = allocator.buffer(size);
+        ArrowBuf current = reusableDecompBuf;
+        if (current != null && current.capacity() >= size) {
+            return current.nioBuffer(0, size);
         }
-        // Explicit (index, length): ArrowBuf may round capacity up, but the codec's size sanity
-        // check expects remaining() == declared decompressed size.
-        return reusableDecompBuf.nioBuffer(0, size);
-    }
-
-    private void closeReusableDecompBuf() {
-        if (reusableDecompBuf == null) {
-            return;
-        }
-        ArrowBuf buf = reusableDecompBuf;
         reusableDecompBuf = null;
-        try {
-            DirectMemoryDebug.poison(buf.nioBuffer(0, Math.toIntExact(buf.capacity())));
-        } finally {
-            buf.close();
+        if (current != null) {
+            // Known undersized: close it. Returning it then immediately borrowing a larger
+            // size would poll the same buf and free it anyway, and would also close other
+            // idle undersized buffers still useful to other columns.
+            current.close();
         }
+        reusableDecompBuf = decompBufferPool.borrow(allocator, size);
+        return reusableDecompBuf.nioBuffer(0, size);
     }
 
     @Override
@@ -336,6 +339,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // Drop the cached dictionary page reference. It is deliberately heap-backed (see
         // readDictionaryPage), so this is reference hygiene, not a buffer-lifetime requirement.
         cachedDictionaryPage = null;
-        closeReusableDecompBuf();
+        ArrowBuf buf = reusableDecompBuf;
+        reusableDecompBuf = null;
+        decompBufferPool.returnBuf(buf);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -318,10 +318,9 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
         reusableDecompBuf = null;
         if (current != null) {
-            // Known undersized: close it. Returning it then immediately borrowing a larger
-            // size would poll the same buf and free it anyway, and would also close other
-            // idle undersized buffers still useful to other columns.
-            current.close();
+            // Park the undersized buf. Closing it here is a glibc hand-back; the pool skips
+            // it on the larger borrow and only evicts when idle occupancy hits the cap.
+            buffers.returnBuf(current);
         }
         reusableDecompBuf = buffers.borrow(size);
         return reusableDecompBuf.nioBuffer(0, size);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -31,7 +30,7 @@ import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.elasticsearch.compute.data.UninitializedArrays;
-import org.elasticsearch.compute.data.arrow.DirectBufferPool;
+import org.elasticsearch.compute.data.arrow.DirectBuffers;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -95,11 +94,9 @@ final class PrefetchedRowGroupBuilder {
      *            or when an individual column lacks an offset index in the filtered path
      * @param codecFactory shared {@link PlainCompressionCodecFactory} used to build per-column
      *            decompressors
-     * @param allocator Arrow allocator used by {@link PrefetchedPageReader} to back native
-     *            decompression buffers; allocations are breaker-accounted via
+     * @param buffers Arrow allocator plus the node-lifetime decompress pool used by
+     *            {@link PrefetchedPageReader}; allocations are breaker-accounted via
      *            {@code BlockFactory.arrowAllocator()}'s {@code CircuitBreakerAllocationListener}
-     * @param decompBufferPool node-lifetime pool of decompress {@link org.apache.arrow.memory.ArrowBuf}s;
-     *            readers borrow on first page and return on close so the next query does not malloc
      */
     static PrefetchedPageReadStore build(
         BlockMetaData block,
@@ -111,8 +108,7 @@ final class PrefetchedRowGroupBuilder {
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks,
         StorageObject storageObject,
         CompressionCodecFactory codecFactory,
-        BufferAllocator allocator,
-        DirectBufferPool decompBufferPool
+        DirectBuffers buffers
     ) {
         Map<String, ColumnDescriptor> descriptorsByPath = new HashMap<>();
         for (ColumnDescriptor desc : projectedSchema.getColumns()) {
@@ -159,12 +155,11 @@ final class PrefetchedRowGroupBuilder {
                         source,
                         block.getRowCount(),
                         decompressor,
-                        allocator,
-                        decompBufferPool,
+                        buffers,
                         rowGroupOrdinal
                     );
                 } else {
-                    reader = buildSequential(column, primitiveType, source, decompressor, allocator, decompBufferPool, rowGroupOrdinal);
+                    reader = buildSequential(column, primitiveType, source, decompressor, buffers, rowGroupOrdinal);
                 }
                 readers.put(descriptor, reader);
             }
@@ -204,8 +199,7 @@ final class PrefetchedRowGroupBuilder {
         ColumnPageBytesSource source,
         long rowGroupRowCount,
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
-        DirectBufferPool decompBufferPool,
+        DirectBuffers buffers,
         int rowGroupOrdinal
     ) {
         DictionaryPage dictPage = readDictionaryPageIfPresent(column, source, rowGroupOrdinal);
@@ -235,7 +229,7 @@ final class PrefetchedRowGroupBuilder {
             pages.add(new PrefetchedPageReader.CompressedPage(decoded, pageStartRow));
             valueCount += decoded.getValueCount();
         }
-        return new PrefetchedPageReader(decompressor, allocator, decompBufferPool, pages, dictPage, valueCount);
+        return new PrefetchedPageReader(decompressor, buffers, pages, dictPage, valueCount);
     }
 
     /**
@@ -248,8 +242,7 @@ final class PrefetchedRowGroupBuilder {
         PrimitiveType primitiveType,
         ColumnPageBytesSource source,
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
-        DirectBufferPool decompBufferPool,
+        DirectBuffers buffers,
         int rowGroupOrdinal
     ) {
         long startingPos = column.getStartingPos();
@@ -289,7 +282,7 @@ final class PrefetchedRowGroupBuilder {
                     valueCount += page.getValueCount();
                 }
             }
-            return new PrefetchedPageReader(decompressor, allocator, decompBufferPool, pages, dictPage, valueCount);
+            return new PrefetchedPageReader(decompressor, buffers, pages, dictPage, valueCount);
         } catch (IOException e) {
             throw new IllegalArgumentException(
                 "Failed to read column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]: " + e.getMessage(),

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -31,6 +31,7 @@ import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.elasticsearch.compute.data.UninitializedArrays;
+import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -97,6 +98,8 @@ final class PrefetchedRowGroupBuilder {
      * @param allocator Arrow allocator used by {@link PrefetchedPageReader} to back native
      *            decompression buffers; allocations are breaker-accounted via
      *            {@code BlockFactory.arrowAllocator()}'s {@code CircuitBreakerAllocationListener}
+     * @param decompBufferPool node-lifetime pool of decompress {@link org.apache.arrow.memory.ArrowBuf}s;
+     *            readers borrow on first page and return on close so the next query does not malloc
      */
     static PrefetchedPageReadStore build(
         BlockMetaData block,
@@ -108,7 +111,8 @@ final class PrefetchedRowGroupBuilder {
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks,
         StorageObject storageObject,
         CompressionCodecFactory codecFactory,
-        BufferAllocator allocator
+        BufferAllocator allocator,
+        DirectBufferPool decompBufferPool
     ) {
         Map<String, ColumnDescriptor> descriptorsByPath = new HashMap<>();
         for (ColumnDescriptor desc : projectedSchema.getColumns()) {
@@ -156,10 +160,11 @@ final class PrefetchedRowGroupBuilder {
                         block.getRowCount(),
                         decompressor,
                         allocator,
+                        decompBufferPool,
                         rowGroupOrdinal
                     );
                 } else {
-                    reader = buildSequential(column, primitiveType, source, decompressor, allocator, rowGroupOrdinal);
+                    reader = buildSequential(column, primitiveType, source, decompressor, allocator, decompBufferPool, rowGroupOrdinal);
                 }
                 readers.put(descriptor, reader);
             }
@@ -200,6 +205,7 @@ final class PrefetchedRowGroupBuilder {
         long rowGroupRowCount,
         BytesInputDecompressor decompressor,
         BufferAllocator allocator,
+        DirectBufferPool decompBufferPool,
         int rowGroupOrdinal
     ) {
         DictionaryPage dictPage = readDictionaryPageIfPresent(column, source, rowGroupOrdinal);
@@ -229,7 +235,7 @@ final class PrefetchedRowGroupBuilder {
             pages.add(new PrefetchedPageReader.CompressedPage(decoded, pageStartRow));
             valueCount += decoded.getValueCount();
         }
-        return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
+        return new PrefetchedPageReader(decompressor, allocator, decompBufferPool, pages, dictPage, valueCount);
     }
 
     /**
@@ -243,6 +249,7 @@ final class PrefetchedRowGroupBuilder {
         ColumnPageBytesSource source,
         BytesInputDecompressor decompressor,
         BufferAllocator allocator,
+        DirectBufferPool decompBufferPool,
         int rowGroupOrdinal
     ) {
         long startingPos = column.getStartingPos();
@@ -282,7 +289,7 @@ final class PrefetchedRowGroupBuilder {
                     valueCount += page.getValueCount();
                 }
             }
-            return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
+            return new PrefetchedPageReader(decompressor, allocator, decompBufferPool, pages, dictPage, valueCount);
         } catch (IOException e) {
             throw new IllegalArgumentException(
                 "Failed to read column [" + column.getPath().toDotString() + "] in row group [" + rowGroupOrdinal + "]: " + e.getMessage(),

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
@@ -155,6 +155,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
                 page.releaseBlocks();
             }
         }
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero after random-order release", 0, breaker.getUsed());
     }
 
@@ -185,6 +186,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
             }
         }
         assertEquals(numRows, totalRows);
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero — a leaked cached BytesRefArray would show here", 0, breaker.getUsed());
     }
 
@@ -252,6 +254,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
             consumer.shutdown();
             assertTrue("consumer did not terminate", consumer.awaitTermination(10, TimeUnit.SECONDS));
         }
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero across all cross-driver iterations", 0, breaker.getUsed());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
@@ -155,7 +155,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
                 page.releaseBlocks();
             }
         }
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero after random-order release", 0, breaker.getUsed());
     }
 
@@ -186,7 +186,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
             }
         }
         assertEquals(numRows, totalRows);
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero — a leaked cached BytesRefArray would show here", 0, breaker.getUsed());
     }
 
@@ -254,7 +254,7 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
             consumer.shutdown();
             assertTrue("consumer did not terminate", consumer.awaitTermination(10, TimeUnit.SECONDS));
         }
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero across all cross-driver iterations", 0, breaker.getUsed());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -78,6 +78,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         }
         assertTrue("Should have read rows", totalRows > 0);
         assertTrue("Breaker should have been used for prefetch", breaker.peakUsed.get() > 0);
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero after iteration", 0, breaker.getUsed());
     }
 
@@ -107,6 +108,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 }
             }
         }
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero", 0, breaker.getUsed());
     }
 
@@ -129,6 +131,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertTrue("Should have read rows via sync fallback", totalRows > 0);
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero after iteration with failures", 0, breaker.getUsed());
     }
 
@@ -151,6 +154,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertTrue("Should have read rows", totalRows > 0);
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero", 0, breaker.getUsed());
         // The window buffer (DEFAULT_WINDOW_SIZE) is now tracked by the circuit breaker, so the
         // peak includes the window. Prefetch and decode allocations are still bounded by parquetData.length.
@@ -176,6 +180,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 page.releaseBlocks();
             }
         }
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero after early close", 0, breaker.getUsed());
     }
 
@@ -210,6 +215,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
             assertTrue("Should have read rows", totalRows > 0);
         });
+        pipeline.blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero after concurrent readers finish", 0, pipeline.breaker.getUsed());
         assertEquals(
             "Arrow allocator should return to baseline after concurrent readers finish",
@@ -248,6 +254,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 throw new AssertionError(e);
             }
         });
+        pipeline.blockFactory.directBufferPool().releaseIdle();
         assertEquals("Breaker should return to zero after concurrent early close", 0, pipeline.breaker.getUsed());
         assertEquals(
             "Arrow allocator should return to baseline after concurrent early close",

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -78,7 +78,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         }
         assertTrue("Should have read rows", totalRows > 0);
         assertTrue("Breaker should have been used for prefetch", breaker.peakUsed.get() > 0);
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero after iteration", 0, breaker.getUsed());
     }
 
@@ -108,7 +108,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 }
             }
         }
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero", 0, breaker.getUsed());
     }
 
@@ -131,7 +131,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertTrue("Should have read rows via sync fallback", totalRows > 0);
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero after iteration with failures", 0, breaker.getUsed());
     }
 
@@ -154,7 +154,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertTrue("Should have read rows", totalRows > 0);
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero", 0, breaker.getUsed());
         // The window buffer (DEFAULT_WINDOW_SIZE) is now tracked by the circuit breaker, so the
         // peak includes the window. Prefetch and decode allocations are still bounded by parquetData.length.
@@ -180,7 +180,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 page.releaseBlocks();
             }
         }
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero after early close", 0, breaker.getUsed());
     }
 
@@ -215,7 +215,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
             assertTrue("Should have read rows", totalRows > 0);
         });
-        pipeline.blockFactory.directBufferPool().releaseIdle();
+        pipeline.blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero after concurrent readers finish", 0, pipeline.breaker.getUsed());
         assertEquals(
             "Arrow allocator should return to baseline after concurrent readers finish",
@@ -254,7 +254,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 throw new AssertionError(e);
             }
         });
-        pipeline.blockFactory.directBufferPool().releaseIdle();
+        pipeline.blockFactory.directBuffers().releaseIdle();
         assertEquals("Breaker should return to zero after concurrent early close", 0, pipeline.breaker.getUsed());
         assertEquals(
             "Arrow allocator should return to baseline after concurrent early close",

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -39,13 +38,11 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
 
     private PlainCompressionCodecFactory codecFactory;
     private BlockFactory blockFactory;
-    private BufferAllocator allocator;
 
     @Before
     public void initCodecAndAllocator() {
         codecFactory = new PlainCompressionCodecFactory();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
     }
 
     @After
@@ -72,8 +69,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         DictionaryPage compressedDict = new DictionaryPage(BytesInput.from(payload), payload.length, 4, Encoding.PLAIN);
         PrefetchedPageReader reader = new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-            allocator,
-            blockFactory.directBufferPool(),
+            blockFactory.directBuffers(),
             List.of(),
             compressedDict,
             0
@@ -115,8 +111,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         );
         return new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-            allocator,
-            blockFactory.directBufferPool(),
+            blockFactory.directBuffers(),
             List.of(new PrefetchedPageReader.CompressedPage(page, -1L)),
             null,
             valueCount

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
@@ -73,6 +73,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         PrefetchedPageReader reader = new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
             allocator,
+            blockFactory.directBufferPool(),
             List.of(),
             compressedDict,
             0
@@ -115,6 +116,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         return new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
             allocator,
+            blockFactory.directBufferPool(),
             List.of(new PrefetchedPageReader.CompressedPage(page, -1L)),
             null,
             valueCount

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -18,6 +18,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +29,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
@@ -40,8 +42,9 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * direct memory grew monotonically across iterations.
  *
  * <p>After the fix, decompression buffers come from a {@link BufferAllocator}-managed
- * {@link org.apache.arrow.memory.ArrowBuf} that is released deterministically when the
- * reader is closed, so each iteration's peak goes back to the baseline within a small delta.
+ * {@link org.apache.arrow.memory.ArrowBuf} returned to {@link DirectBufferPool} on reader
+ * close. Later iterations reuse that buffer: allocator balance after the first cycle is the
+ * pooled size, not zero, and stays flat.
  */
 public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
 
@@ -73,12 +76,15 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
 
         long directBaseline = directMemoryUsedBytes();
         long allocBaseline = allocator.getAllocatedMemory();
+        DirectBufferPool pool = blockFactory.directBufferPool();
+        long pooledAfterFirst = -1L;
 
         for (int i = 0; i < ITERATIONS; i++) {
             try (
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                     allocator,
+                    pool,
                     fixture.copyPages(),
                     null,
                     (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
@@ -89,7 +95,12 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                     consume(page);
                 }
             }
-            assertEquals("allocator must return to baseline after cycle " + i, allocBaseline, allocator.getAllocatedMemory());
+            if (i == 0) {
+                pooledAfterFirst = allocator.getAllocatedMemory();
+                assertThat("first cycle must park a decompress buffer", pooledAfterFirst, greaterThan(allocBaseline));
+            } else {
+                assertEquals("allocator must stay flat after cycle " + i, pooledAfterFirst, allocator.getAllocatedMemory());
+            }
         }
 
         long after = directMemoryUsedBytes();
@@ -104,22 +115,23 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                 + " pages; expected <= "
                 + (MAX_DIRECT_GROWTH_BYTES >>> 20)
                 + " MB. After the fix, decompressToDirectBuffer allocates from a BufferAllocator-managed"
-                + " ArrowBuf released by PrefetchedPageReader.close().",
+                + " ArrowBuf returned to DirectBufferPool by PrefetchedPageReader.close().",
             grew,
             lessThanOrEqualTo(MAX_DIRECT_GROWTH_BYTES)
         );
     }
 
     /**
-     * Concurrent zstd decompress loops must not accumulate native memory. Arrow accounting is
-     * exact (zero after join); MXBean remains a coarse JVM-wide ceiling matching the
-     * single-threaded regression.
+     * Concurrent zstd decompress loops must not accumulate native memory beyond one pooled
+     * buffer per reader. MXBean remains a coarse JVM-wide ceiling matching the single-threaded
+     * regression.
      */
     public void testDirectMemoryStableUnderConcurrentReads() throws Exception {
         ZstdPageFixture fixture = compressedZstdPages();
         long allocBaseline = allocator.getAllocatedMemory();
         long directBaseline = directMemoryUsedBytes();
 
+        DirectBufferPool pool = blockFactory.directBufferPool();
         startInParallel(CONCURRENT_READERS, i -> {
             try {
                 for (int iter = 0; iter < CONCURRENT_ITERS_PER_READER; iter++) {
@@ -127,6 +139,7 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                         PrefetchedPageReader reader = new PrefetchedPageReader(
                             codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                             allocator,
+                            pool,
                             fixture.copyPages(),
                             null,
                             (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
@@ -142,7 +155,13 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                 throw new AssertionError(e);
             }
         });
-        assertEquals("allocator must return to baseline after concurrent reads", allocBaseline, allocator.getAllocatedMemory());
+        long after = allocator.getAllocatedMemory();
+        assertThat("concurrent readers park at least one decompress buffer", after, greaterThan(allocBaseline));
+        assertThat(
+            "concurrent readers must not exceed one buffer per reader",
+            after,
+            lessThanOrEqualTo(allocBaseline + (long) CONCURRENT_READERS * PAGE_PAYLOAD_BYTES)
+        );
         long grew = directMemoryUsedBytes() - directBaseline;
         assertThat(
             "direct-memory grew "

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -18,7 +18,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -42,7 +41,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * direct memory grew monotonically across iterations.
  *
  * <p>After the fix, decompression buffers come from a {@link BufferAllocator}-managed
- * {@link org.apache.arrow.memory.ArrowBuf} returned to {@link DirectBufferPool} on reader
+ * {@link org.apache.arrow.memory.ArrowBuf} returned to {@link org.elasticsearch.compute.data.arrow.DirectBufferPool} on reader
  * close. Later iterations reuse that buffer: allocator balance after the first cycle is the
  * pooled size, not zero, and stays flat.
  */
@@ -76,15 +75,13 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
 
         long directBaseline = directMemoryUsedBytes();
         long allocBaseline = allocator.getAllocatedMemory();
-        DirectBufferPool pool = blockFactory.directBufferPool();
         long pooledAfterFirst = -1L;
 
         for (int i = 0; i < ITERATIONS; i++) {
             try (
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                    allocator,
-                    pool,
+                    blockFactory.directBuffers(),
                     fixture.copyPages(),
                     null,
                     (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
@@ -131,15 +128,13 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
         long allocBaseline = allocator.getAllocatedMemory();
         long directBaseline = directMemoryUsedBytes();
 
-        DirectBufferPool pool = blockFactory.directBufferPool();
         startInParallel(CONCURRENT_READERS, i -> {
             try {
                 for (int iter = 0; iter < CONCURRENT_ITERS_PER_READER; iter++) {
                     try (
                         PrefetchedPageReader reader = new PrefetchedPageReader(
                             codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                            allocator,
-                            pool,
+                            blockFactory.directBuffers(),
                             fixture.copyPages(),
                             null,
                             (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -16,6 +16,7 @@ import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -33,7 +34,8 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * Pins two contracts on {@link PrefetchedPageReader}: live native memory stays O(high-water-mark
  * page), not O(uncompressed column chunk); and equal-sized direct pages malloc the decompress
  * buffer once, not once per page. The reader reuses one buffer (grown only when a later page
- * needs more capacity) and releases it on {@link PrefetchedPageReader#close()}.
+ * needs more capacity) and returns it to {@link DirectBufferPool} on
+ * {@link PrefetchedPageReader#close()} so the next reader/query does not malloc.
  *
  * <p>Before per-page bounding, every {@code decompressToDirectBuffer} output was parked until
  * {@link PrefetchedPageReader#close()} at row-group rollover. The live-bound tests FAIL on that
@@ -53,7 +55,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
     /**
      * Canonical case from the leak investigation: zstd {@link DataPageV2}, decompressed through the
      * direct-to-direct fast path. Asserts the live allocator balance stays bounded by one page as
-     * pages are read, and returns to zero at {@code close()}.
+     * pages are read, and stays parked in the pool at {@code close()} until the pool is closed.
      */
     public void testZstdV2DecompressBufferReleasedPerPageAndOnClose() throws IOException {
         assertPerPageReleaseAndZeroOnClose(buildZstdV2Pages());
@@ -79,10 +81,12 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         Arrays.fill(sizes, PAGE_PAYLOAD_BYTES);
         CountingListener listener = new CountingListener();
         DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
+        DirectBufferPool pool = new DirectBufferPool();
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                 allocator,
+                pool,
                 fixture.pages,
                 null,
                 valueCount(sizes)
@@ -99,9 +103,12 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             } finally {
                 reader.close();
             }
-            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
+            assertThat("close() parks the buffer in the pool", allocator.getAllocatedMemory(), greaterThan(0L));
+            pool.close();
+            assertEquals("pool.close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
         } finally {
             fixture.codecFactory.release();
+            pool.close();
         }
     }
 
@@ -113,10 +120,12 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
         CountingListener listener = new CountingListener();
         DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
+        DirectBufferPool pool = new DirectBufferPool();
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
                 allocator,
+                pool,
                 fixture.pages,
                 null,
                 valueCount(sizes)
@@ -153,17 +162,22 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             } finally {
                 reader.close();
             }
-            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
+            assertThat("close() parks the high-water buffer in the pool", allocator.getAllocatedMemory(), greaterThan(0L));
+            pool.close();
+            assertEquals("pool.close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
         } finally {
             fixture.codecFactory.release();
+            pool.close();
         }
     }
 
     private void assertPerPageReleaseAndZeroOnClose(PagesFixture fixture) {
+        DirectBufferPool pool = new DirectBufferPool();
         try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(fixture.codec),
                 allocator,
+                pool,
                 fixture.pages,
                 null,
                 (long) PAGE_PAYLOAD_BYTES * PAGES
@@ -194,9 +208,63 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             } finally {
                 reader.close();
             }
-            assertEquals("close() must return every decompress buffer to the allocator", 0L, allocator.getAllocatedMemory());
+            assertThat("close() parks the page buffer in the pool", allocator.getAllocatedMemory(), greaterThan(0L));
+            pool.close();
+            assertEquals("pool.close() must return every decompress buffer to the allocator", 0L, allocator.getAllocatedMemory());
         } finally {
             fixture.codecFactory.release();
+            pool.close();
+        }
+    }
+
+    /**
+     * Two readers sharing one pool must not double-allocate: reader 2 reuses reader 1's buffer.
+     */
+    public void testCrossRowGroupBufferReuse() throws IOException {
+        int[] sizes = new int[PAGES];
+        Arrays.fill(sizes, PAGE_PAYLOAD_BYTES);
+        CountingListener listener = new CountingListener();
+        DirectPagesFixture first = buildDirectZstdV2Pages(sizes);
+        DirectPagesFixture second = buildDirectZstdV2Pages(sizes);
+        DirectBufferPool pool = new DirectBufferPool();
+        try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
+            int allocsBefore = listener.allocations;
+            drainReader(first, allocator, pool);
+            long afterFirst = allocator.getAllocatedMemory();
+            assertThat(afterFirst, greaterThanOrEqualTo((long) PAGE_PAYLOAD_BYTES));
+            int allocsAfterFirst = listener.allocations;
+            assertEquals("first reader mallocs once", 1, allocsAfterFirst - allocsBefore);
+
+            drainReader(second, allocator, pool);
+            assertEquals("second reader must reuse the pooled buffer", afterFirst, allocator.getAllocatedMemory());
+            assertEquals("second reader must not malloc", allocsAfterFirst, listener.allocations);
+
+            pool.close();
+            assertEquals(0L, allocator.getAllocatedMemory());
+        } finally {
+            first.codecFactory.release();
+            second.codecFactory.release();
+            pool.close();
+        }
+    }
+
+    private static void drainReader(DirectPagesFixture fixture, RootAllocator allocator, DirectBufferPool pool) throws IOException {
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+            allocator,
+            pool,
+            fixture.pages,
+            null,
+            valueCount(new int[] { PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES })
+        );
+        try {
+            DataPageV2 page;
+            int i = 0;
+            while ((page = (DataPageV2) reader.readPage()) != null) {
+                assertArrayEquals(fixture.payloads.get(i++), page.getData().toByteArray());
+            }
+        } finally {
+            reader.close();
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -17,6 +17,7 @@ import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.elasticsearch.compute.data.arrow.DirectBufferPool;
+import org.elasticsearch.compute.data.arrow.DirectBuffers;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -85,8 +86,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                allocator,
-                pool,
+                new DirectBuffers(allocator, pool),
                 fixture.pages,
                 null,
                 valueCount(sizes)
@@ -124,8 +124,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                allocator,
-                pool,
+                new DirectBuffers(allocator, pool),
                 fixture.pages,
                 null,
                 valueCount(sizes)
@@ -176,8 +175,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 fixture.codecFactory.getDecompressor(fixture.codec),
-                allocator,
-                pool,
+                new DirectBuffers(allocator, pool),
                 fixture.pages,
                 null,
                 (long) PAGE_PAYLOAD_BYTES * PAGES
@@ -251,8 +249,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
     private static void drainReader(DirectPagesFixture fixture, RootAllocator allocator, DirectBufferPool pool) throws IOException {
         PrefetchedPageReader reader = new PrefetchedPageReader(
             fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-            allocator,
-            pool,
+            new DirectBuffers(allocator, pool),
             fixture.pages,
             null,
             valueCount(new int[] { PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES, PAGE_PAYLOAD_BYTES })

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -28,15 +28,14 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
- * Pins two contracts on {@link PrefetchedPageReader}: live native memory stays O(high-water-mark
- * page), not O(uncompressed column chunk); and equal-sized direct pages malloc the decompress
- * buffer once, not once per page. The reader reuses one buffer (grown only when a later page
- * needs more capacity) and returns it to {@link DirectBufferPool} on
- * {@link PrefetchedPageReader#close()} so the next reader/query does not malloc.
+ * Pins two contracts on {@link PrefetchedPageReader}: equal-sized direct pages malloc the
+ * decompress buffer once, not once per page; grow parks the previous buffer in
+ * {@link DirectBufferPool} (glibc: do not close until eviction) and borrows a larger one.
+ * The in-use buffer is returned to the pool on {@link PrefetchedPageReader#close()} so the
+ * next reader/query does not malloc.
  *
  * <p>Before per-page bounding, every {@code decompressToDirectBuffer} output was parked until
  * {@link PrefetchedPageReader#close()} at row-group rollover. The live-bound tests FAIL on that
@@ -113,8 +112,9 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
     }
 
     /**
-     * Growing pages realloc and free the previous buffer; a later smaller page reuses the large
-     * buffer. Live memory never becomes the sum of grown sizes.
+     * Growing pages park the previous buffer in the pool and borrow a larger one. A later
+     * smaller page reuses the large in-use buffer. Parked undersized bufs stay charged until
+     * eviction; live memory may be the sum of distinct grow sizes while under the idle cap.
      */
     public void testBufferReuseHandlesVaryingPageSizes() throws IOException {
         int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
@@ -146,8 +146,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
                             greaterThan(allocationsBefore)
                         );
                         if (liveBefore > 0L) {
-                            // Leak-on-grow would keep the old buf: live ≈ liveBefore + sizes[i].
-                            assertThat("grow must free the previous decompress buffer", live, lessThan(liveBefore + sizes[i]));
+                            assertThat("grow parks the old buf instead of closing it", live, greaterThanOrEqualTo(liveBefore + sizes[i]));
                         }
                         cap = sizes[i];
                     } else {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPage;
@@ -39,13 +38,11 @@ public class PrefetchedPageReaderTests extends ESTestCase {
 
     private PlainCompressionCodecFactory codecFactory;
     private BlockFactory blockFactory;
-    private BufferAllocator allocator;
 
     @Before
     public void initCodecAndAllocator() {
         codecFactory = new PlainCompressionCodecFactory();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
     }
 
     @After
@@ -112,8 +109,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.GZIP), // codec must not be invoked
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 8
@@ -157,8 +153,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             try (
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(codec),
-                    allocator,
-                    blockFactory.directBufferPool(),
+                    blockFactory.directBuffers(),
                     List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                     null,
                     10
@@ -199,8 +194,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -243,8 +237,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -264,8 +257,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(),
                 compressedDict,
                 0
@@ -293,8 +285,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.SNAPPY),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(),
                 compressedDict,
                 0
@@ -313,8 +304,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(),
                 null,
                 0
@@ -328,8 +318,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(),
                 null,
                 0
@@ -343,8 +332,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(),
                 null,
                 12345L
@@ -372,8 +360,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, 42L)),
                 null,
                 5
@@ -405,8 +392,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -450,8 +436,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
-                allocator,
-                blockFactory.directBufferPool(),
+                blockFactory.directBuffers(),
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 10

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
@@ -113,6 +113,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.GZIP), // codec must not be invoked
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 8
@@ -157,6 +158,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(codec),
                     allocator,
+                    blockFactory.directBufferPool(),
                     List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                     null,
                     10
@@ -198,6 +200,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -241,6 +244,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -261,6 +265,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(),
                 compressedDict,
                 0
@@ -289,6 +294,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.SNAPPY),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(),
                 compressedDict,
                 0
@@ -308,6 +314,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(),
                 null,
                 0
@@ -322,6 +329,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(),
                 null,
                 0
@@ -336,6 +344,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(),
                 null,
                 12345L
@@ -364,6 +373,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, 42L)),
                 null,
                 5
@@ -396,6 +406,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -440,6 +451,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
                 allocator,
+                blockFactory.directBufferPool(),
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 10

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -166,7 +166,8 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     prefetched.chunks(),
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.arrowAllocator(),
+                    blockFactory.directBufferPool()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -274,7 +275,8 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                         prefetched.chunks(),
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator()
+                        blockFactory.arrowAllocator(),
+                        blockFactory.directBufferPool()
                     )
                 ) {
                     ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -387,7 +389,8 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     chunks,
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.arrowAllocator(),
+                    blockFactory.directBufferPool()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -166,8 +166,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     prefetched.chunks(),
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator(),
-                    blockFactory.directBufferPool()
+                    blockFactory.directBuffers()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -275,8 +274,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                         prefetched.chunks(),
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator(),
-                        blockFactory.directBufferPool()
+                        blockFactory.directBuffers()
                     )
                 ) {
                     ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -389,8 +387,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     chunks,
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator(),
-                    blockFactory.directBufferPool()
+                    blockFactory.directBuffers()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseBlockLifecycleTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseBlockLifecycleTests.java
@@ -151,7 +151,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals(
             "breaker must return to zero after the failure unwinds (pre-fix, the second "
                 + "close on an already-released predicate Block masked the original breaker exception "
@@ -212,7 +212,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
         }
 
         assertThat("expected at least one successful batch before the trip", rowsConsumed.get(), greaterThanOrEqualTo(1L));
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero after a late-batch failure", 0L, breaker.getUsed());
     }
 
@@ -251,7 +251,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
         }
 
         assertEquals("filter survivor count", 100, rowsRead);
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero after a successful scan", 0L, breaker.getUsed());
     }
 
@@ -296,7 +296,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             }
         }
         assertThat("LIMIT cap respected", rowsRead, equalTo(37));
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero after LIMIT-truncated scan", 0L, breaker.getUsed());
     }
 
@@ -373,7 +373,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals(
             "breaker must return to zero — pre-fix double-close masked the breaker error and " + "left memory stranded",
             0L,
@@ -432,7 +432,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero — pre-fix double-close masked the breaker error", 0L, breaker.getUsed());
     }
 
@@ -484,7 +484,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
-        blockFactory.directBufferPool().releaseIdle();
+        blockFactory.directBuffers().releaseIdle();
         assertEquals("breaker must return to zero — pre-fix double-close masked the breaker error", 0L, breaker.getUsed());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseBlockLifecycleTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseBlockLifecycleTests.java
@@ -151,6 +151,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals(
             "breaker must return to zero after the failure unwinds (pre-fix, the second "
                 + "close on an already-released predicate Block masked the original breaker exception "
@@ -211,6 +212,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
         }
 
         assertThat("expected at least one successful batch before the trip", rowsConsumed.get(), greaterThanOrEqualTo(1L));
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero after a late-batch failure", 0L, breaker.getUsed());
     }
 
@@ -249,6 +251,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
         }
 
         assertEquals("filter survivor count", 100, rowsRead);
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero after a successful scan", 0L, breaker.getUsed());
     }
 
@@ -293,6 +296,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             }
         }
         assertThat("LIMIT cap respected", rowsRead, equalTo(37));
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero after LIMIT-truncated scan", 0L, breaker.getUsed());
     }
 
@@ -369,6 +373,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals(
             "breaker must return to zero — pre-fix double-close masked the breaker error and " + "left memory stranded",
             0L,
@@ -427,6 +432,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero — pre-fix double-close masked the breaker error", 0L, breaker.getUsed());
     }
 
@@ -478,6 +484,7 @@ public class TwoPhaseBlockLifecycleTests extends ESTestCase {
             assertTrue("breaker must have actually fired", breaker.tripped());
         }
 
+        blockFactory.directBufferPool().releaseIdle();
         assertEquals("breaker must return to zero — pre-fix double-close masked the breaker error", 0L, breaker.getUsed());
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -18,6 +16,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.compute.data.Block.MvOrdering;
 import org.elasticsearch.compute.data.arrow.CircuitBreakerAllocationListener;
+import org.elasticsearch.compute.data.arrow.DirectBufferAllocationManager;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -41,15 +40,6 @@ public class BlockFactory {
     public static final ByteSizeValue DEFAULT_BYTES_REF_RAM_OVERESTIMATE_THRESHOLD = ByteSizeValue.ofMb(1);
     // The same as PlannerSettings.BYTES_REF_RAM_OVERESTIMATE_FACTOR
     public static final double DEFAULT_BYTES_REF_RAM_OVERESTIMATE_FACTOR = 2.5;
-
-    /**
-     * Exact-fit rounding policy for the Arrow root allocator. We use {@code arrow-memory-unsafe},
-     * whose {@code UnsafeAllocationManager} is a straight malloc/free with no free list or size
-     * classes. The default power-of-two rounding exists to feed a pooled allocator
-     * ({@code arrow-memory-netty}); without that pool, it only wastes memory (up to 2x for
-     * sub-16 MiB allocations). Pass this policy to let the OS allocator handle alignment.
-     */
-    private static final RoundingPolicy EXACT_FIT_ROUNDING_POLICY = requestSize -> requestSize;
 
     private static final Logger log = LogManager.getLogger(BlockFactory.class);
 
@@ -100,9 +90,13 @@ public class BlockFactory {
             synchronized (this) {
                 if (arrowAllocator == null) {
                     if (this.parent == null) {
-                        // Root block factory
+                        // Root block factory. DirectByteBuffer backing so Arrow is visible to
+                        // MaxDirectMemorySize; cap is MaxDirect minus a small NIO reserve.
                         var listener = new CircuitBreakerAllocationListener(breaker);
-                        var allocator = new RootAllocator(listener, Long.MAX_VALUE, EXACT_FIT_ROUNDING_POLICY);
+                        var allocator = DirectBufferAllocationManager.createRootAllocator(
+                            listener,
+                            DirectBufferAllocationManager.arrowDirectMemoryLimit()
+                        );
                         cleaner.register(this, () -> {
                             try {
                                 allocator.close();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.Block.MvOrdering;
 import org.elasticsearch.compute.data.arrow.CircuitBreakerAllocationListener;
 import org.elasticsearch.compute.data.arrow.DirectBufferAllocationManager;
 import org.elasticsearch.compute.data.arrow.DirectBufferPool;
+import org.elasticsearch.compute.data.arrow.DirectBuffers;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -53,6 +54,7 @@ public class BlockFactory {
     private final double bytesRefRamOverestimateFactor;
     protected volatile BufferAllocator arrowAllocator;
     protected volatile DirectBufferPool directBufferPool;
+    protected volatile DirectBuffers directBuffers;
     private static final Cleaner cleaner = Cleaner.create();
 
     /**
@@ -114,6 +116,7 @@ public class BlockFactory {
                         });
                         directBufferPool = pool;
                         arrowAllocator = allocator;
+                        directBuffers = new DirectBuffers(allocator, pool);
                     } else {
                         arrowAllocator = childFactoryAllocator();
                     }
@@ -139,7 +142,20 @@ public class BlockFactory {
             return parent.directBufferPool();
         }
         arrowAllocator();
-        return directBufferPool;
+        return this.directBufferPool;
+    }
+
+    /**
+     * Allocator and decompress-buffer pool as one object. Use this wherever both are required;
+     * {@link #arrowAllocator()} stays for allocator-only call sites (prefetch, storage windows).
+     * Child factories pair their own allocator with the shared root pool.
+     */
+    public DirectBuffers directBuffers() {
+        if (parent != null) {
+            return new DirectBuffers(arrowAllocator(), parent.directBufferPool());
+        }
+        arrowAllocator();
+        return this.directBuffers;
     }
 
     // For testing

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.compute.data.Block.MvOrdering;
 import org.elasticsearch.compute.data.arrow.CircuitBreakerAllocationListener;
 import org.elasticsearch.compute.data.arrow.DirectBufferAllocationManager;
+import org.elasticsearch.compute.data.arrow.DirectBufferPool;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -51,6 +52,7 @@ public class BlockFactory {
     private final long bytesRefRamOverestimateThreshold;
     private final double bytesRefRamOverestimateFactor;
     protected volatile BufferAllocator arrowAllocator;
+    protected volatile DirectBufferPool directBufferPool;
     private static final Cleaner cleaner = Cleaner.create();
 
     /**
@@ -97,13 +99,20 @@ public class BlockFactory {
                             listener,
                             DirectBufferAllocationManager.arrowDirectMemoryLimit()
                         );
+                        var pool = new DirectBufferPool();
                         cleaner.register(this, () -> {
+                            try {
+                                pool.close();
+                            } catch (Exception e) {
+                                log.error("Error closing the Arrow direct buffer pool", e);
+                            }
                             try {
                                 allocator.close();
                             } catch (Exception e) {
                                 log.error("Error closing the Arrow root allocator", e);
                             }
                         });
+                        directBufferPool = pool;
                         arrowAllocator = allocator;
                     } else {
                         arrowAllocator = childFactoryAllocator();
@@ -118,6 +127,19 @@ public class BlockFactory {
         // Store it locally to avoid crawling the parent chain every time we need it.
         // Overridden in tests
         return parent.arrowAllocator();
+    }
+
+    /**
+     * Node-lifetime pool of reusable Arrow direct buffers. Child factories share the root
+     * pool so buffers survive across queries. Pooled buffers stay charged to the REQUEST
+     * breaker until {@link DirectBufferPool#releaseIdle()} or factory GC.
+     */
+    public DirectBufferPool directBufferPool() {
+        if (parent != null) {
+            return parent.directBufferPool();
+        }
+        arrowAllocator();
+        return directBufferPool;
     }
 
     // For testing

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListener.java
@@ -8,10 +8,16 @@
 package org.elasticsearch.compute.data.arrow;
 
 import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationOutcome;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
 /**
  * Arrow allocation listener that uses a circuit breaker to track memory usage.
+ * <p>
+ * Arrow's {@code BaseAllocator} charges {@link #onPreAllocation} before checking
+ * {@code maxAllocation}. When that cap fails, {@link #onFailedAllocation} undoes
+ * the breaker charge and throws {@link org.elasticsearch.common.breaker.CircuitBreakingException}
+ * so the query returns 429 rather than Arrow's {@code OutOfMemoryException} (HTTP 500).
  */
 
 // Note: it would more naturally fit in the :libs:arrow module, but would require a dependency
@@ -27,5 +33,23 @@ public record CircuitBreakerAllocationListener(CircuitBreaker circuitBreaker) im
     @Override
     public void onRelease(long size) {
         circuitBreaker.addWithoutBreaking(-size);
+    }
+
+    @Override
+    public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
+        circuitBreaker.addWithoutBreaking(-size);
+        throw DirectBufferAllocationManager.circuitBreakingException(size, failedAllocatorLimit(outcome), null);
+    }
+
+    private static long failedAllocatorLimit(AllocationOutcome outcome) {
+        if (outcome == null) {
+            return 0L;
+        }
+        var details = outcome.getDetails();
+        if (details.isEmpty()) {
+            return 0L;
+        }
+        var failed = details.get().getFailedAllocator();
+        return failed == null ? 0L : failed.getLimit();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManager.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManager.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationManager;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.rounding.RoundingPolicy;
+import org.apache.arrow.memory.util.MemoryUtil;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Arrow {@link AllocationManager} backed by {@link ByteBuffer#allocateDirect}.
+ * <p>
+ * That is the only off-heap API HotSpot charges to {@code MaxDirectMemorySize}.
+ * {@code UnsafeAllocationManager} mallocs outside that budget (SIGKILL on a
+ * cgroup-hard container). Request-breaker accounting stays on
+ * {@link CircuitBreakerAllocationListener}. Allocation failure becomes
+ * {@link CircuitBreakingException} (429). RootAllocator max is MaxDirect minus
+ * {@link #NIO_RESERVE_BYTES}. Arrow's config builder is package-private, so
+ * {@link #createRootAllocator} reaches it reflectively.
+ */
+public final class DirectBufferAllocationManager extends AllocationManager {
+
+    public static final long NIO_RESERVE_BYTES = ByteSizeValue.ofMb(32).getBytes();
+
+    static final RoundingPolicy EXACT_FIT_ROUNDING_POLICY = requestSize -> requestSize;
+
+    private static final MethodHandle INVOKE_CLEANER = bindInvokeCleaner();
+    private static final ArrowConfigApi ARROW_CONFIG = bindArrowConfigApi();
+
+    // Process-lifetime 0-size sentinel. UnsafeAllocationManager does the same
+    // (allocateMemory(0) + NO_OP). Must not free: allocator.getEmpty() is shared.
+    private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP, null, 0, MemoryUtil.allocateMemory(0));
+
+    public static final Factory FACTORY = new Factory() {
+        @Override
+        public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+            // Allocate before super(): AllocationManager's ctor associates a BufferLedger.
+            return new DirectBufferAllocationManager(accountingAllocator, allocateDirect(accountingAllocator, size));
+        }
+
+        @Override
+        public ArrowBuf empty() {
+            return EMPTY;
+        }
+    };
+
+    private ByteBuffer buffer;
+    private final long size;
+    private final long address;
+
+    private DirectBufferAllocationManager(BufferAllocator accountingAllocator, ByteBuffer buffer) {
+        super(accountingAllocator);
+        this.buffer = buffer;
+        this.size = buffer.capacity();
+        this.address = MemoryUtil.getByteBufferAddress(buffer);
+    }
+
+    public static RootAllocator createRootAllocator(AllocationListener listener, long maxAllocation) {
+        return createRootAllocator(listener, maxAllocation, FACTORY);
+    }
+
+    // Test-only Factory injection. Production always uses FACTORY. Needed so
+    // buffer() can throw CBE without filling MaxDirect (hostile in a unit JVM).
+    static RootAllocator createRootAllocator(AllocationListener listener, long maxAllocation, Factory factory) {
+        return ARROW_CONFIG.newRootAllocator(listener, maxAllocation, factory);
+    }
+
+    public static long arrowDirectMemoryLimit() {
+        long maxDirect = JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes();
+        // MXBean 0 = unset flag or non-HotSpot; treat as unknown and do not cap here.
+        return maxDirect <= 0L ? Long.MAX_VALUE : Math.max(0L, maxDirect - NIO_RESERVE_BYTES);
+    }
+
+    static CircuitBreakingException circuitBreakingException(long bytesWanted, long byteLimit, Throwable cause) {
+        CircuitBreakingException cbe = new CircuitBreakingException(
+            Strings.format("Unable to allocate [%d] bytes of direct memory for Arrow; limit is [%d] bytes", bytesWanted, byteLimit),
+            bytesWanted,
+            byteLimit,
+            CircuitBreaker.Durability.TRANSIENT
+        );
+        if (cause != null) {
+            cbe.initCause(cause);
+        }
+        return cbe;
+    }
+
+    private static ByteBuffer allocateDirect(BufferAllocator accountingAllocator, long size) {
+        if (size > Integer.MAX_VALUE) {
+            undoPreAllocation(accountingAllocator, size);
+            throw circuitBreakingException(size, Integer.MAX_VALUE, null);
+        }
+        try {
+            return ByteBuffer.allocateDirect((int) size);
+        } catch (OutOfMemoryError e) {
+            throw failedDirectAllocation(accountingAllocator, size, e);
+        }
+    }
+
+    private static void undoPreAllocation(BufferAllocator accountingAllocator, long size) {
+        accountingAllocator.getListener().onRelease(size);
+    }
+
+    static CircuitBreakingException failedDirectAllocation(BufferAllocator accountingAllocator, long size, OutOfMemoryError error) {
+        undoPreAllocation(accountingAllocator, size);
+        return circuitBreakingException(size, arrowDirectMemoryLimit(), error);
+    }
+
+    private record ArrowConfigApi(
+        Method configBuilder,
+        Method setListener,
+        Method setMaxAllocation,
+        Method setRoundingPolicy,
+        Method setFactory,
+        Method build,
+        Constructor<RootAllocator> ctor
+    ) {
+        RootAllocator newRootAllocator(AllocationListener listener, long maxAllocation, Factory factory) {
+            try {
+                Object builder = configBuilder.invoke(null);
+                setListener.invoke(builder, listener);
+                setMaxAllocation.invoke(builder, maxAllocation);
+                setRoundingPolicy.invoke(builder, EXACT_FIT_ROUNDING_POLICY);
+                setFactory.invoke(builder, factory);
+                return ctor.newInstance(build.invoke(builder));
+            } catch (InvocationTargetException e) {
+                throw rethrow(e.getCause());
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError("Arrow RootAllocator config API is not accessible", e);
+            }
+        }
+    }
+
+    @SuppressForbidden(reason = "Arrow hid RootAllocator config behind package-private BaseAllocator")
+    private static ArrowConfigApi bindArrowConfigApi() {
+        try {
+            Method configBuilder = Class.forName("org.apache.arrow.memory.BaseAllocator").getMethod("configBuilder");
+            configBuilder.setAccessible(true);
+            Class<?> builderType = configBuilder.invoke(null).getClass();
+            Constructor<RootAllocator> ctor = RootAllocator.class.getConstructor(
+                Class.forName("org.apache.arrow.memory.BaseAllocator$Config")
+            );
+            ctor.setAccessible(true);
+            return new ArrowConfigApi(
+                configBuilder,
+                builderType.getMethod("listener", AllocationListener.class),
+                builderType.getMethod("maxAllocation", long.class),
+                builderType.getMethod("roundingPolicy", RoundingPolicy.class),
+                builderType.getMethod("allocationManagerFactory", Factory.class),
+                builderType.getMethod("build"),
+                ctor
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @SuppressForbidden(reason = "need jdk.internal.misc.Unsafe.invokeCleaner to free DirectByteBuffer immediately")
+    private static MethodHandle bindInvokeCleaner() {
+        try {
+            Class<?> unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+            Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            return MethodHandles.lookup()
+                .findVirtual(unsafeClass, "invokeCleaner", MethodType.methodType(void.class, ByteBuffer.class))
+                .bindTo(theUnsafe.get(null));
+        } catch (Throwable e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static void freeDirectBuffer(ByteBuffer buffer) {
+        try {
+            INVOKE_CLEANER.invokeExact(buffer);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    private static RuntimeException rethrow(Throwable t) {
+        if (t instanceof RuntimeException re) {
+            return re;
+        }
+        if (t instanceof Error err) {
+            throw err;
+        }
+        throw new AssertionError(t);
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    protected long memoryAddress() {
+        return address;
+    }
+
+    @Override
+    protected void release0() {
+        ByteBuffer toFree = buffer;
+        if (toFree == null) {
+            return;
+        }
+        buffer = null;
+        freeDirectBuffer(toFree);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferPool.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferPool.java
@@ -27,15 +27,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  * that malloc/free churn after warmup. Pooled buffers stay charged to the REQUEST breaker
  * until {@link #releaseIdle()} or {@link #close()}; that residency is the cost of stable RSS.
  * <p>
+ * Undersized idle buffers are kept until the idle cap forces an eviction. Closing them on
+ * borrow would be another glibc hand-back. On overflow, the heuristic keeps the larger of
+ * (incoming, oldest idle).
+ * <p>
  * Thread-safe: several queries may borrow and return concurrently from a shared factory.
+ * {@link ConcurrentLinkedDeque} is lock-free; {@link #MAX_POOLED} is enforced with CAS on
+ * occupancy, not {@code deque.size()} (O(n)).
  */
 public final class DirectBufferPool implements Releasable {
 
     private static final Logger logger = LogManager.getLogger(DirectBufferPool.class);
 
     /**
-     * Caps idle buffers. 32 covers two concurrent 16-column scans; overflow is freed
-     * (falls back to allocate-on-demand).
+     * Caps <em>idle</em> buffers, not in-flight ones. Each live column reader holds one
+     * borrowed buffer that does not count here.
+     * <p>
+     * 32 is a REQUEST-breaker / RSS bound, not a concurrency proof. The original guess was
+     * two overlapping 16-column scans; more concurrent queries allocate extra, then evict
+     * on return (prefer larger). Raising this parks more RSS on the breaker; lowering it
+     * reintroduces glibc churn on overflow close. Not 64 (or 128) until we measure parked
+     * breaker vs concurrent query width — doubling the cap doubles worst-case residency
+     * without changing correctness.
      */
     public static final int MAX_POOLED = 32;
 
@@ -44,53 +57,89 @@ public final class DirectBufferPool implements Releasable {
     private final AtomicBoolean closed = new AtomicBoolean();
 
     /**
-     * Returns a buffer with {@code capacity >= minCapacity}. Prefers an idle pooled buffer;
-     * undersized idle buffers are closed (the remaining malloc source after warmup).
+     * Returns a buffer with {@code capacity >= minCapacity}. Walks idle buffers newest-first
+     * and puts undersized ones back immediately (occupancy unchanged). Allocates only when
+     * nothing idle fits. {@code inspected} bounds the walk so a single undersized buffer
+     * cannot {@code pollLast}/{@code offerFirst} forever.
      */
     public ArrowBuf borrow(BufferAllocator allocator, int minCapacity) {
         Objects.requireNonNull(allocator, "allocator");
         if (minCapacity <= 0) {
             throw new IllegalArgumentException("minCapacity must be positive [" + minCapacity + "]");
         }
-        if (closed.get() == false) {
-            ArrowBuf buf;
-            while ((buf = pool.pollLast()) != null) {
+        if (closed.get()) {
+            return allocator.buffer(minCapacity);
+        }
+        int inspected = 0;
+        ArrowBuf buf;
+        while (inspected < MAX_POOLED && (buf = pool.pollLast()) != null) {
+            inspected++;
+            if (closed.get()) {
                 pooledCount.decrementAndGet();
-                if (buf.capacity() >= minCapacity) {
-                    return buf;
-                }
                 buf.close();
+                return allocator.buffer(minCapacity);
+            }
+            if (buf.capacity() >= minCapacity) {
+                pooledCount.decrementAndGet();
+                return buf;
+            }
+            pool.offerFirst(buf);
+            if (closed.get() && pool.remove(buf)) {
+                pooledCount.decrementAndGet();
+                buf.close();
+                return allocator.buffer(minCapacity);
             }
         }
         return allocator.buffer(minCapacity);
     }
 
     /**
-     * Returns {@code buf} to the pool, or closes it when the pool is shut, full, or {@code buf}
-     * is null. Not idempotent: the caller transfers exclusive ownership and must not return the
-     * same buffer twice.
+     * Returns {@code buf} to the pool, or closes it when the pool is shut, or evicts an older
+     * smaller idle buffer when full. Not idempotent: the caller transfers exclusive ownership
+     * and must not return the same buffer twice.
      */
     public void returnBuf(ArrowBuf buf) {
-        if (buf == null) {
-            return;
-        }
-        if (closed.get() == false) {
-            int c;
-            do {
-                c = pooledCount.get();
-                if (c >= MAX_POOLED || closed.get()) {
-                    buf.close();
-                    return;
-                }
-            } while (pooledCount.compareAndSet(c, c + 1) == false);
-            pool.offer(buf);
-            if (closed.get() && pool.remove(buf)) {
-                pooledCount.decrementAndGet();
+        while (buf != null) {
+            if (closed.get()) {
                 buf.close();
+                return;
             }
-            return;
+            int c = pooledCount.get();
+            if (c >= MAX_POOLED) {
+                buf = evictVictimOrKeep(buf);
+                continue;
+            }
+            if (pooledCount.compareAndSet(c, c + 1)) {
+                pool.offerLast(buf);
+                if (closed.get() && pool.remove(buf)) {
+                    pooledCount.decrementAndGet();
+                    buf.close();
+                }
+                return;
+            }
         }
-        buf.close();
+    }
+
+    /**
+     * Oldest idle vs incoming: keep the larger, close the smaller. {@code null} means incoming
+     * was parked or closed; non-null is the buffer that still needs a slot (retry).
+     * <p>
+     * O(1) under contention — no scan of the deque. Oldest is least-recently-returned (LIFO
+     * borrow / FIFO victim). Capacity tie keeps incoming (fresher).
+     */
+    private ArrowBuf evictVictimOrKeep(ArrowBuf incoming) {
+        ArrowBuf victim = pool.pollFirst();
+        if (victim == null) {
+            incoming.close();
+            return null;
+        }
+        pooledCount.decrementAndGet();
+        if (incoming.capacity() >= victim.capacity()) {
+            victim.close();
+            return incoming;
+        }
+        incoming.close();
+        return victim;
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferPool.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBufferPool.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Cross-query pool of reusable {@link ArrowBuf}s.
+ * <p>
+ * Returning a buffer to the OS ({@link ArrowBuf#close()}) is what feeds glibc arena
+ * retention: the allocator balance goes to zero, RSS does not. Parking a bounded number of
+ * live buffers on the node-level {@link org.elasticsearch.compute.data.BlockFactory} avoids
+ * that malloc/free churn after warmup. Pooled buffers stay charged to the REQUEST breaker
+ * until {@link #releaseIdle()} or {@link #close()}; that residency is the cost of stable RSS.
+ * <p>
+ * Thread-safe: several queries may borrow and return concurrently from a shared factory.
+ */
+public final class DirectBufferPool implements Releasable {
+
+    private static final Logger logger = LogManager.getLogger(DirectBufferPool.class);
+
+    /**
+     * Caps idle buffers. 32 covers two concurrent 16-column scans; overflow is freed
+     * (falls back to allocate-on-demand).
+     */
+    public static final int MAX_POOLED = 32;
+
+    private final ConcurrentLinkedDeque<ArrowBuf> pool = new ConcurrentLinkedDeque<>();
+    private final AtomicInteger pooledCount = new AtomicInteger();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    /**
+     * Returns a buffer with {@code capacity >= minCapacity}. Prefers an idle pooled buffer;
+     * undersized idle buffers are closed (the remaining malloc source after warmup).
+     */
+    public ArrowBuf borrow(BufferAllocator allocator, int minCapacity) {
+        Objects.requireNonNull(allocator, "allocator");
+        if (minCapacity <= 0) {
+            throw new IllegalArgumentException("minCapacity must be positive [" + minCapacity + "]");
+        }
+        if (closed.get() == false) {
+            ArrowBuf buf;
+            while ((buf = pool.pollLast()) != null) {
+                pooledCount.decrementAndGet();
+                if (buf.capacity() >= minCapacity) {
+                    return buf;
+                }
+                buf.close();
+            }
+        }
+        return allocator.buffer(minCapacity);
+    }
+
+    /**
+     * Returns {@code buf} to the pool, or closes it when the pool is shut, full, or {@code buf}
+     * is null. Not idempotent: the caller transfers exclusive ownership and must not return the
+     * same buffer twice.
+     */
+    public void returnBuf(ArrowBuf buf) {
+        if (buf == null) {
+            return;
+        }
+        if (closed.get() == false) {
+            int c;
+            do {
+                c = pooledCount.get();
+                if (c >= MAX_POOLED || closed.get()) {
+                    buf.close();
+                    return;
+                }
+            } while (pooledCount.compareAndSet(c, c + 1) == false);
+            pool.offer(buf);
+            if (closed.get() && pool.remove(buf)) {
+                pooledCount.decrementAndGet();
+                buf.close();
+            }
+            return;
+        }
+        buf.close();
+    }
+
+    /**
+     * Closes every idle buffer. The pool stays open for later borrow/return.
+     * Production never calls this — parked buffers are the glibc-RSS workaround.
+     * Tests call it before asserting the REQUEST breaker and allocator returned to baseline.
+     */
+    public void releaseIdle() {
+        drain();
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true) == false) {
+            return;
+        }
+        drain();
+    }
+
+    private void drain() {
+        ArrowBuf buf;
+        while ((buf = pool.poll()) != null) {
+            pooledCount.decrementAndGet();
+            try {
+                buf.close();
+            } catch (RuntimeException e) {
+                logger.error("Error closing pooled ArrowBuf", e);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBuffers.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/DirectBuffers.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+
+import java.util.Objects;
+
+/**
+ * Allocator plus the node-lifetime {@link DirectBufferPool} that reuses its buffers across
+ * queries. {@link BufferAllocator} is Arrow's type; this record is the unit passed where both
+ * are required instead of two parameters.
+ */
+public record DirectBuffers(BufferAllocator allocator, DirectBufferPool pool) {
+
+    public DirectBuffers {
+        Objects.requireNonNull(allocator, "allocator");
+        Objects.requireNonNull(pool, "pool");
+    }
+
+    public ArrowBuf buffer(long size) {
+        return allocator.buffer(size);
+    }
+
+    public ArrowBuf borrow(int minCapacity) {
+        return pool.borrow(allocator, minCapacity);
+    }
+
+    public void returnBuf(ArrowBuf buf) {
+        pool.returnBuf(buf);
+    }
+
+    public void releaseIdle() {
+        pool.releaseIdle();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListenerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/CircuitBreakerAllocationListenerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.data.arrow;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -27,7 +26,7 @@ public class CircuitBreakerAllocationListenerTests extends ESTestCase {
     }
 
     private BufferAllocator allocator(CircuitBreaker breaker) {
-        return new RootAllocator(new CircuitBreakerAllocationListener(breaker), Long.MAX_VALUE, requestSize -> requestSize);
+        return DirectBufferAllocationManager.createRootAllocator(new CircuitBreakerAllocationListener(breaker), Long.MAX_VALUE);
     }
 
     public void testAllocationWithinLimitSucceeds() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManagerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferAllocationManagerTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.AllocationManager;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.test.ESTestCase;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class DirectBufferAllocationManagerTests extends ESTestCase {
+
+    private static final long FOUR_MB = 4L << 20;
+
+    public void testAllocateAddressAndRoundTrip() {
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try (ArrowBuf buf = allocator.buffer(64)) {
+                assertThat(buf.memoryAddress(), greaterThan(0L));
+                buf.setByte(0, (byte) 42);
+                buf.setByte(63, (byte) 7);
+                assertEquals(42, buf.getByte(0));
+                assertEquals(7, buf.getByte(63));
+                assertTrue(buf.nioBuffer().isDirect());
+            }
+        }
+    }
+
+    public void testReleaseDropsDirectBufferPoolUsage() {
+        long before = directMemoryUsedBytes();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            ArrowBuf buf = allocator.buffer(FOUR_MB);
+            long held = directMemoryUsedBytes();
+            assertThat("allocateDirect must show up on the direct BufferPoolMXBean", held - before, greaterThanOrEqualTo(FOUR_MB));
+            buf.close();
+            long after = directMemoryUsedBytes();
+            assertThat(
+                "cleaner must return direct memory without waiting for GC; grew " + (after - before) + " after close",
+                after - before,
+                lessThanOrEqualTo(1L << 20)
+            );
+        }
+    }
+
+    public void testOverAllocatorMaxThrowsCircuitBreakingException() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(new CircuitBreakerAllocationListener(breaker), 1024)) {
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(2048));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    public void testFactoryOutOfMemoryErrorUndoesBreaker() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        AllocationManager.Factory oomFactory = new AllocationManager.Factory() {
+            @Override
+            public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+                throw DirectBufferAllocationManager.failedDirectAllocation(
+                    accountingAllocator,
+                    size,
+                    new OutOfMemoryError("Direct buffer memory")
+                );
+            }
+
+            @Override
+            public ArrowBuf empty() {
+                return DirectBufferAllocationManager.FACTORY.empty();
+            }
+        };
+        try (
+            RootAllocator allocator = DirectBufferAllocationManager.createRootAllocator(
+                new CircuitBreakerAllocationListener(breaker),
+                Long.MAX_VALUE,
+                oomFactory
+            )
+        ) {
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(64));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertThat(e.getCause(), instanceOf(OutOfMemoryError.class));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    public void testSizeAboveIntegerMaxThrowsCircuitBreakingException() {
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            long tooBig = Integer.MAX_VALUE + 1L;
+            CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> allocator.buffer(tooBig));
+            assertThat(e.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
+            assertThat(e.getBytesWanted(), equalTo(tooBig));
+            assertThat(e.getByteLimit(), equalTo((long) Integer.MAX_VALUE));
+        }
+    }
+
+    public void testArrowDirectMemoryLimitMatchesJvmInfo() {
+        long maxDirect = JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes();
+        long limit = DirectBufferAllocationManager.arrowDirectMemoryLimit();
+        if (maxDirect <= 0L) {
+            assertEquals(Long.MAX_VALUE, limit);
+        } else {
+            assertEquals(Math.max(0L, maxDirect - DirectBufferAllocationManager.NIO_RESERVE_BYTES), limit);
+        }
+    }
+
+    public void testRequestBreakerTripsBeforeDirectCap() {
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(1024));
+        try (
+            var allocator = DirectBufferAllocationManager.createRootAllocator(
+                new CircuitBreakerAllocationListener(breaker),
+                DirectBufferAllocationManager.arrowDirectMemoryLimit()
+            )
+        ) {
+            expectThrows(CircuitBreakingException.class, () -> allocator.buffer(2048));
+            assertEquals(0, breaker.getUsed());
+        }
+    }
+
+    private static long directMemoryUsedBytes() {
+        for (BufferPoolMXBean p : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
+            if ("direct".equals(p.getName())) {
+                return p.getMemoryUsed();
+            }
+        }
+        fail("JVM has no 'direct' BufferPoolMXBean");
+        return 0;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.arrow;
+
+import org.apache.arrow.memory.AllocationListener;
+import org.apache.arrow.memory.ArrowBuf;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class DirectBufferPoolTests extends ESTestCase {
+
+    public void testBorrowReturnLifecycle() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                ArrowBuf first = pool.borrow(allocator, 64);
+                long addr = first.memoryAddress();
+                pool.returnBuf(first);
+                ArrowBuf second = pool.borrow(allocator, 64);
+                assertThat(second, sameInstance(first));
+                assertEquals(addr, second.memoryAddress());
+                assertEquals(first.capacity(), allocator.getAllocatedMemory());
+                pool.returnBuf(second);
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testBorrowGrowsWhenTooSmall() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                ArrowBuf small = pool.borrow(allocator, 64);
+                pool.returnBuf(small);
+                ArrowBuf large = pool.borrow(allocator, 256);
+                assertThat(large.capacity(), greaterThanOrEqualTo(256L));
+                // Undersized idle buffer was closed; only the replacement is live.
+                assertEquals(large.capacity(), allocator.getAllocatedMemory());
+                pool.returnBuf(large);
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testMaxPooledEnforced() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                List<ArrowBuf> held = new ArrayList<>(DirectBufferPool.MAX_POOLED + 1);
+                for (int i = 0; i < DirectBufferPool.MAX_POOLED + 1; i++) {
+                    held.add(pool.borrow(allocator, 64));
+                }
+                long allLive = allocator.getAllocatedMemory();
+                assertThat(allLive, greaterThan((long) DirectBufferPool.MAX_POOLED * 64));
+                for (ArrowBuf buf : held) {
+                    pool.returnBuf(buf);
+                }
+                assertEquals("excess return is freed, not parked", allLive - 64, allocator.getAllocatedMemory());
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testCloseFreesAll() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            int n = randomIntBetween(1, DirectBufferPool.MAX_POOLED);
+            List<ArrowBuf> held = new ArrayList<>(n);
+            for (int i = 0; i < n; i++) {
+                held.add(pool.borrow(allocator, 64));
+            }
+            for (ArrowBuf buf : held) {
+                pool.returnBuf(buf);
+            }
+            assertThat(allocator.getAllocatedMemory(), greaterThan(0L));
+            pool.close();
+            assertEquals(0L, allocator.getAllocatedMemory());
+        }
+    }
+
+    public void testReleaseIdleKeepsPoolOpen() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            ArrowBuf first = pool.borrow(allocator, 64);
+            pool.returnBuf(first);
+            pool.releaseIdle();
+            assertEquals(0L, allocator.getAllocatedMemory());
+            ArrowBuf second = pool.borrow(allocator, 64);
+            assertThat(second.capacity(), greaterThanOrEqualTo(64L));
+            pool.returnBuf(second);
+            pool.close();
+            assertEquals(0L, allocator.getAllocatedMemory());
+        }
+    }
+
+    public void testReturnAfterCloseFrees() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            ArrowBuf buf = pool.borrow(allocator, 64);
+            pool.close();
+            pool.returnBuf(buf);
+            assertEquals(0L, allocator.getAllocatedMemory());
+        }
+    }
+
+    public void testConcurrentBorrowReturn() throws Exception {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            startInParallel(4, i -> {
+                for (int n = 0; n < 50; n++) {
+                    ArrowBuf buf = pool.borrow(allocator, 64 + (n % 3) * 64);
+                    pool.returnBuf(buf);
+                }
+            });
+            assertThat(allocator.getAllocatedMemory(), lessThanOrEqualTo((long) DirectBufferPool.MAX_POOLED * 192));
+            pool.close();
+            assertEquals(0L, allocator.getAllocatedMemory());
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
@@ -132,4 +132,19 @@ public class DirectBufferPoolTests extends ESTestCase {
             assertEquals(0L, allocator.getAllocatedMemory());
         }
     }
+
+    public void testDirectBuffersDelegatesBorrowAndRelease() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            DirectBuffers buffers = new DirectBuffers(allocator, pool);
+            ArrowBuf first = buffers.borrow(64);
+            buffers.returnBuf(first);
+            ArrowBuf second = buffers.borrow(64);
+            assertThat(second, sameInstance(first));
+            buffers.returnBuf(second);
+            buffers.releaseIdle();
+            assertEquals(0L, allocator.getAllocatedMemory());
+            pool.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/arrow/DirectBufferPoolTests.java
@@ -44,12 +44,77 @@ public class DirectBufferPoolTests extends ESTestCase {
         try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
             try {
                 ArrowBuf small = pool.borrow(allocator, 64);
+                long smallCap = small.capacity();
                 pool.returnBuf(small);
                 ArrowBuf large = pool.borrow(allocator, 256);
                 assertThat(large.capacity(), greaterThanOrEqualTo(256L));
-                // Undersized idle buffer was closed; only the replacement is live.
-                assertEquals(large.capacity(), allocator.getAllocatedMemory());
+                // Undersized idle stays parked; closing it would hand pages back to glibc.
+                assertEquals(smallCap + large.capacity(), allocator.getAllocatedMemory());
                 pool.returnBuf(large);
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testBorrowFindsBuriedLargeWithoutClosingSmalls() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                ArrowBuf small1 = pool.borrow(allocator, 64);
+                ArrowBuf large = pool.borrow(allocator, 1024);
+                ArrowBuf small2 = pool.borrow(allocator, 64);
+                long live = allocator.getAllocatedMemory();
+                pool.returnBuf(small1);
+                pool.returnBuf(large);
+                pool.returnBuf(small2);
+                ArrowBuf got = pool.borrow(allocator, 1024);
+                assertThat(got, sameInstance(large));
+                assertEquals("undersized idle must stay parked", live, allocator.getAllocatedMemory());
+                pool.returnBuf(got);
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testBorrowMissDoesNotCloseUndersized() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                for (int cap : new int[] { 64, 128, 256 }) {
+                    ArrowBuf buf = pool.borrow(allocator, cap);
+                    pool.returnBuf(buf);
+                }
+                long smalls = allocator.getAllocatedMemory();
+                ArrowBuf large = pool.borrow(allocator, 1024);
+                assertThat(large.capacity(), greaterThanOrEqualTo(1024L));
+                assertEquals(smalls + large.capacity(), allocator.getAllocatedMemory());
+                pool.returnBuf(large);
+            } finally {
+                pool.close();
+            }
+        }
+    }
+
+    public void testEvictSmallToParkLargeWhenFull() {
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                List<ArrowBuf> held = new ArrayList<>(DirectBufferPool.MAX_POOLED);
+                for (int i = 0; i < DirectBufferPool.MAX_POOLED; i++) {
+                    held.add(pool.borrow(allocator, 64));
+                }
+                for (ArrowBuf buf : held) {
+                    pool.returnBuf(buf);
+                }
+                long fullOfSmall = allocator.getAllocatedMemory();
+                long smallCap = held.getFirst().capacity();
+                ArrowBuf large = pool.borrow(allocator, 1024);
+                assertThat(large.capacity(), greaterThanOrEqualTo(1024L));
+                pool.returnBuf(large);
+                long after = allocator.getAllocatedMemory();
+                assertEquals("evict one small to park the large", fullOfSmall - smallCap + large.capacity(), after);
             } finally {
                 pool.close();
             }
@@ -130,6 +195,43 @@ public class DirectBufferPoolTests extends ESTestCase {
             assertThat(allocator.getAllocatedMemory(), lessThanOrEqualTo((long) DirectBufferPool.MAX_POOLED * 192));
             pool.close();
             assertEquals(0L, allocator.getAllocatedMemory());
+        }
+    }
+
+    /**
+     * Overlapping "queries": each thread holds several buffers at once (columns in a row
+     * group), mixed sizes, in-flight count above {@link DirectBufferPool#MAX_POOLED}. After
+     * join, idle occupancy is capped and a 1024-borrow reuses a parked large buffer (eviction
+     * prefers larger).
+     */
+    public void testConcurrentOverlappingQueriesMixedSizes() throws Exception {
+        int queries = 8;
+        int columns = 8;
+        int[] sizes = { 64, 256, 1024 };
+        DirectBufferPool pool = new DirectBufferPool();
+        try (var allocator = DirectBufferAllocationManager.createRootAllocator(AllocationListener.NOOP, Long.MAX_VALUE)) {
+            try {
+                startInParallel(queries, q -> {
+                    for (int iter = 0; iter < 25; iter++) {
+                        List<ArrowBuf> held = new ArrayList<>(columns);
+                        for (int c = 0; c < columns; c++) {
+                            held.add(pool.borrow(allocator, sizes[(q + c + iter) % sizes.length]));
+                        }
+                        for (ArrowBuf buf : held) {
+                            pool.returnBuf(buf);
+                        }
+                    }
+                });
+                long parked = allocator.getAllocatedMemory();
+                assertThat(parked, greaterThan(0L));
+                ArrowBuf sizeProbe = allocator.buffer(1024);
+                long largeCap = sizeProbe.capacity();
+                sizeProbe.close();
+                assertThat(parked, lessThanOrEqualTo((long) DirectBufferPool.MAX_POOLED * largeCap));
+            } finally {
+                pool.close();
+                assertEquals(0L, allocator.getAllocatedMemory());
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/MockBlockFactory.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/MockBlockFactory.java
@@ -61,6 +61,9 @@ public class MockBlockFactory extends BlockFactory {
 
     public void ensureAllBlocksAreReleased() {
 
+        if (directBufferPool != null) {
+            directBufferPool.close();
+        }
         if (arrowAllocator != null) {
             arrowAllocator.close();
         }


### PR DESCRIPTION
Park Arrow decompress buffers across queries so glibc does not retain freed pages after each query. Rebases on in-query reuse now in main (#157375). Still includes Arrow MaxDirectMemorySize accounting from #157281. Undersized idle buffers stay parked until idle-cap eviction.