### PR TITLE
Fix ES94HnswScalarQuantizedVectorsFormatTests testSimpleOffHeapSize odd-dim int4 failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -787,9 +787,6 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=mapping/42_doc_values_on_failure/index.mapping.doc_values.on_failure=ignore applies to nullability violations (logsdb_columnar)}
   issue: https://github.com/elastic/elasticsearch/issues/157829
-- class: org.elasticsearch.index.codec.vectors.es94.ES94HnswScalarQuantizedVectorsFormatTests
-  method: testSimpleOffHeapSize
-  issue: https://github.com/elastic/elasticsearch/issues/157839
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohexTests
   method: testEvaluateInManyThreads {TestCase=geo_shape with literal precision and bounds}
   issue: https://github.com/elastic/elasticsearch/issues/157840

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedHnswVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedHnswVectorsFormatTestCase.java
@@ -30,7 +30,11 @@ import static org.hamcrest.Matchers.instanceOf;
 public abstract class BaseQuantizedHnswVectorsFormatTestCase extends BaseHnswVectorsFormatTestCase {
 
     public void testRescoreUsesRawVectorSlice() throws IOException {
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; subclasses may randomly pick bits=4.
         int dimension = random().nextInt(12, 64);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
         float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory()) {
             try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedKnnVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedKnnVectorsFormatTestCase.java
@@ -31,7 +31,11 @@ import static org.hamcrest.Matchers.instanceOf;
 public abstract class BaseQuantizedKnnVectorsFormatTestCase extends BaseKnnVectorsFormatTestCase {
 
     public void testRescoreUsesRawVectorSlice() throws IOException {
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; subclasses may randomly pick bits=4.
         int dimension = random().nextInt(12, 64);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
         float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory()) {
             try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedBFloat16VectorsFormatTests.java
@@ -77,7 +77,12 @@ public class ES94HnswScalarQuantizedBFloat16VectorsFormatTests extends BaseQuant
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; randomBitsPerValue may pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         // Use threshold=0 to ensure HNSW graph is always built, but keep assertion tolerant to implementation details.
         KnnVectorsFormat format = new ES94HnswScalarQuantizedVectorsFormat(
             16,

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedVectorsFormatTests.java
@@ -80,7 +80,12 @@ public class ES94HnswScalarQuantizedVectorsFormatTests extends BaseQuantizedHnsw
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; createFormat may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         // Use threshold=0 to ensure HNSW graph is always built, but keep assertion tolerant to implementation details.
         KnnVectorsFormat format = createFormat(16, 100, 1, null, 0);
         var config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format));

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedBFloat16VectorsFormatTests.java
@@ -59,7 +59,12 @@ public class ES94ScalarQuantizedBFloat16VectorsFormatTests extends BaseQuantized
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; getCodec may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             Document doc = new Document();
             doc.add(new KnnFloatVectorField("f", vector, DOT_PRODUCT));

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedVectorsFormatTests.java
@@ -76,7 +76,12 @@ public class ES94ScalarQuantizedVectorsFormatTests extends BaseQuantizedKnnVecto
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; getCodec may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             Document doc = new Document();
             doc.add(new KnnFloatVectorField("f", vector, DOT_PRODUCT));


### PR DESCRIPTION
## Summary

- `testSimpleOffHeapSize` randomly picks bits in `{1,2,4,7}` and dimensions in `[12,500]`. When bits=4 (`PACKED_NIBBLE`) and the dimension is odd, CheckIndex's knn probe returns 0 hits and fails on directory close (`CheckIndexException: Field "f" failed to search k nearest neighbors`).
- Align with other int4 / quantized tests (`SimdVecLibraryInt4Tests`, `Int4VectorScorerFactoryTests`, `BaseQuantizedHnswBFloat16VectorsFormatTestCase`) by forcing even dimensions.
- Apply the same guard to the bfloat16 sibling off-heap test, which had the same pattern.
- Unmute `ES94HnswScalarQuantizedVectorsFormatTests.testSimpleOffHeapSize` (#157839).

Production `int4_hnsw` / `int4_flat` already reject odd dimensions; this is a unit-test harness gap when the ES94 format randomly selects bits=4.

Closes #157839

