### PR TITLE
Fix NPE in snapshot resiliency test helper

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -761,9 +761,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessRealTimeGetIT
   method: testDataVisibility
   issue: https://github.com/elastic/elasticsearch/issues/157732
-- class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotResiliencyWithReadFromObjectStoreTests
-  method: testSuccessfulSnapshotWithConcurrentDynamicMappingUpdates
-  issue: https://github.com/elastic/elasticsearch/issues/157733
 - class: org.elasticsearch.upgrades.DiskBBQVectorSearchIT
   issue: https://github.com/elastic/elasticsearch/issues/157744
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -725,6 +725,8 @@ public class SnapshotResiliencyTestHelper {
                 new TransportFetchPhaseResponseChunkAction(transportService, activeFetchPhaseTasks, namedWriteableRegistry);
                 Map<ActionType<?>, TransportAction<?, ?>> actions = new HashMap<>();
 
+                shardStateAction = new ShardStateAction(clusterService, transportService, allocationService, rerouteService, threadPool);
+
                 // Inject initialization from subclass which may be needed by initializations after this point.
                 doInit(actions, actionFilters);
 
@@ -736,7 +738,6 @@ public class SnapshotResiliencyTestHelper {
                     indicesService,
                     createSnapshotShardContextFactory()
                 );
-                shardStateAction = new ShardStateAction(clusterService, transportService, allocationService, rerouteService, threadPool);
                 nodeConnectionsService = new NodeConnectionsService(clusterService.getSettings(), threadPool, transportService);
                 actions.put(
                     TransportUpdateSnapshotStatusAction.TYPE,


### PR DESCRIPTION
`StatelessSnapshotResiliencyTests.StatelessNode.doInit` constructs `TransportNewCommitNotificationAction` and `TransportShardRefreshAction` which use an uninitialized `shardStateAction`, leading to a NPE. This PR constructs `shardStateAction` before `doInit` is called.

Resolves #157733