### PR TITLE
Fork startRecoveriesUpToLimit off the cluster applier thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -359,7 +359,9 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                 maxConcurrentOutgoingRecoveries = newMax;
             }
             if (oldMax < newMax) {
-                startRecoveriesUpToLimit();
+                // Move off the cluster applier thread. The generic executor has an unbounded queue and the cluster
+                // applier thread stops before the thread pool shuts down so this can never be rejected.
+                transportService.getThreadPool().generic().execute(this::startRecoveriesUpToLimit);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayDeque;
@@ -368,6 +369,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         /// Dequeues and starts pending recoveries up to the max concurrency limit.
         /// Acquires the lock once per dequeued recovery and triggers recovery in same loop, outside the lock.
         void startRecoveriesUpToLimit() {
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
             while (true) {
                 final PendingRecovery nextRecovery;
                 final RecoverySourceHandler nextHandler;


### PR DESCRIPTION
`indices.recovery.max_concurrent_outgoing_recoveries` is a dynamic setting. The `updateMaxConcurrentOutgoingRecoveries` consumer, registered by `PeerRecoverySourceService`, fires directly from the cluster applier thread. It synchronously called `startRecoveriesUpToLimit` directly, which acquires locks, dequeues recoveries, and calls scheduling listeners.

**Change**

Fork to the generic thread pool before doing that work, the same pattern `ThrottlingRecoveryService.fillSlots` already uses.
