### PR TITLE
Test clusters log health response body

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/WaitForHttpResource.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/WaitForHttpResource.java
@@ -14,6 +14,7 @@ import org.gradle.api.logging.Logging;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -121,8 +122,14 @@ public class WaitForHttpResource {
         if (validResponseCodes.contains(response)) {
             logger.info("Got successful response [{}] from URL [{}]", response, url);
             return;
-        } else {
-            throw new IOException(response + " " + connection.getResponseMessage());
+        }
+        throw new IOException(response + " " + connection.getResponseMessage() + " " + readErrorBody(connection));
+    }
+
+    private static String readErrorBody(HttpURLConnection connection) throws IOException {
+        InputStream error = connection.getErrorStream();
+        try (InputStream stream = error != null ? error : connection.getInputStream()) {
+            return stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -782,9 +782,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT
   method: testPointInTimeRelocationReferencingTheSameCommit
   issue: https://github.com/elastic/elasticsearch/issues/157739
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=health/10_basic/cluster health basic test}
-  issue: https://github.com/elastic/elasticsearch/issues/157740
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {bad_ARROW-GH-43605}
   issue: https://github.com/elastic/elasticsearch/issues/157747

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/WaitForHttpResource.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/WaitForHttpResource.java
@@ -139,8 +139,14 @@ public class WaitForHttpResource {
         if (validResponseCodes.contains(response)) {
             logger.info("Got successful response [{}] from URL [{}]", response, url);
             return;
-        } else {
-            throw new IOException(response + " " + connection.getResponseMessage());
+        }
+        throw new IOException(response + " " + connection.getResponseMessage() + " " + readErrorBody(connection));
+    }
+
+    private static String readErrorBody(HttpURLConnection connection) throws IOException {
+        InputStream error = connection.getErrorStream();
+        try (InputStream stream = error != null ? error : connection.getInputStream()) {
+            return stream == null ? "" : new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 


### PR DESCRIPTION
A test flake doesn't have enough information to understand what it's actually happening. 
We can only see that trying to get cluster health times out, but we don't have any more information.
This function tries to get more information by reading the error stream if available, including it in the returned exception.

Relates to: #157607 