### PR TITLE
Use bulk-cancellation-task only when timeout is configured

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -555,12 +555,15 @@ public class IncrementalBulkIT extends ESIntegTestCase {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 
         // Artificially low watermarks to force incrementalOperation.maybeSplit() always split batches.
+        // The session task is only registered when the request timeout is active, so this test configures a
+        // timeout far longer than it can run: it needs the task to exist, not the timeout to fire.
         final String nodeName = internalCluster().startNode(
             Settings.builder()
                 .put(IndexingPressure.SPLIT_BULK_LOW_WATERMARK.getKey(), "1b")
                 .put(IndexingPressure.SPLIT_BULK_LOW_WATERMARK_SIZE.getKey(), "1b")
                 .put(IndexingPressure.SPLIT_BULK_HIGH_WATERMARK.getKey(), "1b")
                 .put(IndexingPressure.SPLIT_BULK_HIGH_WATERMARK_SIZE.getKey(), "1b")
+                .put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), TimeValue.timeValueHours(1))
                 .build()
         );
 
@@ -763,8 +766,16 @@ public class IncrementalBulkIT extends ESIntegTestCase {
         try {
             updateClusterSettings(Settings.builder().put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), timeout));
             try (var handler = service.newBulkRequest()) {
-                // Wait for the scheduled timeout to cancel the session task before touching the handler.
-                assertBusy(() -> assertTrue(isSessionTaskCancelled(taskManager)));
+                // Hold the task: the timeout unregisters it as well as cancelling it, so it cannot be looked
+                // up in the TaskManager afterwards.
+                CancellableTask sessionTask = (CancellableTask) handler.getBulkSessionTask();
+                assertNotNull("a session task must be registered while the request timeout is active", sessionTask);
+
+                // Wait for the scheduled timeout to cancel and unregister the session task.
+                assertBusy(() -> {
+                    assertTrue(sessionTask.isCancelled());
+                    assertTrue("the timeout must unregister the session task", sessionTask(taskManager).isEmpty());
+                });
 
                 AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
                 PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
@@ -775,7 +786,8 @@ public class IncrementalBulkIT extends ESIntegTestCase {
                 assertThat(ex.getMessage(), containsString("request timed out after"));
                 assertThat(ExceptionsHelper.unwrap(ex, TaskCancelledException.class), notNullValue());
                 assertFalse(refCounted.hasReferences());
-                // lastItems() unregisters the session task synchronously inside its finalListener, before the future resolves.
+                // Already reclaimed by the timeout; the handler's single-shot guard stops lastItems() from
+                // unregistering a second time and emitting a spurious removal event.
                 assertTrue(sessionTask(taskManager).isEmpty());
             }
         } finally {
@@ -819,6 +831,11 @@ public class IncrementalBulkIT extends ESIntegTestCase {
 
             AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
             try (var handler = service.newBulkRequest()) {
+                // Hold the task: the timeout unregisters it as well as cancelling it, so it cannot be looked
+                // up in the TaskManager afterwards.
+                CancellableTask sessionTask = (CancellableTask) handler.getBulkSessionTask();
+                assertNotNull("a session task must be registered while the request timeout is active", sessionTask);
+
                 // First chunk: the 1b watermarks force an immediate split, which submits the sub-request and
                 // sets incrementalRequestSubmitted = true. Wait until the sub-request fully completes so the
                 // doc is durable and will not be caught by descendant-cancellation when the timeout fires.
@@ -831,11 +848,14 @@ public class IncrementalBulkIT extends ESIntegTestCase {
                 // call onFailure instead of onResponse; fail fast here rather than with a cryptic safeGet error.
                 assertFalse(
                     "timeout fired before the first sub-request completed; increase the timeout for this test",
-                    isSessionTaskCancelled(taskManager)
+                    sessionTask.isCancelled()
                 );
 
-                // Let the scheduled timeout cancel the session.
-                assertBusy(() -> assertTrue(isSessionTaskCancelled(taskManager)));
+                // Let the scheduled timeout cancel and unregister the session.
+                assertBusy(() -> {
+                    assertTrue(sessionTask.isCancelled());
+                    assertTrue("the timeout must unregister the session task", sessionTask(taskManager).isEmpty());
+                });
 
                 // Final chunk: observes cancellation -> per-item failure, no top-level exception.
                 PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
@@ -855,7 +875,8 @@ public class IncrementalBulkIT extends ESIntegTestCase {
                 assertThat(rootCause.getMessage(), containsString("request timed out after"));
                 assertThat(byFailed.get(true).get(0).getFailure().getStatus(), equalTo(RestStatus.TOO_MANY_REQUESTS));
                 assertFalse(refCounted.hasReferences());
-                // lastItems() unregisters the session task synchronously inside its finalListener, before the future resolves.
+                // Already reclaimed by the timeout; the handler's single-shot guard stops lastItems() from
+                // unregistering a second time and emitting a spurious removal event.
                 assertTrue(sessionTask(taskManager).isEmpty());
             }
         } finally {
@@ -908,10 +929,6 @@ public class IncrementalBulkIT extends ESIntegTestCase {
             .stream()
             .filter(t -> t.getAction().equals(IncrementalBulkService.BULK_SESSION_ACTION))
             .findAny();
-    }
-
-    private static boolean isSessionTaskCancelled(TaskManager taskManager) {
-        return sessionTask(taskManager).map(CancellableTask::isCancelled).orElse(false);
     }
 
     private static void blockWriteCoordinationPool(ThreadPool threadPool, CountDownLatch finishLatch) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -61,9 +61,12 @@ public class IncrementalBulkService {
 
     /**
      * Overall wall-clock timeout for a single incremental bulk request, measured from the moment the
-     * request session is created. A non-positive value (the default) disables the timeout. When it
-     * elapses the request's {@link Handler#bulkSessionTask} is cancelled, which causes the next chunk
-     * to fail with a {@link org.elasticsearch.tasks.TaskCancelledException}.
+     * request session is created. A non-positive value (the default) disables the timeout, and no
+     * {@link Handler#bulkSessionTask} is registered at all: without a timeout there is no bound on how
+     * long a session may stay open, so a registration whose handler is abandoned could never be
+     * reclaimed. When the timeout is configured and elapses, the task is cancelled and then
+     * unregistered, which causes the next chunk to fail with a
+     * {@link org.elasticsearch.tasks.TaskCancelledException}.
      */
     public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.timeSetting(
         "rest.incremental_bulk.request_timeout",
@@ -146,11 +149,12 @@ public class IncrementalBulkService {
             chunkWaitTimeMillisHistogram,
             paramsUsed,
             taskManager,
-            threadPool
+            threadPool,
+            requestTimeout
         );
         // Scheduled after construction (rather than in the Handler constructor) so the timeout callback
         // never captures a partially-initialized Handler.
-        handler.scheduleTimeout(requestTimeout);
+        handler.scheduleTimeout();
         return handler;
     }
 
@@ -205,7 +209,12 @@ public class IncrementalBulkService {
         private BulkRequest bulkRequest = null;
         private final TaskManager taskManager;
         private final ThreadPool threadPool;
+        // Registered only when the request timeout is active; see REQUEST_TIMEOUT.
+        @Nullable
         private final CancellableTask bulkSessionTask;
+        @Nullable
+        private final TimeValue requestTimeout;
+        private final AtomicBoolean sessionTaskUnregistered = new AtomicBoolean();
         // Cancels the request after REQUEST_TIMEOUT elapses; null when no timeout is configured.
         private volatile Scheduler.Cancellable pendingTimeout;
 
@@ -218,31 +227,37 @@ public class IncrementalBulkService {
             LongHistogram chunkWaitTimeMillisHistogram,
             Set<String> paramsUsed,
             TaskManager taskManager,
-            ThreadPool threadPool
+            ThreadPool threadPool,
+            @Nullable TimeValue requestTimeout
         ) {
             this.taskManager = taskManager;
-            try (var ignored = threadPool.getThreadContext().newTraceContext()) {
-                bulkSessionTask = (CancellableTask) taskManager.register(
-                    BULK_SESSION_TASK_TYPE,
-                    BULK_SESSION_ACTION,
-                    new TaskAwareRequest() {
-                        @Override
-                        public void setParentTask(TaskId taskId) {}
+            this.requestTimeout = requestTimeout;
+            if (timeoutIsActive(requestTimeout)) {
+                try (var ignored = threadPool.getThreadContext().newTraceContext()) {
+                    bulkSessionTask = (CancellableTask) taskManager.register(
+                        BULK_SESSION_TASK_TYPE,
+                        BULK_SESSION_ACTION,
+                        new TaskAwareRequest() {
+                            @Override
+                            public void setParentTask(TaskId taskId) {}
 
-                        @Override
-                        public void setRequestId(long requestId) {}
+                            @Override
+                            public void setRequestId(long requestId) {}
 
-                        @Override
-                        public TaskId getParentTask() {
-                            return TaskId.EMPTY_TASK_ID;
+                            @Override
+                            public TaskId getParentTask() {
+                                return TaskId.EMPTY_TASK_ID;
+                            }
+
+                            @Override
+                            public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+                                return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
+                            }
                         }
-
-                        @Override
-                        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-                            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
-                        }
-                    }
-                );
+                    );
+                }
+            } else {
+                bulkSessionTask = null;
             }
 
             this.client = client;
@@ -257,18 +272,62 @@ public class IncrementalBulkService {
         }
 
         /**
-         * Schedules cancellation of this request once {@code requestTimeout} elapses. A no-op when the
-         * timeout is null or non-positive. Called once, immediately after construction.
+         * Whether {@code requestTimeout} enables the overall request timeout. This is the single predicate
+         * deciding both whether {@link #bulkSessionTask} is registered and whether the timeout is scheduled;
+         * the two must never disagree, or a session would be registered with nothing to reclaim it.
+         *
+         * <p>Guards on millis(), not nanos(): {@link ThreadPool#schedule} floors the delay to whole
+         * milliseconds, so a sub-millisecond timeout would otherwise arm a zero-delay task that cancels the
+         * request immediately.
          */
-        private void scheduleTimeout(@Nullable TimeValue requestTimeout) {
-            // Guard on millis(), not nanos(): ThreadPool#schedule floors the delay to whole milliseconds, so a
-            // sub-millisecond timeout would otherwise arm a zero-delay task that cancels the request immediately.
-            if (requestTimeout != null && requestTimeout.millis() > 0) {
-                pendingTimeout = threadPool.schedule(
-                    () -> cancel("request timed out after [" + requestTimeout + "]", () -> {}),
-                    requestTimeout,
-                    threadPool.generic()
-                );
+        private static boolean timeoutIsActive(@Nullable TimeValue requestTimeout) {
+            return requestTimeout != null && requestTimeout.millis() > 0;
+        }
+
+        /**
+         * Schedules cancellation of this request once the request timeout elapses. A no-op when the timeout
+         * is inactive, in which case no session task was registered either. Called once, immediately after
+         * construction.
+         */
+        private void scheduleTimeout() {
+            if (timeoutIsActive(requestTimeout)) {
+                pendingTimeout = threadPool.schedule(this::onTimeout, requestTimeout, threadPool.generic());
+            }
+        }
+
+        private void onTimeout() {
+            cancelAndUnregisterSessionTask("request timed out after [" + requestTimeout + "]");
+        }
+
+        /**
+         * Reclaims the session registration, at most once for the lifetime of this handler. Several paths can
+         * end a session and more than one may run for the same session, but
+         * {@link TaskManager#unregister} must not be called twice for one task.
+         */
+        private void unregisterSessionTask() {
+            if (bulkSessionTask != null && sessionTaskUnregistered.compareAndSet(false, true)) {
+                taskManager.unregister(bulkSessionTask);
+            }
+        }
+
+        /**
+         * Cancels the session and then reclaims it, for the paths that end a session before its response was
+         * produced. The reclaim runs even if the cancellation throws, because this is the terminal reclaim
+         * for a handler that may already have been abandoned: no further chunk will arrive, so neither
+         * {@link #close()} nor {@code lastItems} will run again. A session already reclaimed by
+         * {@code lastItems} completing is left alone.
+         *
+         * <p>The cancellation must precede the reclaim: cancelling a task that is already unregistered
+         * silently does nothing while still reporting success.
+         */
+        private void cancelAndUnregisterSessionTask(String reason) {
+            if (bulkSessionTask == null || sessionTaskUnregistered.get()) {
+                return;
+            }
+            try {
+                cancel(reason, () -> {});
+            } finally {
+                unregisterSessionTask();
             }
         }
 
@@ -288,6 +347,12 @@ public class IncrementalBulkService {
          * {@link org.elasticsearch.tasks.TaskCancellationService} sending {@code cancel_child}.
          */
         public void cancel(String reason, Runnable listener) {
+            if (bulkSessionTask == null) {
+                // No session task is registered unless the request timeout is active, so there is nothing to
+                // cancel and the cancellation is vacuously complete.
+                listener.run();
+                return;
+            }
             try (ThreadContext.StoredContext ignored = threadPool.getThreadContext().stashContext()) {
                 threadPool.getThreadContext().markAsSystemContext();
                 taskManager.cancelTaskAndDescendants(bulkSessionTask, reason, false, ActionListener.running(listener));
@@ -352,7 +417,7 @@ public class IncrementalBulkService {
             assert bulkInProgress == false;
             ActionListener<BulkResponse> finalListener = ActionListener.runBefore(listener, () -> {
                 cancelTimeout();
-                taskManager.unregister(bulkSessionTask);
+                unregisterSessionTask();
             });
             if (bulkActionLevelFailure != null) {
                 shortCircuitDueToTopLevelFailure(items, releasable);
@@ -398,9 +463,7 @@ public class IncrementalBulkService {
                 incrementalOperation.close();
                 releasables.forEach(Releasable::close);
                 releasables.clear();
-                if (taskManager.getCancellableTask(bulkSessionTask.getId()) != null) {
-                    cancel("handler closed", () -> taskManager.unregister(bulkSessionTask));
-                }
+                cancelAndUnregisterSessionTask("handler closed");
             }
         }
 
@@ -451,7 +514,7 @@ public class IncrementalBulkService {
         private boolean internalAddItems(List<DocWriteRequest<?>> items, Releasable releasable) {
             bulkRequest.add(items);
             releasables.add(releasable);
-            if (bulkSessionTask.isCancelled()) {
+            if (bulkSessionTask != null && bulkSessionTask.isCancelled()) {
                 failAndRelease(bulkSessionTask.getTaskCancelledException());
                 return false;
             } else {
@@ -478,10 +541,11 @@ public class IncrementalBulkService {
 
         private void createNewBulkRequest(BulkRequest.IncrementalState incrementalState) {
             assert bulkRequest == null;
-            assert bulkSessionTask != null;
             assert taskManager != null;
             bulkRequest = new BulkRequest();
-            bulkRequest.setParentTask(new TaskId(taskManager.getNodeId(), bulkSessionTask.getId()));
+            if (bulkSessionTask != null) {
+                bulkRequest.setParentTask(new TaskId(taskManager.getNodeId(), bulkSessionTask.getId()));
+            }
             bulkRequest.incrementalState(incrementalState);
 
             if (waitForActiveShards != null) {
@@ -496,7 +560,8 @@ public class IncrementalBulkService {
             bulkRequest.requestParamsUsed(paramsUsed);
         }
 
-        // Visible for testing
+        // Visible for testing; null unless the request timeout is active
+        @Nullable
         protected Task getBulkSessionTask() {
             return bulkSessionTask;
         }

--- a/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -17,6 +18,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -24,7 +26,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -39,23 +43,25 @@ import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link IncrementalBulkService#REQUEST_TIMEOUT} scheduling that this service adds on top of
- * the bulk-session cancellation machinery. The downstream effect of cancellation (the next chunk failing
- * with a {@code TaskCancelledException}) is covered by {@code IncrementalBulkIT}; here we only assert that
- * the timeout reliably triggers cancellation and is cancelled itself once the request finishes.
+ * the bulk-session cancellation machinery, and the registration lifecycle tied to it: the session task
+ * exists only while the timeout is active, and every path that ends a session reclaims it. The downstream
+ * effect of cancellation (the next chunk failing with a {@code TaskCancelledException}) is covered by
+ * {@code IncrementalBulkIT}.
  */
 public class IncrementalBulkServiceTests extends ESTestCase {
 
     /**
-     * Builds a service whose requests run on {@code threadPool}'s simulated clock. A null
-     * {@code requestTimeout} configures the {@link IncrementalBulkService#REQUEST_TIMEOUT} setting to its
-     * disabled default.
+     * Builds a service whose requests run on {@code threadPool}'s simulated clock, backed by a mock
+     * {@link TaskManager}. A null {@code requestTimeout} leaves
+     * {@link IncrementalBulkService#REQUEST_TIMEOUT} at its disabled default, in which case no session task
+     * is registered at all.
      *
-     * <p>{@code taskManager} is a mock rather than a real {@link TaskManager} because the timeout's effect
-     * is delivered through {@code cancelTaskAndDescendants}, which a bare {@code TaskManager} cannot service
-     * without a transport-wired {@code TaskCancellationService}. Mocking it lets us verify the cancellation
-     * call directly; {@code register()} is stubbed to return a real {@link CancellableTask} so the handler
-     * can be constructed and parented. {@code Client} is mocked because these tests only exercise timeout
-     * scheduling and never issue a bulk request.
+     * <p>The mock is for tests that only need to verify which calls were made: the timeout's effect is
+     * delivered through {@code cancelTaskAndDescendants}, which a bare {@code TaskManager} cannot service
+     * without a transport-wired {@code TaskCancellationService}. {@code register()} is stubbed to return a
+     * real {@link CancellableTask} so the handler can be constructed and parented. Tests that need to observe
+     * genuine registration state use {@link #buildService} with a real {@code TaskManager} instead.
+     * {@code Client} is mocked because these tests never issue a bulk request.
      */
     private static IncrementalBulkService newService(ThreadPool threadPool, TimeValue requestTimeout, TaskManager taskManager) {
         CancellableTask task = new CancellableTask(
@@ -68,7 +74,15 @@ public class IncrementalBulkServiceTests extends ESTestCase {
         );
         when(taskManager.register(anyString(), anyString(), any())).thenReturn(task);
         when(taskManager.getNodeId()).thenReturn("test-node");
+        return buildService(threadPool, requestTimeout, taskManager);
+    }
 
+    /**
+     * Builds a service against whichever {@link TaskManager} is supplied, without stubbing it. Tests that need
+     * to observe real registration state pass a real {@link TaskManager}; {@link #newService} layers Mockito
+     * stubbing on top of this for the tests that only verify which calls were made.
+     */
+    private static IncrementalBulkService buildService(ThreadPool threadPool, TimeValue requestTimeout, TaskManager taskManager) {
         Settings.Builder settings = Settings.builder();
         if (requestTimeout != null) {
             settings.put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), requestTimeout);
@@ -121,6 +135,7 @@ public class IncrementalBulkServiceTests extends ESTestCase {
 
         try (var handler = service.newBulkRequest()) {
             assertTrue("a timeout task should be scheduled", taskQueue.hasDeferredTasks());
+            assertNotNull("an active timeout must register a session task to cancel", handler.getBulkSessionTask());
 
             taskQueue.runAllTasksInTimeOrder();
 
@@ -128,16 +143,29 @@ public class IncrementalBulkServiceTests extends ESTestCase {
         }
     }
 
-    public void testNoTimeoutWhenDisabled() {
+    /**
+     * With no active timeout there is nothing that would ever reclaim a session task: the handler may be
+     * abandoned without {@code close()} or {@code lastItems} running, and no scheduled cancellation exists to
+     * bound it. So no task is registered at all, which is what keeps an abandoned session from leaking a
+     * permanent {@link TaskManager} entry.
+     */
+    public void testNoTimeoutAndNoSessionTaskWhenDisabled() {
         DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
 
         // MINUS_ONE disables the timeout; a sub-millisecond value rounds down to a 0ms delay and must also be
         // treated as disabled rather than scheduling a task that cancels the request immediately.
         for (TimeValue timeout : new TimeValue[] { null, TimeValue.MINUS_ONE, TimeValue.timeValueNanos(500_000) }) {
-            IncrementalBulkService service = newService(taskQueue.getThreadPool(), timeout, mock(TaskManager.class));
+            TaskManager taskManager = mock(TaskManager.class);
+            IncrementalBulkService service = newService(taskQueue.getThreadPool(), timeout, taskManager);
             try (var handler = service.newBulkRequest()) {
                 assertFalse("no timeout task should be scheduled when disabled", taskQueue.hasDeferredTasks());
+                assertNull("no session task should be registered when disabled", handler.getBulkSessionTask());
             }
+            // The handler was closed by the try-with-resources: with nothing registered there is nothing to
+            // cancel or reclaim, so close() must not reach the TaskManager at all.
+            verify(taskManager, never()).register(anyString(), anyString(), any());
+            verify(taskManager, never()).cancelTaskAndDescendants(any(), anyString(), anyBoolean(), any());
+            verify(taskManager, never()).unregister(any());
         }
     }
 
@@ -153,5 +181,136 @@ public class IncrementalBulkServiceTests extends ESTestCase {
         // close() cancelled the scheduled task, so advancing past the deadline must not fire the timeout
         taskQueue.runAllTasksInTimeOrder();
         verify(taskManager, never()).cancelTaskAndDescendants(any(), startsWith("request timed out"), anyBoolean(), any());
+    }
+
+    /**
+     * Stub for a cancellation that never completes: {@code cancelTaskAndDescendants} only fires its listener
+     * once every child connection has answered its ban request, and those sends carry no timeout, so an
+     * unresponsive node stalls it indefinitely. A bare {@link TaskManager} cannot reproduce that without a
+     * transport-wired {@code TaskCancellationService}, so the override drops the listener. Registration is
+     * left real, so the tests read genuine registry state rather than a mock's.
+     */
+    private static class StalledCancellationTaskManager extends TaskManager {
+
+        private final AtomicInteger cancellations = new AtomicInteger();
+        private final AtomicInteger unregistrations = new AtomicInteger();
+        private final AtomicBoolean taskRegisteredWhenCancelled = new AtomicBoolean();
+
+        private final boolean throwOnCancel;
+
+        StalledCancellationTaskManager(ThreadPool threadPool) {
+            this(threadPool, false);
+        }
+
+        StalledCancellationTaskManager(ThreadPool threadPool, boolean throwOnCancel) {
+            super(Settings.EMPTY, threadPool, Set.of());
+            this.throwOnCancel = throwOnCancel;
+        }
+
+        @Override
+        public void cancelTaskAndDescendants(
+            CancellableTask task,
+            String reason,
+            boolean waitForCompletion,
+            ActionListener<Void> listener
+        ) {
+            taskRegisteredWhenCancelled.set(getCancellableTask(task.getId()) != null);
+            cancellations.incrementAndGet();
+            if (throwOnCancel) {
+                // The message the real TaskManager uses when its cancellation service was never set.
+                throw new IllegalStateException("TaskCancellationService is not initialized");
+            }
+        }
+
+        @Override
+        public Task unregister(Task task) {
+            unregistrations.incrementAndGet();
+            return super.unregister(task);
+        }
+
+        void assertCancelledThenUnregistered(String what) {
+            assertEquals(what + " must propagate the cancellation", 1, cancellations.get());
+            assertTrue(
+                "cancellation must run before the task is unregistered, otherwise it is silently a no-op",
+                taskRegisteredWhenCancelled.get()
+            );
+            assertTrue(what + " must unregister without waiting for the cancellation to complete", getCancellableTasks().isEmpty());
+            assertEquals(what + " must unregister exactly once", 1, unregistrations.get());
+        }
+    }
+
+    /**
+     * The timeout is the terminal bound on a session's lifetime, so it must reclaim the registration itself:
+     * an abandoned handler receives no further chunk, and neither {@code close()} nor {@code lastItems} will
+     * ever run. Waiting for the cancellation to complete would defeat that, since a stalled ban round-trip
+     * never returns.
+     */
+    public void testTimeoutUnregistersTaskWhenCancellationNeverCompletes() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        ThreadPool threadPool = taskQueue.getThreadPool();
+        StalledCancellationTaskManager taskManager = new StalledCancellationTaskManager(threadPool);
+        IncrementalBulkService service = buildService(threadPool, TimeValue.timeValueSeconds(30), taskManager);
+
+        try (var handler = service.newBulkRequest()) {
+            assertEquals("the bulk session task should be registered", 1, taskManager.getCancellableTasks().size());
+
+            taskQueue.runAllTasksInTimeOrder();
+
+            taskManager.assertCancelledThenUnregistered("the timeout");
+        }
+    }
+
+    /**
+     * The timeout and the normal teardown path can both run for the same session, but only one may reclaim
+     * it, since {@link TaskManager#unregister} is not idempotent.
+     */
+    public void testSessionTaskReclaimedOnceWhenTimeoutPrecedesClose() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        ThreadPool threadPool = taskQueue.getThreadPool();
+        StalledCancellationTaskManager taskManager = new StalledCancellationTaskManager(threadPool);
+        IncrementalBulkService service = buildService(threadPool, TimeValue.timeValueSeconds(30), taskManager);
+
+        var handler = service.newBulkRequest();
+        taskQueue.runAllTasksInTimeOrder();
+        assertTrue("the timeout should have reclaimed the session", taskManager.getCancellableTasks().isEmpty());
+
+        handler.close();
+
+        assertEquals("close() must not unregister a session the timeout already reclaimed", 1, taskManager.unregistrations.get());
+        assertEquals("close() must not re-cancel a session the timeout already reclaimed", 1, taskManager.cancellations.get());
+    }
+
+    /**
+     * {@code cancelTaskAndDescendants} can throw synchronously -- {@link IllegalStateException} when the
+     * cancellation service was never set, or a listener failure rethrown by {@code notifyListeners}. Since
+     * reclaiming the registration is the whole point of these paths, a failed cancellation must not strand it.
+     */
+    public void testSessionTaskUnregisteredWhenCancellationThrows() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        ThreadPool threadPool = taskQueue.getThreadPool();
+        StalledCancellationTaskManager taskManager = new StalledCancellationTaskManager(threadPool, true);
+        IncrementalBulkService service = buildService(threadPool, TimeValue.timeValueSeconds(30), taskManager);
+
+        var handler = service.newBulkRequest();
+        expectThrows(IllegalStateException.class, handler::close);
+
+        assertTrue("a failed cancellation must not strand the registration", taskManager.getCancellableTasks().isEmpty());
+    }
+
+    /**
+     * Same contract for the normal teardown path: a stalled cancellation must not hold the registration open.
+     */
+    public void testCloseUnregistersTaskWhenCancellationNeverCompletes() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        ThreadPool threadPool = taskQueue.getThreadPool();
+        StalledCancellationTaskManager taskManager = new StalledCancellationTaskManager(threadPool);
+        IncrementalBulkService service = buildService(threadPool, TimeValue.timeValueSeconds(30), taskManager);
+
+        var handler = service.newBulkRequest();
+        assertEquals("the bulk session task should be registered", 1, taskManager.getCancellableTasks().size());
+
+        handler.close();
+
+        taskManager.assertCancelledThenUnregistered("close()");
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -482,7 +482,8 @@ public class RestBulkActionTests extends ESTestCase {
                 LongHistogram.NOOP,
                 emptySet(),
                 new TaskManager(Settings.EMPTY, threadPool, Task.HEADERS_TO_COPY),
-                threadPool
+                threadPool,
+                null
             ) {
 
                 @Override


### PR DESCRIPTION
This PR changes bulk cancellation behaviour to run only when timeout is active. We've observed few cases where bulk operation never completes or cancellation stalled leaving Task dangling indefinitely if timeout is not configured. Once we have more robust cancellation path we can unhook timeout.