### PR TITLE
Fix test 340_flattened failures in BWC and Serverless 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -710,9 +710,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.VirtualBatchedCompoundCommitTests
   method: testGetVirtualBatchedCompoundCommitBytesByRangeWithConcurrentAppends
   issue: https://github.com/elastic/elasticsearch/issues/157162
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/340_flattened/Unsupported queries on keyed flattened fields are client errors}
-  issue: https://github.com/elastic/elasticsearch/issues/157192
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/157223

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/340_flattened.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/340_flattened.yml
@@ -705,6 +705,9 @@ setup:
 
 ---
 "Unsupported queries on keyed flattened fields are client errors":
+  - requires:
+      cluster_features: ["mapper.flattened.keyed_unsupported_queries.bad.request"]
+      reason: "before this feature, unsupported queries on keyed flattened fields returned a 5xx"
   - do:
       indices.create:
         index:  keyed_unsupported
@@ -713,6 +716,13 @@ setup:
             properties:
               flattened:
                 type: flattened
+
+  # On stateless a newly created index carries a refresh block, and searches silently skip blocked indices and
+  # return an empty result instead of reaching a shard. Refreshing waits for that block to be lifted, so that the
+  # searches below fail on a shard as expected.
+  - do:
+      indices.refresh:
+        index: keyed_unsupported
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/340_flattened.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/340_flattened.yml
@@ -706,8 +706,12 @@ setup:
 ---
 "Unsupported queries on keyed flattened fields are client errors":
   - requires:
-      cluster_features: ["mapper.flattened.keyed_unsupported_queries.bad.request"]
-      reason: "before this feature, unsupported queries on keyed flattened fields returned a 5xx"
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: GET
+          path: /_search
+          capabilities: [ keyed_flattened_unsupported_queries_bad_request ]
+      reason: "before this capability, unsupported queries on keyed flattened fields returned a 5xx"
   - do:
       indices.create:
         index:  keyed_unsupported

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -48,9 +48,6 @@ public class MapperFeatures implements FeatureSpecification {
     public static final NodeFeature FLATTENED_MAPPED_SUBFIELDS_FEATURE = new NodeFeature("mapper.flattened.mapped_subfields");
     public static final NodeFeature FLATTENED_PASSTHROUGH_FEATURE = new NodeFeature("mapper.flattened.passthrough");
     public static final NodeFeature FLATTENED_COLUMNAR_DOCUMENT_ORDER = new NodeFeature("mapper.flattened.columnar_document_order");
-    public static final NodeFeature FLATTENED_KEYED_UNSUPPORTED_QUERIES_BAD_REQUEST = new NodeFeature(
-        "mapper.flattened.keyed_unsupported_queries.bad.request"
-    );
     public static final NodeFeature RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature("mapper.dense_vector.rescore_vector");
     public static final NodeFeature RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature(
         "mapper.dense_vector.rescore_zero_vector"
@@ -238,7 +235,6 @@ public class MapperFeatures implements FeatureSpecification {
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             FLATTENED_COLUMNAR_DOCUMENT_ORDER,
-            FLATTENED_KEYED_UNSUPPORTED_QUERIES_BAD_REQUEST,
             ARRAY_OBJECTS_LIMIT,
             ES940_DISK_BBQ,
             FLATTENED_PASSTHROUGH_FEATURE,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -48,6 +48,9 @@ public class MapperFeatures implements FeatureSpecification {
     public static final NodeFeature FLATTENED_MAPPED_SUBFIELDS_FEATURE = new NodeFeature("mapper.flattened.mapped_subfields");
     public static final NodeFeature FLATTENED_PASSTHROUGH_FEATURE = new NodeFeature("mapper.flattened.passthrough");
     public static final NodeFeature FLATTENED_COLUMNAR_DOCUMENT_ORDER = new NodeFeature("mapper.flattened.columnar_document_order");
+    public static final NodeFeature FLATTENED_KEYED_UNSUPPORTED_QUERIES_BAD_REQUEST = new NodeFeature(
+        "mapper.flattened.keyed_unsupported_queries.bad.request"
+    );
     public static final NodeFeature RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature("mapper.dense_vector.rescore_vector");
     public static final NodeFeature RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING = new NodeFeature(
         "mapper.dense_vector.rescore_zero_vector"
@@ -235,6 +238,7 @@ public class MapperFeatures implements FeatureSpecification {
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             FLATTENED_COLUMNAR_DOCUMENT_ORDER,
+            FLATTENED_KEYED_UNSUPPORTED_QUERIES_BAD_REQUEST,
             ARRAY_OBJECTS_LIMIT,
             ES940_DISK_BBQ,
             FLATTENED_PASSTHROUGH_FEATURE,

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -70,6 +70,8 @@ public final class SearchCapabilities {
     private static final String KNN_QUERY_VECTOR_BASE64 = "knn_query_vector_base64";
     private static final String AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE = "aggregate_metric_double_defaults_to_average";
     private static final String KNN_RETRIEVER_OPTIONAL_NUM_CANDIDATES = "knn_retriever_optional_num_candidates";
+    /** Query types that keyed {@code flattened} subfields do not support are rejected with a 400 instead of a 500. */
+    private static final String KEYED_FLATTENED_UNSUPPORTED_QUERIES_BAD_REQUEST = "keyed_flattened_unsupported_queries_bad_request";
 
     public static final Set<String> CAPABILITIES;
     static {
@@ -107,6 +109,7 @@ public final class SearchCapabilities {
         capabilities.add(KNN_QUERY_VECTOR_BASE64);
         capabilities.add(AGGREGATE_METRIC_DOUBLE_DEFAULTS_TO_AVERAGE);
         capabilities.add(KNN_RETRIEVER_OPTIONAL_NUM_CANDIDATES);
+        capabilities.add(KEYED_FLATTENED_UNSUPPORTED_QUERIES_BAD_REQUEST);
         CAPABILITIES = Set.copyOf(capabilities);
     }
 }


### PR DESCRIPTION
## Summary

The `search/340_flattened` YAML that asserts keyed flattened `wildcard` / `regexp` / `fuzzy` queries return **400** was failing in two different ways.

- **Mixed-cluster BWC** ([#157192](https://github.com/elastic/elasticsearch/issues/157192)): the test had no feature gate, so a search routed to an older node still returning 500 / `unsupported_operation_exception` failed the 400 assertions.
- **Serverless**: the test created an empty index and searched immediately. On stateless that index still has `INDEX_REFRESH_BLOCK`, search skips it, and the client gets 200 with `_shards.total: 0`.

## What changed

- Added the `keyed_flattened_unsupported_queries_bad_request` capability to `SearchCapabilities` and gated the YAML test with `requires: capabilities` on   `GET /_search`, so mixed clusters skip until every node has the new error mapping.
- After `indices.create`, call `indices.refresh` on `keyed_unsupported`. That waits for  the refresh block to lift so the unsupported queries actually run on a shard.  Mapping, query bodies, and 400 assertions are unchanged.
- Unmuted `MixedClusterClientYamlTestSuiteIT` for this test.

Closes #157192
