### PR TITLE
Remove stale MV_MAX/MV_MIN/MV_MEDIAN gate

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -772,9 +772,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {bad_ARROW-GH-43605}
   issue: https://github.com/elastic/elasticsearch/issues/157747
-- class: org.elasticsearch.xpack.esql.qa.single_node.CrossIndexModeGenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/157521
 - class: org.elasticsearch.snapshots.RestoreOverOpenIndexIT
   method: testOverlappingRestoreTransitionsDoNotCorruptTheSecondRestore
   issue: https://github.com/elastic/elasticsearch/issues/157793

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestTest.java
@@ -578,17 +578,6 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
             || cmdText.contains("MV_DIFFERENCE(")) {
             return false;
         }
-        // MV_MAX / MV_MIN / MV_MEDIAN / MV_PERCENTILE on numeric fields: columnar mode stores
-        // doc-values in ascending order, and the current columnar execution path returns the first
-        // doc-value element rather than scanning for the true extremum or median. This means mv_max
-        // returns the minimum, mv_median returns the first element, etc. — a known columnar bug.
-        // TODO: remove once the columnar MV scalar-aggregate block-execution bug is fixed.
-        if (cmdText.contains("MV_MAX(")
-            || cmdText.contains("MV_MIN(")
-            || cmdText.contains("MV_MEDIAN(")
-            || cmdText.contains("MV_PERCENTILE(")) {
-            return false;
-        }
         // LEAST / GREATEST applied to multi-value fields are element-wise: they pair up values by
         // position across their arguments and return MV results whose element order depends on the
         // insertion / doc-values order of the input fields. Close the gate whenever either appears.


### PR DESCRIPTION
The pushdown block loaders read the correct element (MAX discards all but the last doc value, MIN reads the first), and the compute-engine ascending optimization picks count-1 for MAX, 0 for MIN, and the middle for MEDIAN. Forcing these functions onto every numeric and string field and running the oracle with the gate disabled produced no divergence. MV_PERCENTILE is never generated at all.

Remove the gate so these functions are covered by the oracle.