### PR TITLE
[8.19] ESQL: Fix integer ROUND silently overflowing (#156412)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -813,6 +813,37 @@ ul:ul
 null
 ;
 
+roundIntOverflowAtNegativePrecision
+required_capability: fn_round_int_overflow_warns
+row n = round(2147483647, -1);
+
+warning:Line 1:9: evaluation of [round(2147483647, -1)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:9: java.lang.ArithmeticException: integer overflow
+
+n:integer
+null
+;
+
+roundIntOverflowNoFold
+required_capability: fn_round_int_overflow_warns
+row n = 2145000000 | eval n = round(n, -7);
+
+warning:Line 1:31: evaluation of [round(n, -7)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:31: java.lang.ArithmeticException: integer overflow
+
+n:integer
+null
+;
+
+// an even precision rounds the same input down instead, so it stays inside integer
+roundIntNoOverflowAtEvenPrecision
+required_capability: fn_round_int_overflow_warns
+row n = round(2147483647, -2);
+
+n:integer
+2147483600
+;
+
 roundToInt
 required_capability: round_to
 ROW v = 1

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundIntEvaluator.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import java.lang.ArithmeticException;
 import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
@@ -57,7 +58,7 @@ public final class RoundIntEvaluator implements EvalOperator.ExpressionEvaluator
         if (decimalsVector == null) {
           return eval(page.getPositionCount(), valBlock, decimalsBlock);
         }
-        return eval(page.getPositionCount(), valVector, decimalsVector).asBlock();
+        return eval(page.getPositionCount(), valVector, decimalsVector);
       }
     }
   }
@@ -95,16 +96,26 @@ public final class RoundIntEvaluator implements EvalOperator.ExpressionEvaluator
           result.appendNull();
           continue position;
         }
-        result.appendInt(Round.process(valBlock.getInt(valBlock.getFirstValueIndex(p)), decimalsBlock.getLong(decimalsBlock.getFirstValueIndex(p))));
+        try {
+          result.appendInt(Round.process(valBlock.getInt(valBlock.getFirstValueIndex(p)), decimalsBlock.getLong(decimalsBlock.getFirstValueIndex(p))));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }
   }
 
-  public IntVector eval(int positionCount, IntVector valVector, LongVector decimalsVector) {
-    try(IntVector.FixedBuilder result = driverContext.blockFactory().newIntVectorFixedBuilder(positionCount)) {
+  public IntBlock eval(int positionCount, IntVector valVector, LongVector decimalsVector) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
       position: for (int p = 0; p < positionCount; p++) {
-        result.appendInt(p, Round.process(valVector.getInt(p), decimalsVector.getLong(p)));
+        try {
+          result.appendInt(Round.process(valVector.getInt(p), decimalsVector.getLong(p)));
+        } catch (ArithmeticException e) {
+          warnings().registerException(e);
+          result.appendNull();
+        }
       }
       return result.build();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -98,6 +98,11 @@ public class EsqlCapabilities {
         FN_ROUND_UL_FIXES,
 
         /**
+         * Fix on function {@code ROUND} that reports integer overflow as a warning and a null result.
+         */
+        FN_ROUND_INT_OVERFLOW_WARNS,
+
+        /**
          * Support for function {@code SCALB}.
          */
         FN_SCALB,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Round.java
@@ -123,9 +123,13 @@ public class Round extends EsqlScalarFunction implements OptionalArgument {
         return Maths.round(val, 0).doubleValue();
     }
 
-    @Evaluator(extraName = "Int")
+    // An int argument selects Maths#round(long, long) by widening rather than Maths#round(Number, long),
+    // which needs boxing, so the Integer range check in Maths#convertToIntegerType is never reached. A
+    // plain intValue() then truncates a value rounded past Integer.MAX_VALUE into a negative one. Narrow
+    // explicitly instead, and report the overflow the way the unsigned_long path does: a warning and a null.
+    @Evaluator(extraName = "Int", warnExceptions = ArithmeticException.class)
     static int process(int val, long decimals) {
-        return Maths.round(val, decimals).intValue();
+        return Math.toIntExact(Maths.round(val, decimals));
     }
 
     @Evaluator(extraName = "Long")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundTests.java
@@ -75,7 +75,9 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
             supplier(
                 "<integer>, <long>",
                 DataType.INTEGER,
-                ESTestCase::randomInt,
+                // Safe range: rounding these at any negative precision stays inside integer, so the shared
+                // expected-value function below cannot overflow. Overflow is covered explicitly further down.
+                () -> randomIntBetween(-2_000_000_000, 2_000_000_000),
                 DataType.LONG,
                 ESTestCase::randomLong,
                 "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
@@ -111,7 +113,8 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
             supplier(
                 "<integer>, <integer>",
                 DataType.INTEGER,
-                ESTestCase::randomInt,
+                // Safe range, as above.
+                () -> randomIntBetween(-2_000_000_000, 2_000_000_000),
                 DataType.INTEGER,
                 ESTestCase::randomInt,
                 "RoundIntEvaluator[val=Attribute[channel=0], decimals=CastIntToLongEvaluator[v=Attribute[channel=1]]]",
@@ -216,6 +219,74 @@ public class RoundTests extends AbstractScalarFunctionTestCase {
                     "RoundUnsignedLongEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
                     DataType.UNSIGNED_LONG,
                     equalTo(new BigInteger("10000000000000000000"))
+                )
+            )
+        );
+
+        // Integer overflows. Rounding up at a negative precision can carry past Integer.MAX_VALUE, which
+        // used to wrap silently to a negative result rather than report the overflow.
+        suppliers.add(
+            new TestCaseSupplier(
+                "<max integer>, <-1>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MAX_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-1L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                "<min integer>, <-1>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MIN_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-1L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                // the widest overflow window: 2145000000 carries up to 2150000000
+                "<big integer>, <-7>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(2145000000, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-7L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(null)
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.ArithmeticException: integer overflow")
+            )
+        );
+        suppliers.add(
+            new TestCaseSupplier(
+                // an even precision on the same input rounds down instead, so it stays in range
+                "<max integer>, <-2>",
+                List.of(DataType.INTEGER, DataType.LONG),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Integer.MAX_VALUE, DataType.INTEGER, "number"),
+                        new TestCaseSupplier.TypedData(-2L, DataType.LONG, "decimals")
+                    ),
+                    "RoundIntEvaluator[val=Attribute[channel=0], decimals=Attribute[channel=1]]",
+                    DataType.INTEGER,
+                    equalTo(2147483600)
                 )
             )
         );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Fix integer ROUND silently overflowing (#156412)