### PR TITLE
Unmute SearchWithRejectionsIT.testScrollContextSurvivesQueueRejection

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -501,9 +501,6 @@ tests:
 - class: org.elasticsearch.index.IndexingSlowLogTests
   method: testMultipleSlowLoggersUseSingleLog4jLogger
   issue: https://github.com/elastic/elasticsearch/issues/157531
-- class: org.elasticsearch.search.SearchWithRejectionsIT
-  method: testScrollContextSurvivesQueueRejection
-  issue: https://github.com/elastic/elasticsearch/issues/157416
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=ml/bucket_count_ks_test_agg/Test bucket count ks test with empty alternatives}
   issue: https://github.com/elastic/elasticsearch/issues/157577


### PR DESCRIPTION
The test was muted on `9.5` while it was failing. The self-deadlock in `blockSearchThreadPool` behind those failures was fixed in #157599 and backported by #157683, so the mute can be removed.