### PR TITLE
[ESQL] Reuse heap dest for Parquet page decompress

### DIFF
--- a/docs/changelog/157616.yaml
+++ b/docs/changelog/157616.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157616
+summary: Reuse heap dest for Parquet page decompress
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 
@@ -79,19 +78,6 @@ final class ConstantBlockDetection {
             }
         }
         return blockFactory.newConstantDoubleBlockWith(values[0], rows);
-    }
-
-    static Block tryConstantBytesRef(BytesRef[] values, int rows, BlockFactory blockFactory) {
-        if (rows <= 1) {
-            return blockFactory.newConstantBytesRefBlockWith(rows == 0 ? new BytesRef() : values[0], rows);
-        }
-        BytesRef first = values[0];
-        for (int i = 1; i < rows; i++) {
-            if (first.bytesEquals(values[i]) == false) {
-                return null;
-            }
-        }
-        return blockFactory.newConstantBytesRefBlockWith(new BytesRef(first.bytes, first.offset, first.length), rows);
     }
 
     static Block tryAllNull(BitSet nulls, int rows, BlockFactory blockFactory) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -24,6 +24,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
@@ -90,6 +91,10 @@ import java.util.List;
  * keep encoding consistent across all data pages of a column chunk), the partial ordinal
  * batch is resolved through the dictionary and the remainder is read via the materialized
  * binary path.
+ *
+ * <p>PLAIN BINARY values alias {@code PrefetchedPageReader}'s reused decompress dest, so
+ * KEYWORD/TEXT/UUID copy into the ESQL block via {@code appendBytesRef} before the next
+ * {@code ensurePage()}.
  */
 final class PageColumnReader implements Releasable {
 
@@ -1229,82 +1234,149 @@ final class PageColumnReader implements Releasable {
             return readBytesBatchAsOrdinals(maxRows, blockFactory);
         }
         if (maxDefLevel == 0) {
-            BytesRef[] allValues = new BytesRef[maxRows];
-            int produced = 0;
-            int remaining = maxRows;
+            return readRequiredBytesBatch(maxRows, blockFactory, isUuid);
+        }
+        return readOptionalBytesBatch(maxRows, blockFactory, isUuid);
+    }
+
+    private Block readRequiredBytesBatch(int maxRows, BlockFactory blockFactory, boolean isUuid) {
+        BytesRefBlock.Builder builder = null;
+        BytesRef constant = null;
+        int produced = 0;
+        int remaining = maxRows;
+        long firstPageBytes = -1L;
+        try {
             while (remaining > 0 && ensurePage()) {
                 int fromPage = Math.min(remaining, availableInPage());
                 BytesRef[] vals = readBinaryValues(fromPage);
-                for (int i = 0; i < fromPage; i++) {
-                    allValues[produced + i] = isUuid
-                        ? new BytesRef(ParquetColumnDecoding.formatUuid(vals[i].bytes, vals[i].offset, vals[i].length))
-                        : Utf8Sanitizer.sanitize(vals[i]);
+                materializeBinaries(vals, fromPage, isUuid);
+                if (fromPage > 0 && firstPageBytes < 0) {
+                    firstPageBytes = totalBytes(vals, fromPage);
+                }
+                if (builder != null) {
+                    appendAll(builder, vals, fromPage);
+                } else if (fromPage > 0) {
+                    if (constant == null) {
+                        if (allEqualTo(vals, fromPage, vals[0])) {
+                            constant = BytesRef.deepCopyOf(vals[0]);
+                        } else {
+                            builder = blockFactory.newBytesRefBlockBuilder(maxRows, firstPageBytes);
+                            appendAll(builder, vals, fromPage);
+                        }
+                    } else if (allEqualTo(vals, fromPage, constant) == false) {
+                        builder = blockFactory.newBytesRefBlockBuilder(
+                            maxRows,
+                            (long) produced * constant.length + totalBytes(vals, fromPage)
+                        );
+                        appendConstant(builder, constant, produced);
+                        appendAll(builder, vals, fromPage);
+                        constant = null;
+                    }
                 }
                 advancePosition(fromPage);
                 produced += fromPage;
                 remaining -= fromPage;
             }
-            Block constant = ConstantBlockDetection.tryConstantBytesRef(allValues, produced, blockFactory);
-            if (constant != null) {
-                return constant;
+            if (builder != null) {
+                return builder.build();
             }
-            return buildBytesRefBlock(allValues, null, produced, blockFactory);
+            return blockFactory.newConstantBytesRefBlockWith(constant == null ? new BytesRef() : constant, produced);
+        } finally {
+            Releasables.closeExpectNoException(builder);
         }
-        BytesRef[] allValues = new BytesRef[maxRows];
-        WordMask allNulls = buffers.nullsMask(maxRows);
-        int produced = 0;
-        int remaining = maxRows;
-        while (remaining > 0 && ensurePage()) {
-            int fromPage = Math.min(remaining, availableInPage());
-            WordMask pageNulls = buffers.valueSelection(fromPage);
-            int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
-            BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
-            int valIdx = 0;
-            for (int i = 0; i < fromPage; i++) {
-                if (pageNulls.get(i)) {
-                    allNulls.set(produced + i);
-                } else if (isUuid) {
-                    BytesRef uuidRef = vals[valIdx++];
-                    allValues[produced + i] = new BytesRef(ParquetColumnDecoding.formatUuid(uuidRef.bytes, uuidRef.offset, uuidRef.length));
-                } else {
-                    allValues[produced + i] = Utf8Sanitizer.sanitize(vals[valIdx++]);
-                }
-            }
-            advancePosition(fromPage);
-            produced += fromPage;
-            remaining -= fromPage;
-        }
-        if (allNulls.isEmpty() == false) {
-            Block allNull = ConstantBlockDetection.tryAllNull(allNulls.toBitSet(), produced, blockFactory);
-            if (allNull != null) {
-                return allNull;
-            }
-        }
-        return buildBytesRefBlock(allValues, allNulls, produced, blockFactory);
     }
 
-    /**
-     * Builds a {@code BytesRefBlock} from already-materialized values, pre-sizing the byte storage to
-     * the exact total byte size so the backing {@code BytesRefArray} does not regrow as values are
-     * appended. {@code nulls} may be {@code null} when no position is null; otherwise a set bit marks a
-     * null position that is skipped when sizing and appended as null.
-     */
-    private static Block buildBytesRefBlock(BytesRef[] values, WordMask nulls, int count, BlockFactory blockFactory) {
-        long byteHint = 0;
+    private Block readOptionalBytesBatch(int maxRows, BlockFactory blockFactory, boolean isUuid) {
+        BytesRefBlock.Builder builder = null;
+        int produced = 0;
+        int remaining = maxRows;
+        long firstPageBytes = -1L;
+        try {
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                WordMask pageNulls = buffers.valueSelection(fromPage);
+                int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+                BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+                if (vals != null) {
+                    materializeBinaries(vals, nonNull, isUuid);
+                }
+                if (firstPageBytes < 0 && nonNull > 0) {
+                    firstPageBytes = totalBytes(vals, nonNull);
+                }
+                if (builder != null) {
+                    appendNullableBinaries(builder, vals, pageNulls, fromPage);
+                } else if (nonNull > 0) {
+                    builder = blockFactory.newBytesRefBlockBuilder(maxRows, firstPageBytes);
+                    for (int i = 0; i < produced; i++) {
+                        builder.appendNull();
+                    }
+                    appendNullableBinaries(builder, vals, pageNulls, fromPage);
+                }
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            if (builder == null && produced > 0) {
+                return blockFactory.newConstantNullBlock(produced);
+            }
+            if (builder != null) {
+                return builder.build();
+            }
+            try (var empty = blockFactory.newBytesRefBlockBuilder(produced)) {
+                return empty.build();
+            }
+        } finally {
+            Releasables.closeExpectNoException(builder);
+        }
+    }
+
+    private static BytesRef materializeBinary(BytesRef raw, boolean isUuid) {
+        return isUuid ? new BytesRef(ParquetColumnDecoding.formatUuid(raw.bytes, raw.offset, raw.length)) : Utf8Sanitizer.sanitize(raw);
+    }
+
+    private static void materializeBinaries(BytesRef[] vals, int count, boolean isUuid) {
         for (int i = 0; i < count; i++) {
-            if (nulls == null || nulls.get(i) == false) {
-                byteHint += values[i].length;
+            vals[i] = materializeBinary(vals[i], isUuid);
+        }
+    }
+
+    private static long totalBytes(BytesRef[] vals, int count) {
+        long n = 0;
+        for (int i = 0; i < count; i++) {
+            n += vals[i].length;
+        }
+        return n;
+    }
+
+    private static boolean allEqualTo(BytesRef[] vals, int count, BytesRef expected) {
+        for (int i = 0; i < count; i++) {
+            if (expected.bytesEquals(vals[i]) == false) {
+                return false;
             }
         }
-        try (var builder = blockFactory.newBytesRefBlockBuilder(count, byteHint)) {
-            for (int i = 0; i < count; i++) {
-                if (nulls != null && nulls.get(i)) {
-                    builder.appendNull();
-                } else {
-                    builder.appendBytesRef(values[i]);
-                }
+        return true;
+    }
+
+    private static void appendAll(BytesRefBlock.Builder builder, BytesRef[] vals, int count) {
+        for (int i = 0; i < count; i++) {
+            builder.appendBytesRef(vals[i]);
+        }
+    }
+
+    private static void appendConstant(BytesRefBlock.Builder builder, BytesRef value, int times) {
+        for (int i = 0; i < times; i++) {
+            builder.appendBytesRef(value);
+        }
+    }
+
+    private static void appendNullableBinaries(BytesRefBlock.Builder builder, BytesRef[] vals, WordMask pageNulls, int fromPage) {
+        int valIdx = 0;
+        for (int i = 0; i < fromPage; i++) {
+            if (pageNulls.get(i)) {
+                builder.appendNull();
+            } else {
+                builder.appendBytesRef(vals[valIdx++]);
             }
-            return builder.build();
         }
     }
 
@@ -1470,53 +1542,89 @@ final class PageColumnReader implements Releasable {
     private Block finishMaterializedFallback(int[] ordinals, WordMask nulls, int produced, int remaining, BlockFactory blockFactory) {
         BytesRef[] dict = dictDecoder.getDictionaryBytesRefs(dictionary);
         int total = produced + remaining;
-        BytesRef[] all = new BytesRef[total];
         WordMask combinedNulls = nulls;
-        for (int i = 0; i < produced; i++) {
-            if (combinedNulls != null && combinedNulls.get(i)) {
-                continue;
-            }
-            all[i] = dict[ordinals[i]];
-        }
-        int filled = produced;
-        while (remaining > 0 && ensurePage()) {
-            int fromPage = Math.min(remaining, availableInPage());
-            if (combinedNulls == null) {
-                BytesRef[] vals = readBinaryValues(fromPage);
-                System.arraycopy(vals, 0, all, filled, fromPage);
-            } else {
-                WordMask pageNulls = buffers.valueSelection(fromPage);
-                int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
-                BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
-                int valIdx = 0;
-                for (int i = 0; i < fromPage; i++) {
-                    if (pageNulls.get(i)) {
-                        combinedNulls.set(filled + i);
-                    } else {
-                        all[filled + i] = vals[valIdx++];
+        BytesRefBlock.Builder builder = null;
+        try {
+            boolean prefixHasValue = false;
+            if (produced > 0) {
+                if (combinedNulls == null) {
+                    prefixHasValue = true;
+                } else {
+                    for (int i = 0; i < produced; i++) {
+                        if (combinedNulls.get(i) == false) {
+                            prefixHasValue = true;
+                            break;
+                        }
                     }
                 }
             }
-            advancePosition(fromPage);
-            filled += fromPage;
-            remaining -= fromPage;
+            if (prefixHasValue) {
+                builder = blockFactory.newBytesRefBlockBuilder(total);
+                appendDictPrefix(builder, dict, ordinals, combinedNulls, produced);
+            }
+            int filled = produced;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                if (combinedNulls == null) {
+                    BytesRef[] vals = readBinaryValues(fromPage);
+                    materializeBinaries(vals, fromPage, false);
+                    if (builder == null) {
+                        builder = blockFactory.newBytesRefBlockBuilder(total, totalBytes(vals, fromPage));
+                    }
+                    appendAll(builder, vals, fromPage);
+                } else {
+                    WordMask pageNulls = buffers.valueSelection(fromPage);
+                    int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+                    BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+                    if (vals != null) {
+                        materializeBinaries(vals, nonNull, false);
+                    }
+                    for (int i = 0; i < fromPage; i++) {
+                        if (pageNulls.get(i)) {
+                            combinedNulls.set(filled + i);
+                        }
+                    }
+                    if (builder == null) {
+                        if (nonNull > 0) {
+                            builder = blockFactory.newBytesRefBlockBuilder(total, totalBytes(vals, nonNull));
+                            for (int i = 0; i < filled; i++) {
+                                builder.appendNull();
+                            }
+                            appendNullableBinaries(builder, vals, pageNulls, fromPage);
+                        }
+                    } else {
+                        appendNullableBinaries(builder, vals, pageNulls, fromPage);
+                    }
+                }
+                advancePosition(fromPage);
+                filled += fromPage;
+                remaining -= fromPage;
+            }
+            if (combinedNulls != null && combinedNulls.isEmpty() == false) {
+                Block allNull = ConstantBlockDetection.tryAllNull(combinedNulls.toBitSet(), filled, blockFactory);
+                if (allNull != null) {
+                    return allNull;
+                }
+            }
+            if (builder != null) {
+                return builder.build();
+            }
+            try (var empty = blockFactory.newBytesRefBlockBuilder(filled)) {
+                return empty.build();
+            }
+        } finally {
+            Releasables.closeExpectNoException(builder);
         }
-        if (combinedNulls != null && combinedNulls.isEmpty() == false) {
-            Block allNull = ConstantBlockDetection.tryAllNull(combinedNulls.toBitSet(), filled, blockFactory);
-            if (allNull != null) {
-                return allNull;
+    }
+
+    private static void appendDictPrefix(BytesRefBlock.Builder builder, BytesRef[] dict, int[] ordinals, WordMask nulls, int produced) {
+        for (int i = 0; i < produced; i++) {
+            if (nulls != null && nulls.get(i)) {
+                builder.appendNull();
+            } else {
+                builder.appendBytesRef(Utf8Sanitizer.sanitize(dict[ordinals[i]]));
             }
         }
-        // KEYWORD materialized fallback: {@code all} mixes raw dictionary entries with scalar values read
-        // after the chunk fell off dictionary encoding (this path is never taken for UUID, see readBytesBatch),
-        // so sanitize each position once before building. sanitize returns the input unchanged when it is
-        // already well-formed, so shared dictionary entries are not copied or mutated.
-        for (int i = 0; i < filled; i++) {
-            if (combinedNulls == null || combinedNulls.get(i) == false) {
-                all[i] = Utf8Sanitizer.sanitize(all[i]);
-            }
-        }
-        return buildBytesRefBlock(all, combinedNulls, filled, blockFactory);
     }
 
     // --- Datetime ---

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -1260,7 +1260,7 @@ final class PageColumnReader implements Releasable {
                         if (allEqualTo(vals, fromPage, vals[0])) {
                             constant = BytesRef.deepCopyOf(vals[0]);
                         } else {
-                            builder = blockFactory.newBytesRefBlockBuilder(maxRows, firstPageBytes);
+                            builder = blockFactory.newBytesRefBlockBuilder(maxRows, extrapolateByteHint(firstPageBytes, fromPage, maxRows));
                             appendAll(builder, vals, fromPage);
                         }
                     } else if (allEqualTo(vals, fromPage, constant) == false) {
@@ -1306,7 +1306,7 @@ final class PageColumnReader implements Releasable {
                 if (builder != null) {
                     appendNullableBinaries(builder, vals, pageNulls, fromPage);
                 } else if (nonNull > 0) {
-                    builder = blockFactory.newBytesRefBlockBuilder(maxRows, firstPageBytes);
+                    builder = blockFactory.newBytesRefBlockBuilder(maxRows, extrapolateByteHint(firstPageBytes, fromPage, maxRows));
                     for (int i = 0; i < produced; i++) {
                         builder.appendNull();
                     }
@@ -1322,7 +1322,8 @@ final class PageColumnReader implements Releasable {
             if (builder != null) {
                 return builder.build();
             }
-            try (var empty = blockFactory.newBytesRefBlockBuilder(produced)) {
+            assert produced == 0;
+            try (var empty = blockFactory.newBytesRefBlockBuilder(0)) {
                 return empty.build();
             }
         } finally {
@@ -1348,6 +1349,21 @@ final class PageColumnReader implements Releasable {
         return n;
     }
 
+    private static long extrapolateByteHint(long seenBytes, int seenPositions, int totalPositions) {
+        if (seenPositions <= 0) {
+            return seenBytes;
+        }
+        // Batch 2+ often starts on a leftover tail of 1-few values. Scaling that by maxRows
+        // pre-sizes Bytes.pages[] to a huge empty pointer array that build() never shrinks.
+        if (seenPositions < totalPositions && seenPositions < 32) {
+            return seenBytes;
+        }
+        if (totalPositions > 0 && seenBytes > Long.MAX_VALUE / totalPositions) {
+            return Long.MAX_VALUE;
+        }
+        return seenBytes * totalPositions / seenPositions;
+    }
+
     private static boolean allEqualTo(BytesRef[] vals, int count, BytesRef expected) {
         for (int i = 0; i < count; i++) {
             if (expected.bytesEquals(vals[i]) == false) {
@@ -1370,6 +1386,12 @@ final class PageColumnReader implements Releasable {
     }
 
     private static void appendNullableBinaries(BytesRefBlock.Builder builder, BytesRef[] vals, WordMask pageNulls, int fromPage) {
+        if (vals == null) {
+            for (int i = 0; i < fromPage; i++) {
+                builder.appendNull();
+            }
+            return;
+        }
         int valIdx = 0;
         for (int i = 0; i < fromPage; i++) {
             if (pageNulls.get(i)) {
@@ -1559,7 +1581,7 @@ final class PageColumnReader implements Releasable {
                 }
             }
             if (prefixHasValue) {
-                builder = blockFactory.newBytesRefBlockBuilder(total);
+                builder = blockFactory.newBytesRefBlockBuilder(total, dictPrefixBytes(dict, ordinals, combinedNulls, produced));
                 appendDictPrefix(builder, dict, ordinals, combinedNulls, produced);
             }
             int filled = produced;
@@ -1609,12 +1631,23 @@ final class PageColumnReader implements Releasable {
             if (builder != null) {
                 return builder.build();
             }
-            try (var empty = blockFactory.newBytesRefBlockBuilder(filled)) {
+            assert filled == 0;
+            try (var empty = blockFactory.newBytesRefBlockBuilder(0)) {
                 return empty.build();
             }
         } finally {
             Releasables.closeExpectNoException(builder);
         }
+    }
+
+    private static long dictPrefixBytes(BytesRef[] dict, int[] ordinals, WordMask nulls, int produced) {
+        long n = 0;
+        for (int i = 0; i < produced; i++) {
+            if (nulls == null || nulls.get(i) == false) {
+                n += dict[ordinals[i]].length;
+            }
+        }
+        return n;
     }
 
     private static void appendDictPrefix(BytesRefBlock.Builder builder, BytesRef[] dict, int[] ordinals, WordMask nulls, int produced) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -48,12 +48,14 @@ import java.util.zip.GZIPOutputStream;
  * G1GC region pinning). When either buffer is heap, the decompressor falls back to the
  * byte-array path. Two call sites reach these decompressors:
  * <ul>
- *   <li>{@code PrefetchedPageReader} calls {@code decompress(BytesInput, int)} so compressed
- *       pages land on a heap {@code byte[]}. Uncompressed pages alias the prefetched I/O
- *       {@link BytesInput}. Heap output is charged to the request breaker
- *       for the current page. Snappy's heap JNI still uses {@code GetPrimitiveArrayCritical};
- *       that is the cost of a heap destination versus glibc RSS from direct malloc. LZ4/Zstd
- *       do not take that JNI pin path.</li>
+ *   <li>{@code PrefetchedPageReader} decompresses compressed pages onto a grow-only heap
+ *       {@code byte[]} via {@link HeapDestDecompressor#decompressInto}. Uncompressed pages
+ *       alias the prefetched I/O {@link BytesInput} and are not charged. The reusable dest's
+ *       live capacity is charged to the request breaker until the reader closes.
+ *       Snappy's heap JNI still uses {@code GetPrimitiveArrayCritical}; that is the cost of
+ *       a heap destination versus glibc RSS from direct malloc. LZ4/Zstd do not take that
+ *       JNI pin path. {@code decompress(BytesInput, int)} still allocates for parquet-mr's
+ *       non-prefetched path and for dictionary pages.</li>
  *   <li>Parquet-MR's {@code ColumnChunkPageReadStore.ColumnChunkPageReader.readPage()} (the
  *       non-prefetched path) invokes only the {@code decompress(BytesInput, int)} overload — it
  *       never reaches the {@code ByteBuffer} overload, regardless of the allocator or the
@@ -163,6 +165,40 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
         input.position(origPos + compressedSize);
     }
 
+    /**
+     * Heap decompress into a caller-owned dest. {@code dest.length} may exceed {@code destLen};
+     * implementations write exactly {@code destLen} bytes at {@code dest[0..destLen)} and must
+     * not treat {@code dest.length} as the output cap (Zstd's full-buffer {@code decompressHeap}
+     * overload does that). {@link #decompress(BytesInput, int)} allocates a right-sized array and
+     * delegates here so parquet-mr and dictionary pages keep working.
+     *
+     * <p>{@link NoopDecompressor} does not implement this: uncompressed pages never decompress.
+     */
+    interface HeapDestDecompressor extends BytesInputDecompressor {
+        @Override
+        default BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
+            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
+            decompressInto(bytes, out, decompressedSize);
+            return BytesInput.from(out);
+        }
+
+        void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException;
+    }
+
+    private static void requireDestCapacity(byte[] dest, int destLen) {
+        if (destLen < 0 || destLen > dest.length) {
+            throw new IllegalArgumentException(
+                "decompress destLen [" + destLen + "] is out of range for dest.length [" + dest.length + "]"
+            );
+        }
+    }
+
+    private static void requireExactUncompressedSize(int written, int destLen, String codec) throws IOException {
+        if (written != destLen) {
+            throw new IOException(codec + " decompression produced " + written + " bytes, expected " + destLen + " from page header");
+        }
+    }
+
     // ------------------------------- decompressors -------------------------------
 
     /**
@@ -198,23 +234,31 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * Direct-to-direct {@code Snappy.uncompress(ByteBuffer, ByteBuffer)} remains on the
      * {@code ByteBuffer} overload for tests and the parquet-mr SPI.
      */
-    private static class SnappyBytesDecompressor implements BytesInputDecompressor {
+    private static class SnappyBytesDecompressor implements HeapDestDecompressor {
         @Override
-        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            // PrefetchedPageReader (the optimized path) and parquet-mr's
-            // ColumnChunkPageReadStore.readPage() both reach this BytesInput overload.
+        public void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException {
+            requireDestCapacity(dest, destLen);
+            // JNI Snappy.uncompress uses dest.length as the write allowance. On a reused dest that
+            // is larger than this page, a stream whose uncompressed size exceeds destLen would
+            // clobber dest[destLen..). Check the stream length first, then uncompress.
             // Fast path: avoid BytesInput.toByteArray() for heap-buffer-backed inputs — the default
             // toByteArray() funnels through a sized ByteArrayOutputStream, adding one allocation
             // and one System.arraycopy that the JNI Snappy binding does not need.
-            ByteBuffer input = bytes.toByteBuffer();
+            ByteBuffer input = compressed.toByteBuffer();
             if (input.hasArray()) {
-                Snappy.uncompress(input.array(), input.arrayOffset() + input.position(), input.remaining(), out, 0);
+                snappyUncompress(input.array(), input.arrayOffset() + input.position(), input.remaining(), dest, destLen);
             } else {
-                byte[] in = bytes.toByteArray();
-                Snappy.uncompress(in, 0, in.length, out, 0);
+                byte[] in = compressed.toByteArray();
+                snappyUncompress(in, 0, in.length, dest, destLen);
             }
-            return BytesInput.from(out);
+        }
+
+        private static void snappyUncompress(byte[] src, int srcOff, int srcLen, byte[] dest, int destLen) throws IOException {
+            int declared = Snappy.uncompressedLength(src, srcOff, srcLen);
+            if (declared != destLen) {
+                throw new IOException("Snappy uncompressed length " + declared + " bytes, expected " + destLen + " from page header");
+            }
+            requireExactUncompressedSize(Snappy.uncompress(src, srcOff, srcLen, dest, 0), destLen, "Snappy");
         }
 
         @Override
@@ -236,21 +280,23 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
         public void release() {}
     }
 
-    private static class GzipBytesDecompressor implements BytesInputDecompressor {
+    private static class GzipBytesDecompressor implements HeapDestDecompressor {
         @Override
-        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            try (GZIPInputStream gis = new GZIPInputStream(bytes.toInputStream())) {
+        public void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException {
+            requireDestCapacity(dest, destLen);
+            try (GZIPInputStream gis = new GZIPInputStream(compressed.toInputStream())) {
                 int off = 0;
-                while (off < decompressedSize) {
-                    int read = gis.read(out, off, decompressedSize - off);
+                while (off < destLen) {
+                    int read = gis.read(dest, off, destLen - off);
                     if (read < 0) {
-                        throw new IOException("Premature end of GZIP stream: expected " + decompressedSize + " bytes, got " + off);
+                        throw new IOException("Premature end of GZIP stream: expected " + destLen + " bytes, got " + off);
                     }
                     off += read;
                 }
+                if (gis.read() >= 0) {
+                    throw new IOException("GZIP stream produced more than " + destLen + " uncompressed bytes declared by the page header");
+                }
             }
-            return BytesInput.from(out);
         }
 
         @Override
@@ -280,31 +326,36 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * it merely deferred the same error. Aligns with {@code ZstdDecompressionCodec}'s
      * hard-fail-on-construction stance.
      */
-    private static class ZstdBytesDecompressor implements BytesInputDecompressor {
+    private static class ZstdBytesDecompressor implements HeapDestDecompressor {
         private final PanamaZstd panamaZstd = PanamaZstd.instance();
 
         @Override
-        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
+        public void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException {
+            requireDestCapacity(dest, destLen);
             int written;
             try {
-                // BytesInput.toByteArray() may copy or alias depending on the BytesInput
-                // implementation; we accept whatever parquet-mr hands us. The
-                // PanamaZstd.decompressHeap downcall is critical(true), so the heap segments
-                // cross into libzstd with no off-heap staging copy — same behavior as zstd-jni's
-                // GetPrimitiveArrayCritical path, minus the G1 region pinning.
-                written = panamaZstd.decompressHeap(out, bytes.toByteArray());
+                // PanamaZstd.decompressHeap is critical(true): heap segments cross into libzstd
+                // with no off-heap staging copy. Pass destLen as dstSize, not dest.length: a
+                // reused dest may be larger than this page, and the two-arg decompressHeap(dest,
+                // src) uses dest.length as the cap.
+                ByteBuffer input = compressed.toByteBuffer();
+                if (input.hasArray()) {
+                    written = panamaZstd.decompressHeap(
+                        dest,
+                        0,
+                        destLen,
+                        input.array(),
+                        input.arrayOffset() + input.position(),
+                        input.remaining()
+                    );
+                } else {
+                    byte[] src = compressed.toByteArray();
+                    written = panamaZstd.decompressHeap(dest, 0, destLen, src, 0, src.length);
+                }
             } catch (RuntimeException e) {
                 throw new IOException("Zstd decompression failed", e);
             }
-            // Guard against silent corruption: out is allocated via UninitializedArrays so any
-            // shortfall would leak uninitialized bytes into the BytesInput we hand back.
-            if (written != decompressedSize) {
-                throw new IOException(
-                    "Zstd decompression produced " + written + " bytes, expected " + decompressedSize + " from page header"
-                );
-            }
-            return BytesInput.from(out);
+            requireExactUncompressedSize(written, destLen, "Zstd");
         }
 
         @Override
@@ -343,20 +394,21 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * LZ4 raw decompressor. Aircompressor's {@code Lz4Decompressor} works with both heap and
      * direct {@code ByteBuffer}s, so no fallback is needed.
      */
-    private static class Lz4RawBytesDecompressor implements BytesInputDecompressor {
+    private static class Lz4RawBytesDecompressor implements HeapDestDecompressor {
         private final Lz4Decompressor lz4 = new Lz4Decompressor();
 
         @Override
-        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            ByteBuffer input = bytes.toByteBuffer();
+        public void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException {
+            requireDestCapacity(dest, destLen);
+            ByteBuffer input = compressed.toByteBuffer();
+            int written;
             if (input.hasArray()) {
-                lz4.decompress(input.array(), input.arrayOffset() + input.position(), input.remaining(), out, 0, decompressedSize);
+                written = lz4.decompress(input.array(), input.arrayOffset() + input.position(), input.remaining(), dest, 0, destLen);
             } else {
-                byte[] in = bytes.toByteArray();
-                lz4.decompress(in, 0, in.length, out, 0, decompressedSize);
+                byte[] in = compressed.toByteArray();
+                written = lz4.decompress(in, 0, in.length, dest, 0, destLen);
             }
-            return BytesInput.from(out);
+            requireExactUncompressedSize(written, destLen, "LZ4_RAW");
         }
 
         @Override
@@ -404,15 +456,14 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * mid-2024, and Spark 3.0–3.4 with explicit {@code lz4} compression) but never emits the
      * deprecated codec itself. No entry is registered in the compressors map.
      */
-    private static class Lz4HadoopFramedBytesDecompressor implements BytesInputDecompressor {
+    private static class Lz4HadoopFramedBytesDecompressor implements HeapDestDecompressor {
         private final Lz4Decompressor lz4 = new Lz4Decompressor();
 
         @Override
-        public BytesInput decompress(BytesInput bytes, int decompressedSize) throws IOException {
-            byte[] in = bytes.toByteArray();
-            byte[] out = UninitializedArrays.newByteArray(decompressedSize);
-            decompressHadoopFramed(in, 0, in.length, out, 0, decompressedSize);
-            return BytesInput.from(out);
+        public void decompressInto(BytesInput compressed, byte[] dest, int destLen) throws IOException {
+            requireDestCapacity(dest, destLen);
+            byte[] in = compressed.toByteArray();
+            decompressHadoopFramed(in, 0, in.length, dest, 0, destLen);
         }
 
         @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -315,7 +315,8 @@ public final class PlainCompressionCodecFactory implements CompressionCodecFacto
      * {@code ColumnChunkPageReadStore} is {@code BytesInput}/{@code byte[]} via
      * {@link PanamaZstd#decompressHeap}, bound with {@code Linker.Option.critical(true)} so heap
      * segments cross into libzstd without an off-heap staging copy and without zstd-jni's G1
-     * region pinning. Production readers use this {@code BytesInput} overload.
+     * region pinning. Production data pages use {@link #decompressInto}; {@code decompress(BytesInput,
+     * int)} still allocates for parquet-mr and dictionary pages.
      * The {@code ByteBuffer} overload remains for the parquet-mr SPI and tests; it still uses a
      * direct-to-direct Panama path when both sides are direct.
      *

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -51,7 +51,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>{@link #readPage()} / {@link #readDictionaryPage()} run on the iterator thread.
  * {@link #close()} may race another {@link #close()} (hence {@link #closed}) and may race
  * a read on cancel. Charge counters are {@link java.util.concurrent.atomic.AtomicLong} so
- * that race cannot silently skew the breaker.
+ * that race cannot silently skew the breaker. {@link #reusableDecompBuf} is {@code volatile}
+ * so a close that nulls the dest is visible to a concurrent read; the read path snapshots
+ * the array into a local and does not re-read the field after {@code decompressInto}.
  */
 final class PrefetchedPageReader implements PageReader, Releasable {
 
@@ -78,8 +80,9 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     /**
      * Grow-only dest for {@link PlainCompressionCodecFactory.HeapDestDecompressor}. Never shrunk.
      * Returned data-page {@link BytesInput}s alias this array for the life of the current page.
+     * {@code volatile}: {@link #close()} may null it from another thread while a read is in flight.
      */
-    private byte[] reusableDecompBuf;
+    private volatile byte[] reusableDecompBuf;
     /** Live capacity of {@link #reusableDecompBuf}, or the current allocating-decompress page. */
     private final AtomicLong dataPageCharge = new AtomicLong();
     private final AtomicLong dictCharge = new AtomicLong();
@@ -293,14 +296,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         }
         if (heapDest != null) {
             byte[] dest = ensureDecompCapacity(decompressedSize);
-            try {
-                heapDest.decompressInto(compressed, dest, decompressedSize);
-            } catch (IOException e) {
-                if (closed.get()) {
-                    dropReusableDest();
-                }
-                throw e;
-            }
+            heapDest.decompressInto(compressed, dest, decompressedSize);
             BytesInput decompressed = BytesInput.from(dest, 0, decompressedSize);
             if (closed.get()) {
                 dropReusableDest();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReader.java
@@ -16,6 +16,7 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
@@ -36,12 +37,16 @@ import java.util.concurrent.atomic.AtomicLong;
  * original page type ({@link DataPageV1} stays V1, {@link DataPageV2} stays V2 with only the
  * data portion decompressed). Encryption and CRC verification are not supported.
  *
- * <p>Compressed pages decompress onto a heap {@code byte[]} via
- * {@link BytesInputDecompressor#decompress(BytesInput, int)}. That output is charged to
- * {@code breaker} for the life of the current page (and the cached dictionary, if any) and
- * released before the next page or on {@link #close()}. Uncompressed pages alias the
- * prefetched I/O bytes and are not charged — those bytes are already accounted by the
- * prefetch circuit breaker.
+ * <p>Compressed data pages decompress onto a grow-only heap {@code byte[]} via
+ * {@link PlainCompressionCodecFactory.HeapDestDecompressor#decompressInto} when the codec
+ * supports it. The dest's live capacity is charged to {@code breaker} until {@link #close()};
+ * same-size pages do not re-charge. A grow charges the new size before dropping the old
+ * charge so peak heap and breaker match while both arrays are live. Dictionary pages still
+ * allocate via {@link BytesInputDecompressor#decompress(BytesInput, int)} and keep that
+ * charge until close. Uncompressed pages alias the prefetched I/O bytes and are not charged
+ * — those bytes are already accounted by the prefetch circuit breaker. Failed decompress
+ * after a successful grow keeps the charge (the array is still referenced). A trip in
+ * {@code addEstimateBytesAndMaybeBreak} leaves the previous array and charge unchanged.
  *
  * <p>{@link #readPage()} / {@link #readDictionaryPage()} run on the iterator thread.
  * {@link #close()} may race another {@link #close()} (hence {@link #closed}) and may race
@@ -62,6 +67,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
     record CompressedPage(DataPage page, long firstRowIndex) {}
 
     private final BytesInputDecompressor decompressor;
+    private final PlainCompressionCodecFactory.HeapDestDecompressor heapDest;
     private final CircuitBreaker breaker;
     private final long valueCount;
     private final Deque<CompressedPage> compressedPages;
@@ -69,6 +75,12 @@ final class PrefetchedPageReader implements PageReader, Releasable {
 
     private DictionaryPage cachedDictionaryPage;
     private boolean dictionaryDecompressed;
+    /**
+     * Grow-only dest for {@link PlainCompressionCodecFactory.HeapDestDecompressor}. Never shrunk.
+     * Returned data-page {@link BytesInput}s alias this array for the life of the current page.
+     */
+    private byte[] reusableDecompBuf;
+    /** Live capacity of {@link #reusableDecompBuf}, or the current allocating-decompress page. */
     private final AtomicLong dataPageCharge = new AtomicLong();
     private final AtomicLong dictCharge = new AtomicLong();
     // AtomicBoolean (rather than a plain volatile flag) so concurrent close() callers race
@@ -83,6 +95,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         long valueCount
     ) {
         this.decompressor = decompressor;
+        this.heapDest = decompressor instanceof PlainCompressionCodecFactory.HeapDestDecompressor h ? h : null;
         this.breaker = breaker;
         this.compressedPages = new ArrayDeque<>(compressedPages);
         this.compressedDictionaryPage = compressedDictionaryPage;
@@ -105,17 +118,19 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             // page to decode.
             return null;
         }
-        // Previous page is dead. Both consumers of this reader ask for pages strictly sequentially
-        // and are done with the current page's bytes before they ask for the next one:
-        // - PageColumnReader#loadNextPage (flat columns) runs its remainder-skip off the current
-        // value/def-level buffers BEFORE calling readPage(), and reassigns those buffers to the
-        // new page immediately after;
+        // Previous page dest is overwritten on the reuse path. Consumers must be done with the
+        // current page's bytes before they ask for the next one:
+        // - PageColumnReader primitives/skip finish the current page before readPage(); BINARY
+        // consumers copy into the ESQL block (appendBytesRef / constant deepCopy) before the
+        // next ensurePage()/readPage(). The BytesInput returned here aliases reusableDecompBuf.
         // - parquet-mr's ColumnReaderBase (list columns, via ColumnReadStoreImpl) calls readPage()
         // only from checkRead() once the current page is fully consumed, re-initializes all of
         // its level/value readers from the new page before any further read, and its consumers
         // (ParquetColumnDecoding#readListRow) copy each value to the heap before the consume()
         // that can cross a page boundary.
-        releaseCharge(dataPageCharge);
+        if (heapDest == null) {
+            releaseCharge(dataPageCharge);
+        }
         DataPage page = entry.page();
         if (page instanceof DataPageV1 v1) {
             return decompressV1(v1);
@@ -276,6 +291,23 @@ final class PrefetchedPageReader implements PageReader, Releasable {
             }
             return compressed;
         }
+        if (heapDest != null) {
+            byte[] dest = ensureDecompCapacity(decompressedSize);
+            try {
+                heapDest.decompressInto(compressed, dest, decompressedSize);
+            } catch (IOException e) {
+                if (closed.get()) {
+                    dropReusableDest();
+                }
+                throw e;
+            }
+            BytesInput decompressed = BytesInput.from(dest, 0, decompressedSize);
+            if (closed.get()) {
+                dropReusableDest();
+                throw new ParquetDecodingException("PrefetchedPageReader closed");
+            }
+            return decompressed;
+        }
         breaker.addEstimateBytesAndMaybeBreak(decompressedSize, DECOMP_BREAKER_LABEL);
         boolean success = false;
         try {
@@ -293,6 +325,38 @@ final class PrefetchedPageReader implements PageReader, Releasable {
                 breaker.addWithoutBreaking(-decompressedSize);
             }
         }
+    }
+
+    private byte[] ensureDecompCapacity(int needed) {
+        byte[] buf = reusableDecompBuf;
+        if (buf != null && buf.length >= needed) {
+            return buf;
+        }
+        // Charge the new size on top of any live old charge so breaker tracks peak heap while
+        // both arrays exist; drop the old charge after the new array is published.
+        breaker.addEstimateBytesAndMaybeBreak(needed, DECOMP_BREAKER_LABEL);
+        byte[] next;
+        try {
+            next = UninitializedArrays.newByteArray(needed);
+        } catch (Error | RuntimeException e) {
+            breaker.addWithoutBreaking(-needed);
+            throw e;
+        }
+        reusableDecompBuf = next;
+        long previous = dataPageCharge.getAndSet(needed);
+        if (previous != 0) {
+            breaker.addWithoutBreaking(-previous);
+        }
+        if (closed.get()) {
+            dropReusableDest();
+            throw new ParquetDecodingException("PrefetchedPageReader closed");
+        }
+        return next;
+    }
+
+    private void dropReusableDest() {
+        reusableDecompBuf = null;
+        releaseCharge(dataPageCharge);
     }
 
     private boolean isNoopDecompressor() {
@@ -314,7 +378,7 @@ final class PrefetchedPageReader implements PageReader, Releasable {
         // Drop the cached dictionary page reference. It is heap-backed (see readDictionaryPage),
         // so this is reference hygiene plus breaker release, not a native-buffer lifetime.
         cachedDictionaryPage = null;
-        releaseCharge(dataPageCharge);
+        dropReusableDest();
         releaseCharge(dictCharge);
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -52,6 +52,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -589,6 +590,75 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         assertOptimizedMatchesBaseline(data, columns);
     }
 
+    public void testCompressedUniqueStringsAcrossPages() throws IOException {
+        // PARQUET_1_0 PLAIN aliases the reused dest. Fixed-width values keep page uncompressed
+        // sizes equal so dest is reused rather than grown (a grow would leave the old array
+        // alive and hide a missing copy-out). PARQUET_2_0 DELTA_BYTE_ARRAY copies the page in
+        // initDecoders, so it would not catch a missing copy-out.
+        int rows = 200;
+        int batchSize = 128;
+        MessageType schema = Types.buildMessage()
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("req")
+            .optional(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("opt")
+            .named("unique_str_reuse");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(codecFactory)
+                .withType(schema)
+                .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
+                .withCompressionCodec(CompressionCodecName.SNAPPY)
+                .withDictionaryEncoding(false)
+                .withRowGroupSize(64L * 1024 * 1024)
+                .withPageSize(64)
+                .build()
+        ) {
+            for (int i = 0; i < rows; i++) {
+                Group g = groupFactory.newGroup().append("req", String.format(Locale.ROOT, "req_%05d", i));
+                if (i % 7 != 0) {
+                    g.append("opt", String.format(Locale.ROOT, "opt_%05d", i));
+                }
+                writer.write(g);
+            }
+        }
+        byte[] data = out.toByteArray();
+        try (ParquetFileReader parquetReader = openReader(data)) {
+            OffsetIndex oi = parquetReader.readOffsetIndex(parquetReader.getRowGroups().getFirst().getColumns().getFirst());
+            assertNotNull("column must have an offset index", oi);
+            assertTrue("need ≥2 data pages so dest reuse can clobber", oi.getPageCount() >= 2);
+            assertTrue("batch must span page 0", batchSize > oi.getFirstRowIndex(1));
+        }
+        List<String> columns = List.of("req", "opt");
+        List<Page> pages = readAll(new ParquetFormatReader(blockFactory), data, columns, batchSize);
+        try {
+            assertEquals(batchSize, pages.getFirst().getPositionCount());
+            int pos = 0;
+            for (Page page : pages) {
+                BytesRefBlock req = (BytesRefBlock) page.getBlock(0);
+                BytesRefBlock opt = (BytesRefBlock) page.getBlock(1);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    assertBytesRefAt(req, i, String.format(Locale.ROOT, "req_%05d", pos));
+                    if (pos % 7 == 0) {
+                        assertTrue("opt null@" + pos, opt.isNull(i));
+                    } else {
+                        assertBytesRefAt(opt, i, String.format(Locale.ROOT, "opt_%05d", pos));
+                    }
+                    pos++;
+                }
+            }
+            assertEquals(rows, pos);
+        } finally {
+            pages.forEach(Page::releaseBlocks);
+        }
+        assertOptimizedMatchesBaseline(data, columns);
+    }
+
     // --- Column spec for randomized tests ---
 
     private record ColSpec(
@@ -687,9 +757,13 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
     // --- Read helpers ---
 
     private List<Page> readAll(ParquetFormatReader reader, byte[] data, List<String> columns) throws IOException {
+        return readAll(reader, data, columns, BATCH_SIZE);
+    }
+
+    private List<Page> readAll(ParquetFormatReader reader, byte[] data, List<String> columns, int batchSize) throws IOException {
         StorageObject so = storageObject(data);
         List<Page> pages = new ArrayList<>();
-        try (CloseableIterator<Page> iter = reader.read(so, FormatReadContext.of(columns, BATCH_SIZE))) {
+        try (CloseableIterator<Page> iter = reader.read(so, FormatReadContext.of(columns, batchSize))) {
             while (iter.hasNext()) {
                 pages.add(iter.next());
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -594,7 +594,18 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         // PARQUET_1_0 PLAIN aliases the reused dest. Fixed-width values keep page uncompressed
         // sizes equal so dest is reused rather than grown (a grow would leave the old array
         // alive and hide a missing copy-out). PARQUET_2_0 DELTA_BYTE_ARRAY copies the page in
-        // initDecoders, so it would not catch a missing copy-out.
+        // initDecoders, so it would not catch a missing copy-out. Loop every dest-reuse codec:
+        // a destLen vs dest.length bug is codec-specific (Zstd).
+        for (CompressionCodecName codec : new CompressionCodecName[] {
+            CompressionCodecName.SNAPPY,
+            CompressionCodecName.ZSTD,
+            CompressionCodecName.GZIP,
+            CompressionCodecName.LZ4_RAW }) {
+            assertCompressedUniqueStringsAcrossPages(codec);
+        }
+    }
+
+    private void assertCompressedUniqueStringsAcrossPages(CompressionCodecName codec) throws IOException {
         int rows = 200;
         int batchSize = 128;
         MessageType schema = Types.buildMessage()
@@ -613,7 +624,7 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
                 .withCodecFactory(codecFactory)
                 .withType(schema)
                 .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
-                .withCompressionCodec(CompressionCodecName.SNAPPY)
+                .withCompressionCodec(codec)
                 .withDictionaryEncoding(false)
                 .withRowGroupSize(64L * 1024 * 1024)
                 .withPageSize(64)
@@ -630,14 +641,14 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         byte[] data = out.toByteArray();
         try (ParquetFileReader parquetReader = openReader(data)) {
             OffsetIndex oi = parquetReader.readOffsetIndex(parquetReader.getRowGroups().getFirst().getColumns().getFirst());
-            assertNotNull("column must have an offset index", oi);
-            assertTrue("need ≥2 data pages so dest reuse can clobber", oi.getPageCount() >= 2);
-            assertTrue("batch must span page 0", batchSize > oi.getFirstRowIndex(1));
+            assertNotNull(codec + " column must have an offset index", oi);
+            assertTrue(codec + " need ≥2 data pages so dest reuse can clobber", oi.getPageCount() >= 2);
+            assertTrue(codec + " batch must span page 0", batchSize > oi.getFirstRowIndex(1));
         }
         List<String> columns = List.of("req", "opt");
         List<Page> pages = readAll(new ParquetFormatReader(blockFactory), data, columns, batchSize);
         try {
-            assertEquals(batchSize, pages.getFirst().getPositionCount());
+            assertEquals(codec + " first batch", batchSize, pages.getFirst().getPositionCount());
             int pos = 0;
             for (Page page : pages) {
                 BytesRefBlock req = (BytesRefBlock) page.getBlock(0);
@@ -645,14 +656,14 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
                 for (int i = 0; i < page.getPositionCount(); i++) {
                     assertBytesRefAt(req, i, String.format(Locale.ROOT, "req_%05d", pos));
                     if (pos % 7 == 0) {
-                        assertTrue("opt null@" + pos, opt.isNull(i));
+                        assertTrue(codec + " opt null@" + pos, opt.isNull(i));
                     } else {
                         assertBytesRefAt(opt, i, String.format(Locale.ROOT, "opt_%05d", pos));
                     }
                     pos++;
                 }
             }
-            assertEquals(rows, pos);
+            assertEquals(codec + " rows", rows, pos);
         } finally {
             pages.forEach(Page::releaseBlocks);
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
@@ -96,7 +96,7 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
         byte[] dest = new byte[original.length + between(16, 256)];
         Arrays.fill(dest, (byte) 0x5A);
         int destLen = original.length / 2;
-        assumeTrue("need destLen strictly smaller than the stream", destLen > 0 && destLen < original.length);
+        assert destLen > 0 && destLen < original.length;
         PlainCompressionCodecFactory.HeapDestDecompressor decompressor = (PlainCompressionCodecFactory.HeapDestDecompressor) factory
             .getDecompressor(CompressionCodecName.GZIP);
         IOException e = expectThrows(IOException.class, () -> decompressor.decompressInto(compressed, dest, destLen));
@@ -129,7 +129,7 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
         byte[] dest = new byte[original.length + between(16, 256)];
         Arrays.fill(dest, (byte) 0x5A);
         int destLen = original.length / 2;
-        assumeTrue("need destLen strictly smaller than the stream", destLen > 0 && destLen < original.length);
+        assert destLen > 0 && destLen < original.length;
         PlainCompressionCodecFactory.HeapDestDecompressor decompressor = (PlainCompressionCodecFactory.HeapDestDecompressor) factory
             .getDecompressor(CompressionCodecName.SNAPPY);
         IOException e = expectThrows(IOException.class, () -> decompressor.decompressInto(compressed, dest, destLen));

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -56,6 +57,86 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
 
     public void testLz4RawRoundTrip() throws IOException {
         assertRoundTrip(CompressionCodecName.LZ4_RAW);
+    }
+
+    public void testNoopDecompressorIsNotHeapDest() {
+        BytesInputDecompressor decompressor = factory.getDecompressor(CompressionCodecName.UNCOMPRESSED);
+        assertFalse(decompressor instanceof PlainCompressionCodecFactory.HeapDestDecompressor);
+    }
+
+    public void testDecompressIntoOversizedDest() throws IOException {
+        // Honor destLen, not dest.length: reused dest is often larger than this page.
+        for (CompressionCodecName codec : new CompressionCodecName[] {
+            CompressionCodecName.SNAPPY,
+            CompressionCodecName.ZSTD,
+            CompressionCodecName.GZIP,
+            CompressionCodecName.LZ4_RAW }) {
+            assertDecompressIntoOversizedDest(
+                codec,
+                factory.getCompressor(codec),
+                (PlainCompressionCodecFactory.HeapDestDecompressor) factory.getDecompressor(codec)
+            );
+        }
+        LegacyLz4HadoopFramedCodecFactory lz4Write = new LegacyLz4HadoopFramedCodecFactory();
+        try {
+            assertDecompressIntoOversizedDest(
+                CompressionCodecName.LZ4,
+                lz4Write.getCompressor(CompressionCodecName.LZ4),
+                (PlainCompressionCodecFactory.HeapDestDecompressor) factory.getDecompressor(CompressionCodecName.LZ4)
+            );
+        } finally {
+            lz4Write.release();
+        }
+    }
+
+    public void testGzipDecompressIntoRejectsExtraUncompressedBytes() throws IOException {
+        BytesInputCompressor compressor = factory.getCompressor(CompressionCodecName.GZIP);
+        byte[] original = randomByteArrayOfLength(between(200, 4096));
+        BytesInput compressed = compressor.compress(BytesInput.from(original));
+        byte[] dest = new byte[original.length + between(16, 256)];
+        Arrays.fill(dest, (byte) 0x5A);
+        int destLen = original.length / 2;
+        assumeTrue("need destLen strictly smaller than the stream", destLen > 0 && destLen < original.length);
+        PlainCompressionCodecFactory.HeapDestDecompressor decompressor = (PlainCompressionCodecFactory.HeapDestDecompressor) factory
+            .getDecompressor(CompressionCodecName.GZIP);
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompressInto(compressed, dest, destLen));
+        assertThat(e.getMessage(), containsString("GZIP"));
+        for (int i = destLen; i < dest.length; i++) {
+            assertEquals("must not write past destLen", (byte) 0x5A, dest[i]);
+        }
+    }
+
+    private void assertDecompressIntoOversizedDest(
+        CompressionCodecName codec,
+        BytesInputCompressor compressor,
+        PlainCompressionCodecFactory.HeapDestDecompressor decompressor
+    ) throws IOException {
+        byte[] original = randomByteArrayOfLength(between(100, 4096));
+        BytesInput compressed = compressor.compress(BytesInput.from(original));
+        byte[] dest = new byte[original.length + between(16, 256)];
+        Arrays.fill(dest, (byte) 0x5A);
+        decompressor.decompressInto(compressed, dest, original.length);
+        assertArrayEquals(codec + " prefix", original, Arrays.copyOf(dest, original.length));
+        for (int i = original.length; i < dest.length; i++) {
+            assertEquals(codec + " must not write past destLen at index " + i, (byte) 0x5A, dest[i]);
+        }
+    }
+
+    public void testSnappyDecompressIntoRejectsLengthMismatchOnOversizedDest() throws IOException {
+        BytesInputCompressor compressor = factory.getCompressor(CompressionCodecName.SNAPPY);
+        byte[] original = randomByteArrayOfLength(between(200, 4096));
+        BytesInput compressed = compressor.compress(BytesInput.from(original));
+        byte[] dest = new byte[original.length + between(16, 256)];
+        Arrays.fill(dest, (byte) 0x5A);
+        int destLen = original.length / 2;
+        assumeTrue("need destLen strictly smaller than the stream", destLen > 0 && destLen < original.length);
+        PlainCompressionCodecFactory.HeapDestDecompressor decompressor = (PlainCompressionCodecFactory.HeapDestDecompressor) factory
+            .getDecompressor(CompressionCodecName.SNAPPY);
+        IOException e = expectThrows(IOException.class, () -> decompressor.decompressInto(compressed, dest, destLen));
+        assertThat(e.getMessage(), containsString("Snappy"));
+        for (int i = 0; i < dest.length; i++) {
+            assertEquals("must not write before the uncompressedLength check", (byte) 0x5A, dest[i]);
+        }
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchedPageReaderPerPageReleaseTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
@@ -26,9 +27,9 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Pins two contracts on {@link PrefetchedPageReader}: live breaker residency stays O(one
- * decompressed page) (+ dictionary, if any), not O(uncompressed column chunk); and compressed
- * pages decompress onto a heap {@code byte[]}, not a direct buffer.
+ * Pins two contracts on {@link PrefetchedPageReader}: live breaker residency stays O(max
+ * decompressed page seen) (+ dictionary, if any), not O(uncompressed column chunk); same-size
+ * pages stay charged at one page. Compressed pages decompress onto a reused heap {@code byte[]}.
  *
  * <p>Both a zstd {@link DataPageV2} (the canonical bench case) and a gzip {@link DataPageV1}
  * (codec-uniformity twin, no native-library dependency) are covered for the live bound.
@@ -78,7 +79,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             for (int p = 0; p < PAGES; p++) {
                 assertNotNull(reader.readPage());
                 assertEquals(
-                    "live charge must be dictionary plus the current data page after readPage() #" + (p + 1),
+                    "live charge must be dictionary plus dest capacity (one page) after readPage() #" + (p + 1),
                     dictPayload.length + PAGE_PAYLOAD_BYTES,
                     breaker.getUsed()
                 );
@@ -97,7 +98,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         assertHeapNotDirect(buildGzipV1Pages());
     }
 
-    public void testBreakerChargeTracksCurrentPageSize() throws IOException {
+    public void testBreakerChargeTracksMaxSeenDestCapacity() throws IOException {
         int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
         PagesFixture fixture = buildZstdV2Pages(sizes);
         LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
@@ -109,10 +110,55 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             valueCount(sizes)
         );
         try {
+            int maxSeen = 0;
             for (int size : sizes) {
                 DataPageV2 page = (DataPageV2) reader.readPage();
                 assertNotNull(page);
-                assertEquals(size, breaker.getUsed());
+                maxSeen = Math.max(maxSeen, size);
+                assertEquals("breaker tracks grow-only dest capacity, not the current page size", maxSeen, breaker.getUsed());
+            }
+        } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    public void testReusableDestArrayIdentityAndSliceLength() throws IOException {
+        // Equal-or-smaller pages reuse dest; grow allocates. Slice remaining is page size, not capacity.
+        int[] sizes = { 32 * 1024, 64 * 1024, 128 * 1024, 64 * 1024 };
+        PagesFixture fixture = buildZstdV2Pages(sizes);
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+            breaker,
+            fixture.pages,
+            null,
+            valueCount(sizes)
+        );
+        try {
+            byte[] dest = null;
+            int maxSeen = 0;
+            for (int i = 0; i < sizes.length; i++) {
+                int size = sizes[i];
+                DataPageV2 page = (DataPageV2) reader.readPage();
+                assertNotNull(page);
+                var buf = page.getData().toByteBuffer();
+                assertTrue(buf.hasArray());
+                assertEquals("slice remaining must be the page size, not dest capacity", size, buf.remaining());
+                byte[] array = buf.array();
+                assertArrayEquals("decompressed prefix must match payload", fixture.payloads().get(i), Arrays.copyOf(array, size));
+                if (size > maxSeen) {
+                    if (dest != null) {
+                        assertNotSame("grow must allocate a new dest", dest, array);
+                    }
+                    dest = array;
+                    maxSeen = size;
+                } else {
+                    assertSame("equal-or-smaller page must reuse dest", dest, array);
+                }
+                assertEquals(maxSeen, array.length);
+                assertEquals(maxSeen, breaker.getUsed());
             }
         } finally {
             reader.close();
@@ -173,6 +219,31 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         assertEquals(0L, breaker.getUsed());
     }
 
+    public void testGrowBreakerTripKeepsPreviousDestCharge() throws IOException {
+        // First page charges dest. A later grow that trips must leave that charge in place.
+        int small = 32 * 1024;
+        int large = 128 * 1024;
+        PagesFixture fixture = buildZstdV2Pages(new int[] { small, large });
+        LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofBytes(small + large - 1L));
+        PrefetchedPageReader reader = new PrefetchedPageReader(
+            fixture.codecFactory.getDecompressor(CompressionCodecName.ZSTD),
+            breaker,
+            fixture.pages,
+            null,
+            valueCount(new int[] { small, large })
+        );
+        try {
+            assertNotNull(reader.readPage());
+            assertEquals(small, breaker.getUsed());
+            expectThrows(CircuitBreakingException.class, reader::readPage);
+            assertEquals("failed grow must leave the previous dest charged", small, breaker.getUsed());
+        } finally {
+            reader.close();
+            fixture.codecFactory.release();
+        }
+        assertEquals(0L, breaker.getUsed());
+    }
+
     private void assertPerPageChargeAndZeroOnClose(PagesFixture fixture) throws IOException {
         LimitedBreaker breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(16));
         PrefetchedPageReader reader = new PrefetchedPageReader(
@@ -183,13 +254,16 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             (long) PAGE_PAYLOAD_BYTES * PAGES
         );
         try {
-            assertNotNull(reader.readPage());
+            DataPage first = reader.readPage();
+            assertNotNull(first);
+            byte[] dest = destArray(first);
             assertEquals(PAGE_PAYLOAD_BYTES, breaker.getUsed());
+            assertEquals(PAGE_PAYLOAD_BYTES, dest.length);
 
             for (int p = 1; p < PAGES; p++) {
-                assertNotNull(reader.readPage());
-                // Per-page bound: the previous page's charge is released the moment the
-                // consumer asks for the next page.
+                DataPage page = reader.readPage();
+                assertNotNull(page);
+                assertSame("equal-size pages must reuse dest after readPage() #" + (p + 1), dest, destArray(page));
                 assertEquals(
                     "live decompressed charge must stay one page after readPage() #" + (p + 1),
                     PAGE_PAYLOAD_BYTES,
@@ -236,8 +310,10 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
         BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.ZSTD);
         List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(payloadBytes.length);
+        List<byte[]> payloads = new ArrayList<>(payloadBytes.length);
         for (int payloadSize : payloadBytes) {
             byte[] data = randomByteArrayOfLength(payloadSize);
+            payloads.add(data);
             byte[] compressedData = compressor.compress(BytesInput.from(data)).toByteArray();
             DataPageV2 v2 = new DataPageV2(
                 payloadSize / 4,
@@ -253,15 +329,17 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             );
             pages.add(new PrefetchedPageReader.CompressedPage(v2, -1L));
         }
-        return new PagesFixture(codecFactory, CompressionCodecName.ZSTD, pages);
+        return new PagesFixture(codecFactory, CompressionCodecName.ZSTD, pages, payloads);
     }
 
     private PagesFixture buildGzipV1Pages() throws IOException {
         PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
         BytesInputCompressor compressor = codecFactory.getCompressor(CompressionCodecName.GZIP);
         List<PrefetchedPageReader.CompressedPage> pages = new ArrayList<>(PAGES);
+        List<byte[]> payloads = new ArrayList<>(PAGES);
         for (int p = 0; p < PAGES; p++) {
             byte[] payload = randomByteArrayOfLength(PAGE_PAYLOAD_BYTES);
+            payloads.add(payload);
             byte[] compressed = compressor.compress(BytesInput.from(payload)).toByteArray();
             DataPageV1 v1 = new DataPageV1(
                 BytesInput.from(compressed),
@@ -274,7 +352,7 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
             );
             pages.add(new PrefetchedPageReader.CompressedPage(v1, -1L));
         }
-        return new PagesFixture(codecFactory, CompressionCodecName.GZIP, pages);
+        return new PagesFixture(codecFactory, CompressionCodecName.GZIP, pages, payloads);
     }
 
     private static int[] filledSizes(int size) {
@@ -291,9 +369,16 @@ public class PrefetchedPageReaderPerPageReleaseTests extends ESTestCase {
         return values;
     }
 
+    private static byte[] destArray(DataPage page) throws IOException {
+        var buf = page instanceof DataPageV2 v2 ? v2.getData().toByteBuffer() : ((DataPageV1) page).getBytes().toByteBuffer();
+        assertTrue(buf.hasArray());
+        return buf.array();
+    }
+
     private record PagesFixture(
         PlainCompressionCodecFactory codecFactory,
         CompressionCodecName codec,
-        List<PrefetchedPageReader.CompressedPage> pages
+        List<PrefetchedPageReader.CompressedPage> pages,
+        List<byte[]> payloads
     ) {}
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
@@ -62,10 +62,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         /*
@@ -112,10 +115,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -142,10 +148,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyMissing(first, count);
@@ -163,10 +172,13 @@ public class MultivalueDedupeDoubleRange {
     public DoubleRangeBlock sortToBlock(BlockFactory blockFactory, boolean ascending) {
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -187,13 +199,14 @@ public class MultivalueDedupeDoubleRange {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    sawNull = true;
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> {
-                        sawNull = true;
-                        builder.appendInt(0);
-                    }
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashAdd(builder, hash, v);
@@ -220,10 +233,13 @@ public class MultivalueDedupeDoubleRange {
     public IntBlock hashLookup(BlockFactory blockFactory, LongLongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendInt(0);
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashLookupSingle(builder, hash, v);
@@ -263,10 +279,13 @@ public class MultivalueDedupeDoubleRange {
                     position++;
                 }
                 for (; position < block.getPositionCount(); position++) {
+                    if (block.isNull(position)) {
+                        encodeNull();
+                        continue;
+                    }
                     int count = block.getValueCount(position);
                     int first = block.getFirstValueIndex(position);
                     switch (count) {
-                        case 0 -> encodeNull();
                         case 1 -> {
                             DoubleRange v = block.getDoubleRange(first, work[0]);
                             if (hasCapacity(1)) {


### PR DESCRIPTION
Grow-only dest cuts G1 churn from per-page byte[]s.
PLAIN BINARY copies out before the next page overwrites dest.