### PR TITLE
Optimize roaring_bitmap aggregation with index terms

### DIFF
--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregator.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregator.java
@@ -9,8 +9,15 @@
 
 package org.elasticsearch.index.query.bitmapterms;
 
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.index.fielddata.SortedNumericLongValues;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -19,6 +26,7 @@ import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -45,6 +53,7 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
 
     private final ValuesSource.Numeric valuesSource;
     private final InternalRoaringBitmap.BitmapFormat width;
+    private final String termsField;
     private final LongObjectPagedHashMap<AccountedBitmap> bitmaps;
     private long accountedBitmapBytes;
     private int valuesUntilNextBreakerReservation;
@@ -53,6 +62,7 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
     RoaringBitmapAggregator(
         String name,
         ValuesSource.Numeric valuesSource,
+        ValuesSourceConfig config,
         InternalRoaringBitmap.BitmapFormat width,
         AggregationContext context,
         Aggregator parent,
@@ -61,12 +71,18 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
         super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.width = width;
+        this.termsField = termsFieldIfAvailable(config);
         this.bitmaps = new LongObjectPagedHashMap<>(1, bigArrays());
     }
 
     @Override
     protected LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) throws IOException {
         if (valuesSource == null) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
+        LeafReader reader = aggCtx.getLeafReaderContext().reader();
+        if (termsField != null && reader.getLiveDocs() == null) {
+            collectTerms(reader.terms(termsField));
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
         SortedNumericLongValues values = valuesSource.longValues(aggCtx.getLeafReaderContext());
@@ -76,21 +92,12 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
                 if (values.advanceExact(doc) == false) {
                     return;
                 }
-                AccountedBitmap accountedBitmap = bitmaps.get(owningBucketOrd);
-                if (accountedBitmap == null) {
-                    InternalRoaringBitmap.MutableBitmap bitmap = InternalRoaringBitmap.mutable(width);
-                    accountedBitmap = new AccountedBitmap(bitmap, bitmap.ramBytesUsed());
-                    bitmaps.put(owningBucketOrd, accountedBitmap);
-                    addRequestCircuitBreakerBytes(accountedBitmap.accountedBytes);
-                    accountedBitmapBytes += accountedBitmap.accountedBytes;
-                }
+                AccountedBitmap accountedBitmap = getOrCreateBitmap(owningBucketOrd);
                 int valueCount = values.docValueCount();
                 for (int i = 0; i < valueCount; i++) {
                     long value = values.nextValue();
                     if (value < 0) {
-                        throw new IllegalArgumentException(
-                            "[roaring_bitmap] aggregation only supports non-negative values, but field produced [" + value + "]"
-                        );
+                        throw negativeValue(value);
                     }
                     reserveBreakerBytes();
                     accountedBitmap.bitmap.add(value);
@@ -100,6 +107,88 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
                 }
             }
         };
+    }
+
+    private String termsFieldIfAvailable(ValuesSourceConfig config) {
+        if (valuesSource == null
+            || parent() != null
+            || config.alignsWithSearchIndex() == false
+            || (topLevelQuery() != null && topLevelQuery().getClass() != MatchAllDocsQuery.class)) {
+            return null;
+        }
+        if (config.fieldType() instanceof NumberFieldMapper.NumberFieldType numberFieldType && numberFieldType.isIndexedWithTerms()) {
+            return numberFieldType.name();
+        }
+        return null;
+    }
+
+    boolean usesTermsIndex() {
+        return termsField != null;
+    }
+
+    private void collectTerms(Terms terms) throws IOException {
+        if (terms == null) {
+            return;
+        }
+        BytesRef min = terms.getMin();
+        if (min == null) {
+            return;
+        }
+        long minValue = decodeTerm(min);
+        if (minValue < 0) {
+            throw negativeValue(minValue);
+        }
+
+        AccountedBitmap accountedBitmap = getOrCreateBitmap(0);
+        long termCount = terms.size();
+        if (termCount >= 0) {
+            reserveBreakerBytes(termCount);
+        }
+        TermsEnum termsEnum = terms.iterator();
+        BytesRef term;
+        while ((term = termsEnum.next()) != null) {
+            if (termCount < 0) {
+                reserveBreakerBytes();
+            }
+            accountedBitmap.bitmap.add(decodeTerm(term));
+        }
+        accountBitmapMemory();
+    }
+
+    private long decodeTerm(BytesRef term) {
+        int expectedLength = switch (width) {
+            case INT -> Integer.BYTES;
+            case LONG -> Long.BYTES;
+            case UNMAPPED -> throw new IllegalStateException("cannot decode indexed terms for an unmapped field");
+        };
+        if (term.length != expectedLength) {
+            throw new IllegalStateException(
+                "[roaring_bitmap] aggregation expected indexed terms of length [" + expectedLength + "] but found [" + term.length + "]"
+            );
+        }
+        return switch (width) {
+            case INT -> NumericUtils.sortableBytesToInt(term.bytes, term.offset);
+            case LONG -> NumericUtils.sortableBytesToLong(term.bytes, term.offset);
+            case UNMAPPED -> throw new IllegalStateException("cannot decode indexed terms for an unmapped field");
+        };
+    }
+
+    private AccountedBitmap getOrCreateBitmap(long owningBucketOrd) {
+        AccountedBitmap accountedBitmap = bitmaps.get(owningBucketOrd);
+        if (accountedBitmap == null) {
+            InternalRoaringBitmap.MutableBitmap bitmap = InternalRoaringBitmap.mutable(width);
+            accountedBitmap = new AccountedBitmap(bitmap, bitmap.ramBytesUsed());
+            bitmaps.put(owningBucketOrd, accountedBitmap);
+            addRequestCircuitBreakerBytes(accountedBitmap.accountedBytes);
+            accountedBitmapBytes += accountedBitmap.accountedBytes;
+        }
+        return accountedBitmap;
+    }
+
+    private static IllegalArgumentException negativeValue(long value) {
+        return new IllegalArgumentException(
+            "[roaring_bitmap] aggregation only supports non-negative values, but field produced [" + value + "]"
+        );
     }
 
     @Override
@@ -153,12 +242,16 @@ final class RoaringBitmapAggregator extends MetricsAggregator {
 
     private void reserveBreakerBytes() {
         if (valuesUntilNextBreakerReservation == 0) {
-            long reservation = BREAKER_RESERVATION_VALUES * bytesPerValue();
-            addRequestCircuitBreakerBytes(reservation);
-            accountedBitmapBytes += reservation;
+            reserveBreakerBytes(BREAKER_RESERVATION_VALUES);
             valuesUntilNextBreakerReservation = BREAKER_RESERVATION_VALUES;
         }
         valuesUntilNextBreakerReservation--;
+    }
+
+    private void reserveBreakerBytes(long valueCount) {
+        long reservation = Math.multiplyExact(valueCount, bytesPerValue());
+        addRequestCircuitBreakerBytes(reservation);
+        accountedBitmapBytes += reservation;
     }
 
     private long bytesPerValue() {

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorFactory.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorFactory.java
@@ -41,7 +41,7 @@ final class RoaringBitmapAggregatorFactory extends ValuesSourceAggregatorFactory
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new RoaringBitmapAggregator(name, null, InternalRoaringBitmap.BitmapFormat.UNMAPPED, context, parent, metadata);
+        return new RoaringBitmapAggregator(name, null, config, InternalRoaringBitmap.BitmapFormat.UNMAPPED, context, parent, metadata);
     }
 
     @Override
@@ -66,6 +66,6 @@ final class RoaringBitmapAggregatorFactory extends ValuesSourceAggregatorFactory
                     + "]; only [integer] and [long] fields are supported"
             );
         };
-        return supplier.build(name, numeric, width, context, parent, metadata);
+        return supplier.build(name, numeric, config, width, context, parent, metadata);
     }
 }

--- a/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorSupplier.java
+++ b/modules/bitmap/src/main/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorSupplier.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.query.bitmapterms;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,6 +23,7 @@ interface RoaringBitmapAggregatorSupplier {
     Aggregator build(
         String name,
         ValuesSource.Numeric valuesSource,
+        ValuesSourceConfig config,
         InternalRoaringBitmap.BitmapFormat width,
         AggregationContext context,
         Aggregator parent,

--- a/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorTests.java
+++ b/modules/bitmap/src/test/java/org/elasticsearch/index/query/bitmapterms/RoaringBitmapAggregatorTests.java
@@ -10,30 +10,47 @@
 package org.elasticsearch.index.query.bitmapterms;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
 import static org.elasticsearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
@@ -45,6 +62,16 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class RoaringBitmapAggregatorTests extends AggregatorTestCase {
 
     private static final String FIELD = "id";
+    private static final String CATEGORY = "category";
+    private static final FieldType INDEX_TERMS_TYPE;
+
+    static {
+        INDEX_TERMS_TYPE = new FieldType();
+        INDEX_TERMS_TYPE.setIndexOptions(IndexOptions.DOCS);
+        INDEX_TERMS_TYPE.setOmitNorms(true);
+        INDEX_TERMS_TYPE.setTokenized(false);
+        INDEX_TERMS_TYPE.freeze();
+    }
 
     public void testIntegerValuesAreDistinctAndPortable() throws Exception {
         InternalRoaringBitmap result = aggregate(NumberFieldMapper.NumberType.INTEGER, 5, 10, 5);
@@ -59,6 +86,157 @@ public class RoaringBitmapAggregatorTests extends AggregatorTestCase {
 
         assertThat(result.width(), equalTo(InternalRoaringBitmap.BitmapFormat.LONG));
         assertThat(drain(LongBitmap.deserializePortable(result.bitmap())), equalTo(List.of(1L, aboveIntRange, Long.MAX_VALUE)));
+    }
+
+    public void testTermsIndexFastPathMatchesDocValues() throws Exception {
+        long[] integerValues = { 5, 10, 5, Integer.MAX_VALUE };
+        assertArrayEquals(
+            aggregate(NumberFieldMapper.NumberType.INTEGER, integerValues).bitmap(),
+            aggregateTerms(NumberFieldMapper.NumberType.INTEGER, integerValues).bitmap()
+        );
+
+        long[] longValues = { 1, 1L << 40, Long.MAX_VALUE, 1L << 40 };
+        assertArrayEquals(
+            aggregate(NumberFieldMapper.NumberType.LONG, longValues).bitmap(),
+            aggregateTerms(NumberFieldMapper.NumberType.LONG, longValues).bitmap()
+        );
+    }
+
+    public void testTermsIndexFastPathHandlesMultiValuedFields() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.LONG;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            writer.addDocument(termsDocument(type, 3, 7));
+
+            try (IndexReader reader = writer.getReader()) {
+                InternalRoaringBitmap result = searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType).withCheckAggregator(
+                        aggregator -> assertTrue(((RoaringBitmapAggregator) aggregator).usesTermsIndex())
+                    )
+                );
+                assertThat(drain(LongBitmap.deserializePortable(result.bitmap())), equalTo(List.of(3L, 7L)));
+            }
+        }
+    }
+
+    public void testTermsIndexFastPathAcrossSegments() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.INTEGER;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (
+            Directory directory = newDirectory();
+            IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))
+        ) {
+            writer.addDocument(termsDocument(type, 5, 10));
+            writer.commit();
+            writer.addDocument(termsDocument(type, 10, 15));
+            writer.commit();
+
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                assertThat(reader.leaves().size(), equalTo(2));
+                InternalRoaringBitmap result = searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType).withCheckAggregator(
+                        aggregator -> assertTrue(((RoaringBitmapAggregator) aggregator).usesTermsIndex())
+                    )
+                );
+                assertThat(drain(IntBitmap.deserialize(result.bitmap())), equalTo(List.of(5L, 10L, 15L)));
+            }
+        }
+    }
+
+    public void testTermsIndexFallsBackForFilteredQuery() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.INTEGER;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            Document odd = termsDocument(type, 5);
+            odd.add(new StringField(CATEGORY, "odd", Field.Store.NO));
+            writer.addDocument(odd);
+            Document even = termsDocument(type, 10);
+            even.add(new StringField(CATEGORY, "even", Field.Store.NO));
+            writer.addDocument(even);
+
+            try (IndexReader reader = writer.getReader()) {
+                InternalRoaringBitmap result = searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType).withQuery(
+                        new TermQuery(new Term(CATEGORY, "odd"))
+                    ).withCheckAggregator(aggregator -> assertFalse(((RoaringBitmapAggregator) aggregator).usesTermsIndex()))
+                );
+                assertThat(drain(IntBitmap.deserialize(result.bitmap())), equalTo(List.of(5L)));
+            }
+        }
+    }
+
+    public void testTermsIndexFallsBackWhenSegmentHasDeletions() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.LONG;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (
+            Directory directory = newDirectory();
+            IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))
+        ) {
+            Document live = termsDocument(type, 5);
+            live.add(new StringField("key", "live", Field.Store.NO));
+            writer.addDocument(live);
+            Document deleted = termsDocument(type, 10);
+            deleted.add(new StringField("key", "deleted", Field.Store.NO));
+            writer.addDocument(deleted);
+            writer.commit();
+            writer.deleteDocuments(new Term("key", "deleted"));
+
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                assertTrue(reader.hasDeletions());
+                InternalRoaringBitmap result = searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType)
+                );
+                assertThat(drain(LongBitmap.deserializePortable(result.bitmap())), equalTo(List.of(5L)));
+            }
+        }
+    }
+
+    public void testTermsIndexFallsBackForMissingValue() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.INTEGER;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            writer.addDocument(termsDocument(type, 5));
+            writer.addDocument(new Document());
+
+            try (IndexReader reader = writer.getReader()) {
+                InternalRoaringBitmap result = searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD).missing(7), fieldType).withCheckAggregator(
+                        aggregator -> assertFalse(((RoaringBitmapAggregator) aggregator).usesTermsIndex())
+                    )
+                );
+                assertThat(drain(IntBitmap.deserialize(result.bitmap())), equalTo(List.of(5L, 7L)));
+            }
+        }
+    }
+
+    public void testTermsIndexFallsBackUnderParentAggregation() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.LONG;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            writer.addDocument(termsDocument(type, 5, 10));
+
+            try (IndexReader reader = writer.getReader()) {
+                AggregationBuilder parent = new FilterAggregationBuilder("parent", new MatchAllQueryBuilder()).subAggregation(
+                    new RoaringBitmapAggregationBuilder("ids").field(FIELD)
+                );
+                InternalFilter result = searchAndReduce(reader, new AggTestConfig(parent, fieldType));
+                InternalRoaringBitmap bitmap = result.getAggregations().get("ids");
+                assertThat(drain(LongBitmap.deserializePortable(bitmap.bitmap())), equalTo(List.of(5L, 10L)));
+            }
+        }
+    }
+
+    public void testTermsIndexRejectsNegativeMinimumBeforeCollection() throws Exception {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> aggregateTerms(NumberFieldMapper.NumberType.LONG, 1, -1)
+        );
+        assertThat(exception.getMessage(), containsString("only supports non-negative values"));
     }
 
     public void testMultiValuedField() throws Exception {
@@ -113,6 +291,43 @@ public class RoaringBitmapAggregatorTests extends AggregatorTestCase {
                 )
             ) {
                 Aggregator aggregator = createAggregator(new RoaringBitmapAggregationBuilder("ids").field(FIELD), context);
+                aggregator.preCollection();
+                context.searcher().search(context.query(), aggregator.asCollector());
+                aggregator.postCollection();
+                aggregator.buildTopLevel();
+                assertThat(breaker.getUsed(), greaterThan(baseline));
+            }
+        }
+
+        assertThat(breaker.getUsed(), equalTo(baseline));
+    }
+
+    public void testTermsIndexBreakerBytesAreReleasedOnClose() throws Exception {
+        NumberFieldMapper.NumberType type = NumberFieldMapper.NumberType.LONG;
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        CircuitBreakerService breakerService = LimitedBreaker.service(CircuitBreaker.REQUEST, ByteSizeValue.ofMb(64));
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
+        long baseline = breaker.getUsed();
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            for (int i = 0; i < 20_000; i++) {
+                writer.addDocument(termsDocument(type, ((long) i << 32) | i));
+            }
+            try (
+                IndexReader reader = writer.getReader();
+                AggregationContext context = createAggregationContext(
+                    reader,
+                    createIndexSettings(),
+                    Queries.ALL_DOCS_INSTANCE,
+                    breakerService,
+                    0,
+                    DEFAULT_MAX_BUCKETS,
+                    false,
+                    false,
+                    fieldType
+                )
+            ) {
+                Aggregator aggregator = createAggregator(new RoaringBitmapAggregationBuilder("ids").field(FIELD), context);
+                assertTrue(((RoaringBitmapAggregator) aggregator).usesTermsIndex());
                 aggregator.preCollection();
                 context.searcher().search(context.query(), aggregator.asCollector());
                 aggregator.postCollection();
@@ -218,6 +433,67 @@ public class RoaringBitmapAggregatorTests extends AggregatorTestCase {
                 return searchAndReduce(reader, new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType));
             }
         }
+    }
+
+    private InternalRoaringBitmap aggregateTerms(NumberFieldMapper.NumberType type, long... values) throws Exception {
+        MappedFieldType fieldType = indexTermsFieldType(type);
+        try (Directory directory = newDirectory(); RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+            for (long value : values) {
+                writer.addDocument(termsDocument(type, value));
+            }
+            try (IndexReader reader = writer.getReader()) {
+                return searchAndReduce(
+                    reader,
+                    new AggTestConfig(new RoaringBitmapAggregationBuilder("ids").field(FIELD), fieldType).withCheckAggregator(
+                        aggregator -> assertTrue(((RoaringBitmapAggregator) aggregator).usesTermsIndex())
+                    )
+                );
+            }
+        }
+    }
+
+    private static MappedFieldType indexTermsFieldType(NumberFieldMapper.NumberType type) {
+        return new NumberFieldMapper.NumberFieldType(
+            FIELD,
+            type,
+            IndexType.terms(true, true),
+            false,
+            true,
+            null,
+            Map.of(),
+            null,
+            false,
+            null,
+            null,
+            false,
+            false,
+            true
+        );
+    }
+
+    private static Document termsDocument(NumberFieldMapper.NumberType type, long... values) {
+        Document document = new Document();
+        for (long value : values) {
+            document.add(new Field(FIELD, encodeTerm(type, value), INDEX_TERMS_TYPE));
+            document.add(new SortedNumericDocValuesField(FIELD, value));
+        }
+        return document;
+    }
+
+    private static BytesRef encodeTerm(NumberFieldMapper.NumberType type, long value) {
+        return switch (type) {
+            case INTEGER -> {
+                byte[] bytes = new byte[Integer.BYTES];
+                NumericUtils.intToSortableBytes(Math.toIntExact(value), bytes, 0);
+                yield new BytesRef(bytes);
+            }
+            case LONG -> {
+                byte[] bytes = new byte[Long.BYTES];
+                NumericUtils.longToSortableBytes(value, bytes, 0);
+                yield new BytesRef(bytes);
+            }
+            default -> throw new IllegalArgumentException("unsupported type [" + type + "]");
+        };
     }
 
     private static InternalRoaringBitmap result(InternalRoaringBitmap.BitmapFormat width, long value) throws IOException {

--- a/modules/bitmap/src/yamlRestTest/resources/rest-api-spec/test/bitmap_terms/40_aggregation.yml
+++ b/modules/bitmap/src/yamlRestTest/resources/rest-api-spec/test/bitmap_terms/40_aggregation.yml
@@ -194,3 +194,139 @@
   - match: { hits.total.relation: "eq" }
   # portable 64-bit Roaring serialization of the distinct set {1, Long.MAX_VALUE} -- only the "odd" docs
   - match: { aggregations.ids.value: "AgAAAAAAAAAAAAAAOjAAAAEAAAAAAAAAEAAAAAEA////fzowAAABAAAA//8AABAAAAD//w==" }
+
+---
+"roaring_bitmap aggregation reads integer index terms":
+  - requires:
+      test_runner_features: headers
+
+  - do:
+      indices.create:
+        index: test_roaring_bitmap_aggregation_index_terms
+        body:
+          mappings:
+            properties:
+              id:
+                type: integer
+                index_terms: true
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_roaring_bitmap_aggregation_index_terms
+        body:
+          - '{"index": {}}'
+          - '{"id": 5}'
+          - '{"index": {}}'
+          - '{"id": 10}'
+          - '{"index": {}}'
+          - '{"id": 5}'
+
+  - do:
+      headers:
+        Content-Type: application/json
+        Accept: application/json
+      search:
+        index: test_roaring_bitmap_aggregation_index_terms
+        body:
+          size: 0
+          aggs:
+            ids:
+              roaring_bitmap:
+                field: id
+
+  # portable 32-bit Roaring serialization of the distinct set {5, 10}
+  - match: { aggregations.ids.value: "OjAAAAEAAAAAAAEAEAAAAAUACgA=" }
+
+---
+"roaring_bitmap aggregation reads long index terms":
+  - requires:
+      test_runner_features: headers
+
+  - do:
+      indices.create:
+        index: test_roaring_bitmap_aggregation_long_index_terms
+        body:
+          mappings:
+            properties:
+              id:
+                type: long
+                index_terms: true
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_roaring_bitmap_aggregation_long_index_terms
+        body:
+          - '{"index": {}}'
+          - '{"id": 1}'
+          - '{"index": {}}'
+          - '{"id": 1099511627776}'
+          - '{"index": {}}'
+          - '{"id": 9223372036854775807}'
+          - '{"index": {}}'
+          - '{"id": 1099511627776}'
+
+  - do:
+      headers:
+        Content-Type: application/json
+        Accept: application/json
+      search:
+        index: test_roaring_bitmap_aggregation_long_index_terms
+        body:
+          size: 0
+          aggs:
+            ids:
+              roaring_bitmap:
+                field: id
+
+  # portable 64-bit Roaring serialization of the distinct set {1, 2^40, Long.MAX_VALUE}
+  - match: { aggregations.ids.value: "AwAAAAAAAAAAAAAAOjAAAAEAAAAAAAAAEAAAAAEAAAEAADowAAABAAAAAAAAABAAAAAAAP///386MAAAAQAAAP//AAAQAAAA//8=" }
+
+---
+"roaring_bitmap aggregation with index terms falls back for a filtered query":
+  - requires:
+      test_runner_features: headers
+
+  - do:
+      indices.create:
+        index: test_roaring_bitmap_aggregation_index_terms_filtered
+        body:
+          mappings:
+            properties:
+              id:
+                type: integer
+                index_terms: true
+              category:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        index: test_roaring_bitmap_aggregation_index_terms_filtered
+        body:
+          - '{"index": {}}'
+          - '{"id": 5, "category": "odd"}'
+          - '{"index": {}}'
+          - '{"id": 10, "category": "even"}'
+          - '{"index": {}}'
+          - '{"id": 15, "category": "odd"}'
+
+  - do:
+      headers:
+        Content-Type: application/json
+        Accept: application/json
+      search:
+        index: test_roaring_bitmap_aggregation_index_terms_filtered
+        body:
+          size: 0
+          query:
+            term:
+              category: "odd"
+          aggs:
+            ids:
+              roaring_bitmap:
+                field: id
+
+  # portable 32-bit Roaring serialization of the distinct set {5, 15}
+  - match: { aggregations.ids.value: "OjAAAAEAAAAAAAEAEAAAAAUADwA=" }


### PR DESCRIPTION
## Summary
- read distinct integer and long values directly from the terms index for eligible top-level match-all `roaring_bitmap` aggregations
- retain doc-values collection for filtered queries, parent aggregations, missing values, and segments with deletions
- add breaker accounting plus unit and YAML coverage for fast-path parity and fallbacks

Stacked on [#156384](https://github.com/elastic/elasticsearch/pull/156384) at `81cda7ce7d2`.

## Test plan
- [x] `RoaringBitmapAggregatorTests` in Docker
- [x] `bitmap_terms/40_aggregation` YAML REST suite in Docker
- [x] `:modules:bitmap:spotlessJavaCheck` in Docker

Made with [Cursor](https://cursor.com)