### PR TITLE
fix: Mandatory Date header is absent in HTTP responses - #157382

### DIFF
--- a/docs/changelog/157443.yaml
+++ b/docs/changelog/157443.yaml
@@ -1,0 +1,6 @@
+pr: 157443
+summary: Add mandatory Date header to all HTTP responses
+area: REST API
+type: bug
+issues:
+  - 157382

--- a/server/src/main/java/org/elasticsearch/http/CorsHandler.java
+++ b/server/src/main/java/org/elasticsearch/http/CorsHandler.java
@@ -104,6 +104,8 @@ public class CorsHandler {
     }
 
     public void setCorsResponseHeaders(final HttpRequest httpRequest, final HttpResponse httpResponse) {
+        // RFC 9110: Add Date header to all responses
+        setDateHeader(httpResponse);
         if (config.isCorsSupportEnabled() == false) {
             return;
         }
@@ -129,6 +131,7 @@ public class CorsHandler {
 
     private static HttpResponse forbidden(final HttpRequest request) {
         HttpResponse response = request.createResponse(RestStatus.FORBIDDEN, BytesArray.EMPTY);
+        setDateHeader(response);
         response.addHeader("content-length", "0");
         return response;
     }
@@ -145,8 +148,12 @@ public class CorsHandler {
     }
 
     private static void setPreflightHeaders(final HttpResponse response) {
-        response.addHeader(CorsHandler.DATE, dateTimeFormatter.format(ZonedDateTime.now(ZoneOffset.UTC)));
+        setDateHeader(response);
         response.addHeader("content-length", "0");
+    }
+
+    private static void setDateHeader(final HttpResponse response) {
+        response.addHeader(CorsHandler.DATE, dateTimeFormatter.format(ZonedDateTime.now(ZoneOffset.UTC)));
     }
 
     private boolean setOrigin(final HttpRequest request, final HttpResponse response) {


### PR DESCRIPTION
**Bug-fix**
Root Cause
The Date header was only being added to CORS preflight (OPTIONS) responses
Regular HTTP responses and error responses (e.g., CORS validation failures) were missing the header

Changes:


- Added setDateHeader() helper method - Centralizes Date header generation with RFC 9110 compliant UTC formatting
- Updated setCorsResponseHeaders() - Ensures all regular HTTP responses include the Date header
- Updated forbidden() method - Adds Date header to CORS rejection responses (403 Forbidden)
- Refactored setPreflightHeaders() - Uses the new helper to eliminate code duplication