### PR TITLE
[Draft] SEARCH warming waits for metadata read gaps

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.common.ByteRange;
@@ -692,7 +693,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                 return;
             }
             final CacheFileRegion<KeyType> entry = get(cacheKey, blobLength, region, timestampMillis);
-            entry.populate(regionRange, writer, fetchExecutor, listener);
+            entry.populate(regionRange, writer, fetchExecutor, false, listener);
         } catch (Exception e) {
             listener.onFailure(e);
         }
@@ -714,6 +715,8 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
      * @param writer           a writer that handles writing of newly downloaded data to the shared cache
      * @param fetchExecutor    an executor to use for reading from the blob store
      * @param timestampMillis  representative data timestamp to stamp on the cache region
+     * @param awaitPendingFill when {@code true} and the range is pending fetching via another thread, the listener is not completed until
+     *                         that other thread is done. See {@link CacheFileRegion#populate} for the effect on the listener contract.
      * @param listener         a listener that is completed with {@code true} if the current thread triggered the fetching of the range, in
      *                         which case the data is available in cache. The listener is completed with {@code false} in every other cases:
      *                         if the range to write is already available in cache, if the range is pending fetching via another thread or
@@ -727,9 +730,10 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         final RangeMissingHandler writer,
         final Executor fetchExecutor,
         final long timestampMillis,
+        final boolean awaitPendingFill,
         final ActionListener<Boolean> listener
     ) {
-        fetchRange(cacheKey, region, range, blobLength, writer, fetchExecutor, false, timestampMillis, listener);
+        fetchRange(cacheKey, region, range, blobLength, writer, fetchExecutor, false, timestampMillis, awaitPendingFill, listener);
     }
 
     /**
@@ -753,6 +757,8 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
      * @param force            flag indicating whether the cache should free an occupied region to accommodate the requested
      *                         range when none are free.
      * @param timestampMillis  representative data timestamp to stamp on the cache region
+     * @param awaitPendingFill when {@code true} and the range is pending fetching via another thread, the listener is not completed until
+     *                         that other thread is done. See {@link CacheFileRegion#populate} for the effect on the listener contract.
      * @param listener         a listener that is completed with {@code true} if the current thread triggered the fetching of the range, in
      *                         which case the data is available in cache. The listener is completed with {@code false} in every other cases:
      *                         if the range to write is already available in cache, if the range is pending fetching via another thread or
@@ -767,6 +773,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
         final Executor fetchExecutor,
         final boolean force,
         final long timestampMillis,
+        final boolean awaitPendingFill,
         final ActionListener<Boolean> listener
     ) {
         if (force == false && freeRegions.isEmpty()) {
@@ -794,6 +801,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                 regionRange,
                 writerWithOffset(writer, Math.toIntExact(range.start() - getRegionStart(region))),
                 fetchExecutor,
+                awaitPendingFill,
                 listener
             );
         } catch (Exception e) {
@@ -1386,16 +1394,30 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
          * @param rangeToWrite the range of bytes to populate
          * @param writer a writer that handles writing of newly downloaded data to the shared cache
          * @param executor the executor used to download and to write new data
+         * @param awaitPendingFill when {@code true} and the range is being downloaded and written by another caller, the listener is not
+         *                         completed until that other caller is done. Use this when the caller must not report success for bytes
+         *                         that are not resident in cache yet.
          * @param listener a listener that is completed with {@code true} if the current thread triggered the download and write of the
-         *                 range, in which case the listener is completed once writing is done. The listener is completed with {@code false}
-         *                 if the range to write is already available in cache or if another thread will download and write the range. The
-         *                 listener may be invoked on the current thread, and executor thread or another executor thread used by another
+         *                 range, in which case the listener is completed once writing is done.
+         *                 <p>
+         *                 The listener is completed with {@code false} when the current thread did not trigger the download and write.
+         *                 What that guarantees about residency depends on {@code awaitPendingFill}:
+         *                 <ul>
+         *                     <li>{@code awaitPendingFill == false}: the range is either already available in cache, or another caller
+         *                     will download and write it at some later point. {@code false} therefore says nothing about whether the
+         *                     range is resident.</li>
+         *                     <li>{@code awaitPendingFill == true}: the range is available in cache, either because it already was or
+         *                     because another caller finished downloading and writing it. If that other caller's download or write
+         *                     failed, the listener is completed with its exception instead.</li>
+         *                 </ul>
+         *                 The listener may be invoked on the current thread, an executor thread or another executor thread used by another
          *                 caller.
          */
         void populate(
             final ByteRange rangeToWrite,
             final RangeMissingHandler writer,
             final Executor executor,
+            final boolean awaitPendingFill,
             final ActionListener<Boolean> listener
         ) {
             if (rangeToWrite.isEmpty()) {
@@ -1405,15 +1427,24 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
             try {
                 incRefEnsureOpen();
                 try (RefCountingRunnable refs = new RefCountingRunnable(CacheFileRegion.this::decRef)) {
-                    final var gapsOpt = tracker.waitForRange(
-                        rangeToWrite,
-                        rangeToWrite,
-                        Assertions.ENABLED ? ActionListener.releaseAfter(ActionListener.running(() -> {
+                    // When awaiting a pending fill, the tracker listener is also how a caller that does not own a gap learns that the
+                    // range became resident, or that the owning caller's fill failed.
+                    final SubscribableListener<Void> rangeAvailable = awaitPendingFill ? new SubscribableListener<>() : null;
+                    final ActionListener<Void> trackerListener;
+                    if (rangeAvailable != null) {
+                        // Unlike the assertion-only listener below, this must not swallow failures, so the assertion runs on success only.
+                        trackerListener = ActionListener.releaseAfter(rangeAvailable.delegateFailureIgnoreResponseAndWrap(l -> {
                             assert blobCacheService.regionOwners.get(nonVolatileIO()) == this;
-                        }), refs.acquire()) : refs.acquireListener()
-                    );
+                            l.onResponse(null);
+                        }), refs.acquire());
+                    } else {
+                        trackerListener = Assertions.ENABLED ? ActionListener.releaseAfter(ActionListener.running(() -> {
+                            assert blobCacheService.regionOwners.get(nonVolatileIO()) == this;
+                        }), refs.acquire()) : refs.acquireListener();
+                    }
+                    final var gapsOpt = tracker.waitForRange(rangeToWrite, rangeToWrite, trackerListener);
                     if (gapsOpt.isEmpty()) {
-                        listener.onResponse(false);
+                        completeNotFetched(rangeAvailable, listener);
                         return;
                     }
                     executor.execute(new AbstractRunnable() {
@@ -1423,7 +1454,7 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                         protected void doRun() {
                             final List<SparseFileTracker.Gap> gaps = gapsOpt.get().claim();
                             if (gaps.isEmpty()) {
-                                listener.onResponse(false);
+                                completeNotFetched(rangeAvailable, listener);
                                 return;
                             }
                             final SourceInputStreamFactory streamFactory = writer.sharedInputStreamFactory(gaps);
@@ -1463,6 +1494,19 @@ public class SharedBlobCacheService<KeyType extends SharedBlobCacheService.KeyBa
                 }
             } catch (Exception e) {
                 listener.onFailure(e);
+            }
+        }
+
+        /**
+         * Completes a {@link #populate} listener for a caller that did not claim any gap, either because the range was already resident
+         * or because another caller claimed the remaining gaps first. When {@code rangeAvailable} is {@code null} the caller is not
+         * interested in waiting, otherwise the completion is deferred until the range is resident.
+         */
+        private static void completeNotFetched(@Nullable SubscribableListener<Void> rangeAvailable, ActionListener<Boolean> listener) {
+            if (rangeAvailable == null) {
+                listener.onResponse(false);
+            } else {
+                rangeAvailable.addListener(listener.map(ignored -> false));
             }
         }
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SearchCommitPrefetcher.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SearchCommitPrefetcher.java
@@ -339,6 +339,8 @@ public class SearchCommitPrefetcher {
                         executor,
                         forcePrefetch,
                         timestampMillis,
+                        // maxPrefetchedOffset must only advance for ranges this caller filled itself, so don't wait for other callers
+                        false,
                         refCountingListener.acquire().map(populated -> {
                             if (populated) {
                                 var offsetAfterPopulation = maxPrefetchedOffset.accumulateAndGet(

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
@@ -1741,6 +1741,12 @@ public class SharedBlobCacheWarmingService {
         protected final RefCountingListener listeners;
         protected final AtomicLong tasksCount = new AtomicLong(0L);
         protected final AtomicLong totalBytesCopied = new AtomicLong(0L);
+        /**
+         * Whether a warming task must wait for a range that another caller is already filling, instead of reporting that range done as
+         * soon as it sees someone else owns it. Only search warming needs this guarantee: search shard recovery resumes when warming
+         * reports done, so reporting done for bytes that are not resident yet resumes recovery against a partially warm cache.
+         */
+        protected final boolean awaitPendingFills;
 
         AbstractWarmer(
             WarmingRun warmingRun,
@@ -1749,6 +1755,7 @@ public class SharedBlobCacheWarmingService {
             ActionListener<Void> listener
         ) {
             this.warmingRun = warmingRun;
+            this.awaitPendingFills = warmingRun.type() == Type.SEARCH;
             this.isStoreClosing = isStoreClosing;
             this.directory = directory;
             this.listeners = new RefCountingListener(metering(logging(listener)));
@@ -1920,7 +1927,8 @@ public class SharedBlobCacheWarmingService {
                                 if (ExceptionsHelper.unwrap(e, ResourceAlreadyUploadedException.class) != null) {
                                     logger.debug(() -> "retrying " + blobLocation + " from object store", e);
                                     // retrying runs on {@link StatelessPlugin#FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL}
-                                    // threads, but that is OK because fetchRange doesn't block or wait for anything.
+                                    // threads, but that is OK because fetchRange never blocks a thread: with awaitPendingFills set it
+                                    // waits for another caller's fill, but it does so by subscribing to a listener.
                                     maybeFetchBlobRange(item, cacheBlobReader, cacheKey, l);
                                 } else {
                                     l.onFailure(e);
@@ -1972,6 +1980,7 @@ public class SharedBlobCacheWarmingService {
                         ),
                         fetchExecutor,
                         item.timestampMillis(),
+                        awaitPendingFills,
                         l.map(ignored -> null)
                     );
                 });
@@ -2067,7 +2076,8 @@ public class SharedBlobCacheWarmingService {
                     if (ExceptionsHelper.unwrap(e, ResourceAlreadyUploadedException.class) != null) {
                         logger.debug(() -> "retrying " + blobFile + " " + byteRangeToWarm + " from object store", e);
                         // retrying runs on {@link StatelessPlugin#FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL}
-                        // threads, but that is OK because fetchRange doesn't block or wait for anything.
+                        // threads, but that is OK because fetchRange never blocks a thread: with awaitPendingFills set it waits for
+                        // another caller's fill, but it does so by subscribing to a listener.
                         fetchRange(cacheKey, cacheBlobReader, l);
                     } else {
                         l.onFailure(e);
@@ -2093,6 +2103,7 @@ public class SharedBlobCacheWarmingService {
                     perFileRunner.asExecutor(),
                     true,
                     timestampMillis,
+                    awaitPendingFills,
                     l
                 );
             }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessOnlinePrewarmingService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessOnlinePrewarmingService.java
@@ -247,6 +247,8 @@ public class StatelessOnlinePrewarmingService implements OnlinePrewarmingService
                             }
                         }),
                         timestampMillis,
+                        // online prewarming is best-effort and must stay fast, so don't wait for a range another caller is already filling
+                        false,
                         ActionListener.runAfter(refs.acquire().map(b -> null), store::decRef)
                     );
                 }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/StatelessSharedBlobCacheService.java
@@ -279,6 +279,9 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
 
     /**
      * Fetches and writes in cache a blob byte range, given the {@link CacheBlobReader} and the blob's associated {@link FileCacheKey}.
+     *
+     * @param awaitPendingFill when {@code true}, the listener is not completed for a region that another caller is already filling until
+     *                         that other caller is done. See {@link SharedBlobCacheService#fetchRange} for details.
      */
     private void fetchRange(
         FileCacheKey cacheKey,
@@ -290,6 +293,7 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
         Executor fetchExecutor,
         boolean force,
         long timestampMillis,
+        boolean awaitPendingFill,
         ActionListener<Void> listener,
         String... threadPools
     ) {
@@ -324,6 +328,7 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
                     fetchExecutor,
                     force,
                     timestampMillis,
+                    awaitPendingFill,
                     listeners.acquire().map(populated -> null)
                 );
             }
@@ -340,6 +345,7 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
         Executor fetchExecutor,
         boolean force,
         long timestampMillis,
+        boolean awaitPendingFill,
         ActionListener<Void> listener
     ) {
         fetchRange(
@@ -352,6 +358,7 @@ public class StatelessSharedBlobCacheService extends SharedBlobCacheService<File
             fetchExecutor,
             force,
             timestampMillis,
+            awaitPendingFill,
             listener,
             StatelessPlugin.PREWARM_THREAD_POOL,
             StatelessPlugin.FILL_VIRTUAL_BATCHED_COMPOUND_COMMIT_CACHE_THREAD_POOL


### PR DESCRIPTION
- Introduce a new `boolean awaitPendingFill` flag to `CacheFileRegion::populate` to say if someone else has claimed a gap and is filling it, we can opt-in to wait for that fill to happen
- Use this flag in `Type.SEARCH` warming, to not resume recovery while region0 might not be filled, which will likely be the first thing to be read on recovery