### PR TITLE
[9.4] Fix the dockerOnLinuxExclusions parsers (#157880)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
@@ -253,7 +253,7 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
             }
 
             final String id = deriveId(values);
-            final boolean excluded = getLinuxExclusionList().contains(id);
+            final boolean excluded = getLinuxExclusionList(getParameters().getExclusionsFile()).contains(id);
 
             if (excluded) {
                 LOGGER.warn("Linux OS id [{}] is present in the Docker exclude list. Tasks requiring Docker will be disabled.", id);
@@ -265,15 +265,15 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
         return false;
     }
 
-    private List<String> getLinuxExclusionList() {
-        File exclusionsFile = getParameters().getExclusionsFile();
-
+    // visible for testing
+    static List<String> getLinuxExclusionList(File exclusionsFile) {
         if (exclusionsFile.exists()) {
             try {
                 return Files.readAllLines(exclusionsFile.toPath())
                     .stream()
+                    .map(line -> line.contains("#") ? line.substring(0, line.indexOf('#')) : line)
                     .map(String::trim)
-                    .filter(line -> (line.isEmpty() || line.startsWith("#")) == false)
+                    .filter(line -> line.isEmpty() == false)
                     .collect(Collectors.toList());
             } catch (IOException e) {
                 throw new GradleException("Failed to read " + exclusionsFile.getAbsolutePath(), e);

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
@@ -8,18 +8,28 @@
  */
 package org.elasticsearch.gradle.internal.docker;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.gradle.internal.docker.DockerSupportService.deriveId;
+import static org.elasticsearch.gradle.internal.docker.DockerSupportService.getLinuxExclusionList;
 import static org.elasticsearch.gradle.internal.docker.DockerSupportService.parseOsRelease;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DockerSupportServiceTests {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testParseOsReleaseOnOracle() {
@@ -95,5 +105,32 @@ public class DockerSupportServiceTests {
         osRelease.put("VERSION_ID", "6.10");
 
         assertThat("ol-6.10", equalTo(deriveId(osRelease)));
+    }
+
+    @Test
+    public void testGetLinuxExclusionListMissingFileReturnsEmpty() {
+        File missing = new File(temporaryFolder.getRoot(), "does-not-exist");
+        assertThat(getLinuxExclusionList(missing), equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    public void testGetLinuxExclusionListParsing() throws IOException {
+        File exclusionsFile = temporaryFolder.newFile();
+        Files.writeString(exclusionsFile.toPath(), """
+            # This file header comment is ignored
+
+            debian-8
+            ol-7.7
+
+            sles-12.3 # older version used in Vagrant image
+            sles-12.5
+            # Another full-line comment
+            sles-15.6
+            """);
+
+        assertThat(
+            getLinuxExclusionList(exclusionsFile),
+            equalTo(List.of("debian-8", "ol-7.7", "sles-12.3", "sles-12.5", "sles-15.6"))
+        );
     }
 }

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
@@ -114,8 +114,9 @@ public class DockerAvailability {
             try {
                 return Files.readAllLines(exclusionsFile.toPath())
                     .stream()
+                    .map(line -> line.contains("#") ? line.substring(0, line.indexOf('#')) : line)
                     .map(String::trim)
-                    .filter(line -> (line.isEmpty() || line.startsWith("#")) == false)
+                    .filter(line -> line.isEmpty() == false)
                     .collect(Collectors.toList());
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read " + exclusionsFile.getAbsolutePath(), e);


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix the dockerOnLinuxExclusions parsers (#157880)