### PR TITLE
Return 503 for API key auth when the security index is unavailable

### DIFF
--- a/docs/changelog/157722.yaml
+++ b/docs/changelog/157722.yaml
@@ -1,0 +1,5 @@
+area: Authentication
+issues: []
+pr: 157722
+summary: Return 503 for API key auth when the security index is unavailable
+type: enhancement

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
@@ -70,6 +71,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -107,6 +109,7 @@ import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeRes
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.authz.store.RoleReference;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.metric.SecurityCacheMetrics;
@@ -1298,8 +1301,20 @@ public class ApiKeyService implements Closeable {
                 listener.onResponse(AuthenticationResult.unsuccessful("unable to find apikey with id " + credentials.getId(), null));
             }
         }, e -> {
-            if (ExceptionsHelper.unwrapCause(e) instanceof EsRejectedExecutionException) {
+            final Throwable cause = ExceptionsHelper.unwrapCause(e);
+            if (cause instanceof EsRejectedExecutionException) {
                 listener.onResponse(AuthenticationResult.terminate("server is too busy to respond", e));
+            } else if (TransportActions.isShardNotAvailableException(e) || cause instanceof ConnectTransportException) {
+                // Surface a 503 so clients retry
+                listener.onResponse(
+                    AuthenticationResult.terminate(
+                        "authentication backend temporarily unavailable",
+                        Exceptions.authenticationProcessError(
+                            "authentication backend for apikey with id " + credentials.getId() + " is temporarily unavailable",
+                            e
+                        )
+                    )
+                );
             } else {
                 listener.onResponse(
                     AuthenticationResult.unsuccessful("apikey authentication for id " + credentials.getId() + " encountered a failure", e)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ElasticsearchAuthenticationProcessingError;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
@@ -18,6 +19,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -63,6 +65,7 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchResponseUtils;
@@ -77,6 +80,9 @@ import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.NodeDisconnectedException;
+import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -2739,6 +2745,43 @@ public class ApiKeyServiceTests extends ESTestCase {
         final AuthenticationResult<User> authenticationResult = future.get();
         assertEquals(AuthenticationResult.Status.TERMINATE, authenticationResult.getStatus());
         assertThat(authenticationResult.getMessage(), containsString("server is too busy to respond"));
+    }
+
+    public void testAuthWillTerminateWith503IfBackendUnavailable() throws ExecutionException, InterruptedException {
+        final ApiKeyService service = createApiKeyService(Settings.EMPTY);
+        final List<Exception> backendUnavailableExceptions = List.of(
+            new NoShardAvailableActionException(new ShardId(SECURITY_MAIN_ALIAS, "_na_", 0), "no shard available"),
+            new ConnectTransportException(null, "node not reachable"),
+            new RemoteTransportException("remote", new NodeDisconnectedException(null, "disconnected"))
+        );
+        for (Exception backendUnavailableException : backendUnavailableExceptions) {
+            final AuthenticationResult<User> result = tryAuthenticateWithGetFailure(service, backendUnavailableException);
+            assertEquals(AuthenticationResult.Status.TERMINATE, result.getStatus());
+            assertThat(result.getException(), instanceOf(ElasticsearchAuthenticationProcessingError.class));
+            assertThat(((ElasticsearchAuthenticationProcessingError) result.getException()).status(), is(RestStatus.SERVICE_UNAVAILABLE));
+        }
+    }
+
+    public void testAuthWillContinueIfGetFailsWithUnexpectedException() throws ExecutionException, InterruptedException {
+        final AuthenticationResult<User> result = tryAuthenticateWithGetFailure(
+            createApiKeyService(Settings.EMPTY),
+            new RuntimeException("unexpected")
+        );
+        assertEquals(AuthenticationResult.Status.CONTINUE, result.getStatus());
+        assertThat(result.getMessage(), containsString("encountered a failure"));
+    }
+
+    private AuthenticationResult<User> tryAuthenticateWithGetFailure(ApiKeyService service, Exception failure) throws ExecutionException,
+        InterruptedException {
+        SecurityMocks.mockGetRequestException(client, failure);
+        final ApiKeyCredentials creds = getApiKeyCredentials(
+            randomAlphaOfLength(12),
+            randomAlphaOfLength(16),
+            randomFrom(ApiKey.Type.values())
+        );
+        final PlainActionFuture<AuthenticationResult<User>> future = new PlainActionFuture<>();
+        service.tryAuthenticate(threadPool.getThreadContext(), creds, future);
+        return future.get();
     }
 
     public void testAuthWillTerminateIfHashingThreadPoolIsSaturated() throws IOException, ExecutionException, InterruptedException {


### PR DESCRIPTION
When the GET loading an API key document from the security index failed with a transient error (unassigned shard, lost node connection), the failure surfaced as a 401 `security_exception: unable to authenticate`. Clients treat 401
as a permanent credential rejection and do not retry, so a recoverable backend blip turned into abandoned work even though the key was valid.

`ApiKeyService#loadApiKeyDoc` now classifies these failures with `TransportActions.isShardNotAvailableException` plus `ConnectTransportException`, matching how `TokenService` and `NativeUsersStore` classify the same condition, and terminates authentication with an `ElasticsearchAuthenticationProcessingError`, which the failure handler passes through as a retryable 503.

The failure goes through `AuthenticationResult.terminate` rather than `listener.onFailure` so that the 503 survives the cross cluster access path (which rewraps arbitrary failures into 401), the audit event keeps the API key id,
and the clone API key path keeps its existing 401 contract.

Notes:
* `ConnectTransportException` reports 502 on its own, but `ElasticsearchAuthenticationProcessingError` only allows 500/503, so connection failures surface as 503. Both are retryable.
* Tokens, service account tokens, and native realm users still return 401 for the same condition. Aligning those in `DefaultAuthenticationFailureHandler` is left as a follow up.

Relates: elastic/sdh-elasticsearch#10209