### PR TITLE
[9.5] Account for document source memory during streaming fetch (#157522)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 /**
@@ -328,6 +329,81 @@ public class ChunkedFetchPhaseCircuitBreakerTrippingIT extends ESIntegTestCase {
             long currentBreaker = getRequestBreakerUsed(coordinatorNode);
             assertThat(
                 "Coordinator circuit breaker should be released after single large doc trip",
+                currentBreaker,
+                lessThanOrEqualTo(breakerBefore)
+            );
+        });
+    }
+
+    public void testCircuitBreakerTripsOnDataNodeSourceDuringStreamingFetch() throws Exception {
+        String dataNode = internalCluster().startNode(
+            Settings.builder().put("indices.breaker.request.type", "memory").put("indices.breaker.request.limit", "4mb").build()
+        );
+        String coordinatorNode = internalCluster().startCoordinatingOnlyNode(
+            Settings.builder().put("indices.breaker.request.limit", "200mb").build()
+        );
+        createIndex(INDEX_NAME);
+
+        prepareIndex(INDEX_NAME).setId("huge")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field(SORT_FIELD, 0)
+                    .field("huge_field", Strings.repeat("x", 10_000_000))  // 10MB source, well past the 4MB data node limit
+                    .endObject()
+            )
+            .get();
+        refresh(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        long breakerBefore = getRequestBreakerUsed(dataNode);
+        assertThat(
+            "baseline data node request breaker usage should leave ample headroom below the low limit, otherwise "
+                + "an unrelated allocation -- not the streamed source -- could trip the breaker and fail this test "
+                + "for the wrong reason; current usage: "
+                + breakerBefore,
+            breakerBefore,
+            lessThan(1_000_000L)
+        );
+
+        ElasticsearchException exception = null;
+        SearchResponse resp = null;
+        try {
+            resp = internalCluster().client(coordinatorNode)
+                .prepareSearch(INDEX_NAME)
+                .setQuery(matchAllQuery())
+                .setSize(1)
+                .setAllowPartialSearchResults(false)
+                .get();
+        } catch (ElasticsearchException e) {
+            exception = e;
+        } finally {
+            if (resp != null) {
+                resp.decRef();
+            }
+        }
+
+        assertNotNull("Search should have failed on the data node's oversized source", exception);
+
+        Throwable breakerException = ExceptionsHelper.unwrap(exception, CircuitBreakingException.class);
+        assertNotNull("root cause must be a CircuitBreakingException", breakerException);
+        assertThat(
+            "Trip should be attributed to the streaming per-hit source accounting, not the network buffer",
+            breakerException.getMessage(),
+            containsString("fetch[source]")
+        );
+        assertThat(
+            "Circuit breaking should map to 429 TOO_MANY_REQUESTS",
+            ExceptionsHelper.status(exception),
+            equalTo(RestStatus.TOO_MANY_REQUESTS)
+        );
+
+        assertBusy(() -> {
+            long currentBreaker = getRequestBreakerUsed(dataNode);
+            assertThat(
+                "Data node circuit breaker should be released after tripping on the streamed source, current: "
+                    + currentBreaker
+                    + ", before: "
+                    + breakerBefore,
                 currentBreaker,
                 lessThanOrEqualTo(breakerBefore)
             );

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -192,7 +192,7 @@ public final class FetchPhase {
                 ? Profiler.NOOP
                 : Profilers.startProfilingFetchPhase();
 
-        var docsIterator = createDocsIterator(context, profiler, rankDocs, writer != null ? bytes -> {} : memoryChecker);
+        var docsIterator = createDocsIterator(context, profiler, rankDocs, memoryChecker, writer != null);
 
         // Common completion handler for both sync and streaming modes
         // finalizes profiling, stores the shard result, and signals the outer listener.
@@ -262,14 +262,18 @@ public final class FetchPhase {
     }
 
     /**
-     * Creates the docs iterator that handles per-document fetching and sub-phase processing.
-     * Shared between sync and streaming modes; the memoryChecker parameter controls per-hit memory accounting.
+     * Creates the docs iterator that handles per-document fetching and sub-phase processing, shared between sync and
+     * streaming modes. In streaming mode, only per-hit source/script-field bytes exceeding
+     * {@link SearchContext#memAccountingBufferSize()} are charged to the request circuit breaker;
+     * In non-streaming mode, bytes are accumulated and charged once the threshold is crossed, and
+     * held until the fetch response is released.
      */
     private StreamingFetchPhaseDocsIterator createDocsIterator(
         SearchContext context,
         Profiler profiler,
         RankDocShardInfo rankDocs,
-        @Nullable IntConsumer memoryChecker
+        @Nullable IntConsumer memoryChecker,
+        boolean streaming
     ) {
         var lookup = context.getSearchExecutionContext().getMappingLookup();
 
@@ -303,14 +307,26 @@ public final class FetchPhase {
         FetchContext fetchContext = new FetchContext(context, sourceLoader);
 
         final long[] scriptFieldsBreakerBytes = new long[1];
-        LongConsumer scriptFieldsByteChecker = memoryChecker != null
-            ? bytes -> memoryChecker.accept(bytes > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) bytes)
-            : bytes -> {
+        final long[] streamingHeldBytes = new long[1];
+        LongConsumer scriptFieldsByteChecker;
+        if (streaming) {
+            scriptFieldsByteChecker = bytes -> {
+                if (bytes > context.memAccountingBufferSize()) {
+                    context.circuitBreaker()
+                        .addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[script_field]");
+                    streamingHeldBytes[0] += bytes;
+                }
+            };
+        } else if (memoryChecker != null) {
+            scriptFieldsByteChecker = bytes -> memoryChecker.accept(bytes > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) bytes);
+        } else {
+            scriptFieldsByteChecker = bytes -> {
                 if (bytes > 0) {
                     context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, "script_field");
                     scriptFieldsBreakerBytes[0] += bytes;
                 }
             };
+        }
         fetchContext.setScriptFieldsByteChecker(scriptFieldsByteChecker);
 
         PreloadedSourceProvider sourceProvider = new PreloadedSourceProvider();
@@ -345,17 +361,31 @@ public final class FetchPhase {
             SourceLoader.Leaf leafSourceLoader;
             IdLoader.Leaf leafIdLoader;
 
-            IntConsumer memChecker = memoryChecker != null ? memoryChecker : bytes -> {
+            IntConsumer memChecker = streaming ? bytes -> {
+                if (bytes > context.memAccountingBufferSize()) {
+                    context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[source]");
+                    streamingHeldBytes[0] += bytes;
+                }
+            } : (memoryChecker != null ? memoryChecker : bytes -> {
                 locallyAccumulatedBytes[0] += bytes;
                 if (context.checkCircuitBreaker(locallyAccumulatedBytes[0], "fetch source")) {
                     addRequestBreakerBytes(locallyAccumulatedBytes[0]);
                     locallyAccumulatedBytes[0] = 0;
                 }
-            };
+            });
 
             @Override
             public long getRequestBreakerBytes() {
-                return super.getRequestBreakerBytes() + scriptFieldsBreakerBytes[0];
+                return super.getRequestBreakerBytes() + scriptFieldsBreakerBytes[0] + streamingHeldBytes[0];
+            }
+
+            @Override
+            protected void onHitSerialized() {
+                long held = streamingHeldBytes[0];
+                if (held > 0) {
+                    context.circuitBreaker().addWithoutBreaking(-held, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
+                    streamingHeldBytes[0] = 0;
+                }
             }
 
             @Override
@@ -565,6 +595,11 @@ public final class FetchPhase {
                     context.addFetchThreadsMetrics(docsIterator.getFetchMetricsDelta());
                     ReleasableBytesReference lastChunkBytes = lastChunkBytesRef.getAndSet(null);
                     Releasables.closeWhileHandlingException(lastChunkBytes);
+
+                    long leakedBytes = docsIterator.getRequestBreakerBytes();
+                    if (leakedBytes > 0) {
+                        context.circuitBreaker().addWithoutBreaking(-leakedBytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
+                    }
 
                     buildListener.onFailure(e);
                     mainBuildListener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -312,8 +312,7 @@ public final class FetchPhase {
         if (streaming) {
             scriptFieldsByteChecker = bytes -> {
                 if (bytes > context.memAccountingBufferSize()) {
-                    context.circuitBreaker()
-                        .addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[script_field]");
+                    context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, "fetch[script_field]");
                     streamingHeldBytes[0] += bytes;
                 }
             };
@@ -363,7 +362,7 @@ public final class FetchPhase {
 
             IntConsumer memChecker = streaming ? bytes -> {
                 if (bytes > context.memAccountingBufferSize()) {
-                    context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[source]");
+                    context.circuitBreaker().addEstimateBytesAndMaybeBreak(bytes, "fetch[source]");
                     streamingHeldBytes[0] += bytes;
                 }
             } : (memoryChecker != null ? memoryChecker : bytes -> {
@@ -383,7 +382,7 @@ public final class FetchPhase {
             protected void onHitSerialized() {
                 long held = streamingHeldBytes[0];
                 if (held > 0) {
-                    context.circuitBreaker().addWithoutBreaking(-held, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
+                    context.circuitBreaker().addWithoutBreaking(-held);
                     streamingHeldBytes[0] = 0;
                 }
             }
@@ -598,7 +597,7 @@ public final class FetchPhase {
 
                     long leakedBytes = docsIterator.getRequestBreakerBytes();
                     if (leakedBytes > 0) {
-                        context.circuitBreaker().addWithoutBreaking(-leakedBytes, ChildMemoryCircuitBreaker.CATEGORY_FETCH);
+                        context.circuitBreaker().addWithoutBreaking(-leakedBytes);
                     }
 
                     buildListener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
@@ -76,6 +76,12 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
     }
 
     /**
+     * Invoked after a hit is serialized into the chunk buffer, including on failure. Subclasses can
+     * override to release per-hit resources; must be idempotent. Default is a no-op.
+     */
+    protected void onHitSerialized() {}
+
+    /**
      * Asynchronous iteration using {@link ThrottledIterator} for streaming mode.
      *
      * @param shardTarget         the shard being fetched from
@@ -355,6 +361,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
                         hit.writeTo(chunkBuffer);
                     } finally {
                         hit.decRef();
+                        onHitSerialized();
                     }
                     currentIdx++;
                     hitsInChunk++;

--- a/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
@@ -917,7 +916,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
             @Override
             public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
                 used.addAndGet(bytes);
-                if (label.startsWith(ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[source]")) {
+                if (label.startsWith("fetch[source]")) {
                     sourceCharges.add(label);
                 }
             }

--- a/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -28,14 +28,19 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
@@ -58,6 +63,7 @@ import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
+import org.elasticsearch.search.fetch.chunk.FetchPhaseResponseChunk;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
@@ -73,14 +79,18 @@ import org.elasticsearch.search.query.SearchTimeoutException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.TestSearchContext;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.transport.Transport;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.LongConsumer;
 import java.util.stream.IntStream;
@@ -88,6 +98,7 @@ import java.util.stream.IntStream;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -886,6 +897,199 @@ public class FetchSearchPhaseTests extends ESTestCase {
         }
     }
 
+    public void testStreamingFetchAccountsAndReleasesSourceBytes() throws IOException {
+        Directory dir = newDirectory();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+        String body = "{ \"thefield\": \" " + randomAlphaOfLength(1_200_000) + "\" }";
+        for (int i = 0; i < 3; i++) {
+            Document document = new Document();
+            document.add(new StringField("id", Integer.toString(i), Field.Store.YES));
+            document.add(new StoredField("_source", new BytesRef(body)));
+            w.addDocument(document);
+        }
+        IndexReader r = w.getReader();
+        w.close();
+        ContextIndexSearcher contextIndexSearcher = createSearcher(r);
+
+        AtomicLong used = new AtomicLong();
+        List<String> sourceCharges = new CopyOnWriteArrayList<>();
+        CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST) {
+            @Override
+            public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+                used.addAndGet(bytes);
+                if (label.startsWith(ChildMemoryCircuitBreaker.CATEGORY_FETCH + "[source]")) {
+                    sourceCharges.add(label);
+                }
+            }
+
+            @Override
+            public void addWithoutBreaking(long bytes) {
+                used.addAndGet(bytes);
+            }
+        };
+
+        SearchContext searchContext = createSearchContext(contextIndexSearcher, true, breaker);
+        try {
+            setTotalHits(searchContext, 3);
+            FetchPhase fetchPhase = createSourceCopyingFetchPhase();
+            PageCacheRecycler recycler = new PageCacheRecycler(Settings.EMPTY);
+            AtomicReference<Exception> failure = new AtomicReference<>();
+            fetchPhase.execute(
+                searchContext,
+                new int[] { 0, 1, 2 },
+                null,
+                null,
+                streamingWriter(recycler, breaker),
+                1,
+                Math.toIntExact(ByteSizeValue.ofMb(1).getBytes()),
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                ActionListener.noop(),
+                ActionListener.wrap(ignored -> {}, failure::set)
+            );
+            assertThat(failure.get(), nullValue());
+            // each of the 3 fetched hits' source should be charged against the request breaker under the fetch[source] label
+            assertThat(sourceCharges, hasSize(3));
+        } finally {
+            // releasing the fetch result frees the retained last-chunk pages; after that the breaker must be back to baseline
+            Releasables.close(searchContext);
+            r.close();
+            dir.close();
+        }
+        assertThat("all fetch-phase circuit breaker bytes should be released", used.get(), is(0L));
+    }
+
+    public void testStreamingFetchReleasesLeakedBytesOnFailure() throws IOException {
+        Directory dir = newDirectory();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+        String body = "{ \"thefield\": \" " + randomAlphaOfLength(1_200_000) + "\" }";
+        Document document = new Document();
+        document.add(new StringField("id", "0", Field.Store.YES));
+        document.add(new StoredField("_source", new BytesRef(body)));
+        w.addDocument(document);
+        IndexReader r = w.getReader();
+        w.close();
+        ContextIndexSearcher contextIndexSearcher = createSearcher(r);
+
+        long innerHitsLikeBytes = 1_200_000L;
+        LowLimitCircuitBreaker breaker = new LowLimitCircuitBreaker(1_500_000L);
+
+        SearchContext searchContext = createSearchContext(contextIndexSearcher, true, breaker);
+        try {
+            setTotalHits(searchContext, 1);
+            FetchPhase fetchPhase = new FetchPhase(List.of(fetchContext -> new FetchSubPhaseProcessor() {
+                @Override
+                public void setNextReader(LeafReaderContext readerContext) {}
+
+                @Override
+                public void process(FetchSubPhase.HitContext hitContext) {
+                    fetchContext.chargeScriptFieldsBytes(innerHitsLikeBytes);
+                    Source source = hitContext.source();
+                    hitContext.hit().sourceRef(source.internalSourceRef());
+                }
+
+                @Override
+                public StoredFieldsSpec storedFieldsSpec() {
+                    return StoredFieldsSpec.NEEDS_SOURCE;
+                }
+            }));
+            PageCacheRecycler recycler = new PageCacheRecycler(Settings.EMPTY);
+            AtomicReference<Exception> failure = new AtomicReference<>();
+            fetchPhase.execute(
+                searchContext,
+                new int[] { 0 },
+                null,
+                null,
+                streamingWriter(recycler, breaker),
+                1,
+                Math.toIntExact(ByteSizeValue.ofMb(1).getBytes()),
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                ActionListener.noop(),
+                ActionListener.wrap(ignored -> {}, failure::set)
+            );
+            assertThat(failure.get(), instanceOf(CircuitBreakingException.class));
+        } finally {
+            Releasables.close(searchContext);
+            r.close();
+            dir.close();
+        }
+        assertThat("bytes held for the hit that never reached onHitSerialized() must be released", breaker.getUsed(), is(0L));
+    }
+
+    private static final class LowLimitCircuitBreaker extends NoopCircuitBreaker {
+        private final AtomicLong used = new AtomicLong();
+        private final long limit;
+
+        LowLimitCircuitBreaker(long limit) {
+            super(CircuitBreaker.REQUEST);
+            this.limit = limit;
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            long newUsed = used.addAndGet(bytes);
+            if (newUsed > limit) {
+                used.addAndGet(-bytes);
+                throw new CircuitBreakingException("test breaker tripped", bytes, limit, Durability.TRANSIENT);
+            }
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            used.addAndGet(bytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return used.get();
+        }
+
+        @Override
+        public long getLimit() {
+            return limit;
+        }
+    }
+
+    private static void setTotalHits(SearchContext searchContext, int totalHits) {
+        searchContext.queryResult()
+            .topDocs(
+                new TopDocsAndMaxScore(new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]), Float.NaN),
+                new DocValueFormat[0]
+            );
+    }
+
+    private static FetchPhase createSourceCopyingFetchPhase() {
+        return new FetchPhase(List.of(fetchContext -> new FetchSubPhaseProcessor() {
+            @Override
+            public void setNextReader(LeafReaderContext readerContext) {}
+
+            @Override
+            public void process(FetchSubPhase.HitContext hitContext) {
+                Source source = hitContext.source();
+                hitContext.hit().sourceRef(source.internalSourceRef());
+            }
+
+            @Override
+            public StoredFieldsSpec storedFieldsSpec() {
+                return StoredFieldsSpec.NEEDS_SOURCE;
+            }
+        }));
+    }
+
+    private static FetchPhaseResponseChunk.Writer streamingWriter(PageCacheRecycler recycler, CircuitBreaker breaker) {
+        return new FetchPhaseResponseChunk.Writer() {
+            @Override
+            public void writeResponseChunk(FetchPhaseResponseChunk chunk, ActionListener<Void> listener) {
+                // Acknowledge immediately so streaming production runs to completion inline on the direct executor.
+                listener.onResponse(null);
+            }
+
+            @Override
+            public RecyclerBytesStreamOutput newNetworkBytesStream() {
+                return new RecyclerBytesStreamOutput(new BytesRefRecycler(recycler), breaker);
+            }
+        };
+    }
+
     public void testTimerStoppedAndSubPhasesExceptionsPropagate() throws IOException {
         // if the timer is not stopped properly whilst profiling the fetch phase the exceptions
         // in sub phases#setNextReader will not propagate as the cause that failed the fetch phase (instead a timer illegal state exception
@@ -1059,6 +1263,11 @@ public class FetchSearchPhaseTests extends ESTestCase {
             @Override
             public IdLoader newIdLoader() {
                 return new IdLoader.StoredIdLoader();
+            }
+
+            @Override
+            public SearchShardTarget shardTarget() {
+                return new SearchShardTarget("node", request.shardId(), null);
             }
 
             @Override


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Account for document source memory during streaming fetch (#157522)