### PR TITLE
[9.5] Increase SmokeTest Timeout (#157688)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -400,9 +400,6 @@ tests:
 - class: org.elasticsearch.gateway.GatewayServiceIT
   method: testSettingsAppliedBeforeReroute
   issue: https://github.com/elastic/elasticsearch/issues/155802
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
-  issue: https://github.com/elastic/elasticsearch/issues/155922
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:inlinestats.afterStats}
   issue: https://github.com/elastic/elasticsearch/issues/156013

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -20,7 +20,9 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
 
-@TimeoutSuite(millis = 50 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
+// Sized for the encryption-at-rest CI job, which runs this suite on a dm-crypt volume that roughly
+// halves I/O throughput. Same budget as DocsClientYamlTestSuiteIT, for the same reason.
+@TimeoutSuite(millis = 80 * TimeUnits.MINUTE)
 public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ClassRule


### PR DESCRIPTION
## Summary

Backport of https://github.com/elastic/elasticsearch/pull/157688 to `9.5`.

- Raises `SmokeTestMultiNodeClientYamlTestSuiteIT` `@TimeoutSuite` from 50 to 80 minutes so the encryption-at-rest CI job is not killed mid-suite.
- Unmutes `test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}`. That test was the one holding the baton when the 50-minute budget expired; the mute only exists on 9.5.

## References

Closes #155922
Backport of #157688


Made with [Cursor](https://cursor.com)