### PR TITLE
Backport reindex relocation fixes to 9.5

### DIFF
--- a/docs/changelog/150342.yaml
+++ b/docs/changelog/150342.yaml
@@ -1,0 +1,7 @@
+area: Reindex
+issues:
+ - 150294
+ - 150295
+pr: 150342
+summary: Eagerly fail reindexes that are unable to be relocated
+type: bug

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -38,15 +39,22 @@ import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.tasks.TaskResult;
 import org.elasticsearch.tasks.TaskResultsService;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.NodeShutdownTestUtils;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.NodeNotConnectedException;
+import org.junit.After;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -79,9 +87,16 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
     private static final String SOURCE = "reindex-relocation-source";
     private static final String DEST = "reindex-relocation-dest";
 
+    @After
+    public void clearTransportRules() {
+        for (String node : internalCluster().getNodeNames()) {
+            MockTransportService.getInstance(node).clearAllRules();
+        }
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(ReindexPlugin.class, ReindexManagementPlugin.class);
+        return Arrays.asList(ReindexPlugin.class, ReindexManagementPlugin.class, MockTransportService.TestPlugin.class);
     }
 
     @Override
@@ -513,9 +528,15 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
     }
 
     /**
-     * When the coordinating node stops mid-reindex, the client may get {@link ActionListener#onFailure} with
-     * {@link NodeClosedException}, or {@link ActionListener#onResponse} with a {@link BulkByPaginatedSearchResponse} whose
-     * {@link BulkByPaginatedSearchResponse#getBulkFailures()} wrap {@link NodeClosedException} after bulk indexing hits a closing node.
+     * When the coordinating node stops mid-reindex, the client may see one of:
+     * <ul>
+     *   <li>{@link ActionListener#onFailure} with {@link NodeClosedException} — transport closed before the task exited</li>
+     *   <li>{@link ActionListener#onResponse} with {@link BulkByPaginatedSearchResponse} whose
+     *       {@link BulkByPaginatedSearchResponse#getBulkFailures()} wrap {@link NodeClosedException} — bulk ops hit the closing node</li>
+     *   <li>{@link ActionListener#onResponse} with {@link BulkByPaginatedSearchResponse} whose
+     *       {@link BulkByPaginatedSearchResponse#getReasonCancelled()} is {@code "node shutting down"} — the task was cancelled by
+     *       the shutdown hook and exited before the transport closed</li>
+     * </ul>
      */
     private static boolean reindexClientIndicatesCoordinatingNodeClosed(
         final Throwable clientFailure,
@@ -529,6 +550,9 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
                 if (ExceptionsHelper.unwrapCause(bulkFailure.getCause()) instanceof NodeClosedException) {
                     return true;
                 }
+            }
+            if (ShutdownPrepareService.CANNOT_RELOCATE_REINDEX_CANCEL_REASON.equals(response.getReasonCancelled())) {
+                return true;
             }
         }
         return false;
@@ -641,6 +665,127 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
         return getExceptionName(NodeNotConnectedException.class).equals(type)
             || getExceptionName(NodeDisconnectedException.class).equals(type)
             || getExceptionName(SearchContextMissingException.class).equals(type);
+    }
+
+    /**
+     * Verifies that a reindex task that has committed a relocation handoff ({@code HANDOFF_INITIATED} state) is
+     * <em>not</em> cancelled when the shutdown reindex relocation timeout expires.
+     */
+    @TestLogging(
+        value = "org.elasticsearch.node.ShutdownPrepareService:DEBUG",
+        reason = "So we can know when the task cancellation was attempted"
+    )
+    public void testRelocatingTaskIsNotCancelledOnShutdownTimeout() throws Exception {
+        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
+
+        internalCluster().startMasterOnlyNode();
+        final String dataNodeName = internalCluster().startDataOnlyNode();
+
+        // Short reindex timeout so the cancellation phase fires while the relocation is in-flight.
+        final Settings coordSettings = Settings.builder()
+            .put(MAXIMUM_REINDEXING_TIMEOUT_SETTING.getKey(), TimeValue.timeValueSeconds(1))
+            .build();
+        final String coordNodeName = internalCluster().startCoordinatingOnlyNode(coordSettings);
+
+        ensureStableCluster(3);
+
+        final int numDocs = randomIntBetween(10, 40);
+        createIndex(SOURCE);
+        indexRandom(true, SOURCE, numDocs);
+        assertHitCount(prepareSearch(SOURCE).setSize(0).setTrackTotalHits(true), numDocs);
+
+        final ReindexRequest request = new ReindexRequest().setSourceIndices(SOURCE)
+            .setDestIndex(DEST)
+            .setRefresh(true)
+            .setShouldStoreResult(true)
+            .setEligibleForRelocationOnShutdown(true)
+            .setRequestsPerSecond(0.000001f);
+        request.getSearchRequest().source().size(1000);
+
+        final CountDownLatch listenerDone = new CountDownLatch(1);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        internalCluster().client(coordNodeName).execute(ReindexAction.INSTANCE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(BulkByPaginatedSearchResponse r) {
+                listenerDone.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failure.set(e);
+                listenerDone.countDown();
+            }
+        });
+
+        waitForRootReindexTask(coordNodeName);
+
+        // Block the ResumeReindexAction on the destination node so the task stays in HANDOFF_INITIATED
+        // long enough for the shutdown timeout to fire.
+        final CountDownLatch resumeBlocked = new CountDownLatch(1);
+        final CountDownLatch resumeStarted = new CountDownLatch(1);
+        MockTransportService.getInstance(dataNodeName)
+            .addRequestHandlingBehavior(ResumeReindexAction.NAME, (handler, req, channel, task) -> {
+                resumeStarted.countDown();
+                safeAwait(resumeBlocked);
+                handler.messageReceived(req, channel, task);
+            });
+
+        final var executor = Executors.newSingleThreadExecutor();
+        try (MockLog mockLog = MockLog.capture(ShutdownPrepareService.class)) {
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "ensureCancellable() threw and the cancel was aborted",
+                    ShutdownPrepareService.class.getName(),
+                    Level.DEBUG,
+                    "Unable to cancel reindex task *"
+                )
+            );
+
+            // Run prepareForShutdown in a background thread: it marks the task for relocation then blocks
+            // waiting for the task to exit (which won’t happen until we release the transport block).
+            Future<?> shutdownFuture = executor.submit(
+                () -> internalCluster().getInstance(ShutdownPrepareService.class, coordNodeName).prepareForShutdown()
+            );
+
+            // Rethrottle so the task quickly processes its page and commits the relocation handoff.
+            rethrottleRunningRootReindex(numDocs);
+
+            // Wait until the ResumeReindexAction is in-flight: the task is now in HANDOFF_INITIATED state.
+            safeAwait(resumeStarted);
+
+            // Wait for the cancellation to fail
+            mockLog.awaitAllExpectationsMatched();
+
+            // Release the transport block. With the fix the task was NOT cancelled, so the destination
+            // handler runs and the relocation completes normally.
+            resumeBlocked.countDown();
+
+            // The source task should complete via TaskRelocatedException (relocated, not cancelled).
+            safeAwait(listenerDone);
+            final var taskRelocatedException = asInstanceOf(TaskRelocatedException.class, ExceptionsHelper.unwrapCause(failure.get()));
+            final String relocatedTaskIdString = taskRelocatedException.getRelocatedTaskId().orElseThrow();
+
+            // Wait for prepareForShutdown to return (it will see the task is gone and exit its inner loop).
+            safeGet(shutdownFuture);
+
+            // The relocated task should complete successfully on the data node.
+            final GetTaskResponse relocatedResult = clusterAdmin().prepareGetTask(new TaskId(relocatedTaskIdString))
+                .setWaitForCompletion(true)
+                .setTimeout(TimeValue.timeValueSeconds(60))
+                .get();
+            final var taskResult = relocatedResult.getTask();
+            assertTrue("relocated reindex should complete", taskResult.isCompleted());
+            assertNull("relocated reindex should not have errored", taskResult.getError());
+
+            assertBusy(() -> {
+                assertTrue(indexExists(DEST));
+                flushAndRefresh(DEST);
+                assertHitCount(prepareSearch(DEST).setSize(0).setTrackTotalHits(true), numDocs);
+            }, 30, TimeUnit.SECONDS);
+
+        } finally {
+            ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        }
     }
 
     /**

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.node.ListenableShutdownPrepareService;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.plugins.Plugin;
@@ -96,7 +97,12 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(ReindexPlugin.class, ReindexManagementPlugin.class, MockTransportService.TestPlugin.class);
+        return Arrays.asList(
+            ReindexPlugin.class,
+            ReindexManagementPlugin.class,
+            MockTransportService.TestPlugin.class,
+            ListenableShutdownPrepareService.TestPlugin.class
+        );
     }
 
     @Override
@@ -702,7 +708,8 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
             .setShouldStoreResult(true)
             .setEligibleForRelocationOnShutdown(true)
             .setRequestsPerSecond(requestsPerSecond);
-        request.getSearchRequest().source().size(5);
+        // Batches of 1 should only delay ~300ms, meaning the relocation should start sooner
+        request.getSearchRequest().source().size(1);
 
         final CountDownLatch listenerDone = new CountDownLatch(1);
         final AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -743,14 +750,20 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
                 )
             );
 
+            // Prevent the cancellation from beginning until the task is in HANDOFF_INITIATED state.
+            final var shutdownPrepareService = asInstanceOf(
+                ListenableShutdownPrepareService.class,
+                internalCluster().getInstance(ShutdownPrepareService.class, coordNodeName)
+            );
+            shutdownPrepareService.addTaskTimeoutListener((taskName, tasks) -> {
+                if (ReindexAction.NAME.equals(taskName)) {
+                    safeAwait(resumeStarted);
+                }
+            });
+
             // Run prepareForShutdown in a background thread: it marks the task for relocation then blocks
             // waiting for the task to exit (which won’t happen until we release the transport block).
-            Future<?> shutdownFuture = executor.submit(
-                () -> internalCluster().getInstance(ShutdownPrepareService.class, coordNodeName).prepareForShutdown()
-            );
-
-            // Wait until the ResumeReindexAction is in-flight: the task is now in HANDOFF_INITIATED state.
-            safeAwait(resumeStarted);
+            Future<?> shutdownFuture = executor.submit(shutdownPrepareService::prepareForShutdown);
 
             // Wait for the cancellation to fail
             mockLog.awaitAllExpectationsMatched();

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -689,18 +689,20 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
 
         ensureStableCluster(3);
 
-        final int numDocs = randomIntBetween(10, 40);
+        final int numDocs = randomIntBetween(100, 120);
         createIndex(SOURCE);
         indexRandom(true, SOURCE, numDocs);
         assertHitCount(prepareSearch(SOURCE).setSize(0).setTrackTotalHits(true), numDocs);
 
+        // Reindex should take 30s, doing about 3 docs/s
+        final float requestsPerSecond = numDocs / 30.0f;
         final ReindexRequest request = new ReindexRequest().setSourceIndices(SOURCE)
             .setDestIndex(DEST)
             .setRefresh(true)
             .setShouldStoreResult(true)
             .setEligibleForRelocationOnShutdown(true)
-            .setRequestsPerSecond(0.000001f);
-        request.getSearchRequest().source().size(1000);
+            .setRequestsPerSecond(requestsPerSecond);
+        request.getSearchRequest().source().size(5);
 
         final CountDownLatch listenerDone = new CountDownLatch(1);
         final AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -747,9 +749,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
                 () -> internalCluster().getInstance(ShutdownPrepareService.class, coordNodeName).prepareForShutdown()
             );
 
-            // Rethrottle so the task quickly processes its page and commits the relocation handoff.
-            rethrottleRunningRootReindex(numDocs);
-
             // Wait until the ResumeReindexAction is in-flight: the task is now in HANDOFF_INITIATED state.
             safeAwait(resumeStarted);
 
@@ -759,6 +758,9 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
             // Release the transport block. With the fix the task was NOT cancelled, so the destination
             // handler runs and the relocation completes normally.
             resumeBlocked.countDown();
+
+            // We've seen everything we need to see, rethrottle to allow the task to finish
+            rethrottleRunningRootReindex(numDocs);
 
             // The source task should complete via TaskRelocatedException (relocated, not cancelled).
             safeAwait(listenerDone);

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -769,11 +769,8 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
             mockLog.awaitAllExpectationsMatched();
 
             // Release the transport block. With the fix the task was NOT cancelled, so the destination
-            // handler runs and the relocation completes normally.
+            // handler runs, and the relocation completes normally.
             resumeBlocked.countDown();
-
-            // We've seen everything we need to see, rethrottle to allow the task to finish
-            rethrottleRunningRootReindex(numDocs);
 
             // The source task should complete via TaskRelocatedException (relocated, not cancelled).
             safeAwait(listenerDone);
@@ -782,6 +779,9 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
 
             // Wait for prepareForShutdown to return (it will see the task is gone and exit its inner loop).
             safeGet(shutdownFuture);
+
+            // We've seen everything we need to see, rethrottle to allow the task to finish
+            rethrottleRunningRootReindex(numDocs);
 
             // The relocated task should complete successfully on the data node.
             final GetTaskResponse relocatedResult = clusterAdmin().prepareGetTask(new TaskId(relocatedTaskIdString))

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -162,13 +162,9 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
         shutdownPrepareService.prepareForShutdown();
         // Therefore, we rethrottle the reindexing task to run unlimited requests per second, immediately triggering relocation
         rethrottleRunningRootReindex(numDocs);
-
-        // Wait for the client listener before stopping the node: the relocation is initiated but the listener may be not completed.
-        // Stopping the node concurrently can strand their response handlers in already-terminated thread pools, hanging the listener and
-        // leaking the stranded messages' network buffers
-        assertTrue("reindex listener should complete", listenerDone.await(30, TimeUnit.SECONDS));
-
         internalCluster().stopNode(coordNodeName);
+
+        assertTrue("reindex listener should complete", listenerDone.await(30, TimeUnit.SECONDS));
 
         // Assert that the reindexing task on the first node failed
         final Throwable error = failure.get();
@@ -427,11 +423,7 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
         final Throwable error = failure.get();
         final BulkByPaginatedSearchResponse response = success.get();
         assertTrue(
-            "reindex should surface coordinator shutdown as a transport failure or as bulk failures on the response, but got error=["
-                + error
-                + "], response=["
-                + response
-                + "]",
+            "reindex should surface coordinator shutdown as a transport failure or as bulk failures on the response",
             reindexClientIndicatesCoordinatingNodeClosed(error, response)
         );
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -483,12 +483,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.TDigestPercentilesIT
   method: testSingleValuedFieldPartiallyUnmapped
   issue: https://github.com/elastic/elasticsearch/issues/156864
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testReindexTaskFailsWhenDataNodeIsShuttingDownAndTaskDoesNotFinishInTime
-  issue: https://github.com/elastic/elasticsearch/issues/157345
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testReindexTaskFinishesBeforeNodeShutsDown
-  issue: https://github.com/elastic/elasticsearch/issues/157346
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/157223

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1350,7 +1350,13 @@ class NodeConstruction {
             threadPool
         );
 
-        final var shutdownPrepareService = new ShutdownPrepareService(settings, httpServerTransport, transportService, terminationHandler);
+        final var shutdownPrepareService = serviceProvider.newShutdownPrepareService(
+            pluginsService,
+            settings,
+            httpServerTransport,
+            transportService,
+            terminationHandler
+        );
 
         modules.add(
             loadPersistentTasks(

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -32,6 +32,7 @@ import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.node.internal.TerminationHandler;
 import org.elasticsearch.plugins.PluginsLoader;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.readiness.ReadinessService;
@@ -196,5 +197,15 @@ class NodeServiceProvider {
 
     ReadinessService newReadinessService(PluginsService pluginsService, ClusterService clusterService, Environment environment) {
         return new ReadinessService(clusterService, environment);
+    }
+
+    ShutdownPrepareService newShutdownPrepareService(
+        PluginsService pluginsService,
+        Settings settings,
+        HttpServerTransport httpServerTransport,
+        TransportService transportService,
+        TerminationHandler terminationHandler
+    ) {
+        return new ShutdownPrepareService(settings, httpServerTransport, transportService, terminationHandler);
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -179,16 +179,27 @@ public class ShutdownPrepareService {
         }
     }
 
-    /// The polling interval used by [#awaitTasksComplete]. Chosen to allow short response times, but (since checking the tasks list is
-    /// relatively expensive) not so short that we waste CPU time we could be spending on finishing those tasks.
+    /// The polling interval used by [#awaitTasksCompleteInternal]. Chosen to allow short response times, but (since checking the tasks list
+    /// is relatively expensive) not so short that we waste CPU time we could be spending on finishing those tasks.
     static final TimeValue AWAIT_TASKS_POLL_INTERVAL = TimeValue.timeValueMillis(500);
 
     // exists and package-private for testing
-    static class Sleeper {
+    protected static class Sleeper {
 
         void sleep(TimeValue interval) throws InterruptedException {
             Thread.sleep(interval.millis());
         }
+    }
+
+    protected boolean awaitTasksComplete(
+        TimeValue timeout,
+        Sleeper sleeper,
+        String taskName,
+        TaskManager taskManager,
+        @Nullable Consumer<Task> taskNotifier,
+        @Nullable Consumer<List<Task>> onTimeout
+    ) {
+        return awaitTasksCompleteInternal(timeout, sleeper, taskName, taskManager, taskNotifier, onTimeout);
     }
 
     /// Repeatedly polls the `taskManager` to list tasks whose action name is `taskName`, invoking `sleeper` to sleep for
@@ -196,7 +207,7 @@ public class ShutdownPrepareService {
     /// `timeout`. Invokes `taskNotifier` exactly once for each matching task encountered. Returns true if it found no matching tasks, false
     /// if it timed out or was interrupted.
     // package-private for testing
-    static boolean awaitTasksComplete(
+    static boolean awaitTasksCompleteInternal(
         TimeValue timeout,
         Sleeper sleeper,
         String taskName,

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -11,10 +11,13 @@ package org.elasticsearch.node;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -23,6 +26,7 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.reindex.BulkByPaginatedSearchTask;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.node.internal.TerminationHandler;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
@@ -50,6 +54,8 @@ import java.util.stream.Collectors;
  */
 public class ShutdownPrepareService {
 
+    public static final String CANNOT_RELOCATE_REINDEX_CANCEL_REASON = "node shutting down";
+
     private record ShutdownHook(String name, Runnable action) {}
 
     public static final Setting<TimeValue> MAXIMUM_SHUTDOWN_TIMEOUT_SETTING = Setting.positiveTimeSetting(
@@ -63,6 +69,13 @@ public class ShutdownPrepareService {
         TimeValue.timeValueSeconds(10),
         Setting.Property.NodeScope
     );
+
+    /**
+     * How long we'll wait for the non-relocatable reindexing tasks to cancel before
+     * we proceed with shutdown. This should not be very long because we've already timed out
+     * waiting for the tasks to relocate.
+     */
+    private static final TimeValue REINDEXING_CANCELLATION_TIMEOUT = TimeValue.timeValueSeconds(10);
 
     private static final Logger logger = LogManager.getLogger(ShutdownPrepareService.class);
 
@@ -188,7 +201,8 @@ public class ShutdownPrepareService {
         Sleeper sleeper,
         String taskName,
         TaskManager taskManager,
-        @Nullable Consumer<Task> taskNotifier
+        @Nullable Consumer<Task> taskNotifier,
+        @Nullable Consumer<List<Task>> onTimeout
     ) {
         long millisWaited = 0;
         Set<Long> tasksNotified = new HashSet<>();
@@ -211,6 +225,9 @@ public class ShutdownPrepareService {
                 millisWaited += AWAIT_TASKS_POLL_INTERVAL.millis();
                 if (TimeValue.ZERO.equals(timeout) == false && millisWaited >= timeout.millis()) {
                     logger.warn("timed out after waiting [{}] for [{}] {} tasks to finish", timeout, tasksRemaining.size(), taskName);
+                    if (onTimeout != null) {
+                        onTimeout.accept(tasksRemaining);
+                    }
                     return false;
                 }
                 logger.debug(
@@ -231,16 +248,44 @@ public class ShutdownPrepareService {
     }
 
     private void awaitSearchTasksComplete(TimeValue asyncSearchTimeout, TaskManager taskManager) {
-        awaitTasksComplete(asyncSearchTimeout, new Sleeper(), TransportSearchAction.NAME, taskManager, null);
+        awaitTasksComplete(asyncSearchTimeout, new Sleeper(), TransportSearchAction.NAME, taskManager, null, null);
     }
 
     private void relocateReindexTasksAndAwaitComplete(TimeValue asyncReindexTimeout, TaskManager taskManager) {
+        final var sleeper = new Sleeper();
         awaitTasksComplete(
             asyncReindexTimeout,
-            new Sleeper(),
+            sleeper,
             ReindexAction.NAME,
             taskManager,
-            task -> maybeRequestRelocationForBulkByPaginatedSearch(task, taskManager)
+            task -> maybeRequestRelocationForBulkByPaginatedSearch(task, taskManager),
+            tasks -> {
+                // Cancel any reindex tasks that could not be relocated, then wait a short time
+                // for them to exit the task manager before proceeding with shutdown.
+                tasks.forEach(t -> {
+                    if (t instanceof CancellableTask cancellable) {
+                        try {
+                            // We know that BulkByPaginatedSearchTask implements ensureCancellable, so call it
+                            // first to avoid cancelling actively relocating tasks
+                            // TaskManager should probably do this (see https://github.com/elastic/elasticsearch/issues/155444)
+                            cancellable.ensureCancellable();
+                            taskManager.cancelTaskAndDescendants(
+                                cancellable,
+                                CANNOT_RELOCATE_REINDEX_CANCEL_REASON,
+                                false,
+                                ActionListener.noop()
+                            );
+                        } catch (ElasticsearchStatusException e) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug(() -> Strings.format("Unable to cancel reindex task %s", t), e);
+                            }
+                        }
+                    } else {
+                        assert false : "Expected reindex tasks to be cancellable";
+                    }
+                });
+                awaitTasksComplete(REINDEXING_CANCELLATION_TIMEOUT, sleeper, ReindexAction.NAME, taskManager, null, null);
+            }
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
@@ -51,6 +51,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             mock(),
             actionName,
             taskManager,
+            null,
             null
         );
         assertThat(completed, is(false));
@@ -84,6 +85,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             mock(),
             actionName,
             taskManager,
+            null,
             null
         );
         assertThat(completed, is(true));
@@ -140,7 +142,8 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             mock(),
             actionName,
             taskManager,
-            notified::add
+            notified::add,
+            null
         );
         assertThat(notified, containsInAnyOrder(task1, task2, task3)); // should notify each task exactly once
     }

--- a/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 public class ShutdownPrepareServiceTests extends ESTestCase {
 
-    public void testAwaitTasksComplete_timesOut() {
+    public void testAwaitTasksCompleteInternal_timesOut() {
         String actionName = "test:action/name";
         TaskManager taskManager = mock();
         long taskId = randomNonNegativeLong();
@@ -46,7 +46,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
         );
         when(taskManager.getTasks()).thenReturn(Map.of(taskId, task));
 
-        boolean completed = ShutdownPrepareService.awaitTasksComplete(
+        boolean completed = ShutdownPrepareService.awaitTasksCompleteInternal(
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,
@@ -57,7 +57,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
         assertThat(completed, is(false));
     }
 
-    public void testAwaitTasksComplete_completes() {
+    public void testAwaitTasksCompleteInternal_completes() {
         String actionName = "test:action/name";
         TaskManager taskManager = mock();
         long taskId = randomNonNegativeLong();
@@ -80,7 +80,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             // Third call: empty
             .thenReturn(Map.of());
 
-        boolean completed = ShutdownPrepareService.awaitTasksComplete(
+        boolean completed = ShutdownPrepareService.awaitTasksCompleteInternal(
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,
@@ -91,7 +91,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
         assertThat(completed, is(true));
     }
 
-    public void testAwaitTasksComplete_invokesNotifierExactlyOnceForEachTask() {
+    public void testAwaitTasksCompleteInternal_invokesNotifierExactlyOnceForEachTask() {
         String actionName = "test:action/name";
         TaskManager taskManager = mock();
         String nodeId = randomAlphaOfLength(10);
@@ -137,7 +137,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             .thenReturn(Map.of(taskId2, task2));
 
         List<Task> notified = new ArrayList<>();
-        ShutdownPrepareService.awaitTasksComplete(
+        ShutdownPrepareService.awaitTasksCompleteInternal(
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,

--- a/test/framework/src/main/java/org/elasticsearch/node/ListenableShutdownPrepareService.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/ListenableShutdownPrepareService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.node;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.internal.TerminationHandler;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/// A [ShutdownPrepareService] that allows tests to listen for task timeouts
+public class ListenableShutdownPrepareService extends ShutdownPrepareService {
+
+    /// Notified when [#awaitTasksComplete(TimeValue, Sleeper, String, TaskManager, Consumer, Consumer)] times out
+    public interface TaskTimeoutListener {
+
+        /// @param taskName The type of task that failed
+        /// @param tasks The list of tasks that timed out
+        void onTimeout(String taskName, List<Task> tasks);
+    }
+
+    private final List<TaskTimeoutListener> taskTimeoutListeners = new CopyOnWriteArrayList<>();
+
+    public ListenableShutdownPrepareService(
+        Settings settings,
+        HttpServerTransport httpServerTransport,
+        TransportService transportService,
+        TerminationHandler terminationHandler
+    ) {
+        super(settings, httpServerTransport, transportService, terminationHandler);
+    }
+
+    /// Marker plugin to indicate we should use the listenable service
+    public static class TestPlugin extends org.elasticsearch.plugins.Plugin {}
+
+    public void addTaskTimeoutListener(TaskTimeoutListener listener) {
+        taskTimeoutListeners.add(listener);
+    }
+
+    @Override
+    protected boolean awaitTasksComplete(
+        TimeValue timeout,
+        Sleeper sleeper,
+        String taskName,
+        TaskManager taskManager,
+        @Nullable Consumer<Task> taskNotifier,
+        @Nullable Consumer<List<Task>> onTimeout
+    ) {
+        return awaitTasksCompleteInternal(timeout, sleeper, taskName, taskManager, taskNotifier, tasks -> {
+            notifyTaskTimeout(taskName, tasks);
+            if (onTimeout != null) {
+                onTimeout.accept(tasks);
+            }
+        });
+    }
+
+    private void notifyTaskTimeout(String taskName, List<Task> tasks) {
+        for (TaskTimeoutListener listener : taskTimeoutListeners) {
+            listener.onTimeout(taskName, tasks);
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
@@ -32,6 +32,7 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.node.internal.TerminationHandler;
 import org.elasticsearch.plugins.MockPluginsService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsLoader;
@@ -276,6 +277,20 @@ public class MockNode extends Node {
             } else {
                 return new MockHttpTransport();
             }
+        }
+
+        @Override
+        ShutdownPrepareService newShutdownPrepareService(
+            PluginsService pluginsService,
+            Settings settings,
+            HttpServerTransport httpServerTransport,
+            TransportService transportService,
+            TerminationHandler terminationHandler
+        ) {
+            if (pluginsService.filterPlugins(ListenableShutdownPrepareService.TestPlugin.class).findAny().isPresent()) {
+                return new ListenableShutdownPrepareService(settings, httpServerTransport, transportService, terminationHandler);
+            }
+            return super.newShutdownPrepareService(pluginsService, settings, httpServerTransport, transportService, terminationHandler);
         }
     }
 


### PR DESCRIPTION
There were a bunch of race conditions in reindex relocation, the tests for it, the fixes for those issues, and the tests for the fixes for those issues.

This PR
- Reverts https://github.com/elastic/elasticsearch/pull/157074 (I think this race is fixed by the back-ported PRs below)
- Backports https://github.com/elastic/elasticsearch/pull/150342 (The actual fix for the shutdown race)
- Backports https://github.com/elastic/elasticsearch/pull/156006 (A fix for a race in the test for the previous fix)
- Backports https://github.com/elastic/elasticsearch/pull/156124 (Elaborate test infrastructure to make the test deterministic)
- Backports https://github.com/elastic/elasticsearch/pull/156625 (One more race condition)

All the backports were clean

I could be wrong, perhaps #157074 fixes another race, but the description sounds very much like a manifestation of what #150342 fixed. And interesting that these failures occurred on 9.5 not main (my bad for not back-porting, sincerest apologies)

Fixes #157345 
Fixes #157346 

