### PR TITLE
Fix search shard recovery on warming failure test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -622,9 +622,6 @@ tests:
 - class: org.elasticsearch.xpack.search.AsyncSearchErrorTraceIT
   method: testAsyncSearchFailingQueryErrorTraceFalseOnSubmitAndTrueOnGet
   issue: https://github.com/elastic/elasticsearch/issues/156435
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
-  method: testSearchShardShouldRecoverWhenWarmingFailsOnGetConnection
-  issue: https://github.com/elastic/elasticsearch/issues/156462
 - class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
   method: testPointInTimeRelocationClosingSourceContexts
   issue: https://github.com/elastic/elasticsearch/issues/156463

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
@@ -981,11 +981,14 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
 
         final var stoppedLatch = new CountDownLatch(1);
         final var restartLatch = new CountDownLatch(1);
+        // We want to stall the getConnection for GetVBCCChunk request which is right after registerCommitForRecovery
+        final AtomicBoolean shouldDelayGetConnection = new AtomicBoolean(false);
         final var restartIndexNodeThread = new Thread(() -> {
             try {
                 internalCluster().restartNode(indexNode, new InternalTestCluster.RestartCallback() {
                     @Override
                     public Settings onNodeStopped(String nodeName) throws Exception {
+                        shouldDelayGetConnection.set(false);
                         stoppedLatch.countDown();
                         // The node is stopped. Wait for the search shard warming to fail before restarting it. We don't want it
                         // to restart too soon which might interfere the failure path of the search shard recovery.
@@ -1002,11 +1005,9 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
             }
         });
 
-        // We want to stall the getConnection for GetVBCCChunk request which is right after registerCommitForRecovery
-        final AtomicBoolean shouldDelayGetConnection = new AtomicBoolean(false);
         final MockTransportService searchNodeTransportService = MockTransportService.getInstance(searchNode);
         searchNodeTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
-            if (TransportRegisterCommitForRecoveryAction.NAME.equals(action)) {
+            if (TransportRegisterCommitForRecoveryAction.NAME.equals(action) && stoppedLatch.getCount() > 0) {
                 shouldDelayGetConnection.set(true);
             }
             connection.sendRequest(requestId, action, request, options);
@@ -1015,9 +1016,13 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
         final AtomicBoolean restartOnce = new AtomicBoolean(false);
         final IndicesService searchNodeIndicesService = internalCluster().getInstance(IndicesService.class, searchNode);
         searchNodeTransportService.addGetConnectionBehavior((connectionManager, discoveryNode) -> {
-            if (indexNode.equals(discoveryNode.getName()) && shouldDelayGetConnection.get() && restartOnce.compareAndSet(false, true)) {
-                logger.info("--> stalling getConnection and restart");
-                restartIndexNodeThread.start();
+            if (indexNode.equals(discoveryNode.getName()) && shouldDelayGetConnection.get()) {
+                if (restartOnce.compareAndSet(false, true)) {
+                    logger.info("--> stalling getConnection and restart");
+                    restartIndexNodeThread.start();
+                }
+                // SearchEngine initialization can happen concurrently with warming and also call getConnection
+                // Since it can happen first and trigger the restart, wait here to ensure warming fails with NodeNotConnectedException
                 try {
                     // Wait for the search shard to be removed (due to primary failure) to ensure no retry
                     assertBusy(() -> {


### PR DESCRIPTION
tldr: This test adds send behavior for `TransportRegisterCommitForRecoveryAction` to set a flag to ensure the next `getConnection` call fails. The idea is to fail the `getConnection` called by warming since `TransportRegisterCommitForRecoveryAction` occurs right before. `SearchEngine` initialization can happen concurrently with warming, also calling `getConnection`, racing and breaking some test assumptions.

---

This test failure reproduces very rarely and with different failures, but they seem to be of the same flavor, as printing a stack trace in the `getConnection` interception shows
```
        ...
        at org.elasticsearch.index.shard.IndexShard.createEngine(IndexShard.java:2523)
        at org.elasticsearch.index.shard.IndexShard.innerOpenEngineAndTranslog(IndexShard.java:2497)
        at org.elasticsearch.index.shard.IndexShard.openEngineAndSkipTranslogRecovery(IndexShard.java:2472)
        at org.elasticsearch.xpack.stateless.recovery.TransportStatelessUnpromotableRelocationAction.lambda$doExecute$3(TransportStatelessUnpromotableRelocationAction.java:193)
```
instead of the expected
```
        at org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingService$2.onResponse(SharedBlobCacheWarmingService.java:439)
```
from warming.

In `TransportStatelessUnpromotableRelocationAction`, `SearchEngine` initialization happens after warming in a `SubscribableListener` chain
```
  SubscribableListener.<Void>newForked(l -> {
      indexShard.preRecovery(l);                       // calls beforeIndexShardRecovery, where warming happens
      ...
  }).andThenApply(unused -> {
      ...
      indexShard.openEngineAndSkipTranslogRecovery();  // creates SearchEngine
      ...
  })
```
In `SharedBlobCacheWarmingService.warmCacheForSearchShardRecovery`, when `plan.awaitWarming()` is `false` warming kicks off async, and the listener completes with `null`, starting `SearchEngine` initialization.

`SearchEngine` initialization calls `getConnection()` and can race with warming. If this `getConnection()` is the one that gets intercepted by the test to restart the node and eventually fail, a few issues can occur. For instance, the `getConnection()` from warming can succeed, failing `expectThrows`. In the CI failure it looks like the listener hung as the node got shut down, failing `warmingCompletedFuture.actionGet()`, though I wasn't able to reproduce this.

The fix is to stall all `getConnection()` calls via `assertBusy` to ensure warming fails.
To support this, we want to stop the `assertBusy` calls after warming fails and the node successfully restarts. This involves two changes:
 - `shouldDelayGetConnection` is set to `false` after the node is stopped
 - the search node stops setting `shouldDelayGetConnection` to `true` after `stoppedLatch` is counted down.

A better fix would be to ensure only the `getConnection()` from warming fails, which is what the test aims to do, but I'm not sure if there's a good way to do that.

Resolves #156462