### PR TITLE
[8.19] Fix smart retry for CCR tests (#156417)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -47,9 +47,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Test bad parameters}
   issue: https://github.com/elastic/elasticsearch/issues/156975
-- class: org.elasticsearch.xpack.ccr.ChainIT
-  method: testFollowIndex {targetCluster=FOLLOWER}
-  issue: https://github.com/elastic/elasticsearch/issues/157152
 - class: org.elasticsearch.index.query.SearchExecutionContextTests
   method: testFielddataLookupSometimesLoop
   issue: https://github.com/elastic/elasticsearch/issues/157154

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -19,6 +19,9 @@ base {
   archivesName = 'x-pack-ccr'
 }
 
+// CCR REST tests use ordered target-cluster parameters where earlier phases establish state for later phases.
+smartRetry.pruneIndividualTests.set(false)
+
 dependencies {
   compileOnly project(":server")
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix smart retry for CCR tests (#156417)](https://github.com/elastic/elasticsearch/pull/156417)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #157152