### PR TITLE
[9.4] Increase timeout for SmokeTestMultiNodeClientYamlTestSuiteIT (#155247)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -137,9 +137,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValuesByteRefGroupingAggregatorFunctionTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/155069
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=indices.put_alias/all_path_options/put alias with missing name}
-  issue: https://github.com/elastic/elasticsearch/issues/156886
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
   method: test {csv-spec:lookup-join.mvKeywordExpressionJoinWarningsFromRightSideWhenNotKept}
   issue: https://github.com/elastic/elasticsearch/issues/157303
@@ -149,9 +146,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceTests
   method: testUnifiedCompletionError
   issue: https://github.com/elastic/elasticsearch/issues/157332
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=indices.create/30_dynamic_template/Create index with dynamic_mappings, match is single-valued}
-  issue: https://github.com/elastic/elasticsearch/issues/157333
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/157223

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -20,7 +20,7 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
 
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
+@TimeoutSuite(millis = 50 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ClassRule


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Increase timeout for SmokeTestMultiNodeClientYamlTestSuiteIT (#155247)](https://github.com/elastic/elasticsearch/pull/155247)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #157333
Closes #156886