### PR TITLE
Optimize bitmap_terms BKD query for dense runs

### DIFF
--- a/docs/changelog/157556.yaml
+++ b/docs/changelog/157556.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 157556
+summary: Optimize `bitmap_terms` BKD query for dense runs
+type: enhancement

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQuery.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQuery.java
@@ -106,10 +106,11 @@ public class BitmapBKDQuery extends Query implements Accountable {
                     return null;
                 }
 
+                // Read once and shared: every member that reports a cost returns this, and the streaming
+                // scan also carries it as its own DocIdSetIterator cost.
+                final long estimatedCost = estimateCost(pointValues.getDocCount(), segmentMin, segmentMax);
+
                 if (streams(reader, pointValues)) {
-                    // Both members below need it: cost() returns it, and the scan reports it as its own
-                    // DocIdSetIterator cost. Computing it inside cost() would only compute it twice.
-                    final long estimatedCost = estimateCost(pointValues.getDocCount(), segmentMin, segmentMax);
                     return new ScorerSupplier() {
                         @Override
                         public Scorer get(long leadCost) throws IOException {
@@ -133,8 +134,6 @@ public class BitmapBKDQuery extends Query implements Accountable {
                 }
 
                 return new ScorerSupplier() {
-                    long cost = -1;
-
                     @Override
                     public Scorer get(long leadCost) throws IOException {
                         DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), pointValues);
@@ -144,12 +143,7 @@ public class BitmapBKDQuery extends Query implements Accountable {
 
                     @Override
                     public long cost() {
-                        if (cost == -1) {
-                            // estimateDocCount only ever calls compare(), so the plain merge visitor is
-                            // enough here and no DocIdSetBuilder need be allocated.
-                            cost = pointValues.estimateDocCount(new MergePointVisitor());
-                        }
-                        return cost;
+                        return estimatedCost;
                     }
                 };
             }
@@ -186,17 +180,18 @@ public class BitmapBKDQuery extends Query implements Accountable {
     }
 
     /**
-     * Rough per-segment cost for the streaming path, from segment metadata alone: the bitmap's cardinality
-     * scaled by the average documents per distinct value, clamped to the segment's doc count. That factor is
-     * not 1 just because the field is single-valued &mdash; that bounds values per document, not documents
-     * per value, and many documents may share one. Spreading the documents evenly across the segment's value
-     * span is the only way to get it without reading the tree, since BKD records no distinct-value count.
+     * Rough per-segment cost, from segment metadata alone: the bitmap's cardinality scaled by the average
+     * documents per distinct value, clamped to the segment's doc count. That factor is not 1 just because
+     * the field is single-valued &mdash; that bounds values per document, not documents per value, and many
+     * documents may share one. Spreading the documents evenly across the segment's value span is the only
+     * way to get it without reading the tree, since BKD records no distinct-value count.
      * <p>
-     * {@link PointValues#estimateDocCount} is more accurate and is what the collecting path uses, but it
-     * walks the tree, and a bitmap of scattered values crosses most cells so that walk reaches nearly
-     * every leaf. The collecting path can afford it because it is about to traverse the tree anyway; the
-     * streaming path is built not to, and the built {@code DocIdSet} that would go on to report the true
-     * cost never exists.
+     * {@link PointValues#estimateDocCount} is more accurate, but it walks the tree, and a bitmap of
+     * scattered values crosses most cells so that walk reaches nearly every leaf. A {@code bool} query asks
+     * for a cost in order to decide which clause to lead with, so paying it there means traversing once to
+     * plan and again to execute &mdash; which is the work {@code cost()} is asked in order to avoid. The
+     * streaming path never traverses eagerly at all, and the {@code DocIdSet} that would go on to report a
+     * true cost never exists there.
      * <p>
      * Even spread is a crude assumption. A field holding dense ids plus one distant outlier has a span far
      * wider than its populated range, which flattens the average to one document per value and makes the
@@ -224,13 +219,12 @@ public class BitmapBKDQuery extends Query implements Accountable {
      * sides are scanned at most once, giving O(N_index_leaves + N_bitmap_values) total work across the
      * entire tree.
      * <p>
-     * This half decides <em>which cells match</em> and collects nothing, which is all
-     * {@link PointValues#estimateDocCount} needs — it calls only {@link #compare}. Collecting the
-     * matched documents costs somewhere to put them, so that lives in the subclasses:
-     * {@link CollectingMergePointVisitor} for the whole match set, and
+     * This half decides <em>which cells match</em> and collects nothing. Collecting the matched documents
+     * costs somewhere to put them, and the two paths want different somewheres, so that lives in the
+     * subclasses: {@link CollectingMergePointVisitor} for the whole match set, and
      * {@link BufferingMergePointVisitor} for one cell of it at a time.
      */
-    private class MergePointVisitor implements IntersectVisitor {
+    private abstract class MergePointVisitor implements IntersectVisitor {
         private final BitmapValues.PeekableIterator iterator;
         private final ArrayUtil.ByteArrayComparator comparator;
         /** The bitmap value being merged, encoded. Owned here, so nothing else can recycle it. */
@@ -280,16 +274,6 @@ public class BitmapBKDQuery extends Query implements Accountable {
             takeQueryPoint();
         }
 
-        @Override
-        public void visit(int docID) {
-            throw new UnsupportedOperationException("this visitor does not collect; use one of its subclasses");
-        }
-
-        @Override
-        public void visit(int docID, byte[] packedValue) {
-            throw new UnsupportedOperationException("this visitor does not collect; use one of its subclasses");
-        }
-
         protected boolean matches(byte[] packedValue) {
             while (hasQueryPoint) {
                 int cmp = comparator.compare(queryPoint, 0, packedValue, 0);
@@ -321,13 +305,19 @@ public class BitmapBKDQuery extends Query implements Accountable {
                     return Relation.CELL_OUTSIDE_QUERY;
                 }
 
-                if (cmpMin == 0 && cmpMax == 0) {
-                    // cell min and max are exactly equal to our point,
-                    // which can easily happen if many (> 512) docs share this one value
-                    return Relation.CELL_INSIDE_QUERY;
-                } else {
-                    return Relation.CELL_CROSSES_QUERY;
+                if (cmpMin == 0) {
+                    if (cmpMax == 0) {
+                        // cell min and max are exactly equal to our point,
+                        // which can easily happen if many (> 512) docs share this one value
+                        return Relation.CELL_INSIDE_QUERY;
+                    }
+                    // If the bitmap covers all values in the cell, match it whole without decoding any points.
+                    long cellMax = values.decode(maxPackedValue, 0);
+                    if (cellMax - queryValue < values.cardinality() && values.coversRange(queryValue, cellMax)) {
+                        return Relation.CELL_INSIDE_QUERY;
+                    }
                 }
+                return Relation.CELL_CROSSES_QUERY;
             }
 
             // We exhausted all points in the bitmap
@@ -336,10 +326,9 @@ public class BitmapBKDQuery extends Query implements Accountable {
     }
 
     /**
-     * Adds document collection to {@link MergePointVisitor}, for the pass that actually builds the
-     * matching doc set. Kept separate so that {@link PointValues#estimateDocCount}, which only calls
-     * {@link MergePointVisitor#compare}, does not have to allocate a {@link DocIdSetBuilder} it would
-     * never write to.
+     * Adds document collection to {@link MergePointVisitor}, accumulating the whole match set into a
+     * {@link DocIdSetBuilder}, which is what puts it in doc order. Used wherever the walk's own order
+     * cannot be relied on, which is every segment the index sort does not cover.
      */
     private class CollectingMergePointVisitor extends MergePointVisitor {
         private final DocIdSetBuilder result;
@@ -550,9 +539,10 @@ public class BitmapBKDQuery extends Query implements Accountable {
                 }
                 if (tree.moveToChild()) {
                     // Descend even when the whole cell matches, so that what is buffered is bounded by a
-                    // leaf's points rather than by however many documents an inner cell holds. The extra
-                    // comparisons are free: a child of a cell whose min equals its max has the same min
-                    // and max, so it takes the same branch without moving the bitmap cursor.
+                    // leaf's points rather than by however many documents an inner cell holds. The child
+                    // reaches the same verdict without moving the bitmap cursor, since it spans a subrange
+                    // of a range already found covered; what that costs is one more coversRange probe per
+                    // level, against a whole subtree's worth of documents held in memory at once.
                     continue;
                 }
                 visitor.reset();

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapValues.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/BitmapValues.java
@@ -56,6 +56,15 @@ public interface BitmapValues extends Accountable {
     /** Writes {@link #last()} as sortable bytes. Undefined when empty. */
     void encodeLast(byte[] dest);
 
+    /**
+     * Whether the bitmap covers the inclusive range {@code [min, max]}, meaning it holds every value in
+     * that range. Both bounds must be non-negative, which the queries' precondition on the values gives.
+     * <p>
+     * A {@code false} may mean "cannot be decided cheaply" rather than "not covered": callers use this
+     * only to take a faster path, so declining costs an optimization, never correctness.
+     */
+    boolean coversRange(long min, long max);
+
     PeekableIterator iterator();
 
     /**

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/IntBitmap.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/IntBitmap.java
@@ -110,6 +110,15 @@ public final class IntBitmap implements BitmapValues {
         NumericUtils.intToSortableBytes(bitmap.last(), dest, 0);
     }
 
+    /**
+     * Whether the bitmap covers the inclusive range {@code [min, max]}, meaning it holds every value in
+     * that range.
+     */
+    @Override
+    public boolean coversRange(long min, long max) {
+        return bitmap.contains(min, max + 1);
+    }
+
     @Override
     public PeekableIterator iterator() {
         return new IntValuesIterator(bitmap.getIntIterator());

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/LongBitmap.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/LongBitmap.java
@@ -155,6 +155,15 @@ public final class LongBitmap implements BitmapValues {
         return isEmpty() == false && last < 0;
     }
 
+    /**
+     * Always declines, which {@link BitmapValues#coversRange} permits, because the current implementation
+     * {@link Roaring64NavigableMap} exposes no range-containment method.
+     */
+    @Override
+    public boolean coversRange(long min, long max) {
+        return false;
+    }
+
     /** @return a iterator over the values, in ascending unsigned order */
     @Override
     public PeekableIterator iterator() {

--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/BitmapBKDQueryTests.java
@@ -293,22 +293,23 @@ public class BitmapBKDQueryTests extends ESTestCase {
     }
 
     /**
-     * Cross-checks the merge scan against {@link IntPoint#newSetQuery}/{@link LongPoint#newSetQuery} —
-     * the traditional way to express this query — over random data, sweeping term counts from 1 to 100
-     * where an off-by-one in a hand-written merge is most likely to show.
-     * <p>
-     * Compares the matched document ids rather than just how many matched: two queries can agree on a
-     * count while disagreeing on which documents, and that would be a silent correctness bug.
+     * Correctness cross-check against {@link org.apache.lucene.search.PointInSetQuery} over two layouts:
+     * <ol>
+     *   <li>Random values in a wide range, possibly multi-segment — the general case.</li>
+     *   <li>Dense consecutive values in a single segment, queried with a full-range bitmap — the shape
+     *       that makes cells covering more than one distinct value reachable as {@code CELL_INSIDE_QUERY}.</li>
+     * </ol>
      */
     public void testAgreesWithPointSetQuery() throws IOException {
         for (NumberType type : NumberType.values()) {
             long bound = type == NumberType.INT ? Integer.MAX_VALUE : Long.MAX_VALUE;
+            // Layout 1: random values, possibly multi-segment.
             try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
                 int docCount = randomIntBetween(50, 300);
                 long[] indexed = new long[docCount];
                 for (int i = 0; i < docCount; i++) {
                     // Draw some values from a deliberately narrow range so several documents share one
-                    // value, exercising the bulk-add and CELL_INSIDE_QUERY paths.
+                    // value, exercising the bulk-add and single-value CELL_INSIDE_QUERY path.
                     indexed[i] = randomLongBetween(0, randomBoolean() ? 50 : bound);
                     Document doc = new Document();
                     type.addField(doc, indexed[i]);
@@ -324,6 +325,37 @@ public class BitmapBKDQueryTests extends ESTestCase {
                             equalTo(matchingDocs(searcher, type.pointSetQuery(queried), docCount))
                         );
                     }
+                }
+            }
+            // Layout 2: dense consecutive values, single segment so BKD leaves are predictable.
+            // A bitmap covering [0, docCount) spans every leaf, exercising CELL_INSIDE_QUERY for
+            // cells holding more than one distinct value.
+            int docCount = 2000;
+            long[] run = new long[docCount];
+            for (int i = 0; i < docCount; i++) {
+                run[i] = i;
+            }
+            try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+                for (long value : run) {
+                    Document doc = new Document();
+                    type.addField(doc, value);
+                    w.addDocument(doc);
+                }
+                w.forceMerge(1);
+                try (IndexReader reader = w.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    assertThat(
+                        "type=" + type + " full run",
+                        matchingDocs(searcher, query(type, run), docCount),
+                        equalTo(matchingDocs(searcher, type.pointSetQuery(run), docCount))
+                    );
+                    // Also query the first half to cover inner cells, not only the root.
+                    long[] half = Arrays.copyOf(run, docCount / 2);
+                    assertThat(
+                        "type=" + type + " half run",
+                        matchingDocs(searcher, query(type, half), docCount),
+                        equalTo(matchingDocs(searcher, type.pointSetQuery(half), docCount))
+                    );
                 }
             }
         }


### PR DESCRIPTION
Applies to integer fields only: LongBitmap declines the range-containment check because Roaring64NavigableMap exposes no such method.

When the bitmap contains a contiguous run of values covering an entire BKD cell, report it as CELL_INSIDE_QUERY so Lucene adds its documents without decoding any point values. Previously only single-value cells were matched whole; a cell lying inside a run was reported as CELL_CROSSES_QUERY, so its leaves were decoded and every point compared. A free width guard in front of the probe rules it out early for scattered unique values, where a leaf spans far more values than it holds points and no cell can ever be covered.

The collecting path's cost() also no longer walks the BKD tree. It previously called PointValues#estimateDocCount, which traverses the tree, so a bool query walked it once to plan clause ordering and again to execute. Both paths now share a metadata-only estimate: bitmap cardinality scaled by average documents per distinct value, computed once per segment.

Measured on the prototype of this query, 10M docs in one segment, cardinality 10000, before -> after us/op:

  docsPerValue=100 runLength=4096  topN        2764 ->   60.9  45x
  docsPerValue=100 runLength=64    topN        3370 ->  623     5.4x
  docsPerValue=1   runLength=4096  collectAll   137 ->   65.1   2.1x
  docsPerValue=100 runLength=4096  collectAll  5499 -> 2819     2.0x