### PR TITLE
[9.5] Fix BYTE_LENGTH returning 0 for keywords in columnar mode (#157858)

### DIFF
--- a/docs/changelog/157858.yaml
+++ b/docs/changelog/157858.yaml
@@ -1,0 +1,5 @@
+area: Columnar
+issues: []
+pr: 157858
+summary: Fix BYTE_LENGTH returning 0 for keywords in columnar mode
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilder.java
@@ -81,8 +81,8 @@ public final class SingletonIntBuilder implements BlockLoader.SingletonIntBuilde
     }
 
     @Override
-    public BlockLoader.SingletonIntBuilder appendInts(int[] values, int from, int length) {
-        System.arraycopy(values, from, values, count, length);
+    public BlockLoader.SingletonIntBuilder appendInts(int[] source, int from, int length) {
+        System.arraycopy(source, from, values, count, length);
         count += length;
         return this;
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonIntBuilderTests.java
@@ -121,6 +121,35 @@ public class SingletonIntBuilderTests extends ComputeTestCase {
         }
     }
 
+    /**
+     * Appends int slices via {@link SingletonIntBuilder#appendInts} and asserts the built vector holds them
+     * in order. Guards against a regression where the {@code appendInts} parameter shadowed the instance
+     * {@code values} field, so {@link System#arraycopy} copied the source onto itself and left the builder's
+     * array full of zeros. Uses a non-zero {@code from} offset because that shadowing bug also mishandled it.
+     */
+    public void testAppendInts() {
+        int count = 1000;
+        int[] source = new int[count + 5];
+        for (int i = 0; i < source.length; i++) {
+            source[i] = i * 7 + 3;
+        }
+        int from = 5;
+        try (SingletonIntBuilder builder = new SingletonIntBuilder(count, blockFactory())) {
+            int appended = 0;
+            while (appended < count) {
+                int length = Math.min(randomIntBetween(1, 64), count - appended);
+                builder.appendInts(source, from + appended, length);
+                appended += length;
+            }
+            try (IntVector build = (IntVector) builder.build().asVector()) {
+                assertThat(build.getPositionCount(), equalTo(count));
+                for (int i = 0; i < count; i++) {
+                    assertThat(build.getInt(i), equalTo(source[from + i]));
+                }
+            }
+        }
+    }
+
     static IndexWriter createIndexWriter(Directory directory) throws IOException {
         IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
         iwc.setCodec(TestUtil.alwaysDocValuesFormat(new ES819Version3TSDBDocValuesFormat()));


### PR DESCRIPTION
A backport for #157858