### PR TITLE
[9.5] ESQL: Fix integer ROUND silently overflowing (#156412)

### DIFF
--- a/docs/changelog/156412.yaml
+++ b/docs/changelog/156412.yaml
@@ -1,0 +1,6 @@
+pr: 156412
+summary: Fix ROUND of an integer with a negative precision silently overflowing to a negative value
+area: ES|QL
+type: bug
+issues:
+ - 156411

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -805,6 +805,36 @@ ul:ul
 null
 ;
 
+roundIntOverflowAtNegativePrecision
+required_capability: fn_round_int_overflow_warns
+row n = round(2147483647, -1);
+
+warning:Line 1:9: evaluation of [round(2147483647, -1)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.ArithmeticException: integer overflow
+
+n:integer
+null
+;
+
+roundIntOverflowNoFold
+required_capability: fn_round_int_overflow_warns
+row n = 2145000000 | eval n = round(n, -7);
+
+warning:Line 1:31: evaluation of [round(n, -7)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:31: java.lang.ArithmeticException: integer overflow
+
+n:integer
+null
+;
+
+roundIntNoOverflowAtEvenPrecision
+required_capability: fn_round_int_overflow_warns
+row n = round(2147483647, -2);
+
+n:integer
+2147483600
+;
+
 roundToInt
 required_capability: round_to
 ROW v = 1

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundIntEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
@@ -57,7 +58,7 @@ public final class RoundIntEvaluator implements ExpressionEvaluator {
         if (decimalsVector == null) {
           return eval(page.getPositionCount(), valBlock, decimalsBlock);
         }
-        return eval(page.getPositionCount(), valVector, decimalsVector).asBlock();
+        return eval(page.getPositionCount(), valVector, decimalsVector);
       }
     }
   }
@@ -97,18 +98,28 @@ public final class RoundIntEvaluator implements ExpressionEvaluator {
         }
         int val = valBlock.getInt(valBlock.getFirstValueIndex(p));
         long decimals = decimalsBlock.getLong(decimalsBlock.getFirstValueIndex(p));
-        result.appendInt(Round.process(val, decimals));
+        try {
+          result.appendInt(Round.process(val, decimals));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector valVector, LongVector decimalsVector) {
-    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+  public IntBlock eval(int positionCount, IntVector valVector, LongVector decimalsVector) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
         int val = valVector.getInt(p);
         long decimals = decimalsVector.getLong(p);
-        result.appendInt(p, Round.process(val, decimals));
+        try {
+          result.appendInt(Round.process(val, decimals));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
@@ -47,7 +47,8 @@ public class Round extends EsqlScalarFunction implements OptionalArgument {
         .binary(Round::new)
         .capabilities(
             // Fixes on function {@code ROUND} that avoid it throwing exceptions on runtime for unsigned long cases.
-            "ul_fixes"
+            "ul_fixes",
+            "int_overflow_warns"
         )
         .name("round");
 
@@ -136,9 +137,9 @@ public class Round extends EsqlScalarFunction implements OptionalArgument {
         return Maths.round(val, 0).doubleValue();
     }
 
-    @Evaluator(extraName = "Int")
+    @Evaluator(extraName = "Int", warnExceptions = ArithmeticException.class)
     static int process(int val, long decimals) {
-        return Maths.round(val, decimals).intValue();
+        return Math.toIntExact(Maths.round(val, decimals));
     }
 
     @Evaluator(extraName = "Long")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
@@ -75,7 +75,7 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
             supplier(
                 "<integer>, <long>",
                 DataType.INTEGER,
-                ESTestCase::randomInt,
+                () -> randomIntBetween(-2_000_000_000, 2_000_000_000),
                 DataType.LONG,
                 ESTestCase::randomLong,
                 "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
@@ -111,7 +111,7 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
             supplier(
                 "<integer>, <integer>",
                 DataType.INTEGER,
-                ESTestCase::randomInt,
+                () -> randomIntBetween(-2_000_000_000, 2_000_000_000),
                 DataType.INTEGER,
                 ESTestCase::randomInt,
                 "RoundIntEvaluator[val=Attribute[channel=0], decimals=CastIntToLongEvaluator[v=Attribute[channel=1]]]",
@@ -216,6 +216,71 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
                     "RoundUnsignedLongEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
                     DataType.UNSIGNED_LONG,
                     equalTo(new BigInteger("10000000000000000000"))
+                )
+            )
+        );
+
+        // Integer overflows
+        suppliers.add(
+            new TestCaseSupplier(
+                "<max integer>, <-1>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MAX_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-1L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                "<min integer>, <-1>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MIN_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-1L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                "<big integer>, <-7>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(2145000000, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-7L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                "<max integer>, <-2>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MAX_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-2L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(2147483600)
                 )
             )
         );


### PR DESCRIPTION
Backports the following commits to 9.5:
 - ESQL: Fix integer ROUND silently overflowing (#156412)