### PR TITLE
[9.5] Track point-range breaker memory without a ThreadLocal (#156909)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -55,7 +55,7 @@ import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
  */
 public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     private static final MatchNoDocsQuery REWRITE_TIMEOUT = new MatchNoDocsQuery("rewrite timed out");
+    private static final Releasable NOOP_RELEASABLE = () -> {};
 
     /**
      * The interval at which we check for search cancellation when we cannot use
@@ -80,9 +81,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     @Nullable
     private CircuitBreaker circuitBreaker;
 
-    private final ThreadLocal<long[]> leafExecutionBytes = ThreadLocal.withInitial(() -> new long[1]);
-
-    private final AtomicLong outstandingPointRangeExecutionBytes = new AtomicLong();
+    private final AtomicReference<PointRangeExecutionAccounting> pointRangeAccounting = new AtomicReference<>();
 
     private final MutableQueryTimeout cancellable;
 
@@ -174,45 +173,11 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     }
 
     public void setCircuitBreaker(@Nullable CircuitBreaker circuitBreaker) {
+        PointRangeExecutionAccounting previous = pointRangeAccounting.getAndSet(null);
+        if (previous != null) {
+            previous.close();
+        }
         this.circuitBreaker = circuitBreaker;
-    }
-
-    /**
-     * Reserve {@code bytes} of point-range execution RAM on the request breaker for the leaf currently
-     * being scored on this thread, recording it so {@link #searchLeaf} can release it once the leaf is
-     * done. No-op when no breaker is configured or {@code bytes <= 0}. Propagates
-     * {@link org.elasticsearch.common.breaker.CircuitBreakingException} when the reservation trips the
-     * breaker; in that case nothing is recorded because the breaker did not commit the bytes.
-     */
-    void chargeLeafExecutionBytes(long bytes) {
-        if (circuitBreaker == null || bytes <= 0L) {
-            return;
-        }
-        circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, "pointrange-execution");
-        leafExecutionBytes.get()[0] += bytes;
-        outstandingPointRangeExecutionBytes.addAndGet(bytes);
-    }
-
-    /**
-     * Release any point-range execution RAM charged on this thread since {@code baseline} (the value
-     * returned by an earlier {@link #leafExecutionBytesBaseline()} call), returning the tally to that
-     * baseline. Called from a {@code finally} block in {@link #searchLeaf}.
-     */
-    private void releaseLeafExecutionBytes(long baseline) {
-        if (circuitBreaker == null) {
-            return;
-        }
-        long[] holder = leafExecutionBytes.get();
-        long toRelease = holder[0] - baseline;
-        if (toRelease > 0L) {
-            circuitBreaker.addWithoutBreaking(-toRelease);
-            outstandingPointRangeExecutionBytes.addAndGet(-toRelease);
-        }
-        holder[0] = baseline;
-    }
-
-    private long leafExecutionBytesBaseline() {
-        return circuitBreaker == null ? 0L : leafExecutionBytes.get()[0];
     }
 
     /**
@@ -248,9 +213,9 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         // of memory.
         this.cancellable.clear();
 
-        long remaining = outstandingPointRangeExecutionBytes.getAndSet(0L);
-        if (circuitBreaker != null && remaining > 0L) {
-            circuitBreaker.addWithoutBreaking(-remaining);
+        PointRangeExecutionAccounting accounting = pointRangeAccounting.getAndSet(null);
+        if (accounting != null) {
+            accounting.close();
         }
     }
 
@@ -322,9 +287,36 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
         PointRangeQuery pointRangeQuery = pointRangeQueryOrNull(query);
         if (circuitBreaker != null && pointRangeQuery != null) {
+            getOrCreatePointRangeAccounting();
             return new PointRangeBreakerWeight(this, weight, pointRangeQuery, query instanceof IndexOrDocValuesQuery);
         }
         return weight;
+    }
+
+    void chargeLeaf(LeafReaderContext ctx, long bytes) {
+        PointRangeExecutionAccounting accounting = getOrCreatePointRangeAccounting();
+        if (accounting != null) {
+            accounting.charge(ctx, bytes);
+        }
+    }
+
+    @Nullable
+    private PointRangeExecutionAccounting getOrCreatePointRangeAccounting() {
+        PointRangeExecutionAccounting existing = pointRangeAccounting.get();
+        if (existing != null) {
+            return existing;
+        }
+        CircuitBreaker breaker = this.circuitBreaker;
+        if (breaker == null) {
+            return null;
+        }
+        PointRangeExecutionAccounting created = new PointRangeExecutionAccounting(breaker, getLeafContexts().size());
+        return pointRangeAccounting.compareAndSet(null, created) ? created : pointRangeAccounting.get();
+    }
+
+    /** Test-only */
+    boolean hasPointRangeAccounting() {
+        return pointRangeAccounting.get() != null;
     }
 
     private static PointRangeQuery pointRangeQueryOrNull(Query query) {
@@ -540,8 +532,8 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     protected void searchLeaf(LeafReaderContext ctx, int minDocId, int maxDocId, Weight weight, Collector collector) throws IOException {
         cancellable.checkCancelled();
 
-        final long leafExecutionBaseline = leafExecutionBytesBaseline();
-        try {
+        final PointRangeExecutionAccounting accounting = this.pointRangeAccounting.get();
+        try (Releasable ignored = accounting == null ? NOOP_RELEASABLE : accounting.enterLeaf(ctx)) {
             final LeafCollector leafCollector;
             try {
                 leafCollector = collector.getLeafCollector(ctx);
@@ -589,8 +581,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             // Finish the leaf collection in preparation for the next.
             // This includes any collection that was terminated early via `CollectionTerminatedException`
             leafCollector.finish();
-        } finally {
-            releaseLeafExecutionBytes(leafExecutionBaseline);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/internal/PointRangeBreakerWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/PointRangeBreakerWeight.java
@@ -30,7 +30,8 @@ import java.util.Arrays;
  * {@link ContextIndexSearcher#searchLeaf}. The charge is applied only when the bitset-allocating
  * points branch runs: always for a bare {@link PointRangeQuery}, and for an
  * {@link org.apache.lucene.search.IndexOrDocValuesQuery} only on the path Lucene routes to points
- * (otherwise doc values run and allocate no bitset).
+ * (otherwise doc values run and allocate no bitset). Charges go through {@link ContextIndexSearcher#chargeLeaf}
+ * rather than a cached accounting reference, so this survives a {@link ContextIndexSearcher#setCircuitBreaker} swap.
  */
 final class PointRangeBreakerWeight extends Weight {
 
@@ -74,14 +75,14 @@ final class PointRangeBreakerWeight extends Weight {
             @Override
             public Scorer get(long leadCost) throws IOException {
                 if (indexOrDocValues == false || (cost >>> 3) <= leadCost) {
-                    searcher.chargeLeafExecutionBytes(charge);
+                    searcher.chargeLeaf(context, charge);
                 }
                 return inner.get(leadCost);
             }
 
             @Override
             public BulkScorer bulkScorer() throws IOException {
-                searcher.chargeLeafExecutionBytes(charge);
+                searcher.chargeLeaf(context, charge);
                 return inner.bulkScorer();
             }
 

--- a/server/src/main/java/org/elasticsearch/search/internal/PointRangeExecutionAccounting.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/PointRangeExecutionAccounting.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.core.Releasable;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/**
+ * Tracks point-range execution RAM charged to a single request's circuit breaker, releasing it once each
+ * leaf finishes scoring. One instance is owned by a single {@link ContextIndexSearcher}. Attribution is per
+ * leaf rather than per scope: releasing a leaf drains everything currently charged to it, however it got
+ * there, so an out-of-band charge on a leaf (e.g. a filter bitset materialised ahead of collection) is
+ * released as soon as that leaf is next scored rather than only at {@link #close()}.
+ */
+final class PointRangeExecutionAccounting implements Releasable {
+
+    private final CircuitBreaker breaker;
+    private final AtomicLongArray perLeafBytes;
+
+    PointRangeExecutionAccounting(CircuitBreaker breaker, int leafCount) {
+        this.breaker = breaker;
+        this.perLeafBytes = new AtomicLongArray(leafCount);
+    }
+
+    /**
+     * Reserves {@code bytes} on the request breaker, attributed to {@code ctx}'s leaf. No-op when
+     * {@code bytes <= 0}. Propagates {@link org.elasticsearch.common.breaker.CircuitBreakingException}
+     * without recording anything if the reservation trips the breaker.
+     */
+    void charge(LeafReaderContext ctx, long bytes) {
+        if (bytes <= 0L) {
+            return;
+        }
+        breaker.addEstimateBytesAndMaybeBreak(bytes, "pointrange-execution");
+        perLeafBytes.addAndGet(ctx.ord, bytes);
+    }
+
+    /**
+     * Releases everything currently charged to {@code ctx}'s leaf when the returned {@link Releasable} is
+     * closed. {@link ContextIndexSearcher#searchLeaf} does so from a {@code try}-with-resources block, so
+     * the release always runs, including on exceptions.
+     */
+    Releasable enterLeaf(LeafReaderContext ctx) {
+        final int ord = ctx.ord;
+        return () -> release(ord);
+    }
+
+    private void release(int ord) {
+        final long charged = perLeafBytes.getAndSet(ord, 0L);
+        if (charged > 0L) {
+            breaker.addWithoutBreaking(-charged);
+        }
+    }
+
+    /** Releases any charge still outstanding on any leaf */
+    @Override
+    public void close() {
+        for (int ord = 0; ord < perLeafBytes.length(); ord++) {
+            release(ord);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/internal/PointRangeBreakerWeightTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/PointRangeBreakerWeightTests.java
@@ -11,20 +11,25 @@ package org.elasticsearch.search.internal;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
@@ -36,13 +41,16 @@ import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -51,6 +59,8 @@ import static org.hamcrest.Matchers.greaterThan;
 public class PointRangeBreakerWeightTests extends ESTestCase {
 
     private static final String FIELD = "f";
+    private static final String VECTOR_FIELD = "v";
+    private static final int VECTOR_DIMS = 3;
     private static final String KEYWORD_FIELD = "k";
     private static final String RARE_TERM = "rare";
     private static final int RARE_DOCS = 5;
@@ -87,14 +97,12 @@ public class PointRangeBreakerWeightTests extends ESTestCase {
     }
 
     public void testDenseRangeChargesAndReleasesAcrossSearch() throws IOException {
-        Query dense = LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4));
-        assertChargesThenReleases(dense);
+        assertChargesThenReleases(denseRangeQuery());
     }
 
     public void testIndexOrDocValuesRangeChargesAndReleasesAcrossSearch() throws IOException {
-        Query indexQuery = LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4));
         Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(FIELD, 0L, NUM_DOCS * 3L / 4L);
-        assertChargesThenReleases(new IndexOrDocValuesQuery(indexQuery, dvQuery));
+        assertChargesThenReleases(new IndexOrDocValuesQuery(denseRangeQuery(), dvQuery));
     }
 
     public void testMatchAllRangeChargesNothing() throws IOException {
@@ -106,20 +114,39 @@ public class PointRangeBreakerWeightTests extends ESTestCase {
 
     public void testExpensiveRangeTripsBreakerWithoutLeaking() throws IOException {
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(100L);
-        Query dense = LongPoint.newRangeQuery(FIELD, 0L, (long) (NUM_DOCS * 3 / 4));
-        expectThrows(CircuitBreakingException.class, () -> runSearch(dense, breaker));
+        expectThrows(CircuitBreakingException.class, () -> runSearch(denseRangeQuery(), breaker));
         assertThat("a tripped reservation must not leak onto the breaker", breaker.getUsed(), equalTo(0L));
     }
 
+    public void testPointRangeAccountingNotAllocatedWithoutPointRangeQuery() throws IOException {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+        ContextIndexSearcher searcher = newContextIndexSearcher(reader);
+        searcher.setCircuitBreaker(breaker);
+        int hits = searcher.search(new TermQuery(new Term(KEYWORD_FIELD, RARE_TERM)), new CountingCollectorManager());
+        assertThat("the term query must match documents so the search actually runs", hits, greaterThan(0));
+        assertFalse(
+            "a search whose query tree contains no PointRangeQuery must not allocate accounting",
+            searcher.hasPointRangeAccounting()
+        );
+    }
+
+    public void testPointRangeAccountingAllocatedLazilyForPointRangeQuery() throws IOException {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+        ContextIndexSearcher searcher = newContextIndexSearcher(reader);
+        searcher.setCircuitBreaker(breaker);
+        assertFalse("accounting must not be allocated before any query has run", searcher.hasPointRangeAccounting());
+        searcher.search(denseRangeQuery(), new CountingCollectorManager());
+        assertTrue("wrapping a PointRangeQuery must lazily allocate accounting", searcher.hasPointRangeAccounting());
+    }
+
     public void testPlainRangeInConjunctionChargesViaScorerGetPath() throws IOException {
-        Query points = LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4));
         Query dv = SortedNumericDocValuesField.newSlowRangeQuery(FIELD, 0L, NUM_DOCS * 3L / 4L);
-        assertChargesThenReleases(conjunction(points, dv));
+        assertChargesThenReleases(conjunction(denseRangeQuery(), dv));
     }
 
     public void testIndexOrDocValuesInConjunctionChargesWhenPointsBranchSelected() throws IOException {
         Query indexOrDocValues = new IndexOrDocValuesQuery(
-            LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4)),
+            denseRangeQuery(),
             SortedNumericDocValuesField.newSlowRangeQuery(FIELD, 0L, NUM_DOCS * 3L / 4L)
         );
         Query lead = SortedNumericDocValuesField.newSlowRangeQuery(FIELD, 0L, NUM_DOCS * 3L / 4L);
@@ -128,7 +155,7 @@ public class PointRangeBreakerWeightTests extends ESTestCase {
 
     public void testIndexOrDocValuesInConjunctionSkipsChargeWhenDocValuesBranchSelected() throws IOException {
         Query indexOrDocValues = new IndexOrDocValuesQuery(
-            LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4)),
+            denseRangeQuery(),
             SortedNumericDocValuesField.newSlowRangeQuery(FIELD, 0L, NUM_DOCS * 3L / 4L)
         );
         Query rareLead = new TermQuery(new Term(KEYWORD_FIELD, RARE_TERM));
@@ -141,62 +168,340 @@ public class PointRangeBreakerWeightTests extends ESTestCase {
 
     public void testOutOfBandChargeReleasedOnClose() throws IOException {
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            null,
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            false
-        );
-        searcher.setCircuitBreaker(breaker);
-        Query dense = LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4));
-        Weight weight = searcher.createWeight(searcher.rewrite(dense), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        DenseSearch denseSearch = newDenseSearch(reader, breaker);
         for (LeafReaderContext leaf : reader.leaves()) {
-            ScorerSupplier scorerSupplier = weight.scorerSupplier(leaf);
-            if (scorerSupplier != null) {
-                scorerSupplier.get(Long.MAX_VALUE);
-            }
+            chargeAgainst(denseSearch.weight(), leaf);
         }
         assertThat("the out-of-band scorer must charge execution RAM", breaker.getUsed(), greaterThan(0L));
-        searcher.close();
+        denseSearch.searcher().close();
         assertThat("closing the searcher must release the residual out-of-band charge", breaker.getUsed(), equalTo(0L));
     }
 
     public void testOutOfBandChargeOnAnotherThreadReleasedOnClose() throws Exception {
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
-            reader,
-            IndexSearcher.getDefaultSimilarity(),
-            null,
-            IndexSearcher.getDefaultQueryCachingPolicy(),
-            false
-        );
-        searcher.setCircuitBreaker(breaker);
-        Query dense = LongPoint.newRangeQuery(FIELD, 0L, (NUM_DOCS * 3 / 4));
-        Weight weight = searcher.createWeight(searcher.rewrite(dense), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        DenseSearch denseSearch = newDenseSearch(reader, breaker);
 
         try (ExecutorService worker = Executors.newSingleThreadExecutor()) {
             worker.submit(() -> {
                 for (LeafReaderContext leaf : reader.leaves()) {
-                    ScorerSupplier scorerSupplier = weight.scorerSupplier(leaf);
-                    if (scorerSupplier != null) {
-                        // Force the points branch the way KNN materialises the filter bitset, outside any searchLeaf scope.
-                        scorerSupplier.get(Long.MAX_VALUE);
-                    }
+                    // Force the points branch the way KNN materialises the filter bitset, outside any searchLeaf scope.
+                    chargeAgainst(denseSearch.weight(), leaf);
                 }
                 return null;
             }).get();
         }
 
         assertThat("the worker thread's out-of-band scorer must charge execution RAM", breaker.getUsed(), greaterThan(0L));
-        // close() runs on the test thread, which never charged anything, so its own thread-local is empty;
-        // the release must come from the shared cross-thread counter.
-        searcher.close();
+        // close() runs on the test thread; the release must come from the shared per-leaf array, not from
+        // any per-thread state.
+        denseSearch.searcher().close();
         assertThat("closing on a different thread must still release the worker thread's charge", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testCloseDuringOpenScopeDoesNotDoubleRelease() throws Exception {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+        DenseSearch denseSearch = newDenseSearch(reader, breaker);
+        ContextIndexSearcher searcher = denseSearch.searcher();
+        Weight weight = denseSearch.weight();
+        LeafReaderContext leaf = reader.leaves().get(0);
+
+        CountDownLatch chargedAndCollecting = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        Collector blockingOnFirstDoc = blockOnFirstDoc(chargedAndCollecting, releaseWorker);
+
+        try (ExecutorService worker = Executors.newSingleThreadExecutor()) {
+            Future<?> scoring = worker.submit(() -> {
+                searcher.searchLeaf(leaf, 0, leaf.reader().maxDoc(), weight, blockingOnFirstDoc);
+                return null;
+            });
+            safeAwait(chargedAndCollecting);
+            assertThat("the worker must have charged before we close", breaker.getUsed(), greaterThan(0L));
+
+            searcher.close();
+            assertThat(
+                "close() draining the still-open leaf's charge is the documented out-of-band release",
+                breaker.getUsed(),
+                equalTo(0L)
+            );
+
+            releaseWorker.countDown();
+            scoring.get();
+        }
+        assertThat("the worker's own release must not double-release what close() already drained", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testNestedSearchLeafOnDifferentLeavesReleaseIndependently() throws Exception {
+        withMultiSegmentReader(multiSegmentReader -> {
+            TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+            DenseSearch denseSearch = newDenseSearch(multiSegmentReader, breaker);
+            ContextIndexSearcher searcher = denseSearch.searcher();
+            Weight weight = denseSearch.weight();
+
+            LeafReaderContext outerLeaf = multiSegmentReader.leaves().get(0);
+            LeafReaderContext innerLeaf = multiSegmentReader.leaves().get(1);
+            CountingCollector innerCollector = new CountingCollector();
+
+            Collector outerCollector = new Collector() {
+                @Override
+                public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+                    searcher.searchLeaf(innerLeaf, 0, innerLeaf.reader().maxDoc(), weight, innerCollector);
+                    assertThat(
+                        "the nested leaf's charge must be fully released before the outer leaf charges anything",
+                        breaker.getUsed(),
+                        equalTo(0L)
+                    );
+                    return new CountingCollector().getLeafCollector(context);
+                }
+
+                @Override
+                public ScoreMode scoreMode() {
+                    return ScoreMode.COMPLETE_NO_SCORES;
+                }
+            };
+
+            searcher.searchLeaf(outerLeaf, 0, outerLeaf.reader().maxDoc(), weight, outerCollector);
+
+            assertThat(
+                "the inner leaf must have matched documents for the accounting to be exercised",
+                innerCollector.count,
+                greaterThan(0)
+            );
+            assertThat("both leaves must have charged execution RAM at some point", breaker.peak(), greaterThan(0L));
+            assertThat("the outer leaf's own charge must be released once it is done", breaker.getUsed(), equalTo(0L));
+        });
+    }
+
+    public void testConcurrentSlicesChargeAndReleaseIndependently() throws Exception {
+        withMultiSegmentReader(multiSegmentReader -> {
+            int leafCount = multiSegmentReader.leaves().size();
+            TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+            try (ExecutorService executor = Executors.newFixedThreadPool(leafCount)) {
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    multiSegmentReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    null,
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    false,
+                    executor,
+                    20,
+                    1
+                );
+                searcher.setCircuitBreaker(breaker);
+                assertThat(
+                    "the slicing parameters must actually put each leaf in its own slice, or this test "
+                        + "isn't exercising concurrency across leaves",
+                    searcher.getSlices().length,
+                    equalTo(leafCount)
+                );
+                int hits = searcher.search(denseRangeQuery(), new CountingCollectorManager());
+                assertThat("the range must match documents across multiple concurrently searched leaves", hits, greaterThan(0));
+                assertThat("each leaf's scorer must charge execution RAM", breaker.peak(), greaterThan(0L));
+                assertThat("all per-leaf charges must be released once the concurrent search completes", breaker.getUsed(), equalTo(0L));
+            }
+        });
+    }
+
+    public void testConcurrentPartitionsOfSameLeafDoNotDoubleRelease() throws Exception {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+        DenseSearch denseSearch = newDenseSearch(reader, breaker);
+        ContextIndexSearcher searcher = denseSearch.searcher();
+        Weight weight = denseSearch.weight();
+        LeafReaderContext leaf = reader.leaves().get(0);
+        int mid = leaf.reader().maxDoc() / 2;
+
+        CountDownLatch firstPartitionEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstPartition = new CountDownLatch(1);
+        Collector blockingCollector = blockOnFirstDoc(firstPartitionEntered, releaseFirstPartition);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            Future<?> firstPartition = executor.submit(() -> {
+                searcher.searchLeaf(leaf, 0, mid, weight, blockingCollector);
+                return null;
+            });
+            safeAwait(firstPartitionEntered);
+            assertThat("the first partition must have charged before it blocks in collection", breaker.getUsed(), greaterThan(0L));
+
+            Future<?> secondPartition = executor.submit(() -> {
+                searcher.searchLeaf(leaf, mid, leaf.reader().maxDoc(), weight, new CountingCollector());
+                return null;
+            });
+            secondPartition.get();
+            // Charges are per leaf, not per partition, so releasing partition 2 drains partition 1's charge
+            // too. Only benign while computeSlices emits one whole-segment partition per leaf.
+            assertThat("the second partition's release drains the first partition's still-live charge", breaker.getUsed(), equalTo(0L));
+
+            releaseFirstPartition.countDown();
+            firstPartition.get();
+        }
+        assertThat(
+            "two partitions of the same leaf scored concurrently must each release only what they charged",
+            breaker.getUsed(),
+            equalTo(0L)
+        );
+    }
+
+    public void testSetCircuitBreakerReleasesPreviousOutstandingCharge() throws Exception {
+        TrackingCircuitBreaker firstBreaker = new TrackingCircuitBreaker(-1L);
+        DenseSearch denseSearch = newDenseSearch(reader, firstBreaker);
+        chargeAgainst(denseSearch.weight(), reader.leaves().get(0));
+        assertThat("the out-of-band scorer must charge execution RAM", firstBreaker.getUsed(), greaterThan(0L));
+
+        ContextIndexSearcher searcher = denseSearch.searcher();
+        searcher.setCircuitBreaker(null);
+        assertThat("swapping breakers must release what the old one was still holding", firstBreaker.getUsed(), equalTo(0L));
+
+        searcher.close();
+        assertThat("closing after the swap must not touch the old breaker again", firstBreaker.getUsed(), equalTo(0L));
+    }
+
+    public void testStaleWeightChargesCurrentBreakerAfterSwap() throws Exception {
+        TrackingCircuitBreaker firstBreaker = new TrackingCircuitBreaker(-1L);
+        DenseSearch denseSearch = newDenseSearch(reader, firstBreaker);
+
+        TrackingCircuitBreaker secondBreaker = new TrackingCircuitBreaker(-1L);
+        ContextIndexSearcher searcher = denseSearch.searcher();
+        searcher.setCircuitBreaker(secondBreaker);
+
+        chargeAgainst(denseSearch.weight(), reader.leaves().get(0));
+        assertThat("a stale weight must not charge the breaker it was originally built against", firstBreaker.getUsed(), equalTo(0L));
+        assertThat(
+            "a stale weight must charge whichever breaker is current when it actually runs",
+            secondBreaker.getUsed(),
+            greaterThan(0L)
+        );
+
+        searcher.close();
+        assertThat("closing must release the charge from the currently tracked breaker", secondBreaker.getUsed(), equalTo(0L));
+    }
+
+    public void testStaleWeightChargingAfterBreakerClearedDoesNotThrow() throws Exception {
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+        DenseSearch denseSearch = newDenseSearch(reader, breaker);
+
+        ContextIndexSearcher searcher = denseSearch.searcher();
+        searcher.setCircuitBreaker(null);
+
+        chargeAgainst(denseSearch.weight(), reader.leaves().get(0));
+        assertThat("a stale weight scored with no breaker installed must not charge anything", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testKnnWithPointRangeFilterChargesOutOfBandThenReleasesToBaseline() throws Exception {
+        try (Directory vectorDirectory = newDirectory()) {
+            writeMultiSegmentIndex(vectorDirectory, true);
+            try (DirectoryReader vectorReader = DirectoryReader.open(vectorDirectory)) {
+                assertThat(
+                    "the KNN fixture must produce more than one segment so the point-range filter runs on several leaves",
+                    vectorReader.leaves().size(),
+                    greaterThan(1)
+                );
+
+                TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(-1L);
+                ContextIndexSearcher searcher = newContextIndexSearcher(vectorReader);
+                searcher.setCircuitBreaker(breaker);
+
+                Query filter = denseRangeQuery();
+                KnnFloatVectorQuery knn = new KnnFloatVectorQuery(VECTOR_FIELD, new float[] { 0f, 0f, 0f }, 10, filter);
+
+                int hits = searcher.search(knn, new CountingCollectorManager());
+                assertThat("the filtered KNN search must return matches so the accounting is actually exercised", hits, greaterThan(0));
+                assertThat(
+                    "the point-range filter bitset materialised out-of-band by KNN must charge execution RAM at some point",
+                    breaker.peak(),
+                    greaterThan(0L)
+                );
+                assertThat(
+                    "the out-of-band KNN filter charge must return to baseline once the search completes",
+                    breaker.getUsed(),
+                    equalTo(0L)
+                );
+
+                searcher.close();
+                assertThat("closing after a completed KNN search must leave nothing reserved", breaker.getUsed(), equalTo(0L));
+            }
+        }
+    }
+
+    private static float[] vectorForDoc(int docId) {
+        float[] vector = new float[VECTOR_DIMS];
+        for (int dim = 0; dim < VECTOR_DIMS; dim++) {
+            vector[dim] = docId + dim;
+        }
+        return vector;
+    }
+
+    private static void chargeAgainst(Weight weight, LeafReaderContext ctx) throws IOException {
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(ctx);
+        if (scorerSupplier != null) {
+            scorerSupplier.get(Long.MAX_VALUE);
+        }
+    }
+
+    private static Collector blockOnFirstDoc(CountDownLatch entered, CountDownLatch release) {
+        return new Collector() {
+            @Override
+            public LeafCollector getLeafCollector(LeafReaderContext context) {
+                return new LeafCollector() {
+                    private boolean signalled = false;
+
+                    @Override
+                    public void setScorer(Scorable scorer) {}
+
+                    @Override
+                    public void collect(int doc) {
+                        if (signalled == false) {
+                            signalled = true;
+                            entered.countDown();
+                            safeAwait(release);
+                        }
+                    }
+                };
+            }
+
+            @Override
+            public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE_NO_SCORES;
+            }
+        };
+    }
+
+    private static void withMultiSegmentReader(CheckedConsumer<DirectoryReader, Exception> body) throws Exception {
+        try (Directory directory = newDirectory()) {
+            writeMultiSegmentIndex(directory, false);
+            try (DirectoryReader multiSegmentReader = DirectoryReader.open(directory)) {
+                assertThat(
+                    "the multi-segment fixture must produce more than one leaf to exercise cross-leaf behaviour",
+                    multiSegmentReader.leaves().size(),
+                    greaterThan(1)
+                );
+                body.accept(multiSegmentReader);
+            }
+        }
+    }
+
+    private static void writeMultiSegmentIndex(Directory directory, boolean withVectors) throws IOException {
+        IndexWriterConfig config = new IndexWriterConfig(null).setMergePolicy(NoMergePolicy.INSTANCE);
+        int segments = 4;
+        try (IndexWriter writer = new IndexWriter(directory, config)) {
+            for (int segment = 0; segment < segments; segment++) {
+                for (int docId = segment; docId < NUM_DOCS; docId += segments) {
+                    Document doc = new Document();
+                    doc.add(new LongPoint(FIELD, docId));
+                    if (withVectors) {
+                        doc.add(new KnnFloatVectorField(VECTOR_FIELD, vectorForDoc(docId), VectorSimilarityFunction.EUCLIDEAN));
+                    }
+                    writer.addDocument(doc);
+                }
+                writer.commit();
+            }
+        }
     }
 
     private static Query conjunction(Query first, Query second) {
         return new BooleanQuery.Builder().add(first, BooleanClause.Occur.MUST).add(second, BooleanClause.Occur.MUST).build();
+    }
+
+    private static Query denseRangeQuery() {
+        return LongPoint.newRangeQuery(FIELD, 0L, (long) (NUM_DOCS * 3 / 4));
     }
 
     private void assertChargesThenReleases(Query query) throws IOException {
@@ -208,15 +513,29 @@ public class PointRangeBreakerWeightTests extends ESTestCase {
     }
 
     private int runSearch(Query query, CircuitBreaker breaker) throws IOException {
-        ContextIndexSearcher searcher = new ContextIndexSearcher(
+        ContextIndexSearcher searcher = newContextIndexSearcher(reader);
+        searcher.setCircuitBreaker(breaker);
+        return searcher.search(query, new CountingCollectorManager());
+    }
+
+    private static ContextIndexSearcher newContextIndexSearcher(IndexReader reader) throws IOException {
+        return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             null,
             IndexSearcher.getDefaultQueryCachingPolicy(),
             false
         );
+    }
+
+    /** A searcher with a breaker installed and a {@link #denseRangeQuery} weight already built, ready to score. */
+    private record DenseSearch(ContextIndexSearcher searcher, Weight weight) {}
+
+    private static DenseSearch newDenseSearch(IndexReader reader, CircuitBreaker breaker) throws IOException {
+        ContextIndexSearcher searcher = newContextIndexSearcher(reader);
         searcher.setCircuitBreaker(breaker);
-        return searcher.search(query, new CountingCollectorManager());
+        Weight weight = searcher.createWeight(searcher.rewrite(denseRangeQuery()), ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+        return new DenseSearch(searcher, weight);
     }
 
     private static final class TrackingCircuitBreaker extends NoopCircuitBreaker {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Track point-range breaker memory without a ThreadLocal (#156909)](https://github.com/elastic/elasticsearch/pull/156909)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)