### PR TITLE
[9.4] Migrate searchable-snapshots qa:rest to JUnit rule (#157414)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -44,7 +44,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:multi-cluster-tests-with-security");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:single-node-tests");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-repo-test-kit:qa:rest");
 

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -1,14 +1,10 @@
-import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
-
-apply plugin: 'elasticsearch.legacy-java-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('searchable-snapshots'))))
 }
-
-final File repoDir = file("$buildDir/testclusters/repo")
 
 restResources {
   restApi {
@@ -16,19 +12,12 @@ restResources {
   }
 }
 
-tasks.withType(Test).configureEach {
-  nonInputProperties.systemProperty 'tests.path.repo', repoDir
+tasks.named('javaRestTest') {
+  usesDefaultDistribution("uses the security and searchable-snapshots x-pack features")
 }
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'path.repo', repoDir.absolutePath, IGNORE_VALUE
-  setting 'xpack.license.self_generated.type', 'trial'
-
-  setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
-  setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
-  setting 'xpack.searchable_snapshots.cache_fetch_async_thread_pool.keep_alive', '0ms'
-
-  setting 'xpack.security.enabled', 'true'
-  user username: 'admin', password: 'admin-password', role: 'superuser'
+tasks.named('yamlRestTest') {
+  usesDefaultDistribution("uses the security and searchable-snapshots x-pack features")
+}
+tasks.named('yamlRestCompatTest') {
+  usesDefaultDistribution("uses the security and searchable-snapshots x-pack features")
 }

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/FsSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/FsSearchableSnapshotsIT.java
@@ -6,13 +6,36 @@
  */
 package org.elasticsearch.xpack.searchablesnapshots.rest;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsRestTestCase;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class FsSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster cluster = SearchableSnapshotsRestTestCluster.buildCluster(
+        () -> repoDirectory.getRoot().getPath()
+    );
+
+    @ClassRule
+    public static final TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @Override
     protected String writeRepositoryType() {
@@ -21,7 +44,7 @@ public class FsSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTest
 
     @Override
     protected Settings writeRepositorySettings() {
-        return Settings.builder().put("location", System.getProperty("tests.path.repo")).build();
+        return Settings.builder().put("location", repoDirectory.getRoot().getPath()).build();
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/SearchableSnapshotsRestTestCluster.java
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/SearchableSnapshotsRestTestCluster.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.rest;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+
+import java.util.function.Supplier;
+
+/**
+ * Builds the {@link ElasticsearchCluster} shared by the searchable-snapshots REST test suites. The cluster runs the
+ * default distribution because the tests exercise the security and searchable-snapshots x-pack features, and it exposes
+ * a caller-provided {@code path.repo} so each suite can register a filesystem repository against its own temp directory.
+ */
+final class SearchableSnapshotsRestTestCluster {
+
+    private SearchableSnapshotsRestTestCluster() {}
+
+    static ElasticsearchCluster buildCluster(Supplier<String> repoPath) {
+        return ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .setting("path.repo", repoPath)
+            .setting("xpack.license.self_generated.type", "trial")
+            .setting("xpack.searchable.snapshot.shared_cache.size", "16MB")
+            .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB")
+            .setting("xpack.searchable_snapshots.cache_fetch_async_thread_pool.keep_alive", "0ms")
+            .setting("xpack.security.enabled", "true")
+            .user("admin", "admin-password", "superuser", false)
+            .build();
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/SearchableSnapshotsClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/searchablesnapshots/rest/SearchableSnapshotsClientYamlTestSuiteIT.java
@@ -11,10 +11,32 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 public class SearchableSnapshotsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.searchable.snapshot.shared_cache.size", "16MB")
+        .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB")
+        .setting("xpack.searchable_snapshots.cache_fetch_async_thread_pool.keep_alive", "0ms")
+        .setting("xpack.security.enabled", "true")
+        .user("admin", "admin-password", "superuser", false)
+        .build();
+
+    @ClassRule
+    public static final TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
 
     public SearchableSnapshotsClientYamlTestSuiteIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -23,6 +45,11 @@ public class SearchableSnapshotsClientYamlTestSuiteIT extends ESClientYamlSuiteT
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Migrate searchable-snapshots qa:rest to JUnit rule (#157414)](https://github.com/elastic/elasticsearch/pull/157414)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)