### PR TITLE
[9.5] [ESQL] Ensure remote connected before testing (#157796)

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/csvSpecTest/java/org/elasticsearch/xpack/esql/ccq/AbstractMultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/csvSpecTest/java/org/elasticsearch/xpack/esql/ccq/AbstractMultiClusterSpecIT.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toSet;
@@ -167,6 +168,26 @@ public abstract class AbstractMultiClusterSpecIT extends EsqlSpecTestCase {
         // #152845 fixed the flag propagation, exposing that CCS LOOKUP JOIN after STATS is unsupported.
         "Lookup join before and after stats by"
     );
+
+    /**
+     * The suite starts loading data and running queries as soon as the local node's own HTTP is up, but the cross-cluster
+     * connection to the remote is established asynchronously. Because these suites run with
+     * {@code skip_unavailable=true}, a query issued before the remote has connected silently skips it and fails. So we
+     * must wait until the remote cluster is ready before starting the test suite.
+     */
+    @Override
+    protected void ensureRemoteClustersConnected() throws Exception {
+        // /_remote/info must go to the local (coordinating) cluster only. The shared client() mirrors non-query requests to
+        // the remote too, whose nodes lack the remote_cluster_client role and reject it, so build a throwaway local client.
+        // connected==true is the meaningful signal (num_nodes_connected is capped by connections_per_cluster=1, not node count).
+        HttpHost[] localHosts = parseClusterHosts(localCluster.getHttpAddresses()).toArray(HttpHost[]::new);
+        try (RestClient localClient = super.buildClient(restAdminSettings(), localHosts)) {
+            assertBusy(() -> {
+                var remoteInfo = assertOKAndCreateObjectPath(localClient.performRequest(new Request("GET", "/_remote/info")));
+                assertEquals(Boolean.TRUE, remoteInfo.evaluate(Clusters.REMOTE_CLUSTER_NAME + ".connected"));
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
 
     @Override
     protected void shouldSkipTest(String testName) throws IOException {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -199,6 +199,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     public void setup() throws IOException {
         assumeTrue("test clusters were broken", testClustersOk);
         INGEST.protectedBlock(() -> {
+            ensureRemoteClustersConnected();
             // Inference endpoints must be created before ingesting any datasets that rely on them (mapping of inference_id)
             // If multiple clusters are used, only create endpoints on the local cluster if it supports the inference test service.
             createInferenceEndpointsIfSupported();
@@ -235,6 +236,12 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
             VIEWS.reset();
         }
     }
+
+    /**
+     * Hook, run once per JVM at the start of data ingestion, for suites that need a remote cluster to be connected before
+     * any data load or query is issued.
+     */
+    protected void ensureRemoteClustersConnected() throws Exception {}
 
     public boolean logResults() {
         return false;


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQL] Ensure remote connected before testing (#157796)