### PR TITLE
Reject stale reshard start split request missing IndexReshardingMetadata

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -541,9 +541,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecApproximationBucketIncludeEmptyBucketsIT
   method: test {csv-spec:bucket_include_empty_buckets.Large number of buckets doesn't OOM - stats}
   issue: https://github.com/elastic/elasticsearch/issues/155921
-- class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT
-  method: testReshardWithDisruption
-  issue: https://github.com/elastic/elasticsearch/issues/156004
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testRelocatingTaskIsNotCancelledOnShutdownTimeout
   issue: https://github.com/elastic/elasticsearch/issues/155593

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceService.java
@@ -185,7 +185,14 @@ public class SplitSourceService {
 
         var indexMetadata = clusterService.state().metadata().projectFor(index).getIndexSafe(index);
         var reshardingMetadata = indexMetadata.getReshardingMetadata();
-        assert reshardingMetadata != null && reshardingMetadata.isSplit() : "Unexpected resharding state";
+        if (reshardingMetadata == null || reshardingMetadata.isSplit() == false) {
+            // A start split request can arrive after the split has completed and the resharding metadata was removed from cluster
+            // state, for example when a target shard whose node was isolated mid-split retries the request after rejoining.
+            String message = String.format(Locale.ROOT, "Split target [%s]. No split is in progress. Failing the request.", targetShardId);
+            logger.info(message);
+
+            throw new StaleSplitRequestException(message);
+        }
         int sourceShardIndex = reshardingMetadata.getSplit().sourceShard(targetShardId.getId());
         var sourceShardId = new ShardId(index, sourceShardIndex);
 

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/reshard/SplitSourceServiceTests.java
@@ -8,8 +8,17 @@
 package org.elasticsearch.xpack.stateless.reshard;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +26,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SplitSourceServiceTests extends ESTestCase {
     AtomicLong nowInMillis = new AtomicLong();
@@ -174,6 +186,34 @@ public class SplitSourceServiceTests extends ESTestCase {
         assertEquals(acquired.get(), 2);
         // never actually obtained the resource
         assertEquals(withResource.get(), 0);
+    }
+
+    public void testSetupTargetShardFailsWhenSplitIsNoLongerInProgress() {
+        var indexMetadata = IndexMetadata.builder("test-index").settings(indexSettings(IndexVersion.current(), 1, 0)).build();
+        var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .putProjectMetadata(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true).build())
+            .build();
+
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        // The null args are not reached before the request is rejected.
+        var splitSourceService = new SplitSourceService(
+            null,
+            clusterService,
+            null,
+            mock(StatelessCommitService.class),
+            null,
+            null,
+            null,
+            Settings.EMPTY
+        );
+
+        var exception = expectThrows(
+            StaleSplitRequestException.class,
+            () -> splitSourceService.setupTargetShard(null, new ShardId(indexMetadata.getIndex(), 0), 1L, 1L, ActionListener.noop())
+        );
+        assertThat(exception.getMessage(), containsString("No split is in progress"));
     }
 
     private ActionListener<Releasable> runAndRelease(Runnable runnable) {


### PR DESCRIPTION
This fixes a bug revealed by [CI](https://github.com/elastic/elasticsearch/issues/156004). Gracefully fails the `START_SPLIT` request at source shard when `IndexReshardingMetadata` is missing. This seems possible when a target shard node is isolated, then rejoins the cluster and retries the `START_SPLIT`, while the split was already completed and metadata already cleaned up.

Exception:

```
WARNING: Uncaught exception in thread: Thread[#5702,elasticsearch[node_t4][generic][T#4],...]
java.lang.AssertionError: Unexpected resharding state
	at org.elasticsearch.xpack.stateless.reshard.SplitSourceService.setupTargetShard(SplitSourceService.java:185)
	at org.elasticsearch.action.ActionListener.run(ActionListener.java:490)
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(...)
	at org.elasticsearch.transport.InboundHandler.doHandleRequest(...)
```

Timeline analyzed from [`build failure`](https://gradle-enterprise.elastic.co/s/cmldujdxnzpsu/tests/task/:x-pack:plugin:stateless:internalClusterTest/details/org.elasticsearch.xpack.stateless.reshard.StatelessReshardDisruptionIT/testReshardWithDisruption?page=eyJvdXRwdXQiOnsiMCI6M319&top-execution=1): 3 shards splitting to 6; index nodes `node_t2`, `node_t3`, `node_t4`.

```
06:55:31,672  reshard API called
06:55:31,673  RELOCATE_SHARD: source shard 0, node_t3 -> node_t4
06:55:31,715  target 3 (on node_t3) sends START_SPLIT to node_t4
06:55:31,716  node_t4: "Source shard is not started" -- benign, retried
06:55:31,727  ISOLATE_NODE: node_t3, which holds targets 3 and 5 (both CLONE)
06:55:31,753  master removes node_t3
06:55:31,762  targets 3 and 5 reallocated to node_t4 / node_t2 at primary term 2
06:55:31,916  last source shard -> DONE  =>  resharding metadata removed
06:55:32,233  node_t3 rejoins, still holding its stale target shard instances
              ... stale target retries START_SPLIT -> AssertionError on node_t4
06:56:37,844  node_t3 target 3 fails with NodeDisconnectedException (teardown drops the link)
```

The split completed at `31,916`, before `node_t3` rejoined - it never needed the isolated node.

Relates to #156004