### PR TITLE
[8.19] ES|QL: Prevent COUNT_DISTINCT precision wraparound (#157553)

### DIFF
--- a/docs/changelog/157553.yaml
+++ b/docs/changelog/157553.yaml
@@ -1,0 +1,6 @@
+pr: 157553
+summary: Prevent COUNT_DISTINCT precision thresholds outside the integer range from wrapping
+area: ES|QL
+type: bug
+issues:
+  - 157549

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -2017,6 +2017,26 @@ s2point1:l | s_mv:l | s_param:l | s_expr:l | s_expr_null:l | languages:i
 1          | 4      | 4         | 1        | 0             | null
 ;
 
+countDistinctPrecisionAboveIntegerRangeLong
+required_capability: fn_count_distinct_precision_clamp
+
+FROM employees
+| STATS d = COUNT_DISTINCT(emp_no, 4294967297);
+
+d:long
+100
+;
+
+countDistinctPrecisionAboveIntegerRangeUnsignedLong
+required_capability: fn_count_distinct_precision_clamp
+
+FROM employees
+| STATS d = COUNT_DISTINCT(emp_no, 18446744073709551615);
+
+d:long
+100
+;
+
 evalOverridingKey#[skip:-8.13.1,reason:fixed in 8.13.2]
 FROM employees
 | EVAL k = languages

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1172,6 +1172,11 @@ public class EsqlCapabilities {
          */
         FIX_PARTIAL_PREFIX_COMPOUND_TOPN_PUSHDOWN,
 
+        /**
+         * Clamp {@code COUNT_DISTINCT} precision thresholds before narrowing them to integers.
+         */
+        FN_COUNT_DISTINCT_PRECISION_CLAMP,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunction
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
@@ -38,6 +39,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -50,11 +52,16 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isWho
 import static org.elasticsearch.xpack.esql.core.util.CollectionUtils.nullSafeList;
 
 public class CountDistinct extends AggregateFunction implements OptionalArgument, ToAggregator, SurrogateExpression {
+
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
         "CountDistinct",
         CountDistinct::new
     );
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(CountDistinct.class)
+        .binary(CountDistinct::new)
+        .capabilities("flattened", "precision_clamp")
+        .name("count_distinct");
 
     private static final Map<DataType, Function<Integer, AggregatorFunctionSupplier>> SUPPLIERS = Map.ofEntries(
         // Booleans ignore the precision because there are only two possible values anyway
@@ -212,7 +219,7 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
         DataType type = field().dataType();
         int precision = this.precision == null
             ? DEFAULT_PRECISION
-            : ((Number) this.precision.fold(FoldContext.small() /* TODO remove me */)).intValue();
+            : precisionValue();
         if (SUPPLIERS.containsKey(type) == false) {
             // If the type checking did its job, this should never happen
             throw EsqlIllegalArgumentException.illegalDataType(type);
@@ -221,6 +228,25 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     }
 
     @Override
+    public Nullability nullable() {
+        return Nullability.FALSE;
+    }
+
+    private int precisionValue() {
+        return clampPrecisionThreshold(precision.dataType(), (Number) ((Literal) precision).value());
+    }
+
+    /** Clamps a folded precision literal to {@code [0, {@link Integer#MAX_VALUE}]} without narrowing wraparound. */
+    static int clampPrecisionThreshold(DataType precisionType, Number value) {
+        if (precisionType == DataType.UNSIGNED_LONG) {
+            BigInteger unsignedValue = value instanceof BigInteger bigInteger
+                ? bigInteger
+                : NumericUtils.unsignedLongAsBigInteger(value.longValue());
+            return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
+        }
+        return Math.clamp(value.longValue(), 0, Integer.MAX_VALUE);
+    }
+
     public Expression surrogate() {
         var s = source();
         var field = field();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -19,7 +19,6 @@ import org.elasticsearch.compute.aggregation.CountDistinctIntAggregatorFunctionS
 import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunctionSupplier;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -217,9 +216,7 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     @Override
     public AggregatorFunctionSupplier supplier() {
         DataType type = field().dataType();
-        int precision = this.precision == null
-            ? DEFAULT_PRECISION
-            : precisionValue();
+        int precision = this.precision == null ? DEFAULT_PRECISION : precisionValue();
         if (SUPPLIERS.containsKey(type) == false) {
             // If the type checking did its job, this should never happen
             throw EsqlIllegalArgumentException.illegalDataType(type);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.Example;
-import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -59,10 +58,6 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
         "CountDistinct",
         CountDistinct::new
     );
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(CountDistinct.class)
-        .binary(CountDistinct::new)
-        .capabilities("flattened", "precision_clamp")
-        .name("count_distinct");
 
     private static final Map<DataType, Function<Integer, AggregatorFunctionSupplier>> SUPPLIERS = Map.ofEntries(
         // Booleans ignore the precision because there are only two possible values anyway
@@ -232,7 +227,7 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     }
 
     private int precisionValue() {
-        return clampPrecisionThreshold(precision.dataType(), (Number) ((Literal) precision).value());
+        return clampPrecisionThreshold(precision.dataType(), (Number) precision.fold(FoldContext.small()));
     }
 
     /** Clamps a folded precision literal to {@code [0, {@link Integer#MAX_VALUE}]} without narrowing wraparound. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -220,11 +219,6 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
             throw EsqlIllegalArgumentException.illegalDataType(type);
         }
         return SUPPLIERS.get(type).apply(precision);
-    }
-
-    @Override
-    public Nullability nullable() {
-        return Nullability.FALSE;
     }
 
     private int precisionValue() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.aggregation.CountDistinctIntAggregatorFunctionS
 import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunctionSupplier;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -238,7 +238,7 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
                 : NumericUtils.unsignedLongAsBigInteger(value.longValue());
             return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
         }
-        return Math.clamp(value.longValue(), 0, Integer.MAX_VALUE);
+        return Math.toIntExact(Math.max(0L, Math.min(value.longValue(), Integer.MAX_VALUE)));
     }
 
     public Expression surrogate() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -117,13 +117,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
     }
 
     private static TestCaseSupplier.TypedDataSupplier manyInts(String name) {
-        return new TestCaseSupplier.TypedDataSupplier(
-            name,
-            () -> IntStream.range(0, 1000).boxed().toList(),
-            DataType.INTEGER,
-            false,
-            true
-        );
+        return new TestCaseSupplier.TypedDataSupplier(name, () -> IntStream.range(0, 1000).boxed().toList(), DataType.INTEGER, false, true);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -213,6 +213,6 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
                 : BigInteger.valueOf(value.longValue() ^ Long.MIN_VALUE);
             return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
         }
-        return Math.clamp(((Number) precision.data()).longValue(), 0, Integer.MAX_VALUE);
+        return Math.toIntExact(Math.max(0L, Math.min(((Number) precision.data()).longValue(), Integer.MAX_VALUE)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -92,7 +93,39 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
         }
 
         // "No rows" expects 0 here instead of null
-        return parameterSuppliersFromTypedData(randomizeBytesRefsOffset(suppliers));
+        suppliers = parameterSuppliersFromTypedData(randomizeBytesRefsOffset(suppliers));
+        suppliers.add(
+            makeSupplier(
+                manyInts("<long precision above integer range>"),
+                new TestCaseSupplier.TypedDataSupplier(
+                    "<long precision above integer range>",
+                    () -> (1L << Integer.SIZE) + 1,
+                    DataType.LONG
+                )
+            )
+        );
+        suppliers.add(
+            makeSupplier(
+                manyInts("<unsigned long precision above integer range>"),
+                new TestCaseSupplier.TypedDataSupplier(
+                    "<unsigned long precision above integer range>",
+                    () -> BigInteger.ONE.shiftLeft(Integer.SIZE).add(BigInteger.ONE),
+                    DataType.UNSIGNED_LONG
+                )
+            )
+        );
+        return suppliers;
+    }
+
+    private static TestCaseSupplier.TypedDataSupplier manyInts(String name) {
+        return new TestCaseSupplier.TypedDataSupplier(
+            name,
+            () -> IntStream.range(0, 1000).boxed().toList(),
+            DataType.INTEGER,
+            false,
+            true,
+            List.of()
+        );
     }
 
     @Override
@@ -108,7 +141,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
             var fieldTypedData = fieldSupplier.get();
             var precisionTypedData = precisionSupplier.get().forceLiteral();
             var values = fieldTypedData.multiRowData();
-            var precision = ((Number) precisionTypedData.data()).intValue();
+            var precision = expectedPrecision(precisionTypedData);
 
             long result;
 
@@ -171,5 +204,16 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
 
             return hll.cardinality(0);
         }
+    }
+
+    private static int expectedPrecision(TestCaseSupplier.TypedData precision) {
+        if (precision.type() == DataType.UNSIGNED_LONG) {
+            Number value = (Number) precision.data();
+            BigInteger unsignedValue = value instanceof BigInteger bigInteger
+                ? bigInteger
+                : BigInteger.valueOf(value.longValue() ^ Long.MIN_VALUE);
+            return unsignedValue.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
+        }
+        return Math.clamp(((Number) precision.data()).longValue(), 0, Integer.MAX_VALUE);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -122,8 +122,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
             () -> IntStream.range(0, 1000).boxed().toList(),
             DataType.INTEGER,
             false,
-            true,
-            List.of()
+            true
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -93,7 +93,6 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
         }
 
         // "No rows" expects 0 here instead of null
-        suppliers = parameterSuppliersFromTypedData(randomizeBytesRefsOffset(suppliers));
         suppliers.add(
             makeSupplier(
                 manyInts("<long precision above integer range>"),
@@ -114,7 +113,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
                 )
             )
         );
-        return suppliers;
+        return parameterSuppliersFromTypedData(randomizeBytesRefsOffset(suppliers));
     }
 
     private static TestCaseSupplier.TypedDataSupplier manyInts(String name) {


### PR DESCRIPTION
Backports the following commit to 8.19:
 - Prevent COUNT_DISTINCT precision wraparound (#157553)