### PR TITLE
Fix commit prefetch test to not delay

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -799,9 +799,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohexTests
   method: testEvaluateInManyThreads {TestCase=geo_shape with literal precision and bounds}
   issue: https://github.com/elastic/elasticsearch/issues/157840
-- class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
-  method: testCommitPrefetchingDisabledDoesNotDownloadTheEntireCommit
-  issue: https://github.com/elastic/elasticsearch/issues/157843
 - class: org.elasticsearch.xpack.stateless.snapshots.StatelessSnapshotResiliencyTests
   method: testSuccessfulSnapshotWithConcurrentDynamicMappingUpdates
   issue: https://github.com/elastic/elasticsearch/issues/157844

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SearchCommitPrefetcherIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SearchCommitPrefetcherIT.java
@@ -135,6 +135,9 @@ public class SearchCommitPrefetcherIT extends AbstractStatelessPluginIntegTestCa
                 SearchCommitPrefetcherDynamicSettings.PREFETCH_SEARCH_IDLE_TIME_SETTING.getKey(),
                 skipPrefetchingBecauseSearchIsIdle ? TimeValue.ZERO : TimeValue.THIRTY_SECONDS
             )
+            // Release VBCCs immediately so the notification window cannot accumulate extra indexing-node chunk reads
+            // and push bytesReadFromIndexingNode over bccTotalSizeInBytes before the assertion at line 173.
+            .put(StatelessCommitService.STATELESS_UPLOAD_RELEASE_FILES_AFTER_NOTIFICATION_TIMEOUT.getKey(), TimeValue.ZERO)
             .build();
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNode = startSearchNode(nodeSettings);


### PR DESCRIPTION
The delayed release made the test fail, no longer delay the release of files to avoid accumulating unexpected reads in the test.

Closes #157843