### PR TITLE
[9.4] QL/ES|QL: Reject 2^63 in double-to-long conversion (#157555)

### DIFF
--- a/docs/changelog/157555.yaml
+++ b/docs/changelog/157555.yaml
@@ -1,0 +1,6 @@
+pr: 157555
+summary: Reject 2^63 in QL and ES|QL double-to-long conversion
+area: ES|QL
+type: bug
+issues:
+  - 157551

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -347,6 +347,7 @@ string:keyword | base:integer | to_long:long | to_integer:integer
 
 convertStringToBaseIndexGroup5
 required_capability: base_conversion
+required_capability: fn_to_long_fix_double_to_long_overflow
 
   FROM  base_conversion
 | WHERE group == 5
@@ -359,6 +360,7 @@ warningRegex:Line 3:55: evaluation of \[TO_INTEGER\(string, base\)\] failed, tre
 warningRegex:Line 3:19: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Unable to convert \[8000000000000000\] to number of base \[16\]
 warningRegex:Line 3:19: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Unable to convert \[-8000000000000001\] to number of base \[16\]
 warningRegex:Line 3:19: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[7fffffff\]
+warningRegex:Line 3:19: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[9223372036854775808\]
 warningRegex:Line 3:55: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[2147483648\]
 warningRegex:Line 3:55: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[9223372036854775807\]
 warningRegex:Line 3:55: org.elasticsearch.xpack.esql.core.InvalidArgumentException: Cannot parse number \[9223372036854775808\]
@@ -377,7 +379,7 @@ string:keyword       | base:integer | to_long:long         | to_integer:integer
 2147483647           | 10           | 2147483647	   | 2147483647
 2147483648           | 10           | 2147483648	   | null
 9223372036854775807  | 10           | 9223372036854775807  | null
-9223372036854775808  | 10           | 9223372036854775807  | null
+9223372036854775808  | 10           | null                 | null
 7fffffff             | 16           | 2147483647	   | 2147483647
 7fffffffffffffff     | 16           | 9223372036854775807  | null
 80000000             | 16           | 2147483648	   | null

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
@@ -45,6 +45,9 @@ import static org.elasticsearch.xpack.esql.core.util.NumericUtils.isUnsignedLong
  */
 public final class DataTypeConverter {
 
+    // Long.MAX_VALUE rounds to 2^63 as a double, which is the exclusive upper bound.
+    private static final double DOUBLE_TO_LONG_UPPER_BOUND = (double) Long.MAX_VALUE;
+
     private DataTypeConverter() {}
 
     /**
@@ -311,7 +314,7 @@ public final class DataTypeConverter {
     }
 
     public static long safeDoubleToLong(double x) {
-        if (x > Long.MAX_VALUE || x < Long.MIN_VALUE) {
+        if (x >= DOUBLE_TO_LONG_UPPER_BOUND || x < Long.MIN_VALUE) {
             throw new InvalidArgumentException("[{}] out of [long] range", x);
         }
         return Math.round(x);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSurrogate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSurrogate.java
@@ -54,6 +54,8 @@ public class ToLongSurrogate extends EsqlScalarFunction implements OnlySurrogate
 
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(ToLongSurrogate.class)
         .binary(ToLongSurrogate::new)
+        // Reject doubles at the exactly representable 2^63 boundary instead of saturating to Long.MAX_VALUE.
+        .capabilities("fix_double_to_long_overflow")
         .name("to_long");
 
     @FunctionInfo(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
@@ -34,6 +34,8 @@ import java.util.function.Supplier;
 //
 @FunctionName("_unregestered_to_long_tests")
 public class ToLongTests extends AbstractScalarFunctionTestCase {
+    private static final double MAX_DOUBLE_CONVERTIBLE_TO_LONG = Math.nextDown((double) Long.MAX_VALUE);
+
     public ToLongTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
     }
@@ -139,7 +141,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
         TestCaseSupplier.unary(
             suppliers,
             unaryEvaluatorName("String", "in"),
-            TestCaseSupplier.doubleCases(Long.MIN_VALUE, Long.MAX_VALUE, true)
+            TestCaseSupplier.doubleCases(Long.MIN_VALUE, MAX_DOUBLE_CONVERTIBLE_TO_LONG, true)
                 .stream()
                 .map(
                     tds -> new TestCaseSupplier.TypedDataSupplier(
@@ -214,7 +216,7 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
             DataType.LONG,
             Math::round,
             Long.MIN_VALUE,
-            Long.MAX_VALUE,
+            MAX_DOUBLE_CONVERTIBLE_TO_LONG,
             List.of()
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/DataTypeConversionTests.java
@@ -43,6 +43,9 @@ import static org.elasticsearch.xpack.esql.core.util.DateUtils.asDateTime;
 
 public class DataTypeConversionTests extends ESTestCase {
 
+    private static final double DOUBLE_TO_LONG_UPPER_BOUND = (double) Long.MAX_VALUE;
+    private static final double MAX_DOUBLE_CONVERTIBLE_TO_LONG = Math.nextDown(DOUBLE_TO_LONG_UPPER_BOUND);
+
     public void testConversionToString() {
         DataType to = KEYWORD;
         {
@@ -73,9 +76,18 @@ public class DataTypeConversionTests extends ESTestCase {
         {
             Converter conversion = converterFor(DOUBLE, to);
             assertNull(conversion.convert(null));
+            assertEquals(Long.MIN_VALUE, conversion.convert((double) Long.MIN_VALUE));
+            Exception belowLowerBound = expectThrows(
+                InvalidArgumentException.class,
+                () -> conversion.convert(Math.nextDown((double) Long.MIN_VALUE))
+            );
+            assertEquals("[" + Math.nextDown((double) Long.MIN_VALUE) + "] out of [long] range", belowLowerBound.getMessage());
             assertEquals(10L, conversion.convert(10.0));
             assertEquals(10L, conversion.convert(10.1));
             assertEquals(11L, conversion.convert(10.6));
+            assertEquals(Math.round(MAX_DOUBLE_CONVERTIBLE_TO_LONG), conversion.convert(MAX_DOUBLE_CONVERTIBLE_TO_LONG));
+            Exception boundary = expectThrows(InvalidArgumentException.class, () -> conversion.convert(DOUBLE_TO_LONG_UPPER_BOUND));
+            assertEquals("[" + DOUBLE_TO_LONG_UPPER_BOUND + "] out of [long] range", boundary.getMessage());
             Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert(Double.MAX_VALUE));
             assertEquals("[" + Double.MAX_VALUE + "] out of [long] range", e.getMessage());
         }
@@ -414,8 +426,9 @@ public class DataTypeConversionTests extends ESTestCase {
             assertEquals(10, conversion.convert(10.0));
             assertEquals(10, conversion.convert(10.1));
             assertEquals(11, conversion.convert(10.6));
-            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert(Long.MAX_VALUE));
-            assertEquals("[" + Long.MAX_VALUE + "] out of [integer] range", e.getMessage());
+            long outOfRange = (long) Integer.MAX_VALUE + 1;
+            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert((double) outOfRange));
+            assertEquals("[" + outOfRange + "] out of [integer] range", e.getMessage());
         }
         {
             Converter conversion = converterFor(UNSIGNED_LONG, to);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DataTypeConverter.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/type/DataTypeConverter.java
@@ -49,6 +49,9 @@ import static org.elasticsearch.xpack.ql.util.NumericUtils.isUnsignedLong;
  */
 public final class DataTypeConverter {
 
+    // Long.MAX_VALUE rounds to 2^63 as a double, which is the exclusive upper bound.
+    private static final double DOUBLE_TO_LONG_UPPER_BOUND = (double) Long.MAX_VALUE;
+
     private DataTypeConverter() {}
 
     /**
@@ -392,7 +395,7 @@ public final class DataTypeConverter {
     }
 
     public static long safeDoubleToLong(double x) {
-        if (x > Long.MAX_VALUE || x < Long.MIN_VALUE) {
+        if (x >= DOUBLE_TO_LONG_UPPER_BOUND || x < Long.MIN_VALUE) {
             throw new InvalidArgumentException("[{}] out of [long] range", x);
         }
         return Math.round(x);

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/type/DataTypeConversionTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/type/DataTypeConversionTests.java
@@ -39,6 +39,9 @@ import static org.elasticsearch.xpack.ql.type.DateUtils.asDateTime;
 
 public class DataTypeConversionTests extends ESTestCase {
 
+    private static final double DOUBLE_TO_LONG_UPPER_BOUND = (double) Long.MAX_VALUE;
+    private static final double MAX_DOUBLE_CONVERTIBLE_TO_LONG = Math.nextDown(DOUBLE_TO_LONG_UPPER_BOUND);
+
     public void testSafeToUnsignedLongRejectsOversizedString() {
         // A numeric string long enough to be costly to parse is rejected before BigDecimal construction.
         String oversized = "9".repeat(Numbers.MAX_NUMERIC_STRING_LENGTH + 1);
@@ -75,9 +78,18 @@ public class DataTypeConversionTests extends ESTestCase {
         {
             Converter conversion = converterFor(DOUBLE, to);
             assertNull(conversion.convert(null));
+            assertEquals(Long.MIN_VALUE, conversion.convert((double) Long.MIN_VALUE));
+            Exception belowLowerBound = expectThrows(
+                InvalidArgumentException.class,
+                () -> conversion.convert(Math.nextDown((double) Long.MIN_VALUE))
+            );
+            assertEquals("[" + Math.nextDown((double) Long.MIN_VALUE) + "] out of [long] range", belowLowerBound.getMessage());
             assertEquals(10L, conversion.convert(10.0));
             assertEquals(10L, conversion.convert(10.1));
             assertEquals(11L, conversion.convert(10.6));
+            assertEquals(Math.round(MAX_DOUBLE_CONVERTIBLE_TO_LONG), conversion.convert(MAX_DOUBLE_CONVERTIBLE_TO_LONG));
+            Exception boundary = expectThrows(InvalidArgumentException.class, () -> conversion.convert(DOUBLE_TO_LONG_UPPER_BOUND));
+            assertEquals("[" + DOUBLE_TO_LONG_UPPER_BOUND + "] out of [long] range", boundary.getMessage());
             Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert(Double.MAX_VALUE));
             assertEquals("[" + Double.MAX_VALUE + "] out of [long] range", e.getMessage());
         }
@@ -416,8 +428,9 @@ public class DataTypeConversionTests extends ESTestCase {
             assertEquals(10, conversion.convert(10.0));
             assertEquals(10, conversion.convert(10.1));
             assertEquals(11, conversion.convert(10.6));
-            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert(Long.MAX_VALUE));
-            assertEquals("[" + Long.MAX_VALUE + "] out of [integer] range", e.getMessage());
+            long outOfRange = (long) Integer.MAX_VALUE + 1;
+            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert((double) outOfRange));
+            assertEquals("[" + outOfRange + "] out of [integer] range", e.getMessage());
         }
         {
             Converter conversion = converterFor(UNSIGNED_LONG, to);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverterTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverterTests.java
@@ -569,8 +569,9 @@ public class SqlDataTypeConverterTests extends ESTestCase {
             assertEquals(10, conversion.convert(10.0));
             assertEquals(10, conversion.convert(10.1));
             assertEquals(11, conversion.convert(10.6));
-            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert(Long.MAX_VALUE));
-            assertEquals("[" + Long.MAX_VALUE + "] out of [integer] range", e.getMessage());
+            long outOfRange = (long) Integer.MAX_VALUE + 1;
+            Exception e = expectThrows(InvalidArgumentException.class, () -> conversion.convert((double) outOfRange));
+            assertEquals("[" + outOfRange + "] out of [integer] range", e.getMessage());
         }
         {
             Converter conversion = converterFor(DATE, to);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - QL/ES|QL: Reject 2^63 in double-to-long conversion (#157555)