### PR TITLE
Gate ML datafeed CPS IndicesOptions on credential presence

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -396,8 +396,27 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         }
     }
 
-    public static DatafeedConfig withCrossProjectModeIfEnabled(DatafeedConfig datafeed, CrossProjectModeDecider crossProjectModeDecider) {
-        return withCrossProjectModeIfEnabled(datafeed, crossProjectModeDecider, CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+    /**
+     * Promotes the datafeed's {@link IndicesOptions} to cross-project mode only when CPS is allowed
+     * <em>and</em> {@code crossProjectAllowed} is {@code true}; otherwise the datafeed is returned unchanged
+     * (origin-only).
+     * <p>
+     * The caller supplies credential presence for {@code crossProjectAllowed}. A datafeed (or previewing
+     * caller) with no minted cloud credential runs under an identity that carries no cloud token, so
+     * issuing a CPS-shaped search would fail closed in the auth layer. Keeping such a datafeed origin-only
+     * mirrors the transform {@code SourceConfig.indicesOptions(boolean)} credential-scoping.
+     */
+    public static DatafeedConfig withCrossProjectModeIfEnabled(
+        DatafeedConfig datafeed,
+        CrossProjectModeDecider crossProjectModeDecider,
+        boolean crossProjectAllowed
+    ) {
+        return withCrossProjectModeIfEnabled(
+            datafeed,
+            crossProjectModeDecider,
+            crossProjectAllowed,
+            CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled()
+        );
     }
 
     // visible for testing
@@ -405,12 +424,14 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
     static DatafeedConfig withCrossProjectModeIfEnabled(
         DatafeedConfig datafeed,
         CrossProjectModeDecider crossProjectModeDecider,
+        boolean crossProjectAllowed,
         boolean featureEnabled
     ) {
         Objects.requireNonNull(datafeed, "datafeed must not be null");
         Objects.requireNonNull(crossProjectModeDecider, "crossProjectModeDecider must not be null");
 
-        if (isCPSAllowed(crossProjectModeDecider, featureEnabled) == false) {
+        // Promote to CPS only when the environment allows it and the caller has a credential to fan out with.
+        if ((isCPSAllowed(crossProjectModeDecider, featureEnabled) && crossProjectAllowed) == false) {
             return datafeed;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -1256,7 +1256,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
             new org.elasticsearch.search.crossproject.CrossProjectModeDecider(Settings.EMPTY);
         NullPointerException e = expectThrows(
             NullPointerException.class,
-            () -> DatafeedConfig.withCrossProjectModeIfEnabled(null, decider)
+            () -> DatafeedConfig.withCrossProjectModeIfEnabled(null, decider, true)
         );
         assertThat(e.getMessage(), equalTo("datafeed must not be null"));
     }
@@ -1265,13 +1265,16 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
         DatafeedConfig datafeed = createTestInstance();
         NullPointerException e = expectThrows(
             NullPointerException.class,
-            () -> DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, null)
+            () -> DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, null, true)
         );
         assertThat(e.getMessage(), equalTo("crossProjectModeDecider must not be null"));
     }
 
     public void testWithCrossProjectModeIfEnabled_GivenBothNull() {
-        NullPointerException e = expectThrows(NullPointerException.class, () -> DatafeedConfig.withCrossProjectModeIfEnabled(null, null));
+        NullPointerException e = expectThrows(
+            NullPointerException.class,
+            () -> DatafeedConfig.withCrossProjectModeIfEnabled(null, null, true)
+        );
         assertThat(e.getMessage(), equalTo("datafeed must not be null"));
     }
 
@@ -1282,7 +1285,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", false).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
 
         // Should return the same instance when CPS is disabled
         assertThat(result, sameInstance(datafeed));
@@ -1301,7 +1304,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
 
         // Should return a new instance with CPS enabled
         assertThat(result, not(equalTo(datafeed)));
@@ -1324,7 +1327,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
 
         // Should return the same instance when CPS is already enabled (optimization)
         assertThat(result, sameInstance(datafeed));
@@ -1341,7 +1344,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false, true);
 
         // With the ML CPS feature flag disabled, the cluster-level CPS setting must not promote a
         // local-only datafeed to cross-project mode at runtime.
@@ -1361,7 +1364,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true, true);
 
         assertThat(result, not(sameInstance(datafeed)));
         assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(true));
@@ -1378,7 +1381,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", false).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false, true);
 
         assertThat(result, sameInstance(datafeed));
     }
@@ -1394,7 +1397,10 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 }
             };
 
-        RuntimeException e = expectThrows(RuntimeException.class, () -> DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider));
+        RuntimeException e = expectThrows(
+            RuntimeException.class,
+            () -> DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true)
+        );
         assertThat(e.getMessage(), equalTo("Simulated exception from crossProjectEnabled()"));
     }
 
@@ -1414,7 +1420,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(originalDatafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(originalDatafeed, decider, true);
 
         // Verify all properties except IndicesOptions are preserved
         assertThat(result.getId(), equalTo(originalDatafeed.getId()));
@@ -1441,7 +1447,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
 
         // Should handle project-qualified indices correctly
         assertThat(result.getIndices(), equalTo(datafeed.getIndices()));
@@ -1462,10 +1468,46 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
 
         // Should handle wildcard patterns correctly
         assertThat(result.getIndices(), equalTo(datafeed.getIndices()));
+        assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(true));
+    }
+
+    public void testWithCrossProjectModeIfEnabled_GivenCpsAllowedWithoutCredential_DoesNotPromote() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
+        builder.setIndices(List.of("index1"));
+        builder.setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN);
+        DatafeedConfig datafeed = builder.build();
+
+        org.elasticsearch.search.crossproject.CrossProjectModeDecider decider =
+            new org.elasticsearch.search.crossproject.CrossProjectModeDecider(
+                Settings.builder().put("serverless.cross_project.enabled", true).build()
+            );
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false);
+
+        assertThat(result, sameInstance(datafeed));
+        assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(false));
+    }
+
+    public void testWithCrossProjectModeIfEnabled_GivenCpsAllowedWithCredential_AllowsPromotion() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
+        builder.setIndices(List.of("index1"));
+        builder.setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN);
+        DatafeedConfig datafeed = builder.build();
+
+        org.elasticsearch.search.crossproject.CrossProjectModeDecider decider =
+            new org.elasticsearch.search.crossproject.CrossProjectModeDecider(
+                Settings.builder().put("serverless.cross_project.enabled", true).build()
+            );
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true);
+
+        assertThat(result, not(sameInstance(datafeed)));
         assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(true));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -1333,7 +1333,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
         assertThat(result, sameInstance(datafeed));
     }
 
-    public void testWithCrossProjectModeIfEnabled_GivenFeatureFlagDisabled_NoFlipEvenWithClusterCpsEnabled() {
+    public void testMlCpsFeatureDisabledWithClusterCpsEnabledShouldNotPromoteIndicesOptions() {
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
         builder.setIndices(List.of("index1"));
         builder.setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN);
@@ -1344,7 +1344,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", true).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false, true);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true, false);
 
         // With the ML CPS feature flag disabled, the cluster-level CPS setting must not promote a
         // local-only datafeed to cross-project mode at runtime.
@@ -1352,7 +1352,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
         assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(false));
     }
 
-    public void testWithCrossProjectModeIfEnabled_GivenFeatureFlagEnabled_AndClusterCpsEnabled_Flips() {
+    public void testMlCpsFeatureAndClusterCpsEnabledWithCredentialShouldPromoteIndicesOptions() {
         assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
         builder.setIndices(List.of("index1"));
@@ -1370,7 +1370,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
         assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(true));
     }
 
-    public void testWithCrossProjectModeIfEnabled_GivenFeatureFlagDisabled_AndClusterCpsDisabled_NoFlip() {
+    public void testMlCpsFeatureAndClusterCpsDisabledShouldReturnSameInstance() {
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("datafeed1", "job1");
         builder.setIndices(List.of("index1"));
         builder.setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN);
@@ -1381,7 +1381,7 @@ public class DatafeedConfigTests extends AbstractBWCSerializationTestCase<Datafe
                 Settings.builder().put("serverless.cross_project.enabled", false).build()
             );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, false, true);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, decider, true, false);
 
         assertThat(result, sameInstance(datafeed));
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -104,6 +105,46 @@ public class DatafeedCrossProjectIT extends MlSingleNodeTestCase {
 
         DatafeedConfig retrievedDatafeed = getResponseHolder.get().build();
         assertThat(retrievedDatafeed.getProjectRouting(), equalTo(expectedProjectRouting));
+    }
+
+    public void testStartWithoutCredentialUsesOriginOnlyIndicesOptions() throws Exception {
+        String datafeedId = "datafeed_no_credential";
+        String jobId = "job_no_credential";
+
+        DatafeedConfig.Builder datafeedBuilder = new DatafeedConfig.Builder(datafeedId, jobId);
+        datafeedBuilder.setIndices(List.of("logs-*"));
+
+        AtomicReference<Tuple<DatafeedConfig, DocWriteResponse>> putResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(
+            actionListener -> datafeedConfigProvider.putDatafeedConfig(datafeedBuilder.build(), createSecurityHeader(), actionListener),
+            putResponseHolder,
+            exceptionHolder
+        );
+        assertNull(exceptionHolder.get());
+        assertThat(putResponseHolder.get().v2().status(), equalTo(RestStatus.CREATED));
+
+        AtomicReference<DatafeedConfig.Builder> getResponseHolder = new AtomicReference<>();
+        blockingCall(
+            actionListener -> datafeedConfigProvider.getDatafeedConfig(datafeedId, null, actionListener),
+            getResponseHolder,
+            exceptionHolder
+        );
+        assertNull(exceptionHolder.get());
+
+        DatafeedConfig retrievedDatafeed = getResponseHolder.get().build();
+        assertNull(retrievedDatafeed.getCloudInternalCredential());
+
+        CrossProjectModeDecider decider = new CrossProjectModeDecider(
+            Settings.builder().put("serverless.cross_project.enabled", true).build()
+        );
+        DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(
+            retrievedDatafeed,
+            decider,
+            retrievedDatafeed.getCloudInternalCredential() != null
+        );
+        assertThat(effectiveDatafeed.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(false));
     }
 
     private Map<String, String> createSecurityHeader() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
@@ -11,29 +11,47 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.core.security.cloud.CloudCredentialsExtension;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
+import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import org.junit.Before;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assume.assumeTrue;
 
 public class DatafeedCrossProjectIT extends MlSingleNodeTestCase {
@@ -107,44 +125,53 @@ public class DatafeedCrossProjectIT extends MlSingleNodeTestCase {
         assertThat(retrievedDatafeed.getProjectRouting(), equalTo(expectedProjectRouting));
     }
 
-    public void testStartWithoutCredentialUsesOriginOnlyIndicesOptions() throws Exception {
-        String datafeedId = "datafeed_no_credential";
+    public void testStartWithoutCredentialShouldProcessOriginData() throws Exception {
         String jobId = "job_no_credential";
+        String datafeedId = "datafeed_no_credential";
 
-        DatafeedConfig.Builder datafeedBuilder = new DatafeedConfig.Builder(datafeedId, jobId);
-        datafeedBuilder.setIndices(List.of("logs-*"));
+        client().admin().indices().prepareCreate("data").setMapping("time", "type=date").get();
 
-        AtomicReference<Tuple<DatafeedConfig, DocWriteResponse>> putResponseHolder = new AtomicReference<>();
-        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        client().execute(
+            PutJobAction.INSTANCE,
+            new PutJobAction.Request(
+                new Job.Builder().setId(jobId)
+                    .setAnalysisLimits(new AnalysisLimits(ByteSizeValue.ofMb(2).getMb(), null))
+                    .setAnalysisConfig(new AnalysisConfig.Builder(Collections.singletonList(new Detector.Builder("count", null).build())))
+                    .setDataDescription(new DataDescription.Builder().setTimeFormat(DataDescription.EPOCH_MS))
+            )
+        ).actionGet();
 
-        blockingCall(
-            actionListener -> datafeedConfigProvider.putDatafeedConfig(datafeedBuilder.build(), createSecurityHeader(), actionListener),
-            putResponseHolder,
-            exceptionHolder
+        DatafeedConfig config = BaseMlIntegTestCase.createDatafeed(datafeedId, jobId, Collections.singletonList("data"));
+        client().execute(PutDatafeedAction.INSTANCE, new PutDatafeedAction.Request(config)).actionGet();
+
+        client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId)).actionGet();
+
+        assertBusy(() -> {
+            GetJobsStatsAction.Response statsResponse = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+                .actionGet();
+            assertThat(statsResponse.getResponse().results().get(0).getState(), equalTo(JobState.OPENED));
+        });
+
+        long now = System.currentTimeMillis();
+        long weekAgo = now - 604800000L;
+        BaseMlIntegTestCase.indexDocs(client(), logger, "data", 100, weekAgo, now);
+
+        client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L)).actionGet();
+
+        assertBusy(
+            () -> assertThat(BaseMlIntegTestCase.getDatafeedState(datafeedId), equalTo(DatafeedState.STARTED)),
+            30,
+            TimeUnit.SECONDS
         );
-        assertNull(exceptionHolder.get());
-        assertThat(putResponseHolder.get().v2().status(), equalTo(RestStatus.CREATED));
 
-        AtomicReference<DatafeedConfig.Builder> getResponseHolder = new AtomicReference<>();
-        blockingCall(
-            actionListener -> datafeedConfigProvider.getDatafeedConfig(datafeedId, null, actionListener),
-            getResponseHolder,
-            exceptionHolder
-        );
-        assertNull(exceptionHolder.get());
+        assertBusy(() -> {
+            GetJobsStatsAction.Response statsResponse = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))
+                .actionGet();
+            assertThat(statsResponse.getResponse().results().get(0).getDataCounts().getInputRecordCount(), greaterThan(0L));
+        });
 
-        DatafeedConfig retrievedDatafeed = getResponseHolder.get().build();
-        assertNull(retrievedDatafeed.getCloudInternalCredential());
-
-        CrossProjectModeDecider decider = new CrossProjectModeDecider(
-            Settings.builder().put("serverless.cross_project.enabled", true).build()
-        );
-        DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(
-            retrievedDatafeed,
-            decider,
-            retrievedDatafeed.getCloudInternalCredential() != null
-        );
-        assertThat(effectiveDatafeed.getIndicesOptions().resolveCrossProjectIndexExpression(), equalTo(false));
+        client().execute(StopDatafeedAction.INSTANCE, new StopDatafeedAction.Request(datafeedId)).actionGet();
+        client().execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId)).actionGet();
     }
 
     private Map<String, String> createSecurityHeader() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCrossProjectIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
@@ -158,11 +159,13 @@ public class DatafeedCrossProjectIT extends MlSingleNodeTestCase {
 
         client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L)).actionGet();
 
-        assertBusy(
-            () -> assertThat(BaseMlIntegTestCase.getDatafeedState(datafeedId), equalTo(DatafeedState.STARTED)),
-            30,
-            TimeUnit.SECONDS
-        );
+        assertBusy(() -> {
+            GetDatafeedsStatsAction.Response statsResponse = client().execute(
+                GetDatafeedsStatsAction.INSTANCE,
+                new GetDatafeedsStatsAction.Request(datafeedId)
+            ).actionGet();
+            assertThat(statsResponse.getResponse().results().get(0).getDatafeedState(), equalTo(DatafeedState.STARTED));
+        }, 30, TimeUnit.SECONDS);
 
         assertBusy(() -> {
             GetJobsStatsAction.Response statsResponse = client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedAction.java
@@ -175,12 +175,14 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                 responseHeaderPreservingListener.onFailure(DatafeedConfig.projectRoutingRequiresCpsException());
                 return;
             }
-            // Apply cross-project search mode to IndicesOptions before creating the factory
+            // Apply cross-project search mode to IndicesOptions before creating the factory.
+            // Preview runs under the caller's live credential (not the stored config envelope).
+            final CloudCredential callerCredential = cloudCredentialManager.extractCloudManagedCredential(threadPool.getThreadContext());
             DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeIfEnabled(
                 previewDatafeedConfig,
-                crossProjectModeDecider
+                crossProjectModeDecider,
+                callerCredential != null
             );
-            final CloudCredential callerCredential = cloudCredentialManager.extractCloudManagedCredential(threadPool.getThreadContext());
             final Client previewClient = cloudCredentialManager.wrapClient(
                 new ParentTaskAssigningClient(client, parentTaskId),
                 callerCredential

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/datafeed/TransportStartDatafeedAction.java
@@ -251,7 +251,8 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                 // Apply CPS mode to detect if we're using cross-project search
                 DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(
                     datafeedConfigHolder.get(),
-                    crossProjectModeDecider
+                    crossProjectModeDecider,
+                    datafeedConfigHolder.get().getCloudInternalCredential() != null
                 );
                 boolean isCpsMode = effectiveDatafeed.getIndicesOptions().resolveCrossProjectIndexExpression();
 
@@ -317,7 +318,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
 
         ActionListener<DatafeedConfig.Builder> datafeedListener = ActionListener.wrap(datafeedBuilder -> {
             DatafeedConfig datafeedConfig = datafeedBuilder.build();
-            DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(datafeedConfig, crossProjectModeDecider);
+            DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(
+                datafeedConfig,
+                crossProjectModeDecider,
+                datafeedConfig.getCloudInternalCredential() != null
+            );
             params.setDatafeedIndices(datafeedConfig.getIndices());
             params.setJobId(datafeedConfig.getJobId());
             params.setIndicesOptions(effectiveDatafeed.getIndicesOptions());
@@ -376,7 +381,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         ActionListener<PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams>> listener
     ) {
         // Apply cross-project search mode to IndicesOptions before creating the factory
-        DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(datafeed, crossProjectModeDecider);
+        DatafeedConfig effectiveDatafeed = DatafeedConfig.withCrossProjectModeIfEnabled(
+            datafeed,
+            crossProjectModeDecider,
+            datafeed.getCloudInternalCredential() != null
+        );
 
         DataExtractorFactory.create(
             new ParentTaskAssigningClient(client, clusterService.localNode(), task),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
@@ -393,7 +393,14 @@ public final class CredentialTransitions {
         @Nullable CloudCredential carriedCredential,
         ActionListener<Void> listener
     ) {
-        DatafeedConfig effectiveConfig = DatafeedConfig.withCrossProjectModeIfEnabled(config, crossProjectModeDecider);
+        final CloudCredentialManager credentialManager = credentialManagerSupplier.get();
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final CloudCredential callerCredential = resolveCallerCredential(carriedCredential, threadContext);
+        DatafeedConfig effectiveConfig = DatafeedConfig.withCrossProjectModeIfEnabled(
+            config,
+            crossProjectModeDecider,
+            callerCredential != null
+        );
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0);
         QueryBuilder query = effectiveConfig.getParsedQuery(xContentRegistry);
         if (query != null) {
@@ -408,9 +415,6 @@ public final class CredentialTransitions {
         if (effectiveConfig.getProjectRouting() != null) {
             searchRequest.setProjectRouting(effectiveConfig.getProjectRouting());
         }
-        final CloudCredentialManager credentialManager = credentialManagerSupplier.get();
-        final ThreadContext threadContext = client.threadPool().getThreadContext();
-        final CloudCredential callerCredential = resolveCallerCredential(carriedCredential, threadContext);
         final Client searchClient = credentialManager.wrapClient(client, callerCredential);
         boolean flatWorldOnly = effectiveConfig.getIndices().stream().noneMatch(RemoteClusterAware::isRemoteIndexName);
         ActionListener<Void> probeListener = listener.delegateResponse((l, e) -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -139,7 +139,11 @@ public class DatafeedJobBuilder {
         }
 
         // Apply cross-project search mode to IndicesOptions before creating the factory
-        DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeIfEnabled(datafeedConfig, crossProjectModeDecider);
+        DatafeedConfig effectiveDatafeedConfig = DatafeedConfig.withCrossProjectModeIfEnabled(
+            datafeedConfig,
+            crossProjectModeDecider,
+            datafeedConfig.getCloudInternalCredential() != null
+        );
         PersistedCloudCredential cloudCredential = effectiveDatafeedConfig.getCloudInternalCredential();
         String cloudCredentialId = cloudCredential != null ? cloudCredential.id() : null;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/datafeed/TransportPreviewDatafeedActionTests.java
@@ -115,9 +115,23 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
             Settings.builder().put("serverless.cross_project.enabled", true).build()
         );
 
-        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(builder.build(), decider);
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(builder.build(), decider, true);
 
         assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), is(true));
+    }
+
+    public void testWithCrossProjectModeIfEnabled_GivenNoCallerCredential_DoesNotPromote() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+        DatafeedConfig.Builder builder = new DatafeedConfig.Builder("preview_no_cred_feed", "job_foo");
+        builder.setIndices(Collections.singletonList("logs-*"));
+        builder.setIndicesOptions(org.elasticsearch.action.support.IndicesOptions.STRICT_EXPAND_OPEN);
+        CrossProjectModeDecider decider = new CrossProjectModeDecider(
+            Settings.builder().put("serverless.cross_project.enabled", true).build()
+        );
+
+        DatafeedConfig result = DatafeedConfig.withCrossProjectModeIfEnabled(builder.build(), decider, false);
+
+        assertThat(result.getIndicesOptions().resolveCrossProjectIndexExpression(), is(false));
     }
 
     public void testBuildDateNanosFieldCapsRequest_GivenCpsIndicesOptions_ShouldRequestResolvedTo() {
@@ -128,7 +142,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
         CrossProjectModeDecider decider = new CrossProjectModeDecider(
             Settings.builder().put("serverless.cross_project.enabled", true).build()
         );
-        DatafeedConfig datafeed = DatafeedConfig.withCrossProjectModeIfEnabled(builder.build(), decider);
+        DatafeedConfig datafeed = DatafeedConfig.withCrossProjectModeIfEnabled(builder.build(), decider, true);
         assertThat(datafeed.getIndicesOptions().resolveCrossProjectIndexExpression(), is(true));
 
         FieldCapabilitiesRequest request = TransportPreviewDatafeedAction.buildDateNanosFieldCapsRequest(datafeed, "time");

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.ml.datafeed.CredentialTransitions.Intent;
 import org.elasticsearch.xpack.ml.datafeed.CredentialTransitions.TransitionContext;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -176,6 +177,8 @@ public class CredentialTransitionsTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testValidateSearchBeforeMintWhenCloudCredentialPresentShouldUseWrappedClient() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+
         CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
         InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
         Client delegateClient = mock(Client.class);
@@ -201,7 +204,7 @@ public class CredentialTransitionsTests extends ESTestCase {
             delegateClient,
             xContentRegistry(),
             mock(DatafeedConfigProvider.class),
-            new CrossProjectModeDecider(Settings.EMPTY)
+            new CrossProjectModeDecider(Settings.builder().put("serverless.cross_project.enabled", true).build())
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");
@@ -222,12 +225,16 @@ public class CredentialTransitionsTests extends ESTestCase {
 
         assertThat(failure.get(), equalTo(grantFailure));
         verify(credentialManager).wrapClient(same(delegateClient), eq(callerCredential));
-        verify(wrappedClient).execute(same(TransportSearchAction.TYPE), any(SearchRequest.class), any());
+        ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(wrappedClient).execute(same(TransportSearchAction.TYPE), searchRequestCaptor.capture(), any());
+        assertThat(searchRequestCaptor.getValue().indicesOptions().resolveCrossProjectIndexExpression(), equalTo(true));
         verify(delegateClient, never()).execute(same(TransportSearchAction.TYPE), any(SearchRequest.class), any());
     }
 
     @SuppressWarnings("unchecked")
     public void testValidateSearchBeforeMintWhenNoCloudCredentialShouldUseBareClient() {
+        assumeTrue("CPS feature flag must be enabled", CloudCredentialsExtension.ML_CROSS_PROJECT.isEnabled());
+
         CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
         InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
         Client client = mock(Client.class);
@@ -250,7 +257,7 @@ public class CredentialTransitionsTests extends ESTestCase {
             client,
             xContentRegistry(),
             mock(DatafeedConfigProvider.class),
-            new CrossProjectModeDecider(Settings.EMPTY)
+            new CrossProjectModeDecider(Settings.builder().put("serverless.cross_project.enabled", true).build())
         );
 
         DatafeedConfig.Builder builder = new DatafeedConfig.Builder("df", "job");
@@ -273,7 +280,9 @@ public class CredentialTransitionsTests extends ESTestCase {
         // extract is consulted (atomic capture) and yields null, so the bare client is used
         verify(credentialManager, atLeastOnce()).extractCloudManagedCredential(same(threadContext));
         verify(credentialManager).wrapClient(same(client), nullable(CloudCredential.class));
-        verify(client).execute(same(TransportSearchAction.TYPE), any(SearchRequest.class), any());
+        ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(client).execute(same(TransportSearchAction.TYPE), searchRequestCaptor.capture(), any());
+        assertThat(searchRequestCaptor.getValue().indicesOptions().resolveCrossProjectIndexExpression(), equalTo(false));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- Port transform #157319 credential-scoping to ML datafeeds: `withCrossProjectModeIfEnabled` takes `crossProjectAllowed` and only promotes `IndicesOptions` to cross-project mode when a cloud credential is present.
- Runtime/start paths use stored `getCloudInternalCredential() != null`; preview uses the caller's extracted credential.
- Pre-credential datafeeds on CPS-enabled clusters stay origin-only instead of failing closed in authz/UIAM (same class of bug as ml-team#1949 for transforms).