### PR TITLE
[9.5] Fix mv_min/mv_max on columnar ip fields (#157790)

### DIFF
--- a/docs/changelog/157790.yaml
+++ b/docs/changelog/157790.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 157521
+pr: 157790
+summary: Fix mv_min/mv_max on columnar ip fields
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -632,6 +632,11 @@ public class IpFieldMapper extends FieldMapper {
 
         @Override
         public boolean supportsBlockLoaderConfig(BlockLoaderFunctionConfig config, FieldExtractPreference preference) {
+            // The fn/ pushdown readers (MV_MAX/MV_MIN/BYTE_LENGTH/LENGTH) decode the [len] SeparateCount format; they don't yet
+            // understand the in-order [len+1]/inline-null encoding, so disable pushdown and let the values be loaded and computed on.
+            if (useArrayOrderBinaryDocValues) {
+                return false;
+            }
             if (hasDocValues() && (preference != FieldExtractPreference.STORED || isSyntheticSource)) {
                 return switch (config.function()) {
                     case MV_MAX, MV_MIN -> true;

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
@@ -322,6 +322,20 @@ public class PushExpressionToLoadIT extends ESRestTestCase {
         );
     }
 
+    public void testMvMinToIpHighCardinality() throws IOException {
+        String min = "192.168.0." + between(0, 255);
+        String max = "192.168.3." + between(0, 255);
+        testHighCardinality(
+            b -> b.startObject("test").field("type", "ip").endObject(),
+            b -> b.startArray("test").value(min).value(max).endArray(),
+            "| EVAL test = MV_MIN(test)",
+            matchesList().item(min),
+            // Like keyword, high-cardinality ip stores values as ArrayOrderInlineNull binary doc values, so MV_MIN must push down into
+            // the array-order reader. Reading these with the SeparateCount reader misparses the [valueLen+1] slot prefixes.
+            matchesMap().entry("test:column_at_a_time:BytesRefsFromArrayOrderInlineNullBinarySeparateCount", 1)
+        );
+    }
+
     public void testMvMinToHalfFloat() throws IOException {
         double min = randomDouble();
         double max = 1 + randomDouble();
@@ -441,6 +455,18 @@ public class PushExpressionToLoadIT extends ESRestTestCase {
             "| EVAL test = MV_MAX(test)",
             matchesList().item(max),
             matchesMap().entry("test:column_at_a_time:MvMaxBytesRefsFromOrds.SortedSet", 1)
+        );
+    }
+
+    public void testMvMaxToIpHighCardinality() throws IOException {
+        String min = "192.168.0." + between(0, 255);
+        String max = "192.168.3." + between(0, 255);
+        testHighCardinality(
+            b -> b.startObject("test").field("type", "ip").endObject(),
+            b -> b.startArray("test").value(min).value(max).endArray(),
+            "| EVAL test = MV_MAX(test)",
+            matchesList().item(max),
+            matchesMap().entry("test:column_at_a_time:BytesRefsFromArrayOrderInlineNullBinarySeparateCount", 1)
         );
     }
 


### PR DESCRIPTION
This is technically a backport because it's fixing the same problem and it's backporting the tests. But the actual production code change is different: mv_min/mv_max pushdown support for inline array order values was not backported to 9.5, so instead of fixing the constructor call, this change just disables the pushdown.

# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix mv_min/mv_max on columnar ip fields (#157790)](https://github.com/elastic/elasticsearch/pull/157790)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)