### PR TITLE
[9.5] SQL: Fix result size limit check on INSERT (#157752)

### DIFF
--- a/docs/changelog/157752.yaml
+++ b/docs/changelog/157752.yaml
@@ -1,0 +1,5 @@
+area: SQL
+issues: []
+pr: 157752
+summary: Fix result size limit check on INSERT
+type: bug

--- a/x-pack/plugin/sql/qa/server/src/main/resources/functions.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/functions.csv-spec
@@ -156,6 +156,20 @@ AO             |1
 AP             |2   
 ;
 
+selectInsertEmptyWithLengthPastEnd
+SELECT INSERT('', 1, 2000000000, 'hello') modified;
+
+modified:s
+hello
+;
+
+selectInsertCutLongerThanInput
+SELECT INSERT('ab', 1, 2000000000, 'z') modified;
+
+modified:s
+z
+;
+
 selectSubstringWithGroupBy
 SELECT SUBSTRING("first_name",1,2) modified, COUNT(*) count FROM "test_emp" WHERE ASCII("first_name")=65 GROUP BY SUBSTRING("first_name",1,2) ORDER BY SUBSTRING("first_name",1,2) ASC LIMIT 10;
 

--- a/x-pack/plugin/sql/qa/server/src/main/resources/string-functions.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/string-functions.sql-spec
@@ -91,6 +91,12 @@ SELECT INSERT('Insert [here] your comment!', 8, 20, '(random thoughts about Elas
 insertInline3
 SELECT INSERT('Insert [here] your comment!', 8, 19, '(random thoughts about Elasticsearch)') ins;
 
+insertEmptyWithLengthPastEnd
+SELECT INSERT('', 1, 2000000000, 'hello') ins;
+
+insertCutLongerThanInput
+SELECT INSERT('ab', 1, 2000000000, 'z') ins;
+
 positionInline1
 SELECT POSITION('a','Elasticsearch') pos;
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertFunctionProcessor.java
@@ -63,19 +63,24 @@ public class InsertFunctionProcessor implements Processor {
         Check.isFixedNumberAndInRange(start, "start", (long) Integer.MIN_VALUE + 1, (long) Integer.MAX_VALUE);
         Check.isFixedNumberAndInRange(length, "length", 0L, (long) Integer.MAX_VALUE);
 
+        String str = input.toString();
         int startInt = ((Number) start).intValue() - 1;
         int realStart = startInt < 0 ? 0 : startInt;
 
-        if (startInt > input.toString().length()) {
+        if (startInt > str.length()) {
             return input;
         }
 
-        StringBuilder sb = new StringBuilder(input.toString());
-        String replString = (replacement.toString());
-
+        String replString = replacement.toString();
         int cutLength = ((Number) length).intValue();
-        checkResultLength(sb.length() - cutLength + replString.length());
-        return sb.replace(realStart, realStart + cutLength, replString).toString();
+        int deleted = Math.min(cutLength, str.length() - realStart);
+        long resultLen = (long) str.length() - deleted + replString.length();
+        checkResultLength(resultLen);
+        StringBuilder sb = new StringBuilder((int) resultLen);
+        sb.append(str, 0, realStart);
+        sb.append(replString);
+        sb.append(str, realStart + deleted, str.length());
+        return sb.toString();
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/InsertProcessorTests.java
@@ -142,4 +142,34 @@ public class InsertProcessorTests extends AbstractWireSerializingTestCase<Insert
             () -> new Insert(EMPTY, l(str), l(1), l(replaceWith.length() - 1), l(replaceWith)).makePipe().asProcessor().process(null)
         );
     }
+
+    /**
+     * {@code length} is the requested cut, but {@link StringBuilder#replace} only
+     * deletes up to the end of the input. Subtracting the requested cut from the
+     * estimated size can under-count (or wrap as {@code int}) and skip
+     * {@link StringProcessor#MAX_RESULT_LENGTH}.
+     */
+    public void testInsertResultLengthWhenCutExceedsInput() {
+        String tooLong = "a".repeat((int) MAX_RESULT_LENGTH + 1);
+        maxResultLengthTest(
+            MAX_RESULT_LENGTH + 1,
+            () -> new Insert(EMPTY, l(""), l(1), l(2_000_000_000), l(tooLong)).makePipe().asProcessor().process(null)
+        );
+        maxResultLengthTest(
+            MAX_RESULT_LENGTH + 1,
+            () -> new Insert(EMPTY, l(""), l(1), l(Integer.MAX_VALUE), l(tooLong)).makePipe().asProcessor().process(null)
+        );
+
+        String maxReplacement = "a".repeat((int) MAX_RESULT_LENGTH);
+        // 'he' remains + 1MB replacement
+        maxResultLengthTest(
+            2L + MAX_RESULT_LENGTH,
+            () -> new Insert(EMPTY, l("hello"), l(3), l(100), l(maxReplacement)).makePipe().asProcessor().process(null)
+        );
+
+        assertEquals(
+            MAX_RESULT_LENGTH,
+            new Insert(EMPTY, l(""), l(1), l(2_000_000_000), l(maxReplacement)).makePipe().asProcessor().process(null).toString().length()
+        );
+    }
 }


### PR DESCRIPTION
Backports the following commits to 9.5:
 - SQL: Fix result size limit check on INSERT (#157752)