### PR TITLE
Clamp zero computeNorm to prevent shard corruption on flush

### DIFF
--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -371,7 +371,8 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         );
         LateParsingQuery query = (LateParsingQuery) hasChildQueryBuilder.toQuery(searchExecutionContext);
         Similarity expected = SimilarityService.BUILT_IN.get(similarity).apply(Settings.EMPTY, IndexVersion.current(), null);
-        assertThat(((PerFieldSimilarityWrapper) query.getSimilarity()).get("custom_string"), instanceOf(expected.getClass()));
+        Similarity fieldSim = ((PerFieldSimilarityWrapper) query.getSimilarity()).get("custom_string");
+        assertThat(SimilarityService.unwrap(fieldSim), instanceOf(expected.getClass()));
     }
 
     public void testIgnoreUnmapped() throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
@@ -13,6 +13,8 @@ import org.apache.lucene.index.FieldInvertState;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.similarities.Similarity;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 
 /**
  * A {@link Similarity} wrapper that prevents {@code computeNorm} from returning zero for
@@ -33,6 +35,8 @@ import org.apache.lucene.search.similarities.Similarity;
 // package-private; exposed for testing via NonZeroNormSimilarityTests
 final class NonZeroNormSimilarity extends Similarity {
 
+    private static final Logger logger = LogManager.getLogger(NonZeroNormSimilarity.class);
+
     private final Similarity in;
 
     NonZeroNormSimilarity(Similarity in) {
@@ -46,16 +50,38 @@ final class NonZeroNormSimilarity extends Similarity {
     @Override
     public long computeNorm(FieldInvertState state) {
         final long norm = in.computeNorm(state);
-        // norm == 0 is reserved for "field absent" in Lucene's norm encoding.
-        // Lucene only calls computeNorm when the field has tokens (length > 0), so a zero
-        // return here always indicates a similarity that cannot represent the effective field
-        // length (e.g. BM25 with discountOverlaps=true on a field whose only tokens all have
-        // positionIncrement == 0). Clamp to 1 rather than letting Lucene throw.
-        return norm == 0 ? 1L : norm;
+        if (norm == 0) {
+            // norm == 0 is reserved for "field absent" in Lucene's norm encoding.
+            // Lucene only calls computeNorm when the field has tokens (length > 0), so a zero
+            // return here always indicates a similarity that cannot represent the effective field
+            // length (e.g. BM25 with discountOverlaps=true on a field whose only tokens all have
+            // positionIncrement == 0). Log a warning to help identify the root cause, then clamp
+            // to 1 rather than letting Lucene throw an IllegalStateException that corrupts the shard.
+            logger.warn(
+                "Similarity [{}] returned 0 from computeNorm for field [{}] with length {}; "
+                    + "clamping to 1 to prevent shard corruption. "
+                    + "Check your analysis chain for filters that produce only overlap tokens "
+                    + "(positionIncrement == 0).",
+                in,
+                state.getName(),
+                state.getLength()
+            );
+            return 1L;
+        }
+        return norm;
     }
 
     @Override
     public SimScorer scorer(float boost, CollectionStatistics collectionStats, TermStatistics... termStats) {
         return in.scorer(boost, collectionStats, termStats);
+    }
+
+    /**
+     * Delegates to the wrapped similarity so that the explain API reports the actual
+     * similarity name rather than this wrapper's class name.
+     */
+    @Override
+    public String toString() {
+        return in.toString();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.similarity;
+
+import org.apache.lucene.index.FieldInvertState;
+import org.apache.lucene.search.CollectionStatistics;
+import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.similarities.Similarity;
+
+/**
+ * A {@link Similarity} wrapper that prevents {@code computeNorm} from returning zero for
+ * non-empty fields. Lucene reserves norm {@code 0} to mean "field absent"; any similarity
+ * that returns {@code 0} for a field with at least one token causes Lucene to throw an
+ * {@link IllegalStateException} from {@code IndexingChain.PerField#finish}. That exception
+ * escapes the {@code processDocument} finally-block before
+ * {@code StoredFieldsConsumer.finishDocument} runs, leaving a stored-fields frame open and
+ * desynchronising the writer's doc count. The segment then fails to flush with
+ * {@code "Wrote N docs, finish called with numDocs=M"}, corrupting the shard.
+ *
+ * <p>This wrapper clamps a zero return value to {@code 1}, the smallest valid norm encoding
+ * (equivalent to the shortest possible field length), so that the document is accepted and
+ * the flush completes normally. It is applied to every {@link Similarity} registered in
+ * {@link SimilarityService}, including built-in ones, so that analysis chains which produce
+ * only overlap tokens ({@code positionIncrement == 0}) for some input cannot corrupt a shard.
+ */
+// package-private; exposed for testing via NonZeroNormSimilarityTests
+final class NonZeroNormSimilarity extends Similarity {
+
+    private final Similarity in;
+
+    NonZeroNormSimilarity(Similarity in) {
+        this.in = in;
+    }
+
+    Similarity getDelegate() {
+        return in;
+    }
+
+    @Override
+    public long computeNorm(FieldInvertState state) {
+        final long norm = in.computeNorm(state);
+        // norm == 0 is reserved for "field absent" in Lucene's norm encoding.
+        // Lucene only calls computeNorm when the field has tokens (length > 0), so a zero
+        // return here always indicates a similarity that cannot represent the effective field
+        // length (e.g. BM25 with discountOverlaps=true on a field whose only tokens all have
+        // positionIncrement == 0). Clamp to 1 rather than letting Lucene throw.
+        return norm == 0 ? 1L : norm;
+    }
+
+    @Override
+    public SimScorer scorer(float boost, CollectionStatistics collectionStats, TermStatistics... termStats) {
+        return in.scorer(boost, collectionStats, termStats);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
@@ -28,9 +28,10 @@ import org.elasticsearch.logging.Logger;
  *
  * <p>This wrapper clamps a zero return value to {@code 1}, the smallest valid norm encoding
  * (equivalent to the shortest possible field length), so that the document is accepted and
- * the flush completes normally. It is applied to every {@link Similarity} registered in
- * {@link SimilarityService}, including built-in ones, so that analysis chains which produce
- * only overlap tokens ({@code positionIncrement == 0}) for some input cannot corrupt a shard.
+ * the flush completes normally. In {@link SimilarityService} it is applied at the per-field
+ * level (inside {@link SimilarityService.PerFieldSimilarity#get}) so that the outer
+ * {@code PerFieldSimilarity} class name is preserved in Lucene's explain API (which uses
+ * {@link Class#getSimpleName()} rather than {@link Object#toString()}).
  */
 // package-private; exposed for testing via NonZeroNormSimilarityTests
 final class NonZeroNormSimilarity extends Similarity {
@@ -76,12 +77,4 @@ final class NonZeroNormSimilarity extends Similarity {
         return in.scorer(boost, collectionStats, termStats);
     }
 
-    /**
-     * Delegates to the wrapped similarity so that the explain API reports the actual
-     * similarity name rather than this wrapper's class name.
-     */
-    @Override
-    public String toString() {
-        return in.toString();
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
@@ -17,6 +17,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A {@link Similarity} wrapper that prevents {@code computeNorm} from returning zero for
@@ -42,8 +43,21 @@ final class NonZeroNormSimilarity extends Similarity {
 
     private static final long WARN_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
 
-    /** Last time a zero-norm warning was emitted, in {@link System#nanoTime()} units. */
-    private static volatile long lastWarnNanos = 0;
+    /**
+     * Timestamp of the last emitted zero-norm warning, in {@link System#nanoTime()} units. Seeded a
+     * full interval in the past so that the first zero norm always warns without a sentinel branch.
+     */
+    private static final AtomicLong lastWarnNanos = new AtomicLong(System.nanoTime() - WARN_INTERVAL_NANOS);
+
+    private static boolean shouldWarn() {
+        final long last = lastWarnNanos.get();
+        final long now = System.nanoTime();
+        if (now - last < WARN_INTERVAL_NANOS) {
+            return false;
+        }
+        // Exactly one racing thread wins the CAS and logs; the losers fall through silently.
+        return lastWarnNanos.compareAndSet(last, now);
+    }
 
     private final Similarity in;
 
@@ -63,12 +77,10 @@ final class NonZeroNormSimilarity extends Similarity {
             // Lucene only calls computeNorm when the field has tokens (length > 0), so a zero
             // return here always indicates a similarity that cannot represent the effective field
             // length (e.g. BM25 with discountOverlaps=true on a field whose only tokens all have
-            // positionIncrement == 0). Log a warning (rate-limited to once per minute) to help
+            // positionIncrement == 0). Log a rate-limited warning to help
             // identify the root cause, then clamp to 1 rather than letting Lucene throw an
             // IllegalStateException that corrupts the shard.
-            final long now = System.nanoTime();
-            if (lastWarnNanos == 0 || now - lastWarnNanos >= WARN_INTERVAL_NANOS) {
-                lastWarnNanos = now;
+            if (shouldWarn()) {
                 logger.warn(
                     "Similarity [{}] returned 0 from computeNorm for field [{}] with length {}; "
                         + "clamping to 1 to prevent shard corruption. "

--- a/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/NonZeroNormSimilarity.java
@@ -16,6 +16,8 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A {@link Similarity} wrapper that prevents {@code computeNorm} from returning zero for
  * non-empty fields. Lucene reserves norm {@code 0} to mean "field absent"; any similarity
@@ -38,6 +40,11 @@ final class NonZeroNormSimilarity extends Similarity {
 
     private static final Logger logger = LogManager.getLogger(NonZeroNormSimilarity.class);
 
+    private static final long WARN_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
+
+    /** Last time a zero-norm warning was emitted, in {@link System#nanoTime()} units. */
+    private static volatile long lastWarnNanos = 0;
+
     private final Similarity in;
 
     NonZeroNormSimilarity(Similarity in) {
@@ -56,17 +63,22 @@ final class NonZeroNormSimilarity extends Similarity {
             // Lucene only calls computeNorm when the field has tokens (length > 0), so a zero
             // return here always indicates a similarity that cannot represent the effective field
             // length (e.g. BM25 with discountOverlaps=true on a field whose only tokens all have
-            // positionIncrement == 0). Log a warning to help identify the root cause, then clamp
-            // to 1 rather than letting Lucene throw an IllegalStateException that corrupts the shard.
-            logger.warn(
-                "Similarity [{}] returned 0 from computeNorm for field [{}] with length {}; "
-                    + "clamping to 1 to prevent shard corruption. "
-                    + "Check your analysis chain for filters that produce only overlap tokens "
-                    + "(positionIncrement == 0).",
-                in,
-                state.getName(),
-                state.getLength()
-            );
+            // positionIncrement == 0). Log a warning (rate-limited to once per minute) to help
+            // identify the root cause, then clamp to 1 rather than letting Lucene throw an
+            // IllegalStateException that corrupts the shard.
+            final long now = System.nanoTime();
+            if (lastWarnNanos == 0 || now - lastWarnNanos >= WARN_INTERVAL_NANOS) {
+                lastWarnNanos = now;
+                logger.warn(
+                    "Similarity [{}] returned 0 from computeNorm for field [{}] with length {}; "
+                        + "clamping to 1 to prevent shard corruption. "
+                        + "Check your analysis chain for filters that produce only overlap tokens "
+                        + "(positionIncrement == 0).",
+                    in,
+                    state.getName(),
+                    state.getLength()
+                );
+            }
             return 1L;
         }
         return norm;

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -133,6 +133,15 @@ public final class SimilarityService {
         return new NonZeroNormSimilarity(defaultSimilarity);
     }
 
+    /**
+     * Unwraps a {@link NonZeroNormSimilarity} wrapper, if present, and returns the underlying
+     * {@link Similarity}. Useful in tests that need to inspect the configured similarity type
+     * without being affected by the transparent zero-norm guard wrapper.
+     */
+    public static Similarity unwrap(Similarity similarity) {
+        return similarity instanceof NonZeroNormSimilarity w ? w.getDelegate() : similarity;
+    }
+
     public SimilarityProvider getSimilarity(String name) {
         Supplier<Similarity> sim = similarities.get(name);
         if (sim == null) {

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -115,10 +115,14 @@ public final class SimilarityService {
     }
 
     /**
-     * The similarity to use in searches, which takes into account per-field configuration.
+     * The similarity to use at index time, wrapped in {@link NonZeroNormSimilarity} to prevent
+     * shard corruption when a similarity returns {@code 0} from {@code computeNorm} for a
+     * non-empty field. When a field lookup is provided the result dispatches per-field; otherwise
+     * the default similarity is used for all fields.
      */
     public Similarity similarity(@Nullable Function<String, MappedFieldType> fieldTypeLookup) {
-        return (fieldTypeLookup != null) ? new PerFieldSimilarity(defaultSimilarity, fieldTypeLookup) : defaultSimilarity;
+        Similarity base = (fieldTypeLookup != null) ? new PerFieldSimilarity(defaultSimilarity, fieldTypeLookup) : defaultSimilarity;
+        return new NonZeroNormSimilarity(base);
     }
 
     public SimilarityProvider getSimilarity(String name) {

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -115,14 +115,22 @@ public final class SimilarityService {
     }
 
     /**
-     * The similarity to use at index time, wrapped in {@link NonZeroNormSimilarity} to prevent
-     * shard corruption when a similarity returns {@code 0} from {@code computeNorm} for a
-     * non-empty field. When a field lookup is provided the result dispatches per-field; otherwise
-     * the default similarity is used for all fields.
+     * The similarity to use at index time. When a field lookup is provided the result dispatches
+     * per-field and wraps each field's similarity in {@link NonZeroNormSimilarity} to prevent shard
+     * corruption when a similarity returns {@code 0} from {@code computeNorm} for a non-empty
+     * field. When no field lookup is provided, the default similarity is wrapped directly in
+     * {@link NonZeroNormSimilarity}.
+     *
+     * <p>The wrapping is applied at the per-field level (inside {@link PerFieldSimilarity#get})
+     * rather than around the outer {@link PerFieldSimilarity} so that the class seen by Lucene's
+     * explain API remains {@code PerFieldSimilarity}, matching the pre-fix behaviour.
      */
     public Similarity similarity(@Nullable Function<String, MappedFieldType> fieldTypeLookup) {
-        Similarity base = (fieldTypeLookup != null) ? new PerFieldSimilarity(defaultSimilarity, fieldTypeLookup) : defaultSimilarity;
-        return new NonZeroNormSimilarity(base);
+        if (fieldTypeLookup != null) {
+            return new PerFieldSimilarity(defaultSimilarity, fieldTypeLookup);
+        }
+        // No per-field dispatch: wrap directly so the zero-norm guard is still applied.
+        return new NonZeroNormSimilarity(defaultSimilarity);
     }
 
     public SimilarityProvider getSimilarity(String name) {
@@ -154,9 +162,12 @@ public final class SimilarityService {
         @Override
         public Similarity get(String name) {
             MappedFieldType fieldType = fieldTypeLookup.apply(name);
-            return (fieldType != null && fieldType.getTextSearchInfo().similarity() != null)
+            Similarity sim = (fieldType != null && fieldType.getTextSearchInfo().similarity() != null)
                 ? fieldType.getTextSearchInfo().similarity().get()
                 : defaultSimilarity;
+            // Wrap at the per-field level so that the outer PerFieldSimilarity class name is
+            // preserved in Lucene's explain API (TermQuery uses getClass().getSimpleName()).
+            return new NonZeroNormSimilarity(sim);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/similarity/ZeroNormSimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/ZeroNormSimilarityTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.xcontent.XContentType;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+
 /**
  * Regression test: a similarity returning {@code 0} from {@code computeNorm} for a non-empty
  * field corrupts the segment and fails the shard on flush.
@@ -116,5 +118,9 @@ public class ZeroNormSimilarityTests extends ESSingleNodeTestCase {
         // Before the fix this threw RuntimeException: "Wrote 1 docs, finish called with numDocs=2"
         var flushResponse = indicesAdmin().flush(new FlushRequest(INDEX).force(true).waitIfOngoing(true)).actionGet();
         assertEquals("flush should not produce shard failures", 0, flushResponse.getFailedShards());
+
+        // Confirm both documents survived: refresh_interval=-1 so a manual refresh is needed first.
+        indicesAdmin().prepareRefresh(INDEX).get();
+        assertHitCount(client().prepareSearch(INDEX).setSize(0), 2L);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/similarity/ZeroNormSimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/ZeroNormSimilarityTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.similarity;
+
+import org.apache.lucene.index.FieldInvertState;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Regression test: a similarity returning {@code 0} from {@code computeNorm} for a non-empty
+ * field corrupts the segment and fails the shard on flush.
+ *
+ * <p>A similarity that returns {@code 0} from {@code computeNorm} for a non-empty field used
+ * to throw an {@code IllegalStateException} inside {@code IndexingChain.PerField#finish}. That
+ * exception escaped the {@code processDocument} finally-block before
+ * {@code StoredFieldsConsumer.finishDocument} ran, leaving a stored-fields frame open and
+ * desynchronising the writer's doc count. The segment then failed to flush with
+ * {@code "Wrote N docs, finish called with numDocs=M"}, corrupting the shard.
+ *
+ * <p>After the fix, {@link NonZeroNormSimilarity} wraps every configured similarity and clamps a
+ * zero {@code computeNorm} return to {@code 1}, so affected documents are accepted and the flush
+ * completes normally.
+ */
+public class ZeroNormSimilarityTests extends ESSingleNodeTestCase {
+
+    private static final String INDEX = "test";
+
+    /**
+     * A similarity that always returns {@code 0} from {@code computeNorm}, regardless of field
+     * state. This mimics the customer scenario where an analysis chain produces only
+     * overlap tokens ({@code positionIncrement == 0}), causing BM25 with
+     * {@code discountOverlaps=true} to compute {@code numTerms = length - numOverlap = 0}.
+     */
+    static final class ZeroNormSimilarity extends BM25Similarity {
+        @Override
+        public long computeNorm(FieldInvertState state) {
+            return 0L;
+        }
+
+        @Override
+        public String toString() {
+            return "ZeroNorm";
+        }
+    }
+
+    public static final class ZeroNormSimPlugin extends Plugin {
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            indexModule.addSimilarity(
+                "zero_norm",
+                (Settings settings, IndexVersion version, ScriptService scriptService) -> new ZeroNormSimilarity()
+            );
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(ZeroNormSimPlugin.class);
+    }
+
+    /**
+     * Before the fix, the sequence below resulted in a shard failure:
+     * <ol>
+     *   <li>Index a document whose {@code content} field produces at least one token, so
+     *       {@code invertState.length > 0} and Lucene calls {@code computeNorm}.</li>
+     *   <li>{@code computeNorm} returns {@code 0}; Lucene throws {@code IllegalStateException}.</li>
+     *   <li>The exception exits the {@code processDocument} finally-block before
+     *       {@code finishStoredFields} runs, leaving the stored-fields frame open.</li>
+     *   <li>A subsequent flush sees {@code docBase != maxDoc} and throws
+     *       {@code RuntimeException: "Wrote N docs, finish called with numDocs=M"}.</li>
+     * </ol>
+     * After the fix, step 2 returns {@code 1} instead of {@code 0}, no exception fires,
+     * the document is accepted, and the flush succeeds.
+     */
+    public void testZeroNormDocumentIndexedAndFlushSucceeds() {
+        indicesAdmin().prepareCreate(INDEX)
+            .setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.refresh_interval", "-1")
+                    .put("index.similarity.zero_norm.type", "zero_norm")
+            )
+            .setMapping("id", "type=keyword", "content", "type=text,similarity=zero_norm,norms=true")
+            .get();
+        ensureGreen(INDEX);
+
+        // Index one document that will trigger computeNorm (content is non-empty) and one
+        // that will not (no content field), matching the customer's two-document pattern.
+        BulkResponse bulk = client().prepareBulk()
+            .add(new IndexRequest(INDEX).id("1").source("{\"id\":\"1\",\"content\":\"hello\"}", XContentType.JSON))
+            .add(new IndexRequest(INDEX).id("2").source("{\"id\":\"2\"}", XContentType.JSON))
+            .get();
+
+        assertFalse("all documents should index without failure: " + bulk.buildFailureMessage(), bulk.hasFailures());
+
+        // Before the fix this threw RuntimeException: "Wrote 1 docs, finish called with numDocs=2"
+        var flushResponse = indicesAdmin().flush(new FlushRequest(INDEX).force(true).waitIfOngoing(true)).actionGet();
+        assertEquals("flush should not produce shard failures", 0, flushResponse.getFailedShards());
+    }
+}


### PR DESCRIPTION
A similarity returning `0` from `computeNorm` for a non-empty field throws an `IllegalStateException` inside `IndexingChain.PerField#finish`. That exception exits `processDocument`'s finally-block before `finishStoredFields` runs, leaving the stored-fields frame open. The writer's doc count is then out of sync with `maxDoc`, and the next flush throws `RuntimeException: Wrote N docs, finish called with numDocs=M`, failing the shard.

The fix wraps the `Similarity` returned by `SimilarityService.similarity()` — the single entry-point fed to `IndexWriter.setSimilarity()` — in a new `NonZeroNormSimilarity` that clamps a zero `computeNorm` return to `1` (the shortest valid norm encoding). This covers every configured similarity, including built-ins and per-field overrides, without affecting scoring at query time (`computeNorm` is only called at index time; `scorer()` delegates unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)