### PR TITLE
Widen ESCF column value accessors to public

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/AbstractVarColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/AbstractVarColumn.java
@@ -77,7 +77,7 @@ abstract class AbstractVarColumn extends EscfColumn {
     }
 
     @Override
-    final BytesRef getBinaryValue(int row) {
+    public final BytesRef getBinaryValue(int row) {
         int off = intAt(offsets, row);
         return data.slice(off, intAt(offsets, row + 1) - off).toBytesRef();
     }

--- a/server/src/main/java/org/elasticsearch/escf/ColumnarArrayReader.java
+++ b/server/src/main/java/org/elasticsearch/escf/ColumnarArrayReader.java
@@ -43,6 +43,7 @@ final class ColumnarArrayReader implements ArrayReader {
 
     @Override
     public boolean isNull() {
+        // TODO: this is an encoder detail not a guarantee and should change. Due to two bitsets there actually can be nulls.
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfArrayColumn.java
@@ -63,16 +63,20 @@ final class EscfArrayColumn extends EscfColumn {
     }
 
     @Override
-    ArrayReader getArrayValue(int row) {
+    public ArrayReader getArrayValue(int row) {
         int elemFrom = intAt(rowOffsets, row);
         int elemTo = intAt(rowOffsets, row + 1);
         return new ColumnarArrayReader(child, elemFrom, elemTo);
     }
 
     /**
-     * Returns an element-granular {@link LongTupleCursor} over this array column's long element
-     * values. The child column must be an {@link EscfLongColumn}; throws
+     * Returns an element-granular {@link LongTupleCursor} over this array column's fixed-64 element
+     * values. The child column must be an {@link AbstractFixed64Column} (LONG or DOUBLE); throws
      * {@link UnsupportedOperationException} otherwise.
+     *
+     * <p>As with {@link AbstractFixed64Column#longCursor()}, the yielded {@code longValue()} is the
+     * <em>raw 64-bit stored word</em>: the long value for a {@link EscfLongColumn} child, and
+     * {@code Double.doubleToRawLongBits(d)} for a {@link EscfDoubleColumn} child.
      *
      * <p>For multi-valued rows the same row-id is returned once per element. Empty rows (zero-width
      * offset range) and absent rows (no elements) are skipped automatically.
@@ -81,13 +85,15 @@ final class EscfArrayColumn extends EscfColumn {
     // arrays. Add that when needed.
     @Override
     public LongTupleCursor longCursor() {
-        if (!(child instanceof EscfLongColumn longChild)) {
-            throw new UnsupportedOperationException("longCursor() requires a long child column, got: " + EscfColumnKind.name(child.kind()));
+        if (!(child instanceof AbstractFixed64Column fixedChild)) {
+            throw new UnsupportedOperationException(
+                "longCursor() requires a fixed-64 child column, got: " + EscfColumnKind.name(child.kind())
+            );
         }
         final int numRows = docCount;
         final int[] offs = rowOffsets.ints;
         final int base = rowOffsets.offset;
-        final AbstractFixed64Column.DenseLongValuesCursor values = longChild.longValuesCursor();
+        final AbstractFixed64Column.DenseLongValuesCursor values = fixedChild.longValuesCursor();
         final int startElem = offs[base];
         if (numRows > 0 && startElem > 0) {
             values.skip(startElem); // this window starts mid-child because sliceInternal keeps the child unsliced

--- a/server/src/main/java/org/elasticsearch/escf/EscfBoolColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfBoolColumn.java
@@ -39,7 +39,7 @@ final class EscfBoolColumn extends EscfColumn {
     }
 
     @Override
-    boolean getBooleanValue(int row) {
+    public boolean getBooleanValue(int row) {
         return bitSet(row);
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumn.java
@@ -126,7 +126,11 @@ public abstract class EscfColumn implements SliceableColumn {
         return validity == null;
     }
 
-    final byte getTypeByte(int row) {
+    /**
+     * Returns the {@link SourceValueType} byte for document {@code row}. Returns
+     * {@link SourceValueType#ABSENT} when the row is out of bounds or absent.
+     */
+    public final byte getTypeByte(int row) {
         if (row < 0 || row >= docCount || isAbsent(row)) {
             return SourceValueType.ABSENT;
         }
@@ -136,51 +140,61 @@ public abstract class EscfColumn implements SliceableColumn {
     /** The {@link SourceValueType} byte for document {@code row}, which is known to be present. */
     abstract byte typeByteForPresent(int row);
 
-    final boolean isNull(int row) {
+    /** Returns {@code true} if document {@code row} holds an explicit JSON {@code null}. */
+    public final boolean isNull(int row) {
         return getTypeByte(row) == SourceValueType.NULL;
     }
 
     // Typed value getters — default to throwing; subtypes override what they support.
 
-    boolean getBooleanValue(int row) {
+    /** Returns the boolean value at {@code row}. The column kind must be {@link EscfColumnKind#BOOL}. */
+    public boolean getBooleanValue(int row) {
         throw notA("boolean");
     }
 
-    long getLongValue(int row) {
+    /** Returns the long value at {@code row}. The column kind must be {@link EscfColumnKind#LONG}. */
+    public long getLongValue(int row) {
         throw notA("long");
     }
 
-    double getDoubleValue(int row) {
+    /** Returns the double value at {@code row}. The column kind must be {@link EscfColumnKind#DOUBLE}. */
+    public double getDoubleValue(int row) {
         throw notA("double");
     }
 
-    /** Narrows {@link #getLongValue} to an {@code int}, throwing if out of range. */
-    int getIntValue(int row) {
-        long val = getLongValue(row);
-        if (val < Integer.MIN_VALUE || val > Integer.MAX_VALUE) {
-            throw new ArithmeticException("Long value " + val + " does not fit in int");
-        }
-        return (int) val;
+    /**
+     * Narrows {@link #getLongValue} to an {@code int}, throwing if out of range.
+     * Valid for {@link EscfColumnKind#UNION} columns whose row type is {@link org.elasticsearch.sourcebatch.SourceValueType#INT}.
+     */
+    public int getIntValue(int row) {
+        return Math.toIntExact(getLongValue(row));
     }
 
-    /** Narrows {@link #getDoubleValue} to a {@code float}. */
-    float getFloatValue(int row) {
+    /**
+     * Narrows {@link #getDoubleValue} to a {@code float}.
+     * Valid for {@link EscfColumnKind#UNION} columns whose row type is {@link org.elasticsearch.sourcebatch.SourceValueType#FLOAT}.
+     */
+    public float getFloatValue(int row) {
         return (float) getDoubleValue(row);
     }
 
-    Text getStringValue(int row) {
+    /** Returns the string value at {@code row}. The column kind must be {@link EscfColumnKind#STRING}. */
+    public Text getStringValue(int row) {
         throw notA("string");
     }
 
-    BytesRef getBinaryValue(int row) {
+    /** Returns the binary value at {@code row}. The column kind must be {@link EscfColumnKind#BINARY}. */
+    public BytesRef getBinaryValue(int row) {
         throw notA("binary");
     }
 
-    ArrayReader getArrayValue(int row) {
+    /** Returns the array value at {@code row}. The column kind must be {@link EscfColumnKind#ARRAY}. */
+    public ArrayReader getArrayValue(int row) {
         throw notA("array");
     }
 
-    KeyValueReader getKeyValue(int row) {
+    /** Returns the key-value reader at {@code row}. The column kind must be a key-value type. */
+    public KeyValueReader getKeyValue(int row) {
         throw notA("key-value");
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfDoubleColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfDoubleColumn.java
@@ -31,7 +31,7 @@ final class EscfDoubleColumn extends AbstractFixed64Column {
     }
 
     @Override
-    double getDoubleValue(int row) {
+    public double getDoubleValue(int row) {
         return Double.longBitsToDouble(rawLong(row));
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfLongColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfLongColumn.java
@@ -31,7 +31,7 @@ public final class EscfLongColumn extends AbstractFixed64Column {
     }
 
     @Override
-    long getLongValue(int row) {
+    public long getLongValue(int row) {
         return rawLong(row);
     }
 

--- a/server/src/main/java/org/elasticsearch/escf/EscfStringColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfStringColumn.java
@@ -35,7 +35,7 @@ final class EscfStringColumn extends AbstractVarColumn {
     }
 
     @Override
-    Text getStringValue(int row) {
+    public Text getStringValue(int row) {
         BytesRef ref = getBinaryValue(row);
         return new Text(new XContentString.UTF8Bytes(ref.bytes, ref.offset, ref.length));
     }

--- a/server/src/main/java/org/elasticsearch/escf/EscfUnionColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfUnionColumn.java
@@ -52,7 +52,7 @@ final class EscfUnionColumn extends EscfColumn {
     }
 
     @Override
-    boolean getBooleanValue(int row) {
+    public boolean getBooleanValue(int row) {
         byte t = byteAt(typeVec, row);
         if (t == SourceValueType.TRUE) {
             return true;
@@ -64,42 +64,42 @@ final class EscfUnionColumn extends EscfColumn {
     }
 
     @Override
-    int getIntValue(int row) {
+    public int getIntValue(int row) {
         // INT values are stored as 4 bytes in the UNION column, so this reads directly rather than
         // narrowing getLongValue() as the base class does. Caller must have checked typeByteForPresent.
         return data.getIntLE(intAt(offsets, row));
     }
 
     @Override
-    float getFloatValue(int row) {
+    public float getFloatValue(int row) {
         // FLOAT values are stored as 4 raw bytes (bit-identical IEEE 754), not as a narrowed double.
         // Caller must have checked typeByteForPresent.
         return Float.intBitsToFloat(data.getIntLE(intAt(offsets, row)));
     }
 
     @Override
-    long getLongValue(int row) {
+    public long getLongValue(int row) {
         return data.getLongLE(intAt(offsets, row));
     }
 
     @Override
-    double getDoubleValue(int row) {
+    public double getDoubleValue(int row) {
         return Double.longBitsToDouble(data.getLongLE(intAt(offsets, row)));
     }
 
     @Override
-    Text getStringValue(int row) {
+    public Text getStringValue(int row) {
         BytesRef ref = value(row);
         return new Text(new XContentString.UTF8Bytes(ref.bytes, ref.offset, ref.length));
     }
 
     @Override
-    BytesRef getBinaryValue(int row) {
+    public BytesRef getBinaryValue(int row) {
         return value(row);
     }
 
     @Override
-    ArrayReader getArrayValue(int row) {
+    public ArrayReader getArrayValue(int row) {
         boolean fixed = byteAt(typeVec, row) == SourceValueType.FIXED_ARRAY;
         // InlineArrayReader takes a byte[]; materialise this one value's bytes (zero-copy when contiguous).
         BytesRef ref = value(row);
@@ -107,7 +107,7 @@ final class EscfUnionColumn extends EscfColumn {
     }
 
     @Override
-    KeyValueReader getKeyValue(int row) {
+    public KeyValueReader getKeyValue(int row) {
         // KeyValueReader takes a byte[]; materialise this one value's bytes (zero-copy when contiguous).
         BytesRef ref = value(row);
         return new KeyValueReader(ref.bytes, ref.offset, ref.length);

--- a/server/src/main/java/org/elasticsearch/sourcebatch/SourceSchema.java
+++ b/server/src/main/java/org/elasticsearch/sourcebatch/SourceSchema.java
@@ -123,6 +123,7 @@ public final class SourceSchema {
      * For a leaf "status" directly under root, returns "status".
      */
     public String getFullPath(int leafIdx) {
+        // TODO: Could consider caching this in some type of field name object.
         String leafName = leaves.getName(leafIdx);
         int parentIdx = leaves.getParent(leafIdx);
 

--- a/server/src/test/java/org/elasticsearch/escf/EscfCursorsTests.java
+++ b/server/src/test/java/org/elasticsearch/escf/EscfCursorsTests.java
@@ -244,6 +244,29 @@ public class EscfCursorsTests extends ESTestCase {
         assertLongTuple(2, 3, tuples.get(2));
     }
 
+    /**
+     * A DOUBLE child is a fixed-64 column too, so it shares the long cursor. As with a scalar DOUBLE
+     * column, the yielded word is the raw {@code doubleToRawLongBits} of each element.
+     */
+    public void testDoubleArrayTupleCursorYieldsRawBits() {
+        // 3 rows: [[1.5, -2.25], [], [0.0, Double.NaN]]
+        int[] rowOffsets = { 0, 2, 2, 4 };
+        double[] elements = { 1.5, -2.25, 0.0, Double.NaN };
+        long[] raw = new long[elements.length];
+        for (int i = 0; i < elements.length; i++) {
+            raw[i] = Double.doubleToRawLongBits(elements[i]);
+        }
+        EscfColumn child = EscfColumn.from(EscfColumnData.ofFixed64(EscfColumnKind.DOUBLE, raw.length, null, longBytes(raw)));
+        EscfArrayColumn array = new EscfArrayColumn(3, null, child, intsRef(rowOffsets));
+
+        List<long[]> tuples = drainLongTuples(array.longCursor());
+        assertEquals(4, tuples.size());
+        assertLongTuple(0, raw[0], tuples.get(0));
+        assertLongTuple(0, raw[1], tuples.get(1));
+        assertLongTuple(2, raw[2], tuples.get(2));
+        assertLongTuple(2, raw[3], tuples.get(3));
+    }
+
     public void testLongArrayTupleCursorWrongChildKindThrows() {
         // Build an ARRAY column with a STRING child — longCursor() should throw
         int[] rowOffsets = { 0, 1 };


### PR DESCRIPTION
The typed value getters on EscfColumn (getBooleanValue, getLongValue,
getDoubleValue, getIntValue, getFloatValue, getStringValue,
getBinaryValue, getArrayValue, getKeyValue, getTypeByte, isNull) were
package-private, so consumers outside org.elasticsearch.escf could not
read column values. Make them public and document each one with the
column kind it is valid for.