### PR TITLE
Add transport version for search tier watermark metadata

### DIFF
--- a/server/src/main/resources/transport/upper_bounds/9.6.csv
+++ b/server/src/main/resources/transport/upper_bounds/9.6.csv
@@ -1,1 +1,1 @@
-search_lane_requirements_in_cluster_info,9508000
+search_tier_watermark_metadata,9509000


### PR DESCRIPTION
## Summary

Mints the `search_tier_watermark_metadata` named transport version (`9509000`) for the search-tier storage watermark feature being added in elasticsearch-serverless.

`SearchTierWatermarkMetadata` is a `ClusterState.Custom` that carries a single boolean (`overHighWatermark`) and is published by the search-tier watermark monitor. Its `getMinimalSupportedVersion()` currently returns `TransportVersion.zero()` with a TODO pending this constant.

Once this merges and the serverless submodule is bumped, the serverless PR will replace `TransportVersion.zero()` with `TransportVersion.fromName("search_tier_watermark_metadata")`.

## Test plan

- [ ] No Java changes; existing transport-version tests cover the CSV parsing.