### PR TITLE
Remove stale date trunc optimizer test mute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -148,9 +148,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test {feature:UNMAPPED_FIELDS_LOAD}
   issue: https://github.com/elastic/elasticsearch/issues/148619
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testRightClosedBucketIsNotSubstituted
-  issue: https://github.com/elastic/elasticsearch/issues/149133
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/147383


### PR DESCRIPTION
## Summary

Remove the orphaned mute for `ReplaceDateTruncBucketWithRoundToTests.testRightClosedBucketIsNotSubstituted`. The test was removed in #151744, so this entry can no longer match a test.

Closes #149133.

## Testing

Not run: configuration-only removal for a test method that no longer exists.

Made with [Cursor](https://cursor.com)