### PR TITLE
Grant kibana_system access to Context Engine improvements indices

### DIFF
--- a/docs/changelog/157481.yaml
+++ b/docs/changelog/157481.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 157481
+summary: Grant `kibana_system` access to Context Engine improvements indices
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -760,6 +760,10 @@ class KibanaOwnedReservedRoleDescriptors {
                 // user indices that Kibana creates and manages via the storage adapter
                 // (one index per Kibana space: context-engine-signals-<space>).
                 RoleDescriptor.IndicesPrivileges.builder().indices("context-engine-signals-*").privileges("all").build(),
+                // Context Engine feedback-loop improvements. A regular (non-system) user
+                // index that Kibana creates and manages via the storage adapter, holding
+                // the proposed improvements derived from the signals above.
+                RoleDescriptor.IndicesPrivileges.builder().indices("context-engine-improvements*").privileges("all").build(),
                 // Significant events. Kibana system user manages index plumbing and document access.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".significant_events-*")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1287,6 +1287,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // user indices that Kibana creates and manages via the storage adapter.
         assertReadWriteAndManage(kibanaRole, "context-engine-signals-" + randomAlphaOfLength(randomIntBetween(0, 13)));
 
+        // Context Engine feedback-loop improvements: a regular (non-system) user index
+        // that Kibana creates and manages via the storage adapter.
+        Arrays.asList("context-engine-improvements", "context-engine-improvements-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+            .forEach(index -> assertReadWriteAndManage(kibanaRole, index));
+
         // Agent Builder OTLP telemetry (traces + logs from span events)
         Arrays.asList(
             "traces-agent_builder.otel-" + randomAlphaOfLength(randomIntBetween(0, 13)),


### PR DESCRIPTION
## Summary

The Context Engine feedback loop (Agent Builder / the `context_engine` Kibana plugin) turns trace-derived **signals** about agent behaviour into proposed **improvements** to an AI index's knowledge-indicator pipeline. Those proposals are persisted in a regular user index, `context-engine-improvements`, which Kibana creates and manages via `@kbn/storage-adapter` and writes as the internal user (`kibana_system`).

This grants `kibana_system` `all` on `context-engine-improvements*`, mirroring the `context-engine-signals-*` grant added in #156273 immediately above it in the `kibana_system` reserved role.

Unblocks the Kibana-side improvements store: elastic/kibana#286801. Design: elastic/search-team#15708.

## Notes for reviewers

- Kibana fully manages this index via `@kbn/storage-adapter` across its whole lifecycle — create, mapping/settings management, write (the improvements service), read (list/history), and delete (cleanup when the associated AI index is removed). Hence `all`, consistent with the adjacent signals and SML grants that use the same storage adapter.
- The pattern is `context-engine-improvements*` rather than `context-engine-improvements-*` because, unlike signals, this store is **global rather than per-space** — there is one improvement lineage per AI index, not one index per Kibana space. The trailing wildcard covers the bare index name plus any future suffixing.
- `ReservedRolesStoreTests` updated to assert read/write/manage on both the bare index and a suffixed variant.

## Test plan

- [x] `./gradlew :x-pack:plugin:core:test --tests "*ReservedRolesStoreTests.testKibanaSystemRole"` — BUILD SUCCESSFUL
- [x] `./gradlew :x-pack:plugin:core:spotlessApply` — no changes

Made with [Cursor](https://cursor.com)