### PR TITLE
Do not prewarm _id's for indices with synthetic ids

### DIFF
--- a/docs/changelog/157882.yaml
+++ b/docs/changelog/157882.yaml
@@ -1,0 +1,5 @@
+area: Recovery
+issues: []
+pr: 157882
+summary: Do not prewarm _id's for indices with synthetic ids
+type: bug

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/StatelessPrimaryRelocationTargetService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/recovery/StatelessPrimaryRelocationTargetService.java
@@ -139,7 +139,8 @@ public class StatelessPrimaryRelocationTargetService {
                 recoveryState.setStage(RecoveryState.Stage.TRANSLOG);
                 indexShard.openEngineAndSkipTranslogRecovery();
 
-                if (request.hasRecentIdLookup()) {
+                // Synthetic id's do not use inverted indices and prewarming them is not necessary
+                if (request.hasRecentIdLookup() && indexShard.indexSettings().useTimeSeriesSyntheticId() == false) {
                     try {
                         indexShard.withEngine(engine -> {
                             if (engine instanceof IndexEngine indexEngine) {


### PR DESCRIPTION
CI uncovered an issue with the synthetic id terms#max implementation (which is quite expensive). So I decided to disable it for indices with synthetic ids.

```
[2026-08-27T18:24:46,193][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [index-1-PEVUTto] fatal error in thread [elasticsearch[index-1-PEVUTto][generic][T#6]], exitingjava.lang.AssertionError: -4637206729302476579
	at org.elasticsearch.server@9.6.0-SNAPSHOT/org.elasticsearch.index.mapper.TsidExtractingIdFieldMapper.extractTimestampFromSyntheticId(TsidExtractingIdFieldMapper.java:264)
	at org.elasticsearch.server@9.6.0-SNAPSHOT/org.elasticsearch.index.codec.tsdb.TSDBSyntheticIdFieldsProducer$SyntheticIdTermsEnum.seekCeil(TSDBSyntheticIdFieldsProducer.java:266)
	at org.elasticsearch.server@9.6.0-SNAPSHOT/org.elasticsearch.index.codec.bloomfilter.LazyFilterTermsEnum.seekCeil(LazyFilterTermsEnum.java:27)
	at org.apache.lucene.core@10.5.1/org.apache.lucene.index.Terms.getMax(Terms.java:194)
	at org.elasticsearch.xpack.stateless@9.6.0-SNAPSHOT/org.elasticsearch.xpack.stateless.engine.IndexEngine.lambda$prewarmIdLookups$2(IndexEngine.java:261)
	at org.elasticsearch.server@9.6.0-SNAPSHOT/org.elasticsearch.index.engine.InternalEngine.performActionWithDirectoryReader(InternalEngine.java:4335)
	at org.elasticsearch.xpack.stateless@9.6.0-SNAPSHOT/org.elasticsearch.xpack.stateless.engine.IndexEngine.prewarmIdLookups(IndexEngine.java:251)
```
