### PR TITLE
[9.5] fix(esql): count values for multi-valued keywords (#157315)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -743,6 +743,15 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         /**
+         * Returns true when this field stores keyword values through binary doc values and can store
+         * more than one value for a document. Lucene term statistics do not describe value counts
+         * for this representation, so callers must load the field to count values.
+         */
+        public boolean usesMultivaluedBinaryDocValues() {
+            return usesBinaryDocValues && docValuesParams != null && docValuesParams.multiValue();
+        }
+
+        /**
          * Whether this field stores its (high-cardinality) binary doc values in document order with inline nulls
          * ({@link MultiValuedBinaryDocValuesField.ArrayOrderInlineNull}) rather than via a sidecar offsets field.
          */

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1039,6 +1039,26 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertScriptDocValues(mapperService, List.of("bar", "foo"), equalTo(List.of("bar", "foo")));
     }
 
+    public void testUsesMultivaluedBinaryDocValues() throws IOException {
+        Settings columnarSettings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName()).build();
+        KeywordFieldMapper.KeywordFieldType columnarMultivalue = (KeywordFieldMapper.KeywordFieldType) createMapperService(
+            columnarSettings,
+            fieldMapping(b -> b.field("type", "keyword"))
+        ).fieldType("field");
+        assertTrue(columnarMultivalue.usesMultivaluedBinaryDocValues());
+
+        KeywordFieldMapper.KeywordFieldType columnarSingleValue = (KeywordFieldMapper.KeywordFieldType) createMapperService(
+            columnarSettings,
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", false).endObject())
+        ).fieldType("field");
+        assertFalse(columnarSingleValue.usesMultivaluedBinaryDocValues());
+
+        KeywordFieldMapper.KeywordFieldType standardMultivalue = (KeywordFieldMapper.KeywordFieldType) createMapperService(
+            fieldMapping(b -> b.field("type", "keyword"))
+        ).fieldType("field");
+        assertFalse(standardMultivalue.usesMultivaluedBinaryDocValues());
+    }
+
     /**
      * Keyword high-cardinality doc values have used the SeparateCount format since 9.4.0. This test pins that contract for the
      * current index version.

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/columnar/ColumnarKeywordCountIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/columnar/ColumnarKeywordCountIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.columnar;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ColumnarKeywordCountIT extends AbstractEsqlIntegTestCase {
+
+    @Override
+    protected Settings.Builder setRandomIndexSettings(Random random, Settings.Builder builder) {
+        return super.setRandomIndexSettings(random, builder).remove(IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING.getKey());
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    public void testCountSingleValuedKeywordCountsValues() {
+        createColumnarKeywordIndex("single_value");
+
+        int docs = randomIntBetween(2, 10);
+        for (int doc = 0; doc < docs; doc++) {
+            prepareIndex("single_value").setSource("kw", randomAlphaOfLengthBetween(3, 12)).get();
+        }
+        indicesAdmin().prepareRefresh("single_value").get();
+
+        assertCount("single_value", docs);
+    }
+
+    public void testCountMultivaluedKeywordCountsValues() {
+        createColumnarKeywordIndex("multi_value");
+
+        int expectedCount = 0;
+        int docs = randomIntBetween(2, 10);
+        for (int doc = 0; doc < docs; doc++) {
+            int valuesInDoc = randomIntBetween(2, 8);
+            List<String> values = new ArrayList<>(valuesInDoc);
+            for (int value = 0; value < valuesInDoc; value++) {
+                values.add(randomAlphaOfLengthBetween(3, 12));
+            }
+            expectedCount += valuesInDoc;
+
+            prepareIndex("multi_value").setSource("kw", values).get();
+        }
+        indicesAdmin().prepareRefresh("multi_value").get();
+
+        assertCount("multi_value", expectedCount);
+    }
+
+    private void createColumnarKeywordIndex(String index) {
+        assertAcked(
+            prepareCreate(index).setSettings(
+                Settings.builder()
+                    .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+            ).setMapping("kw", "type=keyword")
+        );
+    }
+
+    private void assertCount(String index, int expectedCount) {
+        try (EsqlQueryResponse response = run("FROM " + index + " | STATS n = COUNT(kw)")) {
+            Iterator<Object> row = response.values().next();
+            assertThat(row.next(), equalTo((long) expectedCount));
+            assertFalse(row.hasNext());
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -396,7 +396,11 @@ public class SearchContextStats implements SearchStats {
                 PointValues values = lr.getPointValues(name);
                 return values == null || values.size() == values.getDocCount();
             };
-        } else if (fieldType instanceof KeywordFieldType) {
+        } else if (fieldType instanceof KeywordFieldType keywordFieldType) {
+            // NOTE: Terms cannot prove value cardinality for these keyword storage shapes.
+            if (canUseKeywordTermsForDocValueCountEquality(keywordFieldType) == false) {
+                return false;
+            }
             tester = lr -> {
                 Terms terms = lr.terms(name);
                 return terms == null || terms.getSumDocFreq() == terms.getDocCount();
@@ -416,6 +420,10 @@ public class SearchContextStats implements SearchStats {
 
         // unsupported type - default to MV
         return false;
+    }
+
+    private static boolean canUseKeywordTermsForDocValueCountEquality(KeywordFieldType fieldType) {
+        return fieldType.usesMultivaluedBinaryDocValues() == false && fieldType.indexType().hasTerms();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/SearchContextStatsTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FloatField;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -19,6 +20,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
@@ -288,6 +290,37 @@ public class SearchContextStatsTests extends MapperServiceTestCase {
             SearchStats stats = SearchContextStats.from(List.of(ctx));
             assertFalse(
                 "keyword field with MVs must not be reported as single-valued",
+                stats.isSingleValue(new FieldAttribute.FieldName("kw"))
+            );
+        } finally {
+            IOUtils.close(reader, mapperService, dir);
+        }
+    }
+
+    public void testDocValuesOnlyKeywordIsNotDetectedAsSingleValued() throws IOException {
+        final MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {};
+        final MapperService mapperService = mapperHelper.createMapperService("""
+            { "doc": { "properties": { "kw": { "type": "keyword", "index": false } } } }""");
+
+        final Directory dir = newDirectory();
+        final IndexReader reader;
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+            writer.addDocument(
+                List.of(new SortedSetDocValuesField("kw", new BytesRef("A")), new SortedSetDocValuesField("kw", new BytesRef("B")))
+            );
+            writer.addDocument(List.of(new SortedSetDocValuesField("kw", new BytesRef("C"))));
+            writer.forceMerge(1);
+            reader = writer.getReader();
+        }
+
+        try {
+            LeafReader leafReader = ((DirectoryReader) reader).leaves().get(0).reader();
+            assertNull(leafReader.terms("kw"));
+
+            SearchExecutionContext ctx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(reader));
+            SearchStats stats = SearchContextStats.from(List.of(ctx));
+            assertFalse(
+                "keyword field without terms must not be reported as single-valued",
                 stats.isSingleValue(new FieldAttribute.FieldName("kw"))
             );
         } finally {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - fix(esql): count values for multi-valued keywords (#157315)