### PR TITLE
[9.4] [ESQL] Ensure remote connected before testing (#157796)

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -41,6 +41,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toSet;
@@ -155,6 +156,26 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         // Lookup join after FORK is not support in CCS yet
         "forkBeforeLookupJoin"
     );
+
+    /**
+     * The suite starts loading data and running queries as soon as the local node's own HTTP is up, but the cross-cluster
+     * connection to the remote is established asynchronously. Because these suites run with
+     * {@code skip_unavailable=true}, a query issued before the remote has connected silently skips it and fails. So we
+     * must wait until the remote cluster is ready before starting the test suite.
+     */
+    @Override
+    protected void ensureRemoteClustersConnected() throws Exception {
+        // /_remote/info must go to the local (coordinating) cluster only. The shared client() mirrors non-query requests to
+        // the remote too, whose nodes lack the remote_cluster_client role and reject it, so build a throwaway local client.
+        // connected==true is the meaningful signal (num_nodes_connected is capped by connections_per_cluster=1, not node count).
+        HttpHost[] localHosts = parseClusterHosts(localCluster.getHttpAddresses()).toArray(HttpHost[]::new);
+        try (RestClient localClient = super.buildClient(restAdminSettings(), localHosts)) {
+            assertBusy(() -> {
+                var remoteInfo = assertOKAndCreateObjectPath(localClient.performRequest(new Request("GET", "/_remote/info")));
+                assertEquals(Boolean.TRUE, remoteInfo.evaluate(Clusters.REMOTE_CLUSTER_NAME + ".connected"));
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
 
     @Override
     protected void shouldSkipTest(String testName) throws IOException {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -175,6 +175,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     public void setup() throws IOException {
         assumeTrue("test clusters were broken", testClustersOk);
         INGEST.protectedBlock(() -> {
+            ensureRemoteClustersConnected();
             // Inference endpoints must be created before ingesting any datasets that rely on them (mapping of inference_id)
             // If multiple clusters are used, only create endpoints on the local cluster if it supports the inference test service.
             createInferenceEndpointsIfSupported();
@@ -232,6 +233,12 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         VIEWS.reset();
         deleteInferenceEndpoints(adminClient());
     }
+
+    /**
+     * Hook, run once per JVM at the start of data ingestion, for suites that need a remote cluster to be connected before
+     * any data load or query is issued.
+     */
+    protected void ensureRemoteClustersConnected() throws Exception {}
 
     public boolean logResults() {
         return false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ESQL] Ensure remote connected before testing (#157796)](https://github.com/elastic/elasticsearch/pull/157796)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)