### PR TITLE
[9.5] Bound serial diff queue allocation

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -262,6 +262,23 @@ public class SerialDiffIT extends AggregationIntegTestCase {
         );
     }
 
+    public void testLargeLagDoesNotExhaustMemory() {
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(INTERVAL_FIELD)
+                    .interval(interval)
+                    .extendedBounds(0L, (long) (interval * (numBuckets - 1)))
+                    .subAggregation(metric)
+                    .subAggregation(diff("diff_values", "the_metric").lag(Integer.MAX_VALUE).gapPolicy(gapPolicy))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getBuckets(), Matchers.hasSize(numBuckets));
+            }
+        );
+    }
+
     public void testInvalidLagSize() {
         try {
             prepareSearch("idx").addAggregation(

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -275,6 +275,9 @@ public class SerialDiffIT extends AggregationIntegTestCase {
                 Histogram histo = response.getAggregations().get("histo");
                 assertThat(histo, notNullValue());
                 assertThat(histo.getBuckets(), Matchers.hasSize(numBuckets));
+                for (Bucket bucket : histo.getBuckets()) {
+                    assertThat(bucket.getAggregations().get("diff_values"), nullValue());
+                }
             }
         );
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
@@ -52,7 +52,7 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
         HistogramFactory factory = (HistogramFactory) histo;
 
         List<Bucket> newBuckets = new ArrayList<>();
-        EvictingQueue<Double> lagWindow = new EvictingQueue<>(lag);
+        EvictingQueue<Double> lagWindow = new EvictingQueue<>(Math.min(lag, buckets.size()));
         int counter = 0;
 
         for (InternalMultiBucketAggregation.InternalBucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
@@ -51,8 +51,12 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
         List<? extends InternalMultiBucketAggregation.InternalBucket> buckets = histo.getBuckets();
         HistogramFactory factory = (HistogramFactory) histo;
 
-        List<Bucket> newBuckets = new ArrayList<>();
-        EvictingQueue<Double> lagWindow = new EvictingQueue<>(Math.min(lag, buckets.size()));
+        if (lag >= buckets.size()) {
+            return aggregation;
+        }
+
+        List<Bucket> newBuckets = new ArrayList<>(buckets.size());
+        EvictingQueue<Double> lagWindow = new EvictingQueue<>(lag);
         int counter = 0;
 
         for (InternalMultiBucketAggregation.InternalBucket bucket : buckets) {


### PR DESCRIPTION
Backport of #157636 to 9.5.

## Summary

Prevent the serial diff pipeline aggregation from allocating an internal queue for a lag that cannot produce a difference. When `lag` is greater than or equal to the number of buckets, the original aggregation is returned unchanged; otherwise, the rebuilt bucket list is pre-sized and the queue is allocated only for the required lag.

## Testing

- Added regression coverage for an extreme lag value with a small histogram.
- Verified that the aggregation completes and does not add difference values.
- Ran the focused aggregation test.
- Ran Spotless checks.