### PR TITLE
QL/ES|QL: throw ArithmeticException on Short and Byte overflow in Maths#convertToIntegerType

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/Maths.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/math/Maths.java
@@ -156,8 +156,14 @@ public final class Maths {
             }
             return number.intValue();
         } else if (type == Short.class) {
+            if (number > Short.MAX_VALUE || number < Short.MIN_VALUE) {
+                throw new ArithmeticException("short overflow");
+            }
             return number.shortValue();
         } else if (type == Byte.class) {
+            if (number > Byte.MAX_VALUE || number < Byte.MIN_VALUE) {
+                throw new ArithmeticException("byte overflow");
+            }
             return number.byteValue();
         }
         return number;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/math/Maths.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/math/Maths.java
@@ -156,8 +156,14 @@ public final class Maths {
             }
             return number.intValue();
         } else if (type == Short.class) {
+            if (number > Short.MAX_VALUE || number < Short.MIN_VALUE) {
+                throw new ArithmeticException("short overflow");
+            }
             return number.shortValue();
         } else if (type == Byte.class) {
+            if (number > Byte.MAX_VALUE || number < Byte.MIN_VALUE) {
+                throw new ArithmeticException("byte overflow");
+            }
             return number.byteValue();
         }
         return number;


### PR DESCRIPTION
### Description
Fixes numeric overflow when rounding `Short` and `Byte` numbers in QL and ES|QL.

Previously, `Maths#convertToIntegerType` verified range boundaries for `Integer`, but narrowed `Short` and `Byte` values using `shortValue()` and `byteValue()` without range checks. Rounding near either boundary with negative precision (e.g. `ROUND(CAST(32767 AS SHORT), -1)` or `ROUND(CAST(127 AS BYTE), -1)`) silently wrapped to negative numbers.

### Solution
- Check `Short.MAX_VALUE` / `Short.MIN_VALUE` and throw `ArithmeticException("short overflow")` when exceeded.
- Check `Byte.MAX_VALUE` / `Byte.MIN_VALUE` and throw `ArithmeticException("byte overflow")` when exceeded.

Closes #157550