### PR TITLE
fix: upgrade quinn-proto to 0.11.15 (GHSA-4w2j-m93h-cj5j)

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet-rs/native/Cargo.lock
+++ b/x-pack/plugin/esql-datasource-parquet-rs/native/Cargo.lock
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
Upgrade quinn-proto from 0.11.14 to 0.11.15 to fix GHSA-4w2j-m93h-cj5j.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-4w2j-m93h-cj5j |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-4w2j-m93h-cj5j` |
| **File** | `x-pack/plugin/esql-datasource-parquet-rs/native/Cargo.lock` (dependency: `quinn-proto`) |
| **Assessment** | Defensive hardening |

**Description**: Quinn: Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly

## Changes
- `x-pack/plugin/esql-datasource-parquet-rs/native/Cargo.lock`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
