### PR TITLE
Fix FLS field names term state filtering

### DIFF
--- a/docs/changelog/157889.yaml
+++ b/docs/changelog/157889.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 157889
+summary: Fix FLS field names term state filtering
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FilterIterator;
+import org.apache.lucene.util.IOBooleanSupplier;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -806,6 +807,12 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
         @Override
         public boolean seekExact(BytesRef term) throws IOException {
             return accept(term) && in.seekExact(term);
+        }
+
+        @Override
+        public IOBooleanSupplier prepareSeekExact(BytesRef term) throws IOException {
+            // TermStates uses this method before seekExact(term, state), so the field filter must be applied at both stages.
+            return accept(term) ? in.prepareSeekExact(term) : null;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -47,6 +47,8 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TermsEnum.SeekStatus;
 import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -1499,6 +1501,34 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
 
         TestUtil.checkReader(ir);
         IOUtils.close(ir, iw, dir);
+    }
+
+    public void testFieldNamesTermStateRespectsFilteredFields() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+
+        Document doc = new Document();
+        doc.add(new StringField("fieldA", "test", Field.Store.NO));
+        doc.add(new StringField("fieldB", "test", Field.Store.NO));
+        doc.add(new StringField(FieldNamesFieldMapper.NAME, "fieldA", Field.Store.NO));
+        doc.add(new StringField(FieldNamesFieldMapper.NAME, "fieldB", Field.Store.NO));
+        iw.addDocument(doc);
+
+        Automaton automaton = Automatons.patterns(List.of("fieldA", FieldNamesFieldMapper.NAME));
+        DirectoryReader reader = FieldSubsetReader.wrap(
+            DirectoryReader.open(iw),
+            new CharacterRunAutomaton(automaton),
+            IgnoredSourceFieldMapper.IgnoredSourceFormat.NO_IGNORED_SOURCE,
+            fieldName -> false
+        );
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        assertEquals(1, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldA"))));
+        assertEquals(0, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldB"))));
+        assertEquals(0L, searcher.search(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldB")), 10).totalHits.value());
+
+        TestUtil.checkReader(reader);
+        IOUtils.close(reader, iw, dir);
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -1503,32 +1504,45 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
         IOUtils.close(ir, iw, dir);
     }
 
-    public void testFieldNamesTermStateRespectsFilteredFields() throws Exception {
-        Directory dir = newDirectory();
-        IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(null));
+    public void testFieldNamesTermStateForDeniedParentWithAllowedMultiField() throws Exception {
+        DocumentMapper mapper = createMapperService(mapping(b -> {
+            b.startObject("my_field");
+            b.field("type", "text");
+            b.field("norms", false);
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").field("doc_values", false).endObject();
+            b.endObject();
+            b.endObject();
+        })).documentMapper();
 
-        Document doc = new Document();
-        doc.add(new StringField("fieldA", "test", Field.Store.NO));
-        doc.add(new StringField("fieldB", "test", Field.Store.NO));
-        doc.add(new StringField(FieldNamesFieldMapper.NAME, "fieldA", Field.Store.NO));
-        doc.add(new StringField(FieldNamesFieldMapper.NAME, "fieldB", Field.Store.NO));
-        iw.addDocument(doc);
+        try (
+            Directory directory = newDirectory();
+            StandardAnalyzer analyzer = new StandardAnalyzer();
+            IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer))
+        ) {
+            ParsedDocument document = mapper.parse(source(b -> b.field("my_field", "test")));
+            writer.addDocuments(document.docs());
 
-        Automaton automaton = Automatons.patterns(List.of("fieldA", FieldNamesFieldMapper.NAME));
-        DirectoryReader reader = FieldSubsetReader.wrap(
-            DirectoryReader.open(iw),
-            new CharacterRunAutomaton(automaton),
-            IgnoredSourceFieldMapper.IgnoredSourceFormat.NO_IGNORED_SOURCE,
-            fieldName -> false
-        );
-        IndexSearcher searcher = new IndexSearcher(reader);
+            Automaton automaton = Automatons.patterns(List.of("my_field.keyword", FieldNamesFieldMapper.NAME));
+            try (
+                DirectoryReader reader = FieldSubsetReader.wrap(
+                    DirectoryReader.open(writer),
+                    new CharacterRunAutomaton(automaton),
+                    IgnoredSourceFieldMapper.IgnoredSourceFormat.NO_IGNORED_SOURCE,
+                    fieldName -> false
+                )
+            ) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                TermQuery parentExistsQuery = new TermQuery(new Term(FieldNamesFieldMapper.NAME, "my_field"));
 
-        assertEquals(1, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldA"))));
-        assertEquals(0, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldB"))));
-        assertEquals(0L, searcher.search(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "fieldB")), 10).totalHits.value());
+                assertEquals(1, searcher.count(new TermQuery(new Term("my_field.keyword", "test"))));
+                assertEquals(1, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "my_field.keyword"))));
+                assertEquals(0, searcher.count(parentExistsQuery));
+                assertEquals(0L, searcher.search(parentExistsQuery, 10).totalHits.value());
 
-        TestUtil.checkReader(reader);
-        IOUtils.close(reader, iw, dir);
+                TestUtil.checkReader(reader);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fix field-level security filtering for _field_names terms during prepareSeekExact.

Lucene uses prepareSeekExact to build a TermState before calling seekExact(term, state). FieldSubsetReader previously delegated preparation to the unfiltered terms enum. This allowed Lucene to create a state for a field hidden by FLS.

The later filtered lookup rejected the hidden term and threw:
```
IllegalStateException: Tried to seek using a TermState from a different reader!
```

The fix applies the field filter during both preparation and lookup. Hidden terms now behave as absent.

