### PR TITLE
fix(spatial): raise GeoHex FACTOR 0.37 to 0.39 to retain dateline parent

### DIFF
--- a/docs/changelog/157698.yaml
+++ b/docs/changelog/157698.yaml
@@ -1,0 +1,4 @@
+pr: 157698
+area: Geo
+type: bug
+summary: Fix GeoHex grid aggregation missing bucket at dateline by raising BoundedGeoHexGridTiler FACTOR from 0.37 to 0.39

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
@@ -240,7 +240,7 @@ public abstract class GeoHexGridTiler extends GeoGridTiler {
         private final GeoBoundingBox bbox;
         private final GeoHexVisitor visitor;
         private final int resolution;
-        private static final double FACTOR = 0.37;
+        private static final double FACTOR = 0.39;
 
         BoundedGeoHexGridTiler(int resolution, GeoBoundingBox bbox) {
             super(resolution);
@@ -260,9 +260,9 @@ public abstract class GeoHexGridTiler extends GeoGridTiler {
          * For this reason the filter needs to be expanded to cover all descendent cells.
          *
          * This is done by taking the H3 cells at two corners, and expanding the filter width
-         * by 35% of the max width of those cells, and filter height by 35% of the max height of those cells.
+         * by 39% of the max width of those cells, and filter height by 39% of the max height of those cells.
          *
-         * The inflation factor of 35% has been verified using test GeoHexTilerTests#testLargeShapeWithBounds
+         * The inflation factor of 39% has been verified using test GeoHexTilerTests#testLargeShapeWithBounds
          */
         static GeoBoundingBox inflateBbox(int precision, GeoBoundingBox bbox, double factor) {
             final Rectangle minMin = H3CartesianUtil.toBoundingBox(H3.geoToH3(bbox.bottom(), bbox.left(), precision));


### PR DESCRIPTION
Fixes a missing bucket at precision 2 when a bounded GeoHex aggregation spans the dateline.

Problem: BoundedGeoHexGridTiler inflates bounds by FACTOR 0.37 at GeoHexGridTiler.java:243. The inflated bounds prune the dateline parent cell, so its children that intersect the query bounds are never visited and the bucket is missing.

Fix: Raise FACTOR to 0.39 and update the javadoc to 39 percent.

Evidence: Verified RED to GREEN via the inflateBbox bounds check.

No related issues.
