### PR TITLE
Fork vbcc cleanup to generic pool

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java
@@ -2504,7 +2504,9 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                 clusterService.localNode().getId(),
                 clusterService,
                 ActionListener.wrap(searchNodesAndCommitsResult -> {
-                    afterNotification.close();
+                    // afterNotification.close() may trigger VBCC cleanup, which involves blocking I/O (blob cache reads via
+                    // Lucene commit deletion). Fork to generic to avoid blocking the transport thread.
+                    threadPool.generic().execute(afterNotification::close);
                     onNewUploadedCommitNotificationResponse(
                         // Open PITs might be transferred between search nodes during relocations, for that reason we are conservative,
                         // and we just consider responses from started or old nodes retaining commits, that way we won't delete any
@@ -2517,7 +2519,7 @@ public class StatelessCommitService extends AbstractLifecycleComponent implement
                     );
                 }, e -> {
                     // Treat failures the same as a successful response: the indexing node cannot meaningfully wait any longer.
-                    afterNotification.close();
+                    threadPool.generic().execute(afterNotification::close);
                     logNotificationException(
                         notificationCommitGeneration,
                         uploadedBcc.primaryTermAndGeneration().generation(),

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommit.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommit.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.snapshots.blobstore.SlicedInputStream;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.stateless.StatelessPlugin;
 import org.elasticsearch.xpack.stateless.commits.StatelessCompoundCommit.InternalFile;
 import org.elasticsearch.xpack.stateless.commits.StatelessCompoundCommit.TimestampFieldValueRange;
@@ -796,6 +797,7 @@ public class VirtualBatchedCompoundCommit extends AbstractRefCounted implements 
 
     @Override
     public void close() {
+        assert Transports.assertNotTransportThread("can invoke lucene deletion policy");
         decRef();
     }
 


### PR DESCRIPTION
The cleanup invokes lucene deletion policy and thus should not run on transport thread.

Closes #157732

Assisted by claude.
