### PR TITLE
[Docs] document ES|QL view index privileges

### DIFF
--- a/docs/reference/elasticsearch/security-privileges.md
+++ b/docs/reference/elasticsearch/security-privileges.md
@@ -321,6 +321,9 @@ When creating roles, refer to this page for a complete list of available privile
 `create_index`
 :   Privilege to create an index or data stream. A create index request may contain aliases to be added to the index once created. In that case the request requires the `manage` privilege as well, on both the index and the aliases names.
 
+`create_view` {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+:   Privilege to create or update an [{{esql}} view](/reference/query-languages/esql/esql-views.md), granted on the view name. It does not grant the privilege to query the view, nor any access to the indices that the view definition references. Refer to [view privileges](/reference/query-languages/esql/esql-views.md#esql-views-privileges).
+
 `cross_cluster_replication` {applies_to}`serverless: unavailable`
 :   Privileges to perform cross-cluster replication for indices located on [remote clusters configured with the API key based model](docs-content://deploy-manage/remote-clusters/remote-clusters-api-key.md). This privilege should only be used for the `privileges` field of [remote indices privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-remote-indices-priv).
 
@@ -338,6 +341,9 @@ When creating roles, refer to this page for a complete list of available privile
 
 `delete_index`
 :   Privilege to delete an index or data stream.
+
+`delete_view` {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+:   Privilege to delete an [{{esql}} view](/reference/query-languages/esql/esql-views.md), granted on the view name. Refer to [view privileges](/reference/query-languages/esql/esql-views.md#esql-views-privileges).
 
 `index`
 :   Privilege to index and update documents.
@@ -372,17 +378,23 @@ When creating roles, refer to this page for a complete list of available privile
 :   All actions that are required to manage the lifecycle of a leader index, which includes [forgetting a follower](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-forget-follower). This privilege is necessary only on clusters that contain leader indices.
 
 
+`manage_view` {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+:   Privilege to create, update, retrieve, and delete [{{esql}} view](/reference/query-languages/esql/esql-views.md) definitions, granted on the view name. It does not grant the privilege to query a view with `FROM`, nor any access to the indices that a view definition references. Refer to [view privileges](/reference/query-languages/esql/esql-views.md#esql-views-privileges).
+
 `monitor`
 :   All actions that are required for monitoring (recovery, segments info, index stats and status).
 
 `read`
-:   Read-only access to actions (count, explain, get, mget, get indexed scripts, more like this, multi percolate/search/termvector, percolate, scroll, clear_scroll, search, suggest, tv, ES|QL query, async ES|QL get, and async ES|QL stop).
+:   Read-only access to actions (count, explain, get, mget, get indexed scripts, more like this, multi percolate/search/termvector, percolate, scroll, clear_scroll, search, suggest, tv, ES|QL query, ES|QL views, async ES|QL get, and async ES|QL stop).
 
 `read_cross_cluster` {applies_to}`serverless: unavailable`
 :   Read-only access to the search action from a [remote cluster](docs-content://deploy-manage/remote-clusters/remote-clusters-self-managed.md).
 
 `read_failure_store` {applies_to}`stack: ga 9.1`
 :   Read-only access to actions performed on a data stream's failure store. Required for access to failure store data (count, explain, get, mget, get indexed scripts, more like this, multi percolate/search/termvector, percolate, scroll, clear_scroll, search, suggest, tv). Applies only to data streams when accessed through the [index component selector syntax](/reference/elasticsearch/rest-apis/api-conventions.md#api-component-selectors).
+
+`read_view_metadata` {applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+:   Privilege to retrieve an [{{esql}} view](/reference/query-languages/esql/esql-views.md) definition, granted on the view name. It does not grant the privilege to query the view, nor any access to the indices that the view definition references. Refer to [view privileges](/reference/query-languages/esql/esql-views.md#esql-views-privileges).
 
 `view_index_metadata`
 :   Read-only access to index and data stream metadata (aliases, exists, field capabilities, field mappings, get index, get data stream, ilm explain, mappings, search shards, settings, validate query). This privilege is available for use primarily by {{kib}} users.

--- a/docs/reference/query-languages/esql/_snippets/common/view_limitations.md
+++ b/docs/reference/query-languages/esql/_snippets/common/view_limitations.md
@@ -1,3 +1,7 @@
+#### Document- and field-level security
+
+A role entry that grants `read` on a view name must not carry DLS or FLS restrictions. If it does, the query fails with a `403`. DLS/FLS on the underlying indices is applied normally. Refer to [view privileges](/reference/query-languages/esql/esql-views.md#esql-views-privileges).
+
 #### Branching inside views
 
 Commands that also generate branched query plans

--- a/docs/reference/query-languages/esql/esql-data-federation-security.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-security.md
@@ -55,7 +55,7 @@ Dataset operations are authorized by the standard {{es}} [index privileges](../.
 
 Creating a dataset that references a data source also requires the `read` data source privilege for that data source. The two are authorized independently.
 
-The `read` privilege granted on a dataset name must not carry document-level or field-level security. `FROM <dataset>` is rejected if it does. The same restriction applies to [{{esql}} views](esql-views.md).
+The `read` privilege granted on a dataset name must not carry document-level or field-level security. `FROM <dataset>` is rejected if it does. The same restriction applies to [{{esql}} views](esql-views.md#esql-views-privileges).
 
 `superuser` has full access to data sources and datasets. Data source management is reached through the cluster `manage` (or `all`) privilege, or through a role explicitly granted `global.data_source` for fine-grained control.
 

--- a/docs/reference/query-languages/esql/esql-views.md
+++ b/docs/reference/query-languages/esql/esql-views.md
@@ -82,6 +82,50 @@ FROM index_pattern
 Where `index_pattern` is a comma-separated list of index or view names, including
 wildcards and date-math.
 
+## Privileges [esql-views-privileges]
+
+View operations use the standard {{es}} [index privileges](../../elasticsearch/security-privileges.md#privileges-list-indices), applied to the view name.
+
+| Operation | Privilege (on the view name) |
+|---|---|
+| Query (`FROM my_view`) | `read`, `all` |
+| Create or update (`PUT /_query/view/<name>`) | `create_view`, `manage_view`, `manage`, `all` |
+| Read definition (`GET /_query/view/<name>`) | `read_view_metadata`, `manage_view`, `manage`, `all` |
+| Delete (`DELETE /_query/view/<name>`) | `delete_view`, `manage_view`, `manage`, `all` |
+
+### Views are not a security boundary
+
+`read` on a view name permits querying the view but does **not** grant access to the data behind it. The caller must also have `read` on every index or alias the view definition resolves to, including through nested views.
+
+Access is enforced at query time. Creating a view requires no privilege over the indices it references.
+
+If some underlying indices are unauthorized, the query fails with a `403`. If none are accessible, it fails with a `400 Unknown index`. Wildcard patterns (`FROM view-*`) silently exclude unauthorized views.
+
+Nested views are resolved under the calling user's credentials. Access to an outer view does not grant access to any inner view it references.
+
+### Document- and field-level security
+
+`read` on a view name must not carry DLS or FLS. If it does, the query fails with a `403` and the `views_with_dls_or_fls` error field lists the affected names. This applies at every nesting level.
+
+DLS or FLS on the **underlying indices** is applied normally.
+
+### Example role
+
+```json
+{
+  "indices": [
+    {
+      "names": ["country_addresses"],
+      "privileges": ["read", "create_view", "read_view_metadata", "delete_view"]
+    },
+    {
+      "names": ["addresses"],
+      "privileges": ["read"]
+    }
+  ]
+}
+```
+
 ## Examples
 
 The following examples show how to use views within the `FROM` command.


### PR DESCRIPTION
Four index privileges added for ES|QL views in #141570 were missing from the canonical reference page, and `esql-views.md` had no security section.

- Adds `create_view`, `delete_view`, `manage_view`, `read_view_metadata` to `security-privileges.md` in alphabetical order
- Extends the `read` entry to note it also permits views.
- Adds a `## Privileges` section to `esql-views.md` covering the operation/privilege table, the non-security-boundary behaviour, DLS/FLS rejection, and an example role
- Adds a DLS/FLS limitation to `view_limitations.md` (shared with `limitations.md`)
- Repoints the cross-reference in `esql-data-federation-security.md` to the new `#esql-views-privileges` anchor

Closes elastic/elasticsearch-team#2329