### PR TITLE
ES|QL: Prevent COUNT_DISTINCT precision wraparound

### DIFF
--- a/docs/changelog/157553.yaml
+++ b/docs/changelog/157553.yaml
@@ -1,0 +1,6 @@
+pr: 157553
+summary: Prevent COUNT_DISTINCT precision thresholds outside the integer range from wrapping
+area: ES|QL
+type: bug
+issues:
+  - 157549

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -2165,6 +2165,26 @@ s2point1:l | s_mv:l | s_param:l | s_expr:l | s_expr_null:l | languages:i
 1          | 4      | 4         | 1        | 0             | null
 ;
 
+countDistinctPrecisionAboveIntegerRangeLong
+required_capability: fn_count_distinct_precision_clamp
+
+FROM employees
+| STATS d = COUNT_DISTINCT(emp_no, 4294967297);
+
+d:long
+100
+;
+
+countDistinctPrecisionAboveIntegerRangeUnsignedLong
+required_capability: fn_count_distinct_precision_clamp
+
+FROM employees
+| STATS d = COUNT_DISTINCT(emp_no, 18446744073709551615);
+
+d:long
+100
+;
+
 evalOverridingKey
 FROM employees
 | EVAL k = languages

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Foldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Foldables.java
@@ -214,15 +214,6 @@ public abstract class Foldables {
         );
     }
 
-    public static int intValueOf(Expression field, String sourceText, String fieldName) {
-        if (field instanceof Literal literal && literal.value() instanceof Number n) {
-            return n.intValue();
-        }
-        throw new EsqlIllegalArgumentException(
-            Strings.format(null, "[{}] value must be a constant number in [{}], found [{}]", fieldName, sourceText, field)
-        );
-    }
-
     public static double doubleValueOf(Expression field, String sourceText, String fieldName) {
         if (field instanceof Literal literal && literal.value() instanceof Number n) {
             return n.doubleValue();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
@@ -40,6 +41,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -49,9 +51,9 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isWholeNumber;
-import static org.elasticsearch.xpack.esql.expression.Foldables.intValueOf;
 
 public class CountDistinct extends AggregateFunction implements OptionalArgument, ToAggregator, SurrogateExpression {
+
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
         "CountDistinct",
@@ -59,7 +61,7 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     );
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(CountDistinct.class)
         .binary(CountDistinct::new)
-        .capabilities("flattened")
+        .capabilities("flattened", "precision_clamp")
         .name("count_distinct");
 
     private static final Map<DataType, Function<Integer, AggregatorFunctionSupplier>> SUPPLIERS = Map.ofEntries(
@@ -243,7 +245,18 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     }
 
     private int precisionValue() {
-        return intValueOf(precision, source().text(), "Precision");
+        return clampPrecisionThreshold(precision.dataType(), (Number) ((Literal) precision).value());
+    }
+
+    /** Clamps a folded precision literal to {@code [0, {@link Integer#MAX_VALUE}]} without narrowing wraparound. */
+    static int clampPrecisionThreshold(DataType precisionType, Number value) {
+        if (precisionType == DataType.UNSIGNED_LONG) {
+            BigInteger unsignedValue = value instanceof BigInteger bigInteger
+                ? bigInteger
+                : NumericUtils.unsignedLongAsBigInteger(value.longValue());
+            return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
+        }
+        return Math.clamp(value.longValue(), 0, Integer.MAX_VALUE);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -120,7 +121,39 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
             // Without precision
             suppliers.add(makeSupplier(emptyFieldSupplier));
         }
+
+        suppliers.add(
+            makeSupplier(
+                manyInts("<long precision above integer range>"),
+                new TestCaseSupplier.TypedDataSupplier(
+                    "<long precision above integer range>",
+                    () -> (1L << Integer.SIZE) + 1,
+                    DataType.LONG
+                )
+            )
+        );
+        suppliers.add(
+            makeSupplier(
+                manyInts("<unsigned long precision above integer range>"),
+                new TestCaseSupplier.TypedDataSupplier(
+                    "<unsigned long precision above integer range>",
+                    () -> BigInteger.ONE.shiftLeft(Integer.SIZE).add(BigInteger.ONE),
+                    DataType.UNSIGNED_LONG
+                )
+            )
+        );
         return suppliers;
+    }
+
+    private static TestCaseSupplier.TypedDataSupplier manyInts(String name) {
+        return new TestCaseSupplier.TypedDataSupplier(
+            name,
+            () -> IntStream.range(0, 1000).boxed().toList(),
+            DataType.INTEGER,
+            false,
+            true,
+            List.of()
+        );
     }
 
     @Override
@@ -136,7 +169,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
             var fieldTypedData = fieldSupplier.get();
             var precisionTypedData = precisionSupplier.get().forceLiteral();
             var values = fieldTypedData.multiRowData();
-            var precision = ((Number) precisionTypedData.data()).intValue();
+            var precision = expectedPrecision(precisionTypedData);
 
             long result;
 
@@ -199,5 +232,16 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
 
             return hll.cardinality(0);
         }
+    }
+
+    private static int expectedPrecision(TestCaseSupplier.TypedData precision) {
+        if (precision.type() == DataType.UNSIGNED_LONG) {
+            Number value = (Number) precision.data();
+            BigInteger unsignedValue = value instanceof BigInteger bigInteger
+                ? bigInteger
+                : BigInteger.valueOf(value.longValue() ^ Long.MIN_VALUE);
+            return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
+        }
+        return Math.clamp(((Number) precision.data()).longValue(), 0, Integer.MAX_VALUE);
     }
 }


### PR DESCRIPTION
## Summary
- clamp signed and unsigned precision thresholds before narrowing to `int`
- preserve the documented maximum-precision behavior for values above the integer range
- add regression coverage for large `long` and `unsigned_long` thresholds

Closes #157549.

This follow-up was found while auditing numeric narrowing after #156411 and #156412.

## Test plan
- [x] `./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinctTests :x-pack:plugin:esql:spotlessJavaCheck`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)