### PR TITLE
Specialize writeText in StreamOutput wrappers

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/TermOverridingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TermOverridingStreamOutput.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.support.master;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.Text;
 
 import java.io.IOException;
 
@@ -57,6 +58,11 @@ class TermOverridingStreamOutput extends StreamOutput {
     @Override
     public void writeGenericString(String value) throws IOException {
         delegate.writeGenericString(value);
+    }
+
+    @Override
+    public void writeText(Text text) throws IOException {
+        delegate.writeText(text);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.Text;
 
 import java.io.BufferedReader;
 import java.io.FilterInputStream;
@@ -260,6 +261,11 @@ public abstract class Streams {
         @Override
         public void writeGenericString(String value) throws IOException {
             delegate.writeGenericString(value);
+        }
+
+        @Override
+        public void writeText(Text text) throws IOException {
+            delegate.writeText(text);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.io.stream;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.Text;
 
 import java.io.IOException;
 
@@ -62,6 +63,11 @@ public final class VersionCheckingStreamOutput extends StreamOutput {
 
     @Override
     public void writeGenericString(String value) throws IOException {
+        // no-op
+    }
+
+    @Override
+    public void writeText(Text text) throws IOException {
         // no-op
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.DoubleBigArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.LongBigArrayBlock;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.Text;
 import org.elasticsearch.xpack.esql.Column;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -223,6 +224,11 @@ public final class PlanStreamOutput extends StreamOutput {
     @Override
     public void writeGenericString(String value) throws IOException {
         delegate.writeGenericString(value);
+    }
+
+    @Override
+    public void writeText(Text text) throws IOException {
+        delegate.writeText(text);
     }
 
     /**


### PR DESCRIPTION
Wrappers around a `StreamOutput` don't override `writeText`, so a wrapped stream falls back to `StreamOutput#writeText` and its scratch buffer rather than the delegate's implementation, which since #157460 encodes straight into the underlying pages or buffer.

This change forwards `writeText` to the delegate in `TermOverridingStreamOutput`, `PlanStreamOutput` and `Streams.FlushOnCloseOutputStream`, next to the `writeString` forwards they already have. `VersionCheckingStreamOutput` writes nowhere, so its `writeText` is now a no-op instead of scanning and encoding a value it discards. `BufferedChecksumStreamOutput` keeps the inherited implementation, which is already right because it routes writes through `this` so the checksum sees the bytes.

No `Text` reaches any of these today, so this is about not leaving the trap for later.

Closes #157801