### PR TITLE
[GCS Snapshots] GCS: fix multipart chunk size; raise floor to 8 MB

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/gcs-repository-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/gcs-repository-settings.md
@@ -105,7 +105,7 @@ The following settings are supported:
 
 
 `multipart_upload_size_threshold` {applies_to}`stack: ga 9.6`
-:   The maximum size of a blob that {{es}} uploads in a single request. Blobs larger than this threshold are uploaded using [GCS resumable uploads](https://cloud.google.com/storage/docs/resumable-uploads). Defaults to `5mb`. The minimum allowed value is `5mb`.
+:   The maximum size of a blob that {{es}} uploads in a single request. Blobs larger than this threshold are uploaded using [GCS resumable uploads](https://cloud.google.com/storage/docs/resumable-uploads). Defaults to `8mb`. The minimum allowed value is `8mb`.
 
 `chunk_size`
 :   Big files can be broken down into multiple smaller blobs in the blob store during snapshotting. It is not recommended to change this value from its default unless there is an explicit reason for limiting the size of blobs in the repository. Setting a value lower than the default can result in an increased number of API calls to the Google Cloud Storage Service during snapshot create as well as restore operations compared to using the default value and thus make both operations slower as well as more costly. Specify the chunk size as a value and unit, for example: `10MB`, `5KB`, `500B`. Defaults to the maximum size of a blob in the Google Cloud Storage Service which is `5TB`.

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -120,7 +120,9 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         final String key = "es.repository_gcs.large_blob_threshold_byte_size";
         final String largeBlobThresholdByteSizeProperty = System.getProperty(key);
         if (largeBlobThresholdByteSizeProperty == null) {
-            LARGE_BLOB_THRESHOLD_BYTE_SIZE = Math.toIntExact(ByteSizeValue.of(5, ByteSizeUnit.MB).getBytes());
+            // https://docs.cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+            // 2026-08-26: "It's recommended that you use at least 8 MiB for the chunk size."
+            LARGE_BLOB_THRESHOLD_BYTE_SIZE = Math.toIntExact(ByteSizeValue.of(8, ByteSizeUnit.MB).getBytes());
         } else {
             final int largeBlobThresholdByteSize;
             try {
@@ -665,7 +667,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         if (failIfAlreadyExists) {
             throw new UnsupportedOperationException("GCS XML API multipart upload does not support failIfAlreadyExists");
         }
-        final long chunkSize = LARGE_BLOB_THRESHOLD_BYTE_SIZE;
+        final long chunkSize = getLargeBlobThresholdInBytes();
         final int nbParts = ConcurrentMultipartHelper.numberOfParts(blobSize, chunkSize);
 
         final StorageClass storageClass = resolveStorageClass(purpose);

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -95,8 +95,10 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
     // When the JVM property that overrides LARGE_BLOB_THRESHOLD_BYTE_SIZE is set (typically in tests to
     // exercise the resumable-upload path with small blobs), lower the minimum to that value so that it can
     // also be set explicitly as a repository setting.
+    // https://docs.cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+    // 2026-08-26: "It's recommended that you use at least 8 MiB for the chunk size."
     private static final ByteSizeValue MULTIPART_UPLOAD_SIZE_THRESHOLD_MIN = ByteSizeValue.of(
-        Math.min((long) GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE, ByteSizeUnit.MB.toBytes(5)),
+        Math.min((long) GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE, ByteSizeUnit.MB.toBytes(8)),
         ByteSizeUnit.BYTES
     );
 

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -190,6 +190,43 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
         testConcurrentWriteBlobAtomic(false);
     }
 
+    public void testConcurrentWriteBlobAtomicRespectsConfiguredThreshold() throws Exception {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final int nbParts = randomIntBetween(2, 5);
+        // Use a small threshold so the test doesn't depend on LARGE_BLOB_THRESHOLD_BYTE_SIZE
+        final long partSize = randomIntBetween(100, 1000);
+        // nbParts = ceil(blobSize / partSize)
+        final long blobSize = randomLongBetween((nbParts - 1) * partSize + 1, nbParts * partSize);
+        assert nbParts == (blobSize + partSize - 1) / partSize;
+
+        final MeteredStorage meteredStorage = mock(MeteredStorage.class);
+        when(meteredStorage.meteredCreateMultipartUpload(any(), any())).thenReturn(
+            CreateMultipartUploadResponse.builder().uploadId(randomAlphaOfLength(25)).build()
+        );
+        when(meteredStorage.meteredUploadPart(any(), any(), any())).thenAnswer(
+            inv -> UploadPartResponse.builder().eTag("test-etag").build()
+        );
+
+        final OperationPurpose purpose = randomPurpose();
+        try (GoogleCloudStorageBlobStore blobStore = buildBlobStore(bucketName, meteredStorage, partSize)) {
+            final ExecutorService executorService = Executors.newFixedThreadPool(1);
+            try {
+                executorService.submit(() -> {
+                    blobStore.blobContainer(BlobPath.EMPTY)
+                        .writeBlobAtomic(purpose, blobName, blobSize, (offset, length) -> new ByteArrayInputStream(new byte[0]), false, executorService);
+                    return null;
+                }).get();
+            } finally {
+                terminate(executorService);
+            }
+
+            verify(meteredStorage, times(1)).meteredCreateMultipartUpload(any(), any());
+            verify(meteredStorage, times(nbParts)).meteredUploadPart(any(), any(), any());
+            verify(meteredStorage, times(1)).meteredCompleteMultipartUpload(any(), any());
+        }
+    }
+
     private void testConcurrentWriteBlobAtomic(boolean singleThread) throws Exception {
         final String bucketName = randomAlphaOfLengthBetween(1, 10);
         final String blobName = randomAlphaOfLengthBetween(1, 10);
@@ -238,6 +275,11 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
     }
 
     private static GoogleCloudStorageBlobStore buildBlobStore(String bucketName, MeteredStorage meteredStorage) throws IOException {
+        return buildBlobStore(bucketName, meteredStorage, GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE);
+    }
+
+    private static GoogleCloudStorageBlobStore buildBlobStore(String bucketName, MeteredStorage meteredStorage, long largeBlobThresholdInBytes)
+        throws IOException {
         final GoogleCloudStorageService storageService = mock(GoogleCloudStorageService.class);
         when(storageService.client(any(), any(), any(), any())).thenReturn(meteredStorage);
         final GoogleCloudStorageClientSettings clientSettings = mock(GoogleCloudStorageClientSettings.class);
@@ -251,7 +293,7 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
             storageService,
             BigArrays.NON_RECYCLING_INSTANCE,
             randomIntBetween(1, 8) * 1024,
-            GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
+            largeBlobThresholdInBytes,
             BackoffPolicy.noBackoff(),
             new GcsRepositoryStatsCollector(),
             null,


### PR DESCRIPTION
In `writeMultipartBlob`, the part size was hardcoded to `LARGE_BLOB_THRESHOLD_BYTE_SIZE` regardless of the
`"multipart_upload_size_threshold"` setting. Raising the setting had no effect on part count or size. This now uses
`getLargeBlobThresholdInBytes()` so chunk size tracks the configured threshold.

It also raises the default and minimum for `"multipart_upload_size_threshold"` from 5 MB to 8 MB, per [GCS's recommendation of at least 8 MiB per chunk](https://docs.cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload). This makes the `"multipart_upload_size_threshold"` setting planned for GCS in 9.6 useable when actually writing multipart blobs as it previously only used the minimum.

Relates to an investigation of https://github.com/elastic/elasticsearch/issues/122036 for GCS with AutoOps, although this feature is unused given that it doesn't land until 9.6.