### PR TITLE
Rate-limit CPS datafeed mint-failure ERROR logs during systemic UIAM failures

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitions.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.RestStatus;
@@ -59,6 +60,30 @@ import static org.elasticsearch.xpack.ml.utils.SecondaryAuthorizationUtils.useSe
 public final class CredentialTransitions {
 
     private static final Logger logger = LogManager.getLogger(CredentialTransitions.class);
+
+    static final TimeValue MINT_FAILURE_LOG_INTERVAL = TimeValue.timeValueMinutes(1);
+
+    /**
+     * Rate-limits repeated CPS datafeed mint-failure ERROR logs on this node during systemic UIAM failures.
+     */
+    static final class MintFailureLogThrottle {
+
+        private long lastEmittedMillis = -1;
+        private int suppressedSinceLastEmit;
+
+        synchronized MintFailureLogDecision recordFailure(long nowMillis) {
+            if (lastEmittedMillis < 0 || nowMillis - lastEmittedMillis >= MINT_FAILURE_LOG_INTERVAL.millis()) {
+                int suppressed = suppressedSinceLastEmit;
+                lastEmittedMillis = nowMillis;
+                suppressedSinceLastEmit = 0;
+                return new MintFailureLogDecision(true, suppressed);
+            }
+            suppressedSinceLastEmit++;
+            return new MintFailureLogDecision(false, 0);
+        }
+    }
+
+    record MintFailureLogDecision(boolean shouldLog, int suppressedCount) {}
 
     /**
      * Result of minting a CPS datafeed cloud API key: the persisted envelope plus security headers
@@ -106,6 +131,7 @@ public final class CredentialTransitions {
     private final NamedXContentRegistry xContentRegistry;
     private final DatafeedConfigProvider datafeedConfigProvider;
     private final CrossProjectModeDecider crossProjectModeDecider;
+    private final MintFailureLogThrottle mintFailureLogThrottle = new MintFailureLogThrottle();
 
     public CredentialTransitions(
         AnomalyDetectionAuditor auditor,
@@ -506,7 +532,21 @@ public final class CredentialTransitions {
                         }
                         onSuccess.accept(new MintedCredential(result.persistedCredential(), mintedHeaders));
                     }), e -> {
-                        logger.error(() -> "[" + datafeedId + "] Failed to mint internal cloud API key for CPS datafeed", e);
+                        MintFailureLogDecision logDecision = mintFailureLogThrottle.recordFailure(threadPool.relativeTimeInMillis());
+                        if (logDecision.shouldLog()) {
+                            if (logDecision.suppressedCount() > 0) {
+                                logger.error(
+                                    () -> "["
+                                        + datafeedId
+                                        + "] Failed to mint internal cloud API key for CPS datafeed; suppressed ["
+                                        + logDecision.suppressedCount()
+                                        + "] additional CPS datafeed mint failures since the previous report",
+                                    e
+                                );
+                            } else {
+                                logger.error(() -> "[" + datafeedId + "] Failed to mint internal cloud API key for CPS datafeed", e);
+                            }
+                        }
                         failurePropagator.onFailure(e);
                     })
                 );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/CredentialTransitionsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
@@ -23,6 +24,7 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.search.crossproject.NoMatchingProjectException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
@@ -45,6 +47,8 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
@@ -52,6 +56,7 @@ import static org.elasticsearch.xpack.core.security.cloud.CloudCredentialTestUti
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
@@ -643,6 +648,221 @@ public class CredentialTransitionsTests extends ESTestCase {
 
         assertThat(persistedCred.get(), equalTo(persisted));
         assertThat(persistedHeaders.get().get(AuthenticationField.AUTHENTICATION_KEY), equalTo(mintedAuth.encode()));
+    }
+
+    public void testMintFailureLogThrottleShouldLogFirstFailureAndSuppressWithinInterval() {
+        CredentialTransitions.MintFailureLogThrottle throttle = new CredentialTransitions.MintFailureLogThrottle();
+        CredentialTransitions.MintFailureLogDecision first = throttle.recordFailure(0);
+        assertThat(first.shouldLog(), is(true));
+        assertThat(first.suppressedCount(), equalTo(0));
+
+        CredentialTransitions.MintFailureLogDecision second = throttle.recordFailure(1);
+        assertThat(second.shouldLog(), is(false));
+
+        CredentialTransitions.MintFailureLogDecision third = throttle.recordFailure(2);
+        assertThat(third.shouldLog(), is(false));
+    }
+
+    public void testMintFailureLogThrottleShouldReportSuppressedCountAtIntervalBoundary() {
+        CredentialTransitions.MintFailureLogThrottle throttle = new CredentialTransitions.MintFailureLogThrottle();
+        throttle.recordFailure(0);
+        throttle.recordFailure(1);
+        throttle.recordFailure(2);
+
+        CredentialTransitions.MintFailureLogDecision atBoundary = throttle.recordFailure(
+            CredentialTransitions.MINT_FAILURE_LOG_INTERVAL.millis()
+        );
+        assertThat(atBoundary.shouldLog(), is(true));
+        assertThat(atBoundary.suppressedCount(), equalTo(2));
+    }
+
+    public void testMintFailureLogThrottleShouldBoundDistinctDatafeedBurst() {
+        CredentialTransitions.MintFailureLogThrottle throttle = new CredentialTransitions.MintFailureLogThrottle();
+        int logCount = 0;
+        for (int i = 0; i < 1_000; i++) {
+            if (throttle.recordFailure(0).shouldLog()) {
+                logCount++;
+            }
+        }
+        assertThat(logCount, equalTo(1));
+    }
+
+    public void testMintFailureLogThrottleShouldMakeOneDecisionUnderConcurrency() throws Exception {
+        CredentialTransitions.MintFailureLogThrottle throttle = new CredentialTransitions.MintFailureLogThrottle();
+        int threads = 20;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        AtomicInteger logCount = new AtomicInteger();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        Thread[] workers = new Thread[threads];
+        for (int t = 0; t < threads; t++) {
+            workers[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    if (throttle.recordFailure(0).shouldLog()) {
+                        logCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    failure.set(e);
+                }
+            });
+            workers[t].start();
+        }
+        for (Thread worker : workers) {
+            worker.join();
+        }
+        assertThat(failure.get(), equalTo(null));
+        assertThat(logCount.get(), equalTo(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMintFailureLoggingShouldPreserveFailurePropagationWhenSuppressed() {
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.relativeTimeInMillis()).thenReturn(1_000L);
+        when(client.threadPool()).thenReturn(threadPool);
+
+        CloudCredential callerCredential = new CloudCredential(new SecureString("caller".toCharArray()));
+        when(credentialManager.extractCloudManagedCredential(same(threadContext))).thenReturn(callerCredential);
+        when(credentialManager.wrapClient(same(client), eq(callerCredential))).thenReturn(client);
+
+        mockSearchProbeSucceeds(client);
+        RuntimeException grantFailure = new RuntimeException("grant failed");
+        stubGrantFailsAfterValidate(apiKeyService, grantFailure);
+
+        CredentialTransitions transitions = new CredentialTransitions(
+            mock(AnomalyDetectionAuditor.class),
+            () -> apiKeyService,
+            () -> credentialManager,
+            client,
+            xContentRegistry(),
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
+        );
+
+        ClusterState clusterState = mock(ClusterState.class);
+        AtomicReference<Exception> firstFailure = new AtomicReference<>();
+        AtomicReference<Exception> secondFailure = new AtomicReference<>();
+
+        Runnable mintTwoDatafeeds = () -> {
+            DatafeedConfig.Builder firstBuilder = new DatafeedConfig.Builder("df-1", "job");
+            firstBuilder.setIndices(List.of("logs-*"));
+            transitions.executePut(
+                Intent.REPLACE,
+                new PutDatafeedAction.Request(firstBuilder.build()),
+                clusterState,
+                threadPool,
+                null,
+                (req, headers, state, listener) -> listener.onFailure(new IllegalStateException("persist should not run")),
+                ActionListener.wrap(ignored -> fail("expected mint failure"), firstFailure::set)
+            );
+
+            DatafeedConfig.Builder secondBuilder = new DatafeedConfig.Builder("df-2", "job");
+            secondBuilder.setIndices(List.of("logs-*"));
+            transitions.executePut(
+                Intent.REPLACE,
+                new PutDatafeedAction.Request(secondBuilder.build()),
+                clusterState,
+                threadPool,
+                null,
+                (req, headers, state, listener) -> listener.onFailure(new IllegalStateException("persist should not run")),
+                ActionListener.wrap(ignored -> fail("expected mint failure"), secondFailure::set)
+            );
+        };
+
+        MockLog.assertThatLogger(
+            mintTwoDatafeeds,
+            CredentialTransitions.class,
+            new MockLog.PatternSeenEventExpectation(
+                "first mint failure logged at ERROR",
+                CredentialTransitions.class.getCanonicalName(),
+                Level.ERROR,
+                ".*\\[df-1\\].*Failed to mint internal cloud API key for CPS datafeed.*"
+            ),
+            new MockLog.PatternNotSeenEventExpectation(
+                "second mint failure suppressed within interval",
+                CredentialTransitions.class.getCanonicalName(),
+                Level.ERROR,
+                ".*\\[df-2\\].*Failed to mint internal cloud API key for CPS datafeed.*"
+            )
+        );
+
+        assertThat(firstFailure.get(), equalTo(grantFailure));
+        assertThat(secondFailure.get(), equalTo(grantFailure));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMintFailureLoggingShouldIncludeSuppressedCountAfterInterval() {
+        CloudCredentialManager credentialManager = mock(CloudCredentialManager.class);
+        InternalCloudApiKeyService apiKeyService = mock(InternalCloudApiKeyService.class);
+        Client client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.relativeTimeInMillis()).thenReturn(0L, 1L, 2L, CredentialTransitions.MINT_FAILURE_LOG_INTERVAL.millis());
+        when(client.threadPool()).thenReturn(threadPool);
+
+        CloudCredential callerCredential = new CloudCredential(new SecureString("caller".toCharArray()));
+        when(credentialManager.extractCloudManagedCredential(same(threadContext))).thenReturn(callerCredential);
+        when(credentialManager.wrapClient(same(client), eq(callerCredential))).thenReturn(client);
+
+        mockSearchProbeSucceeds(client);
+        RuntimeException grantFailure = new RuntimeException("grant failed");
+        stubGrantFailsAfterValidate(apiKeyService, grantFailure);
+
+        CredentialTransitions transitions = new CredentialTransitions(
+            mock(AnomalyDetectionAuditor.class),
+            () -> apiKeyService,
+            () -> credentialManager,
+            client,
+            xContentRegistry(),
+            mock(DatafeedConfigProvider.class),
+            new CrossProjectModeDecider(Settings.EMPTY)
+        );
+
+        ClusterState clusterState = mock(ClusterState.class);
+        Runnable mintThreeTimes = () -> {
+            for (String datafeedId : List.of("df-1", "df-2", "df-3", "df-4")) {
+                DatafeedConfig.Builder builder = new DatafeedConfig.Builder(datafeedId, "job");
+                builder.setIndices(List.of("logs-*"));
+                transitions.executePut(
+                    Intent.REPLACE,
+                    new PutDatafeedAction.Request(builder.build()),
+                    clusterState,
+                    threadPool,
+                    null,
+                    (req, headers, state, listener) -> listener.onFailure(new IllegalStateException("persist should not run")),
+                    ActionListener.wrap(ignored -> fail("expected mint failure"), e -> {})
+                );
+            }
+        };
+
+        MockLog.assertThatLogger(
+            mintThreeTimes,
+            CredentialTransitions.class,
+            new MockLog.PatternSeenEventExpectation(
+                "first mint failure logged at ERROR",
+                CredentialTransitions.class.getCanonicalName(),
+                Level.ERROR,
+                ".*\\[df-1\\].*Failed to mint internal cloud API key for CPS datafeed.*"
+            ),
+            new MockLog.PatternSeenEventExpectation(
+                "interval boundary logs suppressed count",
+                CredentialTransitions.class.getCanonicalName(),
+                Level.ERROR,
+                ".*\\[df-4\\].*Failed to mint internal cloud API key for CPS datafeed;"
+                    + " suppressed \\[2\\] additional CPS datafeed mint failures since the previous report.*"
+            ),
+            new MockLog.PatternNotSeenEventExpectation(
+                "intermediate mint failures suppressed within interval",
+                CredentialTransitions.class.getCanonicalName(),
+                Level.ERROR,
+                ".*\\[df-2\\].*Failed to mint internal cloud API key for CPS datafeed.*"
+            )
+        );
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- Add a node-local one-minute aggregate throttle in `CredentialTransitions.mintCpsKeyForDatafeed` so systemic UIAM grant failures no longer emit one ML ERROR per datafeed per retry.
- Keep ERROR level and immediate first-occurrence visibility; the next sampled ERROR reports how many mint failures were suppressed since the previous report.
- Fail-fast behavior, failure propagation, and UIAM call volume are unchanged.

Fixes elastic/elasticsearch#157518