### PR TITLE
SQL: Reject ROUND overflow for byte and short

### DIFF
--- a/docs/changelog/157554.yaml
+++ b/docs/changelog/157554.yaml
@@ -1,0 +1,6 @@
+pr: 157554
+summary: Reject SQL ROUND results that overflow byte or short
+area: SQL
+type: bug
+issues:
+  - 157550

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/math/Maths.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/math/Maths.java
@@ -156,8 +156,14 @@ public final class Maths {
             }
             return number.intValue();
         } else if (type == Short.class) {
+            if (number > Short.MAX_VALUE || number < Short.MIN_VALUE) {
+                throw new ArithmeticException("short overflow");
+            }
             return number.shortValue();
         } else if (type == Byte.class) {
+            if (number > Byte.MAX_VALUE || number < Byte.MIN_VALUE) {
+                throw new ArithmeticException("byte overflow");
+            }
             return number.byteValue();
         }
         return number;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/math/BinaryMathProcessorTests.java
@@ -117,6 +117,34 @@ public class BinaryMathProcessorTests extends AbstractWireSerializingTestCase<Bi
         );
     }
 
+    public void testRoundRejectsShortOverflow() {
+        ArithmeticException positive = expectThrows(
+            ArithmeticException.class,
+            () -> new Round(EMPTY, l(Short.MAX_VALUE), l(-1)).makePipe().asProcessor().process(null)
+        );
+        assertEquals("short overflow", positive.getMessage());
+
+        ArithmeticException negative = expectThrows(
+            ArithmeticException.class,
+            () -> new Round(EMPTY, l(Short.MIN_VALUE), l(-1)).makePipe().asProcessor().process(null)
+        );
+        assertEquals("short overflow", negative.getMessage());
+    }
+
+    public void testRoundRejectsByteOverflow() {
+        ArithmeticException positive = expectThrows(
+            ArithmeticException.class,
+            () -> new Round(EMPTY, l(Byte.MAX_VALUE), l(-1)).makePipe().asProcessor().process(null)
+        );
+        assertEquals("byte overflow", positive.getMessage());
+
+        ArithmeticException negative = expectThrows(
+            ArithmeticException.class,
+            () -> new Round(EMPTY, l(Byte.MIN_VALUE), l(-1)).makePipe().asProcessor().process(null)
+        );
+        assertEquals("byte overflow", negative.getMessage());
+    }
+
     public void testRoundInputValidation() {
         SqlIllegalArgumentException siae = expectThrows(
             SqlIllegalArgumentException.class,


### PR DESCRIPTION
## Summary
- validate rounded `short` and `byte` values before narrowing
- throw the same type-specific overflow errors already used for `integer`
- cover positive and negative overflow at both narrow boundaries

Closes #157550.

This follow-up was found while auditing numeric narrowing after #156411 and #156412.

## Test plan
- [x] `./gradlew :x-pack:plugin:sql:test --tests org.elasticsearch.xpack.sql.expression.function.scalar.math.BinaryMathProcessorTests :x-pack:plugin:ql:spotlessJavaCheck :x-pack:plugin:sql:spotlessJavaCheck`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)