### PR TITLE
[9.5] Fix ES94HnswScalarQuantizedVectorsFormatTests testSimpleOffHeapSize odd-dim int4 failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedHnswVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedHnswVectorsFormatTestCase.java
@@ -30,7 +30,11 @@ import static org.hamcrest.Matchers.instanceOf;
 public abstract class BaseQuantizedHnswVectorsFormatTestCase extends BaseHnswVectorsFormatTestCase {
 
     public void testRescoreUsesRawVectorSlice() throws IOException {
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; subclasses may randomly pick bits=4.
         int dimension = random().nextInt(12, 64);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
         float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory()) {
             try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedKnnVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseQuantizedKnnVectorsFormatTestCase.java
@@ -31,7 +31,11 @@ import static org.hamcrest.Matchers.instanceOf;
 public abstract class BaseQuantizedKnnVectorsFormatTestCase extends BaseKnnVectorsFormatTestCase {
 
     public void testRescoreUsesRawVectorSlice() throws IOException {
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; subclasses may randomly pick bits=4.
         int dimension = random().nextInt(12, 64);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
         float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory()) {
             try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedBFloat16VectorsFormatTests.java
@@ -77,7 +77,12 @@ public class ES94HnswScalarQuantizedBFloat16VectorsFormatTests extends BaseQuant
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; randomBitsPerValue may pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         // Use threshold=0 to ensure HNSW graph is always built, but keep assertion tolerant to implementation details.
         KnnVectorsFormat format = new ES94HnswScalarQuantizedVectorsFormat(
             16,

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94HnswScalarQuantizedVectorsFormatTests.java
@@ -80,7 +80,12 @@ public class ES94HnswScalarQuantizedVectorsFormatTests extends BaseQuantizedHnsw
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; createFormat may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         // Use threshold=0 to ensure HNSW graph is always built, but keep assertion tolerant to implementation details.
         KnnVectorsFormat format = createFormat(16, 100, 1, null, 0);
         var config = newIndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format));

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedBFloat16VectorsFormatTests.java
@@ -64,7 +64,12 @@ public class ES94ScalarQuantizedBFloat16VectorsFormatTests extends BaseQuantized
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; getCodec may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             Document doc = new Document();
             doc.add(new KnnFloatVectorField("f", vector, DOT_PRODUCT));

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es94/ES94ScalarQuantizedVectorsFormatTests.java
@@ -81,7 +81,12 @@ public class ES94ScalarQuantizedVectorsFormatTests extends BaseQuantizedKnnVecto
     }
 
     public void testSimpleOffHeapSize() throws IOException {
-        float[] vector = randomVector(random().nextInt(12, 500));
+        // Int4 (bits=4 / PACKED_NIBBLE) requires even dimensions; getCodec may randomly pick bits=4.
+        int dimension = random().nextInt(12, 500);
+        if (dimension % 2 != 0) {
+            dimension++;
+        }
+        float[] vector = randomVector(dimension);
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
             Document doc = new Document();
             doc.add(new KnnFloatVectorField("f", vector, DOT_PRODUCT));


### PR DESCRIPTION
Backports #157918 to 9.5.

Manual backport: auto-backport failed on `muted-tests.yml`. The `#157839` mute exists only on `main`, so that file is left unchanged. The even-dimension test fixes cherry-picked cleanly.

Made with [Cursor](https://cursor.com)