### PR TITLE
[GCS Snapshots] restrict response fields and align page metering

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -190,6 +190,24 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         assertEquals("should delete all blobs", 0, container.listBlobsByPrefix(purpose, blobNamePrefix).size());
     }
 
+    public void testListBlobsRequestsRestrictedFields() throws IOException {
+        final var repoName = createRepository(randomRepositoryName(), false);
+        final var repositoriesService = internalCluster().getAnyMasterNodeInstance(RepositoriesService.class);
+        final var repository = (BlobStoreRepository) repositoriesService.repository(repoName);
+        final var container = repository.blobStore().blobContainer(repository.basePath());
+
+        final var purpose = randomPurpose();
+        final int blobSize = randomIntBetween(1, 512);
+        final var blobName = "list-fields-test-" + randomIdentifier();
+        container.writeBlob(purpose, blobName, randomBytesReference(blobSize), false);
+
+        final var listed = container.listBlobsByPrefix(purpose, "list-fields-test-");
+        assertEquals("one blob was written", 1, listed.size());
+        assertEquals("size must be correctly read from the restricted-field response", blobSize, listed.get(blobName).length());
+
+        container.deleteBlobsIgnoringIfNotExists(purpose, List.of(blobName).iterator());
+    }
+
     public void testChunkSize() {
         // default chunk size
         RepositoryMetadata repositoryMetadata = new RepositoryMetadata("repo", GoogleCloudStorageRepository.TYPE, Settings.EMPTY);

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -16,6 +16,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.RequestBody;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobField;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageClass;
@@ -104,6 +105,13 @@ class GoogleCloudStorageBlobStore implements BlobStore {
 
     // MAX deletes per batch is 100 https://docs.cloud.google.com/storage/docs/batch#overview
     public static final int MAX_DELETES_PER_BATCH = 100;
+
+    /**
+     * Restricts list responses to fields actually used by this class. {@link BlobListOption#fields} unconditionally
+     * injects {@code nextPageToken} and {@code prefixes} and always includes {@link BlobField#NAME} and
+     * {@link BlobField#BUCKET}, so pagination and {@link Blob#isDirectory()} are unaffected.
+     */
+    private static final BlobListOption LIST_FIELDS = BlobListOption.fields(BlobField.SIZE);
 
     /**
      * Storage classes that may be configured for snapshot blob uploads.
@@ -295,7 +303,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     Map<String, BlobMetadata> listBlobsByPrefix(OperationPurpose purpose, String path, String prefix) throws IOException {
         final String pathPrefix = buildKey(path, prefix);
         final Map<String, BlobMetadata> mapBuilder = new HashMap<>();
-        client().meteredList(purpose, bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathPrefix))
+        client().meteredList(purpose, bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathPrefix), LIST_FIELDS)
             .iterateAll()
             .forEach(blob -> {
                 assert blob.getName().startsWith(path);
@@ -310,7 +318,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     Map<String, BlobContainer> listChildren(OperationPurpose purpose, BlobPath path) throws IOException {
         final String pathStr = path.buildAsString();
         final Map<String, BlobContainer> mapBuilder = new HashMap<>();
-        client().meteredList(purpose, bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathStr))
+        client().meteredList(purpose, bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathStr), LIST_FIELDS)
             .iterateAll()
             .forEach(blob -> {
                 if (blob.isDirectory()) {
@@ -724,7 +732,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
      */
     DeleteResult deleteDirectory(OperationPurpose purpose, String pathStr) throws IOException {
         DeleteResult deleteResult = DeleteResult.ZERO;
-        MeteredStorage.MeteredBlobPage meteredPage = client().meteredList(purpose, bucketName, BlobListOption.prefix(pathStr));
+        MeteredStorage.MeteredBlobPage meteredPage = client().meteredList(purpose, bucketName, BlobListOption.prefix(pathStr), LIST_FIELDS);
         do {
             final AtomicLong blobsDeleted = new AtomicLong(0L);
             final AtomicLong bytesDeleted = new AtomicLong(0L);

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
@@ -315,45 +315,43 @@ public class MeteredStorage {
             }
         }
 
+        /**
+         * Walks all pages using the already-metered {@link #getNextPage()}, so each HTTP page fetch
+         * is counted as one LIST operation rather than one operation per element.
+         */
         @Override
-        public MeteredIterableBlob iterateAll() {
-            return new MeteredIterableBlob(pages.iterateAll());
+        public Iterable<Blob> iterateAll() {
+            return () -> new Iterator<>() {
+                private MeteredBlobPage current = MeteredBlobPage.this;
+                private Iterator<Blob> values = current.pages.getValues().iterator();
+
+                @Override
+                public boolean hasNext() {
+                    while (values.hasNext() == false) {
+                        if (current.hasNextPage() == false) {
+                            return false;
+                        }
+                        current = current.getNextPage();
+                        values = current.pages.getValues().iterator();
+                    }
+                    return true;
+                }
+
+                @Override
+                public Blob next() {
+                    return values.next();
+                }
+            };
         }
 
+        /**
+         * Returns the current page's blobs directly. The page fetch itself was already metered
+         * (either via {@link MeteredStorage#meteredList} for the first page, or via
+         * {@link #getNextPage()} for subsequent pages), so per-element metering is unnecessary.
+         */
         @Override
-        public MeteredIterableBlob getValues() {
-            return new MeteredIterableBlob(pages.getValues());
-        }
-
-        public class MeteredIterator implements Iterator<Blob> {
-            final Iterator<Blob> iterator;
-
-            MeteredIterator(Iterator<Blob> iterator) {
-                this.iterator = iterator;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return statsCollector.collectSupplier(purpose, LIST, iterator::hasNext);
-            }
-
-            @Override
-            public Blob next() {
-                return statsCollector.collectSupplier(purpose, LIST, iterator::next);
-            }
-        }
-
-        public class MeteredIterableBlob implements Iterable<Blob> {
-            final Iterable<Blob> iterable;
-
-            MeteredIterableBlob(Iterable<Blob> iterable) {
-                this.iterable = iterable;
-            }
-
-            @Override
-            public Iterator<Blob> iterator() {
-                return new MeteredIterator(iterable.iterator());
-            }
+        public Iterable<Blob> getValues() {
+            return pages.getValues();
         }
     }
 

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -36,9 +36,11 @@ import java.net.URLDecoder;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -126,6 +128,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                 final int maxResults = Integer.parseInt(params.getOrDefault("maxResults", String.valueOf(defaultPageLimit.get())));
                 final String delimiter = params.getOrDefault("delimiter", "");
                 final String pageToken = params.get("pageToken");
+                final Set<String> requestedItemFields = parseRequestedItemFields(params.get("fields"));
 
                 final MockGcsBlobStore.PageOfBlobs pageOfBlobs;
                 if (pageToken != null) {
@@ -134,7 +137,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                     pageOfBlobs = mockGcsBlobStore.listBlobs(maxResults, delimiter, prefix);
                 }
 
-                ListBlobsResponse response = new ListBlobsResponse(bucket, pageOfBlobs);
+                ListBlobsResponse response = new ListBlobsResponse(bucket, pageOfBlobs, requestedItemFields);
                 try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
                     response.toXContent(builder, ToXContent.EMPTY_PARAMS);
                     BytesReference responseBytes = BytesReference.bytes(builder);
@@ -324,7 +327,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                     builder.field("done", done);
                     if (done) {
                         assert rewriteResponse.dstBlob() != null;
-                        writeBlobAsXContent(rewriteResponse.dstBlob(), builder, bucket, "resource");
+                        writeBlobAsXContent(rewriteResponse.dstBlob(), builder, bucket, "resource", null);
                     } else {
                         builder.field("rewriteToken", rewriteResponse.rewriteToken());
                     }
@@ -460,7 +463,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
 
     private void writeBlobVersionAsJson(HttpExchange exchange, MockGcsBlobStore.BlobVersion newBlobVersion) throws IOException {
         try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
-            writeBlobAsXContent(newBlobVersion, builder, bucket, null);
+            writeBlobAsXContent(newBlobVersion, builder, bucket, null, null);
             BytesReference responseBytes = BytesReference.bytes(builder);
             exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
             exchange.sendResponseHeaders(RestStatus.OK.getStatus(), responseBytes.length());
@@ -583,7 +586,9 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         }).orElseThrow(() -> failAndThrow("Empty batch item"));
     }
 
-    record ListBlobsResponse(String bucket, MockGcsBlobStore.PageOfBlobs pageOfBlobs) implements ToXContent {
+    record ListBlobsResponse(String bucket, MockGcsBlobStore.PageOfBlobs pageOfBlobs, @Nullable Set<String> requestedItemFields)
+        implements
+            ToXContent {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -594,7 +599,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
             }
             builder.startArray("items");
             for (MockGcsBlobStore.BlobVersion blobVersion : pageOfBlobs().blobs()) {
-                writeBlobAsXContent(blobVersion, builder, bucket, null);
+                writeBlobAsXContent(blobVersion, builder, bucket, null, requestedItemFields);
             }
             builder.endArray();
             builder.field("prefixes", pageOfBlobs.prefixes());
@@ -607,7 +612,8 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         MockGcsBlobStore.BlobVersion blobVersion,
         XContentBuilder builder,
         String bucket,
-        @Nullable String fieldName
+        @Nullable String fieldName,
+        @Nullable Set<String> requestedItemFields
     ) throws IOException {
         if (fieldName == null) {
             builder.startObject();
@@ -617,14 +623,49 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         builder.field("kind", "storage#object");
         builder.field("bucket", bucket);
         builder.field("name", blobVersion.path());
-        builder.field("id", blobVersion.path());
-        builder.field("size", String.valueOf(blobVersion.contents().length()));
-        builder.field("generation", String.valueOf(blobVersion.generation()));
-        builder.field("updated", ISO_MILLIS_UTC.format(blobVersion.lastModified()));
-        if (blobVersion.storageClass() != null) {
+        if (requestedItemFields == null || requestedItemFields.contains("id")) {
+            builder.field("id", blobVersion.path());
+        }
+        if (requestedItemFields == null || requestedItemFields.contains("size")) {
+            builder.field("size", String.valueOf(blobVersion.contents().length()));
+        }
+        if (requestedItemFields == null || requestedItemFields.contains("generation")) {
+            builder.field("generation", String.valueOf(blobVersion.generation()));
+        }
+        if (requestedItemFields == null || requestedItemFields.contains("updated")) {
+            builder.field("updated", ISO_MILLIS_UTC.format(blobVersion.lastModified()));
+        }
+        if (blobVersion.storageClass() != null && (requestedItemFields == null || requestedItemFields.contains("storageClass"))) {
             builder.field("storageClass", blobVersion.storageClass());
         }
         builder.endObject();
+    }
+
+    /**
+     * Parses the GCS {@code fields} query parameter to extract the set of per-item field names.
+     * Returns {@code null} when no restriction is requested (emit all fields).
+     * Handles both {@code items(name,size)} and {@code items/name,items/size} formats.
+     */
+    @Nullable
+    static Set<String> parseRequestedItemFields(@Nullable String fields) {
+        if (fields == null) {
+            return null;
+        }
+        var result = new HashSet<String>();
+        var matcher = FIELDS_ITEMS_PATTERN.matcher(fields);
+        if (matcher.find()) {
+            for (var f : matcher.group(1).split(",")) {
+                result.add(f.trim());
+            }
+        } else {
+            for (var token : fields.split(",")) {
+                token = token.trim();
+                if (token.startsWith("items/")) {
+                    result.add(token.substring("items/".length()));
+                }
+            }
+        }
+        return result;
     }
 
     private void sendError(HttpExchange exchange, MockGcsBlobStore.GcsRestException e) throws IOException {
@@ -664,6 +705,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
     }
 
     private static final Pattern STORAGE_CLASS_PATTERN = Pattern.compile("\"storageClass\"\\s*:\\s*\"([^\"]*)\"");
+    private static final Pattern FIELDS_ITEMS_PATTERN = Pattern.compile("items\\(([^)]+)\\)");
 
     /**
      * Extracts the {@code storageClass} field from a request body containing GCS object metadata JSON. The body may be gzip-compressed

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -673,6 +673,66 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertEquals(Set.of("e/g/"), new HashSet<>(jsonMapView.get("prefixes")));
     }
 
+    public void testListBlobsHonoursFieldsParam() {
+        final var bucket = randomIdentifier();
+        final var handler = new GoogleCloudStorageHttpHandler(bucket);
+        final var blobName = randomIdentifier();
+        final int blobSize = randomIntBetween(1, 1024);
+
+        assertEquals(
+            RestStatus.OK,
+            executeMultipartUpload(handler, bucket, blobName, randomBytesReference(blobSize), null).restStatus()
+        );
+
+        // Without a fields restriction every standard field is present
+        final var fullResponse = handleRequest(
+            handler,
+            "GET",
+            "/storage/v1/b/" + bucket + "/o" + generateQueryString("prefix", blobName)
+        );
+        assertEquals(RestStatus.OK, fullResponse.restStatus());
+        final var fullJson = XContentTestUtils.createJsonMapView(new ByteArrayInputStream(BytesReference.toBytes(fullResponse.body())));
+        final var fullItem = (Map<?, ?>) ((List<?>) fullJson.get("items")).get(0);
+        assertTrue("expected 'id' in unrestricted response", fullItem.containsKey("id"));
+        assertTrue("expected 'generation' in unrestricted response", fullItem.containsKey("generation"));
+        assertTrue("expected 'updated' in unrestricted response", fullItem.containsKey("updated"));
+
+        // With a fields restriction only the requested fields appear in items
+        final var restrictedResponse = handleRequest(
+            handler,
+            "GET",
+            "/storage/v1/b/" + bucket + "/o"
+                + generateQueryString("prefix", blobName, "fields", "items/name,items/size,nextPageToken,prefixes")
+        );
+        assertEquals(RestStatus.OK, restrictedResponse.restStatus());
+        final var restrictedJson = XContentTestUtils.createJsonMapView(
+            new ByteArrayInputStream(BytesReference.toBytes(restrictedResponse.body()))
+        );
+        final var restrictedItem = (Map<?, ?>) ((List<?>) restrictedJson.get("items")).get(0);
+        assertTrue("expected 'name' in restricted response", restrictedItem.containsKey("name"));
+        assertTrue("expected 'size' in restricted response", restrictedItem.containsKey("size"));
+        assertEquals("size must match upload", String.valueOf(blobSize), restrictedItem.get("size"));
+        assertFalse("unexpected 'id' in restricted response", restrictedItem.containsKey("id"));
+        assertFalse("unexpected 'generation' in restricted response", restrictedItem.containsKey("generation"));
+        assertFalse("unexpected 'updated' in restricted response", restrictedItem.containsKey("updated"));
+    }
+
+    public void testParseRequestedItemFields() {
+        assertNull(GoogleCloudStorageHttpHandler.parseRequestedItemFields(null));
+
+        // slash-separated format sent by the GCS SDK
+        assertEquals(
+            Set.of("name", "size"),
+            GoogleCloudStorageHttpHandler.parseRequestedItemFields("items/name,items/size,nextPageToken,prefixes")
+        );
+
+        // parenthesized format (alternative SDK representation)
+        assertEquals(
+            Set.of("name", "size"),
+            GoogleCloudStorageHttpHandler.parseRequestedItemFields("items(name,size),nextPageToken,prefixes")
+        );
+    }
+
     public void testMethodBucketObjectPattern() {
         final var inputs = new String[] {
             "DELETE http://host/storage/v1/b/bucket/o/test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat?generation=1 HTTP/1.1",

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -679,17 +679,10 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         final var blobName = randomIdentifier();
         final int blobSize = randomIntBetween(1, 1024);
 
-        assertEquals(
-            RestStatus.OK,
-            executeMultipartUpload(handler, bucket, blobName, randomBytesReference(blobSize), null).restStatus()
-        );
+        assertEquals(RestStatus.OK, executeMultipartUpload(handler, bucket, blobName, randomBytesReference(blobSize), null).restStatus());
 
         // Without a fields restriction every standard field is present
-        final var fullResponse = handleRequest(
-            handler,
-            "GET",
-            "/storage/v1/b/" + bucket + "/o" + generateQueryString("prefix", blobName)
-        );
+        final var fullResponse = handleRequest(handler, "GET", "/storage/v1/b/" + bucket + "/o" + generateQueryString("prefix", blobName));
         assertEquals(RestStatus.OK, fullResponse.restStatus());
         final var fullJson = XContentTestUtils.createJsonMapView(new ByteArrayInputStream(BytesReference.toBytes(fullResponse.body())));
         final var fullItem = (Map<?, ?>) ((List<?>) fullJson.get("items")).get(0);
@@ -701,7 +694,9 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         final var restrictedResponse = handleRequest(
             handler,
             "GET",
-            "/storage/v1/b/" + bucket + "/o"
+            "/storage/v1/b/"
+                + bucket
+                + "/o"
                 + generateQueryString("prefix", blobName, "fields", "items/name,items/size,nextPageToken,prefixes")
         );
         assertEquals(RestStatus.OK, restrictedResponse.restStatus());


### PR DESCRIPTION
Request only `SIZE` from GCS list APIs, cutting ~700-1500 bytes/item of ACL and metadata overhead from every snapshot listing. For a large cluster, this is extremely significant. This also updates the mock fixture to honor the fields param so tests catch a future regression where we read a field we stopped requesting.

It also replaces per-element metering in MeteredBlobPage with per-page metering: `iterateAll()` now walks pages via the already-metered `getNextPage()` rather than calling `collectSupplier()` on every `hasNext()`/`next()` invocation. `GcsRepositoryStatsCollector` accumulates stats via a `ThreadLocal`; the old design hit it once per blob element, but
it now only hits it once per page fetch. Per page behavior matches the actual GCS operations, so it's not wildly exaggerating listing operations.

Relates to an investigation of https://github.com/elastic/elasticsearch/issues/122036 for GCS with AutoOps.