### PR TITLE
ES|QL: fix null checks in new evaluators

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
@@ -62,10 +62,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         /*
@@ -112,10 +115,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -142,10 +148,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyMissing(first, count);
@@ -163,10 +172,13 @@ public class MultivalueDedupeDoubleRange {
     public DoubleRangeBlock sortToBlock(BlockFactory blockFactory, boolean ascending) {
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -187,13 +199,14 @@ public class MultivalueDedupeDoubleRange {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    sawNull = true;
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> {
-                        sawNull = true;
-                        builder.appendInt(0);
-                    }
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashAdd(builder, hash, v);
@@ -220,10 +233,13 @@ public class MultivalueDedupeDoubleRange {
     public IntBlock hashLookup(BlockFactory blockFactory, LongLongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendInt(0);
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashLookupSingle(builder, hash, v);
@@ -263,10 +279,13 @@ public class MultivalueDedupeDoubleRange {
                     position++;
                 }
                 for (; position < block.getPositionCount(); position++) {
+                    if (block.isNull(position)) {
+                        encodeNull();
+                        continue;
+                    }
                     int count = block.getValueCount(position);
                     int first = block.getFirstValueIndex(position);
                     switch (count) {
-                        case 0 -> encodeNull();
                         case 1 -> {
                             DoubleRange v = block.getDoubleRange(first, work[0]);
                             if (hasCapacity(1)) {

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/WindowFilterDateNanosEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/WindowFilterDateNanosEvaluator.java
@@ -75,10 +75,11 @@ public final class WindowFilterDateNanosEvaluator implements ExpressionEvaluator
   public BooleanBlock eval(int positionCount, LongBlock timestampBlock) {
     try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
+        if (timestampBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (timestampBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeIntersectsDoublePointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeIntersectsDoublePointEvaluator.java
@@ -66,10 +66,11 @@ public final class RangeIntersectsDoublePointEvaluator implements ExpressionEval
     try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange rangeScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (pointBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (pointBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class RangeIntersectsDoublePointEvaluator implements ExpressionEval
               result.appendNull();
               continue position;
         }
+        if (rangeBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rangeBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeIntersectsDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeIntersectsDoubleRangeEvaluator.java
@@ -66,10 +66,11 @@ public final class RangeIntersectsDoubleRangeEvaluator implements ExpressionEval
       DoubleRangeBlockBuilder.DoubleRange aScratch = new DoubleRangeBlockBuilder.DoubleRange();
       DoubleRangeBlockBuilder.DoubleRange bScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (aBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (aBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class RangeIntersectsDoubleRangeEvaluator implements ExpressionEval
               result.appendNull();
               continue position;
         }
+        if (bBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (bBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeMaxDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeMaxDoubleEvaluator.java
@@ -59,10 +59,11 @@ public final class RangeMaxDoubleEvaluator implements ExpressionEvaluator {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange rangeScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (rangeBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rangeBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeMinDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeMinDoubleEvaluator.java
@@ -59,10 +59,11 @@ public final class RangeMinDoubleEvaluator implements ExpressionEvaluator {
     try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange rangeScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (rangeBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rangeBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoublePointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoublePointEvaluator.java
@@ -66,10 +66,11 @@ public final class RangeWithinDoublePointEvaluator implements ExpressionEvaluato
     try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange rangeScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (pointBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (pointBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class RangeWithinDoublePointEvaluator implements ExpressionEvaluato
               result.appendNull();
               continue position;
         }
+        if (rangeBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rangeBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/RangeWithinDoubleRangeEvaluator.java
@@ -66,10 +66,11 @@ public final class RangeWithinDoubleRangeEvaluator implements ExpressionEvaluato
       DoubleRangeBlockBuilder.DoubleRange aScratch = new DoubleRangeBlockBuilder.DoubleRange();
       DoubleRangeBlockBuilder.DoubleRange bScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (aBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (aBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class RangeWithinDoubleRangeEvaluator implements ExpressionEvaluato
               result.appendNull();
               continue position;
         }
+        if (bBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (bBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/ToRangeDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/date/ToRangeDoubleEvaluator.java
@@ -63,10 +63,11 @@ public final class ToRangeDoubleEvaluator implements ExpressionEvaluator {
   public DoubleRangeBlock eval(int positionCount, DoubleBlock fromBlock, DoubleBlock toBlock) {
     try(DoubleRangeBlock.Builder result = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
+        if (fromBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (fromBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -74,10 +75,11 @@ public final class ToRangeDoubleEvaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
+        if (toBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (toBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionExponentialHistogramEvaluator.java
@@ -75,10 +75,11 @@ public final class HistogramFractionExponentialHistogramEvaluator implements Exp
       ExponentialHistogramScratch histogramScratch = new ExponentialHistogramScratch();
       DoubleRangeBlockBuilder.DoubleRange bucketScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (histogramBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (histogramBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -86,10 +87,11 @@ public final class HistogramFractionExponentialHistogramEvaluator implements Exp
               result.appendNull();
               continue position;
         }
+        if (bucketBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (bucketBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramFractionTDigestEvaluator.java
@@ -79,10 +79,11 @@ public final class HistogramFractionTDigestEvaluator implements ExpressionEvalua
       TDigestHolder histogramScratch = new TDigestHolder();
       DoubleRangeBlockBuilder.DoubleRange bucketScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (histogramBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (histogramBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -90,10 +91,11 @@ public final class HistogramFractionTDigestEvaluator implements ExpressionEvalua
               result.appendNull();
               continue position;
         }
+        if (bucketBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (bucketBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstDoubleRangeEvaluator.java
@@ -39,11 +39,11 @@ public final class MvFirstDoubleRangeEvaluator extends AbstractMultivalueFunctio
     try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
       for (int p = 0; p < positionCount; p++) {
-        int valueCount = v.getValueCount(p);
-        if (valueCount == 0) {
+        if (v.isNull(p)) {
           builder.appendNull();
           continue;
         }
+        int valueCount = v.getValueCount(p);
         int first = v.getFirstValueIndex(p);
         int end = first + valueCount;
         DoubleRangeBlockBuilder.DoubleRange result = MvFirst.process(v, first, end, valueScratch);

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastDoubleRangeEvaluator.java
@@ -39,11 +39,11 @@ public final class MvLastDoubleRangeEvaluator extends AbstractMultivalueFunction
     try (DoubleRangeBlock.Builder builder = driverContext.blockFactory().newDoubleRangeBlockBuilder(positionCount)) {
       DoubleRangeBlockBuilder.DoubleRange valueScratch = new DoubleRangeBlockBuilder.DoubleRange();
       for (int p = 0; p < positionCount; p++) {
-        int valueCount = v.getValueCount(p);
-        if (valueCount == 0) {
+        if (v.isNull(p)) {
           builder.appendNull();
           continue;
         }
+        int valueCount = v.getValueCount(p);
         int first = v.getFirstValueIndex(p);
         int end = first + valueCount;
         DoubleRangeBlockBuilder.DoubleRange result = MvLast.process(v, first, end, valueScratch);

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsDoubleRangeEvaluator.java
@@ -67,10 +67,11 @@ public final class EqualsDoubleRangeEvaluator implements ExpressionEvaluator {
       DoubleRangeBlockBuilder.DoubleRange lhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
       DoubleRangeBlockBuilder.DoubleRange rhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -78,10 +79,11 @@ public final class EqualsDoubleRangeEvaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsExponentialHistogramEvaluator.java
@@ -68,10 +68,11 @@ public final class EqualsExponentialHistogramEvaluator implements ExpressionEval
       ExponentialHistogramScratch lhsScratch = new ExponentialHistogramScratch();
       ExponentialHistogramScratch rhsScratch = new ExponentialHistogramScratch();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -79,10 +80,11 @@ public final class EqualsExponentialHistogramEvaluator implements ExpressionEval
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTDigestEvaluator.java
@@ -66,10 +66,11 @@ public final class EqualsTDigestEvaluator implements ExpressionEvaluator {
       TDigestHolder lhsScratch = new TDigestHolder();
       TDigestHolder rhsScratch = new TDigestHolder();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class EqualsTDigestEvaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsDoubleRangeEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsDoubleRangeEvaluator.java
@@ -67,10 +67,11 @@ public final class NotEqualsDoubleRangeEvaluator implements ExpressionEvaluator 
       DoubleRangeBlockBuilder.DoubleRange lhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
       DoubleRangeBlockBuilder.DoubleRange rhsScratch = new DoubleRangeBlockBuilder.DoubleRange();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -78,10 +79,11 @@ public final class NotEqualsDoubleRangeEvaluator implements ExpressionEvaluator 
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsExponentialHistogramEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsExponentialHistogramEvaluator.java
@@ -68,10 +68,11 @@ public final class NotEqualsExponentialHistogramEvaluator implements ExpressionE
       ExponentialHistogramScratch lhsScratch = new ExponentialHistogramScratch();
       ExponentialHistogramScratch rhsScratch = new ExponentialHistogramScratch();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -79,10 +80,11 @@ public final class NotEqualsExponentialHistogramEvaluator implements ExpressionE
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTDigestEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTDigestEvaluator.java
@@ -66,10 +66,11 @@ public final class NotEqualsTDigestEvaluator implements ExpressionEvaluator {
       TDigestHolder lhsScratch = new TDigestHolder();
       TDigestHolder rhsScratch = new TDigestHolder();
       position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (lhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:
@@ -77,10 +78,11 @@ public final class NotEqualsTDigestEvaluator implements ExpressionEvaluator {
               result.appendNull();
               continue position;
         }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
         switch (rhsBlock.getValueCount(p)) {
-          case 0:
-              result.appendNull();
-              continue position;
           case 1:
               break;
           default:


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/153233 slightly changed the generated code, and operators introduced in the meantime still have the old shape. This just fixes it

