### PR TITLE
Unmute org.elasticsearch.xpack.stateless.CorruptionIT.testConcurrentOperations

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -758,9 +758,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.FromDatasetIT
   method: testAbsentDeclaredColumnEmitsResponseWarningNdjson
   issue: https://github.com/elastic/elasticsearch/issues/157593
-- class: org.elasticsearch.xpack.stateless.CorruptionIT
-  method: testConcurrentOperations
-  issue: https://github.com/elastic/elasticsearch/issues/157629
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testTargetWillTransitionToSplitIfSearchShardsActiveTimesOut
   issue: https://github.com/elastic/elasticsearch/issues/157680


### PR DESCRIPTION
It was fixed but not unmuted in #157750.

Fixes #157629
