### PR TITLE
[8.19] [ML] Re-audit datafeed extraction errors periodically

### DIFF
--- a/docs/changelog/157565.yaml
+++ b/docs/changelog/157565.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 157565
+summary: Re-audit datafeed extraction errors periodically
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/ProblemTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/ProblemTracker.java
@@ -34,6 +34,7 @@ class ProblemTracker {
     private volatile boolean hasProblems;
     private volatile boolean hadProblems;
     private volatile String previousProblem;
+    private volatile int consecutiveSameProblemCount;
     private volatile int emptyDataCount;
     private final long numberOfSearchesInADay;
 
@@ -68,7 +69,15 @@ class ProblemTracker {
      */
     private void reportProblem(String template, String problemMessage) {
         hasProblems = true;
-        if (Objects.equals(previousProblem, problemMessage) == false) {
+        if (Objects.equals(previousProblem, problemMessage)) {
+            // Same problem repeating: increment counter and re-audit periodically so a persistent
+            // failure doesn't become permanently invisible after the first dedup suppression.
+            consecutiveSameProblemCount++;
+            if (consecutiveSameProblemCount % numberOfSearchesInADay == 0) {
+                auditor.error(jobId, Messages.getMessage(template, problemMessage));
+            }
+        } else {
+            consecutiveSameProblemCount = 1;
             previousProblem = problemMessage;
             auditor.error(jobId, Messages.getMessage(template, problemMessage));
         }
@@ -103,6 +112,8 @@ class ProblemTracker {
     public void finishReport() {
         if (hasProblems == false && hadProblems) {
             auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_RECOVERED));
+            previousProblem = null;
+            consecutiveSameProblemCount = 0;
         }
 
         hadProblems = hasProblems;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/ProblemTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/ProblemTrackerTests.java
@@ -77,6 +77,40 @@ public class ProblemTrackerTests extends ESTestCase {
         assertTrue(problemTracker.hasProblems());
     }
 
+    public void testReportProblem_GivenSameProblemPersists_ReauditsEveryDayOfSearches() {
+        // First occurrence audits immediately
+        problemTracker.reportExtractionProblem(createExtractionProblem("top level", "cause"));
+
+        // NUM_SEARCHES_IN_DAY - 1 more occurrences: no additional audit yet
+        for (int i = 1; i < NUM_SEARCHES_IN_DAY; i++) {
+            problemTracker.reportExtractionProblem(createExtractionProblem("top level", "cause"));
+        }
+        // We're now at NUM_SEARCHES_IN_DAY total calls, which triggers the first re-audit
+        verify(auditor, times(2)).error("foo", "Datafeed is encountering errors extracting data: cause");
+
+        // Another full day of the same problem triggers another re-audit
+        for (int i = 0; i < NUM_SEARCHES_IN_DAY; i++) {
+            problemTracker.reportExtractionProblem(createExtractionProblem("top level", "cause"));
+        }
+        verify(auditor, times(3)).error("foo", "Datafeed is encountering errors extracting data: cause");
+    }
+
+    public void testReportProblem_GivenSameProblemPersists_CountResetsAfterRecovery() {
+        // Run for a full day and check we re-audit
+        for (int i = 0; i < NUM_SEARCHES_IN_DAY; i++) {
+            problemTracker.reportExtractionProblem(createExtractionProblem("top level", "cause"));
+        }
+        verify(auditor, times(2)).error("foo", "Datafeed is encountering errors extracting data: cause");
+
+        // Simulate recovery (no problem this cycle, then finishReport twice to trigger recovery audit)
+        problemTracker.finishReport();
+        problemTracker.finishReport();
+
+        // Same problem resumes: should re-audit immediately (counter reset) and not wait another day
+        problemTracker.reportExtractionProblem(createExtractionProblem("top level", "cause"));
+        verify(auditor, times(3)).error("foo", "Datafeed is encountering errors extracting data: cause");
+    }
+
     public void testUpdateEmptyDataCount_GivenEmptyNineTimes() {
         for (int i = 0; i < 9; i++) {
             problemTracker.reportEmptyDataCount();


### PR DESCRIPTION
Backport of #157565 to 8.19.

Manual backport required: the cherry-pick conflicted because `ProblemTracker.java` on 8.19 predates the circuit-breaker detection added by a separate PR that was already on `main` when #157565 merged. The `consecutiveSameProblemCount` logic has been applied cleanly to the 8.19 version of the file.