### PR TITLE
[ESQL] Stop unread Parquet I/O under LIMIT

### DIFF
--- a/docs/changelog/157625.yaml
+++ b/docs/changelog/157625.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157625
+summary: Stop unread Parquet row groups and pages under LIMIT
+type: enhancement

--- a/docs/changelog/157625.yaml
+++ b/docs/changelog/157625.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
 pr: 157625
-summary: Stop unread Parquet row groups and pages under LIMIT
+summary: Stop unread Parquet row groups and pages under LIMIT. Sequential page-index preload honors the same column-path gate as coalesced preload.
 type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -257,6 +257,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
     private final boolean lateMaterialization;
     /**
+     * Cached at construction: remaining row budget with no record filter, no ColumnIndex
+     * {@link RowRanges}, no late-materialization, and no dynamic-threshold TopN. The other
+     * inputs are final; {@link #rowBudget} only walks down toward 0 and never back to
+     * {@link FormatReader#NO_LIMIT}, so this never flips for the iterator's lifetime.
+     */
+    private final boolean unfilteredLimit;
+    /**
      * When {@code true}, switches the prefetch + decode pipeline to a per-row-group two-phase
      * I/O flow: Phase 1 fetches only predicate column chunks, the iterator fully decodes them
      * to evaluate the filter and accumulate a global survivor mask, and Phase 2 then fetches
@@ -417,6 +424,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         this.pushedExpressions = pushedExpressions;
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
         this.lateMaterialization = pushedExpressions != null;
+        this.unfilteredLimit = ParquetFormatReader.unfilteredLimit(
+            rowBudget,
+            survivingRowGroups != null,
+            allRowRanges != null,
+            lateMaterialization,
+            dynamicThreshold != null
+        );
         this.survivorMask = lateMaterialization ? new WordMask() : null;
         this.dictionaryBitmaps = lateMaterialization ? new IdentityHashMap<>() : null;
         // Caller supplies null when late materialization is off; defensively also drop it here so
@@ -436,7 +450,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             projectionOnlyColumnPaths,
             fileLocation
         );
-        this.prefetchDepthFloor = unfilteredLimit() ? 1 : computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
+        this.prefetchDepthFloor = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
         this.prefetchDepth = this.prefetchDepthFloor;
 
         reader.setRequestedSchema(projectedSchema);
@@ -455,7 +469,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
             return;
         }
-        if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+        if (budgetExhausted()) {
             return;
         }
         int startOrdinal = nextSurvivingRowGroupOrdinal(0);
@@ -479,7 +493,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
         int nextOrdinal = fromOrdinal;
         while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
-            if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+            if (budgetExhausted()) {
                 break;
             }
             if (limitPrefetchCovered()) {
@@ -514,7 +528,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     // applied to the predicate-column prefetch here.
                     nextRowRanges = null;
                 }
-                RowRanges limitRanges = limitPrefixRowRanges(nextOrdinal, nextBlock);
+                RowRanges limitRanges = limitPrefixRowRanges(nextOrdinal, nextBlock, (long) rowBudget - limitCoveredRows());
                 if (limitRanges != null) {
                     nextRowRanges = nextRowRanges == null ? limitRanges : nextRowRanges.intersect(limitRanges);
                 }
@@ -542,19 +556,23 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
     }
 
+    private boolean budgetExhausted() {
+        return rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0;
+    }
+
     /**
-     * Unfiltered {@code LIMIT}: remaining row budget, no late-materialization (survivors unknown),
-     * no ColumnIndex row ranges, no dynamic-threshold TopN. This is the {@code FROM file | LIMIT n}
-     * path that can stop later groups and prefix-clip the first window.
+     * Source rows already open or queued. Used to stop later-group prefetch and to prefix-clip
+     * a later group's pages to the remaining need rather than the original {@link #rowBudget}.
      */
-    private boolean unfilteredLimit() {
-        return ParquetFormatReader.unfilteredLimit(
-            rowBudget,
-            survivingRowGroups != null,
-            allRowRanges != null,
-            lateMaterialization,
-            dynamicThreshold != null
-        );
+    private long limitCoveredRows() {
+        long rows = 0;
+        if (rowGroupOrdinal >= 0) {
+            rows += rowsRemainingInGroup;
+        }
+        for (PendingPrefetch pending : pendingPrefetches) {
+            rows += reader.getRowGroups().get(pending.ordinal()).getRowCount();
+        }
+        return rows;
     }
 
     /**
@@ -563,35 +581,32 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * may yield zero survivors.
      */
     private boolean limitPrefetchCovered() {
-        if (unfilteredLimit() == false) {
+        if (unfilteredLimit == false) {
             return false;
         }
-        long rows = 0;
-        if (rowGroupOrdinal >= 0) {
-            rows += rowsRemainingInGroup;
-        }
-        for (PendingPrefetch pending : pendingPrefetches) {
-            rows += reader.getRowGroups().get(pending.ordinal()).getRowCount();
-        }
-        return rows >= rowBudget;
+        return limitCoveredRows() >= rowBudget;
     }
 
     /**
-     * Prefix {@code [0, min(rowBudget, rgRows))} when OffsetIndex is present so filtered prefetch
-     * fetches dictionary + overlapping pages instead of the full first chunk. Missing index →
-     * {@code null} (full chunk, same as today). A prefix that covers the whole group is also
-     * {@code null}: clipping would be a no-op.
+     * Prefix {@code [0, min(remainingNeed, rgRows))} when every projected column has an OffsetIndex
+     * so filtered prefetch fetches dictionary + overlapping pages instead of the full chunk.
+     * {@code remainingNeed} is the rows this group can still contribute ({@link #rowBudget} minus
+     * already-open and already-queued groups at prefetch time; remaining {@link #rowBudget} at
+     * decode time). Missing index on any projected column → {@code null} (full chunk):
+     * {@link PrefetchedRowGroupBuilder} falls back to a sequential full-chunk read for index-less
+     * columns, while {@code rowsRemainingInGroup} would still become {@code selectedRowCount()}
+     * of the clipped ranges. Mixed files are rare enough that skipping the clip is safer.
+     * A prefix that covers the whole group is also {@code null}: clipping would be a no-op.
      */
-    private RowRanges limitPrefixRowRanges(int ordinal, BlockMetaData block) {
-        if (unfilteredLimit() == false) {
+    private RowRanges limitPrefixRowRanges(int ordinal, BlockMetaData block, long remainingNeed) {
+        if (unfilteredLimit == false) {
             return null;
         }
-        Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
-        if (hasAnyOffsetIndex(ordinal, phaseColumns) == false) {
+        if (hasAllOffsetIndexes(ordinal, projectedColumnPaths) == false) {
             return null;
         }
         long rgRows = block.getRowCount();
-        long end = Math.min(rowBudget, rgRows);
+        long end = Math.min(remainingNeed, rgRows);
         if (end <= 0) {
             return RowRanges.of(0, 0, rgRows);
         }
@@ -601,16 +616,16 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         return RowRanges.of(0, end, rgRows);
     }
 
-    private boolean hasAnyOffsetIndex(int ordinal, Set<String> columnPaths) {
+    private boolean hasAllOffsetIndexes(int ordinal, Set<String> columnPaths) {
         if (preloadedMetadata == null || columnPaths == null || columnPaths.isEmpty()) {
             return false;
         }
         for (String path : columnPaths) {
-            if (preloadedMetadata.getOffsetIndex(ordinal, path) != null) {
-                return true;
+            if (preloadedMetadata.getOffsetIndex(ordinal, path) == null) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     private boolean rowGroupDominatedByThreshold(BlockMetaData block) {
@@ -834,8 +849,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * Computes the initial (floor) prefetch depth from the projected byte footprint of the
      * first row group. This value serves as the floor for the adaptive depth — the runtime
      * stall detector may increase depth up to {@link #MAX_PREFETCH_DEPTH} but never below
-     * this byte-based result. Unfiltered LIMIT pins the floor (and growth) at 1 instead;
-     * extra groups would never be read.
+     * this byte-based result. {@link #limitPrefetchCovered()} still stops the queue once open
+     * plus queued groups cover an unfiltered {@code LIMIT} budget, so extra groups are not
+     * fetched even when this floor is greater than 1.
      */
     private static int computePrefetchDepth(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
         if (rowGroups.isEmpty()) {
@@ -1063,7 +1079,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (exhausted) {
             return false;
         }
-        if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+        if (budgetExhausted()) {
             exhausted = true;
             releaseHeldIo();
             return false;
@@ -1356,7 +1372,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (thresholdRanges != null) {
             ranges = ranges == null ? thresholdRanges : ranges.intersect(thresholdRanges);
         }
-        RowRanges limitRanges = limitPrefixRowRanges(rowGroupOrdinal, block);
+        RowRanges limitRanges = limitPrefixRowRanges(rowGroupOrdinal, block, rowBudget);
         if (limitRanges != null) {
             ranges = ranges == null ? limitRanges : ranges.intersect(limitRanges);
         }
@@ -1433,6 +1449,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         try {
             while (rowsConsumed < rowGroupRowCount) {
                 if (rowBudget != FormatReader.NO_LIMIT && totalSurvivors >= rowBudget) {
+                    // LIMIT can stop Phase-1 without decoding the tail. sourceRowsPerBatch then
+                    // sums to less than rowGroupRowCount; rowsRemainingInGroup is still set to the
+                    // full group below so per-batch bookkeeping stays in source-row units.
+                    // hasNext() zeroes it when hasMoreBatches() is false after the last emitted batch.
                     break;
                 }
                 int rowsToRead = (int) Math.min(batchSize, rowGroupRowCount - rowsConsumed);
@@ -1486,7 +1506,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
             return false;
         }
-        rowsEliminatedByLateMaterialization += (rowGroupRowCount - totalSurvivors);
+        rowsEliminatedByLateMaterialization += (rowsConsumed - totalSurvivors);
 
         RowRanges survivorRanges = WordMaskRowRangesConverter.fromWordMask(globalSurvivors, rowGroupRowCount);
         // Phase-2 fetch path:
@@ -1865,8 +1885,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * Adjusts {@link #prefetchDepth} based on whether the consumed prefetch future was already
      * complete. A stall ({@code wasReady == false}) means the consumer outpaced the producer —
      * grow depth by {@link #PREFETCH_DEPTH_GROWTH} unless the circuit breaker is under pressure.
-     * Sustained no-stalls mean the queue is deep enough — shrink by 1 after
-     * {@link #SHRINK_AFTER_NO_STALLS} consecutive hits.
+     * Unfiltered LIMIT still grows: {@link #limitPrefetchCovered()} is what stops extra groups
+     * once the remaining budget is queued. Sustained no-stalls mean the queue is deep enough —
+     * shrink by 1 after {@link #SHRINK_AFTER_NO_STALLS} consecutive hits.
      */
     // Package-private for testing
     void adaptPrefetchDepth(boolean wasReady) {
@@ -1876,7 +1897,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 consecutiveNoStalls = 0;
             }
         } else {
-            if (unfilteredLimit() == false && breakerPressure() < BREAKER_GROWTH_THRESHOLD) {
+            if (breakerPressure() < BREAKER_GROWTH_THRESHOLD) {
                 prefetchDepth = Math.min(prefetchDepth + PREFETCH_DEPTH_GROWTH, MAX_PREFETCH_DEPTH);
             }
             consecutiveNoStalls = 0;
@@ -2536,7 +2557,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     @Override
     public void close() throws IOException {
         try {
-            releaseHeldIo();
+            releaseHeldIo(true);
         } finally {
             reader.close();
         }
@@ -2546,8 +2567,21 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * Drops the current row-group store, cancels queued prefetches, and releases breaker-accounted
      * chunk buffers. Used when the row budget is exhausted (before {@link #close()}), at EOF, and
      * from {@link #close()} itself. Idempotent.
+     *
+     * <p>A failing {@code rowGroup.close()} is logged and swallowed on the {@code hasNext} / EOF
+     * path so LIMIT exhaust cannot fail the query. {@link #close()} rethrows it: a failed store
+     * close usually means leaked breaker bytes.
      */
     private void releaseHeldIo() {
+        try {
+            releaseHeldIo(false);
+        } catch (IOException e) {
+            logger.warn("Failed to release held I/O for [{}] in [{}]", rowGroupOrdinal, fileLocation, e);
+        }
+    }
+
+    private void releaseHeldIo(boolean propagateRowGroupClose) throws IOException {
+        Exception rowGroupCloseException = null;
         try {
             closeTwoPhaseState();
             closePageColumnReaders();
@@ -2555,7 +2589,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 try {
                     rowGroup.close();
                 } catch (Exception e) {
-                    logger.warn("Failed to close row-group store for [{}] in [{}]", rowGroupOrdinal, fileLocation, e);
+                    if (propagateRowGroupClose) {
+                        rowGroupCloseException = e;
+                    } else {
+                        logger.warn("Failed to close row-group store for [{}] in [{}]", rowGroupOrdinal, fileLocation, e);
+                    }
                 }
                 rowGroup = null;
             }
@@ -2567,6 +2605,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 // row group (LIMIT exhaust, EOF, TopN early-stop, close).
                 preloadedMetadata.close();
             }
+        }
+        if (rowGroupCloseException != null) {
+            if (rowGroupCloseException instanceof IOException ioe) {
+                throw ioe;
+            }
+            throw new IOException(rowGroupCloseException);
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -436,7 +436,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             projectionOnlyColumnPaths,
             fileLocation
         );
-        this.prefetchDepthFloor = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
+        this.prefetchDepthFloor = unfilteredLimit() ? 1 : computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
         this.prefetchDepth = this.prefetchDepthFloor;
 
         reader.setRequestedSchema(projectedSchema);
@@ -453,6 +453,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             return;
         }
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
+            return;
+        }
+        if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             return;
         }
         int startOrdinal = nextSurvivingRowGroupOrdinal(0);
@@ -476,6 +479,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
         int nextOrdinal = fromOrdinal;
         while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
+            if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
+                break;
+            }
+            if (limitPrefetchCovered()) {
+                break;
+            }
             if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
                 break;
             }
@@ -505,6 +514,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     // applied to the predicate-column prefetch here.
                     nextRowRanges = null;
                 }
+                RowRanges limitRanges = limitPrefixRowRanges(nextOrdinal, nextBlock);
+                if (limitRanges != null) {
+                    nextRowRanges = nextRowRanges == null ? limitRanges : nextRowRanges.intersect(limitRanges);
+                }
                 CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future;
                 if (nextRowRanges != null) {
                     future = ColumnChunkPrefetcher.prefetchAsync(
@@ -527,6 +540,77 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             }
             nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
         }
+    }
+
+    /**
+     * Unfiltered {@code LIMIT}: remaining row budget, no late-materialization (survivors unknown),
+     * no ColumnIndex row ranges, no dynamic-threshold TopN. This is the {@code FROM file | LIMIT n}
+     * path that can stop later groups and prefix-clip the first window.
+     */
+    private boolean unfilteredLimit() {
+        return ParquetFormatReader.unfilteredLimit(
+            rowBudget,
+            survivingRowGroups != null,
+            allRowRanges != null,
+            lateMaterialization,
+            dynamicThreshold != null
+        );
+    }
+
+    /**
+     * True when already-open plus queued row groups contain at least {@link #rowBudget} rows, so
+     * later groups would never be read. Filtered / late-mat LIMIT must not use this: a large group
+     * may yield zero survivors.
+     */
+    private boolean limitPrefetchCovered() {
+        if (unfilteredLimit() == false) {
+            return false;
+        }
+        long rows = 0;
+        if (rowGroupOrdinal >= 0) {
+            rows += rowsRemainingInGroup;
+        }
+        for (PendingPrefetch pending : pendingPrefetches) {
+            rows += reader.getRowGroups().get(pending.ordinal()).getRowCount();
+        }
+        return rows >= rowBudget;
+    }
+
+    /**
+     * Prefix {@code [0, min(rowBudget, rgRows))} when OffsetIndex is present so filtered prefetch
+     * fetches dictionary + overlapping pages instead of the full first chunk. Missing index →
+     * {@code null} (full chunk, same as today). A prefix that covers the whole group is also
+     * {@code null}: clipping would be a no-op.
+     */
+    private RowRanges limitPrefixRowRanges(int ordinal, BlockMetaData block) {
+        if (unfilteredLimit() == false) {
+            return null;
+        }
+        Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
+        if (hasAnyOffsetIndex(ordinal, phaseColumns) == false) {
+            return null;
+        }
+        long rgRows = block.getRowCount();
+        long end = Math.min(rowBudget, rgRows);
+        if (end <= 0) {
+            return RowRanges.of(0, 0, rgRows);
+        }
+        if (end >= rgRows) {
+            return null;
+        }
+        return RowRanges.of(0, end, rgRows);
+    }
+
+    private boolean hasAnyOffsetIndex(int ordinal, Set<String> columnPaths) {
+        if (preloadedMetadata == null || columnPaths == null || columnPaths.isEmpty()) {
+            return false;
+        }
+        for (String path : columnPaths) {
+            if (preloadedMetadata.getOffsetIndex(ordinal, path) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean rowGroupDominatedByThreshold(BlockMetaData block) {
@@ -750,7 +834,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * Computes the initial (floor) prefetch depth from the projected byte footprint of the
      * first row group. This value serves as the floor for the adaptive depth — the runtime
      * stall detector may increase depth up to {@link #MAX_PREFETCH_DEPTH} but never below
-     * this byte-based result.
+     * this byte-based result. Unfiltered LIMIT pins the floor (and growth) at 1 instead;
+     * extra groups would never be read.
      */
     private static int computePrefetchDepth(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
         if (rowGroups.isEmpty()) {
@@ -980,6 +1065,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
         if (rowBudget != FormatReader.NO_LIMIT && rowBudget <= 0) {
             exhausted = true;
+            releaseHeldIo();
             return false;
         }
         // Under two-phase, drain leading fully-filtered batches before deciding: the source-row
@@ -1009,7 +1095,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         }
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
             exhausted = true;
-            cancelPendingPrefetch();
+            releaseHeldIo();
             return false;
         }
         try {
@@ -1082,8 +1168,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 int nextOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
                 if (nextOrdinal >= reader.getRowGroups().size()) {
                     exhausted = true;
-                    cancelPendingPrefetch();
-                    releaseCurrentReservation();
+                    releaseHeldIo();
                     logIteratorDiagnostics();
                     return false;
                 }
@@ -1271,6 +1356,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         if (thresholdRanges != null) {
             ranges = ranges == null ? thresholdRanges : ranges.intersect(thresholdRanges);
         }
+        RowRanges limitRanges = limitPrefixRowRanges(rowGroupOrdinal, block);
+        if (limitRanges != null) {
+            ranges = ranges == null ? limitRanges : ranges.intersect(limitRanges);
+        }
         if (ranges == null) {
             return null;
         }
@@ -1343,6 +1432,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         long rowsConsumed = 0;
         try {
             while (rowsConsumed < rowGroupRowCount) {
+                if (rowBudget != FormatReader.NO_LIMIT && totalSurvivors >= rowBudget) {
+                    break;
+                }
                 int rowsToRead = (int) Math.min(batchSize, rowGroupRowCount - rowsConsumed);
                 BatchPredicateResult batch = decodePredicateBatch(rowsToRead, (int) rowsConsumed, globalSurvivors);
                 predicateBatches.add(batch.compactedPredicateBlocks);
@@ -1784,7 +1876,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 consecutiveNoStalls = 0;
             }
         } else {
-            if (breakerPressure() < BREAKER_GROWTH_THRESHOLD) {
+            if (unfilteredLimit() == false && breakerPressure() < BREAKER_GROWTH_THRESHOLD) {
                 prefetchDepth = Math.min(prefetchDepth + PREFETCH_DEPTH_GROWTH, MAX_PREFETCH_DEPTH);
             }
             consecutiveNoStalls = 0;
@@ -2443,22 +2535,37 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
     @Override
     public void close() throws IOException {
-        cancelPendingPrefetch();
+        try {
+            releaseHeldIo();
+        } finally {
+            reader.close();
+        }
+    }
+
+    /**
+     * Drops the current row-group store, cancels queued prefetches, and releases breaker-accounted
+     * chunk buffers. Used when the row budget is exhausted (before {@link #close()}), at EOF, and
+     * from {@link #close()} itself. Idempotent.
+     */
+    private void releaseHeldIo() {
         try {
             closeTwoPhaseState();
             closePageColumnReaders();
             if (rowGroup != null) {
-                rowGroup.close();
+                try {
+                    rowGroup.close();
+                } catch (Exception e) {
+                    logger.warn("Failed to close row-group store for [{}] in [{}]", rowGroupOrdinal, fileLocation, e);
+                }
                 rowGroup = null;
             }
         } finally {
+            cancelPendingPrefetch();
             releaseCurrentReservation();
-            try {
-                if (preloadedMetadata != null) {
-                    preloadedMetadata.close();
-                }
-            } finally {
-                reader.close();
+            if (preloadedMetadata != null) {
+                // Drop OffsetIndex / ColumnIndex buffers once this iterator will not open another
+                // row group (LIMIT exhaust, EOF, TopN early-stop, close).
+                preloadedMetadata.close();
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -1655,7 +1655,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 reader,
                 context.projectedColumns(),
                 context.batchSize(),
-                NO_LIMIT,
+                context.rowLimit(),
                 context.resolvedAttributes(),
                 // The deferred extractor scopes itself to the file's full footer rather than the
                 // range-filtered subset, so the produced extractor can resolve any file-global
@@ -1878,21 +1878,32 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
 
         // Gate ColumnIndex/OffsetIndex prefetch to the columns a plan actually consumes (see
         // computeIndexColumnPaths). A full scan with no filter and no threshold consumes none of
-        // them, so this emits zero index ranges.
+        // them, so this emits zero index ranges. Unfiltered LIMIT additionally fetches OffsetIndex
+        // for the first K covering row groups so prefix page ranges can clip first-window I/O.
+        boolean unfilteredLimit = unfilteredLimit(
+            rowLimit,
+            FilterCompat.isFilteringRequired(recordFilter),
+            filterPredicate != null,
+            lateMaterializationEnabled && pushedExpressions != null,
+            dynamicThreshold != null
+        );
         IndexColumnPaths indexColumnPaths = computeIndexColumnPaths(
             FilterCompat.isFilteringRequired(recordFilter),
             filterPredicate != null,
             predicateColumnPaths,
             dynamicThreshold != null ? dynamicThreshold.columnName() : null,
-            projectedSchema
+            projectedSchema,
+            unfilteredLimit ? rowLimit : NO_LIMIT
         );
 
+        int offsetIndexRowGroupLimit = unfilteredLimit ? coveringRowGroupLimit(reader.getRowGroups(), rowLimit) : Integer.MAX_VALUE;
         PreloadedRowGroupMetadata preloadedMetadata = PreloadedRowGroupMetadata.preload(
             reader,
             storageObject,
             predicateColumnPaths,
             indexColumnPaths.columnIndexPaths(),
             indexColumnPaths.offsetIndexPaths(),
+            offsetIndexRowGroupLimit,
             blockFactory.breaker()
         );
         boolean metadataHandedOff = false;
@@ -2021,9 +2032,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
     /**
      * Restricts page-index prefetch to the columns a plan actually consumes, so a full scan does not
      * pay for ColumnIndex/OffsetIndex bytes nothing reads. Index ranges are only used when a Parquet
-     * {@link FilterPredicate} drives {@code RowRanges} ({@code pageRangeFilterActive}) or for the
-     * dynamic-threshold sort column. Returns {@code null} sets (unrestricted, legacy behavior) when a
-     * filter is active but its predicate columns can't be enumerated ({@code predicateColumnPaths == null}).
+     * {@link FilterPredicate} drives {@code RowRanges} ({@code pageRangeFilterActive}), for the
+     * dynamic-threshold sort column, or for unfiltered {@code LIMIT} (OffsetIndex on projected
+     * columns so the first-window prefix can skip unread pages). Returns {@code null} sets
+     * (unrestricted, legacy behavior) when a filter is active but its predicate columns can't be
+     * enumerated ({@code predicateColumnPaths == null}).
      */
     static IndexColumnPaths computeIndexColumnPaths(
         boolean filteringRequired,
@@ -2031,6 +2044,24 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
         Set<String> predicateColumnPaths,
         String thresholdColumn,
         MessageType projectedSchema
+    ) {
+        return computeIndexColumnPaths(
+            filteringRequired,
+            pageRangeFilterActive,
+            predicateColumnPaths,
+            thresholdColumn,
+            projectedSchema,
+            NO_LIMIT
+        );
+    }
+
+    static IndexColumnPaths computeIndexColumnPaths(
+        boolean filteringRequired,
+        boolean pageRangeFilterActive,
+        Set<String> predicateColumnPaths,
+        String thresholdColumn,
+        MessageType projectedSchema,
+        int rowLimit
     ) {
         if (filteringRequired && predicateColumnPaths == null) {
             return new IndexColumnPaths(null, null);
@@ -2049,8 +2080,55 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             for (ColumnDescriptor descriptor : projectedSchema.getColumns()) {
                 offsetIndexPaths.add(String.join(".", descriptor.getPath()));
             }
+        } else if (rowLimit != NO_LIMIT) {
+            // Unfiltered LIMIT: OffsetIndex only (ColumnIndex min/max is unused). The row-group
+            // cap is applied at preload time; this only names the projected columns.
+            for (ColumnDescriptor descriptor : projectedSchema.getColumns()) {
+                offsetIndexPaths.add(String.join(".", descriptor.getPath()));
+            }
         }
         return new IndexColumnPaths(columnIndexPaths, offsetIndexPaths);
+    }
+
+    /**
+     * Unfiltered {@code LIMIT}: a remaining row budget with no record filter, no FilterPredicate
+     * page ranges, no late materialization, and no dynamic-threshold TopN. Only then may source
+     * row counts stand in for survivor counts (stop later groups, prefix-clip the first window).
+     */
+    static boolean unfilteredLimit(
+        int rowLimit,
+        boolean filteringRequired,
+        boolean pageRangeFilterActive,
+        boolean lateMaterializationActive,
+        boolean dynamicThresholdActive
+    ) {
+        return rowLimit != NO_LIMIT
+            && filteringRequired == false
+            && pageRangeFilterActive == false
+            && lateMaterializationActive == false
+            && dynamicThresholdActive == false;
+    }
+
+    /**
+     * Fewest leading row groups whose {@code rowCount} sum covers {@code rowLimit}. Used to bound
+     * OffsetIndex preload for unfiltered LIMIT so a multi-thousand-group file does not fetch every
+     * group's page index for {@code LIMIT 1}. {@link FormatReader#NO_LIMIT} returns {@code blocks.size()}.
+     */
+    static int coveringRowGroupLimit(List<BlockMetaData> blocks, int rowLimit) {
+        if (rowLimit == NO_LIMIT) {
+            return blocks.size();
+        }
+        if (rowLimit <= 0) {
+            return 0;
+        }
+        long rows = 0;
+        for (int i = 0; i < blocks.size(); i++) {
+            rows += blocks.get(i).getRowCount();
+            if (rows >= rowLimit) {
+                return i + 1;
+            }
+        }
+        return blocks.size();
     }
 
     private static ColumnDescriptor resolveDynamicThresholdColumn(MessageType schema, DynamicThreshold dynamicThreshold) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -1655,6 +1655,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
                 reader,
                 context.projectedColumns(),
                 context.batchSize(),
+                // Same remaining budget the whole-file path already threads into count-only,
+                // baseline, and optimized iterators. Previously hard-coded NO_LIMIT so a range
+                // split could over-read and the producer discarded surplus. The value is
+                // state.rowsRemaining, so truncation here is equivalent and lets the optimized
+                // path stop unread groups/pages.
                 context.rowLimit(),
                 context.resolvedAttributes(),
                 // The deferred extractor scopes itself to the file's full footer rather than the
@@ -2036,32 +2041,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
      * dynamic-threshold sort column, or for unfiltered {@code LIMIT} (OffsetIndex on projected
      * columns so the first-window prefix can skip unread pages). Returns {@code null} sets
      * (unrestricted, legacy behavior) when a filter is active but its predicate columns can't be
-     * enumerated ({@code predicateColumnPaths == null}).
+     * enumerated ({@code predicateColumnPaths == null}). {@code unfilteredLimitBudget} is the
+     * unfiltered-LIMIT row budget; callers must pass {@link FormatReader#NO_LIMIT} for filtered,
+     * late-mat, and TopN limits so this does not fetch OffsetIndex bytes nothing reads.
      */
     static IndexColumnPaths computeIndexColumnPaths(
         boolean filteringRequired,
         boolean pageRangeFilterActive,
         Set<String> predicateColumnPaths,
         String thresholdColumn,
-        MessageType projectedSchema
-    ) {
-        return computeIndexColumnPaths(
-            filteringRequired,
-            pageRangeFilterActive,
-            predicateColumnPaths,
-            thresholdColumn,
-            projectedSchema,
-            NO_LIMIT
-        );
-    }
-
-    static IndexColumnPaths computeIndexColumnPaths(
-        boolean filteringRequired,
-        boolean pageRangeFilterActive,
-        Set<String> predicateColumnPaths,
-        String thresholdColumn,
         MessageType projectedSchema,
-        int rowLimit
+        int unfilteredLimitBudget
     ) {
         if (filteringRequired && predicateColumnPaths == null) {
             return new IndexColumnPaths(null, null);
@@ -2076,13 +2066,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, ColumnExtrac
             columnIndexPaths.add(thresholdColumn);
             offsetIndexPaths.add(thresholdColumn);
         }
-        if (pageRangeFilterActive) {
-            for (ColumnDescriptor descriptor : projectedSchema.getColumns()) {
-                offsetIndexPaths.add(String.join(".", descriptor.getPath()));
-            }
-        } else if (rowLimit != NO_LIMIT) {
-            // Unfiltered LIMIT: OffsetIndex only (ColumnIndex min/max is unused). The row-group
-            // cap is applied at preload time; this only names the projected columns.
+        // Unfiltered LIMIT: OffsetIndex only (ColumnIndex min/max is unused). The caller must
+        // pass NO_LIMIT when the budget is a filtered / late-mat / TopN limit — those paths
+        // must not fetch OffsetIndex bytes nothing reads. The row-group cap is applied at
+        // preload time; this only names the projected columns.
+        if (pageRangeFilterActive || unfilteredLimitBudget != NO_LIMIT) {
             for (ColumnDescriptor descriptor : projectedSchema.getColumns()) {
                 offsetIndexPaths.add(String.join(".", descriptor.getPath()));
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -169,12 +169,12 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> predicateColumnPaths,
         CircuitBreaker breaker
     ) {
-        return preload(reader, storageObject, predicateColumnPaths, null, null, breaker);
+        return preload(reader, storageObject, predicateColumnPaths, null, null, Integer.MAX_VALUE, breaker);
     }
 
     /**
-     * Variant that additionally restricts which columns contribute ColumnIndex and OffsetIndex
-     * byte-range fetches. The page indexes are only consumed by a subset of plans:
+     * Restricts which columns contribute ColumnIndex and OffsetIndex byte-range fetches. The page
+     * indexes are only consumed by a subset of plans:
      * <ul>
      *   <li>ColumnIndex: predicate columns (page-level {@code RowRanges} computation) and the
      *       dynamic-threshold / top-N sort column (page skipping).</li>
@@ -188,26 +188,14 @@ final class PreloadedRowGroupMetadata implements Releasable {
      * <p>A {@code null} set means "unrestricted" — fetch the index for every column. This preserves
      * the legacy behavior for callers (and tests) that cannot enumerate the consuming columns.
      *
+     * <p>{@code offsetIndexRowGroupLimit} caps OffsetIndex fetches to the first K row groups.
+     * ColumnIndex and dictionary/bloom pre-warm ranges are not capped. {@code Integer.MAX_VALUE}
+     * (or any value {@code >=} the block count) is "all groups".
+     *
      * @param columnIndexPaths dot-string paths of columns whose ColumnIndex should be fetched, or
      *            {@code null} to fetch for all columns
      * @param offsetIndexPaths dot-string paths of columns whose OffsetIndex should be fetched, or
      *            {@code null} to fetch for all columns
-     */
-    static PreloadedRowGroupMetadata preload(
-        ParquetFileReader reader,
-        StorageObject storageObject,
-        Set<String> predicateColumnPaths,
-        Set<String> columnIndexPaths,
-        Set<String> offsetIndexPaths,
-        CircuitBreaker breaker
-    ) {
-        return preload(reader, storageObject, predicateColumnPaths, columnIndexPaths, offsetIndexPaths, Integer.MAX_VALUE, breaker);
-    }
-
-    /**
-     * As {@link #preload(ParquetFileReader, StorageObject, Set, Set, Set, CircuitBreaker)}, plus a
-     * row-group cap on OffsetIndex fetches. ColumnIndex and dictionary/bloom pre-warm ranges are
-     * not capped. {@code Integer.MAX_VALUE} (or any value {@code >=} the block count) is "all groups".
      */
     static PreloadedRowGroupMetadata preload(
         ParquetFileReader reader,
@@ -463,7 +451,9 @@ final class PreloadedRowGroupMetadata implements Releasable {
 
     /**
      * Sequential fallback using {@link ParquetFileReader}'s built-in methods. Honors the same
-     * column-path and OffsetIndex row-group cap as {@link #preloadCoalesced}.
+     * column-path and OffsetIndex row-group cap as {@link #preloadCoalesced}. Intentional: a
+     * coalesced-preload failure must not silently re-fetch every page index (that used to undo
+     * {@code computeIndexColumnPaths} gating, including the full-scan zero-index-GET path).
      */
     private static PreloadedRowGroupMetadata preloadSequential(
         ParquetFileReader reader,

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadata.java
@@ -179,7 +179,8 @@ final class PreloadedRowGroupMetadata implements Releasable {
      *   <li>ColumnIndex: predicate columns (page-level {@code RowRanges} computation) and the
      *       dynamic-threshold / top-N sort column (page skipping).</li>
      *   <li>OffsetIndex: the above, plus projected columns when a filter is active (filtered reads
-     *       skip non-surviving pages via the offset index).</li>
+     *       skip non-surviving pages via the offset index) or when unfiltered LIMIT clips the
+     *       first-window prefix (then only the first K covering row groups are fetched).</li>
      * </ul>
      * For a full scan with no filter and no threshold, no plan consumes the page indexes, so the
      * caller passes empty sets and zero index ranges are fetched.
@@ -200,6 +201,23 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> offsetIndexPaths,
         CircuitBreaker breaker
     ) {
+        return preload(reader, storageObject, predicateColumnPaths, columnIndexPaths, offsetIndexPaths, Integer.MAX_VALUE, breaker);
+    }
+
+    /**
+     * As {@link #preload(ParquetFileReader, StorageObject, Set, Set, Set, CircuitBreaker)}, plus a
+     * row-group cap on OffsetIndex fetches. ColumnIndex and dictionary/bloom pre-warm ranges are
+     * not capped. {@code Integer.MAX_VALUE} (or any value {@code >=} the block count) is "all groups".
+     */
+    static PreloadedRowGroupMetadata preload(
+        ParquetFileReader reader,
+        StorageObject storageObject,
+        Set<String> predicateColumnPaths,
+        Set<String> columnIndexPaths,
+        Set<String> offsetIndexPaths,
+        int offsetIndexRowGroupLimit,
+        CircuitBreaker breaker
+    ) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
         if (rowGroups.isEmpty()) {
             return empty();
@@ -214,13 +232,14 @@ final class PreloadedRowGroupMetadata implements Releasable {
                     predicateColumnPaths,
                     columnIndexPaths,
                     offsetIndexPaths,
+                    offsetIndexRowGroupLimit,
                     breaker
                 );
             } catch (Exception e) {
                 logger.debug("Coalesced metadata preload failed, falling back to sequential: {}", e.getMessage());
             }
         }
-        return preloadSequential(reader, rowGroups);
+        return preloadSequential(reader, rowGroups, columnIndexPaths, offsetIndexPaths, offsetIndexRowGroupLimit);
     }
 
     /**
@@ -246,6 +265,7 @@ final class PreloadedRowGroupMetadata implements Releasable {
         Set<String> predicateColumnPaths,
         Set<String> columnIndexPaths,
         Set<String> offsetIndexPaths,
+        int offsetIndexRowGroupLimit,
         CircuitBreaker breaker
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
@@ -264,7 +284,10 @@ final class PreloadedRowGroupMetadata implements Releasable {
                     addRange(ranges, rangeMetas, ciRef.getOffset(), ciRef.getLength(), rgIdx, col, RangeKind.COLUMN_INDEX);
                 }
                 IndexReference oiRef = col.getOffsetIndexReference();
-                if (oiRef != null && oiRef.getLength() > 0 && (offsetIndexPaths == null || offsetIndexPaths.contains(path))) {
+                if (oiRef != null
+                    && oiRef.getLength() > 0
+                    && rgIdx < offsetIndexRowGroupLimit
+                    && (offsetIndexPaths == null || offsetIndexPaths.contains(path))) {
                     addRange(ranges, rangeMetas, oiRef.getOffset(), oiRef.getLength(), rgIdx, col, RangeKind.OFFSET_INDEX);
                 }
                 if (fetchPreWarm && predicateColumnPaths.contains(path)) {
@@ -439,31 +462,43 @@ final class PreloadedRowGroupMetadata implements Releasable {
     }
 
     /**
-     * Sequential fallback using {@link ParquetFileReader}'s built-in methods.
+     * Sequential fallback using {@link ParquetFileReader}'s built-in methods. Honors the same
+     * column-path and OffsetIndex row-group cap as {@link #preloadCoalesced}.
      */
-    private static PreloadedRowGroupMetadata preloadSequential(ParquetFileReader reader, List<BlockMetaData> rowGroups) {
+    private static PreloadedRowGroupMetadata preloadSequential(
+        ParquetFileReader reader,
+        List<BlockMetaData> rowGroups,
+        Set<String> columnIndexPaths,
+        Set<String> offsetIndexPaths,
+        int offsetIndexRowGroupLimit
+    ) {
         Map<String, ColumnIndex> columnIndexes = new HashMap<>();
         Map<String, OffsetIndex> offsetIndexes = new HashMap<>();
 
         for (int rgIdx = 0; rgIdx < rowGroups.size(); rgIdx++) {
             BlockMetaData block = rowGroups.get(rgIdx);
             for (ColumnChunkMetaData col : block.getColumns()) {
+                String path = col.getPath().toDotString();
                 String k = key(rgIdx, col);
-                try {
-                    ColumnIndex ci = reader.readColumnIndex(col);
-                    if (ci != null) {
-                        columnIndexes.put(k, ci);
+                if (columnIndexPaths == null || columnIndexPaths.contains(path)) {
+                    try {
+                        ColumnIndex ci = reader.readColumnIndex(col);
+                        if (ci != null) {
+                            columnIndexes.put(k, ci);
+                        }
+                    } catch (IOException e) {
+                        logger.debug("Failed to read column index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
                     }
-                } catch (IOException e) {
-                    logger.debug("Failed to read column index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
                 }
-                try {
-                    OffsetIndex oi = reader.readOffsetIndex(col);
-                    if (oi != null) {
-                        offsetIndexes.put(k, oi);
+                if (rgIdx < offsetIndexRowGroupLimit && (offsetIndexPaths == null || offsetIndexPaths.contains(path))) {
+                    try {
+                        OffsetIndex oi = reader.readOffsetIndex(col);
+                        if (oi != null) {
+                            offsetIndexes.put(k, oi);
+                        }
+                    } catch (IOException e) {
+                        logger.debug("Failed to read offset index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
                     }
-                } catch (IOException e) {
-                    logger.debug("Failed to read offset index for [{}] in row group [{}]: {}", col.getPath(), rgIdx, e.getMessage());
                 }
             }
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -70,6 +70,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
@@ -6574,7 +6575,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             false,
             null,
             null,
-            threeColumnSchema()
+            threeColumnSchema(),
+            FormatReader.NO_LIMIT
         );
         assertNotNull("full scan must gate (non-null sets), not fall back to unrestricted", paths.columnIndexPaths());
         assertNotNull(paths.offsetIndexPaths());
@@ -6592,7 +6594,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             true,
             Set.of("a"),
             null,
-            threeColumnSchema()
+            threeColumnSchema(),
+            FormatReader.NO_LIMIT
         );
         assertEquals("only the predicate column needs a column index", Set.of("a"), paths.columnIndexPaths());
         assertEquals(
@@ -6608,7 +6611,14 @@ public class ParquetFormatReaderTests extends ESTestCase {
      */
     public void testComputeIndexColumnPathsNonProjectedPredicateColumn() {
         MessageType projected = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("b").named("schema");
-        ParquetFormatReader.IndexColumnPaths paths = ParquetFormatReader.computeIndexColumnPaths(true, true, Set.of("a"), null, projected);
+        ParquetFormatReader.IndexColumnPaths paths = ParquetFormatReader.computeIndexColumnPaths(
+            true,
+            true,
+            Set.of("a"),
+            null,
+            projected,
+            FormatReader.NO_LIMIT
+        );
         assertEquals(Set.of("a"), paths.columnIndexPaths());
         assertEquals(
             "predicate column a (not projected) and projected column b both need offset index",
@@ -6627,7 +6637,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             false,
             null,
             "a",
-            threeColumnSchema()
+            threeColumnSchema(),
+            FormatReader.NO_LIMIT
         );
         assertEquals(Set.of("a"), paths.columnIndexPaths());
         assertEquals(Set.of("a"), paths.offsetIndexPaths());
@@ -6643,7 +6654,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             true,
             null,
             null,
-            threeColumnSchema()
+            threeColumnSchema(),
+            FormatReader.NO_LIMIT
         );
         assertNull("legacy filter path must not gate", paths.columnIndexPaths());
         assertNull("legacy filter path must not gate", paths.offsetIndexPaths());
@@ -6661,7 +6673,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             false,
             Set.of("a"),
             null,
-            threeColumnSchema()
+            threeColumnSchema(),
+            FormatReader.NO_LIMIT
         );
         assertNotNull("must gate (non-null sets), not fall back to unrestricted", paths.columnIndexPaths());
         assertNotNull(paths.offsetIndexPaths());

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+/**
+ * Unfiltered LIMIT must stop later Parquet row groups, release heap I/O when the budget is
+ * exhausted, and (when OffsetIndex exists) fetch only prefix pages of the first covering groups.
+ */
+public class ParquetLimitIoClipTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Before
+    public void initBlockFactory() {
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
+    }
+
+    public void testRangeReadContextDefaultsToNoLimit() {
+        RangeReadContext ctx = new RangeReadContext(List.of("id"), 10, 0, 100, List.of(), ErrorPolicy.STRICT);
+        assertThat(ctx.rowLimit(), equalTo(FormatReader.NO_LIMIT));
+    }
+
+    public void testComputeIndexColumnPathsUnfilteredLimitAddsOffsetIndexOnly() {
+        MessageType schema = threeColumnSchema();
+        ParquetFormatReader.IndexColumnPaths unlimited = ParquetFormatReader.computeIndexColumnPaths(
+            false,
+            false,
+            null,
+            null,
+            schema,
+            FormatReader.NO_LIMIT
+        );
+        assertTrue(unlimited.columnIndexPaths().isEmpty());
+        assertTrue(unlimited.offsetIndexPaths().isEmpty());
+
+        ParquetFormatReader.IndexColumnPaths limited = ParquetFormatReader.computeIndexColumnPaths(false, false, null, null, schema, 1);
+        assertTrue("LIMIT must not fetch ColumnIndex", limited.columnIndexPaths().isEmpty());
+        assertEquals(Set.of("a", "b", "c"), limited.offsetIndexPaths());
+    }
+
+    public void testUnfilteredLimitHelperMatchesIteratorAndReader() {
+        assertTrue(ParquetFormatReader.unfilteredLimit(1, false, false, false, false));
+        assertFalse(ParquetFormatReader.unfilteredLimit(FormatReader.NO_LIMIT, false, false, false, false));
+        assertFalse(ParquetFormatReader.unfilteredLimit(1, true, false, false, false));
+        assertFalse(ParquetFormatReader.unfilteredLimit(1, false, true, false, false));
+        assertFalse(ParquetFormatReader.unfilteredLimit(1, false, false, true, false));
+        assertFalse(ParquetFormatReader.unfilteredLimit(1, false, false, false, true));
+    }
+
+    public void testReadRangeHonorsRowLimit() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(2000, 2048);
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        try (
+            CloseableIterator<Page> iter = reader.readRange(
+                storage,
+                new RangeReadContext(List.of("id"), 64, 0, parquetData.length, List.of(), ErrorPolicy.STRICT, null, 1)
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    public void testLimitDoesNotPrefetchLaterRowGroups() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(4000, 2048);
+        List<BlockMetaData> blocks = rowGroupsOf(parquetData);
+        int k = ParquetFormatReader.coveringRowGroupLimit(blocks, 1);
+        assertThat(blocks.size(), greaterThan(k));
+
+        RecordingStorageObject limited = new RecordingStorageObject(parquetData);
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                limited,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(256).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            iter.next().releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k);
+    }
+
+    public void testLimitReleasesPrefetchBuffersBeforeClose() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(3000, 2048);
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        CloseableIterator<Page> iter = reader.read(
+            storage,
+            FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(64).rowLimit(1).build()
+        );
+        try {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+            assertThat("prefetch buffers must drop when LIMIT is exhausted, before close()", storage.liveAsyncBytes.get(), equalTo(0));
+        } finally {
+            iter.close();
+        }
+        assertThat(storage.liveAsyncBytes.get(), equalTo(0));
+    }
+
+    public void testLimitFirstRowMatchesFullScan() throws Exception {
+        byte[] parquetData = createTallFile(80, 32, true);
+        long fullFirst;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                new RecordingStorageObject(parquetData),
+                FormatReadContext.of(List.of("id", "payload"), 64)
+            )
+        ) {
+            Page page = iter.next();
+            fullFirst = ((LongBlock) page.getBlock(0)).getLong(0);
+            page.releaseBlocks();
+        }
+        long limitFirst;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                new RecordingStorageObject(parquetData),
+                FormatReadContext.builder().projectedColumns(List.of("id", "payload")).batchSize(64).rowLimit(1).build()
+            )
+        ) {
+            Page page = iter.next();
+            limitFirst = ((LongBlock) page.getBlock(0)).getLong(0);
+            page.releaseBlocks();
+        }
+        assertThat(limitFirst, equalTo(fullFirst));
+    }
+
+    public void testOffsetIndexLimitClipsFirstWindowAndUnlimitedFetchesNoPageIndex() throws Exception {
+        byte[] parquetData = createTallFile(800, 64, true);
+        IndexLayout layout = indexLayout(parquetData);
+        assumeTrue("parquet-mr default writer must emit OffsetIndex for this clip to apply", layout.offsetIndex.length > 0);
+        long firstGroupSpan = firstRowGroupSpan(parquetData);
+        assertThat(firstGroupSpan, greaterThan(16 * 1024L));
+
+        RecordingStorageObject unlimited = new RecordingStorageObject(parquetData);
+        int unlimitedRows = 0;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                unlimited,
+                FormatReadContext.of(List.of("id", "payload"), 256)
+            )
+        ) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                unlimitedRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertThat(unlimitedRows, equalTo(800));
+        assertThat("unlimited scan must not fetch page-index bytes", indexGetCount(unlimited, layout), equalTo(0L));
+
+        RecordingStorageObject limited = new RecordingStorageObject(parquetData);
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                limited,
+                FormatReadContext.builder().projectedColumns(List.of("id", "payload")).batchSize(32).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+        long indexGets = indexGetCount(limited, layout);
+        assertThat("LIMIT 1 should fetch OffsetIndex for the first covering group", indexGets, greaterThan(0L));
+        long dataBytes = dataGetBytes(limited, parquetData.length, layout);
+        assertThat(dataBytes, greaterThan(0L));
+        assertThat("prefix pages must be much smaller than the first row-group span", dataBytes, lessThan(firstGroupSpan / 2));
+    }
+
+    public void testLimitWithoutOffsetIndexStillCorrect() throws Exception {
+        byte[] parquetData = createTallFile(80, 32, false);
+        IndexLayout layout = indexLayout(parquetData);
+        assumeTrue("PARQUET_1_0 writer must omit OffsetIndex refs", layout.offsetIndex.length == 0);
+        List<BlockMetaData> blocks = rowGroupsOf(parquetData);
+        int k = ParquetFormatReader.coveringRowGroupLimit(blocks, 1);
+        assertThat(blocks.size(), greaterThan(k));
+
+        RecordingStorageObject limited = new RecordingStorageObject(parquetData);
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                limited,
+                FormatReadContext.builder().projectedColumns(List.of("id", "payload")).batchSize(32).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k);
+    }
+
+    public void testCoveringRowGroupLimitAndPreloadCapsOffsetIndexToFirstK() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(4000, 2048);
+        ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, blockFactory.breaker()), options)) {
+            List<BlockMetaData> blocks = reader.getRowGroups();
+            assertThat(blocks.size(), greaterThan(1));
+            assumeTrue(
+                "test file must carry OffsetIndex so the cap is observable",
+                blocks.get(0).getColumns().get(0).getOffsetIndexReference() != null
+                    && blocks.get(0).getColumns().get(0).getOffsetIndexReference().getLength() > 0
+            );
+            assertThat(ParquetFormatReader.coveringRowGroupLimit(blocks, FormatReader.NO_LIMIT), equalTo(blocks.size()));
+            assertThat(ParquetFormatReader.coveringRowGroupLimit(blocks, 1), equalTo(1));
+
+            Set<String> allPaths = Set.of("id");
+            int k = ParquetFormatReader.coveringRowGroupLimit(blocks, 1);
+            storage.gets.clear();
+            try (
+                PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.preload(
+                    reader,
+                    storage,
+                    Set.of(),
+                    Set.of(),
+                    allPaths,
+                    k,
+                    blockFactory.breaker()
+                )
+            ) {
+                assertNotNull(metadata.getOffsetIndex(0, "id"));
+                if (blocks.size() > k) {
+                    assertNull("OffsetIndex past K must not be preloaded", metadata.getOffsetIndex(k, "id"));
+                }
+            }
+            long laterOiGets = 0;
+            for (int rg = k; rg < blocks.size(); rg++) {
+                for (ColumnChunkMetaData col : blocks.get(rg).getColumns()) {
+                    var oi = col.getOffsetIndexReference();
+                    if (oi == null || oi.getLength() <= 0) {
+                        continue;
+                    }
+                    long start = oi.getOffset();
+                    long end = start + oi.getLength();
+                    for (long[] get : storage.gets) {
+                        if (get[0] < end && get[0] + get[1] > start) {
+                            laterOiGets++;
+                        }
+                    }
+                }
+            }
+            assertThat("preload must not GET OffsetIndex for rgIdx >= K", laterOiGets, equalTo(0L));
+        }
+    }
+
+    private static MessageType threeColumnSchema() {
+        return Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("a")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("b")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("c")
+            .named("schema");
+    }
+
+    private static long dataGetBytes(RecordingStorageObject storage, int fileLength, IndexLayout layout) {
+        long bytes = 0;
+        for (long[] get : storage.gets) {
+            if (isLikelyFooterGet(get[0], get[1], fileLength) || overlapsAny(get[0], get[1], layout.all())) {
+                continue;
+            }
+            bytes += get[1];
+        }
+        return bytes;
+    }
+
+    private static long indexGetCount(RecordingStorageObject storage, IndexLayout layout) {
+        long count = 0;
+        for (long[] get : storage.gets) {
+            if (overlapsAny(get[0], get[1], layout.all())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private List<BlockMetaData> rowGroupsOf(byte[] parquetData) throws IOException {
+        ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
+        try (
+            ParquetFileReader reader = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new RecordingStorageObject(parquetData), blockFactory.breaker()),
+                options
+            )
+        ) {
+            return List.copyOf(reader.getRowGroups());
+        }
+    }
+
+    private static void assertNoGetsOverlapRowGroupsFrom(RecordingStorageObject storage, List<BlockMetaData> blocks, int fromRg) {
+        for (long[] get : storage.gets) {
+            long getEnd = get[0] + get[1];
+            for (int rg = fromRg; rg < blocks.size(); rg++) {
+                for (ColumnChunkMetaData col : blocks.get(rg).getColumns()) {
+                    long start = col.getStartingPos();
+                    long end = start + col.getTotalSize();
+                    assertFalse(
+                        "LIMIT must not GET later row-group chunk [" + rg + "] at [" + start + "," + end + ")",
+                        get[0] < end && getEnd > start
+                    );
+                }
+            }
+        }
+    }
+
+    private static boolean isLikelyFooterGet(long offset, long length, int fileLength) {
+        return offset + length >= fileLength;
+    }
+
+    private static boolean overlapsAny(long offset, long length, long[][] ranges) {
+        long end = offset + length;
+        for (long[] r : ranges) {
+            if (offset < r[1] && end > r[0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private IndexLayout indexLayout(byte[] parquetData) throws IOException {
+        ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
+        try (
+            ParquetFileReader reader = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new RecordingStorageObject(parquetData), blockFactory.breaker()),
+                options
+            )
+        ) {
+            List<long[]> ci = new ArrayList<>();
+            List<long[]> oi = new ArrayList<>();
+            for (BlockMetaData block : reader.getRowGroups()) {
+                for (ColumnChunkMetaData col : block.getColumns()) {
+                    var ciRef = col.getColumnIndexReference();
+                    if (ciRef != null && ciRef.getLength() > 0) {
+                        ci.add(new long[] { ciRef.getOffset(), ciRef.getOffset() + ciRef.getLength() });
+                    }
+                    var oiRef = col.getOffsetIndexReference();
+                    if (oiRef != null && oiRef.getLength() > 0) {
+                        oi.add(new long[] { oiRef.getOffset(), oiRef.getOffset() + oiRef.getLength() });
+                    }
+                }
+            }
+            return new IndexLayout(ci.toArray(new long[0][]), oi.toArray(new long[0][]));
+        }
+    }
+
+    private long firstRowGroupSpan(byte[] parquetData) throws IOException {
+        ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
+        try (
+            ParquetFileReader reader = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new RecordingStorageObject(parquetData), blockFactory.breaker()),
+                options
+            )
+        ) {
+            BlockMetaData first = reader.getRowGroups().get(0);
+            long span = 0;
+            for (ColumnChunkMetaData col : first.getColumns()) {
+                span += col.getTotalSize();
+            }
+            return span;
+        }
+    }
+
+    private byte[] createMultiRowGroupFile(int rowCount, int rowGroupSize) throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(createOutputFile(outputStream))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(256)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private byte[] createTallFile(int rowCount, int payloadBytes, boolean pageIndex) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("payload")
+            .named("test_schema");
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        String payload = "x".repeat(payloadBytes);
+        ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(createOutputFile(outputStream))
+            .withConf(new PlainParquetConfiguration())
+            .withCodecFactory(new PlainCompressionCodecFactory())
+            .withType(schema)
+            .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+            .withDictionaryEncoding(false)
+            .withRowGroupSize(pageIndex ? 8 * 1024 * 1024L : 2048)
+            .withPageSize(1024);
+        if (pageIndex == false) {
+            // parquet-mr 1.17 rejects truncate-length 0; PARQUET_1_0 omits the page-index structures.
+            builder = builder.withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0);
+        }
+        try (ParquetWriter<Group> writer = builder.build()) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                g.add("payload", i + payload);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    @Override
+                    public long getPos() {
+                        return outputStream.size();
+                    }
+
+                    @Override
+                    public void write(int b) {
+                        outputStream.write(b);
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) {
+                        outputStream.write(b, off, len);
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    private record IndexLayout(long[][] columnIndex, long[][] offsetIndex) {
+        long[][] all() {
+            long[][] both = new long[columnIndex.length + offsetIndex.length][];
+            System.arraycopy(columnIndex, 0, both, 0, columnIndex.length);
+            System.arraycopy(offsetIndex, 0, both, columnIndex.length, offsetIndex.length);
+            return both;
+        }
+    }
+
+    private static final class RecordingStorageObject implements StorageObject {
+        private final byte[] data;
+        final List<long[]> gets = new CopyOnWriteArrayList<>();
+        final AtomicInteger liveAsyncBytes = new AtomicInteger();
+
+        RecordingStorageObject(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://limit-io-clip.parquet");
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return true;
+        }
+
+        @Override
+        public void readBytesAsync(
+            long position,
+            long length,
+            DirectBufferFactory factory,
+            Executor executor,
+            ActionListener<DirectReadBuffer> listener
+        ) {
+            gets.add(new long[] { position, length });
+            executor.execute(() -> {
+                try {
+                    int pos = (int) position;
+                    int len = (int) Math.min(length, data.length - position);
+                    DirectReadBuffer allocated = factory.allocate(len);
+                    ByteBuffer buffer = allocated.buffer();
+                    buffer.put(data, pos, len);
+                    buffer.flip();
+                    liveAsyncBytes.addAndGet(len);
+                    listener.onResponse(new DirectReadBuffer(buffer, () -> {
+                        liveAsyncBytes.addAndGet(-len);
+                        allocated.close();
+                    }));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
@@ -12,12 +12,15 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -32,6 +35,11 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -40,6 +48,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
@@ -47,6 +56,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +67,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
  * Unfiltered LIMIT must stop later Parquet row groups, release heap I/O when the budget is
@@ -139,7 +149,7 @@ public class ParquetLimitIoClipTests extends ESTestCase {
             iter.next().releaseBlocks();
             assertFalse(iter.hasNext());
         }
-        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k);
+        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k, parquetData);
     }
 
     public void testLimitReleasesPrefetchBuffersBeforeClose() throws Exception {
@@ -190,9 +200,9 @@ public class ParquetLimitIoClipTests extends ESTestCase {
     }
 
     public void testOffsetIndexLimitClipsFirstWindowAndUnlimitedFetchesNoPageIndex() throws Exception {
-        byte[] parquetData = createTallFile(800, 64, true);
+        byte[] parquetData = createTallFile(800, 4096, true);
         IndexLayout layout = indexLayout(parquetData);
-        assumeTrue("parquet-mr default writer must emit OffsetIndex for this clip to apply", layout.offsetIndex.length > 0);
+        assertThat("parquet-mr default writer must emit OffsetIndex for this clip to apply", layout.offsetIndex.length, greaterThan(0));
         long firstGroupSpan = firstRowGroupSpan(parquetData);
         assertThat(firstGroupSpan, greaterThan(16 * 1024L));
 
@@ -228,15 +238,19 @@ public class ParquetLimitIoClipTests extends ESTestCase {
         }
         long indexGets = indexGetCount(limited, layout);
         assertThat("LIMIT 1 should fetch OffsetIndex for the first covering group", indexGets, greaterThan(0L));
-        long dataBytes = dataGetBytes(limited, parquetData.length, layout);
+        long dataBytes = dataGetBytes(limited, parquetData, layout);
         assertThat(dataBytes, greaterThan(0L));
-        assertThat("prefix pages must be much smaller than the first row-group span", dataBytes, lessThan(firstGroupSpan / 2));
+        long prefixPages = prefixPageBytes(parquetData, 1);
+        assertThat(
+            "LIMIT 1 data GETs must stay within prefix pages plus one coalesce gap, not the full first group",
+            dataBytes,
+            lessThanOrEqualTo(prefixPages + CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP)
+        );
+        assertThat(firstGroupSpan, greaterThan(CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP));
     }
 
     public void testLimitWithoutOffsetIndexStillCorrect() throws Exception {
-        byte[] parquetData = createTallFile(80, 32, false);
-        IndexLayout layout = indexLayout(parquetData);
-        assumeTrue("PARQUET_1_0 writer must omit OffsetIndex refs", layout.offsetIndex.length == 0);
+        byte[] parquetData = createTallFile(4000, 32, false);
         List<BlockMetaData> blocks = rowGroupsOf(parquetData);
         int k = ParquetFormatReader.coveringRowGroupLimit(blocks, 1);
         assertThat(blocks.size(), greaterThan(k));
@@ -254,7 +268,7 @@ public class ParquetLimitIoClipTests extends ESTestCase {
             page.releaseBlocks();
             assertFalse(iter.hasNext());
         }
-        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k);
+        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k, parquetData);
     }
 
     public void testCoveringRowGroupLimitAndPreloadCapsOffsetIndexToFirstK() throws Exception {
@@ -264,10 +278,11 @@ public class ParquetLimitIoClipTests extends ESTestCase {
         try (ParquetFileReader reader = ParquetFileReader.open(new ParquetStorageObjectAdapter(storage, blockFactory.breaker()), options)) {
             List<BlockMetaData> blocks = reader.getRowGroups();
             assertThat(blocks.size(), greaterThan(1));
-            assumeTrue(
+            assertThat(
                 "test file must carry OffsetIndex so the cap is observable",
                 blocks.get(0).getColumns().get(0).getOffsetIndexReference() != null
-                    && blocks.get(0).getColumns().get(0).getOffsetIndexReference().getLength() > 0
+                    && blocks.get(0).getColumns().get(0).getOffsetIndexReference().getLength() > 0,
+                equalTo(true)
             );
             assertThat(ParquetFormatReader.coveringRowGroupLimit(blocks, FormatReader.NO_LIMIT), equalTo(blocks.size()));
             assertThat(ParquetFormatReader.coveringRowGroupLimit(blocks, 1), equalTo(1));
@@ -311,6 +326,101 @@ public class ParquetLimitIoClipTests extends ESTestCase {
         }
     }
 
+    public void testLimitSpanningTwoRowGroupsDoesNotFetchLaterGroups() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(4000, 2048);
+        List<BlockMetaData> blocks = rowGroupsOf(parquetData);
+        assertThat(blocks.size(), greaterThan(2));
+        int limit = (int) (blocks.get(0).getRowCount() + blocks.get(1).getRowCount() / 2);
+        int k = ParquetFormatReader.coveringRowGroupLimit(blocks, limit);
+        assertThat(k, greaterThan(1));
+        assertThat(blocks.size(), greaterThan(k));
+
+        RecordingStorageObject limited = new RecordingStorageObject(parquetData);
+        int rows = 0;
+        try (
+            CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory).read(
+                limited,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(64).rowLimit(limit).build()
+            )
+        ) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                rows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertThat(rows, equalTo(limit));
+        assertNoGetsOverlapRowGroupsFrom(limited, blocks, k, parquetData);
+    }
+
+    public void testFilteredLimitStillPrefetchesLaterRowGroups() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(4000, 2048);
+        List<BlockMetaData> blocks = rowGroupsOf(parquetData);
+        int k = ParquetFormatReader.coveringRowGroupLimit(blocks, 1);
+        assertThat(blocks.size(), greaterThan(k));
+
+        RecordingStorageObject filtered = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory).withPushedFilter(
+            FilterCompat.get(FilterApi.gtEq(FilterApi.longColumn("id"), 0L))
+        );
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                filtered,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(64).rowLimit(1).build()
+            )
+        ) {
+            assertTrue(iter.hasNext());
+            Page page = iter.next();
+            assertThat(page.getPositionCount(), equalTo(1));
+            page.releaseBlocks();
+            assertFalse(iter.hasNext());
+        }
+        assertTrue(
+            "filtered LIMIT must not treat source row counts as survivors; later groups stay eligible",
+            getsOverlapRowGroupsFrom(filtered, blocks, k, parquetData)
+        );
+    }
+
+    public void testWhereLimitStopsPredicateDecodeInFatFirstGroup() throws Exception {
+        byte[] parquetData = createTallFile(2000, 4096, true);
+        List<BlockMetaData> blocks = rowGroupsOf(parquetData);
+        assertThat(blocks.get(0).getRowCount(), greaterThan(100L));
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        // Not stats-trivial: group max is 1999, so TriviallyPassesChecker cannot skip Phase-1.
+        Expression filter = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 1990L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        RecordingStorageObject storage = new RecordingStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        int rows = 0;
+        CloseableIterator<Page> iter = reader.read(
+            storage,
+            FormatReadContext.builder().projectedColumns(List.of("id", "payload")).batchSize(16).rowLimit(5).build()
+        );
+        try {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                rows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            assertThat(rows, equalTo(5));
+            assertFalse(iter.hasNext());
+            assertThat(storage.liveAsyncBytes.get(), equalTo(0));
+        } finally {
+            iter.close();
+        }
+        IndexLayout layout = indexLayout(parquetData);
+        long dataBytes = dataGetBytes(storage, parquetData, layout);
+        long firstGroupSpan = firstRowGroupSpan(parquetData);
+        assertThat(firstGroupSpan, greaterThan(CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP));
+        assertThat(
+            "Phase-1 LIMIT stop must not fetch the unread tail of the fat first group",
+            dataBytes,
+            lessThanOrEqualTo(prefixPageBytes(parquetData, 5) + CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP)
+        );
+    }
+
     private static MessageType threeColumnSchema() {
         return Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT64)
@@ -322,10 +432,10 @@ public class ParquetLimitIoClipTests extends ESTestCase {
             .named("schema");
     }
 
-    private static long dataGetBytes(RecordingStorageObject storage, int fileLength, IndexLayout layout) {
+    private static long dataGetBytes(RecordingStorageObject storage, byte[] data, IndexLayout layout) {
         long bytes = 0;
         for (long[] get : storage.gets) {
-            if (isLikelyFooterGet(get[0], get[1], fileLength) || overlapsAny(get[0], get[1], layout.all())) {
+            if (isFooterGet(get[0], get[1], data) || overlapsAny(get[0], get[1], layout.all())) {
                 continue;
             }
             bytes += get[1];
@@ -355,24 +465,86 @@ public class ParquetLimitIoClipTests extends ESTestCase {
         }
     }
 
-    private static void assertNoGetsOverlapRowGroupsFrom(RecordingStorageObject storage, List<BlockMetaData> blocks, int fromRg) {
+    private static boolean getsOverlapRowGroupsFrom(RecordingStorageObject storage, List<BlockMetaData> blocks, int fromRg, byte[] data) {
         for (long[] get : storage.gets) {
+            if (isFooterGet(get[0], get[1], data)) {
+                continue;
+            }
             long getEnd = get[0] + get[1];
             for (int rg = fromRg; rg < blocks.size(); rg++) {
                 for (ColumnChunkMetaData col : blocks.get(rg).getColumns()) {
                     long start = col.getStartingPos();
                     long end = start + col.getTotalSize();
-                    assertFalse(
-                        "LIMIT must not GET later row-group chunk [" + rg + "] at [" + start + "," + end + ")",
-                        get[0] < end && getEnd > start
-                    );
+                    if (get[0] < end && getEnd > start) {
+                        return true;
+                    }
                 }
             }
         }
+        return false;
     }
 
-    private static boolean isLikelyFooterGet(long offset, long length, int fileLength) {
-        return offset + length >= fileLength;
+    private static void assertNoGetsOverlapRowGroupsFrom(
+        RecordingStorageObject storage,
+        List<BlockMetaData> blocks,
+        int fromRg,
+        byte[] data
+    ) {
+        assertFalse(
+            "LIMIT must not GET later row-group chunks from [" + fromRg + "]",
+            getsOverlapRowGroupsFrom(storage, blocks, fromRg, data)
+        );
+    }
+
+    private static boolean isFooterGet(long offset, long length, byte[] data) {
+        long start = footerStart(data);
+        return offset < data.length && offset + length > start;
+    }
+
+    private static long footerStart(byte[] data) {
+        int footerLength = ByteBuffer.wrap(data, data.length - 8, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        return data.length - 8L - footerLength;
+    }
+
+    private long prefixPageBytes(byte[] parquetData, int rowLimit) throws IOException {
+        ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
+        try (
+            ParquetFileReader reader = ParquetFileReader.open(
+                new ParquetStorageObjectAdapter(new RecordingStorageObject(parquetData), blockFactory.breaker()),
+                options
+            )
+        ) {
+            long bytes = 0;
+            long remaining = rowLimit;
+            for (BlockMetaData block : reader.getRowGroups()) {
+                if (remaining <= 0) {
+                    break;
+                }
+                long rgRows = block.getRowCount();
+                long end = Math.min(remaining, rgRows);
+                for (ColumnChunkMetaData col : block.getColumns()) {
+                    OffsetIndex oi = reader.readOffsetIndex(col);
+                    if (oi == null) {
+                        bytes += col.getTotalSize();
+                        continue;
+                    }
+                    long firstData = oi.getOffset(0);
+                    if (col.getDictionaryPageOffset() > 0 && col.getDictionaryPageOffset() < firstData) {
+                        bytes += firstData - col.getDictionaryPageOffset();
+                    }
+                    int pageCount = oi.getPageCount();
+                    for (int p = 0; p < pageCount; p++) {
+                        long pageStart = oi.getFirstRowIndex(p);
+                        long pageEnd = (p + 1 < pageCount) ? oi.getFirstRowIndex(p + 1) : rgRows;
+                        if (pageStart < end && pageEnd > 0) {
+                            bytes += oi.getCompressedPageSize(p);
+                        }
+                    }
+                }
+                remaining -= rgRows;
+            }
+            return bytes;
+        }
     }
 
     private static boolean overlapsAny(long offset, long length, long[][] ranges) {
@@ -471,7 +643,8 @@ public class ParquetLimitIoClipTests extends ESTestCase {
             .withRowGroupSize(pageIndex ? 8 * 1024 * 1024L : 2048)
             .withPageSize(1024);
         if (pageIndex == false) {
-            // parquet-mr 1.17 rejects truncate-length 0; PARQUET_1_0 omits the page-index structures.
+            // parquet-mr 1.17 rejects truncate-length 0. PARQUET_1_0 still writes OffsetIndex
+            // refs on this writer; later-group stop does not depend on prefix clip.
             builder = builder.withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0);
         }
         try (ParquetWriter<Group> writer = builder.build()) {
@@ -549,6 +722,7 @@ public class ParquetLimitIoClipTests extends ESTestCase {
 
         @Override
         public InputStream newStream(long position, long length) {
+            gets.add(new long[] { position, length });
             return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
         }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadataTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PreloadedRowGroupMetadataTests.java
@@ -386,6 +386,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of(),
                     Set.of(),
                     Set.of(),
+                    Integer.MAX_VALUE,
                     breaker
                 )
             ) {
@@ -463,6 +464,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of("a"),
                     Set.of("a"),
                     Set.of("a"),
+                    Integer.MAX_VALUE,
                     breaker
                 )
             ) {
@@ -493,6 +495,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     predicates,
                     predicates,
                     predicates,
+                    Integer.MAX_VALUE,
                     breaker
                 )
             ) {
@@ -524,6 +527,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                     Set.of("a"),
                     Set.of("a"),
                     Set.of("a", "b", "c"),
+                    Integer.MAX_VALUE,
                     breaker
                 )
             ) {
@@ -688,6 +692,7 @@ public class PreloadedRowGroupMetadataTests extends ESTestCase {
                         s.predicate(),
                         s.columnIndex(),
                         s.offsetIndex(),
+                        Integer.MAX_VALUE,
                         breaker
                     )
                 ) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
@@ -62,10 +62,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         /*
@@ -112,10 +115,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -142,10 +148,13 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyMissing(first, count);
@@ -163,10 +172,13 @@ public class MultivalueDedupeDoubleRange {
     public DoubleRangeBlock sortToBlock(BlockFactory blockFactory, boolean ascending) {
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -187,13 +199,14 @@ public class MultivalueDedupeDoubleRange {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    sawNull = true;
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> {
-                        sawNull = true;
-                        builder.appendInt(0);
-                    }
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashAdd(builder, hash, v);
@@ -220,10 +233,13 @@ public class MultivalueDedupeDoubleRange {
     public IntBlock hashLookup(BlockFactory blockFactory, LongLongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
+                if (block.isNull(p)) {
+                    builder.appendInt(0);
+                    continue;
+                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
-                    case 0 -> builder.appendInt(0);
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashLookupSingle(builder, hash, v);
@@ -263,10 +279,13 @@ public class MultivalueDedupeDoubleRange {
                     position++;
                 }
                 for (; position < block.getPositionCount(); position++) {
+                    if (block.isNull(position)) {
+                        encodeNull();
+                        continue;
+                    }
                     int count = block.getValueCount(position);
                     int first = block.getFirstValueIndex(position);
                     switch (count) {
-                        case 0 -> encodeNull();
                         case 1 -> {
                             DoubleRange v = block.getDoubleRange(first, work[0]);
                             if (hasCapacity(1)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/mvdedupe/MultivalueDedupeDoubleRange.java
@@ -62,13 +62,10 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    builder.appendNull();
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         /*
@@ -115,13 +112,10 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    builder.appendNull();
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -148,13 +142,10 @@ public class MultivalueDedupeDoubleRange {
         }
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    builder.appendNull();
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyMissing(first, count);
@@ -172,13 +163,10 @@ public class MultivalueDedupeDoubleRange {
     public DoubleRangeBlock sortToBlock(BlockFactory blockFactory, boolean ascending) {
         try (DoubleRangeBlock.Builder builder = blockFactory.newDoubleRangeBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    builder.appendNull();
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> builder.appendNull();
                     case 1 -> builder.appendDoubleRange(block.getDoubleRange(first, work[0]));
                     default -> {
                         copyAndSort(first, count);
@@ -199,14 +187,13 @@ public class MultivalueDedupeDoubleRange {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    sawNull = true;
-                    builder.appendInt(0);
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> {
+                        sawNull = true;
+                        builder.appendInt(0);
+                    }
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashAdd(builder, hash, v);
@@ -233,13 +220,10 @@ public class MultivalueDedupeDoubleRange {
     public IntBlock hashLookup(BlockFactory blockFactory, LongLongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
-                if (block.isNull(p)) {
-                    builder.appendInt(0);
-                    continue;
-                }
                 int count = block.getValueCount(p);
                 int first = block.getFirstValueIndex(p);
                 switch (count) {
+                    case 0 -> builder.appendInt(0);
                     case 1 -> {
                         DoubleRange v = block.getDoubleRange(first, work[0]);
                         hashLookupSingle(builder, hash, v);
@@ -279,13 +263,10 @@ public class MultivalueDedupeDoubleRange {
                     position++;
                 }
                 for (; position < block.getPositionCount(); position++) {
-                    if (block.isNull(position)) {
-                        encodeNull();
-                        continue;
-                    }
                     int count = block.getValueCount(position);
                     int first = block.getFirstValueIndex(position);
                     switch (count) {
+                        case 0 -> encodeNull();
                         case 1 -> {
                             DoubleRange v = block.getDoubleRange(first, work[0]);
                             if (hasCapacity(1)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -1994,7 +1994,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     rangeEnd,
                     PhysicalNames.translateSchema(perFileResolvedAttributes, renames),
                     errorPolicy,
-                    bufferedInformationalWarningSink(state.buffer)
+                    bufferedInformationalWarningSink(state.buffer),
+                    rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining
                 );
                 if (fileContext != null) {
                     rangeCtx.setFileContext(fileContext);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
@@ -29,6 +29,12 @@ public final class RangeReadContext {
     @Nullable
     private final Consumer<String> informationalWarningSink;
     /**
+     * Remaining row budget for this split ({@link FormatReader#NO_LIMIT} when unbounded).
+     * Threaded from the producer so range-aware readers can clip prefetch the same way
+     * whole-file {@link FormatReadContext#rowLimit()} already does.
+     */
+    private final int rowLimit;
+    /**
      * Opaque file-level context, single-writer/single-reader, carried by the owning producer across successive readRange calls.
      */
     @Nullable
@@ -59,6 +65,32 @@ public final class RangeReadContext {
         ErrorPolicy errorPolicy,
         @Nullable Consumer<String> informationalWarningSink
     ) {
+        this(
+            projectedColumns,
+            batchSize,
+            rangeStart,
+            rangeEnd,
+            resolvedAttributes,
+            errorPolicy,
+            informationalWarningSink,
+            FormatReader.NO_LIMIT
+        );
+    }
+
+    /**
+     * As the above, plus {@code rowLimit} — remaining rows this split may emit.
+     * {@link FormatReader#NO_LIMIT} keeps the historical unbounded behavior.
+     */
+    public RangeReadContext(
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy,
+        @Nullable Consumer<String> informationalWarningSink,
+        int rowLimit
+    ) {
         this.projectedColumns = projectedColumns;
         this.batchSize = batchSize;
         this.rangeStart = rangeStart;
@@ -66,6 +98,7 @@ public final class RangeReadContext {
         this.resolvedAttributes = resolvedAttributes;
         this.errorPolicy = errorPolicy;
         this.informationalWarningSink = informationalWarningSink;
+        this.rowLimit = rowLimit;
     }
 
     public List<String> projectedColumns() {
@@ -104,6 +137,10 @@ public final class RangeReadContext {
     @Nullable
     public Consumer<String> informationalWarningSink() {
         return informationalWarningSink;
+    }
+
+    public int rowLimit() {
+        return rowLimit;
     }
 
     @Nullable


### PR DESCRIPTION
Unfiltered FROM file | LIMIT n still fetched every projected chunk of fat first row groups and prefetched later groups. Thread remaining row budget into RangeReadContext so the parquet reader can stop later groups, prefix-clip OffsetIndex pages, and drop held buffers on exhaust.