### PR TITLE
Remove PIT_RELOCATION_FEATURE_FLAG to enable PIT relocation by default

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.reindex.RethrottleRequestBuilder;
 import org.elasticsearch.reindex.TransportReindexAction;
 import org.elasticsearch.reindex.management.ReindexManagementPlugin;
 import org.elasticsearch.search.SearchContextMissingException;
-import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
@@ -121,7 +120,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      * all documents and that the relocated task's reported {@code Status#total} equals the source doc count.
      */
     public void testReindexTaskRelocatesOnNodeShutdown() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();
@@ -246,7 +244,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      * </ol>
      */
     public void testReindexFailsWhenPitRelocationFails() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
 
@@ -377,7 +374,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      * and so an error is returned to the client
      */
     public void testReindexTaskFailsWhenDataNodeIsShuttingDownAndTaskDoesNotFinishInTime() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();
@@ -474,7 +470,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      * the task attempts to complete before node shutdown. Here we allow the test to complete and expect no errors
      */
     public void testReindexTaskFinishesBeforeNodeShutsDown() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();
@@ -708,7 +703,6 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
         reason = "So we can know when the task cancellation was attempted"
     )
     public void testRelocatingTaskIsNotCancelledOnShutdownTimeout() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/RemoteReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/RemoteReindexRelocationOnShutdownIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.reindex.RethrottleRequestBuilder;
 import org.elasticsearch.reindex.TransportReindexAction;
 import org.elasticsearch.rest.root.MainRestPlugin;
-import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
@@ -67,7 +66,6 @@ public class RemoteReindexRelocationOnShutdownIT extends ESIntegTestCase {
     }
 
     public void testRemoteReindexTaskRelocatesOnNodeShutdown() throws Exception {
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -50,7 +50,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.CollectionUtils;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
@@ -341,11 +340,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Setting.Property.NodeScope
     );
 
-    public static final FeatureFlag PIT_RELOCATION_FEATURE_FLAG = new FeatureFlag("pit_relocation_feature");
-
     public static final Setting<Boolean> PIT_RELOCATION_ENABLED = Setting.boolSetting(
         "search.pit_relocation_enabled",
-        PIT_RELOCATION_FEATURE_FLAG.isEnabled(),
+        true,
         Property.OperatorDynamic,
         Property.NodeScope
     );
@@ -508,11 +505,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             .addSettingsUpdateConsumer(MEMORY_ACCOUNTING_BUFFER_SIZE, newValue -> this.memoryAccountingBufferSize = newValue.getBytes());
         prewarmingMaxPoolFactorThreshold = PREWARMING_THRESHOLD_THREADPOOL_SIZE_FACTOR_POOL_SIZE.get(settings);
 
-        if (PIT_RELOCATION_FEATURE_FLAG.isEnabled()) {
-            pitRelocationEnabled = PIT_RELOCATION_ENABLED.get(settings);
-        } else {
-            pitRelocationEnabled = false;
-        }
+        pitRelocationEnabled = PIT_RELOCATION_ENABLED.get(settings);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(PIT_RELOCATION_ENABLED, pitRelocationEnabled -> this.pitRelocationEnabled = pitRelocationEnabled);
     }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
@@ -184,9 +184,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
                 }
             );
             logger.info("---> second search after node restart finished");
-            if (SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled()) {
-                assertThat("Search should not create new contexts", newContexts.get(), equalTo(0L));
-            }
+            assertThat("Search should not create new contexts", newContexts.get(), equalTo(0L));
         } catch (Exception e) {
             logger.error("---> unexpected exception", e);
             throw e;

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotReindexRelocationOnShutdownIT.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotReindexRelocationOnShutdownIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.reindex.RethrottleRequestBuilder;
 import org.elasticsearch.reindex.TransportReindexAction;
 import org.elasticsearch.reindex.management.ReindexManagementPlugin;
-import org.elasticsearch.search.SearchService;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -76,7 +75,6 @@ public class SearchableSnapshotReindexRelocationOnShutdownIT extends BaseSearcha
      */
     public void testReindexRelocatesWithSearchableSnapshotSource() throws Exception {
         disableRepoConsistencyCheck("When the assumeTrue below fails, no node has been started");
-        assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNode();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
@@ -1799,21 +1799,19 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
         }
         ensureGreen(indexName);
 
-        if (SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled()) {
-            // in case of a successful relocation and when source node fails or is stopped, we should be able to continue PIT searches
-            // and verify number of docs retrievable. This will also potentially update the PIT ids to their new location, which is
-            // important
-            // to capture for cleanup later
-            for (var openPit : openPITs) {
-                assertNoFailuresAndResponse(
-                    prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
-                        .setPointInTime(new PointInTimeBuilder(openPit.v1().get()).setKeepAlive(TimeValue.timeValueMinutes(1))),
-                    resp -> {
-                        assertHitCount(resp, openPit.v2());
-                        openPit.v1().set(resp.pointInTimeId());
-                    }
-                );
-            }
+        // in case of a successful relocation and when source node fails or is stopped, we should be able to continue PIT searches
+        // and verify number of docs retrievable. This will also potentially update the PIT ids to their new location, which is
+        // important
+        // to capture for cleanup later
+        for (var openPit : openPITs) {
+            assertNoFailuresAndResponse(
+                prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
+                    .setPointInTime(new PointInTimeBuilder(openPit.v1().get()).setKeepAlive(TimeValue.timeValueMinutes(1))),
+                resp -> {
+                    assertHitCount(resp, openPit.v2());
+                    openPit.v1().set(resp.pointInTimeId());
+                }
+            );
         }
 
         try {
@@ -1827,12 +1825,10 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
             throw e;
         }
 
-        if (SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled()) {
-            // wait for the reaper process to clean up expired PITs on the source node
-            if (testScenario == PITRetentionTestScenarios.SUCCESSFUL_RELOCATION || testScenario == PITRetentionTestScenarios.FAIL_SOURCE) {
-                SearchService searchService = internalCluster().getInstance(SearchService.class, firstSearchNode);
-                assertBusy(() -> assertEquals(0, searchService.getActivePITContexts()));
-            }
+        // wait for the reaper process to clean up expired PITs on the source node
+        if (testScenario == PITRetentionTestScenarios.SUCCESSFUL_RELOCATION || testScenario == PITRetentionTestScenarios.FAIL_SOURCE) {
+            SearchService searchService = internalCluster().getInstance(SearchService.class, firstSearchNode);
+            assertBusy(() -> assertEquals(0, searchService.getActivePITContexts()));
         }
 
         logger.info("Closing PITs");

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
@@ -75,7 +75,6 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
-import static org.elasticsearch.search.SearchService.PIT_RELOCATION_FEATURE_FLAG;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -195,7 +194,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * a separate {@link org.apache.lucene.index.StandardDirectoryReader} per PIT.
      */
     public void testPointInTimeRelocationManyPits() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
 
@@ -323,7 +321,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * to exercise tombstone and version-conflict handling during relocation.
      */
     public void testPointInTimeRelocationPitOnUnflushedIndexState() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         var testNodeSettings = Settings.builder().put(nodeSettings).put(STATELESS_UPLOAD_MAX_SIZE.getKey(), ByteSizeValue.ofGb(1)).build();
 
@@ -492,7 +489,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testPointInTimeRelocation() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -597,7 +593,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testNoPointInTimeRelocationWithSettingDisabled() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -714,7 +709,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testPointInTimeRelocationConcurrentSearches() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -826,7 +820,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
             + "co.elastic.elasticsearch.stateless.recovery.PITRelocationService:DEBUG"
     )
     public void testPointInTimeRelocationClosingSourceContexts() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -916,7 +909,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testPointInTimeRelocationWithUpdatesAndDeletes() {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -1088,7 +1080,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testPointInTimeRelocationReferencingTheSameCommit() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -1152,7 +1143,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * {@code SharedPITCommitReader} cache is introduced.
      */
     public void testRelocatedPitsAtSameCommitHaveOneReaderPerPit() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -1240,7 +1230,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * Leaks are detected by {@link PITRelocationTestPlugin.TrackingSearchDirectory}.
      */
     public void testRelocatedPitContextsReleasedWhenShardClosedDuringHandoff() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
@@ -1319,7 +1308,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testRelocationWithPITReferencingPinnedGenFiles() {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
 
@@ -1419,7 +1407,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
     }
 
     public void testPointInTimeRelocationHandoffBccReadFailureFallsBackToLazyReconstruction() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -1479,7 +1466,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * search results remain correct.
      */
     public void testPointInTimeRelocationNullContextInId() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);
@@ -1601,7 +1587,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * accumulate three CCs in a single VBCC. Each PIT is matched to its CC entry when building the handoff.
      */
     public void testPointInTimeRelocationPitPositionsInBcc() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         // ensure three refresh cycles do not trigger a count-based VBCC upload before relocation
         var nodeSettings = Settings.builder()
             .put(this.nodeSettings)
@@ -1723,7 +1708,6 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
      * context is being silently dropped during handoff.
      */
     public void testPitRelocationMetricsRecorded() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
         var searchNodeB = startSearchNode(nodeSettings);

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationTimestampIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationTimestampIT.java
@@ -51,7 +51,6 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999;
-import static org.elasticsearch.search.SearchService.PIT_RELOCATION_FEATURE_FLAG;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.stateless.commits.StatelessCommitService.STATELESS_UPLOAD_MAX_AMOUNT_COMMITS;
@@ -103,7 +102,6 @@ public class PointInTimeRelocationTimestampIT extends AbstractStatelessPluginInt
     /// right before PIT opens — this is the ground truth against which the wire payload is
     /// compared, which is precise regardless of how many BCCs exist or what timestamps they carry.
     public void testPitRelocationTransfersTimestamps() throws Exception {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         final var indexNode = startMasterAndIndexNode();
         final var searchNodeA = startSearchNode();
         final var searchNodeB = startSearchNode();
@@ -231,7 +229,6 @@ public class PointInTimeRelocationTimestampIT extends AbstractStatelessPluginInt
     ///     mismatch for `_0_1.liv` (BCC_B in SearchDirectory vs BCC_C in CC_C) and stamps
     ///     the wire payload entry with CC_C's timestamp range `[tsC, tsC]`.
     public void testPitRelocationTransfersTimestampForGenerationalFileWithChangedBlobLocation() {
-        assumeTrue("Requires pit relocation feature flag", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         final var indexNode = startMasterAndIndexNode();
         final var searchNodeA = startSearchNode();
         final var searchNodeB = startSearchNode();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardingPitSearchIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardingPitSearchIT.java
@@ -42,7 +42,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
-import static org.elasticsearch.search.SearchService.PIT_RELOCATION_FEATURE_FLAG;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.stateless.reshard.ReshardingTestHelpers.indexMetadata;
 import static org.elasticsearch.xpack.stateless.reshard.ReshardingTestHelpers.makeIdThatRoutesToShard;
@@ -220,7 +219,6 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testPitRelocationDuringReshard() {
-        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         String indexNode = startIndexNode();
         startSearchNode();
@@ -300,7 +298,6 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testLongLivedPitRelocation() {
-        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         startIndexNode();
         startSearchNode();
@@ -351,7 +348,6 @@ public class StatelessReshardingPitSearchIT extends AbstractStatelessPluginInteg
     }
 
     public void testReshardedLongLivedPitRelocation() {
-        assumeTrue("pit relocation must be enabled", PIT_RELOCATION_FEATURE_FLAG.isEnabled());
         var masterNode = startMasterOnlyNode();
         String indexNode = startIndexNode();
         startSearchNode();


### PR DESCRIPTION
PIT relocation has been enabled long enough to remove the remaining feature flag. 
This PR enables PIT relocation unconditionally but keeps the `search.pit_relocation_enabled` 
operator setting as an escape hatch for deployments that might still run into trouble with 
PIT relocation, so we can still disable it dynamically if needed.

Closes #157590

