### PR TITLE
[9.4] Fix a race condition in the WatcherLifeCycleService (#153737)

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleService.java
@@ -46,6 +46,7 @@ public class WatcherLifeCycleService implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(WatcherLifeCycleService.class);
     private final AtomicReference<WatcherState> state = new AtomicReference<>(WatcherState.STARTED);
     private final AtomicReference<List<ShardRouting>> previousShardRoutings = new AtomicReference<>(Collections.emptyList());
+    private final AtomicReference<ClusterState> pendingReloadState = new AtomicReference<>(null);
     private volatile boolean shutDown = false; // indicates that the node has been shutdown and we should never start watcher after this.
     private final WatcherService watcherService;
     private final EnumSet<WatcherState> stopStates = EnumSet.of(WatcherState.STOPPED, WatcherState.STOPPING);
@@ -67,6 +68,7 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         this.state.set(WatcherState.STOPPING);
         shutDown = true;
         clearAllocationIds();
+        pendingReloadState.set(null);
         watcherService.shutDown(() -> {
             this.state.set(WatcherState.STOPPED);
             logger.info("watcher has stopped and shutdown");
@@ -169,17 +171,48 @@ public class WatcherLifeCycleService implements ClusterStateListener {
 
         if (previousShardRoutings.get().equals(localAffectedShardRoutings) == false) {
             if (watcherService.validate(event.state())) {
-                previousShardRoutings.set(localAffectedShardRoutings);
-                if (state.get() == WatcherState.STARTED) {
-                    watcherService.reload(event.state(), "new local watcher shard allocation ids", (exception) -> {
-                        clearAllocationIds(); // will cause reload again
-                    });
-                } else if (isStoppedOrStopping) {
-                    this.state.set(WatcherState.STARTING);
-                    watcherService.start(event.state(), () -> this.state.set(WatcherState.STARTED), (exception) -> {
-                        clearAllocationIds();
-                        this.state.set(WatcherState.STOPPED);
-                    });
+                switch (state.get()) {
+                    case STARTED -> {
+                        previousShardRoutings.set(localAffectedShardRoutings);
+                        watcherService.reload(event.state(), "new local watcher shard allocation ids", (exception) -> {
+                            clearAllocationIds(); // will cause reload again
+                        });
+                    }
+                    case STARTING -> {
+                        // A start task is already on the single-threaded lifecycle executor — do not enqueue a second
+                        // task. Instead record the new cluster state so start()'s success callback can reload
+                        // immediately once it completes, without waiting for the next cluster state event.
+                        previousShardRoutings.set(localAffectedShardRoutings);
+                        pendingReloadState.set(event.state());
+                        // Double-check: if start()'s success callback ran between the switch evaluation above and the
+                        // pendingReloadState.set() (setting state=STARTED and reading a null pendingReloadState),
+                        // pick up the pending reload now so it is not lost.
+                        // Use == STARTED, not != STARTING: a failure callback sets STOPPED, and we must not
+                        // call reload() against a service that never started successfully.
+                        if (state.get() == WatcherState.STARTED) {
+                            ClusterState pending = pendingReloadState.getAndSet(null);
+                            if (pending != null) {
+                                watcherService.reload(pending, "routing changed during start", (e) -> clearAllocationIds());
+                            }
+                        }
+                    }
+                    case STOPPED, STOPPING -> {
+                        previousShardRoutings.set(localAffectedShardRoutings);
+                        pendingReloadState.set(null); // discard any stale pending from a previous cycle
+                        this.state.set(WatcherState.STARTING);
+                        watcherService.start(event.state(), () -> {
+                            this.state.set(WatcherState.STARTED);
+                            // Pick up any routing change that arrived while we were STARTING.
+                            ClusterState pending = pendingReloadState.getAndSet(null);
+                            if (pending != null) {
+                                watcherService.reload(pending, "routing changed during start", (e) -> clearAllocationIds());
+                            }
+                        }, (exception) -> {
+                            clearAllocationIds();
+                            pendingReloadState.set(null);
+                            this.state.set(WatcherState.STOPPED);
+                        });
+                    }
                 }
             } else {
                 clearAllocationIds();
@@ -192,6 +225,7 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         if (clearAllocationIds()) {
             watcherService.pauseExecution(reason);
         }
+        pendingReloadState.set(null);
         this.state.set(WatcherState.STARTED);
     }
 
@@ -204,7 +238,6 @@ public class WatcherLifeCycleService implements ClusterStateListener {
         return watcherMetadata != null && watcherMetadata.manuallyStopped();
     }
 
-    /**
     /**
      * clear out current allocation ids if not already happened
      * @return true, if existing allocation ids were cleaned out, false otherwise

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -271,6 +271,88 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
         assertThat(lifeCycleService.getState().get(), equalTo(WatcherState.STARTED));
     }
 
+    public void testRoutingChangeWhileStartingTriggersReload() {
+        /*
+         * Regression test for a race where a replica shard transitions to STARTED while watcher
+         * is mid-start (state=STARTING, reloadInner in flight). Without handling this case the
+         * stale reloadInner completes with shardCount=1, causing every node to schedule all
+         * watches and producing an alternating throttled/executed history pattern.
+         *
+         * The STARTING state is reached here via validate() returning false on the first
+         * cluster-changed event (e.g. index not yet ready), which drives state to STOPPED; the
+         * next event with the same routing but validate()=true then transitions STOPPED→STARTING.
+         */
+        Index watchIndex = new Index(Watch.INDEX, "uuid");
+        ShardId shardId = new ShardId(watchIndex, 0);
+        DiscoveryNodes nodes = new DiscoveryNodes.Builder().masterNodeId("node_1")
+            .localNodeId("node_1")
+            .add(newNode("node_1"))
+            .add(newNode("node_2"))
+            .build();
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(Watch.INDEX)
+            .settings(settings(IndexVersion.current()).put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), 6))
+            .numberOfShards(1)
+            .numberOfReplicas(1);
+        ProjectMetadata metadata = ProjectMetadata.builder(projectId)
+            .put(IndexTemplateMetadata.builder(HISTORY_TEMPLATE_NAME).patterns(randomIndexPatterns()))
+            .put(indexMetadataBuilder)
+            .build();
+
+        // CS_S: only the primary on the local node (replica not yet allocated)
+        IndexRoutingTable primaryOnly = IndexRoutingTable.builder(watchIndex)
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_1", true, STARTED))
+            .build();
+        ClusterState csWithPrimary = ClusterState.builder(new ClusterName("my-cluster"))
+            .nodes(nodes)
+            .putRoutingTable(projectId, RoutingTable.builder().add(primaryOnly).build())
+            .putProjectMetadata(metadata)
+            .build();
+
+        // CS_3: primary on node_1, replica now STARTED on node_2
+        IndexRoutingTable primaryAndReplica = IndexRoutingTable.builder(watchIndex)
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_1", true, STARTED))
+            .addShard(TestShardRouting.newShardRouting(shardId, "node_2", false, STARTED))
+            .build();
+        ClusterState csWithReplica = ClusterState.builder(new ClusterName("my-cluster"))
+            .nodes(nodes)
+            .putRoutingTable(projectId, RoutingTable.builder().add(primaryAndReplica).build())
+            .putProjectMetadata(metadata)
+            .build();
+
+        ClusterState emptyState = ClusterState.builder(new ClusterName("my-cluster")).nodes(nodes).putProjectMetadata(metadata).build();
+
+        // Step 1: validate() returns false (e.g. index not ready) → state driven to STOPPED
+        // This is to put the lifecycle service in STOPPED state, the bug is in the transition from STOPPED to STARTED
+        when(watcherService.validate(csWithPrimary)).thenReturn(false);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STOPPED));
+
+        // Step 2: same routing, validate() now returns true → STOPPED→STARTING, start(CS_S).
+        // Capture the success callback so we can fire it later to simulate reloadInner completing.
+        ArgumentCaptor<Runnable> successCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(watcherService.validate(csWithPrimary)).thenReturn(true);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithPrimary, emptyState));
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
+        verify(watcherService, times(1)).start(eq(csWithPrimary), successCaptor.capture(), any());
+
+        // Step 3: replica becomes STARTED while start() is still in flight.
+        // The fix must NOT submit a concurrent reload task (at most one lifecycle task in flight).
+        // Instead it records the new cluster state as a pending reload to be drained by the
+        // start() success callback. State must remain STARTING.
+        reset(watcherService);
+        when(watcherService.validate(csWithReplica)).thenReturn(true);
+        lifeCycleService.clusterChanged(new ClusterChangedEvent(randomIdentifier(), csWithReplica, csWithPrimary));
+        verify(watcherService, never()).reload(any(), any(), any());
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTING));
+
+        // Step 4: start()'s success callback fires (reloadInner completes). It must advance state
+        // to STARTED and immediately submit a reload for the pending cluster state, so the routing
+        // change is acted on without waiting for the next cluster state event.
+        successCaptor.getValue().run();
+        assertThat(lifeCycleService.getState().get(), is(WatcherState.STARTED));
+        verify(watcherService, times(1)).reload(eq(csWithReplica), anyString(), any());
+    }
+
     public void testReloadWithIdenticalRoutingTable() {
         /*
          * This tests that the identical routing table causes reload only once.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix a race condition in the WatcherLifeCycleService (#153737)](https://github.com/elastic/elasticsearch/pull/153737)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)