### PR TITLE
Fix BYTE_LENGTH returning 0 for keywords in columnar mode

### DIFF
--- a/docs/changelog/157858.yaml
+++ b/docs/changelog/157858.yaml
@@ -1,0 +1,5 @@
+area: Columnar
+issues: []
+pr: 157858
+summary: Fix BYTE_LENGTH returning 0 for keywords in columnar mode
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
@@ -81,8 +81,8 @@ public final class SingletonIntBuilder implements BlockLoader.SingletonIntBuilde
     }
 
     @Override
-    public BlockLoader.SingletonIntBuilder appendInts(int[] values, int from, int length) {
-        System.arraycopy(values, from, values, count, length);
+    public BlockLoader.SingletonIntBuilder appendInts(int[] source, int from, int length) {
+        System.arraycopy(source, from, values, count, length);
         count += length;
         return this;
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilderTests.java
@@ -121,6 +121,35 @@ public class SingletonIntBuilderTests extends ComputeTestCase {
         }
     }
 
+    /**
+     * Appends int slices via {@link SingletonIntBuilder#appendInts} and asserts the built vector holds them
+     * in order. Guards against a regression where the {@code appendInts} parameter shadowed the instance
+     * {@code values} field, so {@link System#arraycopy} copied the source onto itself and left the builder's
+     * array full of zeros. Uses a non-zero {@code from} offset because that shadowing bug also mishandled it.
+     */
+    public void testAppendInts() {
+        int count = 1000;
+        int[] source = new int[count + 5];
+        for (int i = 0; i < source.length; i++) {
+            source[i] = i * 7 + 3;
+        }
+        int from = 5;
+        try (SingletonIntBuilder builder = new SingletonIntBuilder(count, blockFactory())) {
+            int appended = 0;
+            while (appended < count) {
+                int length = Math.min(randomIntBetween(1, 64), count - appended);
+                builder.appendInts(source, from + appended, length);
+                appended += length;
+            }
+            try (IntVector build = (IntVector) builder.build().asVector()) {
+                assertThat(build.getPositionCount(), equalTo(count));
+                for (int i = 0; i < count; i++) {
+                    assertThat(build.getInt(i), equalTo(source[from + i]));
+                }
+            }
+        }
+    }
+
     static IndexWriter createIndexWriter(Directory directory) throws IOException {
         IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
         iwc.setCodec(TestUtil.alwaysDocValuesFormat(new ES819Version3TSDBDocValuesFormat()));

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestTest.java
@@ -552,13 +552,6 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
         if (cmdText.contains("NOW(") || cmdText.contains("RANDOM(") || cmdText.contains("SAMPLE(")) {
             return false;
         }
-        // BYTE_LENGTH on keyword fields returns 0 in columnar mode due to a known columnar
-        // doc-values read bug. Affects both WHERE predicates (wrong row count) and aggregations
-        // like TOP/STATS (wrong computed values). Close the gate whenever BYTE_LENGTH appears.
-        // TODO: remove once the columnar BYTE_LENGTH doc-values bug is fixed.
-        if (cmdText.contains("BYTE_LENGTH(")) {
-            return false;
-        }
         // Full-text search functions and the `:` operator rely on the inverted index. Columnar
         // mode stores keyword fields exclusively via doc values (index_disabled_by_default=true
         // disables the inverted index for fields that lack an explicit "index: true" mapping), so


### PR DESCRIPTION
`SingletonIntBuilder.appendInts` named its parameter `values`, which shadowed the instance field of the same name. `System.arraycopy` then copied the source array onto itself and never wrote into the builder's backing array, leaving it full of zeros. `BYTE_LENGTH` pushes its length computation down through `OptionalLengthReader.tryReadLength`, which uses this builder, so it always produced 0 in columnar mode.

Rename the parameter to `source` so the copy targets this.values. Add `SingletonIntBuilderTests.testAppendInts` to cover the `appendInts` path, which the existing tests never exercised, and remove the `BYTE_LENGTH` determinism gate that masked the bug in `CrossIndexModeGenerativeRestTest`.