### PR TITLE
[9.5] Fix backwards read of _ignored_source doc values (#157798)

### DIFF
--- a/docs/changelog/157798.yaml
+++ b/docs/changelog/157798.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157798
+summary: Fix backwards read of `_ignored_source` doc values
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -694,12 +694,30 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             return index;
         }
 
+        /**
+         * A negative index means the caller asked for a doc behind the loaded block. {@link #findAndUpdateBlock} only searches forwards,
+         * so it hands back the stale block rather than detecting this, and the caller would otherwise read another doc's bytes.
+         */
+        private String outOfBlock(int docNumber, int idxInBlock, int numDocsInBlock) {
+            return "doc ["
+                + docNumber
+                + "] maps to index ["
+                + idxInBlock
+                + "] of block ["
+                + startDocNumForBlock
+                + ", "
+                + limitDocNumForBlock
+                + ") holding ["
+                + numDocsInBlock
+                + "] docs; docs must be read in ascending order";
+        }
+
         BytesRef decode(int docNumber, int numBlocks) throws IOException {
             long blockId = findAndUpdateBlock(docNumber, numBlocks);
 
             int numDocsInBlock = (int) (limitDocNumForBlock - startDocNumForBlock);
             int idxInBlock = (int) (docNumber - startDocNumForBlock);
-            assert idxInBlock < numDocsInBlock;
+            assert idxInBlock >= 0 && idxInBlock < numDocsInBlock : outOfBlock(docNumber, idxInBlock, numDocsInBlock);
 
             if (blockId != lastBlockId) {
                 decompressBlock(blockId, numDocsInBlock);
@@ -718,7 +736,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
             int numDocsInBlock = (int) (limitDocNumForBlock - startDocNumForBlock);
             int idxInBlock = (int) (docNumber - startDocNumForBlock);
-            assert idxInBlock < numDocsInBlock;
+            assert idxInBlock >= 0 && idxInBlock < numDocsInBlock : outOfBlock(docNumber, idxInBlock, numDocsInBlock);
 
             if (blockId != lastBlockId) {
                 decompressOffsets(blockId, numDocsInBlock);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -118,7 +118,13 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
         private final SourceFilter sourceFilter;
         private final Reader<T> reader;
         private final IgnoredSourceFieldMapper.IgnoredSourceFormat ignoredSourceFormat;
+        /**
+         * Only set for {@link IgnoredSourceFieldMapper.IgnoredSourceFormat#DOC_VALUES_IGNORED_SOURCE}. Unlike the stored field formats,
+         * this is a forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+         */
         private final MultiValuedSortedBinaryDocValues ignoredSourceDocValues;
+        private final Thread creationThread;
+        private int docId = -1;
 
         IgnoredSourceRowStrideReader(
             CircuitBreaker breaker,
@@ -130,6 +136,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
         ) throws IOException {
             breaker.addEstimateBytesAndMaybeBreak(ESTIMATED_SIZE, "load blocks");
             this.breaker = breaker;
+            this.creationThread = Thread.currentThread();
             this.fieldName = fieldName;
             this.sourceFilter = sourceFilter;
             this.reader = reader;
@@ -145,6 +152,9 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
 
         @Override
         public void read(int docId, StoredFields storedFields, Builder builder) throws IOException {
+            assert ignoredSourceDocValues == null || docId >= this.docId
+                : "docs must be read in order, got [" + docId + "] after [" + this.docId + "]";
+            this.docId = docId;
             Map<String, List<IgnoredSourceFieldMapper.NameValue>> valuesGroupedByParent = ignoredSourceFormat.loadIgnoredFields(
                 sourceFilter,
                 storedFields.storedFields(),
@@ -276,7 +286,12 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
 
         @Override
         public boolean canReuse(int startingDocID) {
-            return true;
+            if (ignoredSourceDocValues == null) {
+                // The stored field formats read _ignored_source through the shared StoredFields, which the caller repositions per
+                // document, so this reader keeps no position of its own.
+                return true;
+            }
+            return creationThread == Thread.currentThread() && docId <= startingDocID;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
@@ -99,12 +99,12 @@ public class FallbackSyntheticSourceBlockLoaderTests extends MapperServiceTestCa
         BlockLoader loader
     ) throws IOException {
         var sourceLoader = mapperService.mappingLookup()
-            .newSourceLoader(new SourceFilter(new String[] { "field" }, null), SourceFieldMetrics.NOOP, null);
+            .newSourceLoader(new SourceFilter(new String[] { "field" }, null), SourceFieldMetrics.NOOP);
         StoredFieldsSpec spec = loader.rowStrideStoredFieldSpec()
             .merge(new StoredFieldsSpec(false, false, sourceLoader.requiredStoredFields()));
         return new BlockLoaderStoredFieldsFromLeafLoader(
             StoredFieldLoader.fromSpec(spec).getLoader(ctx, null),
-            sourceLoader.leaf(ctx, null)
+            sourceLoader.leaf(ctx.reader(), null)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
+import org.elasticsearch.search.lookup.SourceFilter;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Tests for {@link FallbackSyntheticSourceBlockLoader}'s row stride reader. When {@code _ignored_source} is stored in binary doc values
+ * the reader holds a forward-only doc values iterator, so it must report that it can't be reused for an earlier document.
+ */
+public class FallbackSyntheticSourceBlockLoaderTests extends MapperServiceTestCase {
+
+    /**
+     * The reader wraps a forward-only {@code _ignored_source} doc values iterator, so {@code canReuse} has to track the last document it
+     * read. Reporting {@code true} for an earlier document lets {@code ValuesSourceReaderOperator} hand the reader a document it has
+     * already passed, which reads whichever binary block happens to be loaded.
+     */
+    public void testCanReuseTracksLastReadDoc() throws IOException {
+        withIndex(3, (mapperService, ctx) -> {
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+            BlockLoader loader = loader(mapperService);
+            try (BlockLoader.RowStrideReader reader = loader.rowStrideReader(breaker, ctx)) {
+                var storedFields = storedFields(mapperService, ctx, loader);
+
+                readDoc(loader, reader, storedFields, 1);
+
+                assertFalse("must not be reused for an earlier doc", reader.canReuse(0));
+                assertTrue("may be reused for the doc it just read", reader.canReuse(1));
+                assertTrue("may be reused for a later doc", reader.canReuse(2));
+            }
+        });
+    }
+
+    /**
+     * The same check across enough documents to span several binary doc values blocks. Reusing the reader here used to read whichever
+     * block was still loaded, which threw an {@link ArrayIndexOutOfBoundsException} for a negative index into the block.
+     */
+    public void testCanReuseAcrossBinaryBlocks() throws IOException {
+        // Values are sized so the 512KB binary block threshold flushes every ~256 docs, putting doc 900 and doc 10 in different blocks.
+        withIndex(1000, 2048, (mapperService, ctx) -> {
+            CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+            BlockLoader loader = loader(mapperService);
+            try (BlockLoader.RowStrideReader reader = loader.rowStrideReader(breaker, ctx)) {
+                readDoc(loader, reader, storedFields(mapperService, ctx, loader), 900);
+                assertFalse("must not be reused for a doc in an earlier block", reader.canReuse(10));
+            }
+        });
+    }
+
+    private BlockLoader loader(MapperService mapperService) {
+        BlockLoader loader = mapperService.fieldType("field")
+            .blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapperService));
+        // Guard against the test silently degrading to a stored field format, which has no per-document reader state.
+        assertThat(loader, instanceOf(FallbackSyntheticSourceBlockLoader.class));
+        assertThat(
+            ((FallbackSyntheticSourceBlockLoader) loader).ignoredSourceFormat(),
+            equalTo(IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE)
+        );
+        return loader;
+    }
+
+    private static void readDoc(
+        BlockLoader loader,
+        BlockLoader.RowStrideReader reader,
+        BlockLoaderStoredFieldsFromLeafLoader storedFields,
+        int doc
+    ) throws IOException {
+        BlockLoader.Builder builder = loader.builder(TestBlock.factory(), 1);
+        storedFields.advanceTo(doc);
+        reader.read(doc, storedFields, builder);
+        builder.build().close();
+    }
+
+    private static BlockLoaderStoredFieldsFromLeafLoader storedFields(
+        MapperService mapperService,
+        LeafReaderContext ctx,
+        BlockLoader loader
+    ) throws IOException {
+        var sourceLoader = mapperService.mappingLookup()
+            .newSourceLoader(new SourceFilter(new String[] { "field" }, null), SourceFieldMetrics.NOOP, null);
+        StoredFieldsSpec spec = loader.rowStrideStoredFieldSpec()
+            .merge(new StoredFieldsSpec(false, false, sourceLoader.requiredStoredFields()));
+        return new BlockLoaderStoredFieldsFromLeafLoader(
+            StoredFieldLoader.fromSpec(spec).getLoader(ctx, null),
+            sourceLoader.leaf(ctx, null)
+        );
+    }
+
+    private void withIndex(int numDocs, CheckedBiConsumer<MapperService, LeafReaderContext, IOException> test) throws IOException {
+        withIndex(numDocs, 8, test);
+    }
+
+    private void withIndex(int numDocs, int valueLength, CheckedBiConsumer<MapperService, LeafReaderContext, IOException> test)
+        throws IOException {
+        var settings = Settings.builder()
+            .put("index.mapping.source.mode", "synthetic")
+            // DOC_VALUES_IGNORED_SOURCE requires the TSDB doc values format to be enabled
+            .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
+            .build();
+        // A keyword without doc values and without stored fields can only be reconstructed from _ignored_source.
+        MapperService mapperService = createMapperService(
+            getVersion(),
+            settings,
+            () -> true,
+            mapping(b -> b.startObject("field").field("type", "keyword").field("doc_values", false).endObject())
+        );
+        withLuceneIndex(mapperService, writer -> {
+            for (int i = 0; i < numDocs; i++) {
+                String value = Strings.padStart(Integer.toString(i), valueLength, 'v');
+                ParsedDocument parsed = mapperService.documentParser()
+                    .parseDocument(source(b -> b.field("field", value)), mapperService.mappingLookup());
+                writer.addDocuments(parsed.docs());
+            }
+            // Keep everything in one segment so the reader is exercised across pages of the same segment.
+            writer.forceMerge(1);
+        }, reader -> {
+            assertThat(reader.leaves(), hasSize(1));
+            test.accept(mapperService, reader.leaves().get(0));
+        });
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix backwards read of _ignored_source doc values (#157798)