### PR TITLE
[9.4] Fix bfloat16 reading from old index versions with endianness mismatches (#157730)

### DIFF
--- a/docs/changelog/157730.yaml
+++ b/docs/changelog/157730.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 157696
+pr: 157730
+summary: Fix bfloat16 reading from old index versions with endianness mismatches
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DenseVectorFromBinaryBlockLoader.java
@@ -149,7 +149,7 @@ public class DenseVectorFromBinaryBlockLoader extends BlockDocValuesReader.DocVa
 
         @Override
         protected void decodeDenseVector(BytesRef bytesRef, float[] scratch) {
-            VectorEncoderDecoder.decodeBFloat16DenseVector(bytesRef, scratch);
+            VectorEncoderDecoder.decodeBFloat16DenseVector(indexVersion, bytesRef, scratch);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
@@ -218,7 +218,7 @@ final class VectorDVLeafFieldData implements LeafFieldData {
 
         @Override
         void decodeDenseVector(IndexVersion indexVersion, BytesRef vectorBR, float[] vector) {
-            VectorEncoderDecoder.decodeBFloat16DenseVector(vectorBR, vector);
+            VectorEncoderDecoder.decodeBFloat16DenseVector(indexVersion, vectorBR, vector);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorEncoderDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorEncoderDecoder.java
@@ -86,11 +86,14 @@ public final class VectorEncoderDecoder {
         }
     }
 
-    public static void decodeBFloat16DenseVector(BytesRef vectorBR, float[] vector) {
+    public static void decodeBFloat16DenseVector(IndexVersion indexVersion, BytesRef vectorBR, float[] vector) {
         if (vectorBR == null) {
             throw new IllegalArgumentException(DenseVectorScriptDocValues.MISSING_VECTOR_FIELD_MESSAGE);
         }
-        ShortBuffer sb = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length).order(ByteOrder.LITTLE_ENDIAN).asShortBuffer();
+        ByteOrder byteOrder = indexVersion.onOrAfter(LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION)
+            ? ByteOrder.LITTLE_ENDIAN
+            : ByteOrder.BIG_ENDIAN;
+        ShortBuffer sb = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length).order(byteOrder).asShortBuffer();
         BFloat16.bFloat16ToFloat(sb, vector);
     }
 

--- a/server/src/main/java/org/elasticsearch/script/field/vectors/BFloat16BinaryDenseVectorDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/vectors/BFloat16BinaryDenseVectorDocValuesField.java
@@ -28,6 +28,6 @@ public class BFloat16BinaryDenseVectorDocValuesField extends BinaryDenseVectorDo
 
     @Override
     void decodeDenseVector(IndexVersion indexVersion, BytesRef vectorBR, float[] vector) {
-        VectorEncoderDecoder.decodeBFloat16DenseVector(vectorBR, vector);
+        VectorEncoderDecoder.decodeBFloat16DenseVector(indexVersion, vectorBR, vector);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -83,6 +83,7 @@ import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DEFA
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
@@ -1094,6 +1095,47 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
         float decodedMagnitude = VectorEncoderDecoder.decodeMagnitude(IndexVersion.current(), vectorBR);
         assertEquals(expectedMagnitude, decodedMagnitude, 0.001f);
         assertArrayEquals("Decoded dense vector values is not equal to the indexed one.", validVector, decodedValues, 0.001f);
+    }
+
+    /**
+     * A {@code bfloat16} vector with {@code index: false} is stored in binary doc values, whose byte order is chosen by index
+     * version - see {@link DenseVectorFieldMapper#LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION}. The decode path must apply the same
+     * rule, otherwise every component reads back byte-swapped on indices created before that version.
+     */
+    public void testNonIndexedBFloat16Vector() throws Exception {
+        // Every component is exactly representable in bfloat16, so the assertions can be exact and the byte order unambiguous
+        float[] vector = { 1.5f, 2.0f, -3.25f };
+        float expectedMagnitude = (float) Math.sqrt(1.5f * 1.5f + 2.0f * 2.0f + 3.25f * 3.25f);
+
+        for (IndexVersion indexVersion : List.of(
+            IndexVersionUtils.randomVersionBetween(
+                IndexVersionUtils.getLowestWriteCompatibleVersion(),
+                IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION)
+            ),
+            IndexVersionUtils.randomVersionBetween(DenseVectorFieldMapper.LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION, IndexVersion.current())
+        )) {
+            String message = "index version [" + indexVersion + "]";
+            DocumentMapper mapper = createDocumentMapper(
+                indexVersion,
+                fieldMapping(
+                    b -> b.field("type", "dense_vector")
+                        .field("element_type", "bfloat16")
+                        .field("dims", vector.length)
+                        .field("index", false)
+                )
+            );
+            ParsedDocument doc = mapper.parse(source(b -> b.array("field", vector)));
+
+            List<IndexableField> fields = doc.rootDoc().getFields("field");
+            assertThat(message, fields, hasSize(1));
+            assertThat(message, fields.get(0), instanceOf(BinaryDocValuesField.class));
+
+            BytesRef vectorBR = fields.get(0).binaryValue();
+            float[] decoded = new float[vector.length];
+            VectorEncoderDecoder.decodeBFloat16DenseVector(indexVersion, vectorBR, decoded);
+            assertArrayEquals(message, vector, decoded, 0f);
+            assertThat(message, VectorEncoderDecoder.decodeMagnitude(indexVersion, vectorBR), equalTo(expectedMagnitude));
+        }
     }
 
     public void testIndexedByteVector() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix bfloat16 reading from old index versions with endianness mismatches (#157730)](https://github.com/elastic/elasticsearch/pull/157730)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)