### PR TITLE
Add this-escape suppressions ahead of JDK 25

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
@@ -72,6 +72,10 @@ public class TermsReduceBenchmark {
 
     private final TermsAggregationBuilder builder = new TermsAggregationBuilder("terms");
 
+    // The reduce-context lambda captures the builder field, so this escapes into the SearchPhaseController
+    // constructor before the JMH-generated subclass is initialized. The captured state is only read later at
+    // benchmark time, so the escape is harmless here.
+    @SuppressWarnings("this-escape")
     private final SearchPhaseController controller = new SearchPhaseController((task, req) -> new AggregationReduceContext.Builder() {
         @Override
         public AggregationReduceContext forPartialReduction(@Nullable Collection<SearchHits> topHitsToRelease) {

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -61,6 +61,8 @@ public abstract class TransportTasksAction<
 
     protected final String transportNodeAction;
 
+    @SuppressWarnings("this-escape") // registers a NodeTransportHandler bound to this action; the handler is only invoked after
+                                     // construction.
     protected TransportTasksAction(
         String actionName,
         ClusterService clusterService,

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/BWCCodec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/BWCCodec.java
@@ -48,6 +48,9 @@ public abstract class BWCCodec extends Codec {
     private final SegmentInfoFormat segmentInfosFormat;
     private final PostingsFormat postingsFormat;
 
+    // Calls the overridable original*Format() methods to build wrapping formats; subclasses must return
+    // constant, construction-independent formats, so this escape is safe.
+    @SuppressWarnings("this-escape")
     protected BWCCodec(String name) {
         super(name);
 


### PR DESCRIPTION
## Summary

Extracts the hand-written `@SuppressWarnings("this-escape")` additions from the JDK 25 baseline branch (#156773) that apply to code already on `main`, so that PR stays smaller and these land independently. Suggested by @javanna in the review of #156773 ("could this change be made on main?").

Three spots are affected:
- `TransportTasksAction` (constructor registers a transport handler bound to `this`, invoked only after construction)
- `BWCCodec` (constructor calls overridable `original*Format()` methods; subclasses return constant, construction-independent formats)
- `TermsReduceBenchmark` (a field-initializer lambda captures another field before the JMH-generated subclass is initialized; read only at benchmark time)

## Why now / why inert

`main` compiles with JDK 21 (`minimumCompilerVersion` = 21), whose constructor-escape analysis does not flag these. JDK 25's stricter analysis does. So the annotations are inert on `main` today but prevent build breaks (the build uses `-Werror -Xlint:all`) once the baseline moves to 25. `TransportUpdateAction`, the fourth spot in the source branch, already carries the annotation on `main`, so it is not included here.

## Test plan

- [x] `:server:compileJava`, `:benchmarks:compileJava`, and `:x-pack:plugin:old-lucene-versions:compileJava` build on `main` with the JDK 21 toolchain.
- No functional change; no changelog needed (internal/test-only).

Made with [Cursor](https://cursor.com)