### PR TITLE
[9.5] Fix simdvec test assertion on JDK 21 (#157311)

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AbstractVectorTestCase.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/AbstractVectorTestCase.java
@@ -40,8 +40,10 @@ public abstract class AbstractVectorTestCase extends ESTestCase {
         var arch = System.getProperty("os.arch");
         var osName = System.getProperty("os.name");
 
-        if ((arch.equals("aarch64") && (osName.startsWith("Mac") || osName.equals("Linux"))
-            || arch.equals("amd64") && osName.equals("Linux"))) {
+        // native support requires JDK 22+ (for heap segment support and native vec lib loading)
+        if (Runtime.version().feature() >= 22
+            && (arch.equals("aarch64") && (osName.startsWith("Mac") || osName.equals("Linux"))
+                || arch.equals("amd64") && osName.equals("Linux"))) {
             assertTrue(factory.usesNative());
         } else {
             // not an arch with native support, so shouldn't be native


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix simdvec test assertion on JDK 21 (#157311)](https://github.com/elastic/elasticsearch/pull/157311)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)