### PR TITLE
Retry rejected scroll open in SearchWithRejectionsIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.hamcrest.Matchers.equalTo;
@@ -84,10 +85,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         }
         refresh();
 
-        SearchResponse openResponse = prepareSearch("test-scroll").setQuery(matchAllQuery())
-            .setSize(1)
-            .setScroll(TimeValue.timeValueMinutes(5))
-            .get();
+        SearchResponse openResponse = openScrollRetryingRejection("test-scroll");
         String scrollId = openResponse.getScrollId();
         Set<String> seenIds = new HashSet<>();
         try {
@@ -131,7 +129,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
                     if (ExceptionsHelper.unwrap(e, EsRejectedExecutionException.class) != null) {
                         throw new AssertionError("retry scroll after rejection", e);
                     }
-                    throw new AssertionError(e);
+                    throw e;
                 }
                 assertThat(seenIds, equalTo(expectedIds));
             }, 10, TimeUnit.SECONDS);
@@ -139,6 +137,21 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
             openResponse.decRef();
             client().prepareClearScroll().addScrollId(scrollId).get();
         }
+    }
+
+    private SearchResponse openScrollRetryingRejection(String index) throws Exception {
+        AtomicReference<SearchResponse> openHolder = new AtomicReference<>();
+        assertBusy(() -> {
+            try {
+                openHolder.set(prepareSearch(index).setQuery(matchAllQuery()).setSize(1).setScroll(TimeValue.timeValueMinutes(5)).get());
+            } catch (Exception e) {
+                if (ExceptionsHelper.unwrap(e, EsRejectedExecutionException.class) != null) {
+                    throw new AssertionError("retry scroll after rejection", e);
+                }
+                throw e;
+            }
+        }, 10, TimeUnit.SECONDS);
+        return openHolder.get();
     }
 
     /**


### PR DESCRIPTION
SearchWithRejectionsIT runs with thread_pool.search.size/queue_size of 1. testScrollContextSurvivesQueueRejection opened the scroll with a one-shot prepareSearch. A transient occupant of that pool can reject the open (SearchPhaseExecutionException caused by EsRejectedExecutionException). assertBusy only retries AssertionError, so the test fails instead of waiting. #156812 already retries saturation and the continuation scroll; the initial open was still uncaught.

This change wraps the open the same way. Non-rejection errors now fail fast on both the open and the continuation, instead of the continuation wrapping every exception in AssertionError.

Fixes #157416