### PR TITLE
[9.4] Fix realtime refresh YAML Tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/termvectors/20_issue7121.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/termvectors/20_issue7121.yml
@@ -2,6 +2,7 @@
   - do:
       indices.create:
           index: testidx
+          wait_for_active_shards: all
           body:
             settings:
               index:
@@ -13,10 +14,6 @@
                 text:
                    type : "text"
                    term_vector : "with_positions_offsets"
-
-  - do:
-      cluster.health:
-        wait_for_no_initializing_shards: true
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/termvectors/30_realtime.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/termvectors/30_realtime.yml
@@ -3,14 +3,11 @@
  - do:
       indices.create:
         index:    test_1
+        wait_for_active_shards: all
         body:
           settings:
             index:
               refresh_interval: -1
-
- - do:
-     cluster.health:
-       wait_for_no_initializing_shards: true
 
  - do:
       index:


### PR DESCRIPTION
Backport of #157614

These tests do not wait for replicas to start before indexing a document, and if that indexing lands before all shards have started then some shards may expose the new document to non-realtime operations like gets and searches. This commit adjusts the `index.create` invocation to wait for all shards to start before proceeding.

Relates #157310