### PR TITLE
[GCS Snapshots] Concurrent batch deletes with per-chunk retry and jitter

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -442,6 +442,9 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                             ByteSizeUnit.MB.toBytes(1),
                             BackoffPolicy.noBackoff(),
                             this.statsCollector(),
+                            command -> command.run(),
+                            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+                            1,
                             null,
                             null
                         );

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GcsRepositoryStatsCollector.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GcsRepositoryStatsCollector.java
@@ -189,6 +189,39 @@ public class GcsRepositoryStatsCollector {
         }
     }
 
+    /**
+     * Records a batch operation where {@code itemCount} logical operations are represented by a
+     * single HTTP request (the batch envelope). GCS billing counts each item in a batch as one
+     * operation, so {@code operationCounter} is incremented by {@code itemCount} rather than 1.
+     */
+    public void collectBatch(OperationPurpose purpose, StorageOperation operation, int itemCount, IORunnable runnable) throws IOException {
+        var t = timer.absoluteTimeInMillis();
+        var stats = initAndGetThreadLocal(purpose, operation);
+        try {
+            runnable.run();
+        } finally {
+            stats.totalDuration += timer.absoluteTimeInMillis() - t;
+            if (stats.requestAttempts > 0) {
+                var operationSuccess = stats.isLastRequestSucceed ? itemCount : 0;
+                var operationError = stats.isLastRequestSucceed ? 0 : 1;
+                var collector = collectors.get(purpose).get(operation);
+                collector.operations.add(operationSuccess);
+                collector.requests.add(stats.requestAttempts);
+                var attr = telemetryAttributes.get(purpose).get(operation);
+                telemetry.operationCounter().incrementBy(operationSuccess, attr);
+                telemetry.unsuccessfulOperationCounter().incrementBy(operationError, attr);
+                telemetry.requestCounter().incrementBy(stats.requestAttempts, attr);
+                telemetry.exceptionCounter().incrementBy(stats.requestError, attr);
+                telemetry.exceptionHistogram().record(stats.requestError, attr);
+                telemetry.throttleCounter().incrementBy(stats.requestThrottle, attr);
+                telemetry.throttleHistogram().record(stats.requestThrottle, attr);
+                telemetry.requestRangeNotSatisfiedExceptionCounter().incrementBy(stats.requestRangeError, attr);
+                telemetry.httpRequestTimeInMillisHistogram().record(stats.totalDuration, attr);
+            }
+            clearThreadLocal();
+        }
+    }
+
     public void collectIORunnable(OperationPurpose purpose, StorageOperation operation, IORunnable runnable) throws IOException {
         var stats = initAndGetThreadLocal(purpose, operation);
         var t = timer.absoluteTimeInMillis();

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -77,13 +77,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.net.HttpURLConnection.HTTP_GONE;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
+import static org.elasticsearch.common.blobstore.ConcurrentBatchHelper.runConcurrentBatches;
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.rest.RestStatus.TOO_MANY_REQUESTS;
 
@@ -148,6 +149,9 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     private volatile boolean closed = false;
     private final boolean tenaciousRetriesEnabled;
     private final long largeBlobThresholdInBytes;
+    private final Executor deleteExecutor;
+    private final int deletionBatchSize;
+    private final int maxConcurrentBatchDeletes;
 
     @Nullable
     private final StorageClass dataStorageClass;
@@ -165,6 +169,9 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         long largeBlobThresholdInBytes,
         BackoffPolicy casBackoffPolicy,
         GcsRepositoryStatsCollector statsCollector,
+        Executor deleteExecutor,
+        int deletionBatchSize,
+        int maxConcurrentBatchDeletes,
         @Nullable String dataStorageClass,
         @Nullable String metadataStorageClass
     ) {
@@ -178,6 +185,9 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         this.bufferSize = bufferSize;
         this.largeBlobThresholdInBytes = largeBlobThresholdInBytes;
         this.casBackoffPolicy = casBackoffPolicy;
+        this.deleteExecutor = deleteExecutor;
+        this.deletionBatchSize = deletionBatchSize;
+        this.maxConcurrentBatchDeletes = maxConcurrentBatchDeletes;
         this.tenaciousRetriesEnabled = storageService.clientSettings(projectId, clientName).getTenaciousRetriesEnabled();
         this.dataStorageClass = initStorageClass(dataStorageClass);
         this.metadataStorageClass = initStorageClass(metadataStorageClass);
@@ -726,24 +736,18 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         DeleteResult deleteResult = DeleteResult.ZERO;
         MeteredStorage.MeteredBlobPage meteredPage = client().meteredList(purpose, bucketName, BlobListOption.prefix(pathStr));
         do {
-            final AtomicLong blobsDeleted = new AtomicLong(0L);
-            final AtomicLong bytesDeleted = new AtomicLong(0L);
-            var blobs = meteredPage.getValues().iterator();
-            deleteBlobs(purpose, new Iterator<>() {
-                @Override
-                public boolean hasNext() {
-                    return blobs.hasNext();
-                }
-
-                @Override
-                public String next() {
-                    final Blob next = blobs.next();
-                    blobsDeleted.incrementAndGet();
-                    bytesDeleted.addAndGet(next.getSize());
-                    return next.getName();
-                }
-            });
-            deleteResult = deleteResult.add(blobsDeleted.get(), bytesDeleted.get());
+            // Pre-drain the page into a list so the counting and name-collection are complete
+            // before deleteBlobs fans out across threads (the page iterator is not thread-safe).
+            long blobsDeleted = 0L;
+            long bytesDeleted = 0L;
+            final var blobNames = new ArrayList<String>();
+            for (Blob blob : meteredPage.getValues()) {
+                blobNames.add(blob.getName());
+                blobsDeleted++;
+                bytesDeleted += blob.getSize();
+            }
+            deleteBlobs(purpose, blobNames.iterator());
+            deleteResult = deleteResult.add(blobsDeleted, bytesDeleted);
             meteredPage = meteredPage.getNextPage();
         } while (meteredPage != null);
         return deleteResult;
@@ -914,89 +918,80 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     }
 
     /**
-     * Deletes multiple blobs from the specific bucket using a batch request
+     * Deletes multiple blobs from the specific bucket using concurrent batch requests.
+     * The iterator is drained on the calling thread into fixed-size chunks before any concurrent
+     * work begins, because the incoming iterators are not thread-safe.
      *
      * @param blobNames names of the blobs to delete
      */
     void deleteBlobs(OperationPurpose purpose, Iterator<String> blobNames) throws IOException {
-        if (blobNames.hasNext() == false) {
-            return;
+        final var batches = new ArrayList<List<String>>();
+        var batch = new ArrayList<String>(deletionBatchSize);
+        while (blobNames.hasNext()) {
+            batch.add(blobNames.next());
+            if (batch.size() == deletionBatchSize) {
+                batches.add(batch);
+                batch = new ArrayList<>(deletionBatchSize);
+            }
         }
+        if (batch.isEmpty() == false) {
+            batches.add(batch);
+        }
+        runConcurrentBatches(batches, maxConcurrentBatchDeletes, deleteExecutor, chunk -> deleteChunkWithRetries(purpose, chunk));
+    }
 
-        record DeleteResult(BlobId blobId, StorageBatchResult<Boolean> result) {}
-        record DeleteFailure(BlobId blobId, int errCode) {}
+    /**
+     * Submits one batch of blobs for deletion, retrying transient failures with exponential
+     * backoff. The retry set shrinks monotonically — a throttled item cannot re-queue the entire
+     * original chunk on each attempt.
+     */
+    private void deleteChunkWithRetries(OperationPurpose purpose, List<String> chunk) throws IOException {
+        record DeleteEntry(BlobId blobId, StorageBatchResult<Boolean> result) {}
 
-        // The following algorithm maximizes the size of every batch by merging retryable items
-        // from the previous batch and new items. When batch results have failed items, we first retry
-        // only a single item using the SDK client's retry strategy (exponential-backoff). Retrying
-        // a single item should provide enough time to back-off from throttling or temporary GCS
-        // failures. Once a single item successfully retries, we proceed with the next batch, combining
-        // the remaining failures and new items.
-        //
-        // Which is roughly looks like this:
-        // - create batch of 100 new items
-        // - submit batch
-        // - receive 100 results, with 10 retryable failures
-        // - retry 1 failure using non-batched delete using SDK retry strategy
-        // - (loop) create batch from 9 remaining failures and 91 new items
+        var pending = chunk.stream().map(name -> BlobId.of(bucketName, name)).toList();
+        final var backoff = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), getMaxRetries()).iterator();
 
-        final var batchResults = new ArrayList<DeleteResult>(MAX_DELETES_PER_BATCH);
-        final var batchFailures = new ArrayList<DeleteFailure>(MAX_DELETES_PER_BATCH);
-        while (blobNames.hasNext() || batchFailures.isEmpty() == false) {
+        while (true) {
+            final var meteredBatch = client().batch(purpose);
+            final var entries = pending.stream().map(id -> new DeleteEntry(id, meteredBatch.delete(id))).toList();
+            meteredBatch.submit();
 
-            // create a new batch from failed and new items, failed first
-            final var batch = client().batch();
-            for (var failure : batchFailures) {
-                batchResults.add(new DeleteResult(failure.blobId, batch.delete(failure.blobId)));
-            }
-            batchFailures.clear();
-            while (blobNames.hasNext() && batchResults.size() < MAX_DELETES_PER_BATCH) {
-                final var blobId = BlobId.of(bucketName, blobNames.next());
-                batchResults.add(new DeleteResult(blobId, batch.delete(blobId)));
-            }
-
-            // The whole batch request uses GCS client's retry logic, but individual item failures are not retried.
-            // Collect all retryable failures or terminate on non-retryable error.
-            try {
-                batch.submit();
-            } catch (Exception e) {
-                throw new IOException("Failed to execute batch", e);
-            }
+            final var retryable = new ArrayList<BlobId>();
             StorageException nonRetryableException = null;
-            for (var deleteResult : batchResults) {
+            for (var entry : entries) {
                 try {
-                    deleteResult.result.get();
+                    entry.result().get();
                 } catch (StorageException e) {
-                    final var errCode = e.getCode();
-                    batchFailures.add(new DeleteFailure(deleteResult.blobId, e.getCode()));
-                    if (nonRetryableException == null && isRetryErrCode(errCode) == false) {
+                    if (isRetryErrCode(e.getCode())) {
+                        retryable.add(entry.blobId());
+                    } else if (nonRetryableException == null) {
                         nonRetryableException = e;
                     }
                 }
             }
+
             if (nonRetryableException != null) {
                 throw new IOException(
-                    "One or more batch items failed, non-retryable exception; all batch failures: " + batchFailures,
+                    "One or more batch items failed with non-retryable error; retryable remaining: " + retryable,
                     nonRetryableException
                 );
             }
-            batchResults.clear();
-
-            // Delete single item using GCS client's retry logic.
-            // It should provide enough back-off before trying next batch.
-            if (batchFailures.isEmpty() == false) {
-                final var retryBlobId = batchFailures.getLast().blobId;
-                try {
-                    client().delete(purpose, retryBlobId);
-                    // remaining items go into the next batch
-                    batchFailures.removeLast();
-                } catch (StorageException e) {
-                    throw new IOException(
-                        "Failed to retry single batch item, blobId=" + retryBlobId + "; all batch failures: " + batchFailures,
-                        e
-                    );
-                }
+            if (retryable.isEmpty()) {
+                return;
             }
+            if (backoff.hasNext() == false) {
+                throw new IOException("Failed to delete " + retryable.size() + " blob(s) after retries, e.g.: " + retryable.get(0));
+            }
+            try {
+                final long base = backoff.next().millis();
+                // Jitter up to 25% of the base delay so concurrent chunk workers that all
+                // receive a 429 at the same moment do not thundering-herd on the next retry.
+                Thread.sleep(base + ThreadLocalRandom.current().nextLong(0, Math.max(1, base / 4)));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while retrying batch deletes", e);
+            }
+            pending = retryable;
         }
     }
 

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -28,6 +28,7 @@ import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.SnapshotMetrics;
 import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.util.Map;
@@ -106,6 +107,27 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
         MULTIPART_UPLOAD_SIZE_THRESHOLD_MIN,
         ByteSizeValue.of(5, ByteSizeUnit.TB)
     );
+
+    /**
+     * Maximum number of blobs per GCS batch delete request. The GCS XML API splits batches at 100
+     * items and loops sub-batches serially on the calling thread, so raising this above 100 would
+     * silently serialize work inside a single worker and defeat the concurrency setting.
+     */
+    static final Setting<Integer> DELETE_OBJECTS_MAX_SIZE = Setting.intSetting(
+        "delete_objects_max_size",
+        GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+        1,
+        GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH
+    );
+
+    /**
+     * Maximum number of concurrent GCS batch delete requests. Each worker runs on the SNAPSHOT
+     * thread pool; the calling thread also participates so progress is guaranteed even when the
+     * pool is saturated. The default of 5 matches the SNAPSHOT pool size on nodes with a heap
+     * below 750 MB ({@link org.elasticsearch.threadpool.ThreadPool#halfAllocatedProcessorsMaxFive})
+     * and leaves headroom on larger nodes whose pool size is 10.
+     */
+    static final Setting<Integer> MAX_CONCURRENT_BATCH_DELETES = Setting.intSetting("max_concurrent_batch_deletes", 5, 1, 100);
 
     private final GoogleCloudStorageService storageService;
     private final ByteSizeValue chunkSize;
@@ -202,6 +224,9 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
             largeBlobThreshold,
             BackoffPolicy.linearBackoff(retryThrottledCasDelayIncrement, retryThrottledCasMaxNumberOfRetries, retryThrottledCasMaxDelay),
             statsCollector,
+            threadPool().executor(ThreadPool.Names.SNAPSHOT),
+            DELETE_OBJECTS_MAX_SIZE.get(metadata.settings()),
+            MAX_CONCURRENT_BATCH_DELETES.get(metadata.settings()),
             dataStorageClass,
             metadataStorageClass
         );

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
@@ -25,6 +25,7 @@ import com.google.cloud.storage.MultipartUploadSettings;
 import com.google.cloud.storage.RequestBody;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.multipartupload.model.AbortMultipartUploadRequest;
 import com.google.cloud.storage.multipartupload.model.AbortMultipartUploadResponse;
@@ -114,8 +115,51 @@ public class MeteredStorage {
         statsCollector.collectIOSupplier(purpose, INSERT, () -> storage.create(blobInfo, buffer, offset, blobSize, targetOptions));
     }
 
-    public StorageBatch batch() {
-        return storage.batch();
+    /**
+     * Returns a metered batch that counts submitted items and records them as DELETE operations
+     * when {@link MeteredStorageBatch#submit()} is called. GCS charges per item in a batch, so
+     * the operation count is set to the item count rather than 1.
+     */
+    public MeteredStorageBatch batch(OperationPurpose purpose) {
+        return new MeteredStorageBatch(storage.batch(), statsCollector, purpose);
+    }
+
+    /**
+     * A {@link StorageBatch} wrapper that meters submitted items and records them as DELETE
+     * operations on {@link #submit()}.
+     */
+    public static class MeteredStorageBatch {
+        private final StorageBatch batch;
+        private final GcsRepositoryStatsCollector statsCollector;
+        private final OperationPurpose purpose;
+        private int itemCount = 0;
+
+        MeteredStorageBatch(StorageBatch batch, GcsRepositoryStatsCollector statsCollector, OperationPurpose purpose) {
+            this.batch = batch;
+            this.statsCollector = statsCollector;
+            this.purpose = purpose;
+        }
+
+        public StorageBatchResult<Boolean> delete(BlobId blobId) {
+            itemCount++;
+            return batch.delete(blobId);
+        }
+
+        /**
+         * Submits the batch, recording {@link #itemCount} DELETE operations against the stats
+         * collector. The METERING_INTERCEPTOR sees one HTTP envelope, so operations must be
+         * counted explicitly here rather than derived from the interceptor's per-request count.
+         */
+        public void submit() throws IOException {
+            final int count = itemCount;
+            statsCollector.collectBatch(purpose, DELETE, count, () -> {
+                try {
+                    batch.submit();
+                } catch (Exception e) {
+                    throw new IOException("Failed to execute batch", e);
+                }
+            });
+        }
     }
 
     public StorageOptions getOptions() {

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudBlobStoreTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudBlobStoreTests.java
@@ -165,6 +165,9 @@ public class GoogleCloudBlobStoreTests extends ESTestCase {
             GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
             BackoffPolicy.noBackoff(),
             mock(GcsRepositoryStatsCollector.class),
+            command -> command.run(),
+            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+            1,
             dataStorageClass,
             metadataStorageClass
         );

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -230,6 +230,9 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
             GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
             BackoffPolicy.linearBackoff(TimeValue.timeValueMillis(1), 3, TimeValue.timeValueSeconds(1)),
             new GcsRepositoryStatsCollector(),
+            command -> command.run(),
+            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+            1,
             null,
             null
         ) {
@@ -545,60 +548,49 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         // See com.google.cloud.storage.spi.v1.HttpStorageRpc.DefaultRpcBatch.MAX_BATCH_SIZE
         final int sdkMaxBatchSize = 100;
         final AtomicInteger receivedBatchRequests = new AtomicInteger();
+        final AtomicInteger totalDeletedItems = new AtomicInteger();
 
-        final int totalDeletes = randomIntBetween(MAX_DELETES_PER_BATCH - 1, MAX_DELETES_PER_BATCH * 2);
-        final AtomicInteger pendingDeletes = new AtomicInteger();
-        final Iterator<String> blobNamesIterator = new Iterator<>() {
-            int totalDeletesSent = 0;
-
-            @Override
-            public boolean hasNext() {
-                return totalDeletesSent < totalDeletes;
-            }
-
-            @Override
-            public String next() {
-                if (pendingDeletes.get() == MAX_DELETES_PER_BATCH) {
-                    // Check that once MAX_DELETES_PER_BATCH deletes are enqueued the pending batch requests are sent
-                    assertThat(receivedBatchRequests.get(), is(greaterThan(0)));
-                    assertThat(receivedBatchRequests.get(), is(lessThanOrEqualTo(MAX_DELETES_PER_BATCH / sdkMaxBatchSize)));
-                    receivedBatchRequests.set(0);
-                    pendingDeletes.set(0);
-                }
-
-                pendingDeletes.incrementAndGet();
-                return Integer.toString(totalDeletesSent++);
-            }
-        };
+        // totalDeletes > MAX_DELETES_PER_BATCH ensures multiple batch HTTP requests are sent
+        final int totalDeletes = randomIntBetween(MAX_DELETES_PER_BATCH + 1, MAX_DELETES_PER_BATCH * 3);
         final BlobContainer blobContainer = blobContainerBuilder().maxRetries(1).build();
         httpServer.createContext("/batch/storage/v1", safeHandler(exchange -> {
-            assert pendingDeletes.get() <= MAX_DELETES_PER_BATCH;
-
             receivedBatchRequests.incrementAndGet();
             final StringBuilder batch = new StringBuilder();
+            int itemsInBatch = 0;
             for (String line : Streams.readAllLines(exchange.getRequestBody())) {
                 if (line.length() == 0 || line.startsWith("--") || line.toLowerCase(Locale.ROOT).startsWith("content")) {
                     batch.append(line).append("\r\n");
                 } else if (line.startsWith("DELETE")) {
                     batch.append("HTTP/1.1 204 NO_CONTENT").append("\r\n");
                     batch.append("\r\n");
+                    itemsInBatch++;
                 }
             }
+            totalDeletedItems.addAndGet(itemsInBatch);
+            assertThat(itemsInBatch, is(lessThanOrEqualTo(sdkMaxBatchSize)));
             byte[] response = batch.toString().getBytes(UTF_8);
             exchange.getResponseHeaders().add("Content-Type", exchange.getRequestHeaders().getFirst("Content-Type"));
             exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
             exchange.getResponseBody().write(response);
         }));
 
+        final Iterator<String> blobNamesIterator = new Iterator<>() {
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return i < totalDeletes;
+            }
+
+            @Override
+            public String next() {
+                return Integer.toString(i++);
+            }
+        };
         blobContainer.deleteBlobsIgnoringIfNotExists(randomPurpose(), blobNamesIterator);
 
-        // Ensure that the remaining deletes are sent in the last batch
-        if (pendingDeletes.get() > 0) {
-            assertThat(receivedBatchRequests.get(), is(greaterThan(0)));
-            assertThat(receivedBatchRequests.get(), is(lessThanOrEqualTo(MAX_DELETES_PER_BATCH / sdkMaxBatchSize)));
-
-            assertThat(pendingDeletes.get(), is(lessThanOrEqualTo(MAX_DELETES_PER_BATCH)));
-        }
+        assertThat(totalDeletedItems.get(), is(totalDeletes));
+        assertThat(receivedBatchRequests.get(), is(greaterThan(1)));
     }
 
     public void testCompareAndExchangeWhenThrottled() throws IOException {

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
@@ -327,6 +327,9 @@ public class GoogleCloudStorageBlobContainerStatsTests extends ESTestCase {
             GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
             BackoffPolicy.constantBackoff(TimeValue.timeValueMillis(10), 10),
             new GcsRepositoryStatsCollector(),
+            command -> command.run(),
+            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+            1,
             null,
             null
         );

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -109,6 +109,9 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
                 GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
                 BackoffPolicy.noBackoff(),
                 new GcsRepositoryStatsCollector(),
+                command -> command.run(),
+                GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+                1,
                 null,
                 null
             )
@@ -119,7 +122,7 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
                 IOException.class,
                 () -> container.deleteBlobsIgnoringIfNotExists(randomPurpose(), blobs.iterator())
             );
-            assertThat(e.getCause(), instanceOf(StorageException.class));
+            assertThat(e.getCause().getCause(), instanceOf(StorageException.class));
         }
     }
 
@@ -254,6 +257,9 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
             GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE,
             BackoffPolicy.noBackoff(),
             new GcsRepositoryStatsCollector(),
+            command -> command.run(),
+            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+            1,
             null,
             null
         );

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreStorageClassTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreStorageClassTests.java
@@ -122,6 +122,9 @@ public class GoogleCloudStorageBlobStoreStorageClassTests extends ESTestCase {
             largeBlobThreshold,
             BackoffPolicy.noBackoff(),
             new GcsRepositoryStatsCollector(),
+            command -> command.run(),
+            GoogleCloudStorageBlobStore.MAX_DELETES_PER_BATCH,
+            1,
             dataStorageClass,
             metadataStorageClass
         );

--- a/server/src/main/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.blobstore;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sibling to {@link ConcurrentMultipartHelper} for concurrent batch operations. Executes a list of
+ * pre-formed batches concurrently up to {@code maxConcurrency}, with the calling thread also
+ * participating so that a saturated executor pool does not deadlock.
+ */
+public class ConcurrentBatchHelper {
+
+    private ConcurrentBatchHelper() {}
+
+    /**
+     * Callback invoked for each batch.
+     */
+    @FunctionalInterface
+    public interface BatchConsumer<T> {
+        void accept(List<T> batch) throws Exception;
+    }
+
+    /**
+     * Executes pre-formed batches concurrently. The calling thread also participates so that a
+     * saturated executor does not deadlock. Rejections from the executor are swallowed; the calling
+     * thread will handle any unclaimed batches.
+     *
+     * @param batches        pre-materialized list of batches; must not be modified concurrently
+     * @param maxConcurrency maximum number of concurrent workers (including the calling thread)
+     * @param executor       executor used to dispatch concurrent batch operations
+     * @param batchConsumer  callback invoked for each batch; must be thread-safe
+     */
+    public static <T> void runConcurrentBatches(
+        List<List<T>> batches,
+        int maxConcurrency,
+        Executor executor,
+        BatchConsumer<T> batchConsumer
+    ) throws IOException {
+        final int nbBatches = batches.size();
+        if (nbBatches == 0) {
+            return;
+        }
+        final AtomicInteger nextBatchIndex = new AtomicInteger(0);
+        final CountDownLatch latch = new CountDownLatch(nbBatches);
+        final ConcurrentLinkedQueue<Exception> exceptions = new ConcurrentLinkedQueue<>();
+
+        final Runnable worker = () -> {
+            int batchIndex;
+            while ((batchIndex = nextBatchIndex.getAndIncrement()) < nbBatches) {
+                if (exceptions.isEmpty()) {
+                    try {
+                        batchConsumer.accept(batches.get(batchIndex));
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+                latch.countDown();
+            }
+        };
+
+        for (int i = 0; i < Math.min(maxConcurrency - 1, nbBatches - 1); i++) {
+            try {
+                executor.execute(worker);
+            } catch (Exception e) {
+                // Rejections are swallowed; the calling thread handles unclaimed batches
+            }
+        }
+        worker.run();
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            exceptions.add(e);
+        }
+
+        if (exceptions.isEmpty() == false) {
+            final Iterator<Exception> it = exceptions.iterator();
+            final IOException exception = new IOException("Failed to delete blobs", it.next());
+            while (it.hasNext()) {
+                exception.addSuppressed(it.next());
+            }
+            throw exception;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelperTests.java
@@ -23,11 +23,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ConcurrentBatchHelperTests extends ESTestCase {
 
     public void testEmptyBatchListIsNoOp() throws IOException {
-        ConcurrentBatchHelper.runConcurrentBatches(
-            List.of(), randomIntBetween(1, 10), command -> {
-                throw new AssertionError("executor must not be called for empty input");
-            }, batch -> {throw new AssertionError("consumer must not be called for empty input");}
-        );
+        ConcurrentBatchHelper.runConcurrentBatches(List.of(), randomIntBetween(1, 10), command -> {
+            throw new AssertionError("executor must not be called for empty input");
+        }, batch -> { throw new AssertionError("consumer must not be called for empty input"); });
     }
 
     public void testAllBatchesExecutedWhenExecutorRejects() throws IOException {
@@ -35,11 +33,9 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
         final List<List<String>> batches = makeBatches(nbBatches);
         final AtomicInteger batchesExecuted = new AtomicInteger(0);
 
-        ConcurrentBatchHelper.runConcurrentBatches(
-            batches, randomIntBetween(2, 10), command -> {
-                throw new RejectedExecutionException("executor is full");
-            }, batch -> batchesExecuted.incrementAndGet()
-        );
+        ConcurrentBatchHelper.runConcurrentBatches(batches, randomIntBetween(2, 10), command -> {
+            throw new RejectedExecutionException("executor is full");
+        }, batch -> batchesExecuted.incrementAndGet());
 
         assertEquals(nbBatches, batchesExecuted.get());
     }
@@ -64,11 +60,10 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
         final RuntimeException cause = new RuntimeException("batch failed");
 
         final IOException e = expectThrows(
-            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
-                batches, 1, Runnable::run, batch -> {
-                    throw cause;
-                }
-            )
+            IOException.class,
+            () -> ConcurrentBatchHelper.runConcurrentBatches(batches, 1, Runnable::run, batch -> {
+                throw cause;
+            })
         );
 
         assertEquals("Failed to delete blobs", e.getMessage());
@@ -84,12 +79,11 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
         final AtomicInteger callCount = new AtomicInteger();
 
         final IOException e = expectThrows(
-            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
-                batches, 1, Runnable::run, batch -> {
-                    callCount.incrementAndGet();
-                    throw cause;
-                }
-            )
+            IOException.class,
+            () -> ConcurrentBatchHelper.runConcurrentBatches(batches, 1, Runnable::run, batch -> {
+                callCount.incrementAndGet();
+                throw cause;
+            })
         );
 
         assertEquals("Failed to delete blobs", e.getMessage());
@@ -101,11 +95,9 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
     public void testSingleBatchNeverUsesExecutor() throws IOException {
         // With nbBatches=1, min(maxConcurrency-1, nbBatches-1) = 0, so the executor is never called.
         final AtomicInteger batchesExecuted = new AtomicInteger();
-        ConcurrentBatchHelper.runConcurrentBatches(
-            makeBatches(1), randomIntBetween(1, 100), command -> {
-                throw new AssertionError("executor must not be called for a single batch");
-            }, batch -> batchesExecuted.incrementAndGet()
-        );
+        ConcurrentBatchHelper.runConcurrentBatches(makeBatches(1), randomIntBetween(1, 100), command -> {
+            throw new AssertionError("executor must not be called for a single batch");
+        }, batch -> batchesExecuted.incrementAndGet());
         assertEquals(1, batchesExecuted.get());
     }
 
@@ -142,11 +134,10 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
         // of the wrapper rather than being double-wrapped.
         final IOException cause = new IOException("IO error during batch");
         final IOException e = expectThrows(
-            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
-                makeBatches(1), 1, Runnable::run, batch -> {
-                    throw cause;
-                }
-            )
+            IOException.class,
+            () -> ConcurrentBatchHelper.runConcurrentBatches(makeBatches(1), 1, Runnable::run, batch -> {
+                throw cause;
+            })
         );
         assertEquals("Failed to delete blobs", e.getMessage());
         assertSame(cause, e.getCause());
@@ -160,15 +151,13 @@ public class ConcurrentBatchHelperTests extends ESTestCase {
         final AtomicInteger executorCalls = new AtomicInteger();
         final AtomicInteger batchesExecuted = new AtomicInteger();
 
-        ConcurrentBatchHelper.runConcurrentBatches(
-            makeBatches(nbBatches), nbBatches, command -> {
-                if (executorCalls.getAndIncrement() < acceptCount) {
-                    command.run();
-                } else {
-                    throw new RejectedExecutionException("pool full");
-                }
-            }, batch -> batchesExecuted.incrementAndGet()
-        );
+        ConcurrentBatchHelper.runConcurrentBatches(makeBatches(nbBatches), nbBatches, command -> {
+            if (executorCalls.getAndIncrement() < acceptCount) {
+                command.run();
+            } else {
+                throw new RejectedExecutionException("pool full");
+            }
+        }, batch -> batchesExecuted.incrementAndGet());
 
         assertEquals(nbBatches, batchesExecuted.get());
     }

--- a/server/src/test/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/ConcurrentBatchHelperTests.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.blobstore;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrentBatchHelperTests extends ESTestCase {
+
+    public void testEmptyBatchListIsNoOp() throws IOException {
+        ConcurrentBatchHelper.runConcurrentBatches(
+            List.of(), randomIntBetween(1, 10), command -> {
+                throw new AssertionError("executor must not be called for empty input");
+            }, batch -> {throw new AssertionError("consumer must not be called for empty input");}
+        );
+    }
+
+    public void testAllBatchesExecutedWhenExecutorRejects() throws IOException {
+        final int nbBatches = randomIntBetween(2, 20);
+        final List<List<String>> batches = makeBatches(nbBatches);
+        final AtomicInteger batchesExecuted = new AtomicInteger(0);
+
+        ConcurrentBatchHelper.runConcurrentBatches(
+            batches, randomIntBetween(2, 10), command -> {
+                throw new RejectedExecutionException("executor is full");
+            }, batch -> batchesExecuted.incrementAndGet()
+        );
+
+        assertEquals(nbBatches, batchesExecuted.get());
+    }
+
+    public void testAllBatchesExecuted() throws IOException {
+        final int nbBatches = randomIntBetween(1, 20);
+        final List<List<String>> batches = makeBatches(nbBatches);
+        final AtomicInteger batchesExecuted = new AtomicInteger(0);
+
+        ConcurrentBatchHelper.runConcurrentBatches(
+            batches,
+            randomIntBetween(1, nbBatches + 1),
+            Runnable::run,
+            batch -> batchesExecuted.incrementAndGet()
+        );
+
+        assertEquals(nbBatches, batchesExecuted.get());
+    }
+
+    public void testExceptionFromBatchPropagatesAsIOException() {
+        final List<List<String>> batches = makeBatches(randomIntBetween(1, 5));
+        final RuntimeException cause = new RuntimeException("batch failed");
+
+        final IOException e = expectThrows(
+            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
+                batches, 1, Runnable::run, batch -> {
+                    throw cause;
+                }
+            )
+        );
+
+        assertEquals("Failed to delete blobs", e.getMessage());
+        assertSame(cause, e.getCause());
+    }
+
+    public void testSubsequentBatchesAreSkippedAfterFailure() {
+        // With maxConcurrency=1 only the calling thread runs, so batches are processed
+        // sequentially. Once the first batch throws, the worker sees a non-empty exception
+        // queue and skips remaining batches (still counting them down so the latch drains).
+        final List<List<String>> batches = makeBatches(randomIntBetween(2, 10));
+        final RuntimeException cause = new RuntimeException("first batch failed");
+        final AtomicInteger callCount = new AtomicInteger();
+
+        final IOException e = expectThrows(
+            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
+                batches, 1, Runnable::run, batch -> {
+                    callCount.incrementAndGet();
+                    throw cause;
+                }
+            )
+        );
+
+        assertEquals("Failed to delete blobs", e.getMessage());
+        assertSame(cause, e.getCause());
+        // Only the first batch was actually processed; the rest were skipped.
+        assertEquals(1, callCount.get());
+    }
+
+    public void testSingleBatchNeverUsesExecutor() throws IOException {
+        // With nbBatches=1, min(maxConcurrency-1, nbBatches-1) = 0, so the executor is never called.
+        final AtomicInteger batchesExecuted = new AtomicInteger();
+        ConcurrentBatchHelper.runConcurrentBatches(
+            makeBatches(1), randomIntBetween(1, 100), command -> {
+                throw new AssertionError("executor must not be called for a single batch");
+            }, batch -> batchesExecuted.incrementAndGet()
+        );
+        assertEquals(1, batchesExecuted.get());
+    }
+
+    public void testMaxConcurrencyExceedsBatchCount() throws IOException {
+        // Dispatcher caps at min(maxConcurrency-1, nbBatches-1) so over-large maxConcurrency
+        // does not cause excess executor submissions or missed batches.
+        final int nbBatches = randomIntBetween(2, 5);
+        final AtomicInteger batchesExecuted = new AtomicInteger();
+        ConcurrentBatchHelper.runConcurrentBatches(
+            makeBatches(nbBatches),
+            nbBatches * 10,
+            Runnable::run,
+            batch -> batchesExecuted.incrementAndGet()
+        );
+        assertEquals(nbBatches, batchesExecuted.get());
+    }
+
+    public void testBatchContentsArePassedCorrectly() throws IOException {
+        final int nbBatches = randomIntBetween(1, 10);
+        final List<List<String>> batches = makeBatches(nbBatches);
+        final Set<String> received = Collections.synchronizedSet(new HashSet<>());
+
+        ConcurrentBatchHelper.runConcurrentBatches(batches, randomIntBetween(1, nbBatches + 1), Runnable::run, received::addAll);
+
+        final Set<String> expected = new HashSet<>();
+        for (int i = 0; i < nbBatches; i++) {
+            expected.add("item-" + i);
+        }
+        assertEquals(expected, received);
+    }
+
+    public void testCheckedIOExceptionPropagates() {
+        // BatchConsumer.accept throws a checked IOException; it should surface as the cause
+        // of the wrapper rather than being double-wrapped.
+        final IOException cause = new IOException("IO error during batch");
+        final IOException e = expectThrows(
+            IOException.class, () -> ConcurrentBatchHelper.runConcurrentBatches(
+                makeBatches(1), 1, Runnable::run, batch -> {
+                    throw cause;
+                }
+            )
+        );
+        assertEquals("Failed to delete blobs", e.getMessage());
+        assertSame(cause, e.getCause());
+    }
+
+    public void testPartialExecutorRejection() throws IOException {
+        // Executor accepts the first few dispatches and rejects the rest.
+        // The calling thread must handle unclaimed batches so the total still equals nbBatches.
+        final int nbBatches = randomIntBetween(3, 10);
+        final int acceptCount = randomIntBetween(1, nbBatches - 1);
+        final AtomicInteger executorCalls = new AtomicInteger();
+        final AtomicInteger batchesExecuted = new AtomicInteger();
+
+        ConcurrentBatchHelper.runConcurrentBatches(
+            makeBatches(nbBatches), nbBatches, command -> {
+                if (executorCalls.getAndIncrement() < acceptCount) {
+                    command.run();
+                } else {
+                    throw new RejectedExecutionException("pool full");
+                }
+            }, batch -> batchesExecuted.incrementAndGet()
+        );
+
+        assertEquals(nbBatches, batchesExecuted.get());
+    }
+
+    private static List<List<String>> makeBatches(int count) {
+        final List<List<String>> batches = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            batches.add(List.of("item-" + i));
+        }
+        return batches;
+    }
+}


### PR DESCRIPTION
The old deleteBlobs algorithm processed batches of up to 100 items serially on the calling thread. On throttling (429/5xx), it collected all failed items but retried only a single one through the SDK client (using the SDK's own exponential backoff as an implicit back-off signal). If that probe recovered, the rest were queued for the next batch. If the probe exhausted the SDK's own retries, all remaining `N-1` items were permanently abandoned — maximum wait, zero recovery. (Put differently, if it works, you now have to do two operations when one would've sufficed, increasing the likelihood of throttling)

The new algorithm:

- Drains the iterator into fixed-size chunks on the calling thread (iterators are not thread-safe and must be consumed serially).
- Dispatches chunks concurrently via `ConcurrentBatchHelper`, a new server-module sibling of `ConcurrentMultipartHelper`. The calling thread participates directly so progress is guaranteed even when the SNAPSHOT thread pool is saturated and rejects tasks.
- Each chunk retries all of its own throttled items together as a sub-batch, eliminating the old `N-1` abandonment failure mode.
- Sleeps between retries with jitter (±25% of the base delay) so workers that receive a 429 simultaneously do not thundering-herd on the next attempt. `BackoffPolicy.exponentialBackoff` has no built-in jitter; `ThreadLocalRandom` supplies it here.
- `MeteredStorageBatch` records `itemCount` `DELETE` operations rather than 1 per HTTP envelope, since GCS billing charges per item in a batch.
- `GcsRepositoryStatsCollector.collectBatch` mirrors this: it increments the operation counter by `itemCount` instead of 1.

Two new repository settings:

- `delete_objects_max_size` (default/max 100): items per GCS batch. (100 is the max per batch from GCS)
- `max_concurrent_batch_deletes` (default 5, max 100): concurrent batch workers. Default matches the SNAPSHOT pool size on nodes with heap below 750 MB and leaves headroom on larger nodes (pool size 10).
