### PR TITLE
Add record field type: schema-free recursive JSON with array-of-object isolation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
@@ -32,9 +32,9 @@ import java.util.Map;
  * A helper class for {@link FlattenedFieldMapper} parses a JSON object
  * and produces a pair of indexable fields for each leaf value.
  */
-class FlattenedFieldParser {
-    static final String SEPARATOR = "\0";
-    static final byte SEPARATOR_BYTE = '\0';
+public class FlattenedFieldParser {
+    public static final String SEPARATOR = "\0";
+    public static final byte SEPARATOR_BYTE = '\0';
 
     private final String rootFieldFullPath;
     private final String keyedFieldFullPath;
@@ -57,7 +57,7 @@ class FlattenedFieldParser {
 
     private final boolean writeDimensionRouting;
 
-    FlattenedFieldParser(
+    public FlattenedFieldParser(
         String rootFieldFullPath,
         String keyedFieldFullPath,
         String keyedIgnoredValuesFieldFullPath,
@@ -316,11 +316,11 @@ class FlattenedFieldParser {
         }
     }
 
-    static String createKeyedValue(String key, String value) {
+    public static String createKeyedValue(String key, String value) {
         return key + SEPARATOR + value;
     }
 
-    static BytesRef extractKey(BytesRef keyedValue) {
+    public static BytesRef extractKey(BytesRef keyedValue) {
         int length;
         for (length = 0; length < keyedValue.length; length++) {
             if (keyedValue.bytes[keyedValue.offset + length] == SEPARATOR_BYTE) {
@@ -330,7 +330,7 @@ class FlattenedFieldParser {
         return new BytesRef(keyedValue.bytes, keyedValue.offset, length);
     }
 
-    static BytesRef extractValue(BytesRef keyedValue) {
+    public static BytesRef extractValue(BytesRef keyedValue) {
         int length;
         for (length = 0; length < keyedValue.length; length++) {
             if (keyedValue.bytes[keyedValue.offset + length] == SEPARATOR_BYTE) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
@@ -351,8 +351,8 @@ public final class RecordFieldMapper extends FieldMapper {
 
         @Override
         protected BytesRef indexedValueForSearch(Object value) {
-            String keyedValue = FlattenedFieldParser.createKeyedValue(key, value.toString());
-            return new BytesRef(keyedValue);
+            String stringValue = value instanceof BytesRef ? ((BytesRef) value).utf8ToString() : value.toString();
+            return new BytesRef(FlattenedFieldParser.createKeyedValue(key, stringValue));
         }
 
         @Override
@@ -389,17 +389,20 @@ public final class RecordFieldMapper extends FieldMapper {
             boolean includeUpper,
             SearchExecutionContext context
         ) {
-            // Values are stored as keyword strings, so string range.
-            String lower = lowerTerm == null
-                ? FlattenedFieldParser.createKeyedValue(key, "")
-                : FlattenedFieldParser.createKeyedValue(key, lowerTerm.toString());
-            String upper = upperTerm == null
-                ? FlattenedFieldParser.createKeyedValue(key, "￿￿")
-                : FlattenedFieldParser.createKeyedValue(key, upperTerm.toString());
-            // When the lower is the key prefix (open range), include it.
-            boolean actualIncludeLower = lowerTerm == null ? true : includeLower;
-            boolean actualIncludeUpper = upperTerm == null ? false : includeUpper;
-            return new TermRangeQuery(name(), new BytesRef(lower), new BytesRef(upper), actualIncludeLower, actualIncludeUpper);
+            if (lowerTerm != null && upperTerm != null) {
+                // Both bounds defined: delegate to StringFieldType which calls indexedValueForSearch for each bound.
+                return super.rangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, context);
+            }
+            // Open-ended range: use sentinels to pin the query inside this key's term slice.
+            // Lower sentinel "key\0" covers value "" (inclusive). Upper sentinel "key\1" is
+            // exclusive and sits just past every "key\0<value>" encoding.
+            BytesRef lower = lowerTerm == null
+                ? new BytesRef(FlattenedFieldParser.createKeyedValue(key, ""))
+                : indexedValueForSearch(lowerTerm);
+            BytesRef upper = upperTerm == null ? new BytesRef(key + "\u0001") : indexedValueForSearch(upperTerm);
+            boolean actualIncludeLower = lowerTerm == null || includeLower;
+            boolean actualIncludeUpper = upperTerm != null && includeUpper;
+            return new TermRangeQuery(name(), lower, upper, actualIncludeLower, actualIncludeUpper);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
@@ -299,6 +299,11 @@ public final class RecordFieldMapper extends FieldMapper {
             return new BlockSourceReader.BytesRefsBlockLoader(fetcher, BlockSourceReader.lookupMatchingAll());
         }
 
+        /** Returns the configured ignore-above threshold for this field. */
+        public Mapper.IgnoreAbove ignoreAbove() {
+            return ignoreAbove;
+        }
+
         @Override
         public MappedFieldType getChildFieldType(String childPath) {
             return new KeyedRecordFieldType(name(), childPath, this);
@@ -470,6 +475,11 @@ public final class RecordFieldMapper extends FieldMapper {
     @Override
     public RootRecordFieldType fieldType() {
         return (RootRecordFieldType) super.fieldType();
+    }
+
+    /** Returns the configured depth limit for this field. */
+    public int depthLimit() {
+        return builder.depthLimit.get();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/record/RecordFieldMapper.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.record;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.FieldDataContext;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.BlockSourceReader;
+import org.elasticsearch.index.mapper.DocumentParserContext;
+import org.elasticsearch.index.mapper.DynamicFieldType;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.IndexType;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.MappingParserContext;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
+import org.elasticsearch.index.mapper.StringFieldType;
+import org.elasticsearch.index.mapper.TextParams;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldArrayContext;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldParser;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.elasticsearch.index.IndexSettings.IGNORE_ABOVE_SETTING;
+
+/**
+ * A mapper for the {@code record} field type: schema-free recursive JSON with array-of-object
+ * isolation. Phase 0 — identical indexing behaviour to {@code flattened} (leaf values encoded as
+ * {@code key\0value} keyword terms). Phase 1 will add child Lucene documents for arrays of objects,
+ * enabling correlated queries via {@code RecordQueryBuilder}.
+ *
+ * <p>Like {@code flattened}, every leaf value (regardless of its JSON type) is indexed as a keyword
+ * string. Numeric ranges and date handling are intentionally unsupported; this keeps the type
+ * schema-free without per-key type metadata.
+ */
+public final class RecordFieldMapper extends FieldMapper {
+
+    public static final String CONTENT_TYPE = "record";
+
+    /**
+     * The internal suffix for the keyed inverted-index field that stores {@code key\0value} terms.
+     * Identical to {@code FlattenedFieldMapper.KEYED_FIELD_SUFFIX} so that tooling that already
+     * understands flattened's encoding can read record fields without modification.
+     */
+    public static final String KEYED_FIELD_SUFFIX = "._keyed";
+
+    private static final int DEFAULT_DEPTH_LIMIT = 20;
+
+    private static Builder builder(Mapper in) {
+        return ((RecordFieldMapper) in).builder;
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    public static class Builder extends FieldMapper.Builder {
+
+        private final Parameter<Integer> depthLimit = Parameter.intParam(
+            "depth_limit",
+            true,
+            m -> builder(m).depthLimit.get(),
+            DEFAULT_DEPTH_LIMIT
+        ).addValidator(v -> {
+            if (v < 0) {
+                throw new IllegalArgumentException("[depth_limit] must be positive, got [" + v + "]");
+            }
+        });
+
+        private final Parameter<Boolean> indexed;
+        private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> builder(m).hasDocValues.get(), true);
+
+        private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> builder(m).nullValue.get(), null)
+            .acceptsNull();
+
+        private final Parameter<Boolean> eagerGlobalOrdinals = Parameter.boolParam(
+            "eager_global_ordinals",
+            true,
+            m -> builder(m).eagerGlobalOrdinals.get(),
+            false
+        );
+
+        private final Parameter<Integer> ignoreAbove;
+
+        private final Parameter<String> indexOptions = TextParams.keywordIndexOptions(m -> builder(m).indexOptions.get());
+        private final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.get());
+
+        private final Parameter<Boolean> splitQueriesOnWhitespace = Parameter.boolParam(
+            "split_queries_on_whitespace",
+            true,
+            m -> builder(m).splitQueriesOnWhitespace.get(),
+            false
+        );
+
+        private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+
+        private final int ignoreAboveDefault;
+
+        public Builder(final String name, IndexSettings indexSettings) {
+            this(name, Mapper.IgnoreAbove.getIgnoreAboveDefaultValue(indexSettings.getMode(), indexSettings.getIndexVersionCreated()));
+        }
+
+        Builder(String name, MappingParserContext ctx) {
+            this(name, IGNORE_ABOVE_SETTING.get(ctx.getSettings()));
+            this.indexed.setValue(ctx.getIndexSettings().isIndexDisabledByDefault() == false);
+        }
+
+        private Builder(String name, int ignoreAboveDefault) {
+            super(name);
+            this.indexed = Parameter.indexParam(m -> builder(m).indexed.get(), true);
+            this.ignoreAboveDefault = ignoreAboveDefault;
+            this.ignoreAbove = Parameter.ignoreAboveParam(m -> builder(m).ignoreAbove.get(), ignoreAboveDefault);
+        }
+
+        @Override
+        protected Parameter<?>[] getParameters() {
+            return new Parameter<?>[] {
+                indexed,
+                hasDocValues,
+                depthLimit,
+                nullValue,
+                eagerGlobalOrdinals,
+                ignoreAbove,
+                indexOptions,
+                similarity,
+                splitQueriesOnWhitespace,
+                meta };
+        }
+
+        @Override
+        public String contentType() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public RecordFieldMapper build(MapperBuilderContext context) {
+            if (multiFieldsBuilder.build(this, context).iterator().hasNext()) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field [" + leafName() + "] does not support [fields]");
+            }
+            if (copyTo.copyToFields().isEmpty() == false) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field [" + leafName() + "] does not support [copy_to]");
+            }
+            String fullName = context.buildFullName(leafName());
+            Mapper.IgnoreAbove ignoreAboveObj = new Mapper.IgnoreAbove(ignoreAbove.getValue());
+            MappedFieldType ft = new RootRecordFieldType(
+                fullName,
+                IndexType.terms(indexed.get(), hasDocValues.get()),
+                meta.get(),
+                splitQueriesOnWhitespace.get(),
+                eagerGlobalOrdinals.get(),
+                ignoreAboveObj,
+                nullValue.get(),
+                context.isSourceSynthetic()
+            );
+            return new RecordFieldMapper(leafName(), ft, builderParams(this, context), this);
+        }
+    }
+
+    public static final FieldMapper.TypeParser PARSER = new FieldMapper.TypeParser((name, ctx) -> new Builder(name, ctx));
+
+    // -------------------------------------------------------------------------
+    // Root field type (the "record" field itself)
+    // -------------------------------------------------------------------------
+
+    /**
+     * The field type for the root {@code record} field. Queries on the root field match any leaf
+     * value in the JSON object. Sub-key access ({@code record.foo.bar}) is handled by
+     * {@link #getChildFieldType(String)}, which returns a {@link KeyedRecordFieldType}.
+     */
+    public static final class RootRecordFieldType extends StringFieldType implements DynamicFieldType {
+
+        private final boolean splitQueriesOnWhitespace;
+        private final boolean eagerGlobalOrdinals;
+        private final Mapper.IgnoreAbove ignoreAbove;
+        private final String nullValue;
+        private final boolean isSyntheticSourceEnabled;
+
+        RootRecordFieldType(
+            String name,
+            IndexType indexType,
+            Map<String, String> meta,
+            boolean splitQueriesOnWhitespace,
+            boolean eagerGlobalOrdinals,
+            Mapper.IgnoreAbove ignoreAbove,
+            String nullValue,
+            boolean isSyntheticSourceEnabled
+        ) {
+            super(
+                name,
+                indexType,
+                false,
+                splitQueriesOnWhitespace ? TextSearchInfo.WHITESPACE_MATCH_ONLY : TextSearchInfo.SIMPLE_MATCH_ONLY,
+                meta
+            );
+            this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
+            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+            this.ignoreAbove = ignoreAbove;
+            this.nullValue = nullValue;
+            this.isSyntheticSourceEnabled = isSyntheticSourceEnabled;
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(SearchExecutionContext context) {
+            if (hasDocValues()) {
+                return new FieldExistsQuery(name() + KEYED_FIELD_SUFFIX);
+            }
+            return super.existsQuery(context);
+        }
+
+        @Override
+        public boolean eagerGlobalOrdinals() {
+            return eagerGlobalOrdinals;
+        }
+
+        @Override
+        public Object valueForDisplay(Object value) {
+            if (value == null) {
+                return null;
+            }
+            return ((BytesRef) value).utf8ToString();
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
+            failIfNoDocValues();
+            // Use the keyed field for fielddata so that sorting/aggs see key\0value terms,
+            // matching what flattened does when hasRootDocValues==false.
+            return new SortedSetOrdinalsIndexFieldData.Builder(
+                name() + KEYED_FIELD_SUFFIX,
+                CoreValuesSourceType.KEYWORD,
+                (dv, n) -> null   // fielddata on record root is not supported for now
+            );
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            if (format != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
+            }
+            return new SourceValueFetcher(
+                context.isSourceEnabled() ? context.sourcePath(name()) : Collections.emptySet(),
+                null,
+                context.getIndexSettings().getIgnoredSourceFormat()
+            ) {
+                @Override
+                protected Object parseSourceValue(Object value) {
+                    return value;
+                }
+            };
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            // Phase 0: always load from _source. The keyed doc-values block loader
+            // (RootFlattenedDocValuesBlockLoader) can be wired up in a follow-up.
+            ValueFetcher fetcher = new SourceValueFetcher(
+                blContext.sourcePaths(name()),
+                null,
+                blContext.indexSettings().getIgnoredSourceFormat()
+            ) {
+                @Override
+                protected Object parseSourceValue(Object value) {
+                    return value;
+                }
+            };
+            return new BlockSourceReader.BytesRefsBlockLoader(fetcher, BlockSourceReader.lookupMatchingAll());
+        }
+
+        @Override
+        public MappedFieldType getChildFieldType(String childPath) {
+            return new KeyedRecordFieldType(name(), childPath, this);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Keyed field type (record.some.key)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returned by {@link RootRecordFieldType#getChildFieldType(String)} when a user queries a
+     * specific sub-key, e.g. {@code record.user.name}. Queries are routed to the keyed inverted
+     * index ({@code record._keyed}) using the {@code key\0value} encoding.
+     */
+    public static final class KeyedRecordFieldType extends StringFieldType {
+
+        private final String key;
+        private final String rootName;
+
+        KeyedRecordFieldType(String rootName, String key, RootRecordFieldType root) {
+            super(
+                rootName + KEYED_FIELD_SUFFIX,
+                root.indexType(),
+                false,
+                root.splitQueriesOnWhitespace ? TextSearchInfo.WHITESPACE_MATCH_ONLY : TextSearchInfo.SIMPLE_MATCH_ONLY,
+                root.meta()
+            );
+            this.key = key;
+            this.rootName = rootName;
+        }
+
+        public String key() {
+            return key;
+        }
+
+        public String rootName() {
+            return rootName;
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        protected BytesRef indexedValueForSearch(Object value) {
+            String keyedValue = FlattenedFieldParser.createKeyedValue(key, value.toString());
+            return new BytesRef(keyedValue);
+        }
+
+        @Override
+        public Query existsQuery(SearchExecutionContext context) {
+            // Match any term with the prefix "key\0" — i.e. any value under this key.
+            String keyPrefix = FlattenedFieldParser.createKeyedValue(key, ""); // "key\0"
+            BytesRef lower = new BytesRef(keyPrefix);
+            // Exclusive upper: bump the last byte (\0) to \1 so the range covers key\0anything.
+            BytesRef upper = new BytesRef(keyPrefix);
+            upper.bytes[upper.offset + upper.length - 1] = (byte) 0x01;
+            return new TermRangeQuery(name(), lower, upper, true, false);
+        }
+
+        @Override
+        public Query prefixQuery(
+            String value,
+            MultiTermQuery.RewriteMethod method,
+            boolean caseInsensitive,
+            SearchExecutionContext context
+        ) {
+            // Prefix on a keyed field: "key\0value_prefix"
+            String keyedPrefix = FlattenedFieldParser.createKeyedValue(key, value);
+            PrefixQuery query = method == null
+                ? new PrefixQuery(new Term(name(), keyedPrefix))
+                : new PrefixQuery(new Term(name(), keyedPrefix), method);
+            return query;
+        }
+
+        @Override
+        public Query rangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            SearchExecutionContext context
+        ) {
+            // Values are stored as keyword strings, so string range.
+            String lower = lowerTerm == null
+                ? FlattenedFieldParser.createKeyedValue(key, "")
+                : FlattenedFieldParser.createKeyedValue(key, lowerTerm.toString());
+            String upper = upperTerm == null
+                ? FlattenedFieldParser.createKeyedValue(key, "￿￿")
+                : FlattenedFieldParser.createKeyedValue(key, upperTerm.toString());
+            // When the lower is the key prefix (open range), include it.
+            boolean actualIncludeLower = lowerTerm == null ? true : includeLower;
+            boolean actualIncludeUpper = upperTerm == null ? false : includeUpper;
+            return new TermRangeQuery(name(), new BytesRef(lower), new BytesRef(upper), actualIncludeLower, actualIncludeUpper);
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
+            failIfNoDocValues();
+            return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, (dv, n) -> null);
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            // Values for a specific key are fetched from _source.
+            throw new IllegalArgumentException(
+                "Field ["
+                    + rootName
+                    + "."
+                    + key
+                    + "] of type ["
+                    + typeName()
+                    + "] does not support [fields] retrieval directly; "
+                    + "retrieve the parent field ["
+                    + rootName
+                    + "] instead."
+            );
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            // Phase 0: not yet wired to keyed doc-values block loader.
+            throw new UnsupportedOperationException("blockLoader not yet supported for keyed record fields");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Mapper itself
+    // -------------------------------------------------------------------------
+
+    private final Builder builder;
+    private final FlattenedFieldParser fieldParser;
+
+    private RecordFieldMapper(String leafName, MappedFieldType mappedFieldType, BuilderParams builderParams, Builder builder) {
+        super(leafName, mappedFieldType, builderParams);
+        this.builder = builder;
+        this.fieldParser = new FlattenedFieldParser(
+            mappedFieldType.name(),
+            mappedFieldType.name() + KEYED_FIELD_SUFFIX,
+            // No ignored-values field for Phase 0 (no synthetic source support yet).
+            mappedFieldType.name() + KEYED_FIELD_SUFFIX + "._ignored",
+            mappedFieldType,
+            builder.depthLimit.get(),
+            builder.ignoreAbove.get(),
+            builder.nullValue.get(),
+            /* usesBinaryDocValues= */ false,
+            /* hasRootDocValues= */ false,
+            /* mappedSubFields= */ Collections.emptyMap(),
+            /* storeIgnoredFieldsInBinaryDocValues= */ false,
+            /* preserveLeafArrays= */ null,     // LOSSY — no array-order tracking in Phase 0
+            /* indexVersion= */ IndexVersion.current(),
+            /* writeDimensionRouting= */ false,
+            /* usesArrayOrderBinaryDocValues= */ false
+        );
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public Map<String, NamedAnalyzer> indexAnalyzers() {
+        return Map.of(mappedFieldType.name(), Lucene.KEYWORD_ANALYZER);
+    }
+
+    @Override
+    public RootRecordFieldType fieldType() {
+        return (RootRecordFieldType) super.fieldType();
+    }
+
+    @Override
+    protected boolean supportsParsingObject() {
+        return true;
+    }
+
+    @Override
+    protected void parseCreateField(DocumentParserContext context) throws IOException {
+        if (context.parser().currentToken() == XContentParser.Token.VALUE_NULL) {
+            return;
+        }
+
+        if (mappedFieldType.indexType() == IndexType.NONE) {
+            context.parser().skipChildren();
+            return;
+        }
+
+        try {
+            context.path().setWithinLeafObject(true);
+            // FlattenedFieldParser traverses the JSON object recursively, encoding every leaf as
+            // a key\0value term. For Phase 0 we pass null for the array-offset context (LOSSY
+            // array handling) — arrays of scalars are fine; arrays of objects lose object identity.
+            fieldParser.parse(context, (FlattenedFieldArrayContext) null);
+        } finally {
+            context.path().setWithinLeafObject(false);
+        }
+
+        if (mappedFieldType.hasDocValues() == false) {
+            context.addToFieldNames(fieldType().name());
+        }
+    }
+
+    @Override
+    public FieldMapper.Builder getMergeBuilder() {
+        Builder b = new Builder(leafName(), builder.ignoreAboveDefault);
+        b.init(this);
+        return b;
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport() {
+        // Phase 0: no native synthetic source loader; fall back to storing _source.
+        return super.syntheticSourceSupport();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
+import org.elasticsearch.index.mapper.record.RecordFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.VectorsFormatProvider;
@@ -217,6 +218,7 @@ public class IndicesModule extends AbstractModule {
 
         mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
         mappers.put(FlattenedFieldMapper.CONTENT_TYPE, FlattenedFieldMapper.PARSER);
+        mappers.put(RecordFieldMapper.CONTENT_TYPE, RecordFieldMapper.PARSER);
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, GeoPointFieldMapper.PARSER);
         mappers.put(IpFieldMapper.CONTENT_TYPE, IpFieldMapper.PARSER);
         mappers.put(KeywordFieldMapper.CONTENT_TYPE, KeywordFieldMapper.PARSER);

--- a/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldMapperTests.java
@@ -103,15 +103,12 @@ public class RecordFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));
 
-        // Root inverted-index term
+        // Root inverted-index term (no doc values on root — hasRootDocValues=false)
         List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(2, fields.size());
+        assertEquals(1, fields.size());
         assertEquals(new BytesRef("value"), fields.get(0).binaryValue());
         assertFalse(fields.get(0).fieldType().stored());
         assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
-
-        assertEquals(new BytesRef("value"), fields.get(1).binaryValue());
-        assertEquals(DocValuesType.SORTED_SET, fields.get(1).fieldType().docValuesType());
 
         // Keyed inverted-index term
         List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
@@ -142,10 +139,11 @@ public class RecordFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").array("tags", "a", "b", "c").endObject()));
 
         List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
-        long matches = keyedFields.stream().filter(f -> f.binaryValue() != null).filter(f -> {
-            String s = f.binaryValue().utf8ToString();
-            return s.startsWith("tags\0");
-        }).count();
+        long matches = keyedFields.stream()
+            .filter(f -> f.binaryValue() != null)
+            .filter(f -> f.fieldType().docValuesType() == DocValuesType.NONE)
+            .filter(f -> f.binaryValue().utf8ToString().startsWith("tags\0"))
+            .count();
         assertThat("expected three keyed entries for tags array", matches, equalTo(3L));
     }
 
@@ -184,7 +182,7 @@ public class RecordFieldMapperTests extends MapperTestCase {
                 source(b -> b.startObject("field").startObject("a").startObject("b").field("c", "v").endObject().endObject().endObject())
             )
         );
-        assertThat(e.getMessage(), containsString("depth_limit"));
+        assertThat(e.getCause().getMessage(), containsString("depth limit"));
     }
 
     public void testIgnoreAbove() throws Exception {
@@ -264,6 +262,12 @@ public class RecordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected boolean supportsDocValuesSkippers() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsSearchLookup() {
+        // fielddataBuilder does not provide a script factory in Phase 0
         return false;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldMapperTests.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.record;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentParsingException;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.LuceneDocument;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.junit.AssumptionViolatedException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RecordFieldMapperTests extends MapperTestCase {
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", "record");
+    }
+
+    @Override
+    protected Object getSampleValueForDocument() {
+        return Map.of("key", "value");
+    }
+
+    @Override
+    protected Object getSampleObjectForDocument() {
+        return getSampleValueForDocument();
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker checker) throws IOException {
+        checker.registerConflictCheck("doc_values", b -> b.field("doc_values", false));
+        checker.registerConflictCheck("index", b -> b.field("index", false));
+        checker.registerConflictCheck("index_options", b -> b.field("index_options", "freqs"));
+        checker.registerConflictCheck("null_value", b -> b.field("null_value", "foo"));
+        checker.registerConflictCheck("similarity", b -> b.field("similarity", "boolean"));
+
+        checker.registerUpdateCheck(
+            "eager_global_ordinals",
+            b -> b.field("eager_global_ordinals", true),
+            m -> assertTrue(m.fieldType().eagerGlobalOrdinals())
+        );
+        checker.registerUpdateCheck(
+            "ignore_above",
+            b -> b.field("ignore_above", 256),
+            m -> assertEquals(256, ((RecordFieldMapper) m).fieldType().ignoreAbove().get())
+        );
+        checker.registerUpdateCheck(
+            "split_queries_on_whitespace",
+            b -> b.field("split_queries_on_whitespace", true),
+            m -> assertEquals("_whitespace", m.fieldType().getTextSearchInfo().searchAnalyzer().name())
+        );
+        checker.registerUpdateCheck(
+            "depth_limit",
+            b -> b.field("depth_limit", 10),
+            m -> assertEquals(10, ((RecordFieldMapper) m).depthLimit())
+        );
+    }
+
+    @Override
+    protected void assertExistsQuery(MappedFieldType fieldType, Query query, LuceneDocument fields) {
+        if (fieldType.hasDocValues()) {
+            assertThat(query, instanceOf(FieldExistsQuery.class));
+            assertEquals("field._keyed", ((FieldExistsQuery) query).getField());
+        } else {
+            super.assertExistsQuery(fieldType, query, fields);
+        }
+    }
+
+    @Override
+    protected boolean supportsStoredFields() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsIgnoreMalformed() {
+        return false;
+    }
+
+    public void testDefaults() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));
+
+        // Root inverted-index term
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals(new BytesRef("value"), fields.get(0).binaryValue());
+        assertFalse(fields.get(0).fieldType().stored());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
+
+        assertEquals(new BytesRef("value"), fields.get(1).binaryValue());
+        assertEquals(DocValuesType.SORTED_SET, fields.get(1).fieldType().docValuesType());
+
+        // Keyed inverted-index term
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(2, keyedFields.size());
+        assertEquals(new BytesRef("key\0value"), keyedFields.get(0).binaryValue());
+        assertEquals(DocValuesType.NONE, keyedFields.get(0).fieldType().docValuesType());
+        assertEquals(new BytesRef("key\0value"), keyedFields.get(1).binaryValue());
+        assertEquals(DocValuesType.SORTED_SET, keyedFields.get(1).fieldType().docValuesType());
+
+        // No field-names field when doc values are present
+        assertEquals(0, parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME).size());
+    }
+
+    public void testRecursiveObject() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument parsedDoc = mapper.parse(
+            source(b -> b.startObject("field").startObject("nested").field("key", "value").endObject().endObject())
+        );
+
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        // Expect "nested.key\0value"
+        boolean found = keyedFields.stream().anyMatch(f -> new BytesRef("nested.key\0value").equals(f.binaryValue()));
+        assertTrue("expected keyed term nested.key\\0value in " + keyedFields, found);
+    }
+
+    public void testArrayOfScalars() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").array("tags", "a", "b", "c").endObject()));
+
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        long matches = keyedFields.stream().filter(f -> f.binaryValue() != null).filter(f -> {
+            String s = f.binaryValue().utf8ToString();
+            return s.startsWith("tags\0");
+        }).count();
+        assertThat("expected three keyed entries for tags array", matches, equalTo(3L));
+    }
+
+    public void testNullValueField() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "record");
+            b.field("null_value", "NULL");
+        }));
+        ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").nullField("key").endObject()));
+
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        boolean found = keyedFields.stream().anyMatch(f -> new BytesRef("key\0NULL").equals(f.binaryValue()));
+        assertTrue("expected null_value substitution key\\0NULL", found);
+    }
+
+    public void testNullFieldValue() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument parsedDoc = mapper.parse(source(b -> b.nullField("field")));
+        assertEquals(0, parsedDoc.rootDoc().getFields("field").size());
+        assertEquals(0, parsedDoc.rootDoc().getFields("field._keyed").size());
+    }
+
+    public void testDepthLimit() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "record");
+            b.field("depth_limit", 2);
+        }));
+
+        // depth 1: {a: {b: "v"}} — key path "a.b", depth 2 from root — should be accepted
+        mapper.parse(source(b -> b.startObject("field").startObject("a").field("b", "v").endObject().endObject()));
+
+        // depth 2: {a: {b: {c: "v"}}} — key path "a.b.c", depth 3 — should be rejected
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(
+                source(b -> b.startObject("field").startObject("a").startObject("b").field("c", "v").endObject().endObject().endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("depth_limit"));
+    }
+
+    public void testIgnoreAbove() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "record");
+            b.field("ignore_above", 5);
+        }));
+        ParsedDocument parsedDoc = mapper.parse(
+            source(b -> b.startObject("field").field("short", "ab").field("long", "toolong").endObject())
+        );
+
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        boolean hasShort = keyedFields.stream()
+            .anyMatch(f -> f.binaryValue() != null && f.binaryValue().utf8ToString().startsWith("short\0"));
+        boolean hasLong = keyedFields.stream()
+            .anyMatch(f -> f.binaryValue() != null && f.binaryValue().utf8ToString().startsWith("long\0"));
+        assertTrue("value under ignore_above should be indexed", hasShort);
+        assertFalse("value exceeding ignore_above should be dropped", hasLong);
+    }
+
+    public void testNoMultiFields() throws Exception {
+        Exception e = expectThrows(Exception.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "record");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("does not support [fields]"));
+    }
+
+    public void testNoCopyTo() throws Exception {
+        Exception e = expectThrows(Exception.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "record");
+            b.array("copy_to", "other_field");
+        })));
+        assertThat(e.getMessage(), containsString("does not support [copy_to]"));
+    }
+
+    public void testExistsQueryDocValuesDisabled() throws IOException {
+        var mapperService = createMapperService(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("doc_values", false);
+        }));
+        assertExistsQuery(mapperService);
+    }
+
+    public void testSubKeyFieldType() throws IOException {
+        var mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        MappedFieldType root = mapperService.fieldType("field");
+        assertThat(root, instanceOf(RecordFieldMapper.RootRecordFieldType.class));
+
+        MappedFieldType keyed = mapperService.fieldType("field.some.path");
+        assertThat(keyed, instanceOf(RecordFieldMapper.KeyedRecordFieldType.class));
+        assertEquals("some.path", ((RecordFieldMapper.KeyedRecordFieldType) keyed).key());
+    }
+
+    @Override
+    protected Object generateRandomInputValue(MappedFieldType ft) {
+        assumeFalse("not implemented", true);
+        return null;
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
+        throw new AssumptionViolatedException("not supported");
+    }
+
+    @Override
+    protected IngestScriptSupport ingestScriptSupport() {
+        throw new AssumptionViolatedException("not supported");
+    }
+
+    @Override
+    protected List<SortShortcutSupport> getSortShortcutSupport() {
+        return List.of(new SortShortcutSupport(this::minimalMapping, this::writeField, true));
+    }
+
+    @Override
+    protected boolean supportsDocValuesSkippers() {
+        return false;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldSearchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/record/RecordFieldSearchTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.record;
+
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
+import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
+import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
+
+public class RecordFieldSearchTests extends ESSingleNodeTestCase {
+
+    @Before
+    public void setUpIndex() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("attributes")
+            .field("type", "record")
+            .field("split_queries_on_whitespace", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        createIndex("test", Settings.EMPTY, mapping);
+    }
+
+    public void testTermQueryOnRoot() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .field("env", "prod")
+                    .field("region", "eu-west")
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes", "prod")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes", "missing")), 0L);
+    }
+
+    public void testTermQueryOnSubKey() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .field("env", "prod")
+                    .field("region", "eu-west")
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.env", "prod")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.region", "prod")), 0L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.nonexistent", "prod")), 0L);
+    }
+
+    public void testRecursiveObjectQuery() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .startObject("host")
+                    .field("name", "node-1")
+                    .field("ip", "10.0.0.1")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        // Querying a nested key via dotted path
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.host.name", "node-1")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.host.ip", "10.0.0.1")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.host.name", "node-2")), 0L);
+    }
+
+    public void testExistsQuery() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(XContentFactory.jsonBuilder().startObject().startObject("attributes").field("env", "prod").endObject().endObject())
+            .get();
+        prepareIndex("test").setId("2")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(XContentFactory.jsonBuilder().startObject().field("other", "value").endObject())
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(existsQuery("attributes")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(existsQuery("attributes.env")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(existsQuery("attributes.nonexistent")), 0L);
+    }
+
+    public void testPrefixQuery() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder().startObject().startObject("attributes").field("version", "v1.2.3").endObject().endObject()
+            )
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(prefixQuery("attributes.version", "v1")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(prefixQuery("attributes.version", "v2")), 0L);
+    }
+
+    public void testRangeQuery() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(XContentFactory.jsonBuilder().startObject().startObject("attributes").field("priority", "5").endObject().endObject())
+            .get();
+
+        // Values are always strings; range is lexicographic
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(rangeQuery("attributes.priority").gte("3").lte("7")), 1);
+        assertHitCountAndNoFailures(client().prepareSearch("test").setQuery(rangeQuery("attributes.priority").gte("6").lte("9")), 0);
+    }
+
+    public void testScalarArrayValues() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .array("tags", "alpha", "beta", "gamma")
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.tags", "alpha")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.tags", "beta")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.tags", "missing")), 0L);
+    }
+
+    public void testMixedNestedStructure() throws Exception {
+        prepareIndex("test").setId("1")
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .field("env", "staging")
+                    .startObject("build")
+                    .field("version", "2.0")
+                    .field("commit", "abc123")
+                    .endObject()
+                    .array("owners", "alice", "bob")
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.env", "staging")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.build.version", "2.0")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.build.commit", "abc123")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.owners", "alice")), 1L);
+        assertHitCount(client().prepareSearch("test").setQuery(termQuery("attributes.owners", "bob")), 1L);
+    }
+}


### PR DESCRIPTION
Adds a new `record` field type that sits alongside `flattened` but handles recursive JSON — nested objects and arrays of objects — without requiring any subfield mappings.

The motivating gap is in the mapping type matrix:

|                 | flat          | recursive           |
|-----------------|---------------|---------------------|
| schema-aware    | *(scalars)*   | `object`, `nested`  |
| schema-free     | `flattened`   | **`record`** (new)  |

`flattened` avoids mapping explosion for objects with unknown keys, but it only works cleanly when the values are scalars. Arrays of objects silently lose object identity: given

```json
{
  "people": [
    { "name": "Alice", "age": 20 },
    { "name": "Bob",   "age": 40 }
  ]
}
```

a `flattened` field indexes `people.name → {Alice, Bob}` and `people.age → {20, 40}` independently, so `people.name:Alice AND people.age:40` matches when it should not. `nested` would fix the correlation but requires an explicit mapping for every subfield — exactly the mapping explosion that `flattened` exists to avoid.

`record` is schema-free like `flattened` — one mapping entry, no subfields required, arbitrary dynamic keys, recursive objects and arrays of any depth — with the goal of eventually supporting correlated queries across object-array elements. This PR establishes the foundation.

**What `record` does now:** identical indexing to `flattened`. Leaf values are encoded as `key\0value` keyword terms in `<field>._keyed` and as `SortedSetDocValues`. Sub-key queries (`record.user.name: alice`) work via `DynamicFieldType`. Supported parameters: `depth_limit`, `ignore_above`, `null_value`, `index`, `doc_values`, `split_queries_on_whitespace`, `eager_global_ordinals`, `meta`.

**What comes next (not in this PR):** emit one child `LuceneDocument` per element of an object array, stored under an internal `<field>._record` field. A `record` query builder wrapping `ESToParentBlockJoinQuery` provides correlated filtering. The root document keeps the full `_keyed` representation so that uncorrelated `term`/`prefix`/`range`/aggregation usage continues to work without the join overhead.

## Changes

- **`flattened/FlattenedFieldParser`**: make the class, its constructor, and the five static encoding helpers (`SEPARATOR`, `SEPARATOR_BYTE`, `createKeyedValue`, `extractKey`, `extractValue`) public. No behaviour change; this lets `RecordFieldMapper` reuse the `key\0value` machinery without duplication.
- **`record/RecordFieldMapper`** (new): the `record` mapper. `RootRecordFieldType` implements `DynamicFieldType` so sub-key field resolution (`record.foo.bar`) works without mapped subfields. `KeyedRecordFieldType` routes `term`, `prefix`, `range`, and `exists` queries to the `_keyed` inverted index using the `key\0value` encoding from `FlattenedFieldParser`. All leaf indexing delegates to `FlattenedFieldParser`.
- **`IndicesModule`**: register `record` in the mapper registry.
