### PR TITLE
Reuse block hash in periodic partial emits

### DIFF
--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/LongLongSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/LongLongSwissHash.java
@@ -276,6 +276,10 @@ public class LongLongSwissHash extends SwissHash implements LongLongHashTable {
             }
         }
 
+        void clear() {
+            Arrays.fill(idPage, (byte) 0xff);
+        }
+
         void transitionToBigCore() {
             growTracking();
             try {
@@ -515,6 +519,11 @@ public class LongLongSwissHash extends SwissHash implements LongLongHashTable {
             }
         }
 
+        void clear() {
+            Arrays.fill(controlData, EMPTY);
+            insertProbes = 0;
+        }
+
         @Override
         protected Status status() {
             return new BigCoreStatus(growCount, capacity, size, nextGrowSize, insertProbes, keyPages.length, idPages.length);
@@ -652,6 +661,17 @@ public class LongLongSwissHash extends SwissHash implements LongLongHashTable {
         Objects.checkIndex(actualId, size());
         final long keyOffset = keyOffset(actualId);
         return smallCore != null ? smallCore.key2(Math.toIntExact(keyOffset)) : bigCore.key2(keyOffset);
+    }
+
+    @Override
+    public void clear() {
+        if (smallCore != null) {
+            smallCore.clear();
+        }
+        if (bigCore != null) {
+            bigCore.clear();
+        }
+        size = 0;
     }
 
     private long keyOffset(final int id) {

--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/LongSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/LongSwissHash.java
@@ -322,6 +322,10 @@ public final class LongSwissHash extends SwissHash implements LongHashTable {
             }
         }
 
+        void clear() {
+            Arrays.fill(idPage, (byte) 0xff);
+        }
+
         void transitionToBigCore() {
             growTracking();
             try {
@@ -545,6 +549,11 @@ public final class LongSwissHash extends SwissHash implements LongHashTable {
             }
         }
 
+        void clear() {
+            Arrays.fill(controlData, EMPTY);
+            insertProbes = 0;
+        }
+
         @Override
         protected Status status() {
             return new BigCoreStatus(growCount, capacity, size, nextGrowSize, insertProbes, keyPages.length, idPages.length);
@@ -652,6 +661,17 @@ public final class LongSwissHash extends SwissHash implements LongHashTable {
         final int actualId = Math.toIntExact(id);
         Objects.checkIndex(actualId, size());
         return smallCore != null ? smallCore.key(actualId) : bigCore.key(actualId);
+    }
+
+    @Override
+    public void clear() {
+        if (smallCore != null) {
+            smallCore.clear();
+        }
+        if (bigCore != null) {
+            bigCore.clear();
+        }
+        size = 0;
     }
 
     private int keyOffset(final int id) {

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/LongLongSwissHashTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/LongLongSwissHashTests.java
@@ -160,6 +160,42 @@ public class LongLongSwissHashTests extends ESTestCase {
         assertThat(recycler.open, hasSize(0));
     }
 
+    public void testClear() {
+        Set<Long> values = randomValues(count);
+        long[] v1 = values.stream().mapToLong(Long::longValue).toArray();
+        long[] v2 = new long[count];
+        for (int i = 0; i < count; i++) {
+            v2[i] = randomLong();
+        }
+
+        TestRecycler recycler = new TestRecycler();
+        CircuitBreaker breaker = new NoopCircuitBreaker("test");
+        try (LongLongSwissHash hash = new LongLongSwissHash(recycler, breaker)) {
+            for (int i = 0; i < count; i++) {
+                assertThat(hash.add(v1[i], v2[i]), equalTo((long) i));
+            }
+            int openPages = recycler.open.size();
+            hash.clear();
+            assertThat(hash.size(), equalTo(0L));
+            assertFalse(hash.iterator().next());
+            for (int i = 0; i < count; i++) {
+                assertThat(hash.find(v1[i], v2[i]), equalTo(-1L));
+            }
+            for (int i = 0; i < count; i++) {
+                assertThat(hash.add(v1[i], v2[i]), equalTo((long) i));
+            }
+            assertThat(hash.size(), equalTo((long) count));
+            for (int i = 0; i < count; i++) {
+                assertThat(hash.find(v1[i], v2[i]), equalTo((long) i));
+                assertThat(hash.getKey1(i), equalTo(v1[i]));
+                assertThat(hash.getKey2(i), equalTo(v2[i]));
+            }
+            assertThat("clear keeps allocated pages for reuse", recycler.open, hasSize(openPages));
+            assertStatus(hash);
+        }
+        assertThat(recycler.open, hasSize(0));
+    }
+
     // High-probability bucket collisions. You just need structural patterns that
     // tend to collide in the bucket selection logic.
 

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/LongSwissHashTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/LongSwissHashTests.java
@@ -229,6 +229,36 @@ public class LongSwissHashTests extends ESTestCase {
         }
     }
 
+    public void testClear() {
+        Set<Long> values = randomValues(count);
+        long[] v = values.stream().mapToLong(Long::longValue).toArray();
+        TestRecycler recycler = new TestRecycler();
+        CircuitBreaker breaker = new NoopCircuitBreaker("test");
+        try (LongSwissHash hash = new LongSwissHash(recycler, breaker)) {
+            for (int i = 0; i < v.length; i++) {
+                assertThat(hash.add(v[i]), equalTo((long) i));
+            }
+            int openPages = recycler.open.size();
+            hash.clear();
+            assertThat(hash.size(), equalTo(0L));
+            assertFalse(hash.iterator().next());
+            for (long value : v) {
+                assertThat(hash.find(value), equalTo(-1L));
+            }
+            for (int i = 0; i < v.length; i++) {
+                assertThat(hash.add(v[i]), equalTo((long) i));
+            }
+            assertThat(hash.size(), equalTo((long) v.length));
+            for (int i = 0; i < v.length; i++) {
+                assertThat(hash.find(v[i]), equalTo((long) i));
+                assertThat(hash.get(i), equalTo(v[i]));
+            }
+            assertThat("clear keeps allocated pages for reuse", recycler.open, hasSize(openPages));
+            assertStatus(hash);
+        }
+        assertThat(recycler.open, hasSize(0));
+    }
+
     // High-probability bucket collisions. You just need structural patterns that
     // tend to collide in the bucket selection logic.
 

--- a/server/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -118,6 +118,12 @@ public final class LongHash extends AbstractHash implements LongHashTable {
     }
 
     @Override
+    public void clear() {
+        size = 0;
+        ids.fill(0, ids.size(), 0);
+    }
+
+    @Override
     public void close() {
         try (Releasable releasable = keys) {
             super.close();

--- a/server/src/main/java/org/elasticsearch/common/util/LongHashTable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongHashTable.java
@@ -36,4 +36,9 @@ public interface LongHashTable extends Releasable {
 
     /** Returns the size (number of key/value pairs) in the table.*/
     long size();
+
+    /**
+     * Removes all entries, keeping the allocated structures for reuse. The hash will be empty after this call returns.
+     */
+    void clear();
 }

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -147,6 +147,12 @@ public final class LongLongHash extends AbstractHash implements LongLongHashTabl
     }
 
     @Override
+    public void clear() {
+        size = 0;
+        ids.fill(0, ids.size(), 0);
+    }
+
+    @Override
     public void close() {
         Releasables.close(keys, () -> super.close());
     }

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHashTable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHashTable.java
@@ -57,4 +57,9 @@ public interface LongLongHashTable extends Releasable, Accountable {
     default void bulkAdd(long[] key1s, long[] key2s, int[] ids, int length) {
         throw new UnsupportedOperationException("bulkAdd is not supported");
     }
+
+    /**
+     * Removes all entries, keeping the allocated structures for reuse. The hash will be empty after this call returns.
+     */
+    void clear();
 }

--- a/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -181,6 +181,32 @@ public class LongHashTests extends ESTestCase {
         hash.close();
     }
 
+    public void testClear() {
+        try (LongHash hash = randomHash()) {
+            int rounds = between(2, 5);
+            for (int round = 0; round < rounds; round++) {
+                int count = randomIntBetween(1, 10_000);
+                Set<Long> distinct = new HashSet<>();
+                while (distinct.size() < count) {
+                    distinct.add(randomLong());
+                }
+                long[] keys = distinct.stream().mapToLong(Long::longValue).toArray();
+                for (int i = 0; i < count; i++) {
+                    assertEquals(i, hash.add(keys[i]));
+                    assertEquals(keys[i], hash.get(i));
+                }
+                assertEquals(count, hash.size());
+
+                hash.clear();
+
+                assertEquals(0, hash.size());
+                for (int i = 0; i < count; i++) {
+                    assertEquals(-1, hash.find(keys[i]));
+                }
+            }
+        }
+    }
+
     public void testAllocation() {
         MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(160), bigArrays -> new LongHash(1, bigArrays));
     }

--- a/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
@@ -16,8 +16,10 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -93,6 +95,37 @@ public class LongLongHashTests extends ESTestCase {
 
     public void testAllocation() {
         MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(256), bigArrays -> new LongLongHash(1, bigArrays));
+    }
+
+    public void testClear() {
+        try (LongLongHash hash = randomHash()) {
+            int rounds = between(2, 5);
+            for (int round = 0; round < rounds; round++) {
+                int count = randomIntBetween(1, 10_000);
+                Set<Long> distinct = new HashSet<>();
+                while (distinct.size() < count) {
+                    distinct.add(randomLong());
+                }
+                long[] key1s = distinct.stream().mapToLong(Long::longValue).toArray();
+                long[] key2s = new long[count];
+                for (int i = 0; i < count; i++) {
+                    key2s[i] = randomLong();
+                }
+                for (int i = 0; i < count; i++) {
+                    assertThat(hash.add(key1s[i], key2s[i]), equalTo((long) i));
+                    assertThat(hash.getKey1(i), equalTo(key1s[i]));
+                    assertThat(hash.getKey2(i), equalTo(key2s[i]));
+                }
+                assertThat(hash.size(), equalTo((long) count));
+
+                hash.clear();
+
+                assertThat(hash.size(), equalTo(0L));
+                for (int i = 0; i < count; i++) {
+                    assertThat(hash.find(key1s[i], key2s[i]), equalTo(-1L));
+                }
+            }
+        }
     }
 
     class Key {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -71,6 +71,13 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRefBlockHash(channel, blockFactory);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -60,6 +60,13 @@ final class DoubleBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        seenNull = false;
+        hash.clear();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -60,6 +60,13 @@ final class IntBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        seenNull = false;
+        hash.clear();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -65,6 +65,13 @@ final class LongBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        seenNull = false;
+        hash.clear();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -71,6 +71,13 @@ public abstract class BlockHash implements Releasable, SeenGroupIds {
     }
 
     /**
+     * Resets this block hash in place if possible; otherwise closes it and creates a new one with the
+     * same configuration. Callers must only use the returned instance afterwards. This lets operators
+     * that emit periodically refill the hash without paying for allocations and resizes again.
+     */
+    public abstract BlockHash resetOrCreate();
+
+    /**
      * Add all values for the "group by" columns in the page to the hash and
      * pass the ordinals to the provided {@link GroupingAggregatorFunction.AddInput}.
      * <p>

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -20,6 +20,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBoolean;
 import org.elasticsearch.core.ReleasableIterator;
 
+import java.util.Arrays;
+
 import static org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBoolean.FALSE_ORD;
 import static org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBoolean.NULL_ORD;
 import static org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBoolean.TRUE_ORD;
@@ -36,6 +38,12 @@ final class BooleanBlockHash extends BlockHash {
     BooleanBlockHash(int channel, BlockFactory blockFactory) {
         super(blockFactory);
         this.channel = channel;
+    }
+
+    @Override
+    public BlockHash resetOrCreate() {
+        Arrays.fill(everSeen, false);
+        return this;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef2BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef2BlockHash.java
@@ -60,6 +60,13 @@ final class BytesRef2BlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRef2BlockHash(blockFactory, channel1, channel2, emitBatchSize);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         BytesRefBlock b1 = page.getBlock(channel1);
         BytesRefBlock b2 = page.getBlock(channel2);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef3BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef3BlockHash.java
@@ -64,6 +64,13 @@ final class BytesRef3BlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRef3BlockHash(blockFactory, channel1, channel2, channel3, emitBatchSize);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         BytesRefBlock b1 = page.getBlock(channel1);
         BytesRefBlock b2 = page.getBlock(channel2);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
@@ -69,6 +69,13 @@ public final class BytesRefLongBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRefLongBlockHash(blockFactory, bytesChannel, longsChannel, reverseOutput, emitBatchSize);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         BytesRefBlock bytesBlock = page.getBlock(bytesChannel);
         BytesRefVector bytesVector = bytesBlock.asVector();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
@@ -79,6 +79,13 @@ final class BytesRefTopNBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRefTopNBlockHash(channel, asc, nullsFirst, limit, blockFactory);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         var block = page.getBlock(channel);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CategorizeBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CategorizeBlockHash.java
@@ -54,6 +54,7 @@ public class CategorizeBlockHash extends BlockHash {
     private final int channel;
     private final AggregatorMode aggregatorMode;
     private final CategorizeDef categorizeDef;
+    private final AnalysisRegistry analysisRegistry;
     private final TokenListCategorizer.CloseableTokenListCategorizer categorizer;
     private final CategorizeEvaluator evaluator;
 
@@ -77,6 +78,7 @@ public class CategorizeBlockHash extends BlockHash {
         this.channel = channel;
         this.aggregatorMode = aggregatorMode;
         this.categorizeDef = categorizeDef;
+        this.analysisRegistry = analysisRegistry;
 
         this.categorizer = new TokenListCategorizer.CloseableTokenListCategorizer(
             new CategorizationBytesRefHash(new BytesRefHash(2048, blockFactory.bigArrays())),
@@ -104,6 +106,13 @@ public class CategorizeBlockHash extends BlockHash {
 
     boolean seenNull() {
         return seenNull;
+    }
+
+    @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new CategorizeBlockHash(blockFactory, channel, aggregatorMode, categorizeDef, analysisRegistry);
+        close();
+        return next;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CategorizePackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CategorizePackedValuesBlockHash.java
@@ -44,6 +44,8 @@ public class CategorizePackedValuesBlockHash extends BlockHash {
 
     private final List<GroupSpec> specs;
     private final AggregatorMode aggregatorMode;
+    private final AnalysisRegistry analysisRegistry;
+    private final int emitBatchSize;
     private final Block[] blocks;
     private final CategorizeBlockHash categorizeBlockHash;
     private final PackedValuesBlockHash packedValuesBlockHash;
@@ -60,6 +62,8 @@ public class CategorizePackedValuesBlockHash extends BlockHash {
 
         this.specs = specs;
         this.aggregatorMode = aggregatorMode;
+        this.analysisRegistry = analysisRegistry;
+        this.emitBatchSize = emitBatchSize;
         blocks = new Block[specs.size()];
 
         List<GroupSpec> delegateSpecs = new ArrayList<>();
@@ -84,6 +88,13 @@ public class CategorizePackedValuesBlockHash extends BlockHash {
                 close();
             }
         }
+    }
+
+    @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new CategorizePackedValuesBlockHash(specs, blockFactory, aggregatorMode, analysisRegistry, emitBatchSize);
+        close();
+        return next;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CompositeTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/CompositeTopNBlockHash.java
@@ -51,6 +51,9 @@ final class CompositeTopNBlockHash extends BlockHash {
     private final boolean primaryAsc;
     private final int primaryGroupingIndex;
     private final int limit;
+    private final List<BlockHash.GroupSpec> groups;
+    private final BlockHash.TopNDef topNDef;
+    private final int emitBatchSize;
 
     /** Non-null when the primary sort key is {@link ElementType#LONG}. */
     private final LongTopNSet longTopValues;
@@ -59,6 +62,9 @@ final class CompositeTopNBlockHash extends BlockHash {
 
     CompositeTopNBlockHash(List<BlockHash.GroupSpec> groups, BlockHash.TopNDef topNDef, BlockFactory blockFactory, int emitBatchSize) {
         super(blockFactory);
+        this.groups = groups;
+        this.topNDef = topNDef;
+        this.emitBatchSize = emitBatchSize;
         this.limit = topNDef.limit();
         BlockHash.SortKey primary = topNDef.primaryKey();
         this.primaryGroupingIndex = primary.groupingIndex();
@@ -93,6 +99,13 @@ final class CompositeTopNBlockHash extends BlockHash {
                 close();
             }
         }
+    }
+
+    @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new CompositeTopNBlockHash(groups, topNDef, blockFactory, emitBatchSize);
+        close();
+        return next;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBytesRefAdaptiveBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBytesRefAdaptiveBlockHash.java
@@ -64,6 +64,14 @@ public final class LongBytesRefAdaptiveBlockHash extends AdaptiveBlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new BytesRefLongVectorOnlyBlockHash(blockFactory);
+        Releasables.close(current);
+        current = next;
+        return this;
+    }
+
+    @Override
     protected void prepareAddInput(Page page) {
         if (current instanceof BytesRefLongVectorOnlyBlockHash vectorHash) {
             if (longVector(page) == null || bytesRefVector(page) == null) {
@@ -138,6 +146,13 @@ public final class LongBytesRefAdaptiveBlockHash extends AdaptiveBlockHash {
                     Releasables.close(bh, llh);
                 }
             }
+        }
+
+        @Override
+        public BlockHash resetOrCreate() {
+            BlockHash next = new BytesRefLongVectorOnlyBlockHash(blockFactory);
+            close();
+            return next;
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongIntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongIntBlockHash.java
@@ -70,6 +70,13 @@ public final class LongIntBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        seenBlocks = false;
+        hash.clear();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         LongBlock longBlock = page.getBlock(longChannel);
         LongVector longVector = longBlock.asVector();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
@@ -47,6 +47,12 @@ final class LongLongBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        hash.clear();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         LongBlock block1 = page.getBlock(channel1);
         LongBlock block2 = page.getBlock(channel2);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongTopNBlockHash.java
@@ -67,6 +67,13 @@ final class LongTopNBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new LongTopNBlockHash(channel, asc, nullsFirst, limit, blockFactory);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
@@ -33,6 +33,12 @@ final class NullBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        seenNull = false;
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -82,6 +82,7 @@ final class PackedValuesBlockHash extends BlockHash {
     private final BreakingBytesRefBuilder bytes;
     private final List<GroupSpec> specs;
     private final BatchWork batchWork;
+    private final CircuitBreaker circuitBreaker;
     private boolean seenNull;
 
     PackedValuesBlockHash(List<GroupSpec> specs, BlockFactory blockFactory, int emitBatchSize) {
@@ -96,6 +97,7 @@ final class PackedValuesBlockHash extends BlockHash {
         super(blockFactory);
         this.specs = specs;
         this.emitBatchSize = emitBatchSize;
+        this.circuitBreaker = circuitBreaker;
         this.nullTrackingBytes = (specs.size() + 7) / 8;
         final int[] columnOffsets = new int[specs.size()];
         int keyLength = nullTrackingBytes;
@@ -136,6 +138,13 @@ final class PackedValuesBlockHash extends BlockHash {
                 close();
             }
         }
+    }
+
+    @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new PackedValuesBlockHash(specs, blockFactory, circuitBreaker, emitBatchSize);
+        close();
+        return next;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
@@ -80,6 +80,13 @@ public final class TimeSeriesBlockHash extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        BlockHash next = new TimeSeriesBlockHash(tsidChannel, timestampChannel, reverseOutput, trackTimestamp, blockFactory);
+        close();
+        return next;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         final BytesRefBlock tsidBlock = page.getBlock(tsidChannel);
         final BytesRefVector tsidVector = tsidBlock.asVector();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -84,6 +84,19 @@ $endif$
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+$if(BytesRef)$
+        BlockHash next = new $Type$BlockHash(channel, blockFactory);
+        close();
+        return next;
+$else$
+        seenNull = false;
+        hash.clear();
+        return this;
+$endif$
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         // TODO track raw counts and which implementation we pick for the profiler - #114008
         var block = page.getBlock(channel);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -505,9 +505,8 @@ public class HashAggregationOperator implements Operator {
 
     private void maybeReinitializeAfterPeriodicallyEmitted() {
         if (rowsReceived > 0 && rowsAddedInCurrentBatch == 0) {
-            blockHash.close();
-            blockHash = null;
-            blockHash = blockHashSupplier.get();
+            blockHash = blockHash.resetOrCreate();
+            // TODO: reuse aggregation states
             for (int i = 0; i < aggregators.size(); i++) {
                 Releasables.close(aggregators.set(i, aggregatorFactories.get(i).apply(driverContext)));
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -172,7 +173,7 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
         int pageCount = between(1, groups < 10 ? 10 : 5);
         int positionCount = randomPositionsPerPage(expectedOrds != null, pageCount, elementTypes);
         int emitBatchSize = randomFrom(100, 1_000, 10_000);
-        try (BlockHash blockHash = newBlockHash(blockFactory, emitBatchSize, elementTypes)) {
+        try (BlockHash blockHash = newBlockHash(blockFactory, emitBatchSize, elementTypes, randomBoolean())) {
             logger.info("checking {}", blockHash);
             /*
              * Only the long/long implementation still doesn't collect nulls. (LONG, BYTES_REF)/(BYTES_REF, LONG)
@@ -275,14 +276,42 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
         };
     }
 
-    private BlockHash newBlockHash(BlockFactory blockFactory, int emitBatchSize, List<ElementType> types) {
+    private BlockHash newBlockHash(BlockFactory blockFactory, int emitBatchSize, List<ElementType> types, boolean addThenReset) {
         List<BlockHash.GroupSpec> specs = new ArrayList<>(types.size());
         for (int c = 0; c < types.size(); c++) {
             specs.add(new BlockHash.GroupSpec(c, types.get(c)));
         }
-        return forcePackedHash
+        BlockHash blockHash = forcePackedHash
             ? new PackedValuesBlockHash(specs, blockFactory, emitBatchSize)
             : BlockHash.build(specs, blockFactory, emitBatchSize, true);
+        if (addThenReset == false) {
+            return blockHash;
+        }
+        int pageCount = between(1, groups < 10 ? 10 : 5);
+        Block[] blocks = new Block[types.size()];
+        boolean success = false;
+        try {
+            for (int i = 0; i < pageCount; i++) {
+                Arrays.fill(blocks, null);
+                int positionCount = randomPositionsPerPage(randomBoolean(), pageCount, types);
+                try {
+                    for (int g = 0; g < blocks.length; g++) {
+                        blocks[g] = new Basic(types.get(g)).randomBlock(positionCount, maxValuesPerPosition, dups).block();
+                    }
+                    BlockHashTests.hash(false, blockHash, ordsAndKeys -> {}, blocks);
+                } finally {
+                    Releasables.close(blocks);
+                }
+            }
+            blockHash = blockHash.resetOrCreate();
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(blockHash);
+            }
+        }
+        assertThat(blockHash.numKeys(), equalTo(0));
+        return blockHash;
     }
 
     private static final int LOOKUP_POSITIONS = 1_000;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashWrapper.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashWrapper.java
@@ -33,6 +33,12 @@ public abstract class BlockHashWrapper extends BlockHash {
     }
 
     @Override
+    public BlockHash resetOrCreate() {
+        blockHash = blockHash.resetOrCreate();
+        return this;
+    }
+
+    @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
         blockHash.add(page, addInput);
     }


### PR DESCRIPTION
When a periodic partial emit occurs (or with future partitioning) in the hash aggregation operator, we expect the block hash and aggregation states to be filled to a similar size again. 

This change adds `resetOrCreate`, which reuses the underlying hash of the block hash where possible, avoiding allocations and expensive resizes. Follow-up PRs will extend this reuse pattern to the remaining block hashes and to aggregation states.