### PR TITLE
Forward-port old-ES fixture 1.4 bump + curl hardening to main

### DIFF
--- a/test/fixtures/old-elasticsearch/build.gradle
+++ b/test/fixtures/old-elasticsearch/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'elasticsearch.deploy-test-fixtures'
 
 description = 'Testcontainers fixture for old Elasticsearch versions'
 
-def fixtureVersion = '1.3'
+def fixtureVersion = '1.4'
 def sharedDockerContext = project.file('src/main/resources/docker')
 
 // Elasticsearch only started publishing native linux-aarch64 distributions in 7.8.0. Earlier

--- a/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/org/elasticsearch/test/fixtures/oldelasticsearch/OldElasticsearchContainer.java
@@ -32,7 +32,7 @@ public class OldElasticsearchContainer extends DockerEnvironmentAwareTestContain
 
     private static final int HTTP_PORT = 9200;
     // Keep in sync with `def fixtureVersion` in test/fixtures/old-elasticsearch/build.gradle.
-    private static final String FIXTURE_IMAGE_VERSION = "1.3";
+    private static final String FIXTURE_IMAGE_VERSION = "1.4";
     private static final Map<String, String> IMAGES = Map.of(
         "0.90.13",
         "docker.elastic.co/elasticsearch-dev/old-elasticsearch-0-90-13-fixture:" + FIXTURE_IMAGE_VERSION,

--- a/test/fixtures/old-elasticsearch/src/main/resources/docker/Dockerfile
+++ b/test/fixtures/old-elasticsearch/src/main/resources/docker/Dockerfile
@@ -13,6 +13,11 @@ WORKDIR /tmp
 # - 2.4.5 lives on download.elastic.co under a Maven-style release path.
 # - >=5.0, <7.9 are architecture-independent zips on artifacts.elastic.co.
 # - >=7.9 ship per-architecture archives that bundle their own JDK.
+# The curl download is retried because fetching the ES distribution from
+# artifacts.elastic.co/download.elastic.co occasionally hits transient network errors
+# (e.g. HTTP/2 stream errors, curl exit 92) that otherwise fail the whole image build and,
+# in turn, the dependent test suites (see #156120). This keeps the local fallback build
+# (used when the prebaked fixture image cannot be pulled) resilient.
 RUN set -e; \
  case "$ES_VERSION" in \
    0.90.13|1.7.6) \
@@ -29,7 +34,7 @@ RUN set -e; \
    *) \
      url="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip"; ext=zip ;; \
  esac; \
- curl -fsSL -o "elasticsearch.${ext}" "$url"; \
+ curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o "elasticsearch.${ext}" "$url"; \
  if [ "$ext" = "zip" ]; then unzip -q "elasticsearch.${ext}"; else tar -xzf "elasticsearch.${ext}"; fi; \
  rm -f "elasticsearch.${ext}"; \
  mv "elasticsearch-${ES_VERSION}" /usr/share/elasticsearch


### PR DESCRIPTION
The old-Elasticsearch Testcontainers fixture images (`old-elasticsearch-*-fixture`) are published by the `elasticsearch-test-fixtures-nightly` pipeline (task `deployFixtureDockerImages`), which **only runs on `main`**.

#157377 bumped `fixtureVersion` `1.3 -> 1.4` (plus `curl` retry hardening in the fallback `Dockerfile`) on **`8.19` only**. Because the publishing nightly runs on `main` — where the version was still `1.3` — the `1.4` images were never baked or pushed. The registry still tops out at `1.3` for every fixture:

```
old-elasticsearch-7-9-3-fixture   -> ["1.3"]
old-elasticsearch-7-10-0-fixture  -> ["1.3"]
```

As a result, `ReindexFromRemote7xIT` on `8.19` requests `old-elasticsearch-7-*-fixture:1.4`, which does not exist, so `PullOrBuildImage` falls back to the local `Dockerfile` build. That fallback build passes on modern agents but fails on legacy `rhel-7`/`sles-12` agents (`curl` exit 2), which is #157454.

This PR forward-ports the `1.4` version bump and the `Dockerfile` `curl` hardening to `main` so the nightly publishes the `1.4` images, after which the `8.19` test can pull them.

Note: intentionally **not** auto-backported — `8.19` already carries these changes via #157377.

Relates to #157454