### PR TITLE
Fix testSortedDeleteTermsResolveAcrossSkipperBlocks

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormatTests.java
@@ -504,7 +504,8 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     }
 
     public void testSoftUpdateResolvesEveryIdAcrossSegments() throws IOException {
-        runTest((writer, parser) -> {
+        // We rely on skippers being enabled
+        runTest(false, (writer, parser) -> {
             final int routing = randomNonNegativeInt();
             // Matches the failing shard: ~7000 docs over consecutive milliseconds, 4 time series, flushed in irregular batches
             final int totalToIndex = randomIntBetween(5000, 8000);
@@ -565,7 +566,8 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     }
 
     public void testSeekCeilWithTimestampAboveTsidMaxAcrossSkipperBlocks() throws IOException {
-        runTest((writer, parser) -> {
+        // We rely on skippers being enabled
+        runTest(false, (writer, parser) -> {
             var segment = indexMultiBlockSegment(writer, parser);
             try (var reader = DirectoryReader.open(writer)) {
                 assertThat(reader.leaves(), hasSize(1));
@@ -590,7 +592,8 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     }
 
     public void testSortedDeleteTermsResolveAcrossSkipperBlocks() throws IOException {
-        runTest((writer, parser) -> {
+        // We rely on skippers being enabled
+        runTest(false, (writer, parser) -> {
             var segment = indexMultiBlockSegment(writer, parser);
             var deletes = new ArrayList<>(segment.ids());
             deletes.add(segment.idInTimestampGap());
@@ -750,18 +753,31 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
      * best way to stay close to the default options of time-series indices, while keeping it light enough for unit tests.
      */
     private static void runTest(CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test) throws IOException {
+        runTest(rarely(), test);
+    }
+
+    private static void runTest(Directory directory, CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test) throws IOException {
+        runTest(rarely(), directory, test);
+    }
+
+    private static void runTest(boolean disableSkippers, CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test)
+        throws IOException {
         final var directory = newDirectory();
         // Checking the index on close requires to support Terms#getMin()/getMax() methods on invalid (or incomplete) terms, something
         // that is not supported in TSDBSyntheticIdFieldsProducer today.
         //
         // TODO would be nice to enable check-index-on-close
         directory.setCheckIndexOnClose(false);
-        runTest(directory, test);
+        runTest(disableSkippers, directory, test);
     }
 
-    private static void runTest(Directory directory, CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test) throws IOException {
+    private static void runTest(
+        boolean disableSkippers,
+        Directory directory,
+        CheckedBiConsumer<IndexWriter, TestDocParser, IOException> test
+    ) throws IOException {
         final var indexName = randomIdentifier();
-        final var indexSettings = buildIndexSettings(indexName);
+        final var indexSettings = buildIndexSettings(indexName, disableSkippers);
         final var mapperService = buildMapperService(indexSettings);
         final var documentParser = buildDocumentParser(mapperService);
 
@@ -788,12 +804,12 @@ public class TSDBSyntheticIdPostingsFormatTests extends ESTestCase {
     /**
      * Builds time-series index settings.
      */
-    private static IndexSettings buildIndexSettings(final String indexName) {
+    private static IndexSettings buildIndexSettings(final String indexName, boolean disableSkippers) {
         final List<String> dimensions = List.of("hostname", "metric.field", "_metric_names_hash");
         var settings = indexSettings(IndexVersion.current(), 1, 0).put(IndexSettings.SYNTHETIC_ID.getKey(), true)
             .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .putList(IndexMetadata.INDEX_DIMENSIONS.getKey(), dimensions);
-        if (rarely()) {
+        if (disableSkippers) {
             settings.put(IndexSettings.USE_DOC_VALUES_SKIPPER.getKey(), false);
         }
         return new IndexSettings(IndexMetadata.builder(indexName).settings(settings.build()).putMapping("""


### PR DESCRIPTION
Ensure that the test that rely on skippers have them enabled always

Closes #157003
Backport of #157264
