### PR TITLE
Fix ArrayOrder block loaders falsely claiming SORTED_ASCENDING

### DIFF
--- a/docs/changelog/157857.yaml
+++ b/docs/changelog/157857.yaml
@@ -1,0 +1,6 @@
+area: Columnar
+issues:
+ - 157817
+pr: 157857
+summary: Fix `ArrayOrder` block loaders falsely claiming SORTED_ASCENDING
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -784,9 +784,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testUploadedCommitPrefetchNeverHitsIndexingNode
   issue: https://github.com/elastic/elasticsearch/issues/157813
-- class: org.elasticsearch.xpack.esql.CsvColumnarIT
-  method: test {csv-spec:inlinestats.inlineStatsDroppingMultipleCommandsGroupingFields}
-  issue: https://github.com/elastic/elasticsearch/issues/157817
 - class: org.elasticsearch.xpack.esql.optimizer.promql.PromqlGoldenTests
   method: testBinaryWithDifferentSelectors {historical}
   issue: https://github.com/elastic/elasticsearch/issues/157827

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BooleansBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BooleansBlockLoader.java
@@ -114,7 +114,10 @@ public class BooleansBlockLoader extends AbstractNumericBlockLoader {
 
         @Override
         protected BooleanBuilder newBuilder(BlockFactory factory, int count) {
-            return factory.booleansFromDocValues(count);
+            // Values are emitted in source insertion order (not sorted ascending), so we must
+            // not claim SORTED_ASCENDING here. The booleansFromDocValues path would be wrong
+            // for any MV function (e.g. MV_MIN) that uses the ascending fast path.
+            return factory.booleans(count);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoublesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DoublesBlockLoader.java
@@ -136,7 +136,8 @@ public class DoublesBlockLoader extends AbstractNumericBlockLoader {
 
         @Override
         protected DoubleBuilder newBuilder(BlockFactory factory, int count) {
-            return factory.doublesFromDocValues(count);
+            // Values are emitted in source insertion order (not sorted ascending).
+            return factory.doubles(count);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/IntsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/IntsBlockLoader.java
@@ -123,7 +123,8 @@ public class IntsBlockLoader extends AbstractNumericBlockLoader {
 
         @Override
         protected IntBuilder newBuilder(BlockFactory factory, int count) {
-            return factory.intsFromDocValues(count);
+            // Values are emitted in source insertion order (not sorted ascending).
+            return factory.ints(count);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/LongsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/LongsBlockLoader.java
@@ -123,7 +123,8 @@ public class LongsBlockLoader extends AbstractNumericBlockLoader {
 
         @Override
         protected LongBuilder newBuilder(BlockFactory factory, int count) {
-            return factory.longsFromDocValues(count);
+            // Values are emitted in source insertion order (not sorted ascending).
+            return factory.longs(count);
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/limit.csv-spec
@@ -549,7 +549,6 @@ Magy               | Stamatiou         | 30404          | 3
 
 sortLimitByNullsFirst
 required_capability: esql_topn_by
-skip_columnar: Sort result ordering differs in columnar mode when MV fields are part of sort criteria
 
 FROM employees
 | SORT is_rehired ASC NULLS FIRST, emp_no
@@ -574,7 +573,6 @@ Shahaf             | Famili            | null              | [false, true]
 
 sortLimitByNullsLast
 required_capability: esql_topn_by
-skip_columnar: Sort result ordering differs in columnar mode when MV fields are part of sort criteria
 
 FROM employees
 | SORT is_rehired ASC NULLS LAST, emp_no

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_percentile.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_percentile.csv-spec
@@ -89,7 +89,6 @@ integer:integer | long:long | double:double
 
 fromIndex
 required_capability: fn_mv_percentile
-skip_columnar: MV_PERCENTILE result differs in columnar mode due to different MV ordering in source
 
 FROM employees
 | EVAL


### PR DESCRIPTION
## Summary

- `ArrayOrder` block loaders for boolean/double/int/long types were calling `*FromDocValues()` factory methods in `newBuilder()`, which set `MvOrdering.SORTED_ASCENDING` on the resulting block.
- `ArrayOrder` reads values in **source insertion order** via an offsets companion field — not doc-values ascending order — so this `SORTED_ASCENDING` claim is incorrect.
- This caused MV functions (`MV_MIN`, `MV_PERCENTILE`) and sort key extractors to take incorrect fast paths that assumed ascending order, producing wrong results in columnar mode.
- Fix: switch each `ArrayOrder.newBuilder()` override to the unordered factory method (`booleans`, `doubles`, `ints`, `longs`).
- Removes three `skip_columnar` directives that were added to work around this bug.

Fixes #157817

## Test plan

- [ ] `CsvColumnarIT.inlineStatsDroppingMultipleCommandsGroupingFields` (unmuted — was the reported failure)
- [ ] `CsvColumnarIT.*fromIndex*` (mv_percentile) — `skip_columnar` removed, test passes
- [ ] `CsvColumnarIT.*sortLimitByNullsFirst*` — `skip_columnar` removed, test passes
- [ ] `CsvColumnarIT.*sortLimitByNullsLast*` — `skip_columnar` removed, test passes