### PR TITLE
Report usages of deprecated S3 repo settings

### DIFF
--- a/modules/repository-s3/qa/deprecations/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3DeprecationsRestIT.java
+++ b/modules/repository-s3/qa/deprecations/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3DeprecationsRestIT.java
@@ -18,6 +18,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
@@ -27,6 +28,9 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -138,6 +142,47 @@ public class RepositoryS3DeprecationsRestIT extends ESRestTestCase {
         } finally {
             assertOK(client().performRequest(new Request("DELETE", "/_snapshot/" + repoName)));
         }
+    }
+
+    private static final String PLACEHOLDER_CLIENT = "placeholder";
+    private static final Map<String, String> DEPRECATED_CLIENT_SETTING_TEST_VALUES = Map.of(
+        "protocol",
+        "https",
+        "use_throttle_retries",
+        "true",
+        "signer_override",
+        "test_signer"
+    );
+
+    public void testUpgradeAssistantReportsDeprecatedClientSettings() throws IOException {
+        for (var deprecatedClientSetting : DEPRECATED_CLIENT_SETTING_TEST_VALUES.entrySet()) {
+            final var settingKey = deprecatedClientSetting.getKey();
+            final var repoName = registerRepository(b -> b.put(settingKey, deprecatedClientSetting.getValue()), Strings.format("""
+                [s3.client.%s.%s] setting was deprecated in Elasticsearch and will be removed in a future release. \
+                See the breaking changes documentation for the next major version.""", PLACEHOLDER_CLIENT, settingKey));
+            try {
+                assertDeprecationIssue(
+                    repoName,
+                    "S3 repository explicitly configures a deprecated client setting",
+                    ReferenceDocs.TROUBLESHOOT_REPOSITORY,
+                    S3Repository.deprecatedClientSettingDeprecationWarning(settingKey)
+                );
+            } finally {
+                assertOK(client().performRequest(new Request("DELETE", "/_snapshot/" + repoName)));
+            }
+        }
+    }
+
+    public void testAllDeprecatedClientSettingsAreCoveredByUpgradeAssistantTest() {
+        final Set<String> deprecatedClientSettings = new HashSet<>();
+        for (final var setting : S3RepositorySettings.DEPRECATED_CLIENT_SETTINGS) {
+            deprecatedClientSettings.add(
+                setting.getConcreteSettingForNamespace(PLACEHOLDER_CLIENT)
+                    .getKey()
+                    .substring(S3ClientSettings.REPOSITORY_CLIENT_SETTINGS_PREFIX.length())
+            );
+        }
+        assertThat(DEPRECATED_CLIENT_SETTING_TEST_VALUES.keySet(), equalTo(deprecatedClientSettings));
     }
 
     private static void assertDeprecationIssue(String repositoryName, String message, ReferenceDocs referenceDocs, String details)

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -52,6 +52,11 @@ final class S3ClientSettings {
 
     /** Placeholder client name for normalizing client settings in the repository settings. */
     private static final String PLACEHOLDER_CLIENT = "placeholder";
+    static final String REPOSITORY_CLIENT_SETTINGS_PREFIX = PREFIX + PLACEHOLDER_CLIENT + '.';
+
+    static Settings normalizeRepositorySettings(Settings repositorySettings) {
+        return Settings.builder().put(repositorySettings).normalizePrefix(REPOSITORY_CLIENT_SETTINGS_PREFIX).build();
+    }
 
     /** The access key (ie login id) for connecting to s3. */
     static final Setting.AffixSetting<SecureString> ACCESS_KEY_SETTING = Setting.affixKeySetting(
@@ -349,10 +354,7 @@ final class S3ClientSettings {
      */
     S3ClientSettings refine(Settings repositorySettings) {
         // Normalize settings to placeholder client settings prefix so that we can use the affix settings directly
-        final Settings normalizedSettings = Settings.builder()
-            .put(repositorySettings)
-            .normalizePrefix(PREFIX + PLACEHOLDER_CLIENT + '.')
-            .build();
+        final Settings normalizedSettings = normalizeRepositorySettings(repositorySettings);
         final HttpScheme newProtocol = getRepoSettingOrDefault(PROTOCOL_SETTING, normalizedSettings, protocol);
         final String newEndpoint = getRepoSettingOrDefault(ENDPOINT_SETTING, normalizedSettings, endpoint);
 
@@ -399,6 +401,11 @@ final class S3ClientSettings {
             tenaciousRetriesEnabled
         );
         final boolean newAlwaysSignRequests = getRepoSettingOrDefault(ALWAYS_SIGN_REQUESTS, normalizedSettings, alwaysSignRequests);
+
+        // Read unused settings too so repository registration emits deprecation warnings for explicit values.
+        getRepoSettingOrDefault(UNUSED_USE_THROTTLE_RETRIES_SETTING, normalizedSettings, true);
+        getRepoSettingOrDefault(UNUSED_SIGNER_OVERRIDE, normalizedSettings, "");
+
         if (Objects.equals(protocol, newProtocol)
             && Objects.equals(endpoint, newEndpoint)
             && Objects.equals(proxyHost, newProxyHost)

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -408,6 +408,13 @@ class S3Repository extends MeteredBlobStoreRepository {
         UNSAFELY_INCOMPATIBLE_WITH_S3_CONDITIONAL_WRITES.getKey()
     );
 
+    static String deprecatedClientSettingDeprecationWarning(String settingKey) {
+        return Strings.format(
+            "This repository's settings include the deprecated S3 client setting [%s] which must be removed before upgrade.",
+            settingKey
+        );
+    }
+
     @Override
     public Collection<RepositoryDeprecationInfo> getDeprecationInfos() {
         final List<RepositoryDeprecationInfo> deprecationInfos = new ArrayList<>();
@@ -422,6 +429,24 @@ class S3Repository extends MeteredBlobStoreRepository {
                     false
                 )
             );
+        }
+        for (String normalizedKey : S3ClientSettings.normalizeRepositorySettings(getMetadata().settings()).keySet()) {
+            for (Setting.AffixSetting<?> setting : S3RepositorySettings.DEPRECATED_CLIENT_SETTINGS) {
+                if (setting.match(normalizedKey)) {
+                    deprecationInfos.add(
+                        new RepositoryDeprecationInfo(
+                            RepositoryDeprecationInfo.Level.CRITICAL,
+                            "S3 repository explicitly configures a deprecated client setting",
+                            ReferenceDocs.TROUBLESHOOT_REPOSITORY,
+                            deprecatedClientSettingDeprecationWarning(
+                                normalizedKey.substring(S3ClientSettings.REPOSITORY_CLIENT_SETTINGS_PREFIX.length())
+                            ),
+                            false
+                        )
+                    );
+                    break;
+                }
+            }
         }
         if (UNSAFELY_INCOMPATIBLE_WITH_S3_CONDITIONAL_WRITES.exists(getMetadata().settings())) {
             deprecationInfos.add(

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -34,7 +34,6 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -132,37 +131,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
 
     @Override
     public List<Setting<?>> getSettings() {
-        return Arrays.asList(
-            // named s3 client configuration settings
-            S3ClientSettings.ACCESS_KEY_SETTING,
-            S3ClientSettings.SECRET_KEY_SETTING,
-            S3ClientSettings.SESSION_TOKEN_SETTING,
-            S3ClientSettings.ENDPOINT_SETTING,
-            S3ClientSettings.PROTOCOL_SETTING,
-            S3ClientSettings.PROXY_HOST_SETTING,
-            S3ClientSettings.PROXY_PORT_SETTING,
-            S3ClientSettings.PROXY_SCHEME_SETTING,
-            S3ClientSettings.PROXY_USERNAME_SETTING,
-            S3ClientSettings.PROXY_PASSWORD_SETTING,
-            S3ClientSettings.READ_TIMEOUT_SETTING,
-            S3ClientSettings.MAX_CONNECTIONS_SETTING,
-            S3ClientSettings.MAX_RETRIES_SETTING,
-            S3ClientSettings.API_CALL_TIMEOUT_SETTING,
-            S3ClientSettings.UNUSED_USE_THROTTLE_RETRIES_SETTING,
-            S3ClientSettings.USE_PATH_STYLE_ACCESS,
-            S3ClientSettings.DISABLE_CHUNKED_ENCODING,
-            S3ClientSettings.UNUSED_SIGNER_OVERRIDE,
-            S3ClientSettings.ADD_PURPOSE_CUSTOM_QUERY_PARAMETER,
-            S3ClientSettings.REGION,
-            S3ClientSettings.CONNECTION_MAX_IDLE_TIME_SETTING,
-            S3ClientSettings.MAX_COPY_SIZE_BEFORE_MULTIPART,
-            S3Service.REPOSITORY_S3_CAS_TTL_SETTING,
-            S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING,
-            S3Repository.ACCESS_KEY_SETTING,
-            S3Repository.SECRET_KEY_SETTING,
-            S3ClientSettings.S3_TENACIOUS_RETRIES_ENABLED_SETTING,
-            S3ClientSettings.ALWAYS_SIGN_REQUESTS
-        );
+        return S3RepositorySettings.SETTINGS;
     }
 
     @Override

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class S3RepositorySettings {
+
+    static final List<Setting<?>> SETTINGS = List.of(
+        // named s3 client configuration settings
+        S3ClientSettings.ACCESS_KEY_SETTING,
+        S3ClientSettings.SECRET_KEY_SETTING,
+        S3ClientSettings.SESSION_TOKEN_SETTING,
+        S3ClientSettings.ENDPOINT_SETTING,
+        S3ClientSettings.PROTOCOL_SETTING,
+        S3ClientSettings.PROXY_HOST_SETTING,
+        S3ClientSettings.PROXY_PORT_SETTING,
+        S3ClientSettings.PROXY_SCHEME_SETTING,
+        S3ClientSettings.PROXY_USERNAME_SETTING,
+        S3ClientSettings.PROXY_PASSWORD_SETTING,
+        S3ClientSettings.READ_TIMEOUT_SETTING,
+        S3ClientSettings.MAX_CONNECTIONS_SETTING,
+        S3ClientSettings.MAX_RETRIES_SETTING,
+        S3ClientSettings.API_CALL_TIMEOUT_SETTING,
+        S3ClientSettings.UNUSED_USE_THROTTLE_RETRIES_SETTING,
+        S3ClientSettings.USE_PATH_STYLE_ACCESS,
+        S3ClientSettings.DISABLE_CHUNKED_ENCODING,
+        S3ClientSettings.UNUSED_SIGNER_OVERRIDE,
+        S3ClientSettings.ADD_PURPOSE_CUSTOM_QUERY_PARAMETER,
+        S3ClientSettings.REGION,
+        S3ClientSettings.CONNECTION_MAX_IDLE_TIME_SETTING,
+        S3ClientSettings.MAX_COPY_SIZE_BEFORE_MULTIPART,
+        S3Service.REPOSITORY_S3_CAS_TTL_SETTING,
+        S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING,
+        S3Repository.ACCESS_KEY_SETTING,
+        S3Repository.SECRET_KEY_SETTING,
+        S3ClientSettings.S3_TENACIOUS_RETRIES_ENABLED_SETTING,
+        S3ClientSettings.ALWAYS_SIGN_REQUESTS
+    );
+
+    static final List<Setting.AffixSetting<?>> DEPRECATED_CLIENT_SETTINGS = deprecatedClientSettings();
+
+    private S3RepositorySettings() {}
+
+    private static List<Setting.AffixSetting<?>> deprecatedClientSettings() {
+        final List<Setting.AffixSetting<?>> deprecatedClientSettings = new ArrayList<>();
+        for (Setting<?> setting : SETTINGS) {
+            if (setting instanceof Setting.AffixSetting<?> affixSetting && setting.getProperties().contains(Setting.Property.Deprecated)) {
+                deprecatedClientSettings.add(affixSetting);
+            }
+        }
+        return List.copyOf(deprecatedClientSettings);
+    }
+}


### PR DESCRIPTION
Following #156897 and #156901 with this commit we now report usages of
deprecated S3 client settings when they are used as repository settings.