### PR TITLE
Fix testPhraseQueryInsideNestedObject flakiness in MatchOnlyTextFieldMapperTests

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -138,7 +138,9 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
                     new ShardId(mapperService.index(), 0)
                 )
             ) {
-                SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(reader));
+                // Pass false to avoid random reader re-wrapping (e.g. SlowCompositeReaderWrapper) that would break
+                // the ElasticsearchLeafReader chain needed by BitsetFilterCache to resolve the shard ID.
+                SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(reader, false));
                 NestedQueryBuilder query = new NestedQueryBuilder(
                     "children",
                     new MatchPhraseQueryBuilder("children.text", "quick brown"),


### PR DESCRIPTION
Disable randomly wrapping directory reader wrapping via Lucene's test framework as it isn't compertatibe with `BitsetFilterCache.getAndLoadIfNotPresent`, which relies on to call `ShardUtils.extractShardId(context.reader())` when executing nested queries.

One possible wrapping is `SlowCompositeReaderWrapper`, which collapses all segments into a synthetic `LeafReader` that does **not** extend `FilterLeafReader`.

This doesn't affect the purpose of the unit test.