### PR TITLE
[ESQL] Cap Parquet prefetch by queued bytes

### DIFF
--- a/docs/changelog/157920.yaml
+++ b/docs/changelog/157920.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157920
+summary: Cap Parquet prefetch by queued bytes
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -91,9 +91,11 @@ import java.util.function.Consumer;
  *
  * <p><b>Memory:</b> Prefetched bytes live on the heap and are charged to the REQUEST circuit
  * breaker via {@link BlockFactory#breaker()}; the charge is released when the chunks'
- * {@link Releasable} is closed at row-group rollover. If the breaker check fails during a
- * prefetch, the future fails, prefetch is skipped, and the query falls back to synchronous
- * I/O for that row group.
+ * {@link Releasable} is closed at row-group rollover. {@link #fillPrefetchQueue} admits
+ * unread queued groups under {@link #MAX_QUEUED_PREFETCH_BYTES}; {@link #prefetchDepth} is a
+ * count wish, not the memory bound. An empty queue always starts the next group so the scan
+ * cannot stall. If the breaker check fails during a prefetch, the future fails, prefetch is
+ * skipped, and the query falls back to synchronous I/O for that row group.
  *
  * <p><b>Trivially-passes guard:</b> when late materialization is enabled and row-group
  * statistics prove every row satisfies the pushed filter ({@link TriviallyPassesChecker}),
@@ -227,18 +229,32 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private final CompressionCodecFactory codecFactory;
     private int rowBudget;
     /**
-     * Async prefetches allowed ahead of the consumed row group. Initialized from
+     * Count wish for async prefetches ahead of the consumed row group. Initialized from
      * {@link #computePrefetchDepth} based on projected column size (1-3), then adapted
      * at runtime: grows by {@link #PREFETCH_DEPTH_GROWTH} on stall detection (the
      * prefetch future was not ready when consumed), shrinks by 1 after
      * {@link #SHRINK_AFTER_NO_STALLS} consecutive no-stall row groups. Growth is
      * suppressed when the circuit breaker exceeds {@link #BREAKER_GROWTH_THRESHOLD}
      * utilization. Bounded by [{@link #prefetchDepthFloor}, {@link #MAX_PREFETCH_DEPTH}].
+     * {@link #fillPrefetchQueue} also refuses extra groups once unread queued bytes would
+     * exceed {@link #prefetchByteBudget}, so a high wish on a wide file may still queue one
+     * group. The in-use current row group is not counted against that budget.
      */
     private int prefetchDepth;
     private final int prefetchDepthFloor;
     private int consecutiveNoStalls;
     private final ArrayDeque<PendingPrefetch> pendingPrefetches = new ArrayDeque<>();
+    /**
+     * Footer-estimated bytes of unread entries in {@link #pendingPrefetches}. Adjusted on
+     * enqueue, consume, skip-mismatch, and cancel. Does not include the in-use current row group.
+     */
+    private long queuedPrefetchBytes;
+    /**
+     * Cap on {@link #queuedPrefetchBytes}. Defaults to {@link #MAX_QUEUED_PREFETCH_BYTES}.
+     * Tests inject a smaller value after construction so the next {@link #fillPrefetchQueue}
+     * honors it without needing large fixtures.
+     */
+    private long prefetchByteBudget = MAX_QUEUED_PREFETCH_BYTES;
     /**
      * Breaker-accounted heap buffers holding the chunks currently in use by {@link #rowGroup}.
      * Released at row-group rollover so the charge returns immediately rather than waiting for
@@ -477,8 +493,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     }
 
     /**
-     * Fills the prefetch queue up to {@link #prefetchDepth} entries, starting from ordinal
-     * {@code fromOrdinal}. Stops early when no more surviving row groups remain. Breaker
+     * Fills the prefetch queue starting from ordinal {@code fromOrdinal}. Admission requires
+     * both {@code size < prefetchDepth} (count wish) and, when the queue is non-empty,
+     * {@code queuedPrefetchBytes + next <= prefetchByteBudget}. An empty queue always
+     * dispatches the next surviving group, even when that group exceeds the byte cap, so the
+     * scan cannot stall. Stops early when no more surviving row groups remain. Breaker
      * accounting for the prefetched bytes happens inside {@code readBytesAsync} via
      * {@code DirectBufferFactory.forBreaker}; if a prefetch trips the breaker it surfaces as
      * a failed future and {@link #takePendingPrefetch} falls back to sync I/O for that row
@@ -511,6 +530,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             if (prefetchBytes <= 0) {
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
+            }
+            // Compare remaining capacity instead of summing: a corrupt footer length must not
+            // wrap the add and admit a group we already know cannot fit.
+            if (pendingPrefetches.isEmpty() == false
+                && (queuedPrefetchBytes >= prefetchByteBudget || prefetchBytes > prefetchByteBudget - queuedPrefetchBytes)) {
+                break;
             }
             try {
                 RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
@@ -547,7 +572,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 } else {
                     future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns, breaker);
                 }
-                pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future));
+                pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future, prefetchBytes));
+                queuedPrefetchBytes += prefetchBytes;
             } catch (Exception e) {
                 logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextOrdinal, fileLocation, e.getMessage());
                 break;
@@ -838,7 +864,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         return ParquetColumnDecoding.isUnsignedInt64(sortColumnPrimitiveType) ? ParquetColumnDecoding.encodeUnsignedLong(raw) : null;
     }
 
+    /** Projected-size threshold that raises the initial count floor to 3. Not a memory cap; see {@link #MAX_QUEUED_PREFETCH_BYTES}. */
     private static final long DEEPER_PREFETCH_BYTES = 32_000_000L;
+    /**
+     * Cap on unread queued prefetch bytes per iterator. Distinct from {@link #DEEPER_PREFETCH_BYTES},
+     * which only sizes the initial count floor. An empty queue always admits one row group even
+     * when that group exceeds this cap, so the scan cannot stall waiting for a group that never
+     * starts.
+     */
+    private static final long MAX_QUEUED_PREFETCH_BYTES = 32_000_000L;
     private static final long SHALLOW_PREFETCH_BYTES = 8_000_000L;
     private static final int MAX_PREFETCH_DEPTH = 8;
     private static final int PREFETCH_DEPTH_GROWTH = 2;
@@ -864,9 +898,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 projectedBytes += col.getTotalSize();
             }
         }
-        // Larger projected sizes need deeper prefetch: an S3 GET for a 20MB string column takes
-        // ~200ms while decode takes ~10ms, so single-ahead can't hide the latency. The circuit
-        // breaker caps actual memory regardless of depth.
+        // Larger projected sizes need a higher count floor: an S3 GET for a 20MB string column
+        // takes ~200ms while decode takes ~10ms, so single-ahead can't hide the latency.
+        // {@link #MAX_QUEUED_PREFETCH_BYTES} limits unread queued bytes; the circuit breaker is
+        // the allocate-time backstop if a footer estimate is wrong.
         //
         // Two-phase note: under two-phase the queued prefetches carry only predicate columns, so
         // the actual queued bytes are a fraction of {@code projectedBytes}. We intentionally keep
@@ -1841,7 +1876,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 break;
             }
             assert head.ordinal() <= expectedOrdinal : "prefetch queue has ordinal " + head.ordinal() + " > expected " + expectedOrdinal;
-            pendingPrefetches.pollFirst();
+            dequeuePending();
             FutureUtils.cancel(head.future());
             head.release();
         }
@@ -1850,7 +1885,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             return null;
         }
 
-        PendingPrefetch head = pendingPrefetches.pollFirst();
+        PendingPrefetch head = dequeuePending();
         try {
             boolean wasReady = head.future().isDone();
             ColumnChunkPrefetcher.PrefetchedChunks result = head.future().join();
@@ -1919,6 +1954,43 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         return prefetchDepth;
     }
 
+    // Visible for testing
+    int pendingPrefetchCount() {
+        return pendingPrefetches.size();
+    }
+
+    // Visible for testing
+    long queuedPrefetchBytes() {
+        return queuedPrefetchBytes;
+    }
+
+    /**
+     * Test-only: replace the queued-byte cap. The next {@link #fillPrefetchQueue} (typically via
+     * {@link #refillPrefetchQueue()}) honors the new value; in-flight entries are unchanged until
+     * cancelled.
+     */
+    void setPrefetchByteBudget(long prefetchByteBudget) {
+        this.prefetchByteBudget = prefetchByteBudget;
+    }
+
+    /**
+     * Test-only: cancel in-flight prefetches and refill from the next surviving ordinal after
+     * the current row group. After construction that is the first group, so tests can inject a
+     * budget and re-admit without 32MB fixtures.
+     */
+    void refillPrefetchQueue() {
+        cancelPendingPrefetch();
+        fillPrefetchQueue(nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1));
+    }
+
+    private PendingPrefetch dequeuePending() {
+        PendingPrefetch pending = pendingPrefetches.pollFirst();
+        assert pending != null : "dequeue from empty prefetch queue";
+        queuedPrefetchBytes -= pending.bytes();
+        assert queuedPrefetchBytes >= 0 : "queuedPrefetchBytes went negative: " + queuedPrefetchBytes;
+        return pending;
+    }
+
     /**
      * Refills the prefetch queue after consuming an entry in {@link #advanceRowGroup()}.
      * Starts from the ordinal after the last queued entry (or after the current row group
@@ -1944,10 +2016,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      */
     private void cancelPendingPrefetch() {
         while (pendingPrefetches.isEmpty() == false) {
-            PendingPrefetch entry = pendingPrefetches.pollFirst();
+            PendingPrefetch entry = dequeuePending();
             FutureUtils.cancel(entry.future());
             entry.release();
         }
+        assert queuedPrefetchBytes == 0 : "queuedPrefetchBytes leaked after cancel: " + queuedPrefetchBytes;
     }
 
     /**
@@ -2636,8 +2709,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * If the prefetch is dequeued for use, that {@link Releasable} is handed off to
      * {@link #currentChunksReleasable}. If it is skipped or cancelled, {@link #release()} drains
      * any already-produced chunks so the breaker bytes return immediately.
+     *
+     * <p>{@link #bytes} is the footer estimate from {@link ColumnChunkPrefetcher#computePrefetchBytes}
+     * used for queued-byte admission; it is not the live breaker charge.
      */
-    private record PendingPrefetch(int ordinal, CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future) {
+    private record PendingPrefetch(int ordinal, CompletableFuture<ColumnChunkPrefetcher.PrefetchedChunks> future, long bytes) {
 
         void release() {
             // Drain the future so the heap buffers the prefetch may have already produced

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -531,10 +531,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
             }
-            // Compare remaining capacity instead of summing: a corrupt footer length must not
-            // wrap the add and admit a group we already know cannot fit.
-            if (pendingPrefetches.isEmpty() == false
-                && (queuedPrefetchBytes >= prefetchByteBudget || prefetchBytes > prefetchByteBudget - queuedPrefetchBytes)) {
+            // Remaining capacity, not a sum: a huge footer length cannot wrap a long add and
+            // admit a group we already know cannot fit. When queued already exceeds the cap
+            // (empty-queue overrun), the right-hand side is negative and any positive
+            // prefetchBytes fails the check.
+            if (pendingPrefetches.isEmpty() == false && prefetchBytes > prefetchByteBudget - queuedPrefetchBytes) {
                 break;
             }
             try {
@@ -872,11 +873,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      * when that group exceeds this cap, so the scan cannot stall waiting for a group that never
      * starts.
      */
-    private static final long MAX_QUEUED_PREFETCH_BYTES = 32_000_000L;
+    static final long MAX_QUEUED_PREFETCH_BYTES = 32_000_000L;
     private static final long SHALLOW_PREFETCH_BYTES = 8_000_000L;
     private static final int MAX_PREFETCH_DEPTH = 8;
     private static final int PREFETCH_DEPTH_GROWTH = 2;
-    private static final int SHRINK_AFTER_NO_STALLS = 3;
+    static final int SHRINK_AFTER_NO_STALLS = 3;
     private static final double BREAKER_GROWTH_THRESHOLD = 0.75;
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
@@ -204,6 +204,160 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
         }
     }
 
+    /**
+     * Small row groups under the default 32MB queued-byte cap fill to the count wish.
+     * This is the complement of the byte-cap tests: the cap must not starve a narrow scan.
+     * It does not by itself prove that a byte cap exists.
+     */
+    public void testDefaultBudgetFillsToCountCap() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
+        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
+
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
+            int ctorCount = opi.pendingPrefetchCount();
+            assertTrue("constructor should queue at least one group", ctorCount >= 1);
+            long rgBytes = opi.queuedPrefetchBytes() / ctorCount;
+            assertTrue("constructor should record prefetch bytes", rgBytes > 0);
+            assertEquals("constructor should fill to the count wish", opi.prefetchDepth(), ctorCount);
+            assertTrue(
+                "queued bytes should be well under the 32MB default: " + opi.queuedPrefetchBytes(),
+                opi.queuedPrefetchBytes() < 32_000_000L
+            );
+
+            growPrefetchDepth(opi, 5);
+            int wish = opi.prefetchDepth();
+            opi.refillPrefetchQueue();
+            assertEquals("narrow scans still fill to the count cap; need ≥" + wish + " row groups", wish, opi.pendingPrefetchCount());
+            assertTrue(opi.queuedPrefetchBytes() >= rgBytes * 2);
+            assertTrue(opi.queuedPrefetchBytes() < 32_000_000L);
+        }
+    }
+
+    /**
+     * An empty queue always admits the next row group even when that group exceeds the byte cap,
+     * so the scan cannot stall. Depth is raised first so count-only admission would queue more
+     * than one group.
+     */
+    public void testByteBudgetOverrunWhenQueueEmpty() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
+        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
+
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
+            growPrefetchDepth(opi, 3);
+            opi.setPrefetchByteBudget(1);
+            opi.refillPrefetchQueue();
+            assertEquals("empty queue admits one group over the cap", 1, opi.pendingPrefetchCount());
+            assertTrue("queued bytes should overrun a 1-byte budget: " + opi.queuedPrefetchBytes(), opi.queuedPrefetchBytes() > 1);
+            assertTrue("byte cap, not the count wish, limited occupancy", opi.pendingPrefetchCount() < opi.prefetchDepth());
+        }
+    }
+
+    /**
+     * A budget equal to the first two groups admits exactly those two, regardless of the count wish.
+     */
+    public void testByteBudgetAdmitsTwoNotThree() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
+        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
+
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
+            int ctorCount = opi.pendingPrefetchCount();
+            assertTrue("constructor should queue at least one group", ctorCount >= 1);
+            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() / ctorCount > 0);
+
+            long bytesTwo = queuedBytesAtDepth(opi, 2);
+            long bytesThree = queuedBytesAtDepth(opi, 3);
+            assertTrue("third group must contribute bytes so a 2-group budget is distinguishable", bytesThree > bytesTwo);
+
+            growPrefetchDepth(opi, 3);
+            opi.setPrefetchByteBudget(bytesTwo);
+            opi.refillPrefetchQueue();
+            assertEquals(2, opi.pendingPrefetchCount());
+            assertEquals("admitted bytes should match the injected 2-group budget", bytesTwo, opi.queuedPrefetchBytes());
+            assertTrue("byte cap, not the count wish, limited occupancy", opi.pendingPrefetchCount() < opi.prefetchDepth());
+        }
+    }
+
+    /**
+     * Stall-growth raises the count wish to {@code MAX_PREFETCH_DEPTH} but does not raise queued
+     * occupancy past the byte cap.
+     */
+    public void testStallsDoNotExceedByteBudget() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
+        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
+
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
+            int ctorCount = opi.pendingPrefetchCount();
+            assertTrue("constructor should queue at least one group", ctorCount >= 1);
+            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() / ctorCount > 0);
+
+            long bytesTwo = queuedBytesAtDepth(opi, 2);
+            long bytesThree = queuedBytesAtDepth(opi, 3);
+            assertTrue("third group must contribute bytes so a 2-group budget is distinguishable", bytesThree > bytesTwo);
+
+            growPrefetchDepth(opi, 8);
+            assertEquals(8, opi.prefetchDepth());
+            opi.setPrefetchByteBudget(bytesTwo);
+            opi.refillPrefetchQueue();
+            assertEquals("stall-growth wish stays at max depth", 8, opi.prefetchDepth());
+            assertEquals("queued occupancy follows the byte cap, not the wish", 2, opi.pendingPrefetchCount());
+            assertEquals("admitted bytes should match the injected 2-group budget", bytesTwo, opi.queuedPrefetchBytes());
+        }
+    }
+
+    private static void growPrefetchDepth(OptimizedParquetColumnIterator opi, int minDepth) {
+        int safety = 0;
+        while (opi.prefetchDepth() < minDepth) {
+            int before = opi.prefetchDepth();
+            opi.adaptPrefetchDepth(false);
+            assertTrue("prefetch depth should grow on stall, was " + before, opi.prefetchDepth() > before);
+            if (++safety > 32) {
+                fail("could not grow prefetch depth to " + minDepth);
+            }
+        }
+    }
+
+    private static void shrinkPrefetchDepthTo(OptimizedParquetColumnIterator opi, int targetDepth) {
+        int safety = 0;
+        while (opi.prefetchDepth() > targetDepth) {
+            int before = opi.prefetchDepth();
+            opi.adaptPrefetchDepth(true);
+            opi.adaptPrefetchDepth(true);
+            opi.adaptPrefetchDepth(true);
+            if (opi.prefetchDepth() >= before) {
+                fail("could not shrink prefetch depth to " + targetDepth + ", stuck at " + opi.prefetchDepth());
+            }
+            if (++safety > 32) {
+                fail("could not shrink prefetch depth to " + targetDepth);
+            }
+        }
+        if (opi.prefetchDepth() != targetDepth) {
+            fail("wanted prefetch depth " + targetDepth + " but got " + opi.prefetchDepth() + " (floor too high for this fixture?)");
+        }
+    }
+
+    /**
+     * Unlimited-budget refill at exactly {@code depth}. Fails if the file has fewer than
+     * {@code depth} row groups or the depth floor is above {@code depth}.
+     */
+    private static long queuedBytesAtDepth(OptimizedParquetColumnIterator opi, int depth) {
+        growPrefetchDepth(opi, depth);
+        shrinkPrefetchDepthTo(opi, depth);
+        opi.setPrefetchByteBudget(Long.MAX_VALUE);
+        opi.refillPrefetchQueue();
+        assertEquals("unlimited budget should fill to the count wish; need ≥" + depth + " row groups", depth, opi.pendingPrefetchCount());
+        long bytes = opi.queuedPrefetchBytes();
+        assertTrue("queued bytes at depth " + depth + " should be positive", bytes > 0);
+        return bytes;
+    }
+
     private void readAll(ParquetFormatReader reader, StorageObject storageObject) throws IOException {
         try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
             while (iter.hasNext()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchLatencySimulationTests.java
@@ -205,33 +205,29 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
     }
 
     /**
-     * Small row groups under the default 32MB queued-byte cap fill to the count wish.
+     * Small row groups under the default queued-byte cap fill to the count wish.
      * This is the complement of the byte-cap tests: the cap must not starve a narrow scan.
      * It does not by itself prove that a byte cap exists.
      */
     public void testDefaultBudgetFillsToCountCap() throws Exception {
-        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
-        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
-        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
-
-        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+        try (CloseableIterator<Page> iter = openOptimized(smallInt64MultiRowGroupFile())) {
             OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
             int ctorCount = opi.pendingPrefetchCount();
             assertTrue("constructor should queue at least one group", ctorCount >= 1);
+            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() > 0);
             long rgBytes = opi.queuedPrefetchBytes() / ctorCount;
-            assertTrue("constructor should record prefetch bytes", rgBytes > 0);
             assertEquals("constructor should fill to the count wish", opi.prefetchDepth(), ctorCount);
             assertTrue(
-                "queued bytes should be well under the 32MB default: " + opi.queuedPrefetchBytes(),
-                opi.queuedPrefetchBytes() < 32_000_000L
+                "queued bytes should be well under the default cap: " + opi.queuedPrefetchBytes(),
+                opi.queuedPrefetchBytes() < OptimizedParquetColumnIterator.MAX_QUEUED_PREFETCH_BYTES
             );
 
             growPrefetchDepth(opi, 5);
             int wish = opi.prefetchDepth();
             opi.refillPrefetchQueue();
-            assertEquals("narrow scans still fill to the count cap; need ≥" + wish + " row groups", wish, opi.pendingPrefetchCount());
+            assertEquals("narrow scans still fill to the count cap; need >=" + wish + " row groups", wish, opi.pendingPrefetchCount());
             assertTrue(opi.queuedPrefetchBytes() >= rgBytes * 2);
-            assertTrue(opi.queuedPrefetchBytes() < 32_000_000L);
+            assertTrue(opi.queuedPrefetchBytes() < OptimizedParquetColumnIterator.MAX_QUEUED_PREFETCH_BYTES);
         }
     }
 
@@ -241,11 +237,7 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
      * than one group.
      */
     public void testByteBudgetOverrunWhenQueueEmpty() throws Exception {
-        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
-        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
-        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
-
-        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+        try (CloseableIterator<Page> iter = openOptimized(smallInt64MultiRowGroupFile())) {
             OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
             growPrefetchDepth(opi, 3);
             opi.setPrefetchByteBudget(1);
@@ -260,15 +252,10 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
      * A budget equal to the first two groups admits exactly those two, regardless of the count wish.
      */
     public void testByteBudgetAdmitsTwoNotThree() throws Exception {
-        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
-        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
-        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
-
-        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+        try (CloseableIterator<Page> iter = openOptimized(smallInt64MultiRowGroupFile())) {
             OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
-            int ctorCount = opi.pendingPrefetchCount();
-            assertTrue("constructor should queue at least one group", ctorCount >= 1);
-            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() / ctorCount > 0);
+            assertTrue("constructor should queue at least one group", opi.pendingPrefetchCount() >= 1);
+            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() > 0);
 
             long bytesTwo = queuedBytesAtDepth(opi, 2);
             long bytesThree = queuedBytesAtDepth(opi, 3);
@@ -288,15 +275,10 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
      * occupancy past the byte cap.
      */
     public void testStallsDoNotExceedByteBudget() throws Exception {
-        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
-        byte[] parquetData = createMultiRowGroupFile(schema, 5000, 4096);
-        CountingStorageObject storage = new CountingStorageObject(parquetData, asyncIoExecutor);
-
-        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+        try (CloseableIterator<Page> iter = openOptimized(smallInt64MultiRowGroupFile())) {
             OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
-            int ctorCount = opi.pendingPrefetchCount();
-            assertTrue("constructor should queue at least one group", ctorCount >= 1);
-            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() / ctorCount > 0);
+            assertTrue("constructor should queue at least one group", opi.pendingPrefetchCount() >= 1);
+            assertTrue("constructor should record prefetch bytes", opi.queuedPrefetchBytes() > 0);
 
             long bytesTwo = queuedBytesAtDepth(opi, 2);
             long bytesThree = queuedBytesAtDepth(opi, 3);
@@ -310,6 +292,39 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
             assertEquals("queued occupancy follows the byte cap, not the wish", 2, opi.pendingPrefetchCount());
             assertEquals("admitted bytes should match the injected 2-group budget", bytesTwo, opi.queuedPrefetchBytes());
         }
+    }
+
+    /**
+     * Consume and cancel must keep queued-byte accounting in sync: a tiny budget scan returns
+     * the same rows as an unconstrained read and drains the queue at exhaustion.
+     */
+    public void testTinyBudgetScanDrainsQueue() throws Exception {
+        byte[] parquetData = smallInt64MultiRowGroupFile();
+        int unconstrained = countRows(new ParquetFormatReader(blockFactory, true), new CountingStorageObject(parquetData, asyncIoExecutor));
+        try (CloseableIterator<Page> iter = openOptimized(parquetData)) {
+            OptimizedParquetColumnIterator opi = (OptimizedParquetColumnIterator) iter;
+            opi.setPrefetchByteBudget(1);
+            opi.refillPrefetchQueue();
+            int rows = 0;
+            while (iter.hasNext()) {
+                rows += iter.next().getPositionCount();
+            }
+            assertEquals(unconstrained, rows);
+            assertEquals(0, opi.queuedPrefetchBytes());
+            assertEquals(0, opi.pendingPrefetchCount());
+        }
+    }
+
+    private byte[] smallInt64MultiRowGroupFile() throws IOException {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+        return createMultiRowGroupFile(schema, 5000, 4096);
+    }
+
+    private CloseableIterator<Page> openOptimized(byte[] parquetData) throws IOException {
+        return new ParquetFormatReader(blockFactory, true).read(
+            new CountingStorageObject(parquetData, asyncIoExecutor),
+            FormatReadContext.of(null, 1024)
+        );
     }
 
     private static void growPrefetchDepth(OptimizedParquetColumnIterator opi, int minDepth) {
@@ -328,9 +343,9 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
         int safety = 0;
         while (opi.prefetchDepth() > targetDepth) {
             int before = opi.prefetchDepth();
-            opi.adaptPrefetchDepth(true);
-            opi.adaptPrefetchDepth(true);
-            opi.adaptPrefetchDepth(true);
+            for (int i = 0; i < OptimizedParquetColumnIterator.SHRINK_AFTER_NO_STALLS; i++) {
+                opi.adaptPrefetchDepth(true);
+            }
             if (opi.prefetchDepth() >= before) {
                 fail("could not shrink prefetch depth to " + targetDepth + ", stuck at " + opi.prefetchDepth());
             }
@@ -352,7 +367,7 @@ public class PrefetchLatencySimulationTests extends ESTestCase {
         shrinkPrefetchDepthTo(opi, depth);
         opi.setPrefetchByteBudget(Long.MAX_VALUE);
         opi.refillPrefetchQueue();
-        assertEquals("unlimited budget should fill to the count wish; need ≥" + depth + " row groups", depth, opi.pendingPrefetchCount());
+        assertEquals("unlimited budget should fill to the count wish; need >=" + depth + " row groups", depth, opi.pendingPrefetchCount());
         long bytes = opi.queuedPrefetchBytes();
         assertTrue("queued bytes at depth " + depth + " should be positive", bytes > 0);
         return bytes;


### PR DESCRIPTION
Prefetch used a row-group count to hide S3 latency, so wide projections queued far more compressed bytes than a small node can spare. Keep the count as a wish and stop admitting extra groups once unread queued bytes hit a per-iterator cap.