### PR TITLE
Remove assertion on recently uploaded BCC when shard closes

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -780,8 +780,8 @@ tests:
   method: testTargetWillTransitionToSplitIfSearchShardsActiveTimesOut
   issue: https://github.com/elastic/elasticsearch/issues/157680
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
-  method: testDeleteAndRecreateIndexDuringReshard
-  issue: https://github.com/elastic/elasticsearch/issues/157725
+  method: testTargetWillTransitionToSplitIfSearchShardsActiveTimesOut
+  issue: https://github.com/elastic/elasticsearch/issues/157680
 - class: org.elasticsearch.xpack.stateless.StatelessSearchIT
   method: testRefreshAndGet
   issue: https://github.com/elastic/elasticsearch/issues/157727

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -779,9 +779,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTargetWillTransitionToSplitIfSearchShardsActiveTimesOut
   issue: https://github.com/elastic/elasticsearch/issues/157680
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
-  method: testTargetWillTransitionToSplitIfSearchShardsActiveTimesOut
-  issue: https://github.com/elastic/elasticsearch/issues/157680
 - class: org.elasticsearch.xpack.stateless.StatelessSearchIT
   method: testRefreshAndGet
   issue: https://github.com/elastic/elasticsearch/issues/157727

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -2786,8 +2786,12 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 IOUtils.closeWhileHandlingException(virtualBcc);
             }
             Releasables.close(new ArrayList<>(recentlyUploadedCleanups.values()));
-            assert recentlyUploadedVbccs.isEmpty();
-            // production fallback for assertion failure, do nothing is expected
+            // There is a narrow race between the upload thread and the cluster-applier thread:
+            // a VBCC may be added to `recentlyUploadedVbccs` by the upload path before its
+            // corresponding cleanup has been registered in `recentlyUploadedCleanups`.
+            // If close() runs in that window, the cleanup will not be visible to the drain
+            // above. The fallback below already defensively closes any remaining VBCCs,
+            // so avoid asserting here to prevent flaky CI failures.
             IOUtils.closeWhileHandlingException(recentlyUploadedVbccs.values());
 
             if (listenersToFail.isEmpty() == false) {


### PR DESCRIPTION
This change relaxes the assertion that recentlyUploadedVbccs
is empty in StatelessCommitService.ShardCommitState.close().

There is small window of time between the moment a VBCC is
added to recentlyUploadedVbccs and its corresponding
cleanup is registered in recentlyUploadedCleanups, during
which the shard commit state can be closed (called by the
cluster state applier thread). In such case the assertion
can fail.

Production code already makes sure to close any remaining
VBCCs in recentlyUploadedVbccs, so removing the assertion
seems OK to me. Alternatively we could synchronize the
registration of the VBCC and the cleanup but that looks
more invasive.

Relates https://github.com/elastic/elasticsearch/pull/151835
Closes https://github.com/elastic/elasticsearch/issues/157725