### PR TITLE
[9.5] Cache computed write load proportions in RoutingAllocation (#156635)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.cluster;
 
-import com.carrotsearch.hppc.ObjectDoubleHashMap;
-
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.routing.ExpectedShardSizeEstimator;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -37,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.DoubleSupplier;
 
 import static org.elasticsearch.cluster.routing.ShardRouting.newUnassigned;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.Reason.REINITIALIZED;
@@ -85,14 +82,6 @@ public class ClusterInfo implements ChunkedToXContent, Writeable, ExpectedShardS
     // max heap size per node ID
     final Map<String, ByteSizeValue> maxHeapSizePerNode;
     final Set<String> nodeIdsWriteLoadHotspotting;
-    /**
-     * Cache the write load of the largest shard, per node, as a proportion of the sum of all the
-     * shard write loads on that node. Computed as an online cache.
-     * This is not serialized or compared within ClusterInfo, as its values are computed
-     * from {@link #shardWriteLoads} by an AllocationDecider.
-
-     */
-    final ObjectDoubleHashMap<String> nodeMaxShardWriteLoadProportion;
     private final Map<ShardId, Set<String>> shardToNodeIds;
 
     protected ClusterInfo() {
@@ -192,7 +181,6 @@ public class ClusterInfo implements ChunkedToXContent, Writeable, ExpectedShardS
         this.shardWriteLoads = Map.copyOf(shardWriteLoads);
         this.maxHeapSizePerNode = Map.copyOf(maxHeapSizePerNode);
         this.nodeIdsWriteLoadHotspotting = Set.copyOf(nodeIdsWriteLoadHotspotting);
-        this.nodeMaxShardWriteLoadProportion = new ObjectDoubleHashMap<>(nodeIdsWriteLoadHotspotting.size());
         this.shardToNodeIds = shardToNodeIds;
     }
 
@@ -238,7 +226,6 @@ public class ClusterInfo implements ChunkedToXContent, Writeable, ExpectedShardS
         } else {
             this.defaultShardHeapUsageForShardsWithoutMetrics = ShardAndIndexHeapUsage.ZERO;
         }
-        this.nodeMaxShardWriteLoadProportion = new ObjectDoubleHashMap<>(this.nodeIdsWriteLoadHotspotting.size());
         this.shardToNodeIds = computeShardToNodeIds(dataPath);
     }
 
@@ -504,34 +491,6 @@ public class ClusterInfo implements ChunkedToXContent, Writeable, ExpectedShardS
 
     public boolean nodeIsWriteLoadHotspotting(String nodeId) {
         return nodeIdsWriteLoadHotspotting.contains(nodeId);
-    }
-
-    public double nodeMaxShardWriteLoadProportion(String nodeId, DoubleSupplier computeIfMissing) {
-        if (nodeMaxShardWriteLoadProportion.containsKey(nodeId)) {
-            assert cachedValueIsConsistent(nodeId, computeIfMissing);
-            return nodeMaxShardWriteLoadProportion.get(nodeId);
-        } else {
-            double shardWriteLoadProportion = computeIfMissing.getAsDouble();
-            nodeMaxShardWriteLoadProportion.put(nodeId, shardWriteLoadProportion);
-            return shardWriteLoadProportion;
-        }
-    }
-
-    private boolean cachedValueIsConsistent(String nodeId, DoubleSupplier computeIfMissing) {
-        final double computed = computeIfMissing.getAsDouble();
-        final double cached = nodeMaxShardWriteLoadProportion.get(nodeId);
-        assert Math.abs(cached - computed) < 1e-9
-            : "We cached a different value than we calculated for "
-                + nodeId
-                + ", this shouldn't happen. cached != computed: "
-                + cached
-                + " != "
-                + computed;
-        return true;
-    }
-
-    public void invalidateNodeMaxShardWriteLoadProportion(String nodeId) {
-        nodeMaxShardWriteLoadProportion.remove(nodeId);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocation.java
@@ -123,6 +123,9 @@ final class MutableRoutingAllocation extends RoutingAllocation {
     public void setSimulatedClusterInfo(ClusterInfo clusterInfo) {
         assert isSimulating : "Should be called only while simulating";
         this.clusterInfo = clusterInfo;
+        // The proportions are derived from the RoutingNodes and the ClusterInfo,
+        // so they must be recomputed for the new ClusterInfo.
+        invalidateNodeMaxShardWriteLoadProportion();
     }
 
     /**
@@ -185,17 +188,21 @@ final class MutableRoutingAllocation extends RoutingAllocation {
     /**
      * Whenever a shard moves in or out of {@link org.elasticsearch.cluster.routing.ShardRoutingState#STARTED}, we invalidate any
      * cached max write-load proportion values for the affected node(s)
+     * <p>
+     * Note that there are other transitions which would affect this number
+     * (e.g., shard failures, relocation failures), but they don't occur in
+     * desired balance computation or reconciliation, so we don't handle them.
      */
     private class MaxWriteLoadProportionCacheInvalidator implements RoutingChangesObserver {
 
         @Override
         public void shardStarted(ShardRouting initializingShard, ShardRouting startedShard) {
-            clusterInfo.invalidateNodeMaxShardWriteLoadProportion(startedShard.currentNodeId());
+            invalidateNodeMaxShardWriteLoadProportion(startedShard.currentNodeId());
         }
 
         @Override
         public void relocationStarted(ShardRouting startedShard, ShardRouting targetRelocatingShard, String reason) {
-            clusterInfo.invalidateNodeMaxShardWriteLoadProportion(startedShard.currentNodeId());
+            invalidateNodeMaxShardWriteLoadProportion(startedShard.currentNodeId());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptySet;
 
@@ -53,6 +54,9 @@ public abstract sealed class RoutingAllocation permits ImmutableRoutingAllocatio
     protected ClusterInfo clusterInfo;
 
     protected final SnapshotShardSizeInfo shardSizeInfo;
+
+    // Lazily populated; MutableRoutingAllocation invalidates entries when shard state changes.
+    final Map<String, Double> nodeMaxShardWriteLoadProportionCache = new ConcurrentHashMap<>();
 
     private Map<ShardId, Set<String>> ignoredShardToNodes = null;
 
@@ -188,6 +192,50 @@ public abstract sealed class RoutingAllocation permits ImmutableRoutingAllocatio
 
     public ClusterInfo clusterInfo() {
         return clusterInfo;
+    }
+
+    /**
+     * Returns the proportion of total write load on the given node attributable to its most write-heavy started shard.
+     * The result is cached per node per allocation pass; {@link MutableRoutingAllocation} invalidates entries as shard
+     * state changes.
+     */
+    public double maxShardWriteLoadProportionForNode(RoutingNode node) {
+        final String nodeId = node.nodeId();
+        final Double cached = nodeMaxShardWriteLoadProportionCache.get(nodeId);
+        if (cached != null) {
+            assert cachedNodeMaxShardWriteLoadProportionIsConsistent(node, cached);
+            return cached;
+        }
+        final double value = computeNodeMaxShardWriteLoadProportion(node);
+        nodeMaxShardWriteLoadProportionCache.put(nodeId, value);
+        return value;
+    }
+
+    private double computeNodeMaxShardWriteLoadProportion(RoutingNode node) {
+        final var shardWriteLoads = clusterInfo.getShardWriteLoads();
+        double totalWriteLoad = 0.0;
+        double maxShardWriteLoad = 0.0;
+        for (ShardRouting shard : node.started()) {
+            double load = shardWriteLoads.getOrDefault(shard.shardId(), 0.0);
+            totalWriteLoad += load;
+            maxShardWriteLoad = Math.max(maxShardWriteLoad, load);
+        }
+        return totalWriteLoad > 0.0 ? maxShardWriteLoad / totalWriteLoad : 0.0;
+    }
+
+    private boolean cachedNodeMaxShardWriteLoadProportionIsConsistent(RoutingNode node, double cached) {
+        final double computed = computeNodeMaxShardWriteLoadProportion(node);
+        assert Math.abs(cached - computed) < 1e-9
+            : "cached value differs from computed for node " + node.nodeId() + ": cached=" + cached + " computed=" + computed;
+        return true;
+    }
+
+    protected void invalidateNodeMaxShardWriteLoadProportion() {
+        nodeMaxShardWriteLoadProportionCache.clear();
+    }
+
+    protected void invalidateNodeMaxShardWriteLoadProportion(String nodeId) {
+        nodeMaxShardWriteLoadProportionCache.remove(nodeId);
     }
 
     public SnapshotShardSizeInfo snapshotShardSizeInfo() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDecider.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardMovementWriteLoadSimulator;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintSettings;
 import org.elasticsearch.common.FrequencyCappedAction;
@@ -25,12 +24,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.DoubleSupplier;
 
 /**
  * Decides whether shards can be allocated to cluster nodes, or can remain on cluster nodes, based on the target node's current write thread
@@ -68,25 +62,6 @@ public class WriteLoadConstraintDecider extends AllocationDecider {
         var nodeWriteThreadPoolStats = nodeUsageStatsForThreadPools.threadPoolUsageStatsMap().get(ThreadPool.Names.WRITE);
         return nodeWriteThreadPoolStats.maxThreadPoolQueueLatencyMillis() >= hotspotQueueLatencyThreshold.millis()
             && nodeWriteThreadPoolStats.averageThreadPoolUtilization() >= hotspotUtilizationThreshold;
-    }
-
-    public static double maxShardWriteLoadProportion(List<ShardId> assignedShardIds, Map<ShardId, Double> shardWriteLoads) {
-        double totalWriteLoad = 0.0;
-        double maxShardWriteLoad = 0.0;
-        for (ShardId shardId : assignedShardIds) {
-            double shardWriteLoad = shardWriteLoads.getOrDefault(shardId, 0.0);
-            totalWriteLoad += shardWriteLoad;
-            if (shardWriteLoad > maxShardWriteLoad) {
-                maxShardWriteLoad = shardWriteLoad;
-            }
-        }
-
-        if (totalWriteLoad > 0.0) {
-            return maxShardWriteLoad / totalWriteLoad;
-        } else {
-            // no shards or some issue -- return 0.0
-            return 0.0;
-        }
     }
 
     public static boolean maxShardWriteLoadProportionIsHigh(double maxShardWriteLoadProportion, double maxShardWriteLoadThreshold) {
@@ -209,23 +184,14 @@ public class WriteLoadConstraintDecider extends AllocationDecider {
             // it with a shard move is useless: the node that receives the shard will hotspot instead, and an important
             // shard will be unavailable briefly when it moves.
             //
-            // The maxShardWriteLoadProportion is computed only for hot-spotting nodes, and cached within cluster info so it
+            // The maxShardWriteLoadProportion is computed only for hot-spotting nodes, and cached within the routing allocation so it
             // is only computed once per balancing round.
             final double maxShardWriteLoadThreshold = writeLoadConstraintSettings.getHotspotMaxShardWriteLoadProportionThreshold();
-            final DoubleSupplier maxShardWriteLoadProportion = () -> allocation.clusterInfo()
-                .nodeMaxShardWriteLoadProportion(
-                    node.nodeId(),
-                    // compute cache entry if absent
-                    () -> {
-                        final var shardIds = node.shardsWithState(ShardRoutingState.STARTED).map(ShardRouting::shardId).toList();
-                        return maxShardWriteLoadProportion(shardIds, allocation.clusterInfo().getShardWriteLoads());
-                    }
-                );
 
             // check that the threshold comparison is enabled (not 0.0) before computing the maxShardWriteLoadProportion
             final double maxShardWriteLoadProportionCalculated = maxShardWriteLoadThreshold == 0.0
                 ? Double.NaN
-                : maxShardWriteLoadProportion.getAsDouble();
+                : allocation.maxShardWriteLoadProportionForNode(node);
             if (maxShardWriteLoadThreshold == 0.0
                 || maxShardWriteLoadProportionIsHigh(maxShardWriteLoadProportionCalculated, maxShardWriteLoadThreshold) == false) {
                 if (logger.isDebugEnabled() || allocation.debugDecision()) {

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -40,6 +41,7 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
         );
     }
 
+<<<<<<< HEAD
     public void testInvalidateNodeMaxShardWriteLoadProportion() {
         ClusterInfo clusterInfo = ClusterInfo.builder().build();
         String invalidatedNodeId = randomIdentifier();
@@ -73,6 +75,46 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
         clusterInfo.invalidateNodeMaxShardWriteLoadProportion(unknownNodeId);
 
         assertTrue(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(cachedNodeId));
+=======
+    public void testCacheUsageFieldsAreTransportVersionGated() throws Exception {
+        final var shardCacheRequirements = Map.of(randomShardId(), new BoostedAndUnboostedCacheRequirements(10L, 20L));
+        final var nodeCacheSizeAndCommitments = Map.of(randomIdentifier(), new NodeCacheSizeAndCommitments(100L, 10L, 30L));
+        final var clusterInfo = ClusterInfo.builder()
+            .shardCacheRequirements(shardCacheRequirements)
+            .nodeCacheSizeAndCommitments(nodeCacheSizeAndCommitments)
+            .build();
+
+        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
+        assertThat(currentVersionCopy.getShardCacheRequirements(), equalTo(shardCacheRequirements));
+        assertThat(currentVersionCopy.getNodeCacheSizeAndCommitments(), equalTo(nodeCacheSizeAndCommitments));
+
+        final var preCacheUsageVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.CACHE_METADATA_IN_CLUSTER_INFO);
+        final var preCacheUsageCopy = copyInstance(clusterInfo, preCacheUsageVersion);
+        assertThat(preCacheUsageCopy.getShardCacheRequirements(), equalTo(Map.of()));
+        assertThat(preCacheUsageCopy.getNodeCacheSizeAndCommitments(), equalTo(Map.of()));
+    }
+
+    public void testHostedShardsFieldsAreTransportVersionGated() throws Exception {
+        final var clusterInfo = ClusterInfo.builder().hostedShardsPartitionSizeByNodeId(randomHostedShardsPartitionSizes()).build();
+
+        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
+        assertThat(currentVersionCopy.getHostedShardsPartitionSizeByNodeId(), equalTo(clusterInfo.getHostedShardsPartitionSizeByNodeId()));
+
+        final var preCacheUsageVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.PARTITION_SIZES_IN_CLUSTER_INFO);
+        final var preCacheUsageCopy = copyInstance(clusterInfo, preCacheUsageVersion);
+        assertThat(preCacheUsageCopy.getHostedShardsPartitionSizeByNodeId(), equalTo(Map.of()));
+    }
+
+    public void testSearchLaneRequirementsAreTransportVersionGated() throws Exception {
+        final var clusterInfo = ClusterInfo.builder().shardSearchLaneRequirements(randomShardSearchLaneRequirements()).build();
+
+        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
+        assertThat(currentVersionCopy.getShardSearchLaneRequirements(), equalTo(clusterInfo.getShardSearchLaneRequirements()));
+
+        final var preLaneVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.SEARCH_LANE_REQUIREMENTS_IN_CLUSTER_INFO);
+        final var preLaneCopy = copyInstance(clusterInfo, preLaneVersion);
+        assertThat(preLaneCopy.getShardSearchLaneRequirements(), equalTo(Map.of()));
+>>>>>>> aef9d77e9938 (Cache computed write load proportions in RoutingAllocation (#156635))
     }
 
     private static double randomWriteLoadProportion() {

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -15,8 +15,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -39,86 +37,6 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
             clusterInfo.getEstimatedShardHeapUsage(new ShardId(new Index(randomIndexName(), "_na_"), randomNonNegativeInt())),
             equalTo(defaultHeapUsage)
         );
-    }
-
-<<<<<<< HEAD
-    public void testInvalidateNodeMaxShardWriteLoadProportion() {
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        String invalidatedNodeId = randomIdentifier();
-        String otherNodeId = randomValueOtherThan(invalidatedNodeId, ESTestCase::randomIdentifier);
-        double initialInvalidatedValue = randomWriteLoadProportion();
-        double otherValue = randomWriteLoadProportion();
-        double recomputedValue = randomValueOtherThan(initialInvalidatedValue, ClusterInfoTests::randomWriteLoadProportion);
-
-        // prime cache for two nodes
-        clusterInfo.nodeMaxShardWriteLoadProportion(invalidatedNodeId, () -> initialInvalidatedValue);
-        clusterInfo.nodeMaxShardWriteLoadProportion(otherNodeId, () -> otherValue);
-        assertTrue(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(invalidatedNodeId));
-        assertTrue(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(otherNodeId));
-
-        clusterInfo.invalidateNodeMaxShardWriteLoadProportion(invalidatedNodeId);
-
-        assertFalse(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(invalidatedNodeId));
-        assertTrue(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(otherNodeId));
-
-        // Re-priming the invalidated entry with a different value succeeds (no assertion fires
-        // because the prior cached value has been removed).
-        assertThat(clusterInfo.nodeMaxShardWriteLoadProportion(invalidatedNodeId, () -> recomputedValue), equalTo(recomputedValue));
-    }
-
-    public void testInvalidateNodeMaxShardWriteLoadProportionForUnknownNodeIsNoop() {
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        String cachedNodeId = randomIdentifier();
-        String unknownNodeId = randomValueOtherThan(cachedNodeId, ESTestCase::randomIdentifier);
-        clusterInfo.nodeMaxShardWriteLoadProportion(cachedNodeId, ClusterInfoTests::randomWriteLoadProportion);
-
-        clusterInfo.invalidateNodeMaxShardWriteLoadProportion(unknownNodeId);
-
-        assertTrue(clusterInfo.nodeMaxShardWriteLoadProportion.containsKey(cachedNodeId));
-=======
-    public void testCacheUsageFieldsAreTransportVersionGated() throws Exception {
-        final var shardCacheRequirements = Map.of(randomShardId(), new BoostedAndUnboostedCacheRequirements(10L, 20L));
-        final var nodeCacheSizeAndCommitments = Map.of(randomIdentifier(), new NodeCacheSizeAndCommitments(100L, 10L, 30L));
-        final var clusterInfo = ClusterInfo.builder()
-            .shardCacheRequirements(shardCacheRequirements)
-            .nodeCacheSizeAndCommitments(nodeCacheSizeAndCommitments)
-            .build();
-
-        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
-        assertThat(currentVersionCopy.getShardCacheRequirements(), equalTo(shardCacheRequirements));
-        assertThat(currentVersionCopy.getNodeCacheSizeAndCommitments(), equalTo(nodeCacheSizeAndCommitments));
-
-        final var preCacheUsageVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.CACHE_METADATA_IN_CLUSTER_INFO);
-        final var preCacheUsageCopy = copyInstance(clusterInfo, preCacheUsageVersion);
-        assertThat(preCacheUsageCopy.getShardCacheRequirements(), equalTo(Map.of()));
-        assertThat(preCacheUsageCopy.getNodeCacheSizeAndCommitments(), equalTo(Map.of()));
-    }
-
-    public void testHostedShardsFieldsAreTransportVersionGated() throws Exception {
-        final var clusterInfo = ClusterInfo.builder().hostedShardsPartitionSizeByNodeId(randomHostedShardsPartitionSizes()).build();
-
-        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
-        assertThat(currentVersionCopy.getHostedShardsPartitionSizeByNodeId(), equalTo(clusterInfo.getHostedShardsPartitionSizeByNodeId()));
-
-        final var preCacheUsageVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.PARTITION_SIZES_IN_CLUSTER_INFO);
-        final var preCacheUsageCopy = copyInstance(clusterInfo, preCacheUsageVersion);
-        assertThat(preCacheUsageCopy.getHostedShardsPartitionSizeByNodeId(), equalTo(Map.of()));
-    }
-
-    public void testSearchLaneRequirementsAreTransportVersionGated() throws Exception {
-        final var clusterInfo = ClusterInfo.builder().shardSearchLaneRequirements(randomShardSearchLaneRequirements()).build();
-
-        final var currentVersionCopy = copyInstance(clusterInfo, TransportVersion.current());
-        assertThat(currentVersionCopy.getShardSearchLaneRequirements(), equalTo(clusterInfo.getShardSearchLaneRequirements()));
-
-        final var preLaneVersion = TransportVersionUtils.getPreviousVersion(ClusterInfo.SEARCH_LANE_REQUIREMENTS_IN_CLUSTER_INFO);
-        final var preLaneCopy = copyInstance(clusterInfo, preLaneVersion);
-        assertThat(preLaneCopy.getShardSearchLaneRequirements(), equalTo(Map.of()));
->>>>>>> aef9d77e9938 (Cache computed write load proportions in RoutingAllocation (#156635))
-    }
-
-    private static double randomWriteLoadProportion() {
-        return randomDoubleBetween(0.0, 1.0, true);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocationTests.java
@@ -13,81 +13,127 @@ import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
-import static org.hamcrest.Matchers.equalTo;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.closeTo;
 
 public class MutableRoutingAllocationTests extends ESAllocationTestCase {
 
+    /**
+     * When a shard becomes STARTED on a node, its write load now contributes to the node's proportion. The cached value
+     * is invalidated so the next call recomputes from the updated routing state.
+     */
     public void testCacheInvalidatedOnShardStarted() {
         String sourceNodeId = randomIdentifier();
         String otherNodeId = randomValueOtherThan(sourceNodeId, ESTestCase::randomIdentifier);
-        double initialSourceValue = randomWriteLoadProportion();
-        double otherValue = randomWriteLoadProportion();
-        double recomputedValue = randomValueOtherThan(initialSourceValue, MutableRoutingAllocationTests::randomWriteLoadProportion);
 
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        MutableRoutingAllocation allocation = newAllocation(clusterInfo, sourceNodeId, otherNodeId);
+        Index index = new Index("test-index", "_na_");
+        ShardId startedShardId = new ShardId(index, 0);    // write load 3.0, always STARTED
+        ShardId initializingShardId = new ShardId(index, 1); // write load 7.0, starts INITIALIZING
 
-        clusterInfo.nodeMaxShardWriteLoadProportion(sourceNodeId, () -> initialSourceValue);
-        clusterInfo.nodeMaxShardWriteLoadProportion(otherNodeId, () -> otherValue);
+        // With only shard0 started: proportion = 3.0/3.0 = 1.0
+        // After shard1 also starts: proportion = max(3.0, 7.0)/(3.0+7.0) = 0.7
+        ClusterInfo clusterInfo = ClusterInfo.builder().shardWriteLoads(Map.of(startedShardId, 3.0, initializingShardId, 7.0)).build();
 
-        ShardRouting initializing = TestShardRouting.newShardRouting(
-            randomIdentifier(),
-            0,
+        ClusterState clusterState = clusterStateWithShards(
             sourceNodeId,
-            true,
-            ShardRoutingState.INITIALIZING
+            otherNodeId,
+            index,
+            TestShardRouting.newShardRouting(startedShardId, sourceNodeId, true, ShardRoutingState.STARTED),
+            TestShardRouting.newShardRouting(initializingShardId, sourceNodeId, true, ShardRoutingState.INITIALIZING)
         );
-        ShardRouting started = initializing.moveToStarted(0L);
 
-        allocation.changes().shardStarted(initializing, started);
+        MutableRoutingAllocation allocation = newAllocation(clusterState, clusterInfo);
+        RoutingNode node = allocation.routingNodes().node(sourceNodeId);
 
-        // The entry for the started shard's node has been invalidated, so we recompute and store the new value.
-        // If the entry had not been invalidated, the stale cached value would mismatch the supplier and trip an assertion.
-        assertThat(clusterInfo.nodeMaxShardWriteLoadProportion(sourceNodeId, () -> recomputedValue), equalTo(recomputedValue));
-        // Other nodes' cache entries are untouched.
-        assertThat(clusterInfo.nodeMaxShardWriteLoadProportion(otherNodeId, () -> otherValue), equalTo(otherValue));
+        // prime cache with only shard0 started
+        assertThat(allocation.maxShardWriteLoadProportionForNode(node), closeTo(1.0, 1e-9));
+
+        // startShard updates the routing node AND fires the cache-invalidation observer
+        ShardRouting initializingShard = node.getByShardId(initializingShardId);
+        allocation.routingNodes().startShard(initializingShard, allocation.changes(), 0L);
+
+        // cache was invalidated; recomputed with both shards started → 0.7
+        assertThat(allocation.maxShardWriteLoadProportionForNode(node), closeTo(0.7, 1e-9));
     }
 
+    /**
+     * When a shard starts relocating away from a node, it leaves the STARTED set. The cached proportion is invalidated
+     * so the next call reflects only the remaining started shards.
+     */
     public void testCacheInvalidatedOnRelocationStarted() {
         String sourceNodeId = randomIdentifier();
         String targetNodeId = randomValueOtherThan(sourceNodeId, ESTestCase::randomIdentifier);
-        double initialSourceValue = randomWriteLoadProportion();
-        double targetValue = randomWriteLoadProportion();
-        double recomputedValue = randomValueOtherThan(initialSourceValue, MutableRoutingAllocationTests::randomWriteLoadProportion);
 
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        MutableRoutingAllocation allocation = newAllocation(clusterInfo, sourceNodeId, targetNodeId);
+        Index index = new Index("test-index", "_na_");
+        ShardId relocatingShardId = new ShardId(index, 0); // write load 3.0, will relocate away
+        ShardId stayingShardId = new ShardId(index, 1);    // write load 7.0, stays started
 
-        clusterInfo.nodeMaxShardWriteLoadProportion(sourceNodeId, () -> initialSourceValue);
-        clusterInfo.nodeMaxShardWriteLoadProportion(targetNodeId, () -> targetValue);
+        // With both shards started: proportion = max(3.0, 7.0)/(3.0+7.0) = 0.7
+        // After shard0 starts reloc: proportion = 7.0/7.0 = 1.0
+        ClusterInfo clusterInfo = ClusterInfo.builder().shardWriteLoads(Map.of(relocatingShardId, 3.0, stayingShardId, 7.0)).build();
 
-        ShardRouting started = TestShardRouting.newShardRouting(randomAlphaOfLength(8), 0, sourceNodeId, true, ShardRoutingState.STARTED);
-        ShardRouting source = started.relocate(targetNodeId, 0L);
-        ShardRouting target = source.getTargetRelocatingShard();
+        ClusterState clusterState = clusterStateWithShards(
+            sourceNodeId,
+            targetNodeId,
+            index,
+            TestShardRouting.newShardRouting(relocatingShardId, sourceNodeId, true, ShardRoutingState.STARTED),
+            TestShardRouting.newShardRouting(stayingShardId, sourceNodeId, true, ShardRoutingState.STARTED)
+        );
 
-        allocation.changes().relocationStarted(started, target, randomAlphaOfLength(10));
+        MutableRoutingAllocation allocation = newAllocation(clusterState, clusterInfo);
+        RoutingNode node = allocation.routingNodes().node(sourceNodeId);
 
-        // Source node entry invalidated; target node entry untouched (only an INITIALIZING shard appears there,
-        // and the cache only depends on STARTED shards).
-        assertThat(clusterInfo.nodeMaxShardWriteLoadProportion(sourceNodeId, () -> recomputedValue), equalTo(recomputedValue));
-        assertThat(clusterInfo.nodeMaxShardWriteLoadProportion(targetNodeId, () -> targetValue), equalTo(targetValue));
+        // prime cache with both shards started
+        assertThat(allocation.maxShardWriteLoadProportionForNode(node), closeTo(0.7, 1e-9));
+
+        // relocateShard moves shard0 to RELOCATING on sourceNode and fires the cache-invalidation observer
+        ShardRouting relocating = node.getByShardId(relocatingShardId);
+        allocation.routingNodes()
+            .relocateShard(
+                relocating,
+                targetNodeId,
+                0L,
+                "test",
+                allocation.changes(),
+                ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
+            );
+
+        // cache was invalidated; recomputed with only shard1 started → 1.0
+        assertThat(allocation.maxShardWriteLoadProportionForNode(node), closeTo(1.0, 1e-9));
     }
 
-    private static MutableRoutingAllocation newAllocation(ClusterInfo clusterInfo, String sourceNodeId, String targetNodeId) {
-        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(newNode(sourceNodeId)).add(newNode(targetNodeId)))
-            .build();
+    private static MutableRoutingAllocation newAllocation(ClusterState clusterState, ClusterInfo clusterInfo) {
         RoutingAllocation mutable = TestRoutingAllocationFactory.forClusterState(clusterState).clusterInfo(clusterInfo).mutable();
         return (MutableRoutingAllocation) (randomBoolean() ? mutable.mutableCloneForSimulation() : mutable);
     }
 
-    private static double randomWriteLoadProportion() {
-        return randomDoubleBetween(0.0, 1.0, true);
+    private static ClusterState clusterStateWithShards(String primaryNodeId, String otherNodeId, Index index, ShardRouting... shards) {
+        IndexMetadata indexMetadata = IndexMetadata.builder(index.getName())
+            .settings(indexSettings(IndexVersion.current(), shards.length, 0))
+            .build();
+        IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index);
+        for (ShardRouting shard : shards) {
+            indexRoutingTable.addShard(shard);
+        }
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(newNode(primaryNodeId)).add(newNode(otherNodeId)))
+            .metadata(Metadata.builder().put(indexMetadata, false))
+            .routingTable(RoutingTable.builder().add(indexRoutingTable.build()).build())
+            .build();
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MutableRoutingAllocationTests.java
@@ -103,15 +103,7 @@ public class MutableRoutingAllocationTests extends ESAllocationTestCase {
 
         // relocateShard moves shard0 to RELOCATING on sourceNode and fires the cache-invalidation observer
         ShardRouting relocating = node.getByShardId(relocatingShardId);
-        allocation.routingNodes()
-            .relocateShard(
-                relocating,
-                targetNodeId,
-                0L,
-                "test",
-                allocation.changes(),
-                ShardRouting.RecoveryPriority.RELOCATION_CAN_REMAIN_NO
-            );
+        allocation.routingNodes().relocateShard(relocating, targetNodeId, 0L, "test", allocation.changes());
 
         // cache was invalidated; recomputed with only shard1 started → 1.0
         assertThat(allocation.maxShardWriteLoadProportionForNode(node), closeTo(1.0, 1e-9));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocationTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class RoutingAllocationTests extends ESTestCase {
+
+    public void testMaxShardWriteLoadProportionForNode_SingleShard() {
+        final var indexName = randomIdentifier();
+        final var clusterState = ClusterStateCreationUtils.state(indexName, 1, 1);
+        final var shard0 = clusterState.routingTable(ProjectId.DEFAULT).index(indexName).shard(0).shardId();
+
+        // only shard means 1.0
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(shard0, randomDoubleBetween(0.001, 20.0, false)), 1.0);
+
+        // inexplicably not in map means 0.0
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(), 0.0);
+
+        // only shard in map, with zero load
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(shard0, 0.0), 0.0);
+
+        // not-only shard in map, with 0 load
+        expectMaxShardWriteLoadProportion(
+            clusterState,
+            Map.of(shard0, 0.0, new ShardId(randomIdentifier(), randomUUID(), 0), randomDoubleBetween(0.0001, 20.0, true)),
+            0.0
+        );
+    }
+
+    public void testMaxShardWriteLoadProportionForNode_MultipleShards() {
+        final var indexName = randomIdentifier();
+        final var clusterState = ClusterStateCreationUtils.state(indexName, 1, 2);
+        final var shard0 = clusterState.routingTable(ProjectId.DEFAULT).index(indexName).shard(0).shardId();
+        final var shard1 = clusterState.routingTable(ProjectId.DEFAULT).index(indexName).shard(1).shardId();
+
+        double shard0Load = randomDoubleBetween(0.0001, 10.0, true);
+        double shard1Load = randomDoubleBetween(shard0Load, 20.0, false);
+
+        // picks the biggest one
+        expectMaxShardWriteLoadProportion(
+            clusterState,
+            Map.of(shard0, shard0Load, shard1, shard1Load),
+            shard1Load / (shard0Load + shard1Load)
+        );
+
+        // both zero
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(shard0, 0.0, shard1, 0.0), 0.0);
+
+        // not in map
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(), 0.0);
+
+        // one in map
+        expectMaxShardWriteLoadProportion(clusterState, Map.of(shard0, 0.0), 0.0);
+
+        // one shard has 100% of the load
+        expectMaxShardWriteLoadProportion(
+            clusterState,
+            randomBoolean()
+                ? Map.of(shard0, randomDoubleBetween(0.0001, 10.0, true), shard1, 0.0)
+                : Map.of(shard0, randomDoubleBetween(0.0001, 10.0, true)),
+            1.0
+        );
+
+        // totally random map entry
+        expectMaxShardWriteLoadProportion(
+            clusterState,
+            Map.of(new ShardId(randomIndexName(), randomUUID(), 0), randomDoubleBetween(0.0001, 20.0, true)),
+            0.0
+        );
+    }
+
+    private void expectMaxShardWriteLoadProportion(ClusterState clusterState, Map<ShardId, Double> clusterInfoWriteLoads, double expected) {
+        final var node0 = clusterState.getRoutingNodes().node("node_0");
+        final var routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState)
+            .clusterInfo(ClusterInfo.builder().shardWriteLoads(clusterInfoWriteLoads).build())
+            .build();
+        assertThat(routingAllocation.maxShardWriteLoadProportionForNode(node0), equalTo(expected));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -617,89 +616,6 @@ public class WriteLoadConstraintDeciderTests extends ESAllocationTestCase {
                     hotspotUtilizationThresholdString
                 )
             )
-        );
-    }
-
-    public void testMaxSingleShardWriteLoadSingleShard() {
-        ShardId testShardId = new ShardId(randomIndexName(), randomUUID(), 0);
-
-        // only shard means 1.0
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId),
-                Map.of(testShardId, randomDoubleBetween(0.001, 20.0, false))
-            ),
-            equalTo(1.0)
-        );
-
-        // inexplicably not in map means 0.0
-        assertThat(WriteLoadConstraintDecider.maxShardWriteLoadProportion(List.of(testShardId), Map.of()), equalTo(0.0));
-
-        // shard is in map with zero load
-        assertThat(WriteLoadConstraintDecider.maxShardWriteLoadProportion(List.of(testShardId), Map.of(testShardId, 0.0)), equalTo(0.0));
-
-        // shard with 0 load
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId),
-                Map.of(testShardId, 0.0, new ShardId(randomIndexName(), randomUUID(), 0), randomDoubleBetween(0.0001, 20.0, true))
-            ),
-            equalTo(0.0)
-        );
-    }
-
-    public void testmaxSingleShardWriteLoadMultipleShards() {
-        ShardId testShardId1 = new ShardId(randomIndexName(), randomUUID(), 0);
-        ShardId testShardId2 = new ShardId(randomIndexName(), randomUUID(), 0);
-
-        double shard1Load = randomDoubleBetween(0.0001, 10.0, true);
-        double shard2Load = randomDoubleBetween(shard1Load, 20.0, false);
-
-        // picks the biggest one
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId1, testShardId2),
-                Map.of(testShardId1, shard1Load, testShardId2, shard2Load)
-            ),
-            equalTo(shard2Load / (shard1Load + shard2Load))
-        );
-
-        // both zero
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId1, testShardId2),
-                Map.of(testShardId1, 0.0, testShardId2, 0.0)
-            ),
-            equalTo(0.0)
-        );
-
-        // not in map
-        assertThat(WriteLoadConstraintDecider.maxShardWriteLoadProportion(List.of(testShardId1, testShardId2), Map.of()), equalTo(0.0));
-
-        // one in map
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(List.of(testShardId1, testShardId2), Map.of(testShardId1, 0.0)),
-            equalTo(0.0)
-        );
-
-        // one shard has 100% of the load
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId1, testShardId2),
-                randomBoolean()
-                    ? Map.of(testShardId1, randomDoubleBetween(0.0001, 10.0, true), testShardId2, 0.0)
-                    : Map.of(testShardId1, randomDoubleBetween(0.0001, 10.0, true))
-            ),
-            equalTo(1.0)
-        );
-
-        // totally random map entry
-        assertThat(
-            WriteLoadConstraintDecider.maxShardWriteLoadProportion(
-                List.of(testShardId1, testShardId2),
-                Map.of(new ShardId(randomIndexName(), randomUUID(), 0), randomDoubleBetween(0.0001, 20.0, true))
-            ),
-            equalTo(0.0)
         );
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Cache computed write load proportions in RoutingAllocation (#156635)](https://github.com/elastic/elasticsearch/pull/156635)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)