### PR TITLE
[9.5] Migrate license-enforcing qa to JUnit cluster rule (#157415)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -29,7 +29,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         ListMultimap<Class<?>, String> map = ArrayListMultimap.create(1, 200);
         // Projects that apply LegacyRestTestBasePlugin directly via the legacy-yaml-rest-test or legacy-java-rest-test plugins.
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:rest");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-based-recoveries:qa:license-enforcing");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-repo-test-kit:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:transform:qa:multi-node-tests");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");

--- a/x-pack/plugin/snapshot-based-recoveries/qa/license-enforcing/build.gradle
+++ b/x-pack/plugin/snapshot-based-recoveries/qa/license-enforcing/build.gradle
@@ -1,5 +1,3 @@
-import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -7,14 +5,12 @@ import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
  * 2.0.
  */
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('snapshot-based-recoveries'))))
 }
-
-final File repoDir = file("$buildDir/testclusters/snapshot-recoveries-repo-license")
 
 restResources {
   restApi {
@@ -22,20 +18,6 @@ restResources {
   }
 }
 
-tasks.withType(Test).configureEach {
-  doFirst {
-    delete(repoDir)
-  }
-  nonInputProperties.systemProperty 'tests.path.repo', repoDir
-}
-
-testClusters.matching { it.name == "javaRestTest" }.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 3
-
-  // This project tests that enterprise licensing is enforced,
-  // therefore we use a basic license
-  setting 'xpack.license.self_generated.type', 'basic'
-  setting 'path.repo', repoDir.absolutePath, IGNORE_VALUE
-  setting 'xpack.security.enabled', 'false'
+tasks.named("javaRestTest").configure {
+  usesDefaultDistribution("requires DEFAULT distribution for license enforcement and snapshot-based recovery")
 }

--- a/x-pack/plugin/snapshot-based-recoveries/qa/license-enforcing/src/javaRestTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/LicenseIsEnforcedDuringSnapshotBasedRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/qa/license-enforcing/src/javaRestTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/LicenseIsEnforcedDuringSnapshotBasedRecoveryIT.java
@@ -11,6 +11,12 @@ import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.util.List;
 import java.util.Map;
@@ -21,6 +27,25 @@ import static org.hamcrest.Matchers.is;
 
 public class LicenseIsEnforcedDuringSnapshotBasedRecoveryIT extends AbstractSnapshotBasedRecoveryRestTestCase {
 
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    // This project tests that enterprise licensing is enforced, therefore we use a basic license
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .nodes(3)
+        .setting("xpack.license.self_generated.type", "basic")
+        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+        .setting("xpack.security.enabled", "false")
+        .build();
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
     @Override
     protected String repositoryType() {
         return "fs";
@@ -28,7 +53,7 @@ public class LicenseIsEnforcedDuringSnapshotBasedRecoveryIT extends AbstractSnap
 
     @Override
     protected Settings repositorySettings() {
-        return Settings.builder().put("location", System.getProperty("tests.path.repo")).build();
+        return Settings.builder().put("location", repoDirectory.getRoot().getPath()).build();
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Migrate license-enforcing qa to JUnit cluster rule (#157415)](https://github.com/elastic/elasticsearch/pull/157415)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)