### PR TITLE
Fix empty collectRange crash in doc-values queries (lucene#16546)

### DIFF
--- a/docs/changelog/157630.yaml
+++ b/docs/changelog/157630.yaml
@@ -1,0 +1,5 @@
+area: Mapping
+issues: []
+pr: 157630
+summary: Fix empty `collectRange` crash in doc-values queries (lucene#16546)
+type: bug

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -96,6 +96,7 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
@@ -692,7 +693,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.document.column.ObjectTupleCursor;
@@ -60,6 +59,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFro
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
@@ -492,7 +492,7 @@ public class IpFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesRangeQuery(field, lower, upper, arrayOrderInlineNull);
             } else {
-                return SortedSetDocValuesField.newSlowRangeQuery(field, lower, upper, true, true);
+                return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(field, lower, upper, true, true);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -96,6 +96,7 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
@@ -813,7 +814,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 
@@ -852,7 +853,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     useArrayOrderBinaryDocValues
                 );
             } else {
-                return SortedSetDocValuesField.newSlowRangeQuery(
+                return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyTypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyTypeFieldMapper.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -64,7 +65,7 @@ public class LegacyTypeFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+            return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
         }
 
         @Override
@@ -81,7 +82,7 @@ public class LegacyTypeFieldMapper extends MetadataFieldMapper {
             boolean includeUpper,
             SearchExecutionContext context
         ) {
-            return SortedSetDocValuesField.newSlowRangeQuery(
+            return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
                 name(),
                 lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                 upperTerm == null ? null : indexedValueForSearch(upperTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
@@ -146,7 +147,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexedNorDocValuesFallback(context);
             if (indexType.hasDocValues()) {
-                return SortedDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             } else {
                 return super.termQuery(value, context);
             }
@@ -173,7 +174,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         ) {
             failIfNotIndexedNorDocValuesFallback(context);
             if (indexType.hasDocValues()) {
-                return SortedDocValuesField.newSlowRangeQuery(
+                return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -90,6 +90,7 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SortedSetDocValuesStringFieldScript;
@@ -972,7 +973,7 @@ public final class TextFieldMapper extends FieldMapper {
             if (usesBinaryDocValues) {
                 return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
             } else {
-                return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper.flattened;
 
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.DirectoryReader;
@@ -106,6 +105,7 @@ import org.elasticsearch.lucene.queries.KeyedArrayOrderInlineNullPrefixQuery;
 import org.elasticsearch.lucene.queries.KeyedArrayOrderInlineNullTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.FlattenedDocValuesField;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
@@ -732,7 +732,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                     }
                     return new ScanningBinaryDocValuesTermQuery(name(), keyedValue, false);
                 } else {
-                    return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
+                    return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
                 }
             } else {
                 return super.termQuery(value, context);
@@ -768,7 +768,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 BytesRef upper = new BytesRef(keyPrefix);
                 upper.bytes[upper.offset + upper.length - 1] = (byte) 0x01; // bump the trailing separator byte for an exclusive upper bound
 
-                return SortedSetDocValuesField.newSlowRangeQuery(name(), lower, upper, true, false);
+                return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(name(), lower, upper, true, false);
             }
             return new PrefixQuery(new Term(name(), keyPrefix));
         }

--- a/server/src/main/java/org/elasticsearch/lucene/document/XRangeBulkScorer.java
+++ b/server/src/main/java/org/elasticsearch/lucene/document/XRangeBulkScorer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.document;
+
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Fork of Lucene 10.5.1's package-private {@code RangeBulkScorer} with a fix for empty scoring
+ * windows ({@code apache/lucene#16546}).
+ *
+ * <p>Delete this class and revert {@link XSortedSkipperScorerSupplier} once Elasticsearch upgrades
+ * to a Lucene release containing that fix.
+ */
+final class XRangeBulkScorer extends BulkScorer {
+    private final int minDocID;
+    private final int maxDocID;
+    private final Scorable scorer;
+    private final DocIdSetIterator iterator;
+
+    XRangeBulkScorer(DocIdSetIterator iterator, float score, int minDocID, int maxDocID) {
+        if (minDocID >= maxDocID) {
+            throw new IllegalArgumentException("minDocID must be less than maxDocID");
+        }
+        this.minDocID = minDocID;
+        this.maxDocID = maxDocID;
+        this.iterator = Objects.requireNonNull(iterator);
+        this.scorer = new Scorable() {
+            @Override
+            public float score() {
+                return score;
+            }
+        };
+    }
+
+    @Override
+    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+        collector.setScorer(scorer);
+        DocIdSetIterator competitiveIterator = collector.competitiveIterator();
+        if (competitiveIterator != null) {
+            if (competitiveIterator.docID() > min) {
+                min = competitiveIterator.docID();
+                min = Math.min(min, max);
+            }
+        }
+        if (max <= minDocID) {
+            iterator.advance(minDocID);
+        } else if (min >= maxDocID) {
+            iterator.advance(maxDocID);
+        } else {
+            int filteredMin = Math.max(min, minDocID);
+            final int filteredMax = Math.min(max, maxDocID);
+            iterator.advance(filteredMin);
+            if (acceptDocs == null) {
+                if (filteredMin < filteredMax) {
+                    collector.collectRange(filteredMin, filteredMax);
+                }
+            } else {
+                int rangeStart = -1;
+                for (int doc = filteredMin; doc < filteredMax; doc++) {
+                    if (acceptDocs.get(doc)) {
+                        if (rangeStart < 0) {
+                            rangeStart = doc;
+                        }
+                    } else if (rangeStart >= 0) {
+                        collector.collectRange(rangeStart, doc);
+                        rangeStart = -1;
+                    }
+                }
+                if (rangeStart >= 0) {
+                    collector.collectRange(rangeStart, filteredMax);
+                }
+            }
+            iterator.advance(filteredMax);
+        }
+        return iterator.docID();
+    }
+
+    @Override
+    public long cost() {
+        return maxDocID - minDocID;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/document/XSortedSkipperScorerSupplier.java
+++ b/server/src/main/java/org/elasticsearch/lucene/document/XSortedSkipperScorerSupplier.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.document;
+
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.LongPredicate;
+
+/**
+ * Fork of Lucene 10.5.1's package-private {@code SortedSkipperScorerSupplier} wired to
+ * {@link XRangeBulkScorer}.
+ *
+ * <p>Delete this class once Elasticsearch upgrades to a Lucene release containing the fix for
+ * {@code apache/lucene#16546}.
+ */
+public abstract class XSortedSkipperScorerSupplier extends ScorerSupplier {
+
+    private final DocValuesSkipper skipper;
+    private final SortField sortField;
+    private final ScoreMode scoreMode;
+    private final float score;
+    private int skipperMinDocId = -1;
+    private int skipperMaxDocId = -1;
+    private boolean skipperMinDocIdExact = false;
+    private boolean skipperMaxDocIdExact = false;
+
+    protected XSortedSkipperScorerSupplier(DocValuesSkipper skipper, SortField sortField, float score, ScoreMode scoreMode) {
+        this.scoreMode = scoreMode;
+        this.score = score;
+        this.skipper = skipper;
+        this.sortField = sortField;
+    }
+
+    protected abstract long getLowerValue() throws IOException;
+
+    protected abstract long getUpperValue() throws IOException;
+
+    protected abstract int nextDoc(int startDocID, LongPredicate predicate) throws IOException;
+
+    @Override
+    public final Scorer get(long leadCost) throws IOException {
+        DocIdRange range = range();
+        DocIdSetIterator iterator = range.minDocID() == range.maxDocID()
+            ? DocIdSetIterator.empty()
+            : DocIdSetIterator.range(range.minDocID(), range.maxDocID());
+        return new ConstantScoreScorer(score, scoreMode, iterator);
+    }
+
+    @Override
+    public final BulkScorer bulkScorer() throws IOException {
+        DocIdRange range = range();
+        if (range.minDocID() == range.maxDocID()) {
+            return emptyBulkScorer();
+        }
+        DocIdSetIterator iterator = DocIdSetIterator.range(range.minDocID(), range.maxDocID());
+        return new XRangeBulkScorer(iterator, score, range.minDocID(), range.maxDocID());
+    }
+
+    @Override
+    public long cost() {
+        if (skipperMinDocId == -1) {
+            try {
+                computeSkipperDocIds();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        if (skipperMaxDocIdExact) {
+            return skipperMaxDocId - skipperMinDocId;
+        }
+        return skipperMaxDocId - skipperMinDocId + skipper.docCount(0);
+    }
+
+    private DocIdRange range() throws IOException {
+        if (skipperMinDocId == -1) {
+            computeSkipperDocIds();
+        }
+        long minOrd = getLowerValue();
+        long maxOrd = getUpperValue();
+        final int minDocID;
+        final int maxDocID;
+        if (sortField.getReverse()) {
+            minDocID = skipperMinDocIdExact ? skipperMinDocId : nextDoc(skipperMinDocId, l -> l <= maxOrd);
+            maxDocID = skipperMaxDocIdExact ? skipperMaxDocId : nextDoc(skipperMaxDocId, l -> l < minOrd);
+        } else {
+            minDocID = skipperMinDocIdExact ? skipperMinDocId : nextDoc(skipperMinDocId, l -> l >= minOrd);
+            maxDocID = skipperMaxDocIdExact ? skipperMaxDocId : nextDoc(skipperMaxDocId, l -> l > maxOrd);
+        }
+        return new DocIdRange(minDocID, maxDocID);
+    }
+
+    private void computeSkipperDocIds() throws IOException {
+        long minOrd = getLowerValue();
+        long maxOrd = getUpperValue();
+        if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
+            skipperMinDocId = skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
+            skipperMinDocIdExact = skipperMaxDocIdExact = true;
+            return;
+        }
+        if (skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
+            skipperMinDocId = 0;
+            skipperMaxDocId = skipper.docCount();
+            skipperMinDocIdExact = skipperMaxDocIdExact = true;
+            return;
+        }
+        if (sortField.getReverse()) {
+            if (skipper.maxValue() <= maxOrd) {
+                skipperMinDocId = 0;
+                skipperMinDocIdExact = true;
+            } else {
+                skipper.advance(Long.MIN_VALUE, maxOrd);
+                skipperMinDocId = skipper.minDocID(0);
+                skipperMinDocIdExact = skipper.maxValue(0) == maxOrd;
+            }
+            if (skipper.minValue() >= minOrd) {
+                skipperMaxDocId = skipper.docCount();
+                skipperMaxDocIdExact = true;
+            } else {
+                skipper.advance(Long.MIN_VALUE, minOrd - 1);
+                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocIdExact = skipper.maxValue(0) < minOrd;
+            }
+        } else {
+            if (skipper.minValue() >= minOrd) {
+                skipperMinDocId = 0;
+                skipperMinDocIdExact = true;
+            } else {
+                skipper.advance(minOrd, Long.MAX_VALUE);
+                skipperMinDocId = skipper.minDocID(0);
+                skipperMinDocIdExact = skipper.minValue(0) == minOrd;
+            }
+            if (skipper.maxValue() <= maxOrd) {
+                skipperMaxDocId = skipper.docCount();
+                skipperMaxDocIdExact = true;
+            } else {
+                skipper.advance(maxOrd + 1, Long.MAX_VALUE);
+                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocIdExact = skipper.minValue(0) > maxOrd;
+            }
+        }
+    }
+
+    private record DocIdRange(int minDocID, int maxDocID) {}
+
+    private static BulkScorer emptyBulkScorer() {
+        return new BulkScorer() {
+            @Override
+            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) {
+                return DocIdSetIterator.NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return 0;
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/XSortedSetDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/XSortedSetDocValuesRangeQuery.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ConstantScoreScorerSupplier;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.DocValuesRangeIterator;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.lucene.document.XSortedSkipperScorerSupplier;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.LongPredicate;
+
+/**
+ * Fork of Lucene 10.5.1's package-private {@code SortedSetDocValuesRangeQuery}, using
+ * {@link XSortedSkipperScorerSupplier} so that {@code RangeBulkScorer} does not pass empty ranges
+ * to {@code LeafCollector.collectRange} ({@code apache/lucene#16546}).
+ *
+ * <p>Delete this class, revert callers to {@link SortedSetDocValuesField#newSlowRangeQuery} and
+ * {@link SortedSetDocValuesField#newSlowExactQuery}, and remove the {@link #newSlowRangeQuery} /
+ * {@link #newSlowExactQuery} statics once Elasticsearch upgrades to a Lucene release containing
+ * that fix.
+ */
+public final class XSortedSetDocValuesRangeQuery extends Query {
+
+    public static Query newSlowRangeQuery(
+        String field,
+        BytesRef lowerValue,
+        BytesRef upperValue,
+        boolean lowerInclusive,
+        boolean upperInclusive
+    ) {
+        return new XSortedSetDocValuesRangeQuery(field, lowerValue, upperValue, lowerInclusive, upperInclusive);
+    }
+
+    public static Query newSlowExactQuery(String field, BytesRef value) {
+        return new XSortedSetDocValuesRangeQuery(field, value, value, true, true);
+    }
+
+    private final String field;
+    private final BytesRef lowerValue;
+    private final BytesRef upperValue;
+    private final boolean lowerInclusive;
+    private final boolean upperInclusive;
+
+    private XSortedSetDocValuesRangeQuery(
+        String field,
+        BytesRef lowerValue,
+        BytesRef upperValue,
+        boolean lowerInclusive,
+        boolean upperInclusive
+    ) {
+        this.field = Objects.requireNonNull(field);
+        this.lowerValue = lowerValue;
+        this.upperValue = upperValue;
+        this.lowerInclusive = lowerInclusive && lowerValue != null;
+        this.upperInclusive = upperInclusive && upperValue != null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (sameClassAs(obj) == false) {
+            return false;
+        }
+        XSortedSetDocValuesRangeQuery that = (XSortedSetDocValuesRangeQuery) obj;
+        return Objects.equals(field, that.field)
+            && Objects.equals(lowerValue, that.lowerValue)
+            && Objects.equals(upperValue, that.upperValue)
+            && lowerInclusive == that.lowerInclusive
+            && upperInclusive == that.upperInclusive;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), field, lowerValue, upperValue, lowerInclusive, upperInclusive);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder b = new StringBuilder();
+        if (this.field.equals(field) == false) {
+            b.append(this.field).append(":");
+        }
+        return b.append(lowerInclusive ? "[" : "{")
+            .append(lowerValue == null ? "*" : lowerValue)
+            .append(" TO ")
+            .append(upperValue == null ? "*" : upperValue)
+            .append(upperInclusive ? "]" : "}")
+            .toString();
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (lowerValue == null && upperValue == null) {
+            return new FieldExistsQuery(field);
+        }
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                if (context.reader().getFieldInfos().fieldInfo(field) == null) {
+                    return null;
+                }
+                DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
+                SortedSetDocValues values = DocValues.getSortedSet(context.reader(), field);
+                final SortedDocValues singleton = DocValues.unwrapSingleton(values);
+                final SortField primarySortField;
+                if (singleton != null && skipper != null && (primarySortField = densePrimarySort(context.reader(), skipper)) != null) {
+                    return getScorerSupplierFromDensePrimarySort(singleton, values, skipper, primarySortField);
+                }
+                return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
+                    @Override
+                    public DocIdSetIterator iterator(long leadCost) throws IOException {
+                        final long minOrd = minOrd(values);
+                        final long maxOrd = maxOrd(values);
+
+                        if (minOrd > maxOrd || (skipper != null && (minOrd > skipper.maxValue() || maxOrd < skipper.minValue()))) {
+                            return DocIdSetIterator.empty();
+                        }
+
+                        if (skipper != null
+                            && skipper.docCount() == context.reader().maxDoc()
+                            && skipper.minValue() >= minOrd
+                            && skipper.maxValue() <= maxOrd) {
+                            return DocIdSetIterator.all(skipper.docCount());
+                        }
+
+                        if (singleton != null) {
+                            return TwoPhaseIterator.asDocIdSetIterator(
+                                DocValuesRangeIterator.forOrdinalRange(singleton, skipper, minOrd, maxOrd)
+                            );
+                        }
+                        return TwoPhaseIterator.asDocIdSetIterator(DocValuesRangeIterator.forOrdinalRange(values, skipper, minOrd, maxOrd));
+                    }
+
+                    @Override
+                    public long cost() {
+                        return values.cost();
+                    }
+                };
+            }
+
+            @Override
+            public int count(LeafReaderContext context) throws IOException {
+                if (context.reader().getFieldInfos().fieldInfo(field) == null) {
+                    return 0;
+                }
+                SortedSetDocValues values = DocValues.getSortedSet(context.reader(), field);
+                final long minOrd = minOrd(values);
+                final long maxOrd = maxOrd(values);
+                if (minOrd > maxOrd) {
+                    return 0;
+                }
+                final DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
+                if (skipper != null) {
+                    if (minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
+                        return 0;
+                    }
+                    if (skipper.docCount() == context.reader().maxDoc() && skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
+                        return context.reader().numDocs();
+                    }
+                }
+                return -1;
+            }
+
+            private ScorerSupplier getScorerSupplierFromDensePrimarySort(
+                SortedDocValues singleton,
+                SortedSetDocValues values,
+                DocValuesSkipper skipper,
+                SortField sortField
+            ) {
+                return new XSortedSkipperScorerSupplier(skipper, sortField, score(), scoreMode) {
+                    long minOrd = -1;
+                    long maxOrd = -1;
+
+                    @Override
+                    protected long getLowerValue() throws IOException {
+                        if (minOrd == -1) {
+                            minOrd = minOrd(values);
+                        }
+                        return minOrd;
+                    }
+
+                    @Override
+                    protected long getUpperValue() throws IOException {
+                        if (maxOrd == -1) {
+                            maxOrd = maxOrd(values);
+                        }
+                        return maxOrd;
+                    }
+
+                    @Override
+                    protected int nextDoc(int startDocId, LongPredicate predicate) throws IOException {
+                        int doc = singleton.docID();
+                        if (startDocId > doc) {
+                            doc = singleton.advance(startDocId);
+                        }
+                        for (; doc < DocIdSetIterator.NO_MORE_DOCS; doc = singleton.nextDoc()) {
+                            if (predicate.test(singleton.ordValue())) {
+                                break;
+                            }
+                        }
+                        return doc;
+                    }
+                };
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return DocValues.isCacheable(ctx, field);
+            }
+        };
+    }
+
+    private long minOrd(SortedSetDocValues values) throws IOException {
+        if (lowerValue == null) {
+            return 0;
+        }
+        final long ord = values.lookupTerm(lowerValue);
+        if (ord < 0) {
+            return -1 - ord;
+        } else if (lowerInclusive) {
+            return ord;
+        } else {
+            return ord + 1;
+        }
+    }
+
+    private long maxOrd(SortedSetDocValues values) throws IOException {
+        if (upperValue == null) {
+            return values.getValueCount() - 1;
+        }
+        final long ord = values.lookupTerm(upperValue);
+        if (ord < 0) {
+            return -2 - ord;
+        } else if (upperInclusive) {
+            return ord;
+        } else {
+            return ord - 1;
+        }
+    }
+
+    private SortField densePrimarySort(LeafReader reader, DocValuesSkipper skipper) {
+        if (skipper.docCount() != reader.maxDoc()) {
+            return null;
+        }
+        final Sort indexSort = reader.getMetaData().sort();
+        if (indexSort == null || indexSort.getSort().length == 0 || indexSort.getSort()[0].getField().equals(field) == false) {
+            return null;
+        }
+        return indexSort.getSort()[0];
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -63,6 +63,7 @@ import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.ScriptCompiler;
 
 import java.io.IOException;
@@ -100,7 +101,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         assertEquals(new TermQuery(new Term("field", "foo")), ft.termQuery("foo", MOCK_CONTEXT));
 
         MappedFieldType ft2 = new KeywordFieldType("field", false, true, Map.of());
-        assertEquals(SortedSetDocValuesField.newSlowExactQuery("field", new BytesRef("foo")), ft2.termQuery("foo", MOCK_CONTEXT));
+        assertEquals(XSortedSetDocValuesRangeQuery.newSlowExactQuery("field", new BytesRef("foo")), ft2.termQuery("foo", MOCK_CONTEXT));
 
         MappedFieldType unsearchable = new KeywordFieldType("field", false, false, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("bar", MOCK_CONTEXT));
@@ -311,7 +312,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
 
         MappedFieldType ft2 = new KeywordFieldType("field", false, true, Map.of());
         assertEquals(
-            SortedSetDocValuesField.newSlowRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
+            XSortedSetDocValuesRangeQuery.newSlowRangeQuery("field", BytesRefs.toBytesRef("foo"), BytesRefs.toBytesRef("bar"), true, false),
             ft2.rangeQuery("foo", "bar", true, false, null, null, null, MOCK_CONTEXT)
         );
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldTypeTests.java
@@ -35,7 +35,7 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
     public void testTermQueryDocValues() {
         BytesRef value = new BytesRef("foo");
         Query query = RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.termQuery(value.utf8ToString(), MOCK_CONTEXT);
-        assertEquals("SortedSetDocValuesRangeQuery", query.getClass().getSimpleName());
+        assertEquals("XSortedSetDocValuesRangeQuery", query.getClass().getSimpleName());
         assertEquals("[" + value + " TO " + value + "]", query.toString("_routing"));
     }
 
@@ -115,7 +115,7 @@ public class RoutingFieldTypeTests extends FieldTypeTestCase {
 
     public void testRangeQueryDocValues() {
         Query query = RoutingFieldMapper.DOC_VALUES_FIELD_TYPE.rangeQuery("foo", "qux", true, false, null, null, null, MOCK_CONTEXT);
-        assertEquals("SortedSetDocValuesRangeQuery", query.getClass().getSimpleName());
+        assertEquals("XSortedSetDocValuesRangeQuery", query.getClass().getSimpleName());
         assertEquals("[" + new BytesRef("foo") + " TO " + new BytesRef("qux") + "}", query.toString("_routing"));
 
         ElasticsearchException ee = expectThrows(

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper.flattened;
 
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -35,6 +34,7 @@ import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.KeyedFlatte
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.queries.KeyedArrayOrderInlineNullTermQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.xcontent.XContentType;
@@ -189,7 +189,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             false
         );
 
-        Query expected = SortedSetDocValuesField.newSlowExactQuery(ft.name(), new BytesRef("key\0value"));
+        Query expected = XSortedSetDocValuesRangeQuery.newSlowExactQuery(ft.name(), new BytesRef("key\0value"));
         assertEquals(expected, ft.termQuery("value", null));
     }
 
@@ -268,7 +268,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         );
 
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        builder.add(SortedSetDocValuesField.newSlowExactQuery(ft.name(), new BytesRef("key\0value")), BooleanClause.Occur.SHOULD);
+        builder.add(XSortedSetDocValuesRangeQuery.newSlowExactQuery(ft.name(), new BytesRef("key\0value")), BooleanClause.Occur.SHOULD);
         Query expected = new ConstantScoreQuery(builder.build());
         assertEquals(expected, ft.termsQuery(List.of("value"), null));
     }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/XSortedSetDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/XSortedSetDocValuesRangeQueryTests.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TotalHitCountCollectorManager;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.search.QueryUtils;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.function.IntFunction;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Fork of Lucene's {@code TestDocValuesQueries} coverage for {@code SortedSetDocValuesRangeQuery},
+ * adapted to exercise {@link XSortedSetDocValuesRangeQuery}.
+ */
+public class XSortedSetDocValuesRangeQueryTests extends ESTestCase {
+
+    private static final int EMPTY_RANGE_EXPECTED_HITS = 10;
+
+    private static Codec docValuesCodec(int skipIntervalSize) {
+        return TestUtil.alwaysDocValuesFormat(new Lucene90DocValuesFormat(skipIntervalSize));
+    }
+
+    public void testBasics() {
+        Query query1 = XSortedSetDocValuesRangeQuery.newSlowExactQuery("field", new BytesRef("foo"));
+        Query query2 = XSortedSetDocValuesRangeQuery.newSlowExactQuery("field", new BytesRef("foo"));
+        Query query3 = XSortedSetDocValuesRangeQuery.newSlowExactQuery("field", new BytesRef("bar"));
+        Query query4 = XSortedSetDocValuesRangeQuery.newSlowRangeQuery("field", new BytesRef("a"), new BytesRef("z"), true, true);
+        QueryUtils.check(query1);
+        QueryUtils.checkEqual(query1, query2);
+        QueryUtils.checkUnequal(query1, query3);
+        QueryUtils.checkUnequal(query1, query4);
+    }
+
+    public void testRewriteUnboundedRange() throws IOException {
+        try (IndexReader reader = new MultiReader()) {
+            IndexSearcher searcher = newSearcher(reader);
+            Query query = XSortedSetDocValuesRangeQuery.newSlowRangeQuery("field", null, null, true, true);
+            assertThat(query.rewrite(searcher), instanceOf(FieldExistsQuery.class));
+        }
+    }
+
+    /**
+     * Fork of Lucene's {@code testSortedSetDocValuesRangeQueryCount}.
+     */
+    public void testSortedSetDocValuesRangeQueryCount() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            for (int i = 0; i < 100; i++) {
+                String val = String.format(Locale.ROOT, "%03d", i);
+                Document doc = new Document();
+                doc.add(SortedSetDocValuesField.indexedField("with_index", new BytesRef(val)));
+                doc.add(new SortedSetDocValuesField("without_index", new BytesRef(val)));
+                if (i != 55) {
+                    doc.add(SortedSetDocValuesField.indexedField("sparse", new BytesRef(val)));
+                }
+                iw.addDocument(doc);
+            }
+            iw.commit();
+            iw.forceMerge(1);
+
+            try (IndexReader reader = iw.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                assertCount(
+                    searcher,
+                    XSortedSetDocValuesRangeQuery.newSlowRangeQuery("nonexistent", new BytesRef("000"), new BytesRef("099"), true, true),
+                    0
+                );
+                assertCount(
+                    searcher,
+                    XSortedSetDocValuesRangeQuery.newSlowRangeQuery("with_index", new BytesRef("000"), new BytesRef("099"), true, true),
+                    100
+                );
+                assertCount(
+                    searcher,
+                    XSortedSetDocValuesRangeQuery.newSlowRangeQuery("without_index", new BytesRef("000"), new BytesRef("099"), true, true),
+                    -1
+                );
+                assertCount(
+                    searcher,
+                    XSortedSetDocValuesRangeQuery.newSlowRangeQuery("with_index", new BytesRef("100"), new BytesRef("199"), true, true),
+                    0
+                );
+            }
+
+            iw.deleteDocuments(
+                XSortedSetDocValuesRangeQuery.newSlowRangeQuery("with_index", new BytesRef("020"), new BytesRef("030"), true, true)
+            );
+            iw.commit();
+
+            try (IndexReader reader = iw.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                assertCount(
+                    searcher,
+                    XSortedSetDocValuesRangeQuery.newSlowRangeQuery("with_index", new BytesRef("000"), new BytesRef("099"), true, true),
+                    89
+                );
+            }
+        }
+    }
+
+    /**
+     * Fork of Lucene's {@code testPrimarySortDenseSortedDocValuesExactMatch}.
+     */
+    public void testPrimarySortDenseExactMatch() throws IOException {
+        doTestPrimarySortDenseExactMatch(
+            SortField.Type.STRING,
+            i -> SortedDocValuesField.indexedField("dv", new BytesRef(Integer.toString(i))),
+            i -> XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
+                "dv",
+                new BytesRef(Integer.toString(i)),
+                new BytesRef(Integer.toString(i)),
+                true,
+                true
+            )
+        );
+    }
+
+    /**
+     * When the queried field is the primary index sort field and dense, {@link XSortedSetDocValuesRangeQuery}
+     * should use {@code XSortedSkipperScorerSupplier} and avoid a two-phase iterator.
+     */
+    public void testSortedSetRangeQueryOptimizesWithDensePrimarySort() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(docValuesCodec(randomIntBetween(4, 16)));
+        config.setIndexSort(new Sort(new SortField("secondary", SortField.Type.STRING)));
+        IndexWriter iw = new IndexWriter(dir, config);
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(SortedDocValuesField.indexedField("secondary", new BytesRef(String.format(Locale.ROOT, "%03d", i))));
+            iw.addDocument(doc);
+        }
+        iw.forceMerge(1);
+        iw.close();
+        DirectoryReader reader = DirectoryReader.open(dir);
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        Query query = XSortedSetDocValuesRangeQuery.newSlowRangeQuery("secondary", new BytesRef("003"), new BytesRef("007"), true, true);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        Scorer scorer = weight.scorer(reader.leaves().get(0));
+        assertNotNull(scorer);
+        assertThat("XSortedSkipperScorerSupplier should be used for dense primary sort", scorer.twoPhaseIterator(), nullValue());
+
+        reader.close();
+        dir.close();
+    }
+
+    /**
+     * Fork of Lucene's {@code testSortedSetRangeQueryDoesNotOptimizeWithActivePrimary}.
+     */
+    public void testSortedSetRangeQueryDoesNotOptimizeWithActivePrimary() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(docValuesCodec(randomIntBetween(4, 16)));
+        config.setIndexSort(new Sort(new SortField("primary", SortField.Type.STRING), new SortField("secondary", SortField.Type.STRING)));
+        IndexWriter iw = new IndexWriter(dir, config);
+        for (int i = 0; i < 10; i++) {
+            String val = String.format(Locale.ROOT, "%03d", i);
+            Document doc = new Document();
+            doc.add(SortedDocValuesField.indexedField("primary", new BytesRef(val)));
+            doc.add(SortedDocValuesField.indexedField("secondary", new BytesRef(val)));
+            iw.addDocument(doc);
+        }
+        iw.forceMerge(1);
+        iw.close();
+        DirectoryReader reader = DirectoryReader.open(dir);
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        Query query = XSortedSetDocValuesRangeQuery.newSlowRangeQuery("secondary", new BytesRef("003"), new BytesRef("007"), true, true);
+        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
+        Scorer scorer = weight.scorer(reader.leaves().get(0));
+        assertNotNull(scorer);
+        assertNotNull("TwoPhaseIterator fallback should be used when secondary is not the effective primary", scorer.twoPhaseIterator());
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testLuceneFailureIsFixedWithWorkaround() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriterConfig config = new IndexWriterConfig();// .setCodec(docValuesCodec(4096));
+        config.setIndexSort(new Sort(new SortedSetSortField("slice", false)));
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, config);
+
+        for (int i = 0; i < 128; i++) {
+            iw.addDocument(doc("aaa", "no"));
+        }
+        for (int i = 0; i < 8192; i++) {
+            iw.addDocument(doc("src", i % 819 == 818 ? "no" : "yes"));
+        }
+        for (int i = 0; i < 128; i++) {
+            iw.addDocument(doc("zzz", "no"));
+        }
+        iw.commit();
+        iw.forceMerge(1);
+
+        try (IndexReader reader = iw.getReader()) {
+            ContextIndexSearcher searcher = new ContextIndexSearcher(reader, null, null, TrivialQueryCachingPolicy.NEVER, true);
+            searcher.addQueryCancellation(() -> {});
+            // fail
+            {
+                Query query = new BooleanQuery.Builder().add(
+                    SortedSetDocValuesField.newSlowExactQuery("slice", new BytesRef("src")),
+                    Occur.FILTER
+                ).add(new TermQuery(new Term("excluded", "yes")), Occur.MUST_NOT).build();
+                expectThrows(
+                    IllegalArgumentException.class,
+                    "This means that lucene #16546 has been fixed and the workaround can be removed",
+                    () -> searcher.search(query, new TotalHitCountCollectorManager(searcher.getSlices()))
+                );
+            }
+            {
+                Query query = new BooleanQuery.Builder().add(
+                    XSortedSetDocValuesRangeQuery.newSlowExactQuery("slice", new BytesRef("src")),
+                    Occur.FILTER
+                ).add(new TermQuery(new Term("excluded", "yes")), Occur.MUST_NOT).build();
+
+                int hits = searcher.search(query, new TotalHitCountCollectorManager(searcher.getSlices()));
+                assertEquals(EMPTY_RANGE_EXPECTED_HITS, hits);
+            }
+        }
+        iw.close();
+        dir.close();
+    }
+
+    private void doTestPrimarySortDenseExactMatch(SortField.Type type, IntFunction<IndexableField> fields, IntFunction<Query> queries)
+        throws IOException {
+        boolean deletes = randomBoolean();
+        Directory dir = newDirectory();
+        int skipIntervalSize = randomIntBetween(4, 4096);
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(docValuesCodec(skipIntervalSize));
+        config.setIndexSort(new Sort(new SortField("dv", type, randomBoolean())));
+        int numBlocks = randomIntBetween(4, 16);
+        int[] sizes = new int[numBlocks];
+        for (int i = 0; i < numBlocks; i++) {
+            sizes[i] = randomIntBetween(1, 250);
+        }
+        int[] totalSizes = new int[numBlocks];
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir, config);
+        for (int i = 0; i < numBlocks; i++) {
+            totalSizes[i] = sizes[i];
+            for (int j = 0; j < sizes[i]; j++) {
+                Document doc = new Document();
+                IndexableField dv = fields.apply(i);
+                doc.add(dv);
+                iw.addDocument(doc);
+                if (deletes && randomInt(10) == 0) {
+                    doc = new Document();
+                    doc.add(dv);
+                    doc.add(new StringField("id", "to_delete", Field.Store.NO));
+                    iw.addDocument(doc);
+                    totalSizes[i]++;
+                }
+            }
+        }
+        iw.commit();
+        iw.forceMerge(1);
+
+        if (deletes) {
+            iw.deleteDocuments(new TermQuery(new Term("id", "to_delete")));
+        }
+
+        final IndexReader reader = iw.getReader();
+        final IndexSearcher searcher = newSearcher(reader, false);
+        iw.close();
+
+        for (int i = 0; i < numBlocks; i++) {
+            final Query q = queries.apply(i);
+            assertEquals(sizes[i], searcher.count(q));
+            assertEquals(sizes[i], searcher.search(q, 1000).totalHits.value());
+            assertEquals(1, reader.leaves().size());
+            LeafReaderContext ctx = reader.leaves().get(0);
+            Query rewritten = searcher.rewrite(q);
+            Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+            ScorerSupplier supplier = weight.scorerSupplier(ctx);
+            assertThat(supplier.cost(), greaterThanOrEqualTo((long) sizes[i]));
+            assertThat(supplier.cost(), lessThanOrEqualTo(totalSizes[i] + 2L * skipIntervalSize));
+        }
+        reader.close();
+        dir.close();
+    }
+
+    private static Document doc(String slice, String excluded) {
+        Document doc = new Document();
+        doc.add(SortedSetDocValuesField.indexedField("slice", new BytesRef(slice)));
+        doc.add(new StringField("excluded", excluded, Field.Store.NO));
+        return doc;
+    }
+
+    private static void assertCount(IndexSearcher searcher, Query query, int expectedCount) throws IOException {
+        Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE, 1.0f);
+        assertEquals(expectedCount, weight.count(searcher.getIndexReader().leaves().getFirst()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/RangeBulkScorerEmptyRangeReproductionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/RangeBulkScorerEmptyRangeReproductionTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.search;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+
+/**
+ * Regression test for the empty {@code collectRange} bug in {@code RangeBulkScorer}
+ * ({@code apache/lucene#16546}).
+ *
+ * <p><b>Root cause.</b> When a {@code RangeBulkScorer} (used for index-sorted doc-values exact
+ * queries) is wrapped by {@code ReqExclBulkScorer}, an empty scoring window can be passed with
+ * {@code min == max}. {@code RangeBulkScorer} unconditionally calls
+ * {@code LeafCollector.collectRange(filteredMin, filteredMax)}, but the default implementation
+ * rejects empty ranges via {@code RangeDocIdStream}.
+ *
+ * <p><b>Elasticsearch trigger path.</b>
+ * <ul>
+ *   <li>{@code index.sort.field} matches the filtered field so {@code termQuery} on an
+ *       {@code index=false} keyword maps to {@code RangeBulkScorer} via
+ *       {@link org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery}.</li>
+ *   <li>{@code index.mapping.use_doc_values_skipper=true} is required to write the doc-values
+ *       skip index that enables the bulk scorer fast path.</li>
+ *   <li>A boolean query with a dense FILTER and a high-exclusion MUST_NOT drives
+ *       {@code ReqExclBulkScorer} to create empty scoring windows.</li>
+ *   <li>Aggregations (and other collectors inheriting the default {@code collectRange}) surface
+ *       the bug as a search failure: {@code IllegalArgumentException: min = 4096 >= max = 4096}.</li>
+ * </ul>
+ */
+public class RangeBulkScorerEmptyRangeReproductionTests extends ESSingleNodeTestCase {
+
+    private static final String INDEX = "range-bulk-scorer-empty-range-repro";
+    private static final String SLICE_FIELD = "slice";
+
+    /** Number of matching docs: one per 819 docs in the dense {@code slice=src} block. */
+    private static final int EXPECTED_HITS = 10;
+
+    @Before
+    public void setupIndex() throws IOException {
+        client().admin().indices().prepareCreate(INDEX).setSettings(baseSettings()).setMapping("""
+            {
+              "properties": {
+                "slice": {"type": "keyword", "index": false},
+                "excluded": {"type": "keyword"}
+              }
+            }
+            """).get();
+
+        for (int i = 0; i < 128; i++) {
+            indexDoc("aaa", "no");
+        }
+        for (int i = 0; i < 8192; i++) {
+            indexDoc("src", i % 819 == 818 ? "no" : "yes");
+        }
+        for (int i = 0; i < 128; i++) {
+            indexDoc("zzz", "no");
+        }
+
+        client().admin().indices().prepareRefresh(INDEX).get();
+        client().admin().indices().prepareForceMerge(INDEX).setMaxNumSegments(1).get();
+    }
+
+    /**
+     * Reproduces the bug through the full Elasticsearch search path with a terms aggregation.
+     * {@code LeafBucketCollector} inherits the default {@code collectRange} implementation.
+     */
+    public void testBoolMustNotWithTermsAggregation() {
+        assertResponse(
+            client().prepareSearch(INDEX)
+                .setTrackTotalHits(true)
+                .setSize(0)
+                .setQuery(query())
+                .addAggregation(AggregationBuilders.terms("by_excluded").field("excluded")),
+            response -> {
+                assertEquals(EXPECTED_HITS, response.getHits().getTotalHits().value());
+                Terms terms = response.getAggregations().get("by_excluded");
+                assertNotNull(terms);
+                assertEquals(1, terms.getBuckets().size());
+                assertEquals("no", terms.getBuckets().getFirst().getKeyAsString());
+                assertEquals(EXPECTED_HITS, terms.getBuckets().getFirst().getDocCount());
+            }
+        );
+    }
+
+    /**
+     * Same query shape without aggregations. Also exercises the bulk scorer fast path during
+     * hit counting.
+     */
+    public void testBoolMustNotHitCount() {
+        assertHitCount(client().prepareSearch(INDEX).setTrackTotalHits(true).setQuery(query()), EXPECTED_HITS);
+    }
+
+    private static QueryBuilder query() {
+        return QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(SLICE_FIELD, "src"))
+            .mustNot(QueryBuilders.termQuery("excluded", "yes"));
+    }
+
+    private static Settings baseSettings() {
+        return Settings.builder()
+            .put("index.queries.cache.enabled", false)
+            .put(IndexSettings.USE_DOC_VALUES_SKIPPER.getKey(), true)
+            .put("index.sort.field", SLICE_FIELD)
+            .put("index.sort.order", "asc")
+            .build();
+    }
+
+    private void indexDoc(String slice, String excluded) throws IOException {
+        prepareIndex(INDEX).setSource(
+            XContentFactory.jsonBuilder().startObject().field(SLICE_FIELD, slice).field("excluded", excluded).endObject()
+        ).get();
+    }
+}

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.downsample;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.internal.hppc.IntArrayList;
 import org.apache.lucene.internal.hppc.LongArrayList;
@@ -45,6 +44,7 @@ import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -253,7 +253,7 @@ class DownsampleShardIndexer {
 
     private Query createQuery() {
         if (this.state.started() && this.state.tsid() != null) {
-            return SortedSetDocValuesField.newSlowRangeQuery(TimeSeriesIdFieldMapper.NAME, this.state.tsid(), null, true, false);
+            return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(TimeSeriesIdFieldMapper.NAME, this.state.tsid(), null, true, false);
         }
         return Queries.ALL_DOCS_INSTANCE;
     }


### PR DESCRIPTION
Fixes search failures from
[apache/lucene#16546](https://github.com/apache/lucene/issues/16546).

On index-sorted doc-values exact queries, `ReqExclBulkScorer` can pass an empty window to
`RangeBulkScorer`, which calls `collectRange(min, max)` with `min == max`.

This is a port of the fix to Elasticsearch.