### PR TITLE
Add stored-field support to DateFieldMapper's columnar parse path

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -279,7 +279,7 @@ public final class DateFieldMapper extends FieldMapper {
 
         private final Parameter<Boolean> index;
         private final DocValuesParameter docValuesParameters;
-        private final Parameter<Boolean> store = Parameter.storeParam(m -> toType(m).store, false);
+        private final Parameter<Boolean> store = Parameter.storeParam(m -> toType(m).stored, false);
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
@@ -1171,7 +1171,7 @@ public final class DateFieldMapper extends FieldMapper {
         }
     }
 
-    private final boolean store;
+    private final boolean stored;
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
     private final DocValuesFieldFactory dvFactory;
@@ -1202,7 +1202,7 @@ public final class DateFieldMapper extends FieldMapper {
         String offsetsFieldName
     ) {
         super(leafName, mappedFieldType, builderParams);
-        this.store = builder.store.getValue();
+        this.stored = builder.store.getValue();
         this.indexed = builder.index.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
         this.dvFactory = new DocValuesFieldFactory(
@@ -1267,7 +1267,7 @@ public final class DateFieldMapper extends FieldMapper {
         // time instead.
         return (indexSettings.getMode().isStrictColumnar() || indexSettings.getMode().isTsdb())
             && docValuesParameters.enabled()
-            && store == false
+            && stored == false
             && hasScript() == false
             && copyTo().copyToFields().isEmpty()
             && multiFields().iterator().hasNext() == false
@@ -1432,10 +1432,10 @@ public final class DateFieldMapper extends FieldMapper {
         } else if (indexed) {
             context.doc().add(new LongPoint(fieldType().name(), timestamp));
         }
-        if (store) {
+        if (stored) {
             context.doc().add(new StoredField(fieldType().name(), timestamp));
         }
-        if (docValuesParameters.enabled() == false && (indexed || store)) {
+        if (docValuesParameters.enabled() == false && (indexed || stored)) {
             // When the field doesn't have doc values so that we can run exists queries, we also need to index the field name separately.
             context.addToFieldNames(fieldType().name());
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -124,6 +124,8 @@ public final class DateFieldMapper extends FieldMapper {
     private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
         .fieldType();
     private static final IndexableFieldType LONG_FIELD_TYPE = new LongField("_sentinel", 0L, Field.Store.NO).fieldType();
+    // Stored-only variant: matches the separate StoredField(name, timestamp) emitted by the row path.
+    private static final IndexableFieldType LONG_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0L).fieldType();
 
     public enum Resolution {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE, DateMillisDocValuesField::new) {
@@ -1267,7 +1269,6 @@ public final class DateFieldMapper extends FieldMapper {
         // time instead.
         return (indexSettings.getMode().isStrictColumnar() || indexSettings.getMode().isTsdb())
             && docValuesParameters.enabled()
-            && stored == false
             && hasScript() == false
             && copyTo().copyToFields().isEmpty()
             && multiFields().iterator().hasNext() == false
@@ -1296,6 +1297,9 @@ public final class DateFieldMapper extends FieldMapper {
             columnFieldType = SORTED_NUMERIC_DV_FIELD_TYPE;
         }
         ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), columnFieldType, LongColumn.NumericKind.LONG));
+        if (stored) {
+            ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), LONG_STORED_ONLY_FIELD_TYPE, LongColumn.NumericKind.LONG));
+        }
         // Publish the timestamp ESCF column on the context so that postColumnarParse hooks
         // (DataStreamTimestampFieldMapper, TsidExtractingIdFieldMapper) can read per-document
         // values without re-scanning the Lucene column list. Mirrors DateFieldMapper.indexValue's

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -1281,11 +1282,11 @@ public final class DateFieldMapper extends FieldMapper {
             case EscfColumnKind.STRING -> datesFromStrings(source);
             case EscfColumnKind.LONG -> datesFromLongs(source);
             default -> throw new UnsupportedOperationException(
-                "mapColumnBatch: ESCF column kind ["
-                    + EscfColumnKind.name(source.kind())
-                    + "] is not yet supported for date field ["
-                    + fullPath()
-                    + "]"
+                Strings.format(
+                    "mapColumnBatch: ESCF column kind [%s] is not yet supported for date field [%s]",
+                    EscfColumnKind.name(source.kind()),
+                    fullPath()
+                )
             );
         };
         final IndexableFieldType columnFieldType;

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.ColumnGroupResolver;
 import org.elasticsearch.index.mapper.ColumnGroupResolver.ColumnGroupLookup;
 import org.elasticsearch.index.mapper.ColumnGroupResolver.ColumnGroupResolution;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -199,6 +200,13 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("b"), ms.mappingLookup(), indexSettings);
         assertNotNull(resolution);
         assertTrue(resolution.columnMappers()[0] instanceof BooleanFieldMapper);
+    }
+
+    public void testDateMapperIsSupported() throws IOException {
+        MapperService ms = mapper(mapping(b -> { b.startObject("ts").field("type", "date").endObject(); }));
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("ts"), ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertTrue(resolution.columnMappers()[0] instanceof DateFieldMapper);
     }
 
     public void testIpMapperIsSupported() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
@@ -278,6 +280,97 @@ public class DateFieldMapperColumnarCompatibilityTests extends AbstractColumnarM
                 doc("d1", 1L, "{\"f\":\"2024-01-15T12:00:00.000Z\"}"),
                 doc("d2", 2L, "{\"f\":\"not-a-date\"}"),
                 doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    // ---- store=true (TIME_SERIES / TSDB mode) ------------------------------------------------
+    //
+    // strict-columnar index modes (COLUMNAR, LOGSDB_COLUMNAR) reject store=true at mapping
+    // validation time. TIME_SERIES is the only columnar-eligible mode that permits it.
+    // These tests use the coordinator-tsid path (index.dimensions) so that metadata fields
+    // are computed columnarally via pre-supplied tsid bytes. The keyword dimension field (dim)
+    // is declared in the mapping but absent from sources to keep it out of the ESCF schema.
+
+    private static final BytesRef ST_TSID = new BytesRef(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 });
+    private static final int ST_ROUTING_HASH = 42;
+    private static final String ST_ROUTING = TimeSeriesRoutingHashFieldMapper.encode(ST_ROUTING_HASH);
+    // epoch millis: 2024-01-15T12:00:00.000Z, 2024-06-01T00:00:00.000Z, 2024-03-15T08:30:00.000Z
+    private static final long ST_TS_A = 1705320000000L;
+    private static final long ST_TS_B = 1717200000000L;
+    private static final long ST_TS_C = 1710491400000L;
+
+    private static Settings tsdbSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+            .put(IndexMetadata.INDEX_DIMENSIONS.getKey(), "dim")
+            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), "-9999-01-01T00:00:00Z")
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), "9999-01-01T00:00:00Z")
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.SYNTHETIC_ID.getKey(), false)
+            .build();
+    }
+
+    public void testStoredStringValue() throws IOException {
+        final String idA = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_A);
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject(FIELD).field("type", "date").field("store", true).endObject();
+        }),
+            tsdbSettings(),
+            batch(
+                "stored string value",
+                1L,
+                doc(idA, ST_ROUTING, ST_TSID, 1L, "{\"@timestamp\":" + ST_TS_A + ",\"f\":\"2024-01-15T12:00:00.000Z\"}")
+            )
+        );
+    }
+
+    public void testStoredLongValue() throws IOException {
+        final String idA = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_A);
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject(FIELD).field("type", "date").field("store", true).endObject();
+        }),
+            tsdbSettings(),
+            batch("stored long value", 1L, doc(idA, ST_ROUTING, ST_TSID, 1L, "{\"@timestamp\":" + ST_TS_A + ",\"f\":" + ST_TS_A + "}"))
+        );
+    }
+
+    public void testStoredWithAbsentDoc() throws IOException {
+        final String idA = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_A);
+        final String idB = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_B);
+        final String idC = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_C);
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject(FIELD).field("type", "date").field("store", true).endObject();
+        }),
+            tsdbSettings(),
+            batch(
+                "stored with absent doc",
+                1L,
+                doc(idA, ST_ROUTING, ST_TSID, 1L, "{\"@timestamp\":" + ST_TS_A + ",\"f\":\"2024-01-15T12:00:00.000Z\"}"),
+                doc(idB, ST_ROUTING, ST_TSID, 2L, "{\"@timestamp\":" + ST_TS_B + "}"),
+                doc(idC, ST_ROUTING, ST_TSID, 3L, "{\"@timestamp\":" + ST_TS_C + ",\"f\":\"2024-03-15T08:30:00.000Z\"}")
+            )
+        );
+    }
+
+    public void testStoredIndexed() throws IOException {
+        final String idA = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_A);
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject(FIELD).field("type", "date").field("store", true).field("index", true).endObject();
+        }),
+            tsdbSettings(),
+            batch(
+                "stored+indexed",
+                1L,
+                doc(idA, ST_ROUTING, ST_TSID, 1L, "{\"@timestamp\":" + ST_TS_A + ",\"f\":\"2024-01-15T12:00:00.000Z\"}")
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperColumnarCompatibilityTests.java
@@ -374,4 +374,22 @@ public class DateFieldMapperColumnarCompatibilityTests extends AbstractColumnarM
             )
         );
     }
+
+    public void testStoredNotIndexed() throws IOException {
+        // index=false → columnFieldType is SORTED_NUMERIC_DV_FIELD_TYPE (plain doc values, no BKD).
+        // Exercises the else-branch of the columnFieldType selection together with the stored column.
+        final String idA = TsidExtractingIdFieldMapper.createId(ST_ROUTING_HASH, ST_TSID, ST_TS_A);
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject("@timestamp").field("type", "date").endObject();
+            b.startObject("dim").field("type", "keyword").field("time_series_dimension", true).endObject();
+            b.startObject(FIELD).field("type", "date").field("store", true).field("index", false).endObject();
+        }),
+            tsdbSettings(),
+            batch(
+                "stored not indexed",
+                1L,
+                doc(idA, ST_ROUTING, ST_TSID, 1L, "{\"@timestamp\":" + ST_TS_A + ",\"f\":\"2024-01-15T12:00:00.000Z\"}")
+            )
+        );
+    }
 }


### PR DESCRIPTION
`DateFieldMapper.mapColumnBatch` previously fell back to the row path whenever `store: true` was set. This removes that restriction.

When `stored==true`, `mapColumnBatch` now emits a second `LONG_STORED_ONLY_FIELD_TYPE` column alongside the normal doc-values/indexed column, mirroring the row path which also emits them as separate Lucene fields. The `stored == false` guard in `supportsColumnarParse` is removed accordingly; in strict-columnar index modes `store: true` is already rejected at mapping creation time, so the only mode that can reach `mapColumnBatch` with `stored==true` is `TIME_SERIES`.