### PR TITLE
[9.5][ML] Surface CCS skipped-cluster stats on datafeed extraction failure

### DIFF
--- a/docs/changelog/157567.yaml
+++ b/docs/changelog/157567.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 157567
+summary: Surface CCS skipped-cluster stats on datafeed extraction failure
+type: bug

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -397,6 +397,16 @@ class DatafeedJob {
                     // Instead, it is preferable to retry the given interval next time an extraction
                     // is triggered.
 
+                    // Update CCS stats with any cluster states the extractor observed before failing.
+                    // This keeps skipped_clusters accurate in the running datafeed stats API even when
+                    // every search round fails due to remote clusters being unavailable. Use the full
+                    // updateCrossClusterSearchStats() path so that any confirmed scope change is also
+                    // audited and annotated rather than silently dropped.
+                    List<LinkedClusterState> partialStates = dataExtractor.getLinkedClusterStates();
+                    if (partialStates.isEmpty() == false) {
+                        updateCrossClusterSearchStats(partialStates);
+                    }
+
                     // For aggregated datafeeds it is possible for our users to use fields without doc values.
                     // In that case, it is really useful to display an error message explaining exactly that.
                     // Unfortunately, there are no great ways to identify the issue but search for 'doc values'

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractor.java
@@ -63,4 +63,18 @@ public interface DataExtractor {
      * @return the end time to which this extractor will search
      */
     long getEndTime();
+
+    /**
+     * Returns the per-cluster states from the most recent search attempt, including from
+     * failed attempts where the extractor threw rather than returning a {@link Result}.
+     * Used by {@link org.elasticsearch.xpack.ml.datafeed.DatafeedJob} to update
+     * {@link org.elasticsearch.xpack.ml.datafeed.CrossClusterSearchStats} even when
+     * extraction fails due to skipped remote clusters.
+     *
+     * @return immutable list of cluster states; empty for local-only datafeeds or if no
+     *         search has been attempted yet
+     */
+    default List<LinkedClusterState> getLinkedClusterStates() {
+        return List.of();
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -125,7 +126,18 @@ abstract class AbstractAggregationDataExtractor implements DataExtractor {
         LOGGER.debug("[{}] Executing aggregated search", context.jobId);
         ActionRequestBuilder<SearchRequest, SearchResponse> searchRequest = buildSearchRequest(buildBaseSearchSource());
         assert searchRequest.request().allowPartialSearchResults() == false;
-        SearchResponse searchResponse = executeSearchRequest(client, context.queryContext, searchRequest);
+        SearchResponse searchResponse;
+        try {
+            searchResponse = executeSearchRequest(client, context.queryContext, searchRequest);
+        } catch (SkippedClustersException e) {
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                e.getLinkedClusterStates()
+            );
+            // Re-throw the original ResourceNotFoundException so callers and exception unwrappers
+            // see the same type and HTTP status as before this wrapper was introduced.
+            throw e.getResourceNotFoundException();
+        }
         try {
             LOGGER.debug("[{}] Search response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());
@@ -137,6 +149,11 @@ abstract class AbstractAggregationDataExtractor implements DataExtractor {
         } finally {
             searchResponse.decRef();
         }
+    }
+
+    @Override
+    public List<LinkedClusterState> getLinkedClusterStates() {
+        return lastLinkedClusterStates;
     }
 
     private void initAggregationProcessor(InternalAggregations aggs) throws IOException {
@@ -165,6 +182,11 @@ abstract class AbstractAggregationDataExtractor implements DataExtractor {
         try {
             DataExtractorUtils.checkForSkippedClusters(searchResponse);
             success = true;
+        } catch (ResourceNotFoundException e) {
+            // Extract cluster states before the response is released so the caller can propagate
+            // them to CrossClusterSearchStats even though extraction is about to fail.
+            List<LinkedClusterState> states = DataExtractorUtils.extractLinkedClusterStates(searchResponse);
+            throw new SkippedClustersException(e, states);
         } finally {
             if (success == false) {
                 searchResponse.decRef();
@@ -228,7 +250,16 @@ abstract class AbstractAggregationDataExtractor implements DataExtractor {
         ActionRequestBuilder<SearchRequest, SearchResponse> searchRequestBuilder = buildSearchRequest(
             DataExtractorUtils.getSearchSourceBuilderForSummary(context.queryContext)
         );
-        SearchResponse searchResponse = executeSearchRequest(client, context.queryContext, searchRequestBuilder);
+        SearchResponse searchResponse;
+        try {
+            searchResponse = executeSearchRequest(client, context.queryContext, searchRequestBuilder);
+        } catch (SkippedClustersException e) {
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                e.getLinkedClusterStates()
+            );
+            throw e.getResourceNotFoundException();
+        }
         try {
             LOGGER.debug("[{}] Aggregating Data summary response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
@@ -160,7 +160,18 @@ class CompositeAggregationDataExtractor implements DataExtractor {
             searchRequest.request().setProjectRouting(context.queryContext.projectRouting);
         }
 
-        SearchResponse searchResponse = AbstractAggregationDataExtractor.executeSearchRequest(client, context.queryContext, searchRequest);
+        SearchResponse searchResponse;
+        try {
+            searchResponse = AbstractAggregationDataExtractor.executeSearchRequest(client, context.queryContext, searchRequest);
+        } catch (SkippedClustersException e) {
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                e.getLinkedClusterStates()
+            );
+            // Re-throw the original ResourceNotFoundException so callers and exception unwrappers
+            // see the same type and HTTP status as before this wrapper was introduced.
+            throw e.getResourceNotFoundException();
+        }
         try {
             LOGGER.trace("[{}] Search composite response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());
@@ -249,16 +260,26 @@ class CompositeAggregationDataExtractor implements DataExtractor {
     }
 
     @Override
+    public List<LinkedClusterState> getLinkedClusterStates() {
+        return lastLinkedClusterStates;
+    }
+
+    @Override
     public DataSummary getSummary() {
         ActionRequestBuilder<SearchRequest, SearchResponse> searchRequestBuilder = DataExtractorUtils.getSearchRequestBuilderForSummary(
             client,
             context.queryContext
         );
-        SearchResponse searchResponse = AbstractAggregationDataExtractor.executeSearchRequest(
-            client,
-            context.queryContext,
-            searchRequestBuilder
-        );
+        SearchResponse searchResponse;
+        try {
+            searchResponse = AbstractAggregationDataExtractor.executeSearchRequest(client, context.queryContext, searchRequestBuilder);
+        } catch (SkippedClustersException e) {
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                e.getLinkedClusterStates()
+            );
+            throw e.getResourceNotFoundException();
+        }
         try {
             LOGGER.debug("[{}] Aggregating Data summary response was obtained", context.jobId);
             timingStatsReporter.reportSearchDuration(searchResponse.getTook());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/SkippedClustersException.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/SkippedClustersException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.xpack.ml.datafeed.LinkedClusterState;
+
+import java.util.List;
+
+/**
+ * Thrown by aggregation data extractors when a CCS search skips one or more remote clusters.
+ * Carries the per-cluster states extracted from the search response before it was released,
+ * so that callers can propagate them to
+ * {@link org.elasticsearch.xpack.ml.datafeed.CrossClusterSearchStats} even when extraction fails.
+ */
+class SkippedClustersException extends RuntimeException {
+
+    private final ResourceNotFoundException resourceNotFoundException;
+    private final List<LinkedClusterState> linkedClusterStates;
+
+    SkippedClustersException(ResourceNotFoundException cause, List<LinkedClusterState> linkedClusterStates) {
+        super(cause.getMessage(), cause);
+        this.resourceNotFoundException = cause;
+        this.linkedClusterStates = List.copyOf(linkedClusterStates);
+    }
+
+    ResourceNotFoundException getResourceNotFoundException() {
+        return resourceNotFoundException;
+    }
+
+    List<LinkedClusterState> getLinkedClusterStates() {
+        return linkedClusterStates;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.chunked;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.SearchInterval;
 import org.elasticsearch.xpack.ml.datafeed.LinkedClusterState;
@@ -89,7 +90,19 @@ public class ChunkedDataExtractor implements DataExtractor {
     }
 
     private void setUpChunkedSearch() {
-        DataSummary dataSummary = dataExtractorFactory.newExtractor(currentStart, context.end()).getSummary();
+        // Keep a reference so that if getSummary() throws (e.g. because a remote cluster was skipped)
+        // we can still recover the cluster states it observed and expose them via getLinkedClusterStates().
+        DataExtractor summaryExtractor = dataExtractorFactory.newExtractor(currentStart, context.end());
+        DataSummary dataSummary;
+        try {
+            dataSummary = summaryExtractor.getSummary();
+        } catch (ResourceNotFoundException e) {
+            List<LinkedClusterState> failedStates = summaryExtractor.getLinkedClusterStates();
+            if (failedStates.isEmpty() == false) {
+                lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(lastLinkedClusterStates, failedStates);
+            }
+            throw e;
+        }
         if (dataSummary.hasData()) {
             currentStart = context.timeAligner().alignToFloor(dataSummary.earliestTime());
             currentEnd = currentStart;
@@ -134,7 +147,18 @@ public class ChunkedDataExtractor implements DataExtractor {
                 isNewSearch = true;
             }
 
-            Result result = currentExtractor.next();
+            Result result;
+            try {
+                result = currentExtractor.next();
+            } catch (IOException | RuntimeException e) {
+                // Capture states from the inner extractor before rethrowing so that
+                // getLinkedClusterStates() gives accurate data to DatafeedJob's catch block.
+                List<LinkedClusterState> innerStates = currentExtractor.getLinkedClusterStates();
+                if (innerStates.isEmpty() == false) {
+                    lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(lastLinkedClusterStates, innerStates);
+                }
+                throw e;
+            }
             lastSearchInterval = result.searchInterval();
             if (result.linkedClusterStates().isEmpty() == false) {
                 lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
@@ -206,6 +230,11 @@ public class ChunkedDataExtractor implements DataExtractor {
     @Override
     public long getEndTime() {
         return context.end();
+    }
+
+    @Override
+    public List<LinkedClusterState> getLinkedClusterStates() {
+        return lastLinkedClusterStates;
     }
 
     ChunkedDataExtractorContext getContext() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -186,6 +186,13 @@ class ScrollDataExtractor implements DataExtractor {
             DataExtractorUtils.checkForSkippedClusters(searchResponse);
             success = true;
         } catch (ResourceNotFoundException e) {
+            // Update lastLinkedClusterStates FIRST so that clearScrollLoggingExceptions() can
+            // correctly classify the scroll as CCS even on the first failure cycle (when
+            // lastLinkedClusterStates would otherwise still be empty).
+            lastLinkedClusterStates = DataExtractorUtils.preferRicherLinkedClusterStates(
+                lastLinkedClusterStates,
+                DataExtractorUtils.extractLinkedClusterStates(searchResponse)
+            );
             clearScrollLoggingExceptions(searchResponse.getScrollId());
             throw e;
         } finally {
@@ -194,6 +201,11 @@ class ScrollDataExtractor implements DataExtractor {
             }
         }
         return searchResponse;
+    }
+
+    @Override
+    public List<LinkedClusterState> getLinkedClusterStates() {
+        return lastLinkedClusterStates;
     }
 
     private SearchRequestBuilder buildSearchRequest(long start) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.datafeed;
 
-import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
@@ -472,93 +471,6 @@ public class DatafeedJobTests extends ESTestCase {
 
         expectThrows(DatafeedJob.ExtractionProblemException.class, () -> datafeedJob.runLookBack(0L, 1000L));
         assertThat(stats.getSkippedClusters(), equalTo(1));
-    }
-
-    public void testCloudCredentialFailureShouldAuditOncePerFailureEpisode() throws Exception {
-        currentTime = 3001;
-        ElasticsearchSecurityException securityFailure = new ElasticsearchSecurityException("invalid key", RestStatus.UNAUTHORIZED);
-        IOException extractionFailure = new IOException(securityFailure);
-        when(dataExtractor.hasNext()).thenReturn(true, true);
-        doThrow(extractionFailure).doThrow(extractionFailure).when(dataExtractor).next();
-
-        DatafeedJob datafeedJob = createDatafeedJob(
-            1000,
-            500,
-            -1,
-            -1,
-            false,
-            DELAYED_DATA_CHECK_FREQ.get(Settings.EMPTY).millis(),
-            new CrossClusterSearchStats(() -> Instant.ofEpochMilli(currentTime)),
-            "key-abc"
-        );
-        ProblemTracker problemTracker = new ProblemTracker(auditor, jobId, datafeedJob.numberOfSearchesIn24Hours());
-        String enrichedMessage = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_KEY_RUNTIME_FAILURE, "key-abc");
-
-        DatafeedJob.ExtractionProblemException firstFailure = expectThrows(
-            DatafeedJob.ExtractionProblemException.class,
-            datafeedJob::runRealtime
-        );
-        problemTracker.reportExtractionProblem(firstFailure);
-        currentTime = 6001;
-        DatafeedJob.ExtractionProblemException secondFailure = expectThrows(
-            DatafeedJob.ExtractionProblemException.class,
-            datafeedJob::runRealtime
-        );
-        problemTracker.reportExtractionProblem(secondFailure);
-        problemTracker.finishReport();
-
-        verify(auditor, times(1)).error(
-            eq(jobId),
-            eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_DATA_EXTRACTION_ERROR, enrichedMessage))
-        );
-    }
-
-    public void testCloudCredentialFailureShouldReAuditAfterSuccessfulExtraction() throws Exception {
-        currentTime = 3001;
-        ElasticsearchSecurityException securityFailure = new ElasticsearchSecurityException("invalid key", RestStatus.UNAUTHORIZED);
-        IOException extractionFailure = new IOException(securityFailure);
-        byte[] contentBytes = "content".getBytes(StandardCharsets.UTF_8);
-        InputStream inputStream = new ByteArrayInputStream(contentBytes);
-        when(dataExtractor.hasNext()).thenReturn(true, true, false, true);
-        doThrow(extractionFailure).doAnswer(
-            invocation -> new DataExtractor.Result(new SearchInterval(1000L, 2000L), Optional.of(inputStream), List.of())
-        ).doThrow(extractionFailure).when(dataExtractor).next();
-
-        DatafeedJob datafeedJob = createDatafeedJob(
-            1000,
-            500,
-            -1,
-            -1,
-            false,
-            DELAYED_DATA_CHECK_FREQ.get(Settings.EMPTY).millis(),
-            new CrossClusterSearchStats(() -> Instant.ofEpochMilli(currentTime)),
-            "key-abc"
-        );
-        ProblemTracker problemTracker = new ProblemTracker(auditor, jobId, datafeedJob.numberOfSearchesIn24Hours());
-        String enrichedMessage = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_KEY_RUNTIME_FAILURE, "key-abc");
-
-        DatafeedJob.ExtractionProblemException firstFailure = expectThrows(
-            DatafeedJob.ExtractionProblemException.class,
-            datafeedJob::runRealtime
-        );
-        problemTracker.reportExtractionProblem(firstFailure);
-        problemTracker.finishReport();
-        currentTime = 6001;
-        datafeedJob.runRealtime();
-        problemTracker.reportNonEmptyDataCount();
-        problemTracker.finishReport();
-        currentTime = 9001;
-        DatafeedJob.ExtractionProblemException secondFailure = expectThrows(
-            DatafeedJob.ExtractionProblemException.class,
-            datafeedJob::runRealtime
-        );
-        problemTracker.reportExtractionProblem(secondFailure);
-        problemTracker.finishReport();
-
-        verify(auditor, times(2)).error(
-            eq(jobId),
-            eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_DATA_EXTRACTION_ERROR, enrichedMessage))
-        );
     }
 
     public void testPostAnalysisProblem() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
@@ -449,6 +451,114 @@ public class DatafeedJobTests extends ESTestCase {
         assertEquals(2000L, endTimeCaptor.getAllValues().get(1).longValue());
         assertThat(flushJobRequests.getAllValues().isEmpty(), is(true));
         verify(client, never()).execute(same(PersistJobAction.INSTANCE), any());
+    }
+
+    public void testSkippedClustersStatsUpdatedOnExtractionFailure() throws Exception {
+        when(dataExtractor.hasNext()).thenReturn(true);
+        when(dataExtractor.next()).thenThrow(new ResourceNotFoundException("remote cluster skipped"));
+        List<LinkedClusterState> skippedStates = List.of(new LinkedClusterState("remote1", LinkedClusterState.Status.SKIPPED, null, 10));
+        when(dataExtractor.getLinkedClusterStates()).thenReturn(skippedStates);
+
+        CrossClusterSearchStats stats = new CrossClusterSearchStats(() -> Instant.ofEpochMilli(currentTime));
+        DatafeedJob datafeedJob = createDatafeedJob(
+            1000,
+            500,
+            -1,
+            -1,
+            randomBoolean(),
+            DELAYED_DATA_CHECK_FREQ.get(Settings.EMPTY).millis(),
+            stats
+        );
+
+        expectThrows(DatafeedJob.ExtractionProblemException.class, () -> datafeedJob.runLookBack(0L, 1000L));
+        assertThat(stats.getSkippedClusters(), equalTo(1));
+    }
+
+    public void testCloudCredentialFailureShouldAuditOncePerFailureEpisode() throws Exception {
+        currentTime = 3001;
+        ElasticsearchSecurityException securityFailure = new ElasticsearchSecurityException("invalid key", RestStatus.UNAUTHORIZED);
+        IOException extractionFailure = new IOException(securityFailure);
+        when(dataExtractor.hasNext()).thenReturn(true, true);
+        doThrow(extractionFailure).doThrow(extractionFailure).when(dataExtractor).next();
+
+        DatafeedJob datafeedJob = createDatafeedJob(
+            1000,
+            500,
+            -1,
+            -1,
+            false,
+            DELAYED_DATA_CHECK_FREQ.get(Settings.EMPTY).millis(),
+            new CrossClusterSearchStats(() -> Instant.ofEpochMilli(currentTime)),
+            "key-abc"
+        );
+        ProblemTracker problemTracker = new ProblemTracker(auditor, jobId, datafeedJob.numberOfSearchesIn24Hours());
+        String enrichedMessage = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_KEY_RUNTIME_FAILURE, "key-abc");
+
+        DatafeedJob.ExtractionProblemException firstFailure = expectThrows(
+            DatafeedJob.ExtractionProblemException.class,
+            datafeedJob::runRealtime
+        );
+        problemTracker.reportExtractionProblem(firstFailure);
+        currentTime = 6001;
+        DatafeedJob.ExtractionProblemException secondFailure = expectThrows(
+            DatafeedJob.ExtractionProblemException.class,
+            datafeedJob::runRealtime
+        );
+        problemTracker.reportExtractionProblem(secondFailure);
+        problemTracker.finishReport();
+
+        verify(auditor, times(1)).error(
+            eq(jobId),
+            eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_DATA_EXTRACTION_ERROR, enrichedMessage))
+        );
+    }
+
+    public void testCloudCredentialFailureShouldReAuditAfterSuccessfulExtraction() throws Exception {
+        currentTime = 3001;
+        ElasticsearchSecurityException securityFailure = new ElasticsearchSecurityException("invalid key", RestStatus.UNAUTHORIZED);
+        IOException extractionFailure = new IOException(securityFailure);
+        byte[] contentBytes = "content".getBytes(StandardCharsets.UTF_8);
+        InputStream inputStream = new ByteArrayInputStream(contentBytes);
+        when(dataExtractor.hasNext()).thenReturn(true, true, false, true);
+        doThrow(extractionFailure).doAnswer(
+            invocation -> new DataExtractor.Result(new SearchInterval(1000L, 2000L), Optional.of(inputStream), List.of())
+        ).doThrow(extractionFailure).when(dataExtractor).next();
+
+        DatafeedJob datafeedJob = createDatafeedJob(
+            1000,
+            500,
+            -1,
+            -1,
+            false,
+            DELAYED_DATA_CHECK_FREQ.get(Settings.EMPTY).millis(),
+            new CrossClusterSearchStats(() -> Instant.ofEpochMilli(currentTime)),
+            "key-abc"
+        );
+        ProblemTracker problemTracker = new ProblemTracker(auditor, jobId, datafeedJob.numberOfSearchesIn24Hours());
+        String enrichedMessage = Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_CPS_KEY_RUNTIME_FAILURE, "key-abc");
+
+        DatafeedJob.ExtractionProblemException firstFailure = expectThrows(
+            DatafeedJob.ExtractionProblemException.class,
+            datafeedJob::runRealtime
+        );
+        problemTracker.reportExtractionProblem(firstFailure);
+        problemTracker.finishReport();
+        currentTime = 6001;
+        datafeedJob.runRealtime();
+        problemTracker.reportNonEmptyDataCount();
+        problemTracker.finishReport();
+        currentTime = 9001;
+        DatafeedJob.ExtractionProblemException secondFailure = expectThrows(
+            DatafeedJob.ExtractionProblemException.class,
+            datafeedJob::runRealtime
+        );
+        problemTracker.reportExtractionProblem(secondFailure);
+        problemTracker.finishReport();
+
+        verify(auditor, times(2)).error(
+            eq(jobId),
+            eq(Messages.getMessage(Messages.JOB_AUDIT_DATAFEED_DATA_EXTRACTION_ERROR, enrichedMessage))
+        );
     }
 
     public void testPostAnalysisProblem() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.datafeed.extractor.chunked;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.core.TimeValue;
@@ -494,6 +495,21 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         assertThat(result.linkedClusterStates(), equalTo(clusterStates));
     }
 
+    public void testLinkedClusterStatesPropagateWhenSetUpChunkedSearchThrows() {
+        DataExtractor extractor = new ChunkedDataExtractor(dataExtractorFactory, createContext(1000L, 2300L));
+
+        List<LinkedClusterState> skippedStates = List.of(new LinkedClusterState("remote_1", LinkedClusterState.Status.SKIPPED, null, 50L));
+        DataExtractor summaryExtractor = new StubSummaryExtractorThrowingWithClusterStates(skippedStates);
+        when(dataExtractorFactory.newExtractor(1000L, 2300L)).thenReturn(summaryExtractor);
+
+        assertThat(extractor.hasNext(), is(true));
+        expectThrows(ResourceNotFoundException.class, extractor::next);
+
+        // Despite the failure, the skipped cluster states observed by the summary extractor
+        // must be surfaced via getLinkedClusterStates() so that callers can update CCS stats.
+        assertThat(extractor.getLinkedClusterStates(), equalTo(skippedStates));
+    }
+
     public void testNoDataSummaryHasNoData() {
         DataSummary summary = new DataSummary(null, null, 0L);
         assertFalse(summary.hasData());
@@ -589,6 +605,55 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         public Result next() {
             Result base = super.next();
             return new Result(base.searchInterval(), base.data(), linkedClusterStates);
+        }
+    }
+
+    /**
+     * A summary extractor that throws {@link ResourceNotFoundException} from {@link #getSummary()} to simulate
+     * a CCS search where a remote cluster is skipped. The skipped cluster states are available via
+     * {@link #getLinkedClusterStates()} so that callers can capture them before the exception propagates.
+     */
+    private static class StubSummaryExtractorThrowingWithClusterStates implements DataExtractor {
+        private final List<LinkedClusterState> linkedClusterStates;
+
+        StubSummaryExtractorThrowingWithClusterStates(List<LinkedClusterState> linkedClusterStates) {
+            this.linkedClusterStates = linkedClusterStates;
+        }
+
+        @Override
+        public DataSummary getSummary() {
+            throw new ResourceNotFoundException("remote cluster skipped");
+        }
+
+        @Override
+        public List<LinkedClusterState> getLinkedClusterStates() {
+            return linkedClusterStates;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public Result next() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public void cancel() {}
+
+        @Override
+        public void destroy() {}
+
+        @Override
+        public long getEndTime() {
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Backport of #157567 to 9.5.

**Conflict resolution**: `DatafeedJobTests.java` on 9.5 was missing the two new imports (`ElasticsearchSecurityException`, `ResourceNotFoundException`) and the three new test methods introduced on main alongside the fix. Both were cleanly added.