### PR TITLE
[ESQL] Allocate parquet I/O onto the heap

### DIFF
--- a/docs/changelog/157446.yaml
+++ b/docs/changelog/157446.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157446
+summary: Allocate parquet I/O onto the heap
+type: enhancement

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectAsyncTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectAsyncTests.java
@@ -11,11 +11,8 @@ import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -42,14 +39,7 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class AzureStorageObjectAsyncTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     private static final String CONNECTION_STRING = "DefaultEndpointsProtocol=http;"
         + "AccountName=devstoreaccount1;"

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
@@ -13,11 +13,8 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -50,14 +47,7 @@ import static org.mockito.Mockito.when;
  */
 public class GcsStorageObjectTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     private final Storage mockStorage = mock(Storage.class);
 
@@ -499,7 +489,7 @@ public class GcsStorageObjectTests extends ESTestCase {
         assertNull(error.get());
         assertNotNull(result.get());
         try (DirectReadBuffer drb = result.get()) {
-            assertTrue("readBytesAsync must return a direct ByteBuffer", drb.buffer().isDirect());
+            assertFalse("readBytesAsync must return a heap ByteBuffer", drb.buffer().isDirect());
             assertEquals(5, drb.buffer().remaining());
         }
         verify(mockReader).seek(10);

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
@@ -20,8 +20,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 
 /**
- * {@link HttpResponse.BodyHandler} implementations that accumulate HTTP response bodies directly
- * into a pre-allocated direct {@link ByteBuffer}, avoiding {@code BodyHandlers.ofByteArray()}.
+ * {@link HttpResponse.BodyHandler} implementations that accumulate HTTP response bodies into a
+ * pre-allocated destination {@link ByteBuffer}, avoiding {@code BodyHandlers.ofByteArray()}.
  *
  * <p>Destination buffers are obtained from a caller-supplied {@link DirectBufferFactory} so the
  * allocation is breaker-accounted. On success the {@link DirectReadBuffer} is handed to the
@@ -34,9 +34,9 @@ final class DirectByteBufferBodyHandlers {
 
     /**
      * Returns a body handler for range reads. When the server responds with {@code 206 Partial Content},
-     * the body is accumulated into a direct buffer of {@code length}. When the server ignores the
+     * the body is accumulated into a buffer of {@code length}. When the server ignores the
      * {@code Range} header and responds with {@code 200 OK}, the first {@code skip} bytes are
-     * discarded and the next {@code length} bytes are accumulated into a direct buffer.
+     * discarded and the next {@code length} bytes are accumulated into a destination buffer.
      *
      * @param factory factory used to produce the destination buffer on the 200/206 paths
      */
@@ -54,7 +54,7 @@ final class DirectByteBufferBodyHandlers {
     }
 
     /**
-     * Accumulates exactly {@code expectedLength} bytes into a direct buffer. Used for {@code 206} responses.
+     * Accumulates exactly {@code expectedLength} bytes into a destination buffer. Used for {@code 206} responses.
      */
     static final class FixedLengthDirectSubscriber implements HttpResponse.BodySubscriber<DirectReadBuffer> {
         private final int expectedLength;
@@ -180,7 +180,7 @@ final class DirectByteBufferBodyHandlers {
     }
 
     /**
-     * Skips {@code skip} bytes then accumulates up to {@code length} bytes into a direct buffer.
+     * Skips {@code skip} bytes then accumulates up to {@code length} bytes into a destination buffer.
      * Used when a server ignores {@code Range} and returns the full body with {@code 200 OK}.
      */
     static final class SkipThenFillDirectSubscriber implements HttpResponse.BodySubscriber<DirectReadBuffer> {

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
@@ -7,11 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasource.http;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -31,14 +28,7 @@ import static org.mockito.Mockito.when;
 
 public class DirectByteBufferBodyHandlersTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testFixedLengthSingleChunk() throws Exception {
         byte[] payload = randomByteArrayOfLength(between(1, 4096));
@@ -51,7 +41,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         subscriber.onComplete();
 
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -68,7 +58,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         subscriber.onComplete();
 
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -118,7 +108,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         subscriber.onComplete();
 
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(expected, toByteArray(result.buffer()));
         }
     }
@@ -183,7 +173,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         subscriber.onComplete();
 
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -218,7 +208,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         subscriber.onComplete();
 
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(expected, toByteArray(result.buffer()));
         }
     }

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
@@ -7,12 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasource.http;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -50,14 +47,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class HttpStorageObjectTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testPath() {
         HttpClient mockClient = mock(HttpClient.class);
@@ -268,12 +258,11 @@ public class HttpStorageObjectTests extends ESTestCase {
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertNotNull(result.get());
-        // Copy the bytes off the allocator-backed buffer so the caller doesn't hold a view of
-        // memory that we release here. The DirectReadBuffer payload is always allocator-backed
-        // (i.e. direct); callers historically asserted isDirect() on the returned buffer.
+        // Copy the bytes off the factory-backed buffer so the caller doesn't hold a view of
+        // memory that we release here. Production factories return a heap ByteBuffer.
         DirectReadBuffer drb = result.get();
         try {
-            assertTrue("readBytesAsync must return a direct ByteBuffer", drb.buffer().isDirect());
+            assertFalse("readBytesAsync must return a heap ByteBuffer", drb.buffer().isDirect());
             return toByteArray(drb.buffer());
         } finally {
             drb.close();

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
@@ -7,11 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasource.http.local;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.StorageIterator;
@@ -42,14 +39,7 @@ import static org.hamcrest.Matchers.containsString;
  */
 public class LocalStorageProviderTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testReadFullFile() throws IOException {
         // Create a temporary file
@@ -269,7 +259,7 @@ public class LocalStorageProviderTests extends ESTestCase {
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertNotNull(result.get());
         try (DirectReadBuffer drb = result.get()) {
-            assertTrue("readBytesAsync must return a direct ByteBuffer", drb.buffer().isDirect());
+            assertFalse("readBytesAsync must return a heap ByteBuffer", drb.buffer().isDirect());
             byte[] actual = new byte[drb.buffer().remaining()];
             drb.buffer().get(actual);
             assertEquals("56789", new String(actual, StandardCharsets.UTF_8));

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocator.java
@@ -9,11 +9,14 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 
 import java.nio.ByteBuffer;
 
 /**
  * A Parquet {@code ByteBufferAllocator} that uses a circuit breaker to manage memory usage.
+ * Charges go through {@link DirectBufferFactory#forAsyncIo(CircuitBreaker)} because
+ * parquet-mr may allocate from generic threads after {@code readBytesAsync}.
  */
 public class CircuitBreakerByteBufferAllocator implements ByteBufferAllocator {
     private final ByteBufferAllocator delegate;
@@ -21,7 +24,7 @@ public class CircuitBreakerByteBufferAllocator implements ByteBufferAllocator {
 
     public CircuitBreakerByteBufferAllocator(ByteBufferAllocator delegate, CircuitBreaker breaker) {
         this.delegate = delegate;
-        this.breaker = breaker;
+        this.breaker = DirectBufferFactory.forAsyncIo(breaker);
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocator.java
@@ -9,14 +9,14 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 
 import java.nio.ByteBuffer;
 
 /**
- * A Parquet {@code ByteBufferAllocator} that uses a circuit breaker to manage memory usage.
- * Charges go through {@link DirectBufferFactory#forAsyncIo(CircuitBreaker)} because
- * parquet-mr may allocate from generic threads after {@code readBytesAsync}.
+ * A Parquet {@code ByteBufferAllocator} that charges allocations to a circuit breaker.
+ * Callers that may allocate off the driver thread must pass
+ * {@link org.elasticsearch.compute.data.LocalCircuitBreaker#forAsyncIo(CircuitBreaker)} themselves;
+ * this class does not rewrite the breaker.
  */
 public class CircuitBreakerByteBufferAllocator implements ByteBufferAllocator {
     private final ByteBufferAllocator delegate;
@@ -24,7 +24,7 @@ public class CircuitBreakerByteBufferAllocator implements ByteBufferAllocator {
 
     public CircuitBreakerByteBufferAllocator(ByteBufferAllocator delegate, CircuitBreaker breaker) {
         this.delegate = delegate;
-        this.breaker = DirectBufferFactory.forAsyncIo(breaker);
+        this.breaker = breaker;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
@@ -55,12 +55,10 @@ final class CoalescedRangeReader {
 
     /**
      * Result of a coalesced read: the slices delivered to each original {@link ByteRange}, plus a
-     * {@link Releasable} that owns the underlying direct memory. The caller must close
+     * {@link Releasable} that owns the underlying buffers. The caller must close
      * {@link #release()} when the slices are no longer needed (typically at row-group rollover) so
-     * the breaker-accounted bytes are returned to the allocator eagerly instead of waiting for the
-     * JVM {@code Cleaner}. The {@code release} closes every {@link DirectReadBuffer} obtained from
-     * {@link StorageObject#readBytesAsync}, which decrements each backing {@code ArrowBuf}'s
-     * reference count and returns the memory to {@code allocator}.
+     * the breaker-accounted bytes are released eagerly instead of waiting for GC. The {@code release}
+     * closes every {@link DirectReadBuffer} obtained from {@link StorageObject#readBytesAsync}.
      */
     record CoalescedRangeResult(Map<ByteRange, ByteBuffer> ranges, Releasable release) {}
 
@@ -71,13 +69,12 @@ final class CoalescedRangeReader {
      *
      * <p>The {@link DirectReadBuffer}s returned by each underlying read are surfaced as a single
      * composite {@link Releasable} on {@link CoalescedRangeResult#release()}; the caller owns them
-     * from that point on and must close the result to release the native memory back to
-     * {@code allocator}.
+     * from that point on and must close the result to release the breaker charge.
      *
      * @param storageObject the storage object to read from
      * @param ranges the byte ranges to fetch (need not be sorted)
      * @param maxCoalesceGap maximum gap in bytes between two ranges to merge them
-     * @param allocator allocator used by the storage object to back each merged-range buffer
+     * @param breaker circuit breaker charged for each merged-range buffer
      * @param executor executor for async dispatch
      * @param listener receives the per-range slices plus the composite {@link Releasable}
      */
@@ -85,7 +82,7 @@ final class CoalescedRangeReader {
         StorageObject storageObject,
         List<ByteRange> ranges,
         long maxCoalesceGap,
-        BufferAllocator allocator,
+        CircuitBreaker breaker,
         Executor executor,
         ActionListener<CoalescedRangeResult> listener
     ) {
@@ -105,9 +102,9 @@ final class CoalescedRangeReader {
         AtomicInteger remaining = new AtomicInteger(merged.size());
         AtomicReference<Exception> firstFailure = new AtomicReference<>();
 
-        // Bridge the Arrow allocator to the SPI's allocator-agnostic factory once, here at the
-        // boundary, so backends do not need to know about BufferAllocator at all.
-        DirectBufferFactory factory = DirectBufferFactory.forAllocator(allocator);
+        // Bridge the circuit breaker to the SPI's factory once, here at the boundary, so
+        // backends do not need to know about CircuitBreaker at all.
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
 
         for (MergedRange mr : merged) {
             storageObject.readBytesAsync(mr.offset, mr.length, factory, executor, new ActionListener<>() {
@@ -124,7 +121,7 @@ final class CoalescedRangeReader {
                     } catch (Throwable t) {
                         // Do not rethrow. {@code result} is already in {@code buffers}, so the terminal
                         // complete() will close it. Rethrowing would let the SPI's default readBytesAsync
-                        // catch also close {@code result}, double-freeing the backing ArrowBuf. Folding
+                        // catch also close {@code result}, double-releasing the buffer. Folding
                         // every throwable (not just Exception) into firstFailure guarantees a failure is
                         // delivered: with the finally below already calling complete(), letting an Error
                         // through instead would deliver a spurious success with truncated slices.
@@ -139,7 +136,7 @@ final class CoalescedRangeReader {
 
                 @Override
                 public void onFailure(Exception e) {
-                    // The backend has already released its ArrowBuf on the failure path; nothing
+                    // The backend has already released its buffer on the failure path; nothing
                     // to clean up for this merged range. Siblings that succeeded are released by
                     // complete() below.
                     if (firstFailure.compareAndSet(null, e) == false) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -7,18 +7,15 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.esql.datasources.spi.DirectMemoryDebug;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.nio.ByteBuffer;
@@ -53,8 +50,7 @@ final class ColumnChunkPrefetcher {
 
     /**
      * Result of a prefetch: the chunks indexed by file position, plus a {@link Releasable} that
-     * owns the underlying direct memory (one child allocator per merged range, plus any extras
-     * produced by {@link #promoteToDirect}). The caller must close {@link #release()} once the
+     * owns the underlying buffers. The caller must close {@link #release()} once the
      * chunks are no longer needed (typically at row-group rollover).
      */
     record PrefetchedChunks(NavigableMap<Long, PrefetchedChunk> chunks, Releasable release) {}
@@ -66,14 +62,14 @@ final class ColumnChunkPrefetcher {
      * @param storageObject the storage backend
      * @param block metadata for the row group to prefetch
      * @param projectedColumns column paths to include (null = all columns)
-     * @param allocator parent allocator from which per-merged-range child allocators are spawned
+     * @param breaker circuit breaker charged for each merged-range buffer
      * @return a future that, on completion, holds the chunk index plus a {@link Releasable}
      */
     static CompletableFuture<PrefetchedChunks> prefetch(
         StorageObject storageObject,
         BlockMetaData block,
         Set<String> projectedColumns,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
         if (ranges.isEmpty()) {
@@ -94,14 +90,14 @@ final class ColumnChunkPrefetcher {
             storageObject,
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
-            allocator,
+            breaker,
             Runnable::run,
             ioFuture
         );
 
         try {
             CoalescedRangeReader.CoalescedRangeResult fetched = ioFuture.actionGet();
-            result.complete(buildPrefetched(fetched, allocator));
+            result.complete(buildPrefetched(fetched));
         } catch (Throwable e) {
             result.completeExceptionally(e);
         }
@@ -117,7 +113,7 @@ final class ColumnChunkPrefetcher {
         StorageObject storageObject,
         BlockMetaData block,
         Set<String> projectedColumns,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
         if (ranges.isEmpty()) {
@@ -137,16 +133,16 @@ final class ColumnChunkPrefetcher {
             storageObject,
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
-            allocator,
+            breaker,
             Runnable::run,
             new ActionListener<>() {
                 @Override
                 public void onResponse(CoalescedRangeReader.CoalescedRangeResult fetched) {
                     try {
-                        PrefetchedChunks chunks = buildPrefetched(fetched, allocator);
+                        PrefetchedChunks chunks = buildPrefetched(fetched);
                         if (result.complete(chunks) == false) {
                             // The future was cancelled between I/O completion and here; release
-                            // the direct memory we just allocated so the breaker charge returns.
+                            // the buffers we just allocated so the breaker charge returns.
                             chunks.release().close();
                         }
                     } catch (Throwable e) {
@@ -296,10 +292,10 @@ final class ColumnChunkPrefetcher {
         PreloadedRowGroupMetadata metadata,
         int rowGroupOrdinal,
         long rowGroupRowCount,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         if (rowRanges == null || rowRanges.isAll()) {
-            return prefetch(storageObject, block, projectedColumns, allocator);
+            return prefetch(storageObject, block, projectedColumns, breaker);
         }
 
         List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
@@ -328,14 +324,14 @@ final class ColumnChunkPrefetcher {
             storageObject,
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
-            allocator,
+            breaker,
             Runnable::run,
             ioFuture
         );
 
         try {
             CoalescedRangeReader.CoalescedRangeResult fetched = ioFuture.actionGet();
-            result.complete(buildPrefetched(fetched, allocator));
+            result.complete(buildPrefetched(fetched));
         } catch (Throwable e) {
             result.completeExceptionally(e);
         }
@@ -350,10 +346,10 @@ final class ColumnChunkPrefetcher {
         PreloadedRowGroupMetadata metadata,
         int rowGroupOrdinal,
         long rowGroupRowCount,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         if (rowRanges == null || rowRanges.isAll()) {
-            return prefetchAsync(storageObject, block, projectedColumns, allocator);
+            return prefetchAsync(storageObject, block, projectedColumns, breaker);
         }
 
         List<CoalescedRangeReader.ByteRange> ranges = computeFilteredPageRanges(
@@ -375,16 +371,16 @@ final class ColumnChunkPrefetcher {
             storageObject,
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
-            allocator,
+            breaker,
             Runnable::run,
             new ActionListener<>() {
                 @Override
                 public void onResponse(CoalescedRangeReader.CoalescedRangeResult fetched) {
                     try {
-                        PrefetchedChunks chunks = buildPrefetched(fetched, allocator);
+                        PrefetchedChunks chunks = buildPrefetched(fetched);
                         if (result.complete(chunks) == false) {
                             // The future was cancelled between I/O completion and here; release
-                            // the direct memory we just allocated so the breaker charge returns.
+                            // the buffers we just allocated so the breaker charge returns.
                             chunks.release().close();
                         }
                     } catch (Throwable e) {
@@ -407,33 +403,28 @@ final class ColumnChunkPrefetcher {
     }
 
     /**
-     * Assembles a {@link PrefetchedChunks} from the coalesced read result. Wraps the result's
-     * own {@link Releasable} together with any extra promote-to-direct allocations so the caller
-     * can close them all in one shot.
+     * Assembles a {@link PrefetchedChunks} from the coalesced read result. Heap buffers stay heap;
+     * {@link ByteBuffer#slice()} normalizes position so {@code PrefetchedSource} can treat
+     * {@code offsetInChunk} as 0-based.
      */
-    private static PrefetchedChunks buildPrefetched(CoalescedRangeReader.CoalescedRangeResult fetched, BufferAllocator allocator) {
+    private static PrefetchedChunks buildPrefetched(CoalescedRangeReader.CoalescedRangeResult fetched) {
         // Keyed by file offset. Column chunks in a valid Parquet file have unique start positions;
         // duplicate offsets would indicate a corrupt or pathological file.
         NavigableMap<Long, PrefetchedChunk> prefetched = new TreeMap<>();
-        List<Releasable> extra = new ArrayList<>();
         try {
             for (var entry : fetched.ranges().entrySet()) {
                 CoalescedRangeReader.ByteRange range = entry.getKey();
-                // promoteToDirect's fast-path (already-direct) returns the slice as delivered
-                // by CoalescedRangeReader: position == relativeOffset within the merged S3 range,
-                // not 0. PrefetchedSource.slice() treats offsetInChunk as a 0-based index into
-                // chunk.data(), so normalise position here via slice(). The heap→direct copy path
-                // already flips the buffer to position=0, so slice() is a no-op for that case.
-                ByteBuffer data = promoteToDirect(entry.getValue(), allocator, extra).slice();
+                // CoalescedRangeReader delivers slices with position == relativeOffset within the
+                // merged range, not 0. PrefetchedSource.slice() treats offsetInChunk as a 0-based
+                // index into chunk.data(), so normalise position here via slice().
+                ByteBuffer data = entry.getValue().slice();
                 prefetched.put(range.offset(), new PrefetchedChunk(range.offset(), range.length(), data));
             }
         } catch (Throwable t) {
-            // Release the read result and any extras we managed to create before re-throwing so
-            // the caller sees a clean failure with no outstanding breaker reservation. We catch
-            // Throwable (not just RuntimeException) so that Errors like OutOfMemoryError — which
-            // are a realistic outcome of allocating large direct buffers — also run the cleanup
-            // path; otherwise the breaker reservation would leak for the lifetime of the JVM.
-            Releasables.close(extra);
+            // Release the read result before re-throwing so the caller sees a clean failure with
+            // no outstanding breaker reservation. We catch Throwable (not just RuntimeException)
+            // so that Errors like OutOfMemoryError also run the cleanup path; otherwise the
+            // breaker reservation would leak for the lifetime of the JVM.
             try {
                 fetched.release().close();
             } catch (Throwable releaseFailure) {
@@ -441,42 +432,7 @@ final class ColumnChunkPrefetcher {
             }
             throw t;
         }
-        Releasable composite = () -> {
-            // Close the underlying coalesced-range child allocators first, then any extras created
-            // by promote-to-direct. Order is irrelevant for correctness but keeps allocator names
-            // visible in leak reports in the original allocation order.
-            try {
-                fetched.release().close();
-            } finally {
-                Releasables.close(extra);
-            }
-        };
-        return new PrefetchedChunks(prefetched, composite);
-    }
-
-    /**
-     * Returns a direct {@link ByteBuffer} view of {@code buffer}. If the input is already direct
-     * (the production path: every backend now returns ArrowBuf-backed direct memory), this is a
-     * no-op. Test stubs that return heap buffers fall through to an allocator-backed copy so the
-     * downstream JNI decompressors can still take their direct-to-direct fast path and the
-     * promoted bytes are also breaker-accounted.
-     */
-    private static ByteBuffer promoteToDirect(ByteBuffer buffer, BufferAllocator allocator, List<Releasable> extra) {
-        if (buffer.isDirect()) {
-            return buffer;
-        }
-        int length = buffer.remaining();
-        ArrowBuf promoted = allocator.buffer(length);
-        ByteBuffer direct = promoted.nioBuffer(0, length);
-        // Poison the region just before release (assertions only) so a page slice that aliases this
-        // promoted chunk and is read after free fails deterministically instead of flakily.
-        extra.add(() -> {
-            DirectMemoryDebug.poison(direct);
-            promoted.close();
-        });
-        direct.put(buffer);
-        direct.flip();
-        return direct;
+        return new PrefetchedChunks(prefetched, fetched.release());
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -89,11 +89,11 @@ import java.util.function.Consumer;
  * decoding and utility helpers via {@link ParquetColumnDecoding}. The baseline remains
  * the stable fallback when {@code optimized_reader=false} is explicitly set via config.
  *
- * <p><b>Memory:</b> Prefetched bytes are accounted on the REQUEST circuit breaker (via
- * {@link BlockFactory#breaker()}) by the Arrow allocator that backs the per-range
- * {@code ArrowBuf}s; the bytes are returned when the chunks' {@link Releasable} is closed at
- * row-group rollover. If the allocator's breaker check fails during a prefetch, the future
- * fails, prefetch is skipped, and the query falls back to synchronous I/O for that row group.
+ * <p><b>Memory:</b> Prefetched bytes live on the heap and are charged to the REQUEST circuit
+ * breaker via {@link BlockFactory#breaker()}; the charge is released when the chunks'
+ * {@link Releasable} is closed at row-group rollover. If the breaker check fails during a
+ * prefetch, the future fails, prefetch is skipped, and the query falls back to synchronous
+ * I/O for that row group.
  *
  * <p><b>Trivially-passes guard:</b> when late materialization is enabled and row-group
  * statistics prove every row satisfies the pushed filter ({@link TriviallyPassesChecker}),
@@ -240,11 +240,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private int consecutiveNoStalls;
     private final ArrayDeque<PendingPrefetch> pendingPrefetches = new ArrayDeque<>();
     /**
-     * Allocator-backed memory holding the chunks currently in use by {@link #rowGroup}. Released
-     * at row-group rollover so the direct memory is freed eagerly rather than waiting for the
-     * JVM {@code Cleaner}. Closing the releasable decrements the underlying {@code ArrowBuf}
-     * reference counts, which in turn returns the bytes to the circuit breaker via
-     * {@link org.elasticsearch.compute.data.arrow.CircuitBreakerAllocationListener}.
+     * Breaker-accounted heap buffers holding the chunks currently in use by {@link #rowGroup}.
+     * Released at row-group rollover so the charge returns immediately rather than waiting for
+     * GC. Closing the releasable releases the {@code DirectReadBuffer} charge via
+     * {@code DirectReadBuffer.close()}.
      */
     private Releasable currentChunksReleasable;
 
@@ -463,10 +462,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * Fills the prefetch queue up to {@link #prefetchDepth} entries, starting from ordinal
      * {@code fromOrdinal}. Stops early when no more surviving row groups remain. Breaker
-     * accounting for the prefetched bytes happens implicitly inside the backend's
-     * {@code readBytesAsync} via the Arrow allocator; if a prefetch trips the breaker it
-     * surfaces as a failed future and {@link #takePendingPrefetch} falls back to sync I/O
-     * for that row group.
+     * accounting for the prefetched bytes happens inside {@code readBytesAsync} via
+     * {@code DirectBufferFactory.forBreaker}; if a prefetch trips the breaker it surfaces as
+     * a failed future and {@link #takePendingPrefetch} falls back to sync I/O for that row
+     * group.
      */
     private void fillPrefetchQueue(int fromOrdinal) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
@@ -516,10 +515,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         preloadedMetadata,
                         nextOrdinal,
                         nextBlock.getRowCount(),
-                        blockFactory.arrowAllocator()
+                        breaker
                     );
                 } else {
-                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns, blockFactory.arrowAllocator());
+                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns, breaker);
                 }
                 pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future));
             } catch (Exception e) {
@@ -1533,16 +1532,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     ) {
         ColumnChunkPrefetcher.PrefetchedChunks phase2Result;
         try {
-            phase2Result = ColumnChunkPrefetcher.prefetchAsync(
-                storageObject,
-                block,
-                projectionOnlyColumnPaths,
-                blockFactory.arrowAllocator()
-            ).join();
+            phase2Result = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths, breaker).join();
         } catch (Exception e) {
-            // No manual breaker accounting here: the Arrow allocator that backs the
-            // prefetch's direct memory automatically releases the reservation when the
-            // failed future is drained by the caller's cleanup path.
+            // No manual breaker accounting here: the DirectReadBuffer closer releases the
+            // reservation when the failed future is drained by the caller's cleanup path.
             throw ParquetReadFailures.wrap(
                 e,
                 "Trivially-passes Phase-2 fetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]"
@@ -1560,7 +1553,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
         // Compose the Phase-1 (still live in currentChunksReleasable) and Phase-2 releasables so
         // both sets of chunks are freed together at the next row-group rollover. Breaker
-        // accounting for both phases is tracked by the allocator-backed ArrowBufs they hold.
+        // accounting for both phases is tracked by the DirectReadBuffers they hold.
         Releasable phase1Releasable = currentChunksReleasable;
         Releasable phase2Releasable = phase2Result != null ? phase2Result.release() : () -> {};
         currentChunksReleasable = () -> Releasables.close(phase1Releasable, phase2Releasable);
@@ -1583,7 +1576,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * Synchronously fetches the Phase-2 (projection-only) chunks for the current row group and
      * builds the projection {@link PrefetchedPageReadStore}. Breaker accounting for the fetched
-     * bytes is tracked by the allocator-backed {@code ArrowBuf}s inside the returned releasable.
+     * bytes is tracked by the DirectReadBuffers inside the returned releasable.
      *
      * @param block metadata for the row group
      * @param survivorRanges row ranges of survivors as produced by {@link WordMaskRowRangesConverter}
@@ -1603,18 +1596,17 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     preloadedMetadata,
                     rowGroupOrdinal,
                     block.getRowCount(),
-                    blockFactory.arrowAllocator()
+                    breaker
                 )
-                : ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths, blockFactory.arrowAllocator());
+                : ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths, breaker);
             result = future.join();
         } catch (Exception e) {
-            // No manual breaker accounting here: the Arrow allocator that backs the
-            // prefetch's direct memory automatically releases the reservation when the
-            // failed future is drained by the caller's cleanup path.
+            // No manual breaker accounting here: the DirectReadBuffer closer releases the
+            // reservation when the failed future is drained by the caller's cleanup path.
             throw ParquetReadFailures.wrap(e, "Phase 2 prefetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]");
         }
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = result != null ? result.chunks() : null;
-        // The Phase-2 chunks' allocator-backed memory is the sole breaker accounting for this row
+        // The Phase-2 chunks' breaker-accounted memory is the sole I/O accounting for this row
         // group's projection columns; closing currentChunksReleasable returns those bytes. The
         // Phase-1 chunks were already released by the caller after predicate decode — assert that
         // here so any future refactor that breaks the precondition surfaces as a test failure
@@ -1718,15 +1710,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /**
      * Dequeues the head of the prefetch queue if it matches {@code expectedOrdinal}, joining its
      * future and returning the prefetched chunks. Entries whose ordinals don't match (because
-     * the stats filter skipped intermediate row groups) are cancelled and any direct memory they
-     * had already produced is drained. Returns {@code null} when there is no usable prefetch
-     * (queue empty, empty result, or the prefetch failed — e.g. allocator tripped the breaker —
+     * the stats filter skipped intermediate row groups) are cancelled and any heap buffers they
+     * had already produced are drained. Returns {@code null} when there is no usable prefetch
+     * (queue empty, empty result, or the prefetch failed — e.g. the breaker tripped —
      * in which case the caller falls back to sync I/O for the requested row group).
      *
      * <p>On success the chunks' {@link Releasable} is handed off to
      * {@link #currentChunksReleasable} and released by {@link #releaseCurrentReservation} at
-     * row-group rollover. The releasable owns the allocator-backed {@code ArrowBuf}s, which is
-     * how the breaker accounting for the prefetched bytes is tracked.
+     * row-group rollover. The releasable owns the {@code DirectReadBuffer}s, which is how the
+     * breaker accounting for the prefetched bytes is tracked.
      */
     private NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> takePendingPrefetch(int expectedOrdinal) {
         releaseCurrentReservation();
@@ -1758,9 +1750,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 return data;
             }
             if (result != null) {
-                // Empty result still owns the breaker-tracked direct memory until released; any
-                // exception from release().close() (e.g. double-decrement of the underlying
-                // ArrowBuf) is a real bug we want to surface rather than silently swallow.
+                // Empty result still owns the breaker-tracked heap buffers until released; any
+                // exception from release().close() is a real bug we want to surface rather than
+                // silently swallow.
                 result.release().close();
             }
             return null;
@@ -1833,9 +1825,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     }
 
     /**
-     * Cancels all pending prefetches and drains their results so any direct memory the prefetch
-     * may already have produced is released back to the breaker via the allocator. Called when
-     * the iterator is exhausted or closed.
+     * Cancels all pending prefetches and drains their results so any heap buffers the prefetch
+     * may already have produced release their breaker charge. Called when the iterator is
+     * exhausted or closed.
      */
     private void cancelPendingPrefetch() {
         while (pendingPrefetches.isEmpty() == false) {
@@ -1846,10 +1838,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     }
 
     /**
-     * Frees the allocator-backed direct memory holding the chunks currently in use by the row
+     * Frees the breaker-accounted heap buffers holding the chunks currently in use by the row
      * group. Called when those chunks are about to be replaced (next advance) or dropped (close).
-     * Closing the releasable returns the bytes to the breaker via the Arrow allocator listener.
-     * Idempotent.
+     * Closing the releasable releases the {@code DirectReadBuffer} charge. Idempotent.
      */
     private void releaseCurrentReservation() {
         if (currentChunksReleasable != null) {
@@ -2489,8 +2480,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * Wraps an in-flight prefetch future.
      *
      * <p>The {@link #future} resolves to a {@link ColumnChunkPrefetcher.PrefetchedChunks} whose
-     * {@link ColumnChunkPrefetcher.PrefetchedChunks#release()} owns the underlying direct memory
-     * (and, transitively, the circuit-breaker accounting via the Arrow allocator listener).
+     * {@link ColumnChunkPrefetcher.PrefetchedChunks#release()} owns the underlying heap buffers
+     * (and, transitively, the circuit-breaker charge via {@code DirectReadBuffer.close()}).
      * If the prefetch is dequeued for use, that {@link Releasable} is handed off to
      * {@link #currentChunksReleasable}. If it is skipped or cancelled, {@link #release()} drains
      * any already-produced chunks so the breaker bytes return immediately.
@@ -2498,18 +2489,18 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private record PendingPrefetch(int ordinal, CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future) {
 
         void release() {
-            // Drain the future so the direct memory the prefetch may have already produced is
-            // released. We use getNow() to avoid a wait if the I/O is still in flight; in that
-            // case FutureUtils.cancel() (called by the queue-management code before us) will
-            // either complete the future exceptionally (no chunks to release) or propagate the
-            // cancellation up to the storage backend.
+            // Drain the future so the heap buffers the prefetch may have already produced
+            // release their breaker charge. We use getNow() to avoid a wait if the I/O is still
+            // in flight; in that case FutureUtils.cancel() (called by the queue-management code
+            // before us) will either complete the future exceptionally (no chunks to release) or
+            // propagate the cancellation up to the storage backend.
             ColumnChunkPrefetcher.PrefetchedChunks chunks;
             try {
                 chunks = future.getNow(null);
             } catch (CompletionException | CancellationException ignored) {
                 // Future completed exceptionally (or was cancelled) — no chunks were ever produced
                 // so there is nothing for us to release. Narrowing the catch keeps real bugs in
-                // release().close() (e.g. ArrowBuf double-decrement) visible to the caller.
+                // release().close() visible to the caller.
                 return;
             }
             if (chunks != null) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1151,7 +1151,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         chunks,
                         storageObject,
                         codecFactory,
-                        blockFactory.breaker()
+                        breaker
                     );
                     rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
                     triggerNextRowGroupPrefetch();
@@ -1325,7 +1325,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             phase1Chunks,
             storageObject,
             codecFactory,
-            blockFactory.breaker()
+            breaker
         );
         rowGroup = predicateStore;
         initPredicateColumnReaders();
@@ -1567,7 +1567,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             merged,
             storageObject,
             codecFactory,
-            blockFactory.breaker()
+            breaker
         );
         rowsRemainingInGroup = rowGroup.getRowCount();
         initColumnReaders(null);
@@ -1623,7 +1623,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             chunks,
             storageObject,
             codecFactory,
-            blockFactory.breaker()
+            breaker
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1152,7 +1152,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                         chunks,
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator()
+                        blockFactory.breaker()
                     );
                     rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
                     triggerNextRowGroupPrefetch();
@@ -1326,7 +1326,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             phase1Chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.breaker()
         );
         rowGroup = predicateStore;
         initPredicateColumnReaders();
@@ -1574,7 +1574,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             merged,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.breaker()
         );
         rowsRemainingInGroup = rowGroup.getRowCount();
         initColumnReaders(null);
@@ -1631,7 +1631,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             chunks,
             storageObject,
             codecFactory,
-            blockFactory.arrowAllocator()
+            blockFactory.breaker()
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -720,7 +720,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                 prefetched,
                 storageObject,
                 reader.codecFactory(),
-                blockFactory.arrowAllocator()
+                blockFactory.breaker()
             )
         ) {
             if (info.maxRepLevel() == 0) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -280,7 +280,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             ColumnChunkPrefetcher.PrefetchedChunks>[]) new CompletableFuture<?>[buckets.size()];
         for (int i = 0; i < buckets.size(); i++) {
             BlockMetaData block = blocks.get(buckets.get(i).rowGroupIndex);
-            futures[i] = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projection, blockFactory.arrowAllocator());
+            futures[i] = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projection, blockFactory.breaker());
         }
 
         // result[c][b] = block for column c in bucket b (bucket-visit order). We populate this
@@ -439,9 +439,9 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                     try {
                         landed.release().close();
                     } catch (Throwable releaseFailure) {
-                        // Surface release failures (e.g. ArrowBuf double-decrement) as suppressed
-                        // exceptions on the original error so they don't mask the root cause and
-                        // we still drain the rest of the prefetched chunks.
+                        // Surface release failures as suppressed exceptions on the original error
+                        // so they don't mask the root cause and we still drain the rest of the
+                        // prefetched chunks.
                         t.addSuppressed(releaseFailure);
                     }
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -515,8 +515,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         // parquet-mr defaults useColumnIndexFilter=true (since 1.12.0), so when a FilterPredicate
         // is set via withRecordFilter, page-index filtering (ColumnIndex/OffsetIndex) is automatically
         // active in addition to row-group level statistics, dictionary, and bloom filter checks.
-        // Note: all read operations happen synchronously with the ESQL engine. If some operations
-        // change to be async, we'll have to unwrap the breaker if it's a LocalBreaker.
+        // Footer prefetch and parquet-mr allocations can complete on generic/HTTP threads.
+        // CircuitBreakerByteBufferAllocator unwraps a LocalCircuitBreaker to the parent request breaker.
         //
         // Keep the delegate heap-backed. parquet-mr's DirectByteBufferAllocator.release() is empty, so a
         // direct delegate returns the breaker charge but leaves the memory to a Cleaner -- reclamation

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.compute.data.Utf8Sanitizer;
@@ -516,13 +517,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         // is set via withRecordFilter, page-index filtering (ColumnIndex/OffsetIndex) is automatically
         // active in addition to row-group level statistics, dictionary, and bloom filter checks.
         // Footer prefetch and parquet-mr allocations can complete on generic/HTTP threads.
-        // CircuitBreakerByteBufferAllocator unwraps a LocalCircuitBreaker to the parent request breaker.
+        // Unwrap a LocalCircuitBreaker here so the allocator stays a pass-through.
         //
         // Keep the delegate heap-backed. parquet-mr's DirectByteBufferAllocator.release() is empty, so a
         // direct delegate returns the breaker charge but leaves the memory to a Cleaner -- reclamation
         // becomes a function of GC frequency, which a large heap starves. Nothing reads these buffers
         // natively either: they are footers and dictionary-page copies, both copied to the heap next step.
-        var breaker = blockFactory.breaker();
+        var breaker = LocalCircuitBreaker.forAsyncIo(blockFactory.breaker());
         var allocator = new CircuitBreakerByteBufferAllocator(new HeapByteBufferAllocator(), breaker);
         return PlainParquetReadOptions.builder(codecFactory).withAllocator(allocator);
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
@@ -674,7 +673,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
-        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.arrowAllocator());
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.breaker());
         ParquetReadOptions options = readOptionsBuilder().build();
 
         try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
@@ -740,8 +739,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         }
 
         int tailLen = (int) Math.min(FOOTER_TAIL_PREFETCH_BYTES, length);
-        BufferAllocator allocator = blockFactory.arrowAllocator();
-        DirectBufferFactory factory = DirectBufferFactory.forAllocator(allocator);
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(blockFactory.breaker());
 
         object.readBytesAsync(length - tailLen, tailLen, factory, executor, ActionListener.wrap(tail -> {
             final byte[] tailBytes;
@@ -1281,7 +1279,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             // it emits any other column. Pushed filters, late materialization, page skipping, and
             // row-group skipping all stay on — each surviving row carries its identity, and the
             // matching extractor binds those identities back to the file's full footer.
-            ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.arrowAllocator());
+            ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.breaker());
             long footerStartNanos = System.nanoTime();
             ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, readOptionsBuilder().build());
             counters.addFooterRead(System.nanoTime() - footerStartNanos, sizeOrZero(object), reader.getFooter().getBlocks().size());
@@ -1355,7 +1353,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
 
     @Override
     public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
-        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.arrowAllocator());
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object, blockFactory.breaker());
         ParquetReadOptions options = readOptionsBuilder().build();
         try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
             List<BlockMetaData> rowGroups = reader.getRowGroups();
@@ -1613,7 +1611,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             ParquetStorageObjectAdapter parquetInputFile = ParquetStorageObjectAdapter.forRange(
                 object,
                 rangeEnd - rangeStart,
-                blockFactory.arrowAllocator()
+                blockFactory.breaker()
             );
             ParquetReadOptions rangeOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd).build();
             // Footer resolution order:
@@ -1890,7 +1888,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             predicateColumnPaths,
             indexColumnPaths.columnIndexPaths(),
             indexColumnPaths.offsetIndexPaths(),
-            blockFactory.arrowAllocator()
+            blockFactory.breaker()
         );
         boolean metadataHandedOff = false;
         try {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.io.SeekableInputStream;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
-import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -169,14 +169,14 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
      * otherwise a new range is fetched via {@link StorageObject#newStream(long, long)}.
      *
      * <p>Window fills use {@link StorageObject#newStream(long, long)} with chunked
-     * {@link InputStream#read(byte[], int, int)} calls capped to {@link #STREAM_READ_CHUNK_SIZE}
-     * to prevent the JDK's thread-local direct ByteBuffer pool from growing to window size.
-     * The window is invalidated before each I/O so a partial-read failure never leaves
-     * stale data visible to subsequent reads.
+     * {@link InputStream#read(byte[], int, int)} into {@code window}. The chunk cap bounds the
+     * JDK's temporary direct buffer, not a heap destination — {@code read(byte[], off, len)}
+     * never allocates {@code len} heap bytes. The window is invalidated before each I/O so a
+     * partial-read failure never leaves stale data visible to subsequent reads.
      */
     private static class WindowedSeekableInputStream extends SeekableInputStream {
 
-        /** Caps each stream-read iteration to limit per-chunk heap allocation. */
+        /** Caps each stream-read iteration so the JDK's thread-local direct buffer stays bounded. */
         private static final int STREAM_READ_CHUNK_SIZE = 256 * 1024;
 
         private static final String WINDOW_BREAKER_LABEL = "parquet sliding window";
@@ -187,9 +187,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private final int windowSize;
         private final CircuitBreaker breaker;
         private final byte[] window;
-        // Staging buffer filled from the InputStream then copied into {@link #window}. Caps each
-        // stream-read iteration so a single read() cannot allocate a window-sized heap array.
-        private final byte[] streamReadBuf = UninitializedArrays.newByteArray(STREAM_READ_CHUNK_SIZE);
 
         /**
          * Supplier that returns the adapter's current pre-warmed chunks map (or {@code null}).
@@ -217,7 +214,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             this.cacheKey = cacheKey;
             this.length = length;
             this.windowSize = windowSize;
-            this.breaker = DirectBufferFactory.forAsyncIo(breaker);
+            this.breaker = LocalCircuitBreaker.forAsyncIo(breaker);
             this.breaker.addEstimateBytesAndMaybeBreak(windowSize, WINDOW_BREAKER_LABEL);
             byte[] allocated;
             try {
@@ -298,7 +295,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 int totalRead = 0;
                 while (totalRead < target) {
                     int chunk = Math.min(STREAM_READ_CHUNK_SIZE, target - totalRead);
-                    int n = in.read(streamReadBuf, 0, chunk);
+                    int n = in.read(window, totalRead, chunk);
                     if (n < 0) {
                         throw new IOException(
                             "Unexpected end of stream while filling window at position " + pos + "; read " + totalRead + " of " + target
@@ -307,7 +304,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                     if (n == 0 && chunk > 0) {
                         throw new IOException("InputStream.read returned 0 while " + chunk + " bytes were requested");
                     }
-                    System.arraycopy(streamReadBuf, 0, window, totalRead, n);
                     totalRead += n;
                 }
                 windowStart = pos;
@@ -387,14 +383,8 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             // visible if a later step throws.
             windowStart = -1;
             windowLength = 0;
-            ByteBuffer src = chunk.data().duplicate();
-            int srcIndex = src.position() + offsetInChunk;
-            if (src.hasArray()) {
-                System.arraycopy(src.array(), src.arrayOffset() + srcIndex, window, 0, copyLen);
-            } else {
-                src.position(srcIndex);
-                src.get(window, 0, copyLen);
-            }
+            ByteBuffer src = chunk.data();
+            src.get(src.position() + offsetInChunk, window, 0, copyLen);
             windowStart = pos;
             windowLength = copyLen;
             return true;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -7,9 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.io.SeekableInputStream;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -44,7 +43,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     private final long length;
     private final FooterByteCache.Key cacheKey;
     private final int windowSize;
-    private final BufferAllocator allocator;
+    private final CircuitBreaker breaker;
 
     /**
      * Optional pre-warmed cache installed before {@code RowGroupFilter} runs. When set, reads
@@ -70,10 +69,10 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     static final int MAX_WINDOW_SIZE = 16 * 1024 * 1024;
 
     /**
-     * Creates an adapter with the default 4MB sliding window backed by the given Arrow allocator.
+     * Creates an adapter with the default 4MB sliding window charged to the given circuit breaker.
      */
-    public ParquetStorageObjectAdapter(StorageObject storageObject, BufferAllocator allocator) {
-        this(storageObject, DEFAULT_WINDOW_SIZE, allocator);
+    public ParquetStorageObjectAdapter(StorageObject storageObject, CircuitBreaker breaker) {
+        this(storageObject, DEFAULT_WINDOW_SIZE, breaker);
     }
 
     /**
@@ -83,18 +82,18 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
      *
      * @param rangeBytes byte span of the range being read; clamped to [{@link #DEFAULT_WINDOW_SIZE}, {@link #MAX_WINDOW_SIZE}]
      */
-    public static ParquetStorageObjectAdapter forRange(StorageObject storageObject, long rangeBytes, BufferAllocator allocator) {
+    public static ParquetStorageObjectAdapter forRange(StorageObject storageObject, long rangeBytes, CircuitBreaker breaker) {
         int windowSize = (int) Math.min(Math.max(rangeBytes, DEFAULT_WINDOW_SIZE), MAX_WINDOW_SIZE);
-        return new ParquetStorageObjectAdapter(storageObject, windowSize, allocator);
+        return new ParquetStorageObjectAdapter(storageObject, windowSize, breaker);
     }
 
-    private ParquetStorageObjectAdapter(StorageObject storageObject, int windowSize, BufferAllocator allocator) {
+    private ParquetStorageObjectAdapter(StorageObject storageObject, int windowSize, CircuitBreaker breaker) {
         if (storageObject == null) {
             throw new QlIllegalArgumentException("storageObject cannot be null");
         }
         this.storageObject = storageObject;
         this.windowSize = windowSize;
-        this.allocator = allocator;
+        this.breaker = breaker;
         try {
             this.length = storageObject.length();
         } catch (IOException e) {
@@ -139,7 +138,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         // opened before {@link #installPreWarmedChunks} (notably the one parquet-mr opens at
         // {@code ParquetFileReader.open}) must still observe a later install, otherwise the
         // pre-warm optimization would be silently bypassed.
-        return new WindowedSeekableInputStream(storageObject, cacheKey, length, windowSize, allocator, this::currentPreWarmedChunks);
+        return new WindowedSeekableInputStream(storageObject, cacheKey, length, windowSize, breaker, this::currentPreWarmedChunks);
     }
 
     private NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> currentPreWarmedChunks() {
@@ -179,13 +178,16 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         /** Caps each stream-read iteration to limit per-chunk heap allocation. */
         private static final int STREAM_READ_CHUNK_SIZE = 256 * 1024;
 
+        private static final String WINDOW_BREAKER_LABEL = "parquet sliding window";
+
         private final StorageObject storageObject;
         private final FooterByteCache.Key cacheKey;
         private final long length;
         private final int windowSize;
-        private final ArrowBuf window;
-        // ArrowBuf.getBytes(inputstream) internally allocates an 8 kB buffer. To avoid it,
-        // use a staging buffer filled from the InputStream then copied into {@link #window}.
+        private final CircuitBreaker breaker;
+        private final byte[] window;
+        // Staging buffer filled from the InputStream then copied into {@link #window}. Caps each
+        // stream-read iteration so a single read() cannot allocate a window-sized heap array.
         private final byte[] streamReadBuf = UninitializedArrays.newByteArray(STREAM_READ_CHUNK_SIZE);
 
         /**
@@ -207,14 +209,23 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             FooterByteCache.Key cacheKey,
             long length,
             int windowSize,
-            BufferAllocator allocator,
+            CircuitBreaker breaker,
             Supplier<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> preWarmedChunksSupplier
         ) {
             this.storageObject = storageObject;
             this.cacheKey = cacheKey;
             this.length = length;
             this.windowSize = windowSize;
-            this.window = allocator.buffer(windowSize);
+            this.breaker = breaker;
+            breaker.addEstimateBytesAndMaybeBreak(windowSize, WINDOW_BREAKER_LABEL);
+            byte[] allocated;
+            try {
+                allocated = UninitializedArrays.newByteArray(windowSize);
+            } catch (Throwable t) {
+                breaker.addWithoutBreaking(-windowSize);
+                throw t;
+            }
+            this.window = allocated;
             this.preWarmedChunksSupplier = preWarmedChunksSupplier;
             this.windowStart = -1;
             this.windowLength = 0;
@@ -295,7 +306,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                     if (n == 0 && chunk > 0) {
                         throw new IOException("InputStream.read returned 0 while " + chunk + " bytes were requested");
                     }
-                    window.setBytes(totalRead, streamReadBuf, 0, n);
+                    System.arraycopy(streamReadBuf, 0, window, totalRead, n);
                     totalRead += n;
                 }
                 windowStart = pos;
@@ -304,7 +315,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
             if (windowLength > 0 && windowStart + windowLength == length) {
                 byte[] tailBytes = UninitializedArrays.newByteArray(windowLength);
-                window.getBytes(0L, tailBytes, 0, windowLength);
+                System.arraycopy(window, 0, tailBytes, 0, windowLength);
                 tailCache.put(cacheKey, tailBytes);
             }
         }
@@ -376,7 +387,13 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             windowStart = -1;
             windowLength = 0;
             ByteBuffer src = chunk.data().duplicate();
-            window.setBytes(0L, src, src.position() + offsetInChunk, copyLen);
+            int srcIndex = src.position() + offsetInChunk;
+            if (src.hasArray()) {
+                System.arraycopy(src.array(), src.arrayOffset() + srcIndex, window, 0, copyLen);
+            } else {
+                src.position(srcIndex);
+                src.get(window, 0, copyLen);
+            }
             windowStart = pos;
             windowLength = copyLen;
             return true;
@@ -388,7 +405,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 int from = (int) (pos - cachedStart);
                 windowStart = -1;
                 windowLength = 0;
-                window.setBytes(0L, cached, from, toRead);
+                System.arraycopy(cached, from, window, 0, toRead);
                 windowStart = pos;
                 windowLength = toRead;
                 return true;
@@ -419,7 +436,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return -1;
             }
             int offset = (int) (position - windowStart);
-            int b = window.getByte(offset) & 0xFF;
+            int b = window[offset] & 0xFF;
             position++;
             return b;
         }
@@ -447,7 +464,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             }
             int toRead = Math.min(len, availableInWindow);
             int offset = (int) (position - windowStart);
-            window.getBytes(offset, b, off, toRead);
+            System.arraycopy(window, offset, b, off, toRead);
             position += toRead;
             return toRead;
         }
@@ -480,7 +497,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 closed = true;
                 windowStart = -1;
                 windowLength = 0;
-                window.close();
+                breaker.addWithoutBreaking(-windowSize);
             }
         }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -14,6 +14,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -216,13 +217,13 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             this.cacheKey = cacheKey;
             this.length = length;
             this.windowSize = windowSize;
-            this.breaker = breaker;
-            breaker.addEstimateBytesAndMaybeBreak(windowSize, WINDOW_BREAKER_LABEL);
+            this.breaker = DirectBufferFactory.forAsyncIo(breaker);
+            this.breaker.addEstimateBytesAndMaybeBreak(windowSize, WINDOW_BREAKER_LABEL);
             byte[] allocated;
             try {
                 allocated = UninitializedArrays.newByteArray(windowSize);
             } catch (Throwable t) {
-                breaker.addWithoutBreaking(-windowSize);
+                this.breaker.addWithoutBreaking(-windowSize);
                 throw t;
             }
             this.window = allocated;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -50,8 +50,10 @@ import java.util.zip.GZIPOutputStream;
  * <ul>
  *   <li>{@code PrefetchedPageReader} calls {@code decompress(BytesInput, int)} so compressed
  *       pages land on a heap {@code byte[]}. Uncompressed pages alias the prefetched I/O
- *       {@link BytesInput} (still a direct slice until prefetch itself is heap-backed).
- *       Heap output is charged to the request breaker for the current page.</li>
+ *       {@link BytesInput}. Heap output is charged to the request breaker
+ *       for the current page. Snappy's heap JNI still uses {@code GetPrimitiveArrayCritical};
+ *       that is the cost of a heap destination versus glibc RSS from direct malloc. LZ4/Zstd
+ *       do not take that JNI pin path.</li>
  *   <li>Parquet-MR's {@code ColumnChunkPageReadStore.ColumnChunkPageReader.readPage()} (the
  *       non-prefetched path) invokes only the {@code decompress(BytesInput, int)} overload — it
  *       never reaches the {@code ByteBuffer} overload, regardless of the allocator or the
@@ -190,16 +192,11 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
     }
 
     /**
-     * Snappy decompressor. Two JNI overloads are used depending on input shape:
-     * <ul>
-     *   <li>{@code Snappy.uncompress(byte[], int, int, byte[], int)} when the compressed input is
-     *       backed by a Java heap array (the common case for the prefetch path: column chunks
-     *       arrive as {@link ByteBuffer#wrap(byte[], int, int)}-style {@code BytesInput}s).</li>
-     *   <li>{@code Snappy.uncompress(ByteBuffer, ByteBuffer)} when both input and output are
-     *       direct buffers — the only case where the JNI binding can avoid a copy.</li>
-     * </ul>
-     * The JNI call returns the number of decompressed bytes written but does not advance the
-     * output buffer position; we advance it manually for the {@code ByteBuffer} overload.
+     * Snappy decompressor. Heap {@code BytesInput} uses
+     * {@code Snappy.uncompress(byte[], ...)} ({@code GetPrimitiveArrayCritical}). That G1 pin is
+     * the cost of a heap destination versus glibc RSS from the old direct malloc path.
+     * Direct-to-direct {@code Snappy.uncompress(ByteBuffer, ByteBuffer)} remains on the
+     * {@code ByteBuffer} overload for tests and the parquet-mr SPI.
      */
     private static class SnappyBytesDecompressor implements BytesInputDecompressor {
         @Override
@@ -271,10 +268,10 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * <p>The hot path for {@code PrefetchedPageReader} and parquet-mr's
      * {@code ColumnChunkPageReadStore} is {@code BytesInput}/{@code byte[]} via
      * {@link PanamaZstd#decompressHeap}, bound with {@code Linker.Option.critical(true)} so heap
-     * segments cross into libzstd without an off-heap staging copy — equivalent to zstd-jni's
-     * {@code GetPrimitiveArrayCritical} path but without G1's region pinning. The
-     * {@code ByteBuffer} overload still takes a direct-to-direct Panama path when both sides are
-     * direct.
+     * segments cross into libzstd without an off-heap staging copy and without zstd-jni's G1
+     * region pinning. Production readers use this {@code BytesInput} overload.
+     * The {@code ByteBuffer} overload remains for the parquet-mr SPI and tests; it still uses a
+     * direct-to-direct Panama path when both sides are direct.
      *
      * <p>When the Panama binding is unavailable on a platform ({@link PanamaZstd#isAvailable()}
      * returns {@code false}), both paths fail with the same {@link IllegalStateException} from
@@ -351,9 +348,14 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
 
         @Override
         public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] in = bytes.toByteArray();
             byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            lz4.decompress(in, 0, in.length, out, 0, decompressedSize);
+            ByteBuffer input = bytes.toByteBuffer();
+            if (input.hasArray()) {
+                lz4.decompress(input.array(), input.arrayOffset() + input.position(), input.remaining(), out, 0, decompressedSize);
+            } else {
+                byte[] in = bytes.toByteArray();
+                lz4.decompress(in, 0, in.length, out, 0, decompressedSize);
+            }
             return BytesInput.from(out);
         }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -48,13 +48,10 @@ import java.util.zip.GZIPOutputStream;
  * G1GC region pinning). When either buffer is heap, the decompressor falls back to the
  * byte-array path. Two call sites reach these decompressors:
  * <ul>
- *   <li>{@code PrefetchedPageReader} explicitly calls the {@code decompress(ByteBuffer, int,
- *       ByteBuffer, int)} overload with both sides guaranteed direct: all {@code StorageObject}
- *       backends return direct {@link java.nio.ByteBuffer}s from {@code readBytesAsync}, and
- *       {@link ColumnChunkPrefetcher} promotes any heap buffer to direct as defense-in-depth for
- *       future backends. Page slices derived from that direct buffer are already direct when they
- *       reach {@code PrefetchedPageReader}, so the direct-to-direct fast path is always taken with
- *       no per-page copy.</li>
+ *   <li>{@code PrefetchedPageReader} calls {@code decompress(BytesInput, int)} so compressed
+ *       pages land on a heap {@code byte[]}. Uncompressed pages alias the prefetched I/O
+ *       {@link BytesInput} (still a direct slice until prefetch itself is heap-backed).
+ *       Heap output is charged to the request breaker for the current page.</li>
  *   <li>Parquet-MR's {@code ColumnChunkPageReadStore.ColumnChunkPageReader.readPage()} (the
  *       non-prefetched path) invokes only the {@code decompress(BytesInput, int)} overload — it
  *       never reaches the {@code ByteBuffer} overload, regardless of the allocator or the
@@ -169,10 +166,10 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
     /**
      * Pass-through decompressor for files written with {@link CompressionCodecName#UNCOMPRESSED}.
      *
-     * <p>Visible at package level so {@link PrefetchedPageReader#decompressToDirectBuffer} can
-     * detect this case via {@code instanceof} and skip the {@code allocateDirect} + memcopy that
-     * the {@code ByteBuffer} overload below would otherwise perform. The marker check is a narrow
-     * coupling to the only built-in pass-through codec.
+     * <p>Visible at package level so {@link PrefetchedPageReader} can detect this case via
+     * {@code instanceof} and return the compressed input as-is (no heap copy, no breaker charge)
+     * instead of routing through {@code decompress(BytesInput, int)}. The marker check is a
+     * narrow coupling to the only built-in pass-through codec.
      */
     static class NoopDecompressor implements BytesInputDecompressor {
         @Override
@@ -208,10 +205,8 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
         @Override
         public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
             byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            // PrefetchedPageReader (the optimized path) uses the ByteBuffer overload with Arrow
-            // buffers on both sides. This BytesInput overload is what everything else reaches:
-            // parquet-mr's ColumnChunkPageReadStore.readPage() on the baseline path, and
-            // ParquetFileReader.readDictionary during dictionary filtering on the optimized path.
+            // PrefetchedPageReader (the optimized path) and parquet-mr's
+            // ColumnChunkPageReadStore.readPage() both reach this BytesInput overload.
             // Fast path: avoid BytesInput.toByteArray() for heap-buffer-backed inputs — the default
             // toByteArray() funnels through a sized ByteArrayOutputStream, adding one allocation
             // and one System.arraycopy that the JNI Snappy binding does not need.
@@ -273,15 +268,13 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
     /**
      * Zstd decompressor.
      *
-     * <p>Both code paths — the direct→direct hot path invoked by parquet-mr's
-     * {@code ColumnChunkPageReadStore} and our own {@code PrefetchedPageReader}, and the cold
-     * {@code BytesInput}/{@code byte[]} path — delegate to {@link PanamaZstd}, the shared Panama
-     * FFI binding that lives in {@code esql-datasource-compression-libs} (so Iceberg/ORC adopters
-     * can route their direct paths through the same code). This eliminates zstd-jni from the
-     * production runtime classpath entirely. The cold path uses {@code PanamaZstd.decompressHeap}
-     * which is bound with {@code Linker.Option.critical(true)}, so heap segments cross into
-     * libzstd without an off-heap staging copy — equivalent to zstd-jni's
-     * {@code GetPrimitiveArrayCritical} path but without G1's region pinning.
+     * <p>The hot path for {@code PrefetchedPageReader} and parquet-mr's
+     * {@code ColumnChunkPageReadStore} is {@code BytesInput}/{@code byte[]} via
+     * {@link PanamaZstd#decompressHeap}, bound with {@code Linker.Option.critical(true)} so heap
+     * segments cross into libzstd without an off-heap staging copy — equivalent to zstd-jni's
+     * {@code GetPrimitiveArrayCritical} path but without G1's region pinning. The
+     * {@code ByteBuffer} overload still takes a direct-to-direct Panama path when both sides are
+     * direct.
      *
      * <p>When the Panama binding is unavailable on a platform ({@link PanamaZstd#isAvailable()}
      * returns {@code false}), both paths fail with the same {@link IllegalStateException} from

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStore.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStore.java
@@ -19,11 +19,10 @@ import java.util.Map;
  * In-memory {@link PageReadStore} backed by per-column {@link PrefetchedPageReader}s. Replaces
  * parquet-mr's {@code ColumnChunkPageReadStore} on the optimized iterator's read path.
  *
- * <p>Each {@link PrefetchedPageReader} owns native decompression buffers ({@link
- * org.apache.arrow.memory.ArrowBuf}s) allocated from the supplied {@code BufferAllocator}.
- * {@link #close()} releases all per-column readers and is idempotent; callers must ensure no
- * {@link DictionaryPage} or {@link org.apache.parquet.column.page.DataPage} returned from a
- * reader is used after close.
+ * <p>Each {@link PrefetchedPageReader} charges heap decompression output to the request
+ * breaker for the current page and cached dictionary. {@link #close()} releases those charges
+ * and is idempotent. Uncompressed pages may alias prefetched I/O bytes; those must not be used
+ * after the backing chunks are released.
  */
 final class PrefetchedPageReadStore implements PageReadStore, DictionaryPageReadStore {
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
@@ -17,11 +15,10 @@ import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.xpack.esql.datasources.spi.DirectMemoryDebug;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -38,16 +35,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * original page type ({@link DataPageV1} stays V1, {@link DataPageV2} stays V2 with only the
  * data portion decompressed). Encryption and CRC verification are not supported.
  *
- * <p>Decompression uses one reusable {@link ArrowBuf} from the supplied {@link BufferAllocator},
- * exposed via {@link ArrowBuf#nioBuffer(long, int)} for the direct-to-direct JNI fast path.
- * {@link #readPage()} overwrites that buffer. It grows only when a later page needs more
- * capacity — breaker residency is the high-water-mark page, not the current page — and is
- * released on {@link #close()}. Heap-backed compressed input still copies through a per-page
- * scratch buffer; production prefetch already yields direct slices, so that path is idle.
- * Returned {@link DataPage}s and {@link BytesInput}s alias the current buffer and must not be
- * used after the next {@link #readPage()} or {@link #close()}.
+ * <p>Compressed pages decompress onto a heap {@code byte[]} via
+ * {@link BytesInputDecompressor#decompress(BytesInput, int)}. That output is charged to
+ * {@code breaker} for the life of the current page (and the cached dictionary, if any) and
+ * released before the next page or on {@link #close()}. Uncompressed pages alias the
+ * prefetched I/O bytes and are not charged — those bytes are already accounted by the
+ * prefetch allocator. Heap {@code byte[]}s remain valid after the next {@link #readPage()};
+ * the breaker tracks only the current page plus dictionary so peak residency is O(one page).
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
+
+    private static final String DECOMP_BREAKER_LABEL = "parquet page decompression";
 
     /**
      * A compressed data page paired with its {@code firstRowIndex}. Required because
@@ -59,30 +57,28 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     record CompressedPage(DataPage page, long firstRowIndex) {}
 
     private final BytesInputDecompressor decompressor;
-    private final BufferAllocator allocator;
+    private final CircuitBreaker breaker;
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
     private final DictionaryPage compressedDictionaryPage;
-    // Reusable decompress-output buffer. Grown when a page needs more capacity; released on
-    // close(). Overwritten in place across pages so we do not malloc/free per page — that churn
-    // is what retained glibc arenas after the allocator balance had already returned to baseline.
-    private ArrowBuf reusableDecompBuf;
 
     private DictionaryPage cachedDictionaryPage;
     private boolean dictionaryDecompressed;
+    private long dataPageCharge;
+    private long dictCharge;
     // AtomicBoolean (rather than a plain volatile flag) so concurrent close() callers race
-    // on a single compareAndSet and only one thread actually releases the owned buffers.
+    // on a single compareAndSet and only one thread actually releases the breaker charge.
     private final AtomicBoolean closed = new AtomicBoolean();
 
     PrefetchedPageReader(
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
+        CircuitBreaker breaker,
         List<CompressedPage> compressedPages,
         DictionaryPage compressedDictionaryPage,
         long valueCount
     ) {
         this.decompressor = decompressor;
-        this.allocator = allocator;
+        this.breaker = breaker;
         this.compressedPages = new ArrayDeque<>(compressedPages);
         this.compressedDictionaryPage = compressedDictionaryPage;
         this.valueCount = valueCount;
@@ -97,8 +93,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     public DataPage readPage() {
         CompressedPage entry = compressedPages.poll();
         if (entry == null) {
-            // Queue drained. The last page returned stays live (the consumer may still be decoding
-            // it) until close() releases the reusable buffer; there is no new page to decode.
+            // Queue drained. The last page's breaker charge stays until close(); there is no new
+            // page to decode.
             return null;
         }
         // Previous page is dead. Both consumers of this reader ask for pages strictly sequentially
@@ -111,10 +107,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // its level/value readers from the new page before any further read, and its consumers
         // (ParquetColumnDecoding#readListRow) copy each value to the heap before the consume()
         // that can cross a page boundary.
-        // Overwrite the reusable decompress buffer rather than free+malloc: per-page free fed
-        // glibc arena retention even when the allocator balance returned to baseline. Live
-        // working set stays O(one page); parking a new buffer per page until close() is the
-        // accumulation the OOM-killer saw.
+        dataPageCharge = releaseCharge(dataPageCharge);
         DataPage page = entry.page();
         if (page instanceof DataPageV1 v1) {
             return decompressV1(v1);
@@ -133,28 +126,36 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         if (dictionaryDecompressed) {
             return cachedDictionaryPage;
         }
+        int uncompressedSize = compressedDictionaryPage.getUncompressedSize();
+        boolean charge = isNoopDecompressor() == false;
+        if (charge) {
+            breaker.addEstimateBytesAndMaybeBreak(uncompressedSize, DECOMP_BREAKER_LABEL);
+        }
+        boolean success = false;
         try {
-            // Use the heap decompressor path (not decompressToDirectBuffer) so the
-            // returned BytesInput is backed by a plain byte[] rather than an ArrowBuf.
-            // DictionaryPageReader (parquet-mr) caches this DictionaryPage indefinitely
-            // in a ConcurrentHashMap; if the decompressed bytes aliased an ArrowBuf they
-            // would become dangling as soon as the owning PrefetchedPageReader is closed
-            // at row-group rollover. The compressed input (compressedDictionaryPage.getBytes())
-            // is also heap-backed — PrefetchedRowGroupBuilder.makeDictionaryPage eagerly
-            // copies it from the PrefetchedChunk's direct buffer, which can be released
-            // before this call. Dictionary pages are small; neither copy is performance-critical.
-            BytesInput decompressed = decompressor.decompress(
-                compressedDictionaryPage.getBytes(),
-                compressedDictionaryPage.getUncompressedSize()
-            );
+            // Heap decompressor path so the returned BytesInput is a plain byte[] rather than an
+            // alias of the prefetched chunk. DictionaryPageReader (parquet-mr) caches this
+            // DictionaryPage indefinitely in a ConcurrentHashMap; if the decompressed bytes
+            // aliased a prefetch ArrowBuf they would become dangling as soon as this reader is
+            // closed at row-group rollover. The compressed input is also heap-backed —
+            // PrefetchedRowGroupBuilder.makeDictionaryPage eagerly copies it from the
+            // PrefetchedChunk. Uncompressed dictionaries skip the breaker charge and alias that
+            // heap copy.
+            BytesInput decompressed = decompressor.decompress(compressedDictionaryPage.getBytes(), uncompressedSize);
             cachedDictionaryPage = new DictionaryPage(
                 decompressed,
-                compressedDictionaryPage.getUncompressedSize(),
+                uncompressedSize,
                 compressedDictionaryPage.getDictionarySize(),
                 compressedDictionaryPage.getEncoding()
             );
+            dictCharge = charge ? uncompressedSize : 0;
+            success = true;
         } catch (IOException e) {
             throw new ParquetDecodingException("Could not decompress dictionary page", e);
+        } finally {
+            if (success == false && charge) {
+                breaker.addWithoutBreaking(-uncompressedSize);
+            }
         }
         // Set the cache flag only after a successful decompression. If decompression throws,
         // the next call will retry instead of silently returning a null cachedDictionaryPage.
@@ -164,7 +165,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     private DataPageV1 decompressV1(DataPageV1 v1) {
         try {
-            BytesInput decompressed = decompressToDirectBuffer(v1.getBytes(), v1.getUncompressedSize());
+            BytesInput decompressed = decompressToHeap(v1.getBytes(), v1.getUncompressedSize());
             int indexRowCount = v1.getIndexRowCount().orElse(-1);
             long firstRowIndex = v1.getFirstRowIndex().orElse(-1L);
             if (firstRowIndex >= 0 && indexRowCount >= 0) {
@@ -231,7 +232,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
                     v2.getStatistics()
                 );
             }
-            BytesInput decompressedData = decompressToDirectBuffer(v2.getData(), uncompressedDataSize);
+            BytesInput decompressedData = decompressToHeap(v2.getData(), uncompressedDataSize);
             return DataPageV2.uncompressed(
                 v2.getRowCount(),
                 v2.getNullCount(),
@@ -248,84 +249,43 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
     }
 
-    /**
-     * Decompresses {@code compressed} into a direct {@link ByteBuffer}, then wraps the result
-     * as a {@link BytesInput}. Both the input and output sides are direct so each codec takes its
-     * direct-to-direct JNI fast path (Zstd: {@code decompressDirectByteBuffer}; Snappy:
-     * {@code Snappy.uncompress(ByteBuffer, ByteBuffer)}), avoiding
-     * {@code GetPrimitiveArrayCritical} JNI pinning and the G1GC evacuation failures it causes.
-     *
-     * <p>For the prefetched path, {@link ColumnChunkPrefetcher} promotes each S3 response buffer
-     * from heap to direct once at fetch time (one copy per coalesced range), so page slices
-     * derived from it are already direct and the conditional copy below is a no-op. The copy
-     * remains as a safety net for the non-prefetched sync fallback path.
-     *
-     * <p>Uncompressed Parquet files take a short-circuit: when the decompressor is the pass-through
-     * {@link PlainCompressionCodecFactory.NoopDecompressor} and the input slice is already direct,
-     * the input is returned as-is. This avoids one {@code ByteBuffer.allocateDirect(pageSize)} plus
-     * a full page memcopy per V1 data page (and per dictionary page) — wasted work since
-     * {@code NoopDecompressor} would just copy the input into the output buffer verbatim. DataPageV2
-     * already has its own {@code isCompressed()=false} early exit upstream of this method; V1 has no
-     * equivalent flag in the page header, so the marker check on the decompressor instance is the
-     * only signal we have at the page-read layer. See elastic/esql-planning#804.
-     */
-    private BytesInput decompressToDirectBuffer(BytesInput compressed, int decompressedSize) throws IOException {
-        ByteBuffer input = compressed.toByteBuffer();
-        if (decompressor instanceof PlainCompressionCodecFactory.NoopDecompressor && input.isDirect()) {
-            if (input.remaining() != decompressedSize) {
+    private BytesInput decompressToHeap(BytesInput compressed, int decompressedSize) throws IOException {
+        // V1 has no isCompressed flag; NoopDecompressor is the only signal at this layer.
+        // Alias I/O bytes and skip the breaker — prefetch already charged them. See #804.
+        if (isNoopDecompressor()) {
+            if (compressed.size() != decompressedSize) {
                 throw new ParquetDecodingException(
                     "Uncompressed page size mismatch: input has "
-                        + input.remaining()
+                        + compressed.size()
                         + " bytes but page header declares "
                         + decompressedSize
                 );
             }
-            return BytesInput.from(input);
+            return compressed;
         }
-        // Scratch buffer used only when the input is on the heap and must be copied to direct
-        // memory to take the codec's direct-to-direct JNI fast path. decompress() consumes it
-        // synchronously, so it is released in the finally below rather than held on the reader.
-        ArrowBuf scratch = null;
+        breaker.addEstimateBytesAndMaybeBreak(decompressedSize, DECOMP_BREAKER_LABEL);
+        boolean success = false;
         try {
-            if (input.isDirect() == false) {
-                scratch = allocator.buffer(input.remaining());
-                ByteBuffer directInput = scratch.nioBuffer(0, input.remaining());
-                directInput.put(input);
-                directInput.flip();
-                input = directInput;
-            }
-            ByteBuffer output = allocateDirect(decompressedSize);
-            decompressor.decompress(input, Math.toIntExact(compressed.size()), output, decompressedSize);
-            output.flip();
-            return BytesInput.from(output);
+            BytesInput decompressed = decompressor.decompress(compressed, decompressedSize);
+            dataPageCharge = decompressedSize;
+            success = true;
+            return decompressed;
         } finally {
-            if (scratch != null) {
-                scratch.close();
+            if (success == false) {
+                breaker.addWithoutBreaking(-decompressedSize);
             }
         }
     }
 
-    private ByteBuffer allocateDirect(int size) {
-        if (reusableDecompBuf == null || reusableDecompBuf.capacity() < size) {
-            closeReusableDecompBuf();
-            reusableDecompBuf = allocator.buffer(size);
-        }
-        // Explicit (index, length): ArrowBuf may round capacity up, but the codec's size sanity
-        // check expects remaining() == declared decompressed size.
-        return reusableDecompBuf.nioBuffer(0, size);
+    private boolean isNoopDecompressor() {
+        return decompressor instanceof PlainCompressionCodecFactory.NoopDecompressor;
     }
 
-    private void closeReusableDecompBuf() {
-        if (reusableDecompBuf == null) {
-            return;
+    private long releaseCharge(long bytes) {
+        if (bytes != 0) {
+            breaker.addWithoutBreaking(-bytes);
         }
-        ArrowBuf buf = reusableDecompBuf;
-        reusableDecompBuf = null;
-        try {
-            DirectMemoryDebug.poison(buf.nioBuffer(0, Math.toIntExact(buf.capacity())));
-        } finally {
-            buf.close();
-        }
+        return 0;
     }
 
     @Override
@@ -333,9 +293,10 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         if (closed.compareAndSet(false, true) == false) {
             return;
         }
-        // Drop the cached dictionary page reference. It is deliberately heap-backed (see
-        // readDictionaryPage), so this is reference hygiene, not a buffer-lifetime requirement.
+        // Drop the cached dictionary page reference. It is heap-backed (see readDictionaryPage),
+        // so this is reference hygiene plus breaker release, not a native-buffer lifetime.
         cachedDictionaryPage = null;
-        closeReusableDecompBuf();
+        dataPageCharge = releaseCharge(dataPageCharge);
+        dictCharge = releaseCharge(dictCharge);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@code breaker} for the life of the current page (and the cached dictionary, if any) and
  * released before the next page or on {@link #close()}. Uncompressed pages alias the
  * prefetched I/O bytes and are not charged — those bytes are already accounted by the
- * prefetch allocator. Heap {@code byte[]}s remain valid after the next {@link #readPage()};
+ * prefetch circuit breaker. Heap {@code byte[]}s remain valid after the next {@link #readPage()};
  * the breaker tracks only the current page plus dictionary so peak residency is O(one page).
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
@@ -136,8 +136,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             // Heap decompressor path so the returned BytesInput is a plain byte[] rather than an
             // alias of the prefetched chunk. DictionaryPageReader (parquet-mr) caches this
             // DictionaryPage indefinitely in a ConcurrentHashMap; if the decompressed bytes
-            // aliased a prefetch ArrowBuf they would become dangling as soon as this reader is
-            // closed at row-group rollover. The compressed input is also heap-backed —
+            // aliased a prefetch buffer they would outlive this reader's close at row-group
+            // rollover. The compressed input is also heap-backed —
             // PrefetchedRowGroupBuilder.makeDictionaryPage eagerly copies it from the
             // PrefetchedChunk. Uncompressed dictionaries skip the breaker charge and alias that
             // heap copy.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * {@link PageReader} backed by an in-memory queue of compressed {@link DataPage}s plus an
@@ -40,8 +41,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@code breaker} for the life of the current page (and the cached dictionary, if any) and
  * released before the next page or on {@link #close()}. Uncompressed pages alias the
  * prefetched I/O bytes and are not charged — those bytes are already accounted by the
- * prefetch circuit breaker. Heap {@code byte[]}s remain valid after the next {@link #readPage()};
- * the breaker tracks only the current page plus dictionary so peak residency is O(one page).
+ * prefetch circuit breaker.
+ *
+ * <p>{@link #readPage()} / {@link #readDictionaryPage()} run on the iterator thread.
+ * {@link #close()} may race another {@link #close()} (hence {@link #closed}) and may race
+ * a read on cancel. Charge counters are {@link java.util.concurrent.atomic.AtomicLong} so
+ * that race cannot silently skew the breaker.
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
 
@@ -64,8 +69,8 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     private DictionaryPage cachedDictionaryPage;
     private boolean dictionaryDecompressed;
-    private long dataPageCharge;
-    private long dictCharge;
+    private final AtomicLong dataPageCharge = new AtomicLong();
+    private final AtomicLong dictCharge = new AtomicLong();
     // AtomicBoolean (rather than a plain volatile flag) so concurrent close() callers race
     // on a single compareAndSet and only one thread actually releases the breaker charge.
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -91,6 +96,9 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     @Override
     public DataPage readPage() {
+        if (closed.get()) {
+            throw new ParquetDecodingException("PrefetchedPageReader closed");
+        }
         CompressedPage entry = compressedPages.poll();
         if (entry == null) {
             // Queue drained. The last page's breaker charge stays until close(); there is no new
@@ -107,7 +115,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // its level/value readers from the new page before any further read, and its consumers
         // (ParquetColumnDecoding#readListRow) copy each value to the heap before the consume()
         // that can cross a page boundary.
-        dataPageCharge = releaseCharge(dataPageCharge);
+        releaseCharge(dataPageCharge);
         DataPage page = entry.page();
         if (page instanceof DataPageV1 v1) {
             return decompressV1(v1);
@@ -148,8 +156,13 @@ final class PrefetchedPageReader implements PageReader, Releasable {
                 compressedDictionaryPage.getDictionarySize(),
                 compressedDictionaryPage.getEncoding()
             );
-            dictCharge = charge ? uncompressedSize : 0;
+            dictCharge.set(charge ? uncompressedSize : 0);
+            // Charge is owned by dictCharge now; close() or releaseCharge below uncharges it.
             success = true;
+            if (closed.get()) {
+                releaseCharge(dictCharge);
+                throw new ParquetDecodingException("PrefetchedPageReader closed");
+            }
         } catch (IOException e) {
             throw new ParquetDecodingException("Could not decompress dictionary page", e);
         } finally {
@@ -267,8 +280,13 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         boolean success = false;
         try {
             BytesInput decompressed = decompressor.decompress(compressed, decompressedSize);
-            dataPageCharge = decompressedSize;
+            dataPageCharge.set(decompressedSize);
+            // Charge is owned by dataPageCharge now; close() or releaseCharge below uncharges it.
             success = true;
+            if (closed.get()) {
+                releaseCharge(dataPageCharge);
+                throw new ParquetDecodingException("PrefetchedPageReader closed");
+            }
             return decompressed;
         } finally {
             if (success == false) {
@@ -281,11 +299,11 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         return decompressor instanceof PlainCompressionCodecFactory.NoopDecompressor;
     }
 
-    private long releaseCharge(long bytes) {
+    private void releaseCharge(AtomicLong charge) {
+        long bytes = charge.getAndSet(0);
         if (bytes != 0) {
             breaker.addWithoutBreaking(-bytes);
         }
-        return 0;
     }
 
     @Override
@@ -296,7 +314,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // Drop the cached dictionary page reference. It is heap-backed (see readDictionaryPage),
         // so this is reference hygiene plus breaker release, not a native-buffer lifetime.
         cachedDictionaryPage = null;
-        dataPageCharge = releaseCharge(dataPageCharge);
-        dictCharge = releaseCharge(dictCharge);
+        releaseCharge(dataPageCharge);
+        releaseCharge(dictCharge);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -698,9 +698,9 @@ final class PrefetchedRowGroupBuilder {
         if (buffer.hasArray()) {
             return BytesInput.from(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
         }
-        // Direct buffer: wrap as-is so uncompressed pages can alias I/O (no copy) and compressed
-        // codecs see the original slice. Heap codecs may still copy via toByteArray() until
-        // prefetch itself is heap-backed.
+        // Heap buffer: wrap as-is so uncompressed pages alias I/O (no copy). Compressed codecs
+        // see the original slice; production prefetch is heap-backed so hasArray() always wins
+        // here. This fall-through is for test stubs that still hand out direct buffers.
         return BytesInput.from(buffer.duplicate());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilder.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -30,6 +29,7 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -93,9 +93,8 @@ final class PrefetchedRowGroupBuilder {
      *            or when an individual column lacks an offset index in the filtered path
      * @param codecFactory shared {@link PlainCompressionCodecFactory} used to build per-column
      *            decompressors
-     * @param allocator Arrow allocator used by {@link PrefetchedPageReader} to back native
-     *            decompression buffers; allocations are breaker-accounted via
-     *            {@code BlockFactory.arrowAllocator()}'s {@code CircuitBreakerAllocationListener}
+     * @param breaker request breaker used by {@link PrefetchedPageReader} to charge heap
+     *            decompression output for the current data page and cached dictionary
      */
     static PrefetchedPageReadStore build(
         BlockMetaData block,
@@ -107,7 +106,7 @@ final class PrefetchedRowGroupBuilder {
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks,
         StorageObject storageObject,
         CompressionCodecFactory codecFactory,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         Map<String, ColumnDescriptor> descriptorsByPath = new HashMap<>();
         for (ColumnDescriptor desc : projectedSchema.getColumns()) {
@@ -154,11 +153,11 @@ final class PrefetchedRowGroupBuilder {
                         source,
                         block.getRowCount(),
                         decompressor,
-                        allocator,
+                        breaker,
                         rowGroupOrdinal
                     );
                 } else {
-                    reader = buildSequential(column, primitiveType, source, decompressor, allocator, rowGroupOrdinal);
+                    reader = buildSequential(column, primitiveType, source, decompressor, breaker, rowGroupOrdinal);
                 }
                 readers.put(descriptor, reader);
             }
@@ -198,7 +197,7 @@ final class PrefetchedRowGroupBuilder {
         ColumnPageBytesSource source,
         long rowGroupRowCount,
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
+        CircuitBreaker breaker,
         int rowGroupOrdinal
     ) {
         DictionaryPage dictPage = readDictionaryPageIfPresent(column, source, rowGroupOrdinal);
@@ -228,7 +227,7 @@ final class PrefetchedRowGroupBuilder {
             pages.add(new PrefetchedPageReader.CompressedPage(decoded, pageStartRow));
             valueCount += decoded.getValueCount();
         }
-        return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
+        return new PrefetchedPageReader(decompressor, breaker, pages, dictPage, valueCount);
     }
 
     /**
@@ -241,7 +240,7 @@ final class PrefetchedRowGroupBuilder {
         PrimitiveType primitiveType,
         ColumnPageBytesSource source,
         BytesInputDecompressor decompressor,
-        BufferAllocator allocator,
+        CircuitBreaker breaker,
         int rowGroupOrdinal
     ) {
         long startingPos = column.getStartingPos();
@@ -281,7 +280,7 @@ final class PrefetchedRowGroupBuilder {
                     valueCount += page.getValueCount();
                 }
             }
-            return new PrefetchedPageReader(decompressor, allocator, pages, dictPage, valueCount);
+            return new PrefetchedPageReader(decompressor, breaker, pages, dictPage, valueCount);
         } catch (IOException e) {
             throw ParquetReadFailures.wrap(
                 e,
@@ -699,8 +698,9 @@ final class PrefetchedRowGroupBuilder {
         if (buffer.hasArray()) {
             return BytesInput.from(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
         }
-        // Direct buffer: wrap as-is so decompressToDirectBuffer sees isDirect()==true and skips
-        // the heap→direct copy that would otherwise fire per page.
+        // Direct buffer: wrap as-is so uncompressed pages can alias I/O (no copy) and compressed
+        // codecs see the original slice. Heap codecs may still copy via toByteArray() until
+        // prefetch itself is heap-backed.
         return BytesInput.from(buffer.duplicate());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.format.Util;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -18,6 +17,7 @@ import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.hadoop.metadata.IndexReference;
 import org.apache.parquet.schema.MessageType;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.logging.LogManager;
@@ -76,7 +76,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
     private final MessageType schema;
 
     /**
-     * Owns the allocator-backed direct memory holding {@link #preWarmedChunks} (and the
+     * Owns the breaker-accounted buffers holding {@link #preWarmedChunks} (and the
      * temporary buffers used by the coalesced index fetch). Closed when this metadata is no
      * longer needed — typically at the end of the iterator's lifecycle. Never null;
      * {@link #empty()} uses a no-op releasable.
@@ -111,11 +111,10 @@ final class PreloadedRowGroupMetadata implements Releasable {
     }
 
     /**
-     * Idempotent and safe to call from multiple threads. Necessary because the underlying
-     * releasable wraps refcounted {@link org.apache.arrow.memory.ArrowBuf}s whose
-     * {@code close()} throws when the reference count reaches zero a second time. The
-     * {@link AtomicBoolean} mirrors {@link PrefetchedPageReader#close()} so both
-     * direct-memory-owning components have identical close semantics.
+     * Idempotent and safe to call from multiple threads. The underlying releasable owns
+     * breaker-accounted heap buffers; {@code DirectReadBuffer.close()} is itself CAS-guarded,
+     * and this {@link AtomicBoolean} matches {@link PrefetchedPageReader#close()} so both
+     * components have identical close semantics.
      */
     @Override
     public void close() {
@@ -151,8 +150,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
      * <p>Falls back to {@link ParquetFileReader}'s sequential reading when no storage object
      * is provided (e.g., in-memory test files).
      */
-    static PreloadedRowGroupMetadata preload(ParquetFileReader reader, StorageObject storageObject, BufferAllocator allocator) {
-        return preload(reader, storageObject, null, allocator);
+    static PreloadedRowGroupMetadata preload(ParquetFileReader reader, StorageObject storageObject, CircuitBreaker breaker) {
+        return preload(reader, storageObject, null, breaker);
     }
 
     /**
@@ -168,9 +167,9 @@ final class PreloadedRowGroupMetadata implements Releasable {
         ParquetFileReader reader,
         StorageObject storageObject,
         Set<String> predicateColumnPaths,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
-        return preload(reader, storageObject, predicateColumnPaths, null, null, allocator);
+        return preload(reader, storageObject, predicateColumnPaths, null, null, breaker);
     }
 
     /**
@@ -199,7 +198,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> predicateColumnPaths,
         Set<String> columnIndexPaths,
         Set<String> offsetIndexPaths,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
         if (rowGroups.isEmpty()) {
@@ -215,7 +214,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
                     predicateColumnPaths,
                     columnIndexPaths,
                     offsetIndexPaths,
-                    allocator
+                    breaker
                 );
             } catch (Exception e) {
                 logger.debug("Coalesced metadata preload failed, falling back to sequential: {}", e.getMessage());
@@ -247,7 +246,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> predicateColumnPaths,
         Set<String> columnIndexPaths,
         Set<String> offsetIndexPaths,
-        BufferAllocator allocator
+        CircuitBreaker breaker
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
         List<RangeMeta> rangeMetas = new ArrayList<>();
@@ -290,7 +289,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
             storageObject,
             ranges,
             CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP,
-            allocator,
+            breaker,
             Runnable::run,
             future
         );

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocatorTests.java
@@ -56,7 +56,7 @@ public class CircuitBreakerByteBufferAllocatorTests extends ESTestCase {
         setup.join();
 
         try {
-            var parquetAllocator = allocator(local);
+            var parquetAllocator = allocator(LocalCircuitBreaker.forAsyncIo(local));
             ByteBuffer buf = parquetAllocator.allocate(64);
             assertEquals(64, parent.getUsed());
             parquetAllocator.release(buf);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CircuitBreakerByteBufferAllocatorTests.java
@@ -12,7 +12,11 @@ import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 
 import java.nio.ByteBuffer;
@@ -38,6 +42,30 @@ public class CircuitBreakerByteBufferAllocatorTests extends ESTestCase {
         assertEquals(512, breaker.getUsed());
         allocator.release(buf);
         assertEquals(0, breaker.getUsed());
+    }
+
+    public void testAllocateFromOtherThreadChargesParentBreaker() throws Exception {
+        assumeTrue("requires assertions enabled (-ea) to detect the I/O-thread race", assertionsEnabled());
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(1)).withCircuitBreaking();
+        CircuitBreaker parent = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        LocalCircuitBreaker local = new LocalCircuitBreaker(parent, 0, 0);
+
+        Thread setup = new Thread(() -> assertTrue(local.assertBeginRunLoop()), "setup-pin-driver-breaker");
+        setup.start();
+        setup.join();
+
+        try {
+            var parquetAllocator = allocator(local);
+            ByteBuffer buf = parquetAllocator.allocate(64);
+            assertEquals(64, parent.getUsed());
+            parquetAllocator.release(buf);
+            assertEquals(0, parent.getUsed());
+        } finally {
+            assertTrue(local.assertEndRunLoop());
+            local.close();
+            assertEquals(0, parent.getUsed());
+        }
     }
 
     public void testLargeAllocationTripsBreaker() {
@@ -125,6 +153,13 @@ public class CircuitBreakerByteBufferAllocatorTests extends ESTestCase {
         // Breaker accepts reservation, allocation fails
         expectThrows(IllegalArgumentException.class, () -> allocator.allocate(200));
         assertEquals(0, breaker.getUsed());
+    }
+
+    @SuppressWarnings("AssertWithSideEffects")
+    private static boolean assertionsEnabled() {
+        boolean enabled = false;
+        assert enabled = true;
+        return enabled;
     }
 
     static class TestAllocator implements ByteBufferAllocator {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
@@ -7,13 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasource.parquet.CoalescedRangeReader.ByteRange;
@@ -48,25 +45,18 @@ import static org.hamcrest.Matchers.instanceOf;
 public class CoalescedRangeReaderTests extends ESTestCase {
 
     private CircuitBreaker breaker;
-    private BufferAllocator allocator;
-    private BlockFactory blockFactory;
 
     @Before
     public void initAllocator() {
-        // A real (limited) breaker rather than a noop one: BlockFactory wires it into the Arrow
-        // allocator via CircuitBreakerAllocationListener, so every coalesced buffer is charged on
-        // allocate and uncharged on close. breaker.getUsed() is therefore the ground-truth leak
-        // signal - a NoopCircuitBreaker reports 0 unconditionally and would hide a leak.
+        // A real (limited) breaker rather than a noop one so breaker.getUsed() is the ground-truth
+        // leak signal - a NoopCircuitBreaker reports 0 unconditionally and would hide a leak.
         breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
-        allocator = blockFactory.arrowAllocator();
     }
 
     @After
     public void assertNoOutstandingMemory() {
         // Global leak net: whatever each test did, no coalesced buffer may remain charged.
         assertEquals("circuit breaker still holds bytes at teardown", 0L, breaker.getUsed());
-        assertEquals("allocator still holds bytes at teardown", 0L, allocator.getAllocatedMemory());
     }
 
     public void testMergeAdjacentRanges() {
@@ -176,7 +166,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
         AtomicReference<CoalescedRangeResult> resultRef = new AtomicReference<>();
         AtomicReference<Exception> failureRef = new AtomicReference<>();
 
-        CoalescedRangeReader.readCoalesced(storageObject, ranges, 50, allocator, Runnable::run, new ActionListener<>() {
+        CoalescedRangeReader.readCoalesced(storageObject, ranges, 50, breaker, Runnable::run, new ActionListener<>() {
             @Override
             public void onResponse(CoalescedRangeResult result) {
                 resultRef.set(result);
@@ -228,7 +218,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
         AtomicReference<CoalescedRangeResult> resultRef = new AtomicReference<>();
 
         // null StorageObject is safe here: the empty-ranges path returns before any I/O
-        CoalescedRangeReader.readCoalesced(null, List.of(), 0, allocator, Runnable::run, new ActionListener<>() {
+        CoalescedRangeReader.readCoalesced(null, List.of(), 0, breaker, Runnable::run, new ActionListener<>() {
             @Override
             public void onResponse(CoalescedRangeResult result) {
                 resultRef.set(result);
@@ -287,7 +277,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
             failingObject,
             List.of(new ByteRange(0, 100)),
             0,
-            allocator,
+            breaker,
             Runnable::run,
             new ActionListener<>() {
                 @Override
@@ -403,7 +393,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
         AtomicReference<CoalescedRangeResult> resultRef = new AtomicReference<>();
         AtomicReference<Exception> failureRef = new AtomicReference<>();
 
-        CoalescedRangeReader.readCoalesced(shortReadObject, ranges, 1024, allocator, Runnable::run, new ActionListener<>() {
+        CoalescedRangeReader.readCoalesced(shortReadObject, ranges, 1024, breaker, Runnable::run, new ActionListener<>() {
             @Override
             public void onResponse(CoalescedRangeResult result) {
                 resultRef.set(result);
@@ -516,7 +506,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
                 AtomicReference<CoalescedRangeResult> resultRef = new AtomicReference<>();
                 AtomicReference<Exception> failureRef = new AtomicReference<>();
 
-                CoalescedRangeReader.readCoalesced(injecting, ranges, 1024, allocator, executor, new ActionListener<>() {
+                CoalescedRangeReader.readCoalesced(injecting, ranges, 1024, breaker, executor, new ActionListener<>() {
                     @Override
                     public void onResponse(CoalescedRangeResult result) {
                         resultRef.set(result);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
@@ -15,14 +14,15 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.After;
 import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
@@ -47,13 +47,16 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class ColumnChunkPrefetcherTests extends ESTestCase {
 
-    private BufferAllocator allocator;
-    private BlockFactory blockFactory;
+    private CircuitBreaker breaker;
 
     @Before
     public void initAllocator() {
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+        breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+    }
+
+    @After
+    public void assertNoOutstandingMemory() {
+        assertEquals("circuit breaker still holds bytes at teardown", 0L, breaker.getUsed());
     }
 
     public void testComputeColumnChunkRangesAllColumns() {
@@ -102,7 +105,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
         StorageObject storage = createStorageObject(fileData);
         BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 50), new ColMeta("col_b", 200, 60));
 
-        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, allocator);
+        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, breaker);
 
         ColumnChunkPrefetcher.PrefetchedChunks prefetched = future.get();
         try {
@@ -135,7 +138,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
             storage,
             block,
             null,
-            allocator
+            breaker
         );
 
         ColumnChunkPrefetcher.PrefetchedChunks prefetched = future.get();
@@ -147,13 +150,11 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
     }
 
     /**
-     * Production {@code StorageObject} backends all return direct buffers from
-     * {@code readBytesAsync}, but {@link ColumnChunkPrefetcher} defensively promotes any heap
-     * buffer to direct so that the JNI/Panama decompression path is never starved of direct
-     * memory if a future backend deviates from that convention. This test forces a heap-backed
-     * response and asserts the {@code PrefetchedChunk} ends up direct.
+     * Heap buffers from {@code readBytesAsync} stay heap. Production factories already allocate
+     * heap; this stub forces a wrapped {@code byte[]} so the prefetcher cannot accidentally
+     * promote back to direct.
      */
-    public void testPrefetchPromotesHeapBufferToDirect() throws Exception {
+    public void testPrefetchKeepsHeapBuffer() throws Exception {
         byte[] fileData = new byte[1000];
         for (int i = 0; i < fileData.length; i++) {
             fileData[i] = (byte) (i & 0xFF);
@@ -185,7 +186,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
                     int len = (int) Math.min(length, fileData.length - position);
                     byte[] copy = new byte[len];
                     System.arraycopy(fileData, pos, copy, 0, len);
-                    // Intentionally heap-backed: ColumnChunkPrefetcher must promote this to direct.
+                    // Intentionally heap-backed: ColumnChunkPrefetcher must not promote this to direct.
                     listener.onResponse(new DirectReadBuffer(ByteBuffer.wrap(copy), () -> {}));
                 });
             }
@@ -217,7 +218,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
             storage,
             block,
             null,
-            allocator
+            breaker
         );
 
         ColumnChunkPrefetcher.PrefetchedChunks prefetched = future.get();
@@ -225,7 +226,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
             NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> result = prefetched.chunks();
             ColumnChunkPrefetcher.PrefetchedChunk chunk = result.get(100L);
             assertThat(chunk, notNullValue());
-            assertTrue("PrefetchedChunk must be direct after promotion", chunk.data().isDirect());
+            assertFalse("PrefetchedChunk must stay heap", chunk.data().isDirect());
 
             byte[] expected = new byte[50];
             System.arraycopy(fileData, 100, expected, 0, 50);
@@ -300,7 +301,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
 
         BlockMetaData block = createBlockWithColumns(new ColMeta("a", 100, 500), new ColMeta("b", 2000, 500), new ColMeta("c", 5000, 500));
 
-        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, allocator);
+        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, breaker);
 
         ColumnChunkPrefetcher.PrefetchedChunks prefetched = future.get();
         try {
@@ -349,7 +350,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
             failingStorage,
             block,
             null,
-            allocator
+            breaker
         );
 
         assertTrue(future.isCompletedExceptionally());
@@ -423,7 +424,7 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
         BlockMetaData block = new BlockMetaData();
         block.setRowCount(0);
 
-        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, allocator);
+        CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future = ColumnChunkPrefetcher.prefetch(storage, block, null, breaker);
 
         ColumnChunkPrefetcher.PrefetchedChunks prefetched = future.get();
         try {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -415,7 +415,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
 
     private ParquetFileReader openReader(byte[] data) throws IOException {
         return ParquetFileReader.open(
-            new ParquetStorageObjectAdapter(storageObject(data), blockFactory.arrowAllocator()),
+            new ParquetStorageObjectAdapter(storageObject(data), blockFactory.breaker()),
             PlainParquetReadOptions.builder(codecFactory).build()
         );
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
@@ -113,7 +113,7 @@ public class ParquetColumnExtractorTests extends ESTestCase {
     private ParquetMetadata loadFooter(StorageObject so) throws IOException {
         try (
             ParquetFileReader fr = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(so, blockFactory.arrowAllocator()),
+                new ParquetStorageObjectAdapter(so, blockFactory.breaker()),
                 PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build()
             )
         ) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -3243,7 +3243,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             .build();
         try (
             org.apache.parquet.hadoop.ParquetFileReader reader = org.apache.parquet.hadoop.ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(storageObject, blockFactory.arrowAllocator()),
+                new ParquetStorageObjectAdapter(storageObject, blockFactory.breaker()),
                 options
             )
         ) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -965,7 +965,7 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
     private Set<Long> oracleA_apacheMr(byte[] parquetBytes, Expression filter) throws IOException {
         FilterPredicate filterPredicate = safeTranslateForApacheMr(filter);
         GroupReaderBuilder builder = new GroupReaderBuilder(
-            new ParquetStorageObjectAdapter(inMemoryStorageObject(parquetBytes), blockFactory.arrowAllocator())
+            new ParquetStorageObjectAdapter(inMemoryStorageObject(parquetBytes), blockFactory.breaker())
         );
         if (filterPredicate != null) {
             builder.withFilter(FilterCompat.get(filterPredicate));

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.conf.PlainParquetConfiguration;
@@ -27,9 +26,8 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -52,22 +50,16 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
-    private BlockFactory blockFactory;
-    private BufferAllocator allocator;
+    private CircuitBreaker breaker;
 
     @Before
-    public void initAllocatorAndClearFooterCache() {
-        // Store blockFactory to prevent GC from closing the RootAllocator while tests run.
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+    public void initBreakerAndClearFooterCache() {
+        breaker = new NoopCircuitBreaker("test");
         ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
     public void testNullStorageObjectThrowsException() {
-        QlIllegalArgumentException e = expectThrows(
-            QlIllegalArgumentException.class,
-            () -> new ParquetStorageObjectAdapter(null, allocator)
-        );
+        QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> new ParquetStorageObjectAdapter(null, breaker));
         assertEquals("storageObject cannot be null", e.getMessage());
     }
 
@@ -76,7 +68,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         assertEquals(1024, adapter.getLength());
     }
@@ -86,7 +78,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertNotNull(stream);
@@ -98,7 +90,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertEquals(1, stream.read());
@@ -112,7 +104,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] buffer = new byte[5];
@@ -127,7 +119,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(5);
@@ -141,7 +133,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             // Read some bytes to advance position
@@ -161,7 +153,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[100];
         StorageObject storageObject = createStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             IOException e = expectThrows(IOException.class, () -> stream.seek(-1));
@@ -173,7 +165,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[100];
         StorageObject storageObject = createStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             IOException e = expectThrows(IOException.class, () -> stream.seek(200));
@@ -185,7 +177,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] buffer = new byte[5];
@@ -199,7 +191,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] buffer = new byte[10];
@@ -213,7 +205,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocate(5);
@@ -229,7 +221,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocate(5);
@@ -247,7 +239,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocate(10);
@@ -267,7 +259,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocate(8);
@@ -288,7 +280,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocateDirect(5);
@@ -306,7 +298,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buffer = ByteBuffer.allocateDirect(5);
@@ -325,7 +317,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buf = ByteBuffer.allocate(3);
@@ -348,7 +340,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(5);
@@ -366,7 +358,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(3);
@@ -381,7 +373,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(3);
@@ -395,7 +387,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             ByteBuffer buf = ByteBuffer.allocateDirect(data.length);
@@ -412,7 +404,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             long skipped = stream.skip(3);
@@ -462,7 +454,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyStorageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyStorageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertEquals(0, stream.getPos());
@@ -520,7 +512,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.read();
@@ -579,7 +571,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject, breaker);
         long tailStart = data.length - 1024;
 
         byte[] first = new byte[1024];
@@ -640,7 +632,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyCounting, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyCounting, breaker);
         byte[] read = new byte[size];
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.readFully(read);
@@ -657,7 +649,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertNotNull(stream);
@@ -671,7 +663,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         StorageObject storageObject = createRangeReadStorageObject(data);
 
         long rangeBytes = 8 * 1024 * 1024L; // 8 MiB
-        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, rangeBytes, allocator);
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, rangeBytes, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertNotNull(stream);
@@ -723,7 +715,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         };
 
         long hugeRange = 64 * 1024 * 1024L; // 64 MiB — should be capped to MAX_WINDOW_SIZE
-        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(measuringStorageObject, hugeRange, allocator);
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(measuringStorageObject, hugeRange, breaker);
 
         byte[] buf = new byte[size];
         try (SeekableInputStream stream = adapter.newStream()) {
@@ -742,7 +734,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         StorageObject storageObject = createRangeReadStorageObject(data);
 
         long tinyRange = 1024L; // 1 KiB — should be floored to DEFAULT_WINDOW_SIZE
-        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, tinyRange, allocator);
+        ParquetStorageObjectAdapter adapter = ParquetStorageObjectAdapter.forRange(storageObject, tinyRange, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] buf = new byte[data.length];
@@ -793,7 +785,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         };
 
         // With default 4 MiB window, reading 6 MiB requires 2 range requests
-        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(countingStorageObject, allocator);
+        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(countingStorageObject, breaker);
         byte[] buf = new byte[size];
         try (SeekableInputStream stream = defaultAdapter.newStream()) {
             stream.readFully(buf);
@@ -805,7 +797,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         ParquetStorageObjectAdapter adaptiveAdapter = ParquetStorageObjectAdapter.forRange(
             countingStorageObject,
             8 * 1024 * 1024L,
-            allocator
+            breaker
         );
         try (SeekableInputStream stream = adaptiveAdapter.newStream()) {
             stream.readFully(buf);
@@ -861,7 +853,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[1024];
         randomBytes(data);
         StorageObject storage = createRangeReadStorageObject(data);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] result = new byte[100];
@@ -882,7 +874,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] buf = new byte[1024];
@@ -912,7 +904,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
         byte[] result = new byte[size];
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.readFully(result);
@@ -940,7 +932,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             { 2_000_000, 32768 },
             { 0, 4096 } };
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             for (int[] region : readRegions) {
@@ -963,7 +955,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             assertEquals(1, stream.read());
@@ -1023,7 +1015,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         // HadoopParquetConfiguration, which fails in tests without Woodstox on the classpath.
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
         for (int iter = 0; iter < iterations; iter++) {
-            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
             long sum = 0;
             long count = 0;
@@ -1057,7 +1049,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         int threadCount = randomIntBetween(4, 8);
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
@@ -1126,7 +1118,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         int tailStart = data.length - 1024;
         byte[] expected = java.util.Arrays.copyOfRange(data, tailStart, data.length);
 
-        ParquetStorageObjectAdapter first = new ParquetStorageObjectAdapter(obj1, allocator);
+        ParquetStorageObjectAdapter first = new ParquetStorageObjectAdapter(obj1, breaker);
         try (SeekableInputStream s = first.newStream()) {
             s.seek(tailStart);
             byte[] w = new byte[1024];
@@ -1135,7 +1127,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         }
         assertEquals(1, rangeReadCount[0]);
 
-        ParquetStorageObjectAdapter second = new ParquetStorageObjectAdapter(obj2, allocator);
+        ParquetStorageObjectAdapter second = new ParquetStorageObjectAdapter(obj2, breaker);
         try (SeekableInputStream s = second.newStream()) {
             s.seek(tailStart);
             byte[] w = new byte[1024];
@@ -1205,7 +1197,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         for (int i = 0; i < 8; i++) {
             threads[i] = new Thread(() -> {
                 try {
-                    ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(obj, allocator);
+                    ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(obj, breaker);
                     try (SeekableInputStream s = adapter.newStream()) {
                         barrier.await(5, TimeUnit.SECONDS);
                         s.seek(tailStart);
@@ -1244,7 +1236,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[n];
         random().nextBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             byte[] got = new byte[100];
@@ -1286,8 +1278,8 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         byte[] data = new byte[n];
         random().nextBytes(data);
         StorageObject storage = createRangeReadStorageObject(data);
-        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(storage, allocator);
-        ParquetStorageObjectAdapter rangeAdapter = ParquetStorageObjectAdapter.forRange(storage, 8L * 1024 * 1024, allocator);
+        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(storage, breaker);
+        ParquetStorageObjectAdapter rangeAdapter = ParquetStorageObjectAdapter.forRange(storage, 8L * 1024 * 1024, breaker);
 
         try (SeekableInputStream a = defaultAdapter.newStream(); SeekableInputStream b = rangeAdapter.newStream()) {
             byte[] g1 = new byte[100];
@@ -1402,7 +1394,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         // Pre-warm the [200, 400) range.
         java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
@@ -1430,7 +1422,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         // Pre-warm the [100, 200) range only.
         java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
@@ -1468,7 +1460,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         try (SeekableInputStream stream = adapter.newStream()) {
             // Install the pre-warm map AFTER the stream was opened — same shape as production.
@@ -1496,7 +1488,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
         ByteBuffer warm = ByteBuffer.wrap(data, 0, 256).slice();
@@ -1529,7 +1521,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         java.util.NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new java.util.TreeMap<>();
         ByteBuffer warm = ByteBuffer.wrap(data, 0, 256).slice();
@@ -1557,7 +1549,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         AtomicInteger rangeReadCount = new AtomicInteger();
         StorageObject storage = createCountingRangeReadStorageObject(data, rangeReadCount);
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storage, breaker);
 
         adapter.installPreWarmedChunks(new java.util.TreeMap<>());
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -28,6 +28,11 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -83,6 +88,37 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         try (SeekableInputStream stream = adapter.newStream()) {
             assertNotNull(stream);
             assertEquals(0, stream.getPos());
+        }
+    }
+
+    /**
+     * Window construction charges the breaker. parquet-mr may open the stream on a generic
+     * thread while the driver holds {@link LocalCircuitBreaker#assertBeginRunLoop()}.
+     */
+    public void testNewStreamFromOtherThreadChargesParentBreaker() throws Exception {
+        assumeTrue("requires assertions enabled (-ea) to detect the I/O-thread race", assertionsEnabled());
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(16)).withCircuitBreaking();
+        CircuitBreaker parent = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        LocalCircuitBreaker local = new LocalCircuitBreaker(parent, 0, 0);
+
+        Thread setup = new Thread(() -> assertTrue(local.assertBeginRunLoop()), "setup-pin-driver-breaker");
+        setup.start();
+        setup.join();
+
+        try {
+            byte[] data = new byte[100];
+            randomBytes(data);
+            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(createStorageObject(data), local);
+            try (SeekableInputStream stream = adapter.newStream()) {
+                assertEquals(ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE, parent.getUsed());
+                assertNotNull(stream);
+            }
+            assertEquals(0, parent.getUsed());
+        } finally {
+            assertTrue(local.assertEndRunLoop());
+            local.close();
+            assertEquals(0, parent.getUsed());
         }
     }
 
@@ -1675,5 +1711,12 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
                 return StoragePath.of("memory://test.parquet");
             }
         };
+    }
+
+    @SuppressWarnings("AssertWithSideEffects")
+    private static boolean assertionsEnabled() {
+        boolean enabled = false;
+        assert enabled = true;
+        return enabled;
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -400,7 +400,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
     /**
      * Allocator-backed in-memory storage: default {@code readBytesAsync} allocates through
      * {@link DirectBufferFactory}. Distinct from {@link #createAsyncStorageObject}, which uses a
-     * heap {@code ByteBuffer} and a no-op closer so older breaker tests do not charge Arrow for
+     * heap {@code ByteBuffer} and a no-op closer so older breaker tests do not charge the breaker for
      * prefetch bytes. Do not merge the two stubs.
      */
     private static final class InMemoryStorageObject implements StorageObject {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReadStoreTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -19,8 +18,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -38,14 +35,12 @@ import static org.hamcrest.Matchers.sameInstance;
 public class PrefetchedPageReadStoreTests extends ESTestCase {
 
     private PlainCompressionCodecFactory codecFactory;
-    private BlockFactory blockFactory;
-    private BufferAllocator allocator;
+    private NoopCircuitBreaker breaker;
 
     @Before
-    public void initCodecAndAllocator() {
+    public void initCodecAndBreaker() {
         codecFactory = new PlainCompressionCodecFactory();
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+        breaker = new NoopCircuitBreaker("test");
     }
 
     @After
@@ -72,7 +67,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         DictionaryPage compressedDict = new DictionaryPage(BytesInput.from(payload), payload.length, 4, Encoding.PLAIN);
         PrefetchedPageReader reader = new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-            allocator,
+            breaker,
             List.of(),
             compressedDict,
             0
@@ -95,8 +90,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
     }
 
     public void testCloseIsIdempotent() {
-        // close() now actively releases ArrowBufs owned by per-column readers; the second call
-        // must be a safe no-op.
+        // close() releases per-column breaker charges; the second call must be a safe no-op.
         PrefetchedPageReadStore store = new PrefetchedPageReadStore(Map.of(newColumn("a"), newPageReader(0)), 0);
         store.close();
         store.close();
@@ -114,7 +108,7 @@ public class PrefetchedPageReadStoreTests extends ESTestCase {
         );
         return new PrefetchedPageReader(
             codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-            allocator,
+            breaker,
             List.of(new PrefetchedPageReader.CompressedPage(page, -1L)),
             null,
             valueCount

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPage;
@@ -15,52 +14,37 @@ import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.lang.management.BufferPoolMXBean;
-import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-
 /**
- * Regression for the direct-memory leak on the parquet decompression path
+ * Regression for decompress-buffer accounting on the parquet page-read path.
  *
  * <p>Loops {@link PrefetchedPageReader#readPage} over a few hundred small zstd-compressed pages
- * and asserts JVM-tracked direct memory stays bounded. Before the fix, every page allocated
- * a fresh {@code ByteBuffer.allocateDirect} that only the {@code Cleaner} could reclaim, and
- * the {@code Cleaner} only runs on Old/Mixed GC — which the tight loop never triggers, so
- * direct memory grew monotonically across iterations.
- *
- * <p>After the fix, decompression buffers come from a {@link BufferAllocator}-managed
- * {@link org.apache.arrow.memory.ArrowBuf} that is released deterministically when the
- * reader is closed, so each iteration's peak goes back to the baseline within a small delta.
+ * and asserts the request breaker returns to zero after every read-close cycle. Heap codecs
+ * allocate {@code byte[]}s that GC owns; this test does not claim JVM-wide direct RSS is flat
+ * (prefetch I/O still uses native buffers until a follow-up).
  */
 public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
 
     private static final int ITERATIONS = 500;
     private static final int PAGES_PER_ITERATION = 50;
-    private static final int PAGE_PAYLOAD_BYTES = 64 * 1024;          // 64 KB decompressed
-    private static final long MAX_DIRECT_GROWTH_BYTES = 64L * 1024 * 1024; // 64 MB ceiling
+    private static final int PAGE_PAYLOAD_BYTES = 64 * 1024;
     private static final int CONCURRENT_READERS = 4;
     private static final int CONCURRENT_ITERS_PER_READER = 50;
 
     private PlainCompressionCodecFactory codecFactory;
-    private BlockFactory blockFactory;
-    private BufferAllocator allocator;
 
     @Before
-    public void initCodecAndAllocator() {
+    public void initCodec() {
         codecFactory = new PlainCompressionCodecFactory();
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
     }
 
     @After
@@ -68,17 +52,15 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
         codecFactory.release();
     }
 
-    public void testRepeatedZstdDecompressionStaysWithinDirectMemoryBudget() throws IOException {
+    public void testRepeatedZstdDecompressionReleasesBreakerCharge() throws IOException {
         ZstdPageFixture fixture = compressedZstdPages();
-
-        long directBaseline = directMemoryUsedBytes();
-        long allocBaseline = allocator.getAllocatedMemory();
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofGb(1));
 
         for (int i = 0; i < ITERATIONS; i++) {
             try (
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                    allocator,
+                    breaker,
                     fixture.copyPages(),
                     null,
                     (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
@@ -89,44 +71,25 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                     consume(page);
                 }
             }
-            assertEquals("allocator must return to baseline after cycle " + i, allocBaseline, allocator.getAllocatedMemory());
+            assertEquals("breaker must return to zero after cycle " + i, 0L, breaker.getUsed());
         }
-
-        long after = directMemoryUsedBytes();
-        long grew = after - directBaseline;
-        assertThat(
-            "direct-memory grew "
-                + (grew >>> 20)
-                + " MB across "
-                + ITERATIONS
-                + " iters x "
-                + PAGES_PER_ITERATION
-                + " pages; expected <= "
-                + (MAX_DIRECT_GROWTH_BYTES >>> 20)
-                + " MB. After the fix, decompressToDirectBuffer allocates from a BufferAllocator-managed"
-                + " ArrowBuf released by PrefetchedPageReader.close().",
-            grew,
-            lessThanOrEqualTo(MAX_DIRECT_GROWTH_BYTES)
-        );
     }
 
     /**
-     * Concurrent zstd decompress loops must not accumulate native memory. Arrow accounting is
-     * exact (zero after join); MXBean remains a coarse JVM-wide ceiling matching the
-     * single-threaded regression.
+     * Concurrent zstd decompress loops must not leave breaker charge behind. Each reader uses
+     * its own breaker so threads cannot race on {@code used}.
      */
-    public void testDirectMemoryStableUnderConcurrentReads() throws Exception {
+    public void testBreakerChargeStableUnderConcurrentReads() throws Exception {
         ZstdPageFixture fixture = compressedZstdPages();
-        long allocBaseline = allocator.getAllocatedMemory();
-        long directBaseline = directMemoryUsedBytes();
 
         startInParallel(CONCURRENT_READERS, i -> {
+            LimitedBreaker breaker = new LimitedBreaker("test-" + i, ByteSizeValue.ofGb(1));
             try {
                 for (int iter = 0; iter < CONCURRENT_ITERS_PER_READER; iter++) {
                     try (
                         PrefetchedPageReader reader = new PrefetchedPageReader(
                             codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                            allocator,
+                            breaker,
                             fixture.copyPages(),
                             null,
                             (long) PAGE_PAYLOAD_BYTES * PAGES_PER_ITERATION
@@ -137,22 +100,12 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
                             consume(page);
                         }
                     }
+                    assertEquals(0L, breaker.getUsed());
                 }
             } catch (IOException e) {
                 throw new AssertionError(e);
             }
         });
-        assertEquals("allocator must return to baseline after concurrent reads", allocBaseline, allocator.getAllocatedMemory());
-        long grew = directMemoryUsedBytes() - directBaseline;
-        assertThat(
-            "direct-memory grew "
-                + (grew >>> 20)
-                + " MB under concurrent zstd reads; expected <= "
-                + (MAX_DIRECT_GROWTH_BYTES >>> 20)
-                + " MB",
-            grew,
-            lessThanOrEqualTo(MAX_DIRECT_GROWTH_BYTES)
-        );
     }
 
     private ZstdPageFixture compressedZstdPages() throws IOException {
@@ -189,22 +142,10 @@ public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
     }
 
     private static void consume(DataPage page) throws IOException {
-        // Force the BytesInput contents through to a heap copy (simulates the Block-construction
-        // consumer) and let the array go out of scope. The copy must complete before the reader
-        // is closed because closing the reader releases the underlying ArrowBuf.
         DataPageV1 v1 = (DataPageV1) page;
         byte[] sink = v1.getBytes().toByteArray();
         if (sink.length < 0) {
             throw new AssertionError(); // anti-DCE guard; JIT cannot fold sink.length < 0 to false
         }
-    }
-
-    private static long directMemoryUsedBytes() {
-        for (BufferPoolMXBean p : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
-            if ("direct".equals(p.getName())) {
-                return p.getMemoryUsed();
-            }
-        }
-        return 0;
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderLeakRegressionTests.java
@@ -29,8 +29,7 @@ import java.util.List;
  *
  * <p>Loops {@link PrefetchedPageReader#readPage} over a few hundred small zstd-compressed pages
  * and asserts the request breaker returns to zero after every read-close cycle. Heap codecs
- * allocate {@code byte[]}s that GC owns; this test does not claim JVM-wide direct RSS is flat
- * (prefetch I/O still uses native buffers until a follow-up).
+ * allocate {@code byte[]}s that GC owns; this test does not claim JVM-wide RSS is flat.
  */
 public class PrefetchedPageReaderLeakRegressionTests extends ESTestCase {
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -7,217 +7,247 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.AllocationListener;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-
 /**
- * Pins two contracts on {@link PrefetchedPageReader}: live native memory stays O(high-water-mark
- * page), not O(uncompressed column chunk); and equal-sized direct pages malloc the decompress
- * buffer once, not once per page. The reader reuses one buffer (grown only when a later page
- * needs more capacity) and releases it on {@link PrefetchedPageReader#close()}.
+ * Pins two contracts on {@link PrefetchedPageReader}: live breaker residency stays O(one
+ * decompressed page) (+ dictionary, if any), not O(uncompressed column chunk); and compressed
+ * pages decompress onto a heap {@code byte[]}, not a direct buffer.
  *
- * <p>Before per-page bounding, every {@code decompressToDirectBuffer} output was parked until
- * {@link PrefetchedPageReader#close()} at row-group rollover. The live-bound tests FAIL on that
- * accumulation. Reuse failures (malloc per page with live still O(one page)) still pass those
- * tests — {@link #testBufferReuseReducesAllocationCount} is the malloc pin.
- *
- * <p>Both a zstd {@link DataPageV2} (the canonical bench case, direct-to-direct JNI fast path) and
- * a gzip {@link DataPageV1} (the codec-uniformity twin, heap-staged, no native-library dependency)
- * are covered for the live bound. Allocation-count tests use direct compressed input so the
- * heap-to-direct scratch path cannot hide output-buffer reuse.
+ * <p>Both a zstd {@link DataPageV2} (the canonical bench case) and a gzip {@link DataPageV1}
+ * (codec-uniformity twin, no native-library dependency) are covered for the live bound.
  */
 public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
 
-    private static final int PAGE_PAYLOAD_BYTES = 64 * 1024; // power of two: Arrow capacity rounding is exact
+    private static final int PAGE_PAYLOAD_BYTES = 64 * 1024;
     private static final int PAGES = 4;
 
     /**
-     * Canonical case from the leak investigation: zstd {@link DataPageV2}, decompressed through the
-     * direct-to-direct fast path. Asserts the live allocator balance stays bounded by one page as
-     * pages are read, and returns to zero at {@code close()}.
+     * Canonical case from the leak investigation: zstd {@link DataPageV2}. Asserts the breaker
+     * tracks one page as pages are read, and returns to zero at {@code close()}.
      */
-    public void testZstdV2DecompressBufferReleasedPerPageAndOnClose() throws IOException {
-        assertPerPageReleaseAndZeroOnClose(buildZstdV2Pages());
+    public void testZstdV2DecompressChargeReleasedPerPageAndOnClose() throws IOException {
+        assertPerPageChargeAndZeroOnClose(buildZstdV2Pages());
     }
 
     /**
-     * Codec-uniformity twin: gzip {@link DataPageV1}, heap-staged into the direct output buffer.
-     * GZIP has no native-library dependency, so this covers the release bound on platforms without
-     * native zstd and confirms the fix is codec-agnostic (same {@code decompressToDirectBuffer}
-     * output buffer for every codec).
+     * Codec-uniformity twin: gzip {@link DataPageV1}. GZIP has no native-library dependency, so
+     * this covers the release bound on platforms without native zstd.
      */
-    public void testGzipV1DecompressBufferReleasedPerPageAndOnClose() throws IOException {
-        assertPerPageReleaseAndZeroOnClose(buildGzipV1Pages());
+    public void testGzipV1DecompressChargeReleasedPerPageAndOnClose() throws IOException {
+        assertPerPageChargeAndZeroOnClose(buildGzipV1Pages());
     }
 
     /**
-     * Equal-sized zstd V2 pages with direct compressed input (the production S3 path) must
-     * malloc the decompress buffer once, not once per page. Heap-backed compressed input is
-     * not used here: that path allocates a scratch buffer per page and would hide reuse.
+     * Dictionary charge is independent of the current data-page charge: live used bytes are
+     * dict + one page, and both drop to zero on close.
      */
-    public void testBufferReuseReducesAllocationCount() throws IOException {
-        int[] sizes = new int[PAGES];
-        Arrays.fill(sizes, PAGE_PAYLOAD_BYTES);
-        CountingListener listener = new CountingListener();
-        DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
-        try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
-            PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                allocator,
-                fixture.pages,
-                null,
-                valueCount(sizes)
-            );
-            try {
-                int baseline = listener.allocations;
-                for (int p = 0; p < PAGES; p++) {
-                    DataPageV2 page = (DataPageV2) reader.readPage();
-                    assertNotNull(page);
-                    assertArrayEquals(fixture.payloads.get(p), page.getData().toByteArray());
-                }
-                assertNull(reader.readPage());
-                assertEquals("equal-sized direct pages must malloc the decompress buffer once", 1, listener.allocations - baseline);
-            } finally {
-                reader.close();
-            }
-            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
-        } finally {
-            fixture.codecFactory.release();
-        }
-    }
-
-    /**
-     * Growing pages realloc and free the previous buffer; a later smaller page reuses the large
-     * buffer. Live memory never becomes the sum of grown sizes.
-     */
-    public void testBufferReuseHandlesVaryingPageSizes() throws IOException {
-        int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
-        CountingListener listener = new CountingListener();
-        DirectPagesFixture fixture = buildDirectZstdV2Pages(sizes);
-        try (RootAllocator allocator = new RootAllocator(listener, Long.MAX_VALUE)) {
-            PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
-                allocator,
-                fixture.pages,
-                null,
-                valueCount(sizes)
-            );
-            try {
-                long cap = 0L;
-                long peakLive = 0L;
-                for (int i = 0; i < sizes.length; i++) {
-                    long liveBefore = allocator.getAllocatedMemory();
-                    int allocationsBefore = listener.allocations;
-                    DataPageV2 page = (DataPageV2) reader.readPage();
-                    assertNotNull(page);
-                    assertArrayEquals(fixture.payloads.get(i), page.getData().toByteArray());
-                    long live = allocator.getAllocatedMemory();
-                    if (sizes[i] > cap) {
-                        assertThat(
-                            "page larger than the reusable buffer must allocate",
-                            listener.allocations,
-                            greaterThan(allocationsBefore)
-                        );
-                        if (liveBefore > 0L) {
-                            // Leak-on-grow would keep the old buf: live ≈ liveBefore + sizes[i].
-                            assertThat("grow must free the previous decompress buffer", live, lessThan(liveBefore + sizes[i]));
-                        }
-                        cap = sizes[i];
-                    } else {
-                        assertEquals("page that fits in the reusable buffer must not allocate", allocationsBefore, listener.allocations);
-                        assertEquals("smaller page must keep the high-water buffer", peakLive, live);
-                    }
-                    peakLive = Math.max(peakLive, live);
-                }
-                assertEquals("three grows, then one reuse", 3, listener.allocations);
-                assertThat(allocator.getAllocatedMemory(), greaterThan(0L));
-            } finally {
-                reader.close();
-            }
-            assertEquals("close() must return the reused buffer to the allocator", 0L, allocator.getAllocatedMemory());
-        } finally {
-            fixture.codecFactory.release();
-        }
-    }
-
-    private void assertPerPageReleaseAndZeroOnClose(PagesFixture fixture) {
-        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
-            PrefetchedPageReader reader = new PrefetchedPageReader(
-                fixture.codecFactory.getDecompressor(fixture.codec),
-                allocator,
-                fixture.pages,
-                null,
-                (long) PAGE_PAYLOAD_BYTES * PAGES
-            );
-            try {
+    public void testBreakerChargeReleasedPerPage() throws IOException {
+        PagesFixture fixture = buildGzipV1Pages();
+        BytesInputCompressor compressor = fixture.codecFactory.getCompressor(CompressionCodecName.GZIP);
+        byte[] dictPayload = randomByteArrayOfLength(1024);
+        byte[] compressedDictBytes = compressor.compress(BytesInput.from(dictPayload)).toByteArray();
+        DictionaryPage compressedDict = new DictionaryPage(BytesInput.from(compressedDictBytes), dictPayload.length, 4, Encoding.PLAIN);
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(CompressionCodecName.GZIP),
+            breaker,
+            fixture.pages,
+            compressedDict,
+            (long) PAGE_PAYLOAD_BYTES * PAGES
+        );
+        try {
+            assertNotNull(reader.readDictionaryPage());
+            assertEquals(dictPayload.length, breaker.getUsed());
+            for (int p = 0; p < PAGES; p++) {
                 assertNotNull(reader.readPage());
-                long oneLivePage = allocator.getAllocatedMemory();
-                assertThat(
-                    "one decompressed page must be live after the first readPage()",
-                    oneLivePage,
-                    greaterThanOrEqualTo((long) PAGE_PAYLOAD_BYTES)
+                assertEquals(
+                    "live charge must be dictionary plus the current data page after readPage() #" + (p + 1),
+                    dictPayload.length + PAGE_PAYLOAD_BYTES,
+                    breaker.getUsed()
                 );
-
-                for (int p = 1; p < PAGES; p++) {
-                    assertNotNull(reader.readPage());
-                    // Per-page bound: the previous page's decompress buffer is dead the moment the
-                    // consumer asks for the next page. FAILS pre-fix — the balance grows by one page
-                    // per readPage() until close(), which is the accumulation the bench OOM surfaced.
-                    assertThat(
-                        "live decompressed memory must stay bounded by one page after readPage() #" + (p + 1),
-                        allocator.getAllocatedMemory(),
-                        lessThanOrEqualTo(oneLivePage)
-                    );
-                }
-                // Reader drained: the tail page stays live until close().
-                assertNull(reader.readPage());
-                assertThat("decompress buffer must stay live after the last readPage()", allocator.getAllocatedMemory(), greaterThan(0L));
-            } finally {
-                reader.close();
             }
-            assertEquals("close() must return every decompress buffer to the allocator", 0L, allocator.getAllocatedMemory());
+            assertNull(reader.readPage());
+            assertEquals(dictPayload.length + PAGE_PAYLOAD_BYTES, breaker.getUsed());
         } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    public void testHeapDecompressionNeverAllocatesDirect() throws IOException {
+        assertHeapNotDirect(buildZstdV2Pages());
+        assertHeapNotDirect(buildGzipV1Pages());
+    }
+
+    public void testBreakerChargeTracksCurrentPageSize() throws IOException {
+        int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
+        PagesFixture fixture = buildZstdV2Pages(sizes);
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+            breaker,
+            fixture.pages,
+            null,
+            valueCount(sizes)
+        );
+        try {
+            for (int size : sizes) {
+                DataPageV2 page = (DataPageV2) reader.readPage();
+                assertNotNull(page);
+                assertEquals(size, breaker.getUsed());
+            }
+        } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    public void testUncompressedPagesDoNotChargeBreaker() throws IOException {
+        PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
+        try {
+            byte[] payload = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+            DataPageV1 v1 = new DataPageV1(
+                BytesInput.from(payload),
+                PAGE_PAYLOAD_BYTES / 4,
+                payload.length,
+                new IntStatistics(),
+                Encoding.RLE,
+                Encoding.RLE,
+                Encoding.PLAIN
+            );
+            LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(1));
+            try (
+                PrefetchedPageReader reader = new PrefetchedPageReader(
+                    codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
+                    breaker,
+                    List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
+                    null,
+                    PAGE_PAYLOAD_BYTES / 4
+                )
+            ) {
+                assertNotNull(reader.readPage());
+                assertEquals(0L, breaker.getUsed());
+            }
+            assertEquals(0L, breaker.getUsed());
+        } finally {
+            codecFactory.release();
+        }
+    }
+
+    public void testBreakerTripDoesNotLeaveCharge() throws IOException {
+        PagesFixture fixture = buildGzipV1Pages();
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(1));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(fixture.codec),
+            breaker,
+            fixture.pages,
+            null,
+            (long) PAGE_PAYLOAD_BYTES * PAGES
+        );
+        try {
+            expectThrows(CircuitBreakingException.class, reader::readPage);
+            assertEquals(0L, breaker.getUsed());
+        } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    private void assertPerPageChargeAndZeroOnClose(PagesFixture fixture) throws IOException {
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(fixture.codec),
+            breaker,
+            fixture.pages,
+            null,
+            (long) PAGE_PAYLOAD_BYTES * PAGES
+        );
+        try {
+            assertNotNull(reader.readPage());
+            assertEquals(PAGE_PAYLOAD_BYTES, breaker.getUsed());
+
+            for (int p = 1; p < PAGES; p++) {
+                assertNotNull(reader.readPage());
+                // Per-page bound: the previous page's charge is released the moment the
+                // consumer asks for the next page.
+                assertEquals(
+                    "live decompressed charge must stay one page after readPage() #" + (p + 1),
+                    PAGE_PAYLOAD_BYTES,
+                    breaker.getUsed()
+                );
+            }
+            assertNull(reader.readPage());
+            assertEquals("last page charge stays live after the queue drains", PAGE_PAYLOAD_BYTES, breaker.getUsed());
+        } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    private void assertHeapNotDirect(PagesFixture fixture) throws IOException {
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(fixture.codec),
+            breaker,
+            fixture.pages,
+            null,
+            (long) PAGE_PAYLOAD_BYTES * PAGES
+        );
+        try {
+            if (fixture.codec == CompressionCodecName.ZSTD) {
+                DataPageV2 page = (DataPageV2) reader.readPage();
+                assertFalse(page.getData().toByteBuffer().isDirect());
+            } else {
+                DataPageV1 page = (DataPageV1) reader.readPage();
+                assertFalse(page.getBytes().toByteBuffer().isDirect());
+            }
+        } finally {
+            reader.close();
             fixture.codecFactory.release();
         }
     }
 
     private PagesFixture buildZstdV2Pages() throws IOException {
+        return buildZstdV2Pages(filledSizes(PAGE_PAYLOAD_BYTES));
+    }
+
+    private PagesFixture buildZstdV2Pages(int[] payloadBytes) throws IOException {
         PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
         BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
-        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(PAGES);
-        for (int p = 0; p < PAGES; p++) {
-            byte[] data = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(payloadBytes.length);
+        for (int payloadSize : payloadBytes) {
+            byte[] data = randomByteArrayOfLength(payloadSize);
             byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
-            // Empty repetition/definition levels, so uncompressedSize == the decompressed data size
-            // (decompressV2 subtracts the rl/dl byte counts to derive the data-only size).
             DataPageV2 v2 = new DataPageV2(
-                PAGE_PAYLOAD_BYTES / 4,
+                payloadSize / 4,
                 0,
-                PAGE_PAYLOAD_BYTES / 4,
+                payloadSize / 4,
                 BytesInput.empty(),
                 BytesInput.empty(),
                 Encoding.PLAIN,
                 BytesInput.from(compressedData),
-                PAGE_PAYLOAD_BYTES,
+                payloadSize,
                 new IntStatistics(),
                 true
             );
@@ -247,36 +277,10 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         return new PagesFixture(codecFactory, CompressionCodecName.GZIP, pages);
     }
 
-    /**
-     * Zstd V2 pages whose compressed bytes are already direct, matching the production S3 path
-     * so {@code decompressToDirectBuffer} skips the heap-to-direct scratch allocation.
-     */
-    private DirectPagesFixture buildDirectZstdV2Pages(int... payloadBytes) throws IOException {
-        PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
-        BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
-        List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(payloadBytes.length);
-        List<byte[]> payloads = new ArrayList<>(payloadBytes.length);
-        for (int payloadSize : payloadBytes) {
-            byte[] data = randomByteArrayOfLength(payloadSize);
-            payloads.add(data);
-            byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
-            ByteBuffer direct = ByteBuffer.allocateDirect(compressedData.length);
-            direct.put(compressedData).flip();
-            DataPageV2 v2 = new DataPageV2(
-                payloadSize / 4,
-                0,
-                payloadSize / 4,
-                BytesInput.empty(),
-                BytesInput.empty(),
-                Encoding.PLAIN,
-                BytesInput.from(direct),
-                payloadSize,
-                new IntStatistics(),
-                true
-            );
-            pages.add(new PrefetchedPageReader.CompressedPage(v2, -1L));
-        }
-        return new DirectPagesFixture(codecFactory, pages, payloads);
+    private static int[] filledSizes(int size) {
+        int[] sizes = new int[PAGES];
+        Arrays.fill(sizes, size);
+        return sizes;
     }
 
     private static long valueCount(int[] payloadBytes) {
@@ -292,19 +296,4 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         CompressionCodecName codec,
         List<PrefetchedPageReader.CompressedPage> pages
     ) {}
-
-    private record DirectPagesFixture(
-        PlainCompressionCodecFactory codecFactory,
-        List<PrefetchedPageReader.CompressedPage> pages,
-        List<byte[]> payloads
-    ) {}
-
-    private static final class CountingListener implements AllocationListener {
-        private int allocations;
-
-        @Override
-        public void onAllocation(long size) {
-            allocations++;
-        }
-    }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPage;
@@ -21,8 +20,6 @@ import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompre
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -38,14 +35,12 @@ import static org.hamcrest.Matchers.nullValue;
 public class PrefetchedPageReaderTests extends ESTestCase {
 
     private PlainCompressionCodecFactory codecFactory;
-    private BlockFactory blockFactory;
-    private BufferAllocator allocator;
+    private NoopCircuitBreaker breaker;
 
     @Before
-    public void initCodecAndAllocator() {
+    public void initCodecAndBreaker() {
         codecFactory = new PlainCompressionCodecFactory();
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+        breaker = new NoopCircuitBreaker("test");
     }
 
     @After
@@ -112,7 +107,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.GZIP), // codec must not be invoked
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 8
@@ -156,7 +151,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             try (
                 PrefetchedPageReader reader = new PrefetchedPageReader(
                     codecFactory.getDecompressor(codec),
-                    allocator,
+                    breaker,
                     List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                     null,
                     10
@@ -197,7 +192,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -240,7 +235,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -260,7 +255,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(),
                 compressedDict,
                 0
@@ -288,7 +283,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.SNAPPY),
-                allocator,
+                breaker,
                 List.of(),
                 compressedDict,
                 0
@@ -307,7 +302,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(),
                 null,
                 0
@@ -321,7 +316,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(),
                 null,
                 0
@@ -335,7 +330,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(),
                 null,
                 12345L
@@ -363,7 +358,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v1, 42L)),
                 null,
                 5
@@ -395,7 +390,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v1, -1L)),
                 null,
                 10
@@ -411,7 +406,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             assertThat(outV1.getDlEncoding(), equalTo(Encoding.RLE));
             assertThat(outV1.getBytes().toByteArray(), equalTo(payload));
             ByteBuffer decompressedBuf = outV1.getBytes().toByteBuffer();
-            assertTrue("decompressed V1 page must be backed by a direct buffer to avoid G1GC pinning", decompressedBuf.isDirect());
+            assertFalse("round-trip decompressed V1 bytes are heap-backed", decompressedBuf.isDirect());
             assertNull(reader.readPage());
         }
     }
@@ -439,7 +434,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 decompressor,
-                allocator,
+                breaker,
                 List.of(new PrefetchedPageReader.CompressedPage(v2, -1L)),
                 null,
                 10
@@ -457,7 +452,7 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             assertThat(outV2.getDefinitionLevels().toByteArray(), equalTo(dl));
             assertThat(outV2.getData().toByteArray(), equalTo(data));
             ByteBuffer decompressedBuf = outV2.getData().toByteBuffer();
-            assertTrue("decompressed V2 data must be backed by a direct buffer to avoid G1GC pinning", decompressedBuf.isDirect());
+            assertFalse("round-trip decompressed V2 data is heap-backed", decompressedBuf.isDirect());
             assertNull(reader.readPage());
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderTests.java
@@ -172,16 +172,13 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         }
     }
 
-    public void testUncompressedV1PageWithDirectInputSkipsAllocAndCopy() throws IOException {
-        // Regression coverage for elastic/esql-planning#804: when the codec is UNCOMPRESSED and
-        // the page slice is already direct (the prefetched path), decompressV1 must return a view
-        // over the input buffer rather than allocating a fresh direct buffer and memcopying into
-        // it.
+    public void testUncompressedV1PageWithHeapInputSkipsAllocAndCopy() throws IOException {
+        // When the codec is UNCOMPRESSED, decompressV1 must return a view over the input buffer
+        // rather than allocating a fresh buffer and copying.
         byte[] payload = randomBytesOfLength(64);
-        ByteBuffer direct = ByteBuffer.allocateDirect(payload.length);
-        direct.put(payload).flip();
+        ByteBuffer heap = ByteBuffer.wrap(payload);
         DataPageV1 v1 = new DataPageV1(
-            BytesInput.from(direct.duplicate()),
+            BytesInput.from(heap.duplicate()),
             10,
             payload.length,
             intStats(),
@@ -206,25 +203,20 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             assertThat(out.getRlEncoding(), equalTo(Encoding.RLE));
             assertThat(out.getDlEncoding(), equalTo(Encoding.RLE));
             ByteBuffer decompressedBuf = out.getBytes().toByteBuffer();
-            assertTrue("Uncompressed V1 page must be backed by a direct buffer", decompressedBuf.isDirect());
+            assertFalse("Uncompressed V1 page aliases the heap I/O buffer", decompressedBuf.isDirect());
             assertThat(out.getBytes().toByteArray(), equalTo(payload));
-            // Mutating the underlying direct buffer must show through the returned BytesInput — i.e.,
-            // the page reader handed back a view rather than a copy of the input. The buffer
-            // duplicate's position/limit are independent of the original, so writing through the
-            // original is safe.
             byte sentinel = (byte) (payload[0] ^ 0xFF);
-            direct.put(0, sentinel);
-            assertEquals("Returned BytesInput must alias the direct input slice, not a copy", sentinel, out.getBytes().toByteArray()[0]);
+            heap.put(0, sentinel);
+            assertEquals("Returned BytesInput must alias the heap input slice, not a copy", sentinel, out.getBytes().toByteArray()[0]);
         }
     }
 
     public void testUncompressedV1PageWithDirectInputRejectsSizeMismatch() {
         byte[] payload = randomBytesOfLength(64);
-        ByteBuffer direct = ByteBuffer.allocateDirect(payload.length);
-        direct.put(payload).flip();
+        ByteBuffer heap = ByteBuffer.wrap(payload);
         int declaredSize = payload.length - 1;
         DataPageV1 v1 = new DataPageV1(
-            BytesInput.from(direct.duplicate()),
+            BytesInput.from(heap.duplicate()),
             10,
             declaredSize,
             intStats(),
@@ -246,12 +238,11 @@ public class PrefetchedPageReaderTests extends ESTestCase {
         }
     }
 
-    public void testUncompressedDictionaryPageWithDirectInputSkipsAllocAndCopy() throws IOException {
+    public void testUncompressedDictionaryPageWithHeapInputSkipsAllocAndCopy() throws IOException {
         // Same short-circuit, exercised through the dictionary-page path.
         byte[] payload = randomBytesOfLength(48);
-        ByteBuffer direct = ByteBuffer.allocateDirect(payload.length);
-        direct.put(payload).flip();
-        DictionaryPage compressedDict = new DictionaryPage(BytesInput.from(direct.duplicate()), payload.length, 4, Encoding.PLAIN);
+        ByteBuffer heap = ByteBuffer.wrap(payload);
+        DictionaryPage compressedDict = new DictionaryPage(BytesInput.from(heap.duplicate()), payload.length, 4, Encoding.PLAIN);
         try (
             PrefetchedPageReader reader = new PrefetchedPageReader(
                 codecFactory.getDecompressor(CompressionCodecName.UNCOMPRESSED),
@@ -264,11 +255,11 @@ public class PrefetchedPageReaderTests extends ESTestCase {
             DictionaryPage out = reader.readDictionaryPage();
             assertThat(out, notNullValue());
             ByteBuffer decompressedBuf = out.getBytes().toByteBuffer();
-            assertTrue("Uncompressed dictionary page must be backed by a direct buffer", decompressedBuf.isDirect());
+            assertFalse("Uncompressed dictionary page aliases the heap I/O buffer", decompressedBuf.isDirect());
             byte sentinel = (byte) (payload[0] ^ 0xFF);
-            direct.put(0, sentinel);
+            heap.put(0, sentinel);
             assertEquals(
-                "Returned BytesInput must alias the direct dictionary input slice, not a copy",
+                "Returned BytesInput must alias the heap dictionary input slice, not a copy",
                 sentinel,
                 out.getBytes().toByteArray()[0]
             );

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderBytesInputTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderBytesInputTests.java
@@ -24,9 +24,10 @@ import java.nio.ByteBuffer;
  * (Reference identity does not work — the helpers wrap via {@code buffer.duplicate()}, which
  * returns a new {@code ByteBuffer} instance that shares backing memory.)
  *
- * <p>This invariant is what lets {@code PrefetchedPageReader.decompressToDirectBuffer} take its
- * zero-copy path on the prefetched route. Locking it here so an innocuous refactor of either
- * helper can't silently re-introduce a per-page heap copy.
+ * <p>This invariant is what lets uncompressed {@code PrefetchedPageReader} pages alias I/O
+ * without a wrap-time copy. Compressed codecs may still copy via {@code toByteArray()} while
+ * prefetch remains direct. Locking the wrap here so a refactor of either helper cannot silently
+ * re-introduce a per-page heap copy at slice time.
  */
 public class PrefetchedRowGroupBuilderBytesInputTests extends ESTestCase {
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -227,7 +227,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     prefetched.chunks(),
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.breaker()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -335,7 +335,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                         prefetched.chunks(),
                         storageObject,
                         codecFactory,
-                        blockFactory.arrowAllocator()
+                        blockFactory.breaker()
                     )
                 ) {
                     ColumnDescriptor desc = schema.getColumns().getFirst();
@@ -448,7 +448,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     chunks,
                     storageObject,
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.breaker()
                 )
             ) {
                 ColumnDescriptor desc = schema.getColumns().getFirst();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -138,7 +138,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     null,
                     throwingOnStream(injected),
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.breaker()
                 )
             );
             assertThat(ex, instanceOf(ExternalClientException.class));
@@ -166,7 +166,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     null,
                     throwingOnStream(injected),
                     codecFactory,
-                    blockFactory.arrowAllocator()
+                    blockFactory.breaker()
                 )
             );
             assertSame(injected, ex);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedRowGroupBuilderParityTests.java
@@ -223,7 +223,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
                     schema,
                     projected,
                     rowRanges,
-                    PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.arrowAllocator()),
+                    PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.breaker()),
                     prefetched.chunks(),
                     storageObject,
                     codecFactory,
@@ -307,9 +307,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
             long rowCount = block.getRowCount();
 
             // Confirm the file actually has multiple pages so the test is meaningful.
-            try (
-                PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.arrowAllocator())
-            ) {
+            try (PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.breaker())) {
                 org.apache.parquet.internal.column.columnindex.OffsetIndex oi = metadata.getOffsetIndex(0, "id");
                 assertNotNull("offset index must be present (writer should emit it for sorted V1/V2 files)", oi);
                 assertTrue("expected multiple pages to exercise firstRowIndex; got " + oi.getPageCount(), oi.getPageCount() >= 4);
@@ -428,7 +426,7 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
     ) throws IOException {
         try (
             PreloadedRowGroupMetadata metadata = withOffsetIndex
-                ? PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.arrowAllocator())
+                ? PreloadedRowGroupMetadata.preload(reader, storageObject, blockFactory.breaker())
                 : PreloadedRowGroupMetadata.empty()
         ) {
             Set<String> projected = Set.of("id");
@@ -515,14 +513,14 @@ public class PrefetchedRowGroupBuilderParityTests extends ESTestCase {
             storageObject,
             block,
             projected,
-            blockFactory.arrowAllocator()
+            blockFactory.breaker()
         );
         return future.join();
     }
 
     private ParquetFileReader openReader(byte[] file) throws IOException {
         return ParquetFileReader.open(
-            new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), blockFactory.arrowAllocator()),
+            new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), blockFactory.breaker()),
             PlainParquetReadOptions.builder(codecFactory).build()
         );
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadataTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadataTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.DictionaryPage;
@@ -27,6 +26,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Verifies that {@link PreloadedRowGroupMetadata#preload(ParquetFileReader, StorageObject, Set, BufferAllocator)}
+ * Verifies that {@link PreloadedRowGroupMetadata#preload(ParquetFileReader, StorageObject, Set, CircuitBreaker)}
  * pre-fetches dictionary page bytes for predicate columns into a coalesced batch fetch and that
  * the resulting {@code preWarmedChunks} map can be installed on the adapter so subsequent reads
  * are served from memory.
@@ -72,12 +72,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class PreloadedRowGroupMetadataTests extends ESTestCase {
 
     private BlockFactory blockFactory;
-    private BufferAllocator allocator;
+    private CircuitBreaker breaker;
 
     @Before
     public void initBlockFactoryAndAllocator() throws Exception {
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+        breaker = blockFactory.breaker();
         ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
@@ -100,11 +100,11 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
             int rgCount = reader.getRowGroups().size();
             assertTrue("Test setup must produce at least one row group", rgCount >= 1);
 
-            PreloadedRowGroupMetadata withPrewarm = PreloadedRowGroupMetadata.preload(reader, storage, Set.of("v"), allocator);
+            PreloadedRowGroupMetadata withPrewarm = PreloadedRowGroupMetadata.preload(reader, storage, Set.of("v"), breaker);
             NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = withPrewarm.preWarmedChunks();
 
             // Count how many of the row groups actually have a dictionary page; only those
@@ -156,8 +156,8 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
-            PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, storage, Set.of("v"), allocator);
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
+            PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, storage, Set.of("v"), breaker);
             assertFalse("Pre-warm map must be populated to exercise the ArrowBuf-backed releasable", metadata.preWarmedChunks().isEmpty());
             metadata.close();
             // Without the idempotency guard this second close throws on ArrowBuf double-decrement.
@@ -175,16 +175,16 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
-            try (PreloadedRowGroupMetadata withoutPrewarm = PreloadedRowGroupMetadata.preload(reader, storage, allocator)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
+            try (PreloadedRowGroupMetadata withoutPrewarm = PreloadedRowGroupMetadata.preload(reader, storage, breaker)) {
                 assertTrue("Default preload must not pre-warm dictionary pages", withoutPrewarm.preWarmedChunks().isEmpty());
             }
 
-            try (PreloadedRowGroupMetadata withEmptyPredicates = PreloadedRowGroupMetadata.preload(reader, storage, Set.of(), allocator)) {
+            try (PreloadedRowGroupMetadata withEmptyPredicates = PreloadedRowGroupMetadata.preload(reader, storage, Set.of(), breaker)) {
                 assertTrue("Empty predicate set must disable pre-warm", withEmptyPredicates.preWarmedChunks().isEmpty());
             }
 
-            try (PreloadedRowGroupMetadata withNullPredicates = PreloadedRowGroupMetadata.preload(reader, storage, null, allocator)) {
+            try (PreloadedRowGroupMetadata withNullPredicates = PreloadedRowGroupMetadata.preload(reader, storage, null, breaker)) {
                 assertTrue("Null predicate set must disable pre-warm", withNullPredicates.preWarmedChunks().isEmpty());
             }
         }
@@ -209,7 +209,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
         try (
             ParquetFileReader reader = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), allocator),
+                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), breaker),
                 options
             )
         ) {
@@ -241,10 +241,10 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
             }
         });
 
-        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorage, allocator);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorage, breaker);
         try (ParquetFileReader reader = ParquetFileReader.open(adapter, options)) {
             // Pre-fetch + install: exactly the production wiring.
-            try (PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, countingStorage, Set.of("v"), allocator)) {
+            try (PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, countingStorage, Set.of("v"), breaker)) {
                 assertFalse("Pre-warm map must be populated", metadata.preWarmedChunks().isEmpty());
                 int dictReadsAfterPreload = dictionaryRangeReads.get();
 
@@ -305,9 +305,9 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
             StorageObject asyncStorage = createAsyncRangeReadStorageObject(parquetData, ioPool, asyncReadCount);
 
             ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(asyncStorage, allocator);
+            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(asyncStorage, breaker);
             try (ParquetFileReader reader = ParquetFileReader.open(adapter, options)) {
-                try (PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, asyncStorage, Set.of("v"), allocator)) {
+                try (PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(reader, asyncStorage, Set.of("v"), breaker)) {
                     NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = metadata.preWarmedChunks();
                     assertFalse("Pre-warm map must contain dictionary chunks even when reads complete async", chunks.isEmpty());
                     assertTrue("Async reads must have been dispatched", asyncReadCount.get() > 0);
@@ -357,7 +357,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         long[][] indexRanges;
         try (
             ParquetFileReader probe = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), allocator),
+                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), breaker),
                 options
             )
         ) {
@@ -375,7 +375,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
             }
         });
 
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(countingStorage, allocator), options)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(countingStorage, breaker), options)) {
             // Footer reads happen during open and never overlap the index ranges; capture the count
             // afterwards so the assertion isolates the preload's contribution.
             int readsBeforePreload = indexRangeReads.get();
@@ -386,7 +386,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of(),
                     Set.of(),
                     Set.of(),
-                    allocator
+                    breaker
                 )
             ) {
                 assertFalse("Full scan must not preload any column index", metadata.hasColumnIndexes());
@@ -412,7 +412,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         long[][] indexRanges;
         try (
             ParquetFileReader probe = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), allocator),
+                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), breaker),
                 options
             )
         ) {
@@ -454,7 +454,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
             assertHasPageIndexReferences(reader, "a", "b", "c");
             try (
                 PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(
@@ -463,7 +463,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of("a"),
                     Set.of("a"),
                     Set.of("a"),
-                    allocator
+                    breaker
                 )
             ) {
                 assertColumnPreloaded(metadata, reader.getRowGroups().size(), "a", true);
@@ -483,7 +483,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
             assertHasPageIndexReferences(reader, "a", "b", "c");
             Set<String> predicates = Set.of("a", "c");
             try (
@@ -493,7 +493,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     predicates,
                     predicates,
                     predicates,
-                    allocator
+                    breaker
                 )
             ) {
                 assertColumnPreloaded(metadata, reader.getRowGroups().size(), "a", true);
@@ -515,7 +515,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         StorageObject storage = createRangeReadStorageObject(parquetData);
 
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
-        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, allocator), options)) {
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, breaker), options)) {
             assertHasPageIndexReferences(reader, "a", "b", "c");
             try (
                 PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(
@@ -524,7 +524,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of("a"),
                     Set.of("a"),
                     Set.of("a", "b", "c"),
-                    allocator
+                    breaker
                 )
             ) {
                 int rgCount = reader.getRowGroups().size();
@@ -620,7 +620,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
         PageIndexRanges ranges;
         try (
             ParquetFileReader probe = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), allocator),
+                new ParquetStorageObjectAdapter(createRangeReadStorageObject(parquetData), breaker),
                 options
             )
         ) {
@@ -675,7 +675,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     idxReads.incrementAndGet();
                 }
             });
-            try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(counting, allocator), options)) {
+            try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(counting, breaker), options)) {
                 // Footer reads during open never overlap the index ranges; snapshot afterwards so the
                 // measurement isolates the preload's contribution.
                 long ciAfterOpen = ciBytes.get();
@@ -688,7 +688,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                         s.predicate(),
                         s.columnIndex(),
                         s.offsetIndex(),
-                        allocator
+                        breaker
                     )
                 ) {
                     assertNotNull(metadata);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/StatisticsRowGroupFilterParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/StatisticsRowGroupFilterParityTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
@@ -25,6 +24,7 @@ import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -55,7 +55,7 @@ import java.util.Set;
 public class StatisticsRowGroupFilterParityTests extends ESTestCase {
 
     private BlockFactory blockFactory;
-    private BufferAllocator allocator;
+    private CircuitBreaker breaker;
 
     private static final int ROWS_PER_GROUP = 1024;
     private static final int ROW_GROUPS = 4;
@@ -65,7 +65,7 @@ public class StatisticsRowGroupFilterParityTests extends ESTestCase {
     @Before
     public void initBlockFactoryAndCodec() throws Exception {
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        allocator = blockFactory.arrowAllocator();
+        breaker = blockFactory.breaker();
         codecFactory = new PlainCompressionCodecFactory();
     }
 
@@ -155,7 +155,7 @@ public class StatisticsRowGroupFilterParityTests extends ESTestCase {
         Set<Long> survivingStarts = new HashSet<>();
         try (
             ParquetFileReader reader = ParquetFileReader.open(
-                new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), allocator),
+                new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), breaker),
                 PlainParquetReadOptions.builder(codecFactory).withRecordFilter(FilterCompat.get(predicate)).build()
             )
         ) {
@@ -187,7 +187,7 @@ public class StatisticsRowGroupFilterParityTests extends ESTestCase {
 
     private ParquetFileReader openReader(byte[] file) throws IOException {
         return ParquetFileReader.open(
-            new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), allocator),
+            new ParquetStorageObjectAdapter(new InMemoryStorageObject(file), breaker),
             PlainParquetReadOptions.builder(codecFactory).build()
         );
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/StorageReadDirectMemoryLeakRegressionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/StorageReadDirectMemoryLeakRegressionTests.java
@@ -7,13 +7,11 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -27,21 +25,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Regression test for the direct-memory leak fixed in esql-planning#851: every
+ * Regression test: every
  * {@link StorageObject#readBytesAsync(long, long, DirectBufferFactory, java.util.concurrent.Executor, ActionListener)}
- * call must allocate through the supplied {@link DirectBufferFactory} (which is backed by a
- * {@link BufferAllocator}) so the caller can release the memory
- * deterministically.
+ * call must allocate through the supplied {@link DirectBufferFactory} so the caller can release
+ * the memory deterministically.
  *
  * <p>The checks below pin the contract from both sides:
  * <ul>
- *   <li>When the caller closes the returned {@link DirectReadBuffer}, the parent allocator's
- *       {@code getAllocatedMemory()} drops back to baseline — proving the reference count
- *       reaches zero and memory is returned.</li>
- *   <li>When the caller does <b>not</b> close the {@link DirectReadBuffer}, the parent
- *       allocator's {@code getAllocatedMemory()} grows monotonically — proving that the
- *       memory was routed through the allocator (not a hidden {@code allocateDirect}), and
- *       that closing the allocator alone is not what releases it.</li>
+ *   <li>When the caller closes the returned {@link DirectReadBuffer}, the circuit breaker drops
+ *       back to baseline — proving the charge is released.</li>
+ *   <li>When the caller does <b>not</b> close the {@link DirectReadBuffer}, the breaker grows
+ *       monotonically — proving that the memory was routed through the factory (not a hidden
+ *       {@code allocateDirect}).</li>
  * </ul>
  *
  * <p>The storage backend is a trivial in-memory stub that exercises the default
@@ -53,31 +48,26 @@ public class StorageReadDirectMemoryLeakRegressionTests extends ESTestCase {
     private static final int PAYLOAD_SIZE = 8 * 1024;
     private static final int CYCLES = 256;
 
-    public void testReadBytesAsyncReleasesAllocatorMemoryOnClose() throws Exception {
+    public void testReadBytesAsyncReleasesBreakerOnClose() throws Exception {
         byte[] payload = randomByteArrayOfLength(PAYLOAD_SIZE);
         StorageObject storage = new InMemoryStorageObject(payload);
 
-        try (RootAllocator root = new RootAllocator(Long.MAX_VALUE)) {
-            assertEquals("RootAllocator starts empty", 0L, root.getAllocatedMemory());
-            DirectBufferFactory factory = DirectBufferFactory.forAllocator(root);
+        CircuitBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        assertEquals("breaker starts empty", 0L, breaker.getUsed());
 
-            for (int i = 0; i < CYCLES; i++) {
-                PlainActionFuture<DirectReadBuffer> future = new PlainActionFuture<>();
-                storage.readBytesAsync(0, PAYLOAD_SIZE, factory, Runnable::run, future);
-                DirectReadBuffer result = future.actionGet();
-                try {
-                    assertEquals(PAYLOAD_SIZE, result.buffer().remaining());
-                    assertTrue("readBytesAsync must return a direct buffer", result.buffer().isDirect());
-                    assertEquals("RootAllocator must hold exactly the in-flight payload", PAYLOAD_SIZE, root.getAllocatedMemory());
-                } finally {
-                    result.close();
-                }
-                assertEquals(
-                    "RootAllocator must be empty after each cycle once the DirectReadBuffer is closed",
-                    0L,
-                    root.getAllocatedMemory()
-                );
+        for (int i = 0; i < CYCLES; i++) {
+            PlainActionFuture<DirectReadBuffer> future = new PlainActionFuture<>();
+            storage.readBytesAsync(0, PAYLOAD_SIZE, factory, Runnable::run, future);
+            DirectReadBuffer result = future.actionGet();
+            try {
+                assertEquals(PAYLOAD_SIZE, result.buffer().remaining());
+                assertFalse("readBytesAsync must return a heap buffer", result.buffer().isDirect());
+                assertEquals("breaker must hold exactly the in-flight payload", PAYLOAD_SIZE, breaker.getUsed());
+            } finally {
+                result.close();
             }
+            assertEquals("breaker must be empty after each cycle once the DirectReadBuffer is closed", 0L, breaker.getUsed());
         }
     }
 
@@ -86,78 +76,44 @@ public class StorageReadDirectMemoryLeakRegressionTests extends ESTestCase {
         StorageObject storage = new InMemoryStorageObject(payload);
 
         // We deliberately do NOT close the DirectReadBuffers within the loop — the test asserts
-        // that direct memory is actually routed through the allocator (and therefore visible as
-        // an outstanding allocation), as opposed to being allocated behind the allocator's back
-        // via ByteBuffer.allocateDirect (which is what the original bug did). The DirectReadBuffers
-        // are closed in the finally block so the RootAllocator can shut down cleanly.
-        try (RootAllocator root = new RootAllocator(Long.MAX_VALUE)) {
-            DirectBufferFactory factory = DirectBufferFactory.forAllocator(root);
-            int cyclesBeforeLeakCheck = 16;
-            List<DirectReadBuffer> kept = new ArrayList<>(cyclesBeforeLeakCheck);
-            try {
-                long previous = 0L;
-                for (int i = 0; i < cyclesBeforeLeakCheck; i++) {
-                    PlainActionFuture<DirectReadBuffer> future = new PlainActionFuture<>();
-                    storage.readBytesAsync(0, PAYLOAD_SIZE, factory, Runnable::run, future);
-                    DirectReadBuffer result = future.actionGet();
-                    kept.add(result);
-                    assertEquals(PAYLOAD_SIZE, result.buffer().remaining());
-
-                    long current = root.getAllocatedMemory();
-                    assertTrue(
-                        "Allocation must grow with each cycle when nothing is released; previous=" + previous + ", current=" + current,
-                        current > previous
-                    );
-                    previous = current;
-                }
-                assertTrue(
-                    "Total outstanding memory must be at least cycles * payload size",
-                    root.getAllocatedMemory() >= (long) cyclesBeforeLeakCheck * PAYLOAD_SIZE
-                );
-            } finally {
-                for (DirectReadBuffer r : kept) {
-                    r.close();
-                }
-            }
-        }
-    }
-
-    /**
-     * Sanity check that the production {@link BlockFactory#arrowAllocator()} also routes the
-     * allocation correctly — production code paths use this allocator rather than a bare
-     * {@link RootAllocator}.
-     */
-    public void testReadBytesAsyncThroughBlockFactoryAllocator() throws Exception {
-        byte[] payload = randomByteArrayOfLength(PAYLOAD_SIZE);
-        StorageObject storage = new InMemoryStorageObject(payload);
-
-        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
-        BufferAllocator allocator = blockFactory.arrowAllocator();
-        DirectBufferFactory factory = DirectBufferFactory.forAllocator(allocator);
-        long baseline = allocator.getAllocatedMemory();
-
-        for (int i = 0; i < CYCLES; i++) {
-            PlainActionFuture<DirectReadBuffer> future = new PlainActionFuture<>();
-            storage.readBytesAsync(0, PAYLOAD_SIZE, factory, Runnable::run, future);
-            DirectReadBuffer result = future.actionGet();
-            try {
+        // that bytes are actually routed through the factory (and therefore visible as an
+        // outstanding breaker charge), as opposed to being allocated behind the factory's back
+        // via ByteBuffer.allocateDirect. The DirectReadBuffers are closed in the finally block.
+        CircuitBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(64));
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        int cyclesBeforeLeakCheck = 16;
+        List<DirectReadBuffer> kept = new ArrayList<>(cyclesBeforeLeakCheck);
+        try {
+            long previous = 0L;
+            for (int i = 0; i < cyclesBeforeLeakCheck; i++) {
+                PlainActionFuture<DirectReadBuffer> future = new PlainActionFuture<>();
+                storage.readBytesAsync(0, PAYLOAD_SIZE, factory, Runnable::run, future);
+                DirectReadBuffer result = future.actionGet();
+                kept.add(result);
                 assertEquals(PAYLOAD_SIZE, result.buffer().remaining());
-                assertTrue(result.buffer().isDirect());
-            } finally {
-                result.close();
+
+                long current = breaker.getUsed();
+                assertTrue(
+                    "Charge must grow with each cycle when nothing is released; previous=" + previous + ", current=" + current,
+                    current > previous
+                );
+                previous = current;
             }
-            assertEquals(
-                "BlockFactory's arrow allocator must be back at baseline after each cycle",
-                baseline,
-                allocator.getAllocatedMemory()
+            assertTrue(
+                "Total outstanding charge must be at least cycles * payload size",
+                breaker.getUsed() >= (long) cyclesBeforeLeakCheck * PAYLOAD_SIZE
             );
+        } finally {
+            for (DirectReadBuffer r : kept) {
+                r.close();
+            }
+            assertEquals("breaker must be empty after closing kept buffers", 0L, breaker.getUsed());
         }
     }
 
     /**
      * In-memory {@link StorageObject} that uses the default {@code readBytesAsync} implementation
-     * supplied by {@link StorageObject}. The default impl is the one that allocates through the
-     * supplied {@link BufferAllocator}; this stub deliberately does not override it so the test
+     * supplied by {@link StorageObject}. This stub deliberately does not override it so the test
      * exercises exactly that code path.
      */
     private static final class InMemoryStorageObject implements StorageObject {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
@@ -1280,7 +1280,7 @@ public class TwoPhaseReaderTests extends ESTestCase {
         throws IOException {
         StorageObject storage = new CountingStorageObject(parquetData, false);
         ParquetReader.Builder<Group> builder = new ParquetReader.Builder<Group>(
-            new ParquetStorageObjectAdapter(storage, blockFactory.arrowAllocator()),
+            new ParquetStorageObjectAdapter(storage, blockFactory.breaker()),
             new PlainParquetConfiguration()
         ) {
             @Override
@@ -1307,7 +1307,7 @@ public class TwoPhaseReaderTests extends ESTestCase {
         throws IOException {
         StorageObject storage = new CountingStorageObject(parquetData, false);
         ParquetReader.Builder<Group> builder = new ParquetReader.Builder<Group>(
-            new ParquetStorageObjectAdapter(storage, blockFactory.arrowAllocator()),
+            new ParquetStorageObjectAdapter(storage, blockFactory.breaker()),
             new PlainParquetConfiguration()
         ) {
             @Override

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An {@link AsyncResponseTransformer} that accumulates the response body into a single, pre-sized
- * direct {@link ByteBuffer}, eliminating the redundant per-chunk allocations and copies performed
+ * destination {@link ByteBuffer}, eliminating the redundant per-chunk allocations and copies performed
  * by the SDK's default {@link AsyncResponseTransformer#toBytes()} and avoiding a subsequent
- * heap-to-direct promotion in {@code S3StorageObject.readBytesAsync}.
+ * extra copy in {@code S3StorageObject.readBytesAsync}.
  *
  * <p>The default {@code toBytes()} uses {@code ByteArrayAsyncResponseTransformer$BaosSubscriber},
  * which on every {@code onNext(ByteBuffer)} call:
@@ -45,9 +45,9 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>This transformer takes the expected payload length up front (which we always know for
  * range-read requests, and which the S3 service confirms in {@code Content-Length}), allocates
- * one direct destination buffer of exactly that size in {@link #prepare()}, and copies each
- * {@code onNext(ByteBuffer)} chunk directly into the destination at the running offset. That
- * collapses three SDK-internal copies into a single chunk-to-direct-buffer copy.
+ * one destination buffer of exactly that size in {@link #prepare()}, and copies each
+ * {@code onNext(ByteBuffer)} chunk into the destination at the running offset. That
+ * collapses three SDK-internal copies into a single chunk-to-destination copy.
  *
  * <p><b>Synchronization:</b> Reactive Streams serializes the {@link Subscriber}'s own signals, but
  * {@link #exceptionOccurred} is a transformer-level callback outside that ordering and can race the
@@ -140,7 +140,7 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
     }
 
     /**
-     * Copies each incoming {@link ByteBuffer} chunk directly into a pre-sized direct destination,
+     * Copies each incoming {@link ByteBuffer} chunk into a pre-sized destination,
      * tracking the running offset. Fails fast if the cumulative size of received chunks would
      * exceed the expected length (a mismatch between the requested range and the server's
      * response body) or falls short of it on completion.

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -431,7 +431,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
             return;
         }
         if (length > Integer.MAX_VALUE) {
-            // The async path materializes the response into a single direct ByteBuffer; ranges larger than 2 GiB
+            // The async path materializes the response into a single ByteBuffer; ranges larger than 2 GiB
             // are not supportable here. Callers needing larger reads must split the range or fall
             // back to the streaming sync path via newStream(position, length).
             listener.onFailure(new IllegalArgumentException("length must fit in an int for async reads, got: " + length));
@@ -444,7 +444,7 @@ public final class S3StorageObject extends AbstractMeteredStorageObject {
         GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(key).range(rangeHeader).build();
 
         // Use a custom transformer instead of AsyncResponseTransformer.toBytes() so each chunk is
-        // copied straight into a pre-sized direct ByteBuffer (single chunk-to-destination copy),
+        // copied straight into a pre-sized destination ByteBuffer (single chunk-to-destination copy),
         // rather than the SDK's default BAOS-based pipeline which materializes the body 3+ times.
         // See KnownLengthAsyncResponseTransformer for the full rationale.
         long startNanos = System.nanoTime();

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
@@ -10,10 +10,10 @@ package org.elasticsearch.xpack.esql.datasource.s3;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
-import org.apache.arrow.memory.BufferAllocator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LimitedBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -43,14 +43,7 @@ import static org.hamcrest.Matchers.instanceOf;
  */
 public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testRejectsNegativeExpectedLength() {
         IllegalArgumentException ex = expectThrows(
@@ -63,7 +56,7 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
     public void testSingleChunkHeapByteBuffer() throws Exception {
         byte[] payload = randomByteArrayOfLength(between(1, 4096));
         try (DirectReadBuffer result = runTransformer(payload.length, response(payload.length), List.of(ByteBuffer.wrap(payload)))) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -72,7 +65,7 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         byte[] payload = randomByteArrayOfLength(between(64, 8192));
         List<ByteBuffer> chunks = splitIntoChunks(payload, between(2, 8), false);
         try (DirectReadBuffer result = runTransformer(payload.length, response(payload.length), chunks)) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -81,7 +74,7 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         byte[] payload = randomByteArrayOfLength(between(64, 8192));
         List<ByteBuffer> chunks = splitIntoChunks(payload, between(2, 8), true);
         try (DirectReadBuffer result = runTransformer(payload.length, response(payload.length), chunks)) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -97,14 +90,14 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         assertThat(chunk.arrayOffset(), greaterThanOrEqualTo(slack));
 
         try (DirectReadBuffer result = runTransformer(payload.length, response(payload.length), List.of(chunk))) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
 
     public void testEmptyResponse() throws Exception {
         try (DirectReadBuffer result = runTransformer(0, response(0), List.of())) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertEquals(0, result.buffer().remaining());
         }
     }
@@ -230,7 +223,7 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         });
 
         try (DirectReadBuffer result = secondAttempt.get()) {
-            assertTrue(result.buffer().isDirect());
+            assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
     }
@@ -238,32 +231,31 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
     public void testOnCompleteReleasesBufferWhenItLosesTheCompletionRace() throws Exception {
         // If a concurrent exceptionOccurred fails the future before onComplete completes it, onComplete's
         // complete() returns false; it then solely owns the buffer it took via getAndSet and must release it,
-        // or the direct memory leaks. The child allocator surfaces any leak as non-zero allocated bytes.
-        try (BufferAllocator child = ALLOCATOR.newChildAllocator("onComplete-race", 0, Long.MAX_VALUE)) {
-            DirectBufferFactory factory = DirectBufferFactory.forAllocator(child);
-            byte[] payload = randomByteArrayOfLength(256);
-            KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
-                payload.length,
-                factory
-            );
-            CompletableFuture<DirectReadBuffer> future = transformer.prepare();
-            transformer.onResponse(response(payload.length));
+        // or the breaker charge leaks.
+        CircuitBreaker breaker = new LimitedBreaker("onComplete-race", ByteSizeValue.ofMb(16));
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        byte[] payload = randomByteArrayOfLength(256);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            payload.length,
+            factory
+        );
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        transformer.onResponse(response(payload.length));
 
-            RuntimeException raced = new RuntimeException("exceptionOccurred won the completion race");
-            transformer.onStream(new SdkPublisher<>() {
-                @Override
-                public void subscribe(Subscriber<? super ByteBuffer> s) {
-                    s.onSubscribe(new TestSubscription());
-                    s.onNext(ByteBuffer.wrap(payload)); // fills the destination: offset == capacity
-                    future.completeExceptionally(raced); // a concurrent exceptionOccurred fails the future first
-                    s.onComplete(); // onComplete loses the race; it must release the buffer it could not hand off
-                }
-            });
+        RuntimeException raced = new RuntimeException("exceptionOccurred won the completion race");
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new TestSubscription());
+                s.onNext(ByteBuffer.wrap(payload)); // fills the destination: offset == capacity
+                future.completeExceptionally(raced); // a concurrent exceptionOccurred fails the future first
+                s.onComplete(); // onComplete loses the race; it must release the buffer it could not hand off
+            }
+        });
 
-            ExecutionException ex = expectThrows(ExecutionException.class, future::get);
-            assertSame(raced, ex.getCause());
-            assertEquals("onComplete must release the buffer it could not hand off", 0L, child.getAllocatedMemory());
-        }
+        ExecutionException ex = expectThrows(ExecutionException.class, future::get);
+        assertSame(raced, ex.getCause());
+        assertEquals("onComplete must release the buffer it could not hand off", 0L, breaker.getUsed());
     }
 
     public void testResponseObjectExposedViaGetter() throws Exception {
@@ -310,7 +302,7 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
             }
         });
         DirectReadBuffer result = future.get();
-        assertTrue(result.buffer().isDirect());
+        assertFalse(result.buffer().isDirect());
         return result;
     }
 

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectAsyncTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObjectAsyncTests.java
@@ -15,11 +15,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -49,14 +46,7 @@ import static org.mockito.Mockito.when;
  */
 public class S3StorageObjectAsyncTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     private static final String BUCKET = "test-bucket";
     private static final String KEY = "data/file.parquet";
@@ -108,7 +98,7 @@ public class S3StorageObjectAsyncTests extends ESTestCase {
 
         assertTrue(latch.await(5, TimeUnit.SECONDS));
         try (DirectReadBuffer drb = result.get()) {
-            assertTrue("readBytesAsync must return a direct ByteBuffer", drb.buffer().isDirect());
+            assertFalse("readBytesAsync must return a heap ByteBuffer", drb.buffer().isDirect());
             byte[] bytes = new byte[drb.buffer().remaining()];
             drb.buffer().get(bytes);
             assertArrayEquals(PAYLOAD, bytes);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -91,6 +91,16 @@ public class BlockFactory {
         return breaker;
     }
 
+    /**
+     * Returns the Arrow {@link BufferAllocator} bound to this factory. One root allocator per
+     * top-level factory; child factories share it. There is no per-query close hook
+     * ({@code BlockFactory} is not {@link org.elasticsearch.core.Releasable}).
+     *
+     * @deprecated Do not allocate storage-read buffers here. Those paths use heap {@code byte[]}
+     *             charged to {@link #breaker()}. This allocator remains for wrapping Arrow vectors
+     *             (compute ArrowBuf blocks, parquet-rs, Flight).
+     */
+    @Deprecated
     public BufferAllocator arrowAllocator() {
         // There's one root Arrow allocator per top-level block factory.
         // Ideally, we should have one child allocator per ESQL query to check buffer leaks at the end of each query, but there's no

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
@@ -98,6 +98,18 @@ public final class LocalCircuitBreaker implements CircuitBreaker, Releasable {
         return breaker;
     }
 
+    /**
+     * Breaker that is safe to charge from I/O / generic threads.
+     * {@link LocalCircuitBreaker} is pinned to the driver thread; HTTP/S3 completion callbacks
+     * must charge its {@link #parentBreaker()} instead. Identity for any other breaker.
+     */
+    public static CircuitBreaker forAsyncIo(CircuitBreaker breaker) {
+        if (breaker instanceof LocalCircuitBreaker local) {
+            return local.parentBreaker();
+        }
+        return breaker;
+    }
+
     @Override
     public long getUsed() {
         return breaker.getUsed();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DirectByteBufferCopies.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DirectByteBufferCopies.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import java.nio.ByteBuffer;
 
 /**
- * Utilities for copying streaming {@link ByteBuffer} chunks into a pre-sized direct destination.
+ * Utilities for copying streaming {@link ByteBuffer} chunks into a pre-sized destination buffer.
  */
 public final class DirectByteBufferCopies {
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 
 import java.io.IOException;
 
@@ -31,9 +32,25 @@ public interface DirectBufferFactory {
     DirectReadBuffer allocate(int length) throws IOException;
 
     /**
+     * Breaker that is safe to charge from I/O / generic threads.
+     * {@link LocalCircuitBreaker} is pinned to the driver thread; HTTP/S3 completion callbacks
+     * must charge its parent request breaker instead. Identity for any other breaker.
+     */
+    static CircuitBreaker forAsyncIo(CircuitBreaker breaker) {
+        if (breaker instanceof LocalCircuitBreaker local) {
+            return local.parentBreaker();
+        }
+        return breaker;
+    }
+
+    /**
      * Returns a factory that allocates a heap {@code byte[]} of {@code length} bytes and charges
      * {@code breaker}. {@link DirectReadBuffer#close()} releases the charge. This is the production
      * bridge from a {@link CircuitBreaker} to {@link DirectBufferFactory}.
+     *
+     * <p>When {@code breaker} is a {@link LocalCircuitBreaker}, charges go to
+     * {@link #forAsyncIo(CircuitBreaker)} so {@link StorageObject#readBytesAsync} completions
+     * on generic threads do not trip the driver's single-thread assertion.
      */
     static DirectBufferFactory forBreaker(CircuitBreaker breaker) {
         return len -> DirectReadBuffer.allocate(breaker, len);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
@@ -8,18 +8,19 @@
 package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 
 import java.io.IOException;
 
 /**
  * Producer of {@link DirectReadBuffer}s for {@link StorageObject#readBytesAsync}.
  *
- * <p>A factory bundles together "where the bytes go" (a destination off-heap buffer) and "what
- * gets charged for them" (the underlying allocator / circuit breaker). Backends only see this
- * one-method abstraction, so they need not depend on any specific direct-memory implementation
- * (Arrow today, anything else later). The bridge from a concrete allocator to this interface is
- * confined to {@link #forAllocator(BufferAllocator)} and to call sites that build a factory
- * differently (e.g. tests that fake the allocation).
+ * <p>A factory bundles together "where the bytes go" (a destination buffer) and "what gets
+ * charged for them". Backends only see this one-method abstraction, so they need not depend
+ * on any specific buffer implementation. Production code uses {@link #forBreaker(CircuitBreaker)}
+ * (heap {@code byte[]}, charged to the breaker, released on {@link DirectReadBuffer#close()}).
+ * {@link #forAllocator(BufferAllocator)} is deprecated: Arrow-backed I/O is no longer the
+ * production path.
  *
  * <p>{@link #allocate(int)} may throw {@link IOException} when the underlying allocator refuses
  * the allocation (circuit-breaker trip, OOM, etc.). On success the returned buffer is uninitialized
@@ -30,11 +31,21 @@ public interface DirectBufferFactory {
     DirectReadBuffer allocate(int length) throws IOException;
 
     /**
-     * Returns a factory that allocates from the given Arrow {@link BufferAllocator}. This is the
-     * one supported bridge from a concrete allocator to {@link DirectBufferFactory}; production
-     * code calls it once at the boundary that owns the allocator (currently
-     * {@code CoalescedRangeReader}).
+     * Returns a factory that allocates a heap {@code byte[]} of {@code length} bytes and charges
+     * {@code breaker}. {@link DirectReadBuffer#close()} releases the charge. This is the production
+     * bridge from a {@link CircuitBreaker} to {@link DirectBufferFactory}.
      */
+    static DirectBufferFactory forBreaker(CircuitBreaker breaker) {
+        return len -> DirectReadBuffer.allocate(breaker, len);
+    }
+
+    /**
+     * Returns a factory that allocates from the given Arrow {@link BufferAllocator}.
+     *
+     * @deprecated production I/O uses {@link #forBreaker(CircuitBreaker)}. Kept for tests and
+     *             Arrow-backed callers that still allocate off-heap.
+     */
+    @Deprecated
     static DirectBufferFactory forAllocator(BufferAllocator allocator) {
         return len -> DirectReadBuffer.allocate(allocator, len);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
@@ -32,28 +32,17 @@ public interface DirectBufferFactory {
     DirectReadBuffer allocate(int length) throws IOException;
 
     /**
-     * Breaker that is safe to charge from I/O / generic threads.
-     * {@link LocalCircuitBreaker} is pinned to the driver thread; HTTP/S3 completion callbacks
-     * must charge its parent request breaker instead. Identity for any other breaker.
-     */
-    static CircuitBreaker forAsyncIo(CircuitBreaker breaker) {
-        if (breaker instanceof LocalCircuitBreaker local) {
-            return local.parentBreaker();
-        }
-        return breaker;
-    }
-
-    /**
      * Returns a factory that allocates a heap {@code byte[]} of {@code length} bytes and charges
      * {@code breaker}. {@link DirectReadBuffer#close()} releases the charge. This is the production
      * bridge from a {@link CircuitBreaker} to {@link DirectBufferFactory}.
      *
-     * <p>When {@code breaker} is a {@link LocalCircuitBreaker}, charges go to
-     * {@link #forAsyncIo(CircuitBreaker)} so {@link StorageObject#readBytesAsync} completions
-     * on generic threads do not trip the driver's single-thread assertion.
+     * <p>Charges go through {@link LocalCircuitBreaker#forAsyncIo(CircuitBreaker)} so
+     * {@link StorageObject#readBytesAsync} completions on generic threads do not trip a
+     * driver-pinned local breaker.
      */
     static DirectBufferFactory forBreaker(CircuitBreaker breaker) {
-        return len -> DirectReadBuffer.allocate(breaker, len);
+        CircuitBreaker io = LocalCircuitBreaker.forAsyncIo(breaker);
+        return len -> DirectReadBuffer.allocate(io, len);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
@@ -9,31 +9,34 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasable;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Result of {@link StorageObject#readBytesAsync(long, long, DirectBufferFactory, java.util.concurrent.Executor,
- * org.elasticsearch.action.ActionListener)}: the bytes plus a {@link Releasable} that frees the
- * native memory backing them.
+ * org.elasticsearch.action.ActionListener)}: the bytes plus a {@link Releasable} that releases
+ * whatever backed them (breaker charge for heap buffers, native memory for Arrow-backed ones).
  *
- * <p>The {@code buffer} is a direct {@link ByteBuffer} view of an {@link ArrowBuf} obtained from
- * the caller-supplied {@link DirectBufferFactory} (via {@link DirectBufferFactory#allocate(int)}).
- * The caller must invoke {@link #close()} once the bytes have been consumed: closing decrements
- * the {@code ArrowBuf}'s reference count, which is what actually returns the memory to the
- * underlying allocator. Closing the allocator alone is not enough — Arrow's
- * {@code BaseAllocator.close()} treats outstanding {@code ArrowBuf}s as a leak.
+ * <p>The {@code buffer} is a {@link ByteBuffer} obtained from the caller-supplied
+ * {@link DirectBufferFactory} (via {@link DirectBufferFactory#allocate(int)}). Production
+ * factories ({@link DirectBufferFactory#forBreaker(CircuitBreaker)}) wrap a heap {@code byte[]};
+ * {@link DirectBufferFactory#forAllocator(BufferAllocator)} wraps an {@link ArrowBuf}. The
+ * buffer is not required to be direct. The caller must invoke {@link #close()} once the bytes
+ * have been consumed.
  *
- * <p>Using {@link #buffer()} after {@link #close()} reads dangling memory; the underlying chunk
- * may have been recycled into another allocation.
+ * <p>Using {@link #buffer()} after {@link #close()} is undefined: a heap array may still be
+ * reachable, but an Arrow-backed view reads dangling memory that may have been recycled.
  *
  * <h2>Use-after-free / double-free detection (assertions only)</h2>
- * <p>The bytes are exposed as a detached {@link ByteBuffer} (via {@code ArrowBuf.nioBuffer(...)}),
- * so reads through that view <em>bypass Arrow's reference-count tracking entirely</em> — the Arrow
- * debug allocator can detect a double-free or a leak, but it is blind to a read that aliases this
- * buffer after {@link #close()} has freed it. That is the failure mode behind the nondeterministic
- * zstd {@code "Src size is incorrect"} / {@code "Destination buffer is too small"} corruption: a
+ * <p>When the buffer is a detached {@link ByteBuffer} view of an {@link ArrowBuf} (the
+ * {@link DirectBufferFactory#forAllocator(BufferAllocator)} path), reads through that view
+ * <em>bypass Arrow's reference-count tracking entirely</em> — the Arrow debug allocator can
+ * detect a double-free or a leak, but it is blind to a read that aliases this buffer after
+ * {@link #close()} has freed it. That is the failure mode behind the nondeterministic zstd
+ * {@code "Src size is incorrect"} / {@code "Destination buffer is too small"} corruption: a
  * slice handed out before close is read after the backing {@link ArrowBuf} was returned to the
  * allocator and recycled.
  *
@@ -44,14 +47,17 @@ import java.nio.ByteBuffer;
  *       at {@link #close()} ("who deallocated this"),</li>
  *   <li>throws on a second {@link #close()} (double-free) and on any {@link #buffer()} access after
  *       close (use-after-free), attaching both stack traces, and</li>
- *   <li><b>poisons</b> the direct memory with a recognizable pattern immediately before releasing it,
+ *   <li><b>poisons</b> direct memory with a recognizable pattern immediately before releasing it,
  *       so any surviving alias that reads the freed region fails the same way on every run instead
- *       of occasionally seeing still-intact bytes.</li>
+ *       of occasionally seeing still-intact bytes. Heap buffers skip poisoning ({@link
+ *       DirectMemoryDebug#poison(ByteBuffer)} is a no-op when {@code isDirect()} is false).</li>
  * </ul>
  * All of this compiles out (no allocation, no poisoning) when assertions are disabled, so the
  * production read path is unchanged.
  */
 public final class DirectReadBuffer implements Releasable {
+
+    private static final String STORAGE_READ_BREAKER_LABEL = "storage read buffer";
 
     private final ByteBuffer buffer;
     private final Releasable release;
@@ -65,6 +71,40 @@ public final class DirectReadBuffer implements Releasable {
         this.buffer = buffer;
         this.release = release;
         this.allocSite = DirectMemoryDebug.trackingEnabled() ? new Throwable("DirectReadBuffer allocated here") : null;
+    }
+
+    /**
+     * Bridge used by {@link DirectBufferFactory#forBreaker(CircuitBreaker)}: allocates a heap
+     * {@code byte[]} of {@code length} bytes, charges {@code breaker}, and wraps it as a
+     * {@link DirectReadBuffer}. {@link #close()} releases the charge. Backends should call
+     * {@link DirectBufferFactory#allocate(int)} instead of this method directly.
+     *
+     * <p>The returned buffer's contents are uninitialized; the caller is responsible for filling
+     * {@link #buffer()} before delivering it downstream and for calling {@link #close()} once
+     * consumption is complete (or on the failure path).
+     *
+     * <p>Breaker trips and {@link OutOfMemoryError} from the array allocation undo the charge
+     * before propagating so callers can distinguish a circuit-breaker rejection (eligible for a
+     * 429 response) from an I/O error.
+     */
+    public static DirectReadBuffer allocate(CircuitBreaker breaker, int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative, got: " + length);
+        }
+        breaker.addEstimateBytesAndMaybeBreak(length, STORAGE_READ_BREAKER_LABEL);
+        final byte[] bytes;
+        try {
+            bytes = new byte[length];
+        } catch (Throwable t) {
+            breaker.addWithoutBreaking(-length);
+            throw t;
+        }
+        AtomicBoolean chargeReleased = new AtomicBoolean();
+        return new DirectReadBuffer(ByteBuffer.wrap(bytes), () -> {
+            if (chargeReleased.compareAndSet(false, true)) {
+                breaker.addWithoutBreaking(-length);
+            }
+        });
     }
 
     /**
@@ -97,9 +137,9 @@ public final class DirectReadBuffer implements Releasable {
     }
 
     /**
-     * The bytes. Must not be accessed after {@link #close()}; doing so reads freed (and possibly
-     * recycled) native memory. When {@code es.arrow.debug_buffers} is on, a post-close access throws
-     * with the allocation and free stack traces attached.
+     * The bytes. Must not be accessed after {@link #close()}; doing so is undefined for Arrow-backed
+     * buffers (freed, possibly recycled native memory). When {@code es.arrow.debug_buffers} is on,
+     * a post-close access throws with the allocation and free stack traces attached.
      */
     public ByteBuffer buffer() {
         if (DirectMemoryDebug.trackingEnabled() && released) {
@@ -116,16 +156,17 @@ public final class DirectReadBuffer implements Releasable {
     @Override
     public void close() {
         if (DirectMemoryDebug.trackingEnabled()) {
-            // A second close would double-free the ArrowBuf. Surface it here with both stacks
-            // rather than letting Arrow throw a context-free IllegalReferenceCountException.
+            // A second close would double-free an ArrowBuf or double-release a breaker charge.
+            // Surface it here with both stacks rather than letting the backing store throw a
+            // context-free exception.
             if (released) {
                 throw doubleFree();
             }
             freeSite = new Throwable("DirectReadBuffer freed here");
             released = true;
         }
-        // Poison before releasing (self-gated by es.arrow.* knobs) so any surviving alias that
-        // reads this region after free fails deterministically instead of flakily.
+        // Poison before releasing (self-gated by es.arrow.* knobs; no-op for heap buffers) so any
+        // surviving alias that reads this region after free fails deterministically instead of flakily.
         DirectMemoryDebug.poison(buffer);
         release.close();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 
 import java.nio.ByteBuffer;
@@ -87,18 +89,18 @@ public final class DirectReadBuffer implements Releasable {
      * before propagating so callers can distinguish a circuit-breaker rejection (eligible for a
      * 429 response) from an I/O error.
      *
-     * <p>Charges go through {@link DirectBufferFactory#forAsyncIo(CircuitBreaker)}: a
+     * <p>Charges go through {@link LocalCircuitBreaker#forAsyncIo(CircuitBreaker)}: a
      * driver-local breaker is not safe to touch from HTTP/S3 completion threads.
      */
     public static DirectReadBuffer allocate(CircuitBreaker breaker, int length) {
         if (length < 0) {
             throw new IllegalArgumentException("length must be non-negative, got: " + length);
         }
-        CircuitBreaker ioBreaker = DirectBufferFactory.forAsyncIo(breaker);
+        CircuitBreaker ioBreaker = LocalCircuitBreaker.forAsyncIo(breaker);
         ioBreaker.addEstimateBytesAndMaybeBreak(length, STORAGE_READ_BREAKER_LABEL);
         final byte[] bytes;
         try {
-            bytes = new byte[length];
+            bytes = UninitializedArrays.newByteArray(length);
         } catch (Throwable t) {
             ioBreaker.addWithoutBreaking(-length);
             throw t;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
@@ -86,23 +86,27 @@ public final class DirectReadBuffer implements Releasable {
      * <p>Breaker trips and {@link OutOfMemoryError} from the array allocation undo the charge
      * before propagating so callers can distinguish a circuit-breaker rejection (eligible for a
      * 429 response) from an I/O error.
+     *
+     * <p>Charges go through {@link DirectBufferFactory#forAsyncIo(CircuitBreaker)}: a
+     * driver-local breaker is not safe to touch from HTTP/S3 completion threads.
      */
     public static DirectReadBuffer allocate(CircuitBreaker breaker, int length) {
         if (length < 0) {
             throw new IllegalArgumentException("length must be non-negative, got: " + length);
         }
-        breaker.addEstimateBytesAndMaybeBreak(length, STORAGE_READ_BREAKER_LABEL);
+        CircuitBreaker ioBreaker = DirectBufferFactory.forAsyncIo(breaker);
+        ioBreaker.addEstimateBytesAndMaybeBreak(length, STORAGE_READ_BREAKER_LABEL);
         final byte[] bytes;
         try {
             bytes = new byte[length];
         } catch (Throwable t) {
-            breaker.addWithoutBreaking(-length);
+            ioBreaker.addWithoutBreaking(-length);
             throw t;
         }
         AtomicBoolean chargeReleased = new AtomicBoolean();
         return new DirectReadBuffer(ByteBuffer.wrap(bytes), () -> {
             if (chargeReleased.compareAndSet(false, true)) {
-                breaker.addWithoutBreaking(-length);
+                ioBreaker.addWithoutBreaking(-length);
             }
         });
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
@@ -119,15 +119,16 @@ public interface StorageObject {
      * listener has {@code capacity() == length} (the requested length) and {@code remaining()}
      * equal to the number of bytes actually read. On a short read these differ — consumers must
      * use {@code remaining()} (or {@code limit() - position()}) to size their work, never
-     * {@code capacity()}. The buffer is direct.
+     * {@code capacity()}. The buffer is not required to be direct; production factories
+     * return a heap {@code byte[]} view.
      * <p>
      * On end-of-content at {@code position} the buffer is delivered with {@code remaining() == 0}.
      *
      * <p>
      * <b>Buffer ownership:</b> the storage object obtains exactly one {@link DirectReadBuffer} of
      * {@code length} bytes from {@code factory}. The caller must invoke {@link DirectReadBuffer#close()}
-     * once the bytes have been consumed; closing releases the buffer back to its underlying
-     * allocator. See {@link DirectReadBuffer} for the contract.
+     * once the bytes have been consumed; closing releases the buffer (breaker charge for heap,
+     * native memory for Arrow-backed factories). See {@link DirectReadBuffer} for the contract.
      *
      * <p>
      * <b>Implementation contract:</b> if the read fails, implementations must close the
@@ -158,9 +159,9 @@ public interface StorageObject {
             listener.onFailure(new IllegalArgumentException("length must fit in an int for async reads, got: " + length));
             return;
         }
-        // Allocate on the calling thread so a direct-memory OOM (or breaker trip) surfaces
-        // synchronously via the listener instead of escaping the executor's Runnable as an Error
-        // and leaving the listener permanently uncompleted.
+        // Allocate on the calling thread so a breaker trip or OOM surfaces synchronously via
+        // the listener instead of escaping the executor's Runnable as an Error and leaving the
+        // listener permanently uncompleted.
         final DirectReadBuffer drb;
         boolean submitted = false;
         try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObjectTests.java
@@ -7,13 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
@@ -50,14 +47,7 @@ import static org.mockito.Mockito.when;
  */
 public class ConcurrencyLimitedStorageObjectTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testStreamCloseReleasesPermit() throws Exception {
         ConcurrencyLimiter limiter = new ConcurrencyLimiter(3);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
@@ -7,11 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -46,14 +43,7 @@ import static org.mockito.Mockito.when;
  */
 public class QueryBudgetedStorageObjectTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testStreamCloseReleasesBudget() throws Exception {
         QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObjectTests.java
@@ -7,11 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -32,14 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class RangeStorageObjectTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     private static final byte[] FILE_BYTES = "Hello, World! This is test data for range reads.".getBytes(StandardCharsets.UTF_8);
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProviderTests.java
@@ -7,12 +7,9 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.apache.arrow.memory.BufferAllocator;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
@@ -36,14 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class RetryableStorageProviderTests extends ESTestCase {
 
-    // Hold a strong reference to the BlockFactory so the JVM Cleaner does not close the
-    // arrow root allocator mid-test (BlockFactory.arrowAllocator() registers a cleaner action
-    // on its own BlockFactory instance, which is otherwise unreachable from ALLOCATOR alone).
-    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
-        .breaker(new NoopCircuitBreaker("test"))
-        .build();
-    private static final BufferAllocator ALLOCATOR = BLOCK_FACTORY.arrowAllocator();
-    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forAllocator(ALLOCATOR);
+    private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
 
     public void testNewObjectWrapsWithRetry() throws IOException {
         AtomicInteger streamCalls = new AtomicInteger();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactoryTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Heap I/O buffers are filled on HTTP/S3 completion threads. Those threads must not
+ * charge a driver-pinned {@link LocalCircuitBreaker}.
+ */
+public class DirectBufferFactoryTests extends ESTestCase {
+
+    /**
+     * Same shape as CI: driver pins {@link LocalCircuitBreaker} via
+     * {@link LocalCircuitBreaker#assertBeginRunLoop()}, then a generic/I/O thread allocates.
+     * Charging the local breaker directly must trip {@code assertSingleThread}; allocating
+     * through {@link DirectReadBuffer} / {@link DirectBufferFactory#forBreaker} must charge
+     * the parent request breaker instead.
+     */
+    public void testAsyncIoChargesParentBreakerNotLocal() throws Exception {
+        assumeTrue("requires assertions enabled (-ea) to detect the I/O-thread race", assertionsEnabled());
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(1)).withCircuitBreaking();
+        CircuitBreaker parent = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        LocalCircuitBreaker local = new LocalCircuitBreaker(parent, 0, 0);
+
+        Thread setup = new Thread(() -> assertTrue(local.assertBeginRunLoop()), "setup-pin-driver-breaker");
+        setup.start();
+        setup.join();
+
+        try {
+            AssertionError probe = expectThrows(AssertionError.class, () -> local.addEstimateBytesAndMaybeBreak(1L, "probe"));
+            assertThat(probe.getMessage(), containsString("Local breaker must be accessed by a single thread"));
+
+            try (DirectReadBuffer allocated = DirectReadBuffer.allocate(local, 64)) {
+                assertThat(allocated.buffer().remaining(), equalTo(64));
+                assertThat(parent.getUsed(), equalTo(64L));
+            }
+            assertThat(parent.getUsed(), equalTo(0L));
+
+            DirectBufferFactory factory = DirectBufferFactory.forBreaker(local);
+            try (DirectReadBuffer allocated = factory.allocate(32)) {
+                assertThat(allocated.buffer().remaining(), equalTo(32));
+                assertThat(parent.getUsed(), equalTo(32L));
+            }
+            assertThat(parent.getUsed(), equalTo(0L));
+        } finally {
+            assertTrue(local.assertEndRunLoop());
+            local.close();
+            assertThat("parent breaker must reset to zero after release", parent.getUsed(), equalTo(0L));
+        }
+    }
+
+    @SuppressWarnings("AssertWithSideEffects")
+    private static boolean assertionsEnabled() {
+        boolean enabled = false;
+        assert enabled = true;
+        return enabled;
+    }
+}


### PR DESCRIPTION
Decode and I/O allocateDirect both fed glibc RSS after free. Heap codecs already exist; data-page decode and prefetch/window I/O now copy SDK/Netty chunks into breaker-charged heap, same copy count as today. arrowAllocator is deprecated so new storage I/O does not use it. Keep it for wrapping Arrow vectors: compute ArrowBuf blocks and Flight.