### PR TITLE
Add cluster name and UUID to REST response headers

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/RestControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/RestControllerIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.features.NodeFeature;
@@ -58,6 +59,14 @@ public class RestControllerIT extends ESIntegTestCase {
         final var response = client.performRequest(new Request("GET", ChunkedResponseWithHeadersPlugin.ROUTE));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals(ChunkedResponseWithHeadersPlugin.HEADER_VALUE, response.getHeader(ChunkedResponseWithHeadersPlugin.HEADER_NAME));
+    }
+
+    public void testClusterInfoResponseHeaders() throws IOException {
+        final var response = getRestClient().performRequest(new Request("GET", "/_cluster/health"));
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        assertEquals(clusterService.getClusterName().value(), response.getHeader("X-elastic-cluster-name"));
+        assertEquals(clusterService.state().metadata().clusterUUID(), response.getHeader("X-elastic-cluster-uuid"));
     }
 
     public void testHeadersAreCollapsed() throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -530,7 +530,14 @@ public class ActionModule extends AbstractModule {
         if (customController != null) {
             restController = customController;
         } else {
-            restController = new RestController(restInterceptor, nodeClient, circuitBreakerService, usageService, telemetryProvider);
+            restController = new RestController(
+                restInterceptor,
+                nodeClient,
+                circuitBreakerService,
+                usageService,
+                telemetryProvider,
+                clusterService
+            );
         }
         reservedClusterStateService = new ReservedClusterStateService(
             clusterService,

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -17,6 +17,8 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -90,6 +92,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
     static final String ELASTIC_PRODUCT_HTTP_HEADER = "X-elastic-product";
     static final String ELASTIC_PRODUCT_HTTP_HEADER_VALUE = "Elasticsearch";
+    static final String CLUSTER_NAME_HTTP_HEADER = "X-elastic-cluster-name";
+    static final String CLUSTER_UUID_HTTP_HEADER = "X-elastic-cluster-uuid";
     static final Set<String> RESERVED_PATHS = Set.of("/__elb_health__", "/__elb_health__/zk", "/_health", "/_health/zk");
     private static final BytesReference FAVICON_RESPONSE;
     public static final String STATUS_CODE_KEY = "es_rest_status_code";
@@ -121,6 +125,10 @@ public class RestController implements HttpServerTransport.Dispatcher {
     // If true, the ServerlessScope annotations will be enforced
     private final ServerlessApiProtections apiProtections;
 
+    // Provides the cluster name and UUID stamped on every response; may be null when the controller has no cluster state access
+    @Nullable
+    private final ClusterService clusterService;
+
     public static final String METRIC_REQUESTS_TOTAL = "es.rest.requests.total";
 
     public RestController(
@@ -129,6 +137,17 @@ public class RestController implements HttpServerTransport.Dispatcher {
         CircuitBreakerService circuitBreakerService,
         UsageService usageService,
         TelemetryProvider telemetryProvider
+    ) {
+        this(restInterceptor, client, circuitBreakerService, usageService, telemetryProvider, null);
+    }
+
+    public RestController(
+        RestInterceptor restInterceptor,
+        NodeClient client,
+        CircuitBreakerService circuitBreakerService,
+        UsageService usageService,
+        TelemetryProvider telemetryProvider,
+        @Nullable ClusterService clusterService
     ) {
         this.usageService = usageService;
         this.instrumentation = telemetryProvider.getHttpServerInstrumentation();
@@ -140,6 +159,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         this.interceptor = restInterceptor;
         this.client = client;
         this.circuitBreakerService = circuitBreakerService;
+        this.clusterService = clusterService;
         registerHandlerNoWrap(RestRequest.Method.GET, "/favicon.ico", RestApiVersion.current(), new RestFavIconHandler());
         this.apiProtections = new ServerlessApiProtections(false);
     }
@@ -421,9 +441,26 @@ public class RestController implements HttpServerTransport.Dispatcher {
         return route.getMethod() == method && route.getPath().equals(path) && route.getRestApiVersion() == version;
     }
 
+    /**
+     * Stamps the cluster name and, once it has been committed, the cluster UUID on the response as HTTP headers. These let clients and
+     * downstream observability tooling correlate a response with the cluster that produced it. This is a no-op when the controller was
+     * created without access to cluster state, and the UUID header is omitted until the cluster UUID is committed.
+     */
+    private void addClusterInfoResponseHeaders(ThreadContext threadContext) {
+        if (clusterService == null) {
+            return;
+        }
+        threadContext.addResponseHeader(CLUSTER_NAME_HTTP_HEADER, clusterService.getClusterName().value());
+        final Metadata metadata = clusterService.state().metadata();
+        if (metadata.clusterUUIDCommitted()) {
+            threadContext.addResponseHeader(CLUSTER_UUID_HTTP_HEADER, metadata.clusterUUID());
+        }
+    }
+
     @Override
     public void dispatchRequest(RestRequest request, RestChannel channel, ThreadContext threadContext) {
         threadContext.addResponseHeader(ELASTIC_PRODUCT_HTTP_HEADER, ELASTIC_PRODUCT_HTTP_HEADER_VALUE);
+        addClusterInfoResponseHeaders(threadContext);
         try {
             tryAllHandlers(request, channel, threadContext);
         } catch (Exception e) {
@@ -439,6 +476,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
     @Override
     public void dispatchBadRequest(final RestChannel channel, final ThreadContext threadContext, final Throwable cause) {
         threadContext.addResponseHeader(ELASTIC_PRODUCT_HTTP_HEADER, ELASTIC_PRODUCT_HTTP_HEADER_VALUE);
+        addClusterInfoResponseHeaders(threadContext);
         try {
             final Exception e;
             if (cause == null) {

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -13,6 +13,10 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -72,6 +76,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.rest.RestController.CLUSTER_NAME_HTTP_HEADER;
+import static org.elasticsearch.rest.RestController.CLUSTER_UUID_HTTP_HEADER;
 import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER;
 import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER_VALUE;
 import static org.elasticsearch.rest.RestController.HANDLER_NAME_KEY;
@@ -170,6 +176,59 @@ public class RestControllerTests extends ESTestCase {
         List<String> expectedProductResponseHeader = new ArrayList<>();
         expectedProductResponseHeader.add(ELASTIC_PRODUCT_HTTP_HEADER_VALUE);
         assertEquals(expectedProductResponseHeader, threadContext.getResponseHeaders().getOrDefault(ELASTIC_PRODUCT_HTTP_HEADER, null));
+    }
+
+    public void testApplyClusterInfoResponseHeaders() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("test-cluster"));
+        final Metadata metadata = Metadata.builder().clusterUUID("test-uuid").clusterUUIDCommitted(true).build();
+        when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test-cluster")).metadata(metadata).build());
+        final RestController restController = new RestController(
+            null,
+            null,
+            circuitBreakerService,
+            usageService,
+            telemetryProvider,
+            clusterService
+        );
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        assertEquals(List.of("test-cluster"), threadContext.getResponseHeaders().getOrDefault(CLUSTER_NAME_HTTP_HEADER, null));
+        assertEquals(List.of("test-uuid"), threadContext.getResponseHeaders().getOrDefault(CLUSTER_UUID_HTTP_HEADER, null));
+    }
+
+    public void testClusterUuidResponseHeaderOmittedUntilCommitted() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("test-cluster"));
+        // UUID is not yet committed, so only the cluster name header should be present
+        final Metadata metadata = Metadata.builder().clusterUUIDCommitted(false).build();
+        when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test-cluster")).metadata(metadata).build());
+        final RestController restController = new RestController(
+            null,
+            null,
+            circuitBreakerService,
+            usageService,
+            telemetryProvider,
+            clusterService
+        );
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        assertEquals(List.of("test-cluster"), threadContext.getResponseHeaders().getOrDefault(CLUSTER_NAME_HTTP_HEADER, null));
+        assertNull(threadContext.getResponseHeaders().getOrDefault(CLUSTER_UUID_HTTP_HEADER, null));
+    }
+
+    public void testClusterInfoResponseHeadersAbsentWithoutClusterService() {
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final RestController restController = new RestController(null, null, circuitBreakerService, usageService, telemetryProvider);
+        RestRequest fakeRequest = new FakeRestRequest.Builder(xContentRegistry()).build();
+        AssertingChannel channel = new AssertingChannel(fakeRequest, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRequest, channel, threadContext);
+        assertNull(threadContext.getResponseHeaders().getOrDefault(CLUSTER_NAME_HTTP_HEADER, null));
+        assertNull(threadContext.getResponseHeaders().getOrDefault(CLUSTER_UUID_HTTP_HEADER, null));
     }
 
     public void testRequestWithDisallowedMultiValuedHeader() {


### PR DESCRIPTION
Stamp X-elastic-cluster-name and X-elastic-cluster-uuid on every REST response via RestController, sourced from ClusterService. The UUID header is omitted until the cluster UUID is committed. These headers let clients and downstream tooling correlate a response with the originating cluster.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
