### PR TITLE
Remove Azure's max_connections account's dependency 

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -64,8 +64,7 @@ final class AzureStorageSettings {
     public static final AffixSetting<Integer> MAX_CONNECTIONS_SETTING = Setting.affixKeySetting(
         AZURE_CLIENT_PREFIX_KEY,
         "max_connections",
-        key -> Setting.intSetting(key, AzureClientProvider.MAX_OPEN_CONNECTIONS, 1, Property.NodeScope),
-        () -> ACCOUNT_SETTING
+        key -> Setting.intSetting(key, AzureClientProvider.MAX_OPEN_CONNECTIONS, 1, Property.NodeScope)
     );
 
     /** max_retries: Number of retries in case of Azure errors. Defaults to 3 (RequestRetryOptions). */


### PR DESCRIPTION
**Problem**
We would like to setup `azure.client.default.max_connections` similarly to `s3.client.default.max_connections` in _Serverless_. However, because it has an account dependency, we cannot simply set `azure.client.default.max_connections` in a general configuration file. S3 does [not have a dependency](https://github.com/elastic/elasticsearch/blob/9.5/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java#L136) and hence can do this.

**Solution**
Remove the dependency. Another option would be to make sure we set Azure's `max_connections` value when creating the Azure clients (i.e., when we deploy) but this would imply we set `max_connections` at a different place from where the S3 `max_connections` are set.