### PR TITLE
Name the binary doc-values format once

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -60,6 +60,7 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.ArrayOrderBinaryDocValuesSyntheticFieldLoaderLayer;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
@@ -87,7 +88,6 @@ import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -386,6 +386,11 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
          */
         public boolean usesArrayOrderBinaryDocValues() {
             return useArrayOrderBinaryDocValues;
+        }
+
+        /** Which framing a doc-values query has to decode for this field. */
+        private BinaryDocValuesFormat binaryFormat() {
+            return useArrayOrderBinaryDocValues ? BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL : BinaryDocValuesFormat.SEPARATE_COUNT;
         }
 
         /**
@@ -692,7 +697,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             failIfNotIndexedNorDocValuesFallback(context);
 
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), binaryFormat());
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
@@ -708,7 +713,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
             List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, binaryFormat());
             } else {
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
             }
@@ -726,7 +731,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, binaryFormat());
             }
             if (caseInsensitive == false) {
                 return new PrefixQuery(new Term(name(), value), MultiTermQuery.DOC_VALUES_REWRITE);
@@ -752,7 +757,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, binaryFormat());
             }
             if (caseInsensitive == false) {
                 Term term = new Term(name(), value);
@@ -792,7 +797,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     syntaxFlags,
                     matchFlags,
                     maxDeterminizedStates,
-                    useArrayOrderBinaryDocValues,
+                    binaryFormat(),
                     context.getCircuitBreaker()
                 );
             }
@@ -964,10 +969,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                         // Single-valued binary doc values are written as plain (no separate counts column), so read them as plain.
                         return new BytesRefsFromBinaryBlockLoader(name());
                     }
-                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(
-                        name(),
-                        useArrayOrderBinaryDocValues ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE
-                    );
+                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), binaryFormat());
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                 }
@@ -1091,7 +1093,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     CoreValuesSourceType.KEYWORD,
                     TextDocValuesField::new,
                     indexVersion,
-                    useArrayOrderBinaryDocValues
+                    binaryFormat()
                 );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericLongValues;
 import org.elasticsearch.index.fielddata.plain.MultiValuedBinaryDocValuesSortField;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.lucene.comparators.XLongComparator;
 import org.elasticsearch.lucene.comparators.XNumericComparator;
@@ -297,9 +298,9 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
             int maxDoc = reader.maxDoc();
             int minValueDoc = sortField.getReverse() ? maxDoc - 1 : 0;
             int maxValueDoc = sortField.getReverse() ? 0 : maxDoc - 1;
-            boolean arrayOrder = binarySortField.isArrayOrder();
-            BytesRef min = decodeHostNameValueAt(reader, minValueDoc, false, arrayOrder);
-            BytesRef max = decodeHostNameValueAt(reader, maxValueDoc, true, arrayOrder);
+            BinaryDocValuesFormat binaryFormat = binarySortField.binaryFormat();
+            BytesRef min = decodeHostNameValueAt(reader, minValueDoc, false, binaryFormat);
+            BytesRef max = decodeHostNameValueAt(reader, maxValueDoc, true, binaryFormat);
             return min != null && min.equals(max);
         }
         // host.name has no doc values at all in this segment (e.g. the field is absent).
@@ -308,12 +309,13 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
 
     /**
      * Decodes the minimum ({@code maxMode=false}) or maximum ({@code maxMode=true}) {@code host.name} value stored at
-     * {@code doc}, reusing {@link MultiValuedBinaryDocValuesSortField#decodeExtreme} to extract sort keys from the
-     * {@code SeparateCount}/{@code ArrayOrderInlineNull} binary formats. Returns {@code null} if {@code doc} has no
-     * value (e.g. all-null or empty array).
+     * {@code doc}, reusing {@link MultiValuedBinaryDocValuesSortField#decodeExtreme} to extract sort keys from
+     * whichever binary format the field uses. Returns {@code null} if {@code doc} has no value (e.g. all-null or
+     * empty array).
      */
     @Nullable
-    private static BytesRef decodeHostNameValueAt(LeafReader reader, int doc, boolean maxMode, boolean arrayOrder) throws IOException {
+    private static BytesRef decodeHostNameValueAt(LeafReader reader, int doc, boolean maxMode, BinaryDocValuesFormat binaryFormat)
+        throws IOException {
         BinaryDocValues bdv = reader.getBinaryDocValues("host.name");
         if (bdv.advanceExact(doc) == false) {
             return null;
@@ -325,6 +327,6 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
         if (counts != null && counts.advanceExact(doc)) {
             count = counts.longValue();
         }
-        return MultiValuedBinaryDocValuesSortField.decodeExtreme(bdv.binaryValue(), count, maxMode, arrayOrder);
+        return MultiValuedBinaryDocValuesSortField.decodeExtreme(bdv.binaryValue(), count, maxMode, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -19,6 +19,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.N
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
@@ -33,7 +34,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
     protected final IndexVersion indexVersion;
-    protected final boolean arrayOrder;
+    protected final BinaryDocValuesFormat binaryFormat;
 
     public BytesBinaryIndexFieldData(
         String fieldName,
@@ -41,7 +42,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion
     ) {
-        this(fieldName, valuesSourceType, toScriptFieldFactory, indexVersion, false);
+        this(fieldName, valuesSourceType, toScriptFieldFactory, indexVersion, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
     public BytesBinaryIndexFieldData(
@@ -49,13 +50,13 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
         ValuesSourceType valuesSourceType,
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion,
-        boolean arrayOrder
+        BinaryDocValuesFormat binaryFormat
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
         this.indexVersion = indexVersion;
-        this.arrayOrder = arrayOrder;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -74,7 +75,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
             ? SortField.STRING_LAST
             : SortField.STRING_FIRST;
         boolean maxMode = sortMode == MultiValueMode.MAX;
-        return new MultiValuedBinaryDocValuesSortField(getFieldName(), reverse, luceneMissingValue, maxMode, arrayOrder);
+        return new MultiValuedBinaryDocValuesSortField(getFieldName(), reverse, luceneMissingValue, maxMode, binaryFormat);
     }
 
     @Override
@@ -100,7 +101,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion, arrayOrder);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion, binaryFormat);
     }
 
     @Override
@@ -113,7 +114,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
         private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
         private final ValuesSourceType valuesSourceType;
         private final IndexVersion indexVersion;
-        private final boolean arrayOrder;
+        private final BinaryDocValuesFormat binaryFormat;
 
         public Builder(
             String name,
@@ -121,7 +122,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
             ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
             IndexVersion indexVersion
         ) {
-            this(name, valuesSourceType, toScriptFieldFactory, indexVersion, false);
+            this(name, valuesSourceType, toScriptFieldFactory, indexVersion, BinaryDocValuesFormat.SEPARATE_COUNT);
         }
 
         public Builder(
@@ -129,19 +130,19 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
             ValuesSourceType valuesSourceType,
             ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
             IndexVersion indexVersion,
-            boolean arrayOrder
+            BinaryDocValuesFormat binaryFormat
         ) {
             this.name = name;
             this.valuesSourceType = valuesSourceType;
             this.toScriptFieldFactory = toScriptFieldFactory;
             this.indexVersion = indexVersion;
-            this.arrayOrder = arrayOrder;
+            this.binaryFormat = binaryFormat;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             // Ignore breaker
-            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory, indexVersion, arrayOrder);
+            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory, indexVersion, binaryFormat);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortingArrayOrderBinaryDocValues;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 
@@ -28,7 +29,7 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
     private final LeafReader leafReader;
     private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
     private final IndexVersion indexVersion;
-    private final boolean arrayOrder;
+    private final BinaryDocValuesFormat binaryFormat;
 
     protected MultiValuedBinaryDVLeafFieldData(
         String fieldName,
@@ -36,7 +37,7 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion
     ) {
-        this(fieldName, leafReader, toScriptFieldFactory, indexVersion, false);
+        this(fieldName, leafReader, toScriptFieldFactory, indexVersion, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
     protected MultiValuedBinaryDVLeafFieldData(
@@ -44,14 +45,14 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         LeafReader leafReader,
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion,
-        boolean arrayOrder
+        BinaryDocValuesFormat binaryFormat
     ) {
         super();
         this.fieldName = fieldName;
         this.leafReader = leafReader;
         this.toScriptFieldFactory = toScriptFieldFactory;
         this.indexVersion = indexVersion;
-        this.arrayOrder = arrayOrder;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -69,7 +70,7 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         try {
             // Need to return a new instance each time this gets invoked,
             // otherwise a positioned or exhausted instance can be returned:
-            if (arrayOrder) {
+            if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
                 // High-cardinality columnar fields store values in document order with inline nulls (ArrayOrderInlineNull).
                 return SortingArrayOrderBinaryDocValues.from(leafReader, fieldName);
             }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortField.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FilterBinaryDocValues;
@@ -21,48 +22,50 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 
 import java.io.IOException;
 
 /**
- * A {@link BinarySortField} for keyword/IP fields stored as high-cardinality binary doc values, in either the
- * {@link MultiValuedBinaryDocValuesField.SeparateCount} format (values deduplicated and stored sorted) or the
- * {@link MultiValuedBinaryDocValuesField.ArrayOrderInlineNull} format (values stored in document order, with inline
- * nulls) — see {@link #isArrayOrder()}.
+ * A {@link BinarySortField} for keyword/IP fields stored as high-cardinality binary doc values, in whichever
+ * {@link BinaryDocValuesFormat} the mapping chose — see {@link #binaryFormat()}.
  *
- * <p>For single-valued documents the binary payload is the raw term bytes and no decoding is needed in either
- * format. For multi-valued documents this class extracts either the minimum or maximum value as the sort key,
- * consistent with how {@code SortedSetSortField} behaves with a {@code MIN} or {@code MAX} selector.
+ * <p>For single-valued documents the blob is the raw term bytes and no decoding is needed. For multi-valued
+ * documents this class extracts either the minimum or maximum value as the sort key, consistent with how
+ * {@code SortedSetSortField} behaves with a {@code MIN} or {@code MAX} selector.
  */
 public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
 
     public static final String PROVIDER_NAME = "MultiValuedBinaryDocValuesSortField";
 
     private final boolean maxMode;
-    private final boolean arrayOrder;
+    private final BinaryDocValuesFormat binaryFormat;
 
     /** Returns {@code true} when this field uses the maximum (last) value for multi-valued documents. */
     boolean isMaxMode() {
         return maxMode;
     }
 
-    /**
-     * Returns {@code true} when this field's binary doc values use the {@code ArrayOrderInlineNull} encoding
-     * (document order, inline nulls) rather than {@code SeparateCount} (deduplicated, sorted).
-     */
-    public boolean isArrayOrder() {
-        return arrayOrder;
+    /** How this field's binary doc values are laid out, and so which decoder extracts a sort key from them. */
+    public BinaryDocValuesFormat binaryFormat() {
+        return binaryFormat;
     }
 
     public MultiValuedBinaryDocValuesSortField(String field, boolean reverse, Object missingValue, boolean maxMode) {
-        this(field, reverse, missingValue, maxMode, false);
+        this(field, reverse, missingValue, maxMode, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
-    public MultiValuedBinaryDocValuesSortField(String field, boolean reverse, Object missingValue, boolean maxMode, boolean arrayOrder) {
+    public MultiValuedBinaryDocValuesSortField(
+        String field,
+        boolean reverse,
+        Object missingValue,
+        boolean maxMode,
+        BinaryDocValuesFormat binaryFormat
+    ) {
         super(field, reverse, missingValue, PROVIDER_NAME);
         this.maxMode = maxMode;
-        this.arrayOrder = arrayOrder;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -90,21 +93,20 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
         if (countsSkipper != null && countsSkipper.maxValue() <= 1) {
             return values;
         }
-        return new MinMaxBinaryDocValues(values, counts, maxMode, arrayOrder);
+        return new MinMaxBinaryDocValues(values, counts, maxMode, binaryFormat);
     }
 
     /**
      * Decodes the minimum ({@code maxMode=false}) or maximum ({@code maxMode=true}) sort key from a document's raw
-     * binary doc values payload with the given value {@code count}, dispatching to whichever decoder matches this
-     * field's encoding ({@code arrayOrder}). Shared by {@link MinMaxBinaryDocValues#binaryValue()} and
-     * {@code LongValuesComparatorSource}'s host.name singleton check.
+     * binary doc values blob, dispatching to whichever decoder matches the field's {@code format}. Shared by
+     * {@link MinMaxBinaryDocValues#binaryValue()} and {@code LongValuesComparatorSource}'s host.name singleton check.
      */
-    public static BytesRef decodeExtreme(BytesRef raw, long count, boolean maxMode, boolean arrayOrder) {
+    public static BytesRef decodeExtreme(BytesRef raw, long count, boolean maxMode, BinaryDocValuesFormat format) {
         if (count <= 1) {
             // count=1 (or a lone slot): raw bytes are the sort key in either encoding, no decoding needed.
             return raw;
         }
-        if (arrayOrder) {
+        if (format == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             return MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.decodeExtreme(raw, (int) count, maxMode);
         }
         return MultiValuedBinaryDocValuesField.SeparateCount.decodeExtreme(raw, maxMode);
@@ -117,13 +119,13 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
     private static final class MinMaxBinaryDocValues extends FilterBinaryDocValues {
         private final NumericDocValues counts;
         private final boolean maxMode;
-        private final boolean arrayOrder;
+        private final BinaryDocValuesFormat binaryFormat;
 
-        MinMaxBinaryDocValues(BinaryDocValues values, NumericDocValues counts, boolean maxMode, boolean arrayOrder) {
+        MinMaxBinaryDocValues(BinaryDocValues values, NumericDocValues counts, boolean maxMode, BinaryDocValuesFormat binaryFormat) {
             super(values);
             this.counts = counts;
             this.maxMode = maxMode;
-            this.arrayOrder = arrayOrder;
+            this.binaryFormat = binaryFormat;
         }
 
         @Override
@@ -159,7 +161,7 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
 
         @Override
         public BytesRef binaryValue() throws IOException {
-            return decodeExtreme(in.binaryValue(), counts.longValue(), maxMode, arrayOrder);
+            return decodeExtreme(in.binaryValue(), counts.longValue(), maxMode, binaryFormat);
         }
     }
 
@@ -184,8 +186,15 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
                 default -> null;
             };
             boolean maxMode = in.readInt() == 1;
-            boolean arrayOrder = in.readInt() == 1;
-            return new MultiValuedBinaryDocValuesSortField(field, reverse, missingValue, maxMode, arrayOrder);
+            // An ordinal, holding the former boolean's 0/1: SEPARATE_COUNT and ARRAY_ORDER_INLINE_NULL keep those
+            // positions, so segments written before this was an enum read back unchanged. A value we do not know is a
+            // corrupt segment, or one from a newer node that appended a format; either way we cannot decode the field.
+            int formatOrdinal = in.readInt();
+            BinaryDocValuesFormat[] formats = BinaryDocValuesFormat.values();
+            if (formatOrdinal < 0 || formatOrdinal >= formats.length) {
+                throw new CorruptIndexException("unknown binary doc values format ordinal [" + formatOrdinal + "]", in);
+            }
+            return new MultiValuedBinaryDocValuesSortField(field, reverse, missingValue, maxMode, formats[formatOrdinal]);
         }
 
         @Override
@@ -203,7 +212,7 @@ public final class MultiValuedBinaryDocValuesSortField extends BinarySortField {
                 out.writeInt(0);
             }
             out.writeInt(msf.maxMode ? 1 : 0);
-            out.writeInt(msf.arrayOrder ? 1 : 0);
+            out.writeInt(msf.binaryFormat.ordinal());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -30,7 +31,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
     protected final IndexVersion indexVersion;
-    protected final boolean arrayOrder;
+    protected final BinaryDocValuesFormat binaryFormat;
 
     public StringBinaryIndexFieldData(
         String fieldName,
@@ -38,7 +39,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion
     ) {
-        this(fieldName, valuesSourceType, toScriptFieldFactory, indexVersion, false);
+        this(fieldName, valuesSourceType, toScriptFieldFactory, indexVersion, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
     public StringBinaryIndexFieldData(
@@ -46,13 +47,13 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
         ValuesSourceType valuesSourceType,
         ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
         IndexVersion indexVersion,
-        boolean arrayOrder
+        BinaryDocValuesFormat binaryFormat
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
         this.indexVersion = indexVersion;
-        this.arrayOrder = arrayOrder;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -73,7 +74,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion, arrayOrder);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion, binaryFormat);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+/**
+ * How a field lays out its binary doc values, and so which decoder reads them back. One per framing that a
+ * {@link MultiValuedBinaryDocValuesField} writes, which is not quite one per subclass: {@code KeyedArrayOrderInlineNull}
+ * shares {@link #ARRAY_ORDER_INLINE_NULL} with {@code ArrayOrderInlineNull}, and the legacy {@code IntegratedCount}
+ * carries its count in the blob and so has no constant here — it is read by {@code BytesRefsFromCustomBinaryBlockLoader}
+ * on its own path.
+ *
+ * <p>They are not interchangeable, and decoding one as another silently returns wrong values rather than
+ * failing — a length prefix reads as a character. So every reader is told which to expect: the doc-values
+ * queries, fielddata, index sorting and the block loaders all take this from the mapping that decided how the
+ * values were written.
+ *
+ * <p>{@link #ordinal()} is persisted in segment info by
+ * {@link org.elasticsearch.index.fielddata.plain.MultiValuedBinaryDocValuesSortField}, which Lucene rebuilds at
+ * merge time with no mapping in reach. Existing segments hold the {@code 0}/{@code 1} of the boolean this
+ * replaced, which is why {@link #SEPARATE_COUNT} and {@link #ARRAY_ORDER_INLINE_NULL} have to keep those
+ * positions; append new constants rather than reordering.
+ */
+public enum BinaryDocValuesFormat {
+    /**
+     * {@code [len][value]...} with the count in a {@code .counts} companion; a lone value stored raw. Values are
+     * sorted and deduplicated, so array order does not survive.
+     */
+    SEPARATE_COUNT,
+
+    /**
+     * {@code [len+1][value]...} with the slot count in a {@code .counts} companion; a lone value stored raw. Slots
+     * are in document order and a {@code [vint 0]} slot is a null, which is what the length bias buys.
+     */
+    ARRAY_ORDER_INLINE_NULL
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -50,7 +50,6 @@ import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromOrdsBlockLoader;
@@ -404,6 +403,11 @@ public class IpFieldMapper extends FieldMapper {
             return useArrayOrderBinaryDocValues;
         }
 
+        /** Which framing a reader of this field's binary doc values has to decode. */
+        private BinaryDocValuesFormat binaryFormat() {
+            return useArrayOrderBinaryDocValues ? BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL : BinaryDocValuesFormat.SEPARATE_COUNT;
+        }
+
         private static InetAddress parse(Object value) {
             if (value instanceof InetAddress) {
                 return (InetAddress) value;
@@ -490,7 +494,12 @@ public class IpFieldMapper extends FieldMapper {
             final BytesRef upper = new BytesRef(pointRangeQuery.getUpperPoint());
 
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesRangeQuery(field, lower, upper, arrayOrderInlineNull);
+                return new ScanningBinaryDocValuesRangeQuery(
+                    field,
+                    lower,
+                    upper,
+                    arrayOrderInlineNull ? BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL : BinaryDocValuesFormat.SEPARATE_COUNT
+                );
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(field, lower, upper, true, true);
             }
@@ -600,21 +609,18 @@ public class IpFieldMapper extends FieldMapper {
                             // Single-valued binary doc values are written as plain (no separate counts column), so read them as plain.
                             return new BytesRefsFromBinaryBlockLoader(name());
                         }
-                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(
-                            name(),
-                            useArrayOrderBinaryDocValues ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE
-                        );
+                        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), binaryFormat());
                     } else {
                         return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize(), readInArrayOrder);
                     }
                 }
-                ArrayOrderSource arrayOrderSource = useArrayOrderBinaryDocValues ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE;
+                BinaryDocValuesFormat binaryFormat = binaryFormat();
                 return switch (cfg.function()) {
                     case MV_MAX -> usesBinaryDocValues
-                        ? new MvMaxBytesRefsFromBinaryBlockLoader(name(), arrayOrderSource)
+                        ? new MvMaxBytesRefsFromBinaryBlockLoader(name(), binaryFormat)
                         : new MvMaxBytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                     case MV_MIN -> usesBinaryDocValues
-                        ? new MvMinBytesRefsFromBinaryBlockLoader(name(), arrayOrderSource)
+                        ? new MvMinBytesRefsFromBinaryBlockLoader(name(), binaryFormat)
                         : new MvMinBytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                     default -> throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
                 };
@@ -683,7 +689,7 @@ public class IpFieldMapper extends FieldMapper {
                     CoreValuesSourceType.IP,
                     IpDocValuesField::new,
                     indexVersion,
-                    useArrayOrderBinaryDocValues
+                    binaryFormat()
                 );
             }
             return new SortedSetOrdinalsIndexFieldData.Builder(name(), CoreValuesSourceType.IP, IpDocValuesField::new);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -76,7 +76,6 @@ import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.ByteLengthFromBytesRefDocValuesBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFromBinaryBlockLoader;
@@ -818,18 +817,29 @@ public final class KeywordFieldMapper extends FieldMapper {
          */
         public enum DocValuesDiskFormat {
             /** No doc values are written for this field. */
-            NONE(false),
+            NONE(null),
             /** Lucene's sorted-set doc values: sorted and deduplicated, with array order (if kept) in {@code .offsets}. */
-            SORTED_SET(false),
-            /** {@code [len][value]...}, count in a {@code .counts} companion; a lone value stored raw. */
-            BINARY_SEPARATE_COUNT(true),
-            /** {@code [len+1][value]...} with inline nulls, slot count in {@code .counts}; a lone value stored raw. */
-            BINARY_ARRAY_ORDER_INLINE_NULL(true);
+            SORTED_SET(null),
+            /** A {@link MultiValuedBinaryDocValuesField} framed as {@link BinaryDocValuesFormat#SEPARATE_COUNT}. */
+            BINARY_SEPARATE_COUNT(BinaryDocValuesFormat.SEPARATE_COUNT),
+            /** A {@link MultiValuedBinaryDocValuesField} framed as {@link BinaryDocValuesFormat#ARRAY_ORDER_INLINE_NULL}. */
+            BINARY_ARRAY_ORDER_INLINE_NULL(BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
 
-            private final boolean binary;
+            @Nullable
+            private final BinaryDocValuesFormat binaryFormat;
 
-            DocValuesDiskFormat(boolean binary) {
-                this.binary = binary;
+            DocValuesDiskFormat(@Nullable BinaryDocValuesFormat binaryFormat) {
+                this.binaryFormat = binaryFormat;
+            }
+
+            /**
+             * How the bytes are framed, or {@code null} for the layouts that write no binary blob. Naming the
+             * framing here rather than restating it keeps the byte layout documented in one place, so a new
+             * framing is described once in {@link BinaryDocValuesFormat} and only referred to from here.
+             */
+            @Nullable
+            public BinaryDocValuesFormat binaryFormat() {
+                return binaryFormat;
             }
 
             /**
@@ -838,13 +848,26 @@ public final class KeywordFieldMapper extends FieldMapper {
              * doc-values queries, fielddata and block loaders all have to take a different path for them.
              */
             public boolean isBinary() {
-                return binary;
+                return binaryFormat != null;
             }
         }
 
         /** Where this field's doc values are written; see {@link DocValuesDiskFormat}. */
         public DocValuesDiskFormat diskFormat() {
             return diskFormat;
+        }
+
+        /**
+         * How this field's binary doc values are framed, and so which decoder reads them back. Every reader of them
+         * takes this — the doc-values queries, fielddata, index sorting and the block loaders alike.
+         *
+         * <p>{@code null} when {@link #usesBinaryDocValues()} is false: a field that writes no binary blob has no
+         * framing, and naming one anyway would be a guess a caller could act on. Callers reach this behind that
+         * check, or pass it to a reader that only consults it once it finds a binary column.
+         */
+        @Nullable
+        public BinaryDocValuesFormat binaryFormat() {
+            return diskFormat.binaryFormat();
         }
 
         /**
@@ -890,7 +913,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termQuery(value, context);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), storesArrayOrderInline());
+                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), binaryFormat());
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
@@ -903,7 +926,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 return super.termsQuery(values, context);
             } else if (usesBinaryDocValues()) {
                 List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
-                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, storesArrayOrderInline());
+                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, binaryFormat());
             } else {
                 Collection<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
@@ -928,7 +951,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     upperTerm == null ? null : indexedValueForSearch(upperTerm),
                     includeLower,
                     includeUpper,
-                    storesArrayOrderInline()
+                    binaryFormat()
                 );
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowRangeQuery(
@@ -994,7 +1017,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     caseInsensitive,
-                    storesArrayOrderInline()
+                    binaryFormat()
                 );
             } else {
                 if (caseInsensitive == false) {
@@ -1094,29 +1117,33 @@ public final class KeywordFieldMapper extends FieldMapper {
                         if (docValuesParams != null && docValuesParams.multiValue() == false) {
                             return new BytesRefsFromBinaryBlockLoader(name());
                         } else {
-                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(
-                                name(),
-                                storesArrayOrderInline() ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE
-                            );
+                            return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), binaryFormat());
                         }
                     } else {
                         return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize(), preservesArrayOrder);
                     }
                 }
-                ArrayOrderSource arrayOrderSource = storesArrayOrderInline() ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE;
+                // Null for a sorted-set field, which only LENGTH can be here for; it resolves the sorted-set column first and never
+                // reaches the branch that reads this. The rest are either binary-only or take it inside a usesBinaryDocValues() arm.
+                BinaryDocValuesFormat binaryFormat = binaryFormat();
                 return switch (cfg.function()) {
-                    case BYTE_LENGTH -> new ByteLengthFromBytesRefDocValuesBlockLoader(blContext.warnings(), name(), arrayOrderSource);
+                    // Only pushed down for binary doc values, so the framing is always known here - see supportsBlockLoaderFunction.
+                    case BYTE_LENGTH -> new ByteLengthFromBytesRefDocValuesBlockLoader(
+                        blContext.warnings(),
+                        name(),
+                        Objects.requireNonNull(binaryFormat)
+                    );
                     case LENGTH -> new Utf8CodePointsFromOrdsBlockLoader(
                         blContext.warnings(),
                         name(),
                         blContext.ordinalsByteSize(),
-                        arrayOrderSource
+                        binaryFormat
                     );
                     case MV_MAX -> usesBinaryDocValues()
-                        ? new MvMaxBytesRefsFromBinaryBlockLoader(name(), arrayOrderSource)
+                        ? new MvMaxBytesRefsFromBinaryBlockLoader(name(), binaryFormat)
                         : new MvMaxBytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                     case MV_MIN -> usesBinaryDocValues()
-                        ? new MvMinBytesRefsFromBinaryBlockLoader(name(), arrayOrderSource)
+                        ? new MvMinBytesRefsFromBinaryBlockLoader(name(), binaryFormat)
                         : new MvMinBytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                     default -> throw new UnsupportedOperationException("unknown fusion config [" + cfg.function() + "]");
                 };
@@ -1261,7 +1288,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     CoreValuesSourceType.KEYWORD,
                     KeywordDocValuesField::new,
                     indexVersion,
-                    storesArrayOrderInline()
+                    binaryFormat()
                 );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
@@ -1352,7 +1379,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 if (usesBinaryDocValues()) {
-                    return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, storesArrayOrderInline());
+                    return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, binaryFormat());
                 }
 
                 if (caseInsensitive == false) {
@@ -1421,7 +1448,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                         syntaxFlags,
                         matchFlags,
                         maxDeterminizedStates,
-                        storesArrayOrderInline(),
+                        binaryFormat(),
                         context.getCircuitBreaker()
                     );
                 } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -80,7 +80,6 @@ import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -913,6 +912,11 @@ public final class TextFieldMapper extends FieldMapper {
             return useArrayOrderBinaryDocValues;
         }
 
+        /** Which framing a doc-values query has to decode for this field. */
+        private BinaryDocValuesFormat binaryFormat() {
+            return useArrayOrderBinaryDocValues ? BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL : BinaryDocValuesFormat.SEPARATE_COUNT;
+        }
+
         @Override
         public boolean eagerGlobalOrdinals() {
             return eagerGlobalOrdinals;
@@ -971,7 +975,7 @@ public final class TextFieldMapper extends FieldMapper {
             failIfNotIndexedNorDocValuesFallback(context);
 
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), binaryFormat());
             } else {
                 return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
             }
@@ -987,7 +991,7 @@ public final class TextFieldMapper extends FieldMapper {
 
             List<BytesRef> bytesRefs = values.stream().map(this::indexedValueForSearch).toList();
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesTermInSetQuery(name(), bytesRefs, binaryFormat());
             } else {
                 return SortedSetDocValuesField.newSlowSetQuery(name(), bytesRefs);
             }
@@ -1015,7 +1019,7 @@ public final class TextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesPrefixQuery(name(), value, caseInsensitive, binaryFormat());
             }
             if (caseInsensitive == false) {
                 return new PrefixQuery(new Term(name(), value), MultiTermQuery.DOC_VALUES_REWRITE);
@@ -1041,7 +1045,7 @@ public final class TextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, binaryFormat());
             }
             if (caseInsensitive == false) {
                 Term term = new Term(name(), value);
@@ -1081,7 +1085,7 @@ public final class TextFieldMapper extends FieldMapper {
                     syntaxFlags,
                     matchFlags,
                     maxDeterminizedStates,
-                    useArrayOrderBinaryDocValues,
+                    binaryFormat(),
                     context.getCircuitBreaker()
                 );
             }
@@ -1388,10 +1392,7 @@ public final class TextFieldMapper extends FieldMapper {
                     if (docValuesParams != null && docValuesParams.multiValue() == false) {
                         return new BytesRefsFromBinaryBlockLoader(name());
                     }
-                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(
-                        name(),
-                        useArrayOrderBinaryDocValues ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE
-                    );
+                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), binaryFormat());
                 } else {
                     return new BytesRefsFromOrdsBlockLoader(name(), blContext.ordinalsByteSize());
                 }
@@ -1604,7 +1605,7 @@ public final class TextFieldMapper extends FieldMapper {
                     CoreValuesSourceType.KEYWORD,
                     TextDocValuesField::new,
                     indexCreatedVersion,
-                    useArrayOrderBinaryDocValues
+                    binaryFormat()
                 );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryMultiSeparateCountBlockLoader.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.BinaryAndCounts;
@@ -28,24 +29,16 @@ import java.io.IOException;
  */
 public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
 
-    /**
-     * Where a document's array order is recorded.
-     */
-    public enum ArrayOrderSource {
-        NONE,  // no ordering
-        INLINE  // order is already preserved in the binary blob, so reads the blob directly
-    }
-
     private final String fieldName;
-    private final ArrayOrderSource arrayOrderSource;
+    private final BinaryDocValuesFormat binaryFormat;
 
     public BytesRefsFromBinaryMultiSeparateCountBlockLoader(String fieldName) {
-        this(fieldName, ArrayOrderSource.NONE);
+        this(fieldName, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
-    public BytesRefsFromBinaryMultiSeparateCountBlockLoader(String fieldName, ArrayOrderSource arrayOrderSource) {
+    public BytesRefsFromBinaryMultiSeparateCountBlockLoader(String fieldName, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = fieldName;
-        this.arrayOrderSource = arrayOrderSource;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -90,7 +83,7 @@ public class BytesRefsFromBinaryMultiSeparateCountBlockLoader extends BlockDocVa
             // present blob is a single raw value and an absent blob is a lone null / empty array, which the plain reader emits as null.
             return new BytesRefsFromBinaryBlockLoader.BytesRefsFromBinary(bc.binary());
         }
-        if (arrayOrderSource == ArrayOrderSource.INLINE) {
+        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             // Multi-slot documents exist (maxValue >= 2): decode the in-order inline-null format, advancing on the counts column since an
             // all-null or empty array writes a count but no binary blob.
             return new ArrayOrderInlineNull(bc.binary(), bc.counts());

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/ByteLengthFromBytesRefDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/ByteLengthFromBytesRefDocValuesBlockLoader.java
@@ -12,11 +12,11 @@ package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.Warnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.BinaryAndCounts;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingBinaryDocValues;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingNumericDocValues;
@@ -29,16 +29,16 @@ import java.io.IOException;
 public final class ByteLengthFromBytesRefDocValuesBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
     private final String fieldName;
     private final Warnings warnings;
-    private final ArrayOrderSource arrayOrderSource;
+    private final BinaryDocValuesFormat binaryFormat;
 
     public ByteLengthFromBytesRefDocValuesBlockLoader(Warnings warnings, String fieldName) {
-        this(warnings, fieldName, ArrayOrderSource.NONE);
+        this(warnings, fieldName, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
-    public ByteLengthFromBytesRefDocValuesBlockLoader(Warnings warnings, String fieldName, ArrayOrderSource arrayOrderSource) {
+    public ByteLengthFromBytesRefDocValuesBlockLoader(Warnings warnings, String fieldName, BinaryDocValuesFormat binaryFormat) {
         this.warnings = warnings;
         this.fieldName = fieldName;
-        this.arrayOrderSource = arrayOrderSource;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -55,7 +55,7 @@ public final class ByteLengthFromBytesRefDocValuesBlockLoader extends BlockDocVa
         if (bc.counts() == null) {
             return new SingleValued(bc.binary());
         }
-        if (arrayOrderSource == ArrayOrderSource.INLINE) {
+        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             return new MultiValuedBinaryArrayOrderInlineNull(warnings, bc.counts(), bc.binary());
         }
         return new MultiValuedBinaryWithSeparateCounts(warnings, bc.counts(), bc.binary());

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMaxBytesRefsFromBinaryBlockLoader.java
@@ -12,11 +12,11 @@ package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractBytesRefsFromBinaryReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueArrayOrderInlineNullBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.BinaryAndCounts;
@@ -29,11 +29,11 @@ import java.util.Objects;
 public class MvMaxBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
 
     private final String fieldName;
-    private final ArrayOrderSource arrayOrderSource;
+    private final BinaryDocValuesFormat binaryFormat;
 
-    public MvMaxBytesRefsFromBinaryBlockLoader(String fieldName, ArrayOrderSource arrayOrderSource) {
+    public MvMaxBytesRefsFromBinaryBlockLoader(String fieldName, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = fieldName;
-        this.arrayOrderSource = arrayOrderSource;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -45,7 +45,7 @@ public class MvMaxBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
         if (bc.counts() == null) {
             return new BytesRefsFromBinaryBlockLoader.BytesRefsFromBinary(bc.binary());
         }
-        if (arrayOrderSource == ArrayOrderSource.INLINE) {
+        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             return new MvMaxBytesRefsFromArrayOrderInlineNull(bc.binary(), bc.counts());
         }
         return new MvMaxBytesRefsFromBinarySeparateCount(bc.binary(), bc.counts());

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/MvMinBytesRefsFromBinaryBlockLoader.java
@@ -12,11 +12,11 @@ package org.elasticsearch.index.mapper.blockloader.docvalues.fn;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.AbstractBytesRefsFromBinaryReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueArrayOrderInlineNullBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.BinaryAndCounts;
@@ -31,11 +31,11 @@ import java.util.Objects;
  */
 public class MvMinBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
     private final String fieldName;
-    private final ArrayOrderSource arrayOrderSource;
+    private final BinaryDocValuesFormat binaryFormat;
 
-    public MvMinBytesRefsFromBinaryBlockLoader(String fieldName, ArrayOrderSource arrayOrderSource) {
+    public MvMinBytesRefsFromBinaryBlockLoader(String fieldName, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = fieldName;
-        this.arrayOrderSource = arrayOrderSource;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class MvMinBytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.Do
         if (bc.counts() == null) {
             return new BytesRefsFromBinaryBlockLoader.BytesRefsFromBinary(bc.binary());
         }
-        if (arrayOrderSource == ArrayOrderSource.INLINE) {
+        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             return new MinFromArrayOrderInlineNull(bc.binary(), bc.counts());
         }
         return new MinFromBinarySeparateCount(bc.binary(), bc.counts());

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/Utf8CodePointsFromOrdsBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/Utf8CodePointsFromOrdsBlockLoader.java
@@ -17,11 +17,12 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.FeatureFlag;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.Warnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.BinaryAndCounts;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.SortedDvSingletonOrSet;
 import org.elasticsearch.index.mapper.blockloader.docvalues.tracking.TrackingBinaryDocValues;
@@ -58,17 +59,28 @@ public class Utf8CodePointsFromOrdsBlockLoader extends BlockDocValuesReader.DocV
 
     private final String fieldName;
     private final ByteSizeValue size;
-    private final ArrayOrderSource arrayOrderSource;
+    @Nullable
+    private final BinaryDocValuesFormat binaryFormat;
 
     public Utf8CodePointsFromOrdsBlockLoader(Warnings warnings, String fieldName, ByteSizeValue size) {
-        this(warnings, fieldName, size, ArrayOrderSource.NONE);
+        this(warnings, fieldName, size, BinaryDocValuesFormat.SEPARATE_COUNT);
     }
 
-    public Utf8CodePointsFromOrdsBlockLoader(Warnings warnings, String fieldName, ByteSizeValue size, ArrayOrderSource arrayOrderSource) {
+    /**
+     * @param binaryFormat how the field's binary doc values are framed, or {@code null} if it has none. This loader
+     *                     resolves sorted-set doc values first and only consults the framing if it finds a binary
+     *                     column instead, so a field that reaches it by the sorted-set path has nothing to declare.
+     */
+    public Utf8CodePointsFromOrdsBlockLoader(
+        Warnings warnings,
+        String fieldName,
+        ByteSizeValue size,
+        @Nullable BinaryDocValuesFormat binaryFormat
+    ) {
         this.warnings = warnings;
         this.fieldName = fieldName;
         this.size = size;
-        this.arrayOrderSource = arrayOrderSource;
+        this.binaryFormat = binaryFormat;
     }
 
     @Override
@@ -95,7 +107,7 @@ public class Utf8CodePointsFromOrdsBlockLoader extends BlockDocValuesReader.DocV
         if (bc == null) {
             return ConstantNull.COLUMN_READER;
         }
-        if (arrayOrderSource == ArrayOrderSource.INLINE) {
+        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
             return new MultiValuedBinaryArrayOrderInlineNull(warnings, bc.counts(), bc.binary());
         }
         return new MultiValuedBinaryWithSeparateCounts(warnings, bc.counts(), bc.binary());

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -73,6 +73,7 @@ import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparator
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.BatchMappingContext;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.CustomDocValuesField;
@@ -729,7 +730,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                     if (usesArrayOrderBinaryDocValues) {
                         return new KeyedArrayOrderInlineNullTermQuery(name(), keyedValue);
                     }
-                    return new ScanningBinaryDocValuesTermQuery(name(), keyedValue, false);
+                    return new ScanningBinaryDocValuesTermQuery(name(), keyedValue, BinaryDocValuesFormat.SEPARATE_COUNT);
                 } else {
                     return XSortedSetDocValuesRangeQuery.newSlowExactQuery(name(), indexedValueForSearch(value));
                 }
@@ -759,7 +760,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                         return new KeyedArrayOrderInlineNullPrefixQuery(name(), new BytesRef(keyPrefix));
                     }
                     // Separate-count binary blob: slots are full key\0value, so a prefix scan finds any value under this key.
-                    return new ScanningBinaryDocValuesPrefixQuery(name(), keyPrefix, false, false);
+                    return new ScanningBinaryDocValuesPrefixQuery(name(), keyPrefix, false, BinaryDocValuesFormat.SEPARATE_COUNT);
                 }
 
                 // SortedSet doc-values: match any ord in [key\0, key\1) i.e. any value stored under this key.

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesAutomatonQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesAutomatonQuery.java
@@ -11,6 +11,7 @@ package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 /**
  * Base class for binary doc values queries that match documents using a {@link ByteRunAutomaton}.
@@ -21,8 +22,8 @@ abstract class AbstractBinaryDocValuesAutomatonQuery extends AbstractBinaryDocVa
 
     final ByteRunAutomaton automaton;
 
-    AbstractBinaryDocValuesAutomatonQuery(String fieldName, ByteRunAutomaton automaton, boolean arrayOrderInlineNull) {
-        super(fieldName, value -> automaton.run(value.bytes, value.offset, value.length), arrayOrderInlineNull);
+    AbstractBinaryDocValuesAutomatonQuery(String fieldName, ByteRunAutomaton automaton, BinaryDocValuesFormat binaryFormat) {
+        super(fieldName, value -> automaton.run(value.bytes, value.offset, value.length), binaryFormat);
         this.automaton = automaton;
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueArrayOrderInlineNullBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
@@ -41,14 +42,12 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
 
     protected final String fieldName;
     protected final Predicate<BytesRef> matcher;
-    // Whether the field stores its multi-valued binary doc values in the ArrayOrderInlineNull format rather than the SeparateCount format.
-    // The two encodings are not interchangeable, so the decoder must be chosen up front.
-    final boolean arrayOrderInlineNull;
+    protected final BinaryDocValuesFormat binaryFormat;
 
-    AbstractBinaryDocValuesQuery(String fieldName, Predicate<BytesRef> matcher, boolean arrayOrderInlineNull) {
+    AbstractBinaryDocValuesQuery(String fieldName, Predicate<BytesRef> matcher, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = Objects.requireNonNull(fieldName);
         this.matcher = Objects.requireNonNull(matcher);
-        this.arrayOrderInlineNull = arrayOrderInlineNull;
+        this.binaryFormat = Objects.requireNonNull(binaryFormat);
     }
 
     @Override
@@ -98,17 +97,17 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             return null;
         }
         final NumericDocValues counts = context.reader().getNumericDocValues(fieldName + COUNT_FIELD_SUFFIX);
-        if (arrayOrderInlineNull) {
-            // ArrayOrderInlineNull always writes the .counts field (even for an all-null or empty array, which writes no blob), so when
-            // this flag is set the counts column drives iteration and count==1 is handled inside the inline-null reader as the raw case.
-            assert counts != null : "ArrayOrderInlineNull field [" + fieldName + "] must have a " + COUNT_FIELD_SUFFIX + " companion";
-            return arrayOrderInlineNullIterator(values, counts, matcher, matchCost);
-        }
-        if (counts != null) {
-            return multiValuedIterator(values, counts, matcher, matchCost);
-        } else {
-            return singleValuedIterator(values, matcher, matchCost);
-        }
+        return switch (binaryFormat) {
+            case ARRAY_ORDER_INLINE_NULL -> {
+                // ArrayOrderInlineNull always writes the .counts field (even for an all-null or empty array, which writes no blob), so
+                // the counts column drives iteration and count==1 is handled inside the inline-null reader as the raw case.
+                assert counts != null : "ArrayOrderInlineNull field [" + fieldName + "] must have a " + COUNT_FIELD_SUFFIX + " companion";
+                yield arrayOrderInlineNullIterator(values, counts, matcher, matchCost);
+            }
+            case SEPARATE_COUNT -> counts != null
+                ? multiValuedIterator(values, counts, matcher, matchCost)
+                : singleValuedIterator(values, matcher, matchCost);
+        };
     }
 
     protected abstract float matchCost();

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.simdvec.ESVectorUtil;
@@ -44,13 +45,13 @@ import static org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.Sep
 public final class BinaryDocValuesContainsTermQuery extends Query {
     final String fieldName;
     final BytesRef containsTerm;
-    // See AbstractBinaryDocValuesQuery#arrayOrderInlineNull: selects the inline-null decoder for the multi-valued fallback path.
-    final boolean arrayOrderInlineNull;
+    // Selects the decoder for the multi-valued fallback path; see BinaryDocValuesFormat.
+    final BinaryDocValuesFormat binaryFormat;
 
-    BinaryDocValuesContainsTermQuery(String fieldName, BytesRef containsTerm, boolean arrayOrderInlineNull) {
+    BinaryDocValuesContainsTermQuery(String fieldName, BytesRef containsTerm, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = Objects.requireNonNull(fieldName);
         this.containsTerm = Objects.requireNonNull(containsTerm);
-        this.arrayOrderInlineNull = arrayOrderInlineNull;
+        this.binaryFormat = Objects.requireNonNull(binaryFormat);
     }
 
     @Override
@@ -102,7 +103,7 @@ public final class BinaryDocValuesContainsTermQuery extends Query {
                         }
                         Predicate<BytesRef> predicate = bytes -> contains(bytes, containsTerm);
                         final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
-                        return arrayOrderInlineNull
+                        return binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL
                             ? AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, predicate, matchCost())
                             : AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, predicate, matchCost());
                     }
@@ -140,12 +141,14 @@ public final class BinaryDocValuesContainsTermQuery extends Query {
             return false;
         }
         BinaryDocValuesContainsTermQuery that = (BinaryDocValuesContainsTermQuery) o;
-        return Objects.equals(fieldName, that.fieldName) && Objects.equals(containsTerm, that.containsTerm);
+        return Objects.equals(fieldName, that.fieldName)
+            && Objects.equals(containsTerm, that.containsTerm)
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, containsTerm);
+        return Objects.hash(classHash(), fieldName, containsTerm, binaryFormat);
     }
 
     public static boolean contains(BytesRef value, BytesRef term) {

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -27,6 +27,7 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 
@@ -40,13 +41,13 @@ final class BinaryDocValuesLengthQuery extends Query {
 
     final String fieldName;
     final int length;
-    // See AbstractBinaryDocValuesQuery#arrayOrderInlineNull: selects the inline-null decoder for the multi-valued fallback path.
-    final boolean arrayOrderInlineNull;
+    // Selects the decoder for the multi-valued fallback path; see BinaryDocValuesFormat.
+    final BinaryDocValuesFormat binaryFormat;
 
-    BinaryDocValuesLengthQuery(String fieldName, int length, boolean arrayOrderInlineNull) {
+    BinaryDocValuesLengthQuery(String fieldName, int length, BinaryDocValuesFormat binaryFormat) {
         this.fieldName = Objects.requireNonNull(fieldName);
         this.length = length;
-        this.arrayOrderInlineNull = arrayOrderInlineNull;
+        this.binaryFormat = Objects.requireNonNull(binaryFormat);
     }
 
     @Override
@@ -89,7 +90,7 @@ final class BinaryDocValuesLengthQuery extends Query {
                             return direct.tryLengthIterator(length);
                         }
                         Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;
-                        if (arrayOrderInlineNull) {
+                        if (binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL) {
                             return AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, lengthPredicate, matchCost);
                         } else if (countsSkipper != null) {
                             return AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, lengthPredicate, matchCost);
@@ -131,12 +132,12 @@ final class BinaryDocValuesLengthQuery extends Query {
             return false;
         }
         BinaryDocValuesLengthQuery that = (BinaryDocValuesLengthQuery) o;
-        return Objects.equals(fieldName, that.fieldName) && length == that.length;
+        return Objects.equals(fieldName, that.fieldName) && length == that.length && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, length);
+        return Objects.hash(classHash(), fieldName, length, binaryFormat);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/KeyedArrayOrderInlineNullPrefixQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/KeyedArrayOrderInlineNullPrefixQuery.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ public class KeyedArrayOrderInlineNullPrefixQuery extends AbstractBinaryDocValue
     private final BytesRef prefix;
 
     public KeyedArrayOrderInlineNullPrefixQuery(String fieldName, BytesRef prefix) {
-        super(fieldName, slot -> startsWith(slot, prefix), true);
+        super(fieldName, slot -> startsWith(slot, prefix), BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
         this.prefix = Objects.requireNonNull(prefix);
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/queries/KeyedArrayOrderInlineNullTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/KeyedArrayOrderInlineNullTermQuery.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -32,7 +33,7 @@ public class KeyedArrayOrderInlineNullTermQuery extends AbstractBinaryDocValuesQ
     private final BytesRef term;
 
     public KeyedArrayOrderInlineNullTermQuery(String fieldName, BytesRef term) {
-        super(fieldName, term::equals, true);
+        super(fieldName, term::equals, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
         this.term = Objects.requireNonNull(term);
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesPrefixQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesPrefixQuery.java
@@ -12,6 +12,7 @@ package org.elasticsearch.lucene.queries;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -29,8 +30,13 @@ public final class ScanningBinaryDocValuesPrefixQuery extends AbstractBinaryDocV
     private final String prefix;
     private final boolean caseInsensitive;
 
-    public ScanningBinaryDocValuesPrefixQuery(String fieldName, String prefix, boolean caseInsensitive, boolean arrayOrderInlineNull) {
-        super(fieldName, buildMatcher(Objects.requireNonNull(prefix), caseInsensitive), arrayOrderInlineNull);
+    public ScanningBinaryDocValuesPrefixQuery(
+        String fieldName,
+        String prefix,
+        boolean caseInsensitive,
+        BinaryDocValuesFormat binaryFormat
+    ) {
+        super(fieldName, buildMatcher(Objects.requireNonNull(prefix), caseInsensitive), binaryFormat);
         this.prefix = prefix;
         this.caseInsensitive = caseInsensitive;
     }
@@ -77,11 +83,14 @@ public final class ScanningBinaryDocValuesPrefixQuery extends AbstractBinaryDocV
             return false;
         }
         ScanningBinaryDocValuesPrefixQuery that = (ScanningBinaryDocValuesPrefixQuery) o;
-        return caseInsensitive == that.caseInsensitive && Objects.equals(fieldName, that.fieldName) && Objects.equals(prefix, that.prefix);
+        return caseInsensitive == that.caseInsensitive
+            && Objects.equals(fieldName, that.fieldName)
+            && Objects.equals(prefix, that.prefix)
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, prefix, caseInsensitive);
+        return Objects.hash(classHash(), fieldName, prefix, caseInsensitive, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQuery.java
@@ -13,6 +13,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -35,8 +36,8 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
     private final boolean includeLower;
     private final boolean includeUpper;
 
-    public ScanningBinaryDocValuesRangeQuery(String fieldName, BytesRef lower, BytesRef upper, boolean arrayOrderInlineNull) {
-        this(fieldName, lower, upper, true, true, arrayOrderInlineNull);
+    public ScanningBinaryDocValuesRangeQuery(String fieldName, BytesRef lower, BytesRef upper, BinaryDocValuesFormat binaryFormat) {
+        this(fieldName, lower, upper, true, true, binaryFormat);
     }
 
     public ScanningBinaryDocValuesRangeQuery(
@@ -45,9 +46,9 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
         BytesRef upper,
         boolean includeLower,
         boolean includeUpper,
-        boolean arrayOrderInlineNull
+        BinaryDocValuesFormat binaryFormat
     ) {
-        super(fieldName, rangeMatcher(lower, upper, includeLower, includeUpper), arrayOrderInlineNull);
+        super(fieldName, rangeMatcher(lower, upper, includeLower, includeUpper), binaryFormat);
         this.lower = lower;
         this.upper = upper;
         this.includeLower = includeLower;
@@ -77,7 +78,7 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
     @Override
     public Query rewrite(IndexSearcher indexSearcher) throws IOException {
         if (lower != null && upper != null && includeLower && includeUpper && lower.bytesEquals(upper)) {
-            return new ScanningBinaryDocValuesTermQuery(fieldName, lower, arrayOrderInlineNull);
+            return new ScanningBinaryDocValuesTermQuery(fieldName, lower, binaryFormat);
         }
         return super.rewrite(indexSearcher);
     }
@@ -106,11 +107,11 @@ public final class ScanningBinaryDocValuesRangeQuery extends AbstractBinaryDocVa
             && Objects.equals(upper, that.upper)
             && includeLower == that.includeLower
             && includeUpper == that.includeUpper
-            && arrayOrderInlineNull == that.arrayOrderInlineNull;
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, lower, upper, includeLower, includeUpper, arrayOrderInlineNull);
+        return Objects.hash(classHash(), fieldName, lower, upper, includeLower, includeUpper, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRegexpQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRegexpQuery.java
@@ -12,6 +12,7 @@ package org.elasticsearch.lucene.queries;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.util.Objects;
 
@@ -43,7 +44,7 @@ public final class ScanningBinaryDocValuesRegexpQuery extends AbstractBinaryDocV
         int syntaxFlags,
         int matchFlags,
         int maxDeterminizedStates,
-        boolean arrayOrderInlineNull,
+        BinaryDocValuesFormat binaryFormat,
         @Nullable CircuitBreaker circuitBreaker
     ) {
         super(
@@ -56,7 +57,7 @@ public final class ScanningBinaryDocValuesRegexpQuery extends AbstractBinaryDocV
                 maxDeterminizedStates,
                 circuitBreaker
             ),
-            arrayOrderInlineNull
+            binaryFormat
         );
         this.pattern = Objects.requireNonNull(pattern);
         this.syntaxFlags = syntaxFlags;
@@ -90,11 +91,12 @@ public final class ScanningBinaryDocValuesRegexpQuery extends AbstractBinaryDocV
             && Objects.equals(pattern, that.pattern)
             && syntaxFlags == that.syntaxFlags
             && matchFlags == that.matchFlags
-            && maxDeterminizedStates == that.maxDeterminizedStates;
+            && maxDeterminizedStates == that.maxDeterminizedStates
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, pattern, syntaxFlags, matchFlags, maxDeterminizedStates);
+        return Objects.hash(classHash(), fieldName, pattern, syntaxFlags, matchFlags, maxDeterminizedStates, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermInSetQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermInSetQuery.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.BytesRefComparator;
 import org.apache.lucene.util.StringSorter;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -32,12 +33,12 @@ public final class ScanningBinaryDocValuesTermInSetQuery extends AbstractBinaryD
     private final PrefixCodedTerms termData;
     private final int termDataHashCode;
 
-    public ScanningBinaryDocValuesTermInSetQuery(String fieldName, List<BytesRef> terms, boolean arrayOrderInlineNull) {
-        this(fieldName, packTerms(fieldName, Objects.requireNonNull(terms)), arrayOrderInlineNull);
+    public ScanningBinaryDocValuesTermInSetQuery(String fieldName, List<BytesRef> terms, BinaryDocValuesFormat binaryFormat) {
+        this(fieldName, packTerms(fieldName, Objects.requireNonNull(terms)), binaryFormat);
     }
 
-    private ScanningBinaryDocValuesTermInSetQuery(String fieldName, PrefixCodedTerms termData, boolean arrayOrderInlineNull) {
-        super(fieldName, buildMatchPredicate(termData), arrayOrderInlineNull);
+    private ScanningBinaryDocValuesTermInSetQuery(String fieldName, PrefixCodedTerms termData, BinaryDocValuesFormat binaryFormat) {
+        super(fieldName, buildMatchPredicate(termData), binaryFormat);
         this.termData = termData;
         this.termDataHashCode = termData.hashCode();
     }
@@ -120,11 +121,14 @@ public final class ScanningBinaryDocValuesTermInSetQuery extends AbstractBinaryD
             return false;
         }
         ScanningBinaryDocValuesTermInSetQuery that = (ScanningBinaryDocValuesTermInSetQuery) o;
-        return Objects.equals(fieldName, that.fieldName) && termDataHashCode == that.termDataHashCode && termData.equals(that.termData);
+        return Objects.equals(fieldName, that.fieldName)
+            && termDataHashCode == that.termDataHashCode
+            && termData.equals(that.termData)
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, termDataHashCode);
+        return Objects.hash(classHash(), fieldName, termDataHashCode, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQuery.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -39,15 +40,15 @@ public class ScanningBinaryDocValuesTermQuery extends AbstractBinaryDocValuesQue
 
     private final BytesRef term;
 
-    public ScanningBinaryDocValuesTermQuery(String fieldName, BytesRef term, boolean arrayOrderInlineNull) {
-        super(fieldName, term::equals, arrayOrderInlineNull);
+    public ScanningBinaryDocValuesTermQuery(String fieldName, BytesRef term, BinaryDocValuesFormat binaryFormat) {
+        super(fieldName, term::equals, binaryFormat);
         this.term = Objects.requireNonNull(term);
     }
 
     @Override
     public Query rewrite(IndexSearcher searcher) throws IOException {
         if (term.length == 0) {
-            return new BinaryDocValuesLengthQuery(fieldName, 0, arrayOrderInlineNull);
+            return new BinaryDocValuesLengthQuery(fieldName, 0, binaryFormat);
         }
         return this;
     }
@@ -92,11 +93,11 @@ public class ScanningBinaryDocValuesTermQuery extends AbstractBinaryDocValuesQue
             return false;
         }
         ScanningBinaryDocValuesTermQuery that = (ScanningBinaryDocValuesTermQuery) o;
-        return Objects.equals(fieldName, that.fieldName) && Objects.equals(term, that.term);
+        return Objects.equals(fieldName, that.fieldName) && Objects.equals(term, that.term) && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, term);
+        return Objects.hash(classHash(), fieldName, term, binaryFormat);
     }
 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesWildcardQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesWildcardQuery.java
@@ -18,6 +18,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -34,8 +35,13 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
     private final String pattern;
     private final boolean caseInsensitive;
 
-    public ScanningBinaryDocValuesWildcardQuery(String fieldName, String pattern, boolean caseInsensitive, boolean arrayOrderInlineNull) {
-        super(fieldName, buildByteRunAutomaton(fieldName, pattern, caseInsensitive), arrayOrderInlineNull);
+    public ScanningBinaryDocValuesWildcardQuery(
+        String fieldName,
+        String pattern,
+        boolean caseInsensitive,
+        BinaryDocValuesFormat binaryFormat
+    ) {
+        super(fieldName, buildByteRunAutomaton(fieldName, pattern, caseInsensitive), binaryFormat);
         this.pattern = Objects.requireNonNull(pattern);
         this.caseInsensitive = caseInsensitive;
     }
@@ -56,7 +62,7 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
         if (caseInsensitive == false) {
             var innerPattern = getContainsPattern(pattern);
             if (innerPattern != null) {
-                return new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(innerPattern), arrayOrderInlineNull);
+                return new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(innerPattern), binaryFormat);
             }
         }
         return super.rewrite(indexSearcher);
@@ -104,11 +110,12 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
         ScanningBinaryDocValuesWildcardQuery that = (ScanningBinaryDocValuesWildcardQuery) o;
         return Objects.equals(fieldName, that.fieldName)
             && Objects.equals(pattern, that.pattern)
-            && caseInsensitive == that.caseInsensitive;
+            && caseInsensitive == that.caseInsensitive
+            && binaryFormat == that.binaryFormat;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, pattern, caseInsensitive);
+        return Objects.hash(classHash(), fieldName, pattern, caseInsensitive, binaryFormat);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDocValuesSortFieldTests.java
@@ -26,6 +26,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
 public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
 
     // =========================================================================
@@ -239,8 +242,13 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 LeafReader leaf = getOnlyLeafReader(reader);
                 for (boolean maxMode : new boolean[] { false, true }) {
-                    BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField("name", false, SortField.STRING_LAST, maxMode, true)
-                        .getSortKeyDocValues(leaf);
+                    BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField(
+                        "name",
+                        false,
+                        SortField.STRING_LAST,
+                        maxMode,
+                        ARRAY_ORDER_INLINE_NULL
+                    ).getSortKeyDocValues(leaf);
                     assertTrue(dvs.advanceExact(0));
                     assertEquals("maxMode=" + maxMode, new BytesRef("alice"), dvs.binaryValue());
                 }
@@ -260,8 +268,13 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
             w.addDocument(doc);
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 LeafReader leaf = getOnlyLeafReader(reader);
-                BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField("name", false, SortField.STRING_LAST, false, true)
-                    .getSortKeyDocValues(leaf);
+                BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField(
+                    "name",
+                    false,
+                    SortField.STRING_LAST,
+                    false,
+                    ARRAY_ORDER_INLINE_NULL
+                ).getSortKeyDocValues(leaf);
                 assertTrue(dvs.advanceExact(0));
                 assertEquals(new BytesRef("bob"), dvs.binaryValue());
             }
@@ -277,8 +290,13 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
             w.addDocument(doc);
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 LeafReader leaf = getOnlyLeafReader(reader);
-                BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField("name", false, SortField.STRING_LAST, true, true)
-                    .getSortKeyDocValues(leaf);
+                BinaryDocValues dvs = new MultiValuedBinaryDocValuesSortField(
+                    "name",
+                    false,
+                    SortField.STRING_LAST,
+                    true,
+                    ARRAY_ORDER_INLINE_NULL
+                ).getSortKeyDocValues(leaf);
                 assertTrue(dvs.advanceExact(0));
                 assertEquals(new BytesRef("zebra"), dvs.binaryValue());
             }
@@ -297,13 +315,23 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
             w.addDocument(doc);
             try (DirectoryReader reader = DirectoryReader.open(w)) {
                 LeafReader leaf = getOnlyLeafReader(reader);
-                BinaryDocValues minDvs = new MultiValuedBinaryDocValuesSortField("name", false, SortField.STRING_LAST, false, true)
-                    .getSortKeyDocValues(leaf);
+                BinaryDocValues minDvs = new MultiValuedBinaryDocValuesSortField(
+                    "name",
+                    false,
+                    SortField.STRING_LAST,
+                    false,
+                    ARRAY_ORDER_INLINE_NULL
+                ).getSortKeyDocValues(leaf);
                 assertTrue(minDvs.advanceExact(0));
                 assertEquals(new BytesRef("bob"), minDvs.binaryValue());
 
-                BinaryDocValues maxDvs = new MultiValuedBinaryDocValuesSortField("name", false, SortField.STRING_LAST, true, true)
-                    .getSortKeyDocValues(leaf);
+                BinaryDocValues maxDvs = new MultiValuedBinaryDocValuesSortField(
+                    "name",
+                    false,
+                    SortField.STRING_LAST,
+                    true,
+                    ARRAY_ORDER_INLINE_NULL
+                ).getSortKeyDocValues(leaf);
                 assertTrue(maxDvs.advanceExact(0));
                 assertEquals(new BytesRef("zebra"), maxDvs.binaryValue());
             }
@@ -334,8 +362,17 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
         assertRoundTrip(new MultiValuedBinaryDocValuesSortField("host.name", true, SortField.STRING_LAST, false));
     }
 
-    public void testProviderRoundTrip_arrayOrderTrue() throws IOException {
-        assertRoundTrip(new MultiValuedBinaryDocValuesSortField("host.name", false, SortField.STRING_LAST, true, true));
+    public void testProviderRoundTrip_arrayOrderInlineNull() throws IOException {
+        assertRoundTrip(new MultiValuedBinaryDocValuesSortField("host.name", false, SortField.STRING_LAST, true, ARRAY_ORDER_INLINE_NULL));
+    }
+
+    /**
+     * The format is written as an ordinal, and has to keep the {@code 0}/{@code 1} the boolean it replaced wrote, so
+     * that segments written before it was an enum still read back as themselves.
+     */
+    public void testProviderWireFormatIsStableForTheFormatsThatReplacedABoolean() {
+        assertEquals(0, SEPARATE_COUNT.ordinal());
+        assertEquals(1, ARRAY_ORDER_INLINE_NULL.ordinal());
     }
 
     private static void assertRoundTrip(MultiValuedBinaryDocValuesSortField original) throws IOException {
@@ -347,6 +384,6 @@ public class MultiValuedBinaryDocValuesSortFieldTests extends ESTestCase {
         assertEquals(original.getReverse(), restored.getReverse());
         assertEquals(original.getMissingValue(), restored.getMissingValue());
         assertEquals(original.isMaxMode(), restored.isMaxMode());
-        assertEquals(original.isArrayOrder(), restored.isArrayOrder());
+        assertEquals(original.binaryFormat(), restored.binaryFormat());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
 public class IpFieldTypeTests extends FieldTypeTestCase {
 
     private static Query convertToDocValuesQuery(Query query) {
@@ -88,7 +90,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         assertEquals(convertToDocValuesQuery(query), ftOnlyDocValues.termQuery(ip, MOCK_CONTEXT));
         BytesRef encodedIp = new BytesRef(InetAddressPoint.encode(inetIp));
         assertEquals(
-            new ScanningBinaryDocValuesRangeQuery("field", encodedIp, encodedIp, false),
+            new ScanningBinaryDocValuesRangeQuery("field", encodedIp, encodedIp, SEPARATE_COUNT),
             ftOnlyBinaryDocValues.termQuery(ip, MOCK_CONTEXT)
         );
 
@@ -100,7 +102,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         assertEquals(convertToDocValuesQuery(query), ftOnlyDocValues.termQuery(ip, MOCK_CONTEXT));
         encodedIp = new BytesRef(InetAddressPoint.encode(inetIp));
         assertEquals(
-            new ScanningBinaryDocValuesRangeQuery("field", encodedIp, encodedIp, false),
+            new ScanningBinaryDocValuesRangeQuery("field", encodedIp, encodedIp, SEPARATE_COUNT),
             ftOnlyBinaryDocValues.termQuery(ip, MOCK_CONTEXT)
         );
 
@@ -116,7 +118,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
                 "field",
                 new BytesRef(((PointRangeQuery) query).getLowerPoint()),
                 new BytesRef(((PointRangeQuery) query).getUpperPoint()),
-                false
+                SEPARATE_COUNT
             ),
             ftOnlyBinaryDocValues.termQuery(prefix, MOCK_CONTEXT)
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -72,6 +72,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -144,7 +145,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             builder,
             true
         );
-        assertEquals(new ScanningBinaryDocValuesTermQuery("field", new BytesRef("foo"), false), ft.termQuery("foo", MOCK_CONTEXT));
+        assertEquals(new ScanningBinaryDocValuesTermQuery("field", new BytesRef("foo"), SEPARATE_COUNT), ft.termQuery("foo", MOCK_CONTEXT));
     }
 
     public void testTermQueryWithNormalizer() {
@@ -338,7 +339,14 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             true
         );
         assertEquals(
-            new ScanningBinaryDocValuesRangeQuery("field", BytesRefs.toBytesRef("bar"), BytesRefs.toBytesRef("foo"), true, false, false),
+            new ScanningBinaryDocValuesRangeQuery(
+                "field",
+                BytesRefs.toBytesRef("bar"),
+                BytesRefs.toBytesRef("foo"),
+                true,
+                false,
+                SEPARATE_COUNT
+            ),
             ft.rangeQuery("bar", "foo", true, false, null, null, null, MOCK_CONTEXT)
         );
     }
@@ -355,10 +363,13 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             true
         );
         assertEquals(
-            new ScanningBinaryDocValuesPrefixQuery("field", "foo", false, false),
+            new ScanningBinaryDocValuesPrefixQuery("field", "foo", false, SEPARATE_COUNT),
             ft.prefixQuery("foo", null, false, MOCK_CONTEXT)
         );
-        assertEquals(new ScanningBinaryDocValuesPrefixQuery("field", "foo", true, false), ft.prefixQuery("foo", null, true, MOCK_CONTEXT));
+        assertEquals(
+            new ScanningBinaryDocValuesPrefixQuery("field", "foo", true, SEPARATE_COUNT),
+            ft.prefixQuery("foo", null, true, MOCK_CONTEXT)
+        );
     }
 
     public void testWildcardQueryHighCardinality() {
@@ -372,7 +383,10 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             builder,
             true
         );
-        assertEquals(new ScanningBinaryDocValuesWildcardQuery("field", "foo*", false, false), ft.wildcardQuery("foo*", null, MOCK_CONTEXT));
+        assertEquals(
+            new ScanningBinaryDocValuesWildcardQuery("field", "foo*", false, SEPARATE_COUNT),
+            ft.wildcardQuery("foo*", null, MOCK_CONTEXT)
+        );
     }
 
     public void testRegexpQueryHighCardinality() {
@@ -387,7 +401,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             true
         );
         assertEquals(
-            new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, 0, 10, false, null),
+            new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, 0, 10, SEPARATE_COUNT, null),
             ft.regexpQuery("foo.*", 0, 0, 10, null, MOCK_CONTEXT)
         );
     }
@@ -414,7 +428,7 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
 
         // The normalizer must lowercase the pattern before building the regexp query
         assertEquals(
-            new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, 0, 10, false, null),
+            new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, 0, 10, SEPARATE_COUNT, null),
             ft.regexpQuery("FOO.*", 0, 0, 10, null, MOCK_CONTEXT)
         );
     }
@@ -447,7 +461,10 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         // Binary DV → ScanningBinaryDocValuesRegexpQuery, which handles matchFlags via RegExp(pattern, syntaxFlags, matchFlags)
         MappedFieldType binaryFt = new KeywordFieldType("field", false, true, true, Map.of());
         q = binaryFt.regexpQuery("foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, null, MOCK_CONTEXT);
-        assertEquals(new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, false, null), q);
+        assertEquals(
+            new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, SEPARATE_COUNT, null),
+            q
+        );
     }
 
     public void testFuzzyQuery() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/ArrayOrderInlineNullFnBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/ArrayOrderInlineNullFnBlockLoaderTests.java
@@ -20,13 +20,13 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ArrayOrderInlineNull;
 import org.elasticsearch.index.mapper.TestBlock;
 import org.elasticsearch.index.mapper.blockloader.MockWarnings;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -129,12 +129,15 @@ public class ArrayOrderInlineNullFnBlockLoaderTests extends ESTestCase {
     }
 
     private static BlockLoader.ColumnAtATimeReader referenceReader(CircuitBreaker breaker, LeafReaderContext ctx) throws IOException {
-        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(FIELD, ArrayOrderSource.INLINE).reader(breaker, ctx);
+        return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(FIELD, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL).reader(
+            breaker,
+            ctx
+        );
     }
 
     public void testMvMax() throws IOException {
         withIndex(scenarioDocs(), ctx -> {
-            var loader = new MvMaxBytesRefsFromBinaryBlockLoader(FIELD, ArrayOrderSource.INLINE);
+            var loader = new MvMaxBytesRefsFromBinaryBlockLoader(FIELD, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
             try (var reference = referenceReader(BREAKER, ctx); var reader = loader.reader(BREAKER, ctx)) {
                 assertThat(reader, hasToString("MvMaxBytesRefsFromBinary.ArrayOrderInlineNull"));
                 BlockLoader.Docs docs = TestBlock.docs(ctx);
@@ -147,7 +150,7 @@ public class ArrayOrderInlineNullFnBlockLoaderTests extends ESTestCase {
 
     public void testMvMin() throws IOException {
         withIndex(scenarioDocs(), ctx -> {
-            var loader = new MvMinBytesRefsFromBinaryBlockLoader(FIELD, ArrayOrderSource.INLINE);
+            var loader = new MvMinBytesRefsFromBinaryBlockLoader(FIELD, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
             try (var reference = referenceReader(BREAKER, ctx); var reader = loader.reader(BREAKER, ctx)) {
                 assertThat(reader, hasToString("MvMinBytesRefsFromBinary.ArrayOrderInlineNull"));
                 BlockLoader.Docs docs = TestBlock.docs(ctx);
@@ -160,7 +163,7 @@ public class ArrayOrderInlineNullFnBlockLoaderTests extends ESTestCase {
 
     public void testByteLength() throws IOException {
         checkLength("ByteLengthFromBytesRef.MultiValuedBinaryArrayOrderInlineNull", warnings -> {
-            var loader = new ByteLengthFromBytesRefDocValuesBlockLoader(warnings, FIELD, ArrayOrderSource.INLINE);
+            var loader = new ByteLengthFromBytesRefDocValuesBlockLoader(warnings, FIELD, BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL);
             return loader;
         }, bytes -> bytes.length);
     }
@@ -171,7 +174,7 @@ public class ArrayOrderInlineNullFnBlockLoaderTests extends ESTestCase {
                 warnings,
                 FIELD,
                 ByteSizeValue.ofKb(between(1, 100)),
-                ArrayOrderSource.INLINE
+                BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL
             );
             return loader;
         }, bytes -> bytes.utf8ToString().codePointCount(0, bytes.utf8ToString().length()));

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMaxBytesRefsBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMaxBytesRefsBlockLoaderTests.java
@@ -18,11 +18,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.mapper.AbstractBlockLoaderTestCase;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.index.mapper.TestBlock;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
@@ -73,7 +73,7 @@ public class BinaryMvMaxBytesRefsBlockLoaderTests extends AbstractBlockLoaderTes
                 LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
 
                 var stringsLoader = new BytesRefsFromBinaryMultiSeparateCountBlockLoader("field");
-                var mvMinLoader = new MvMaxBytesRefsFromBinaryBlockLoader("field", ArrayOrderSource.NONE);
+                var mvMinLoader = new MvMaxBytesRefsFromBinaryBlockLoader("field", BinaryDocValuesFormat.SEPARATE_COUNT);
                 try (var stringsReader = stringsLoader.reader(breaker, ctx); var mvMinReader = mvMinLoader.reader(breaker, ctx)) {
                     assertThat(mvMinReader, readerMatcher());
                     BlockLoader.Docs docs = TestBlock.docs(ctx);

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMinBytesRefsBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryMvMinBytesRefsBlockLoaderTests.java
@@ -18,11 +18,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.mapper.AbstractBlockLoaderTestCase;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.index.mapper.TestBlock;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
@@ -72,7 +72,7 @@ public class BinaryMvMinBytesRefsBlockLoaderTests extends AbstractBlockLoaderTes
                 LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
 
                 var stringsLoader = new BytesRefsFromBinaryMultiSeparateCountBlockLoader("field");
-                var mvMinLoader = new MvMinBytesRefsFromBinaryBlockLoader("field", ArrayOrderSource.NONE);
+                var mvMinLoader = new MvMinBytesRefsFromBinaryBlockLoader("field", BinaryDocValuesFormat.SEPARATE_COUNT);
                 try (var stringsReader = stringsLoader.reader(breaker, ctx); var mvMinReader = mvMinLoader.reader(breaker, ctx)) {
                     assertThat(mvMinReader, readerMatcher());
                     BlockLoader.Docs docs = TestBlock.docs(ctx);

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryUtf8CodePointLengthBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/docvalues/fn/BinaryUtf8CodePointLengthBlockLoaderTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.mapper.AbstractBlockLoaderTestCase;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.index.mapper.TestBlock;
@@ -79,7 +80,7 @@ public class BinaryUtf8CodePointLengthBlockLoaderTests extends AbstractBlockLoad
                     warnings,
                     "field",
                     ByteSizeValue.ofKb(between(1, 100)),
-                    BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource.NONE
+                    BinaryDocValuesFormat.SEPARATE_COUNT
                 );
 
                 BlockLoader.Docs docs = TestBlock.docs(ctx);

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.lucene.search.MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -144,7 +145,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             false
         );
 
-        Query expected = new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), false);
+        Query expected = new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), SEPARATE_COUNT);
         assertEquals(expected, ft.termQuery("value", null));
     }
 
@@ -168,7 +169,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         Query query = ft.termQuery("value", null);
         // The array-order path uses KeyedArrayOrderInlineNullTermQuery, a distinct class from
         // ScanningBinaryDocValuesTermQuery, giving each path a distinct query-cache identity.
-        assertNotEquals(new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), false), query);
+        assertNotEquals(new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), SEPARATE_COUNT), query);
         assertTrue(query instanceof KeyedArrayOrderInlineNullTermQuery);
     }
 
@@ -211,7 +212,10 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         );
 
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        builder.add(new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), false), BooleanClause.Occur.SHOULD);
+        builder.add(
+            new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0value"), SEPARATE_COUNT),
+            BooleanClause.Occur.SHOULD
+        );
         Query expected = new ConstantScoreQuery(builder.build());
         assertEquals(expected, ft.termsQuery(List.of("value"), null));
     }
@@ -245,8 +249,14 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         // plain ScanningBinaryDocValuesTermQuery. The resulting query must not equal the non-array-order
         // equivalent so the two paths get separate query-cache entries.
         BooleanQuery.Builder nonArrayBuilder = new BooleanQuery.Builder();
-        nonArrayBuilder.add(new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0v1"), false), BooleanClause.Occur.SHOULD);
-        nonArrayBuilder.add(new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0v2"), false), BooleanClause.Occur.SHOULD);
+        nonArrayBuilder.add(
+            new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0v1"), SEPARATE_COUNT),
+            BooleanClause.Occur.SHOULD
+        );
+        nonArrayBuilder.add(
+            new ScanningBinaryDocValuesTermQuery(ft.name(), new BytesRef("key\0v2"), SEPARATE_COUNT),
+            BooleanClause.Occur.SHOULD
+        );
         assertNotEquals(new ConstantScoreQuery(nonArrayBuilder.build()), result);
     }
 

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQueryTests.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery.contains;
 
 public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
@@ -55,11 +57,18 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                     // A multi-valued doc is present, so the maxValue<=1 gate disables the whole-blob tryContainsIterator and the per-value
                     // decode fallback runs. "et" is contained by "beta" in the multi-value and single-value docs; the all-null doc that
                     // immediately precedes the single-value "beta" doc must not be matched.
-                    assertEquals(2, searcher.count(new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("et"), true)));
+                    assertEquals(
+                        2,
+                        searcher.count(new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("et"), ARRAY_ORDER_INLINE_NULL))
+                    );
                     // The bytes {'a', 0x03, 'b'} appear contiguously in the raw multi-value blob of ["xa","bz"] (the 0x03 is the length
                     // prefix of "bz"), so a whole-blob scan would falsely match. Per-value decoding tests "xa" and "bz" individually and
                     // correctly finds no match — guarding that the gate routes multi-value contains away from the raw-blob fast path.
-                    var framingTerm = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(new byte[] { 'a', 0x03, 'b' }), true);
+                    var framingTerm = new BinaryDocValuesContainsTermQuery(
+                        fieldName,
+                        new BytesRef(new byte[] { 'a', 0x03, 'b' }),
+                        ARRAY_ORDER_INLINE_NULL
+                    );
                     assertEquals(0, searcher.count(framingTerm));
                 }
             }
@@ -176,7 +185,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"), false);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"), SEPARATE_COUNT);
                     assertEquals(3, searcher.count(query));
                 }
             }
@@ -198,7 +207,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("ell"), false);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("ell"), SEPARATE_COUNT);
                     assertEquals(2, searcher.count(query));
                 }
             }
@@ -214,7 +223,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"), false);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"), SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -228,7 +237,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"), false);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("test"), SEPARATE_COUNT);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -245,7 +254,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("xyz"), false);
+                    Query query = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("xyz"), SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -278,14 +287,14 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                     );
                     searcher.setCircuitBreaker(breaker);
 
-                    Query present = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"), false);
+                    Query present = new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef("search"), SEPARATE_COUNT);
                     expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 
                     // A field absent from the segment opens no binary doc values reader, so the checkpoint must not fire.
                     checkpointedBytes.set(-1);
-                    Query absent = new BinaryDocValuesContainsTermQuery("missing", new BytesRef("search"), false);
+                    Query absent = new BinaryDocValuesContainsTermQuery("missing", new BytesRef("search"), SEPARATE_COUNT);
                     assertEquals(0, searcher.count(absent));
                     assertEquals(-1L, checkpointedBytes.get());
 
@@ -298,10 +307,10 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
     }
 
     public void testEqualsAndHashCode() {
-        BinaryDocValuesContainsTermQuery q1 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"), false);
-        BinaryDocValuesContainsTermQuery q2 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"), false);
-        BinaryDocValuesContainsTermQuery q3 = new BinaryDocValuesContainsTermQuery("other", new BytesRef("term"), false);
-        BinaryDocValuesContainsTermQuery q4 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("other"), false);
+        BinaryDocValuesContainsTermQuery q1 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"), SEPARATE_COUNT);
+        BinaryDocValuesContainsTermQuery q2 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("term"), SEPARATE_COUNT);
+        BinaryDocValuesContainsTermQuery q3 = new BinaryDocValuesContainsTermQuery("other", new BytesRef("term"), SEPARATE_COUNT);
+        BinaryDocValuesContainsTermQuery q4 = new BinaryDocValuesContainsTermQuery("field", new BytesRef("other"), SEPARATE_COUNT);
 
         assertEquals(q1, q2);
         assertEquals(q1.hashCode(), q2.hashCode());
@@ -315,7 +324,7 @@ public class BinaryDocValuesContainsTermQueryTests extends ESTestCase {
                 addSingleValueDoc(writer, "field", "hello");
                 try (DirectoryReader reader = forbidBinaryDvOpenReader(writer.getReader())) {
                     final IndexSearcher searcher = new IndexSearcher(reader);
-                    final Weight weight = new BinaryDocValuesContainsTermQuery("field", new BytesRef("hello"), false).createWeight(
+                    final Weight weight = new BinaryDocValuesContainsTermQuery("field", new BytesRef("hello"), SEPARATE_COUNT).createWeight(
                         searcher,
                         ScoreMode.COMPLETE_NO_SCORES,
                         1f

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQueryTests.java
@@ -40,6 +40,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
 public class BinaryDocValuesLengthQueryTests extends ESTestCase {
 
     public void testArrayOrderInlineNull() throws Exception {
@@ -56,9 +59,9 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     // length 0 matches the empty string in the multi-value doc and the single empty-string doc, but never the all-null
                     // slot (null is distinct from the empty string) — including the all-null doc that immediately precedes it.
-                    assertEquals(2, searcher.count(new BinaryDocValuesLengthQuery(fieldName, 0, true)));
+                    assertEquals(2, searcher.count(new BinaryDocValuesLengthQuery(fieldName, 0, ARRAY_ORDER_INLINE_NULL)));
                     // length 3 matches only "xyz".
-                    assertEquals(1, searcher.count(new BinaryDocValuesLengthQuery(fieldName, 3, true)));
+                    assertEquals(1, searcher.count(new BinaryDocValuesLengthQuery(fieldName, 3, ARRAY_ORDER_INLINE_NULL)));
                 }
             }
         }
@@ -87,7 +90,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (int len = 0; len <= 10; len++) {
-                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, false));
+                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, SEPARATE_COUNT));
                         assertEquals(lengthToCount[len], numMatches);
                     }
                 }
@@ -125,7 +128,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (int len = 0; len <= 10; len++) {
-                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, false));
+                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, SEPARATE_COUNT));
                         assertEquals(lengthToCount[len], numMatches);
                     }
                 }
@@ -176,7 +179,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (int len = 0; len <= 10; len++) {
-                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, false));
+                        long numMatches = searcher.count(new BinaryDocValuesLengthQuery(fieldName, len, SEPARATE_COUNT));
                         assertEquals(lengthToCount[len], numMatches);
                     }
                 }
@@ -217,14 +220,14 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                     );
                     searcher.setCircuitBreaker(breaker);
 
-                    Query present = new BinaryDocValuesLengthQuery(fieldName, 1, false);
+                    Query present = new BinaryDocValuesLengthQuery(fieldName, 1, SEPARATE_COUNT);
                     expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 
                     // A field absent from the segment opens no binary doc values reader, so the checkpoint must not fire.
                     checkpointedBytes.set(-1);
-                    Query absent = new BinaryDocValuesLengthQuery("missing", 1, false);
+                    Query absent = new BinaryDocValuesLengthQuery("missing", 1, SEPARATE_COUNT);
                     assertEquals(0, searcher.count(absent));
                     assertEquals(-1L, checkpointedBytes.get());
 
@@ -244,7 +247,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 writer.addDocument(document);
                 try (DirectoryReader reader = forbidBinaryDvOpenReader(writer.getReader())) {
                     final IndexSearcher searcher = new IndexSearcher(reader);
-                    final Weight weight = new BinaryDocValuesLengthQuery("field", 5, false).createWeight(
+                    final Weight weight = new BinaryDocValuesLengthQuery("field", 5, SEPARATE_COUNT).createWeight(
                         searcher,
                         ScoreMode.COMPLETE_NO_SCORES,
                         1f
@@ -305,7 +308,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesLengthQuery(fieldName, 1, false);
+                    Query query = new BinaryDocValuesLengthQuery(fieldName, 1, SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -330,7 +333,7 @@ public class BinaryDocValuesLengthQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new BinaryDocValuesLengthQuery(fieldName, 1, false);
+                    Query query = new BinaryDocValuesLengthQuery(fieldName, 1, SEPARATE_COUNT);
                     assertEquals(1, searcher.count(query));
                 }
             }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesPrefixQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesPrefixQueryTests.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -51,10 +53,16 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     // prefix "be" matches "beta" (multi-value doc) and "best" (single-value doc); the all-null doc preceding "best" must
                     // not be matched.
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "be", false, true)));
+                    assertEquals(
+                        2,
+                        searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "be", false, ARRAY_ORDER_INLINE_NULL))
+                    );
                     // prefix "a" matches only "alpha".
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "a", false, true)));
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "zz", false, true)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "a", false, ARRAY_ORDER_INLINE_NULL)));
+                    assertEquals(
+                        0,
+                        searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "zz", false, ARRAY_ORDER_INLINE_NULL))
+                    );
                 }
             }
         }
@@ -94,16 +102,16 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // prefix "a" matches apple (2), apricot (5), avocado (10)
-                    assertEquals(17, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "a", false, false)));
+                    assertEquals(17, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "a", false, SEPARATE_COUNT)));
                     // prefix "ap" matches apple (2), apricot (5)
-                    assertEquals(7, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "ap", false, false)));
+                    assertEquals(7, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "ap", false, SEPARATE_COUNT)));
                     // prefix "b" matches banana (1), blueberry (3)
-                    assertEquals(4, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "b", false, false)));
+                    assertEquals(4, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "b", false, SEPARATE_COUNT)));
                     // exact prefix matches all docs with that value
                     for (var entry : expectedCounts.entrySet()) {
                         assertEquals(
                             entry.getValue().longValue(),
-                            searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, entry.getKey(), false, false))
+                            searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, entry.getKey(), false, SEPARATE_COUNT))
                         );
                     }
                 }
@@ -120,7 +128,7 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "foo", false, false)));
+                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "foo", false, SEPARATE_COUNT)));
                 }
             }
         }
@@ -143,7 +151,7 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "foo", false, false)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "foo", false, SEPARATE_COUNT)));
                 }
             }
         }
@@ -182,7 +190,7 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                     Query baselineQuery = new PrefixQuery(new Term("baseline_field", prefix), MultiTermQuery.DOC_VALUES_REWRITE);
                     TopDocs baselineResults = searcher.search(baselineQuery, 32);
 
-                    Query contenderQuery = new ScanningBinaryDocValuesPrefixQuery("contender_field", prefix, false, false);
+                    Query contenderQuery = new ScanningBinaryDocValuesPrefixQuery("contender_field", prefix, false, SEPARATE_COUNT);
                     TopDocs contenderResults = searcher.search(contenderQuery, 32);
 
                     assertThat(contenderResults.totalHits, equalTo(baselineResults.totalHits));
@@ -209,14 +217,14 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // "elastic" case-insensitive prefix matches "Elasticsearch" and "ELASTIC"
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "elastic", true, false)));
+                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "elastic", true, SEPARATE_COUNT)));
                     // case-sensitive matches only the exact-cased docs
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "elastic", false, false)));
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "Elastic", false, false)));
+                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "elastic", false, SEPARATE_COUNT)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "Elastic", false, SEPARATE_COUNT)));
                     // "log" case-insensitive matches "Logstash"
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "log", true, false)));
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "LOG", true, false)));
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "log", false, false)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "log", true, SEPARATE_COUNT)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "LOG", true, SEPARATE_COUNT)));
+                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "log", false, SEPARATE_COUNT)));
                 }
             }
         }
@@ -233,8 +241,8 @@ public class ScanningBinaryDocValuesPrefixQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // empty prefix matches everything
-                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "", false, false)));
-                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "", true, false)));
+                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "", false, SEPARATE_COUNT)));
+                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesPrefixQuery(fieldName, "", true, SEPARATE_COUNT)));
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRangeQueryTests.java
@@ -24,6 +24,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
 public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
 
     public void testRangeUsesBytesRefOrdering() throws Exception {
@@ -34,7 +37,14 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                 writer.addDocument(docWithValue(fieldName, "\uF000"));
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("\uE000"), null, true, true, false);
+                    Query query = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("\uE000"),
+                        null,
+                        true,
+                        true,
+                        SEPARATE_COUNT
+                    );
                     assertEquals(2, searcher.count(query));
                 }
             }
@@ -56,14 +66,28 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                         new BytesRef("gamma"),
                         true,
                         true,
-                        false
+                        SEPARATE_COUNT
                     );
                     assertEquals(3, searcher.count(closed));
 
-                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, null, new BytesRef("gamma"), true, false, false);
+                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        null,
+                        new BytesRef("gamma"),
+                        true,
+                        false,
+                        SEPARATE_COUNT
+                    );
                     assertEquals(2, searcher.count(lowerOpen));
 
-                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("alpha"), null, false, true, false);
+                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("alpha"),
+                        null,
+                        false,
+                        true,
+                        SEPARATE_COUNT
+                    );
                     assertEquals(2, searcher.count(upperOpen));
                 }
             }
@@ -83,10 +107,20 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     // [alpha, beta] matches "alpha"/"beta" in the multi-value doc and "beta" in the single-value doc; the all-null doc
                     // preceding the latter must not be matched.
-                    var alphaToBeta = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("alpha"), new BytesRef("beta"), true);
+                    var alphaToBeta = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("alpha"),
+                        new BytesRef("beta"),
+                        ARRAY_ORDER_INLINE_NULL
+                    );
                     assertEquals(2, searcher.count(alphaToBeta));
                     // [delta, gamma] matches only the last doc ("delta"/"gamma").
-                    var deltaToGamma = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("delta"), new BytesRef("gamma"), true);
+                    var deltaToGamma = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("delta"),
+                        new BytesRef("gamma"),
+                        ARRAY_ORDER_INLINE_NULL
+                    );
                     assertEquals(1, searcher.count(deltaToGamma));
                 }
             }
@@ -140,7 +174,7 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                 writer.addDocument(docWithIps("10.0.0.3", "10.0.0.4"));
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, false);
+                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, SEPARATE_COUNT);
                     assertEquals(2, searcher.count(query));
                 }
             }
@@ -163,14 +197,28 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                         new BytesRef("delta"),
                         true,
                         true,
-                        false
+                        SEPARATE_COUNT
                     );
                     assertEquals(2, searcher.count(closed));
 
-                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, null, new BytesRef("beta"), true, true, false);
+                    Query lowerOpen = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        null,
+                        new BytesRef("beta"),
+                        true,
+                        true,
+                        SEPARATE_COUNT
+                    );
                     assertEquals(2, searcher.count(lowerOpen));
 
-                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(fieldName, new BytesRef("delta"), null, true, true, false);
+                    Query upperOpen = new ScanningBinaryDocValuesRangeQuery(
+                        fieldName,
+                        new BytesRef("delta"),
+                        null,
+                        true,
+                        true,
+                        SEPARATE_COUNT
+                    );
                     assertEquals(2, searcher.count(upperOpen));
                 }
             }
@@ -186,7 +234,7 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, false);
+                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -199,7 +247,7 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, false);
+                    Query query = new ScanningBinaryDocValuesRangeQuery(fieldName, lower, upper, SEPARATE_COUNT);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -208,12 +256,12 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
 
     public void testRewriteToTermQueryWhenBoundsEqual() throws Exception {
         BytesRef term = new BytesRef("alpha");
-        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, false);
+        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, SEPARATE_COUNT);
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(new ScanningBinaryDocValuesTermQuery("field", term, false), range.rewrite(searcher));
+                    assertEquals(new ScanningBinaryDocValuesTermQuery("field", term, SEPARATE_COUNT), range.rewrite(searcher));
                 }
             }
         }
@@ -221,7 +269,7 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
 
     public void testRewriteKeepsExclusiveEqualBoundsRange() throws Exception {
         BytesRef term = new BytesRef("alpha");
-        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, false, true, false);
+        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", term, term, false, true, SEPARATE_COUNT);
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 try (IndexReader reader = writer.getReader()) {
@@ -235,7 +283,7 @@ public class ScanningBinaryDocValuesRangeQueryTests extends ESTestCase {
     public void testRewriteKeepsTrueRange() throws Exception {
         BytesRef lower = encodeIp("192.168.1.0");
         BytesRef upper = encodeIp("192.168.1.255");
-        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", lower, upper, false);
+        ScanningBinaryDocValuesRangeQuery range = new ScanningBinaryDocValuesRangeQuery("field", lower, upper, SEPARATE_COUNT);
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
                 try (IndexReader reader = writer.getReader()) {

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRegexpQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesRegexpQueryTests.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -58,13 +60,21 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     // "be.*" matches "beta" in the multi-value doc and the single-value doc; the all-null doc preceding the latter must
                     // not be matched.
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "be.*", 0, 0, 1000, true, null)));
+                    assertEquals(
+                        2,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "be.*", 0, 0, 1000, ARRAY_ORDER_INLINE_NULL, null))
+                    );
                     // "(alpha|delta)" matches the first and last docs.
                     assertEquals(
                         2,
-                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "(alpha|delta)", 0, 0, 1000, true, null))
+                        searcher.count(
+                            new ScanningBinaryDocValuesRegexpQuery(fieldName, "(alpha|delta)", 0, 0, 1000, ARRAY_ORDER_INLINE_NULL, null)
+                        )
                     );
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "zeta", 0, 0, 1000, true, null)));
+                    assertEquals(
+                        0,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "zeta", 0, 0, 1000, ARRAY_ORDER_INLINE_NULL, null))
+                    );
                 }
             }
         }
@@ -106,18 +116,21 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
 
                     // "a.*" matches apple, apricot, avocado
                     long aCount = expectedCounts.get("apple") + expectedCounts.get("apricot") + expectedCounts.get("avocado");
-                    assertEquals(aCount, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, false, null)));
+                    assertEquals(
+                        aCount,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, SEPARATE_COUNT, null))
+                    );
 
                     // "b.*" matches banana
                     assertEquals(
                         expectedCounts.get("banana").longValue(),
-                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "b.*", 0, 0, 1000, false, null))
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "b.*", 0, 0, 1000, SEPARATE_COUNT, null))
                     );
 
                     // "cherry" exact matches cherry
                     assertEquals(
                         expectedCounts.get("cherry").longValue(),
-                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "cherry", 0, 0, 1000, false, null))
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "cherry", 0, 0, 1000, SEPARATE_COUNT, null))
                     );
                 }
             }
@@ -133,7 +146,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, false, null);
+                    Query query = new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, SEPARATE_COUNT, null);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -147,7 +160,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, false, null);
+                    Query query = new ScanningBinaryDocValuesRegexpQuery(fieldName, "a.*", 0, 0, 1000, SEPARATE_COUNT, null);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -202,7 +215,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                         RegExp.ALL,
                         0,
                         1000,
-                        false,
+                        SEPARATE_COUNT,
                         null
                     );
                     TopDocs contenderResults = searcher.search(contenderQuery, 64);
@@ -231,13 +244,24 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
 
                     // Case-sensitive: only lowercase "foo" matches "foo"
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "foo", 0, 0, 1000, false, null)));
+                    assertEquals(
+                        1,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "foo", 0, 0, 1000, SEPARATE_COUNT, null))
+                    );
 
                     // Case-insensitive via RegExp.ASCII_CASE_INSENSITIVE matchFlag: matches "foo" and "FOO" (none here, so still 1)
                     assertEquals(
                         1,
                         searcher.count(
-                            new ScanningBinaryDocValuesRegexpQuery(fieldName, "foo", 0, RegExp.ASCII_CASE_INSENSITIVE, 1000, false, null)
+                            new ScanningBinaryDocValuesRegexpQuery(
+                                fieldName,
+                                "foo",
+                                0,
+                                RegExp.ASCII_CASE_INSENSITIVE,
+                                1000,
+                                SEPARATE_COUNT,
+                                null
+                            )
                         )
                     );
 
@@ -245,7 +269,15 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                     assertEquals(
                         1,
                         searcher.count(
-                            new ScanningBinaryDocValuesRegexpQuery(fieldName, "hello", 0, RegExp.ASCII_CASE_INSENSITIVE, 1000, false, null)
+                            new ScanningBinaryDocValuesRegexpQuery(
+                                fieldName,
+                                "hello",
+                                0,
+                                RegExp.ASCII_CASE_INSENSITIVE,
+                                1000,
+                                SEPARATE_COUNT,
+                                null
+                            )
                         )
                     );
 
@@ -253,12 +285,23 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                     assertEquals(
                         1,
                         searcher.count(
-                            new ScanningBinaryDocValuesRegexpQuery(fieldName, "world", 0, RegExp.ASCII_CASE_INSENSITIVE, 1000, false, null)
+                            new ScanningBinaryDocValuesRegexpQuery(
+                                fieldName,
+                                "world",
+                                0,
+                                RegExp.ASCII_CASE_INSENSITIVE,
+                                1000,
+                                SEPARATE_COUNT,
+                                null
+                            )
                         )
                     );
 
                     // Case-sensitive "hello" does NOT match "Hello"
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "hello", 0, 0, 1000, false, null)));
+                    assertEquals(
+                        0,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, "hello", 0, 0, 1000, SEPARATE_COUNT, null))
+                    );
                 }
             }
         }
@@ -275,14 +318,25 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // ".*" matches all docs
-                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, ".*", 0, 0, 1000, false, null)));
+                    assertEquals(
+                        3,
+                        searcher.count(new ScanningBinaryDocValuesRegexpQuery(fieldName, ".*", 0, 0, 1000, SEPARATE_COUNT, null))
+                    );
                 }
             }
         }
     }
 
     public void testToString() {
-        ScanningBinaryDocValuesRegexpQuery query = new ScanningBinaryDocValuesRegexpQuery("my_field", "foo.*", 0, 0, 1000, false, null);
+        ScanningBinaryDocValuesRegexpQuery query = new ScanningBinaryDocValuesRegexpQuery(
+            "my_field",
+            "foo.*",
+            0,
+            0,
+            1000,
+            SEPARATE_COUNT,
+            null
+        );
         // toString must always use the stored field name, not the Lucene context parameter
         assertThat(query.toString("other_field"), containsString("my_field"));
         assertThat(query.toString(""), containsString("my_field"));
@@ -290,7 +344,15 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
 
     public void testVisitor() {
         String fieldName = "my_field";
-        ScanningBinaryDocValuesRegexpQuery query = new ScanningBinaryDocValuesRegexpQuery(fieldName, "hel.*", 0, 0, 1000, false, null);
+        ScanningBinaryDocValuesRegexpQuery query = new ScanningBinaryDocValuesRegexpQuery(
+            fieldName,
+            "hel.*",
+            0,
+            0,
+            1000,
+            SEPARATE_COUNT,
+            null
+        );
 
         // consumeTermsMatching must be called with the correct field and a working automaton
         boolean[] called = { false };
@@ -330,7 +392,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
         CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(100));
         expectThrows(
             CircuitBreakingException.class,
-            () -> new ScanningBinaryDocValuesRegexpQuery("field", "a{100000000}", RegExp.ALL, 0, 1000, false, breaker)
+            () -> new ScanningBinaryDocValuesRegexpQuery("field", "a{100000000}", RegExp.ALL, 0, 1000, SEPARATE_COUNT, breaker)
         );
         assertEquals("no memory should remain reserved after the breaker trips", 0, breaker.getUsed());
     }
@@ -339,7 +401,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
         CircuitBreaker tinyBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(1));
         expectThrows(
             CircuitBreakingException.class,
-            () -> new ScanningBinaryDocValuesRegexpQuery("field", "a{1000}", RegExp.ALL, 0, 10000, false, tinyBreaker)
+            () -> new ScanningBinaryDocValuesRegexpQuery("field", "a{1000}", RegExp.ALL, 0, 10000, SEPARATE_COUNT, tinyBreaker)
         );
         assertEquals(0, tinyBreaker.getUsed());
 
@@ -350,7 +412,7 @@ public class ScanningBinaryDocValuesRegexpQueryTests extends ESTestCase {
             RegExp.ALL,
             0,
             10000,
-            false,
+            SEPARATE_COUNT,
             largeBreaker
         );
         assertNotNull(query);

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermInSetQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermInSetQueryTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.test.ESTestCase;
 
@@ -42,10 +43,11 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                     // {beta, zeta}: beta is in the multi-value and single-value docs (the all-null doc preceding the latter must not be
                     // matched), zeta is absent.
                     var betaOrZeta = List.of(new BytesRef("beta"), new BytesRef("zeta"));
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, betaOrZeta, true)));
+                    var format = BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, betaOrZeta, format)));
                     // {alpha, delta}: alpha is in the first doc, delta in the last.
                     var alphaOrDelta = List.of(new BytesRef("alpha"), new BytesRef("delta"));
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, alphaOrDelta, true)));
+                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, alphaOrDelta, format)));
                 }
             }
         }
@@ -87,7 +89,9 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
                         List<BytesRef> terms = List.of(new BytesRef(entry.getKey()));
-                        long count = searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, false));
+                        long count = searcher.count(
+                            new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, BinaryDocValuesFormat.SEPARATE_COUNT)
+                        );
                         assertEquals(entry.getValue().longValue(), count);
                     }
                 }
@@ -98,12 +102,16 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
 
                     // Query for "a" or "b" should return count of a + count of b
                     List<BytesRef> terms = List.of(new BytesRef("a"), new BytesRef("b"));
-                    long count = searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, false));
+                    long count = searcher.count(
+                        new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, BinaryDocValuesFormat.SEPARATE_COUNT)
+                    );
                     assertEquals(expectedCounts.get("a") + expectedCounts.get("b"), count);
 
                     // Query for "c", "d", "e" should return sum of their counts
                     List<BytesRef> terms2 = List.of(new BytesRef("c"), new BytesRef("d"), new BytesRef("e"));
-                    long count2 = searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms2, false));
+                    long count2 = searcher.count(
+                        new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms2, BinaryDocValuesFormat.SEPARATE_COUNT)
+                    );
                     assertEquals(expectedCounts.get("c") + expectedCounts.get("d") + expectedCounts.get("e"), count2);
                 }
 
@@ -111,7 +119,9 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     List<BytesRef> terms = List.of(new BytesRef("nonexistent"));
-                    long count = searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, false));
+                    long count = searcher.count(
+                        new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, BinaryDocValuesFormat.SEPARATE_COUNT)
+                    );
                     assertEquals(0, count);
                 }
 
@@ -119,7 +129,9 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     List<BytesRef> terms = List.of(new BytesRef("a"), new BytesRef("nonexistent"));
-                    long count = searcher.count(new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, false));
+                    long count = searcher.count(
+                        new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms, BinaryDocValuesFormat.SEPARATE_COUNT)
+                    );
                     assertEquals(expectedCounts.get("a").longValue(), count);
                 }
             }
@@ -135,7 +147,11 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesTermInSetQuery(fieldName, List.of(new BytesRef("a")), false);
+                    Query query = new ScanningBinaryDocValuesTermInSetQuery(
+                        fieldName,
+                        List.of(new BytesRef("a")),
+                        BinaryDocValuesFormat.SEPARATE_COUNT
+                    );
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -160,7 +176,11 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesTermInSetQuery(fieldName, List.of(new BytesRef("a")), false);
+                    Query query = new ScanningBinaryDocValuesTermInSetQuery(
+                        fieldName,
+                        List.of(new BytesRef("a")),
+                        BinaryDocValuesFormat.SEPARATE_COUNT
+                    );
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -168,7 +188,10 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
     }
 
     public void testNullTermsThrows() {
-        expectThrows(NullPointerException.class, () -> new ScanningBinaryDocValuesTermInSetQuery("field", null, false));
+        expectThrows(
+            NullPointerException.class,
+            () -> new ScanningBinaryDocValuesTermInSetQuery("field", null, BinaryDocValuesFormat.SEPARATE_COUNT)
+        );
     }
 
     public void testEqualsAndHashCode() {
@@ -177,10 +200,11 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
         List<BytesRef> terms2 = List.of(new BytesRef("a"), new BytesRef("b"));
         List<BytesRef> terms3 = List.of(new BytesRef("a"), new BytesRef("c"));
 
-        ScanningBinaryDocValuesTermInSetQuery query1 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms1, false);
-        ScanningBinaryDocValuesTermInSetQuery query2 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms2, false);
-        ScanningBinaryDocValuesTermInSetQuery query3 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms3, false);
-        ScanningBinaryDocValuesTermInSetQuery query4 = new ScanningBinaryDocValuesTermInSetQuery("other", terms1, false);
+        var format = BinaryDocValuesFormat.SEPARATE_COUNT;
+        ScanningBinaryDocValuesTermInSetQuery query1 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms1, format);
+        ScanningBinaryDocValuesTermInSetQuery query2 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms2, format);
+        ScanningBinaryDocValuesTermInSetQuery query3 = new ScanningBinaryDocValuesTermInSetQuery(fieldName, terms3, format);
+        ScanningBinaryDocValuesTermInSetQuery query4 = new ScanningBinaryDocValuesTermInSetQuery("other", terms1, format);
 
         // Same terms, same field
         assertEquals(query1, query2);
@@ -207,8 +231,9 @@ public class ScanningBinaryDocValuesTermInSetQueryTests extends ESTestCase {
         );
         List<BytesRef> termsWithoutDuplicates = List.of(new BytesRef("a"), new BytesRef("b"));
 
-        ScanningBinaryDocValuesTermInSetQuery query1 = new ScanningBinaryDocValuesTermInSetQuery("field", termsWithDuplicates, false);
-        ScanningBinaryDocValuesTermInSetQuery query2 = new ScanningBinaryDocValuesTermInSetQuery("field", termsWithoutDuplicates, false);
+        var format = BinaryDocValuesFormat.SEPARATE_COUNT;
+        ScanningBinaryDocValuesTermInSetQuery query1 = new ScanningBinaryDocValuesTermInSetQuery("field", termsWithDuplicates, format);
+        ScanningBinaryDocValuesTermInSetQuery query2 = new ScanningBinaryDocValuesTermInSetQuery("field", termsWithoutDuplicates, format);
 
         assertEquals(query1, query2);
         assertEquals(query1.hashCode(), query2.hashCode());

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesTermQueryTests.java
@@ -42,6 +42,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
 public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
     public void testArrayOrderInlineNull() throws Exception {
@@ -57,9 +60,18 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     // "beta" is carried by the multi-value doc and the single-value doc; the all-null doc that immediately precedes the
                     // single-value "beta" doc must not be matched (guards advanceExact vs advance on the binary cursor).
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("beta"), true)));
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("alpha"), true)));
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("zeta"), true)));
+                    assertEquals(
+                        2,
+                        searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("beta"), ARRAY_ORDER_INLINE_NULL))
+                    );
+                    assertEquals(
+                        1,
+                        searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("alpha"), ARRAY_ORDER_INLINE_NULL))
+                    );
+                    assertEquals(
+                        0,
+                        searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("zeta"), ARRAY_ORDER_INLINE_NULL))
+                    );
                 }
             }
         }
@@ -100,7 +112,9 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
-                        long count = searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef(entry.getKey()), false));
+                        long count = searcher.count(
+                            new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef(entry.getKey()), SEPARATE_COUNT)
+                        );
                         assertEquals(entry.getValue().longValue(), count);
                     }
                 }
@@ -117,7 +131,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), false);
+                    Query query = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -142,7 +156,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), false);
+                    Query query = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), SEPARATE_COUNT);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -169,7 +183,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 BytesRef term = new BytesRef("hello");
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, false)));
+                    assertEquals(3, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, SEPARATE_COUNT)));
                 }
             }
         }
@@ -197,7 +211,10 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("search"), false)));
+                    assertEquals(
+                        2,
+                        searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("search"), SEPARATE_COUNT))
+                    );
                 }
             }
         }
@@ -212,7 +229,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("xyz"), false)));
+                    assertEquals(0, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("xyz"), SEPARATE_COUNT)));
                 }
             }
         }
@@ -237,7 +254,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    slowCount = searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, false));
+                    slowCount = searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, SEPARATE_COUNT));
                 }
             }
         }
@@ -253,7 +270,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    fastCount = searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, false));
+                    fastCount = searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, SEPARATE_COUNT));
                 }
             }
         }
@@ -272,7 +289,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query rewritten = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef(""), false).rewrite(searcher);
+                    Query rewritten = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef(""), SEPARATE_COUNT).rewrite(searcher);
                     assertThat(rewritten, Matchers.instanceOf(BinaryDocValuesLengthQuery.class));
                 }
             }
@@ -291,7 +308,11 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    ScanningBinaryDocValuesTermQuery q = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("hello"), false);
+                    ScanningBinaryDocValuesTermQuery q = new ScanningBinaryDocValuesTermQuery(
+                        fieldName,
+                        new BytesRef("hello"),
+                        SEPARATE_COUNT
+                    );
                     assertSame("rewrite must return this for a non-empty term", q, q.rewrite(searcher));
                 }
             }
@@ -316,7 +337,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 BytesRef term = new BytesRef("hello");
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, true)));
+                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, ARRAY_ORDER_INLINE_NULL)));
                 }
             }
         }
@@ -337,7 +358,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 BytesRef term = new BytesRef("hello");
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, true)));
+                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesTermQuery(fieldName, term, ARRAY_ORDER_INLINE_NULL)));
                 }
             }
         }
@@ -369,14 +390,14 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                     );
                     searcher.setCircuitBreaker(breaker);
 
-                    Query present = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("hello"), false);
+                    Query present = new ScanningBinaryDocValuesTermQuery(fieldName, new BytesRef("hello"), SEPARATE_COUNT);
                     expectThrows(CircuitBreakingException.class, () -> searcher.count(present));
                     // Checkpointed with 0 bytes so the child breaker never accumulates and nothing needs releasing.
                     assertEquals(0L, checkpointedBytes.get());
 
                     // A field absent from the segment opens no binary doc values reader, so the checkpoint must not fire.
                     checkpointedBytes.set(-1);
-                    Query absent = new ScanningBinaryDocValuesTermQuery("missing", new BytesRef("hello"), false);
+                    Query absent = new ScanningBinaryDocValuesTermQuery("missing", new BytesRef("hello"), SEPARATE_COUNT);
                     assertEquals(0, searcher.count(absent));
                     assertEquals(-1L, checkpointedBytes.get());
 
@@ -389,10 +410,10 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
     }
 
     public void testEqualsAndHashCode() {
-        ScanningBinaryDocValuesTermQuery q1 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("term"), false);
-        ScanningBinaryDocValuesTermQuery q2 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("term"), false);
-        ScanningBinaryDocValuesTermQuery q3 = new ScanningBinaryDocValuesTermQuery("other", new BytesRef("term"), false);
-        ScanningBinaryDocValuesTermQuery q4 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("other"), false);
+        ScanningBinaryDocValuesTermQuery q1 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("term"), SEPARATE_COUNT);
+        ScanningBinaryDocValuesTermQuery q2 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("term"), SEPARATE_COUNT);
+        ScanningBinaryDocValuesTermQuery q3 = new ScanningBinaryDocValuesTermQuery("other", new BytesRef("term"), SEPARATE_COUNT);
+        ScanningBinaryDocValuesTermQuery q4 = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("other"), SEPARATE_COUNT);
 
         assertEquals(q1, q2);
         assertEquals(q1.hashCode(), q2.hashCode());
@@ -406,7 +427,7 @@ public class ScanningBinaryDocValuesTermQueryTests extends ESTestCase {
                 addSingleValueDoc(writer, "field", "hello");
                 try (DirectoryReader reader = forbidBinaryDvOpenReader(writer.getReader())) {
                     final IndexSearcher searcher = new IndexSearcher(reader);
-                    final Weight weight = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("hello"), false).createWeight(
+                    final Weight weight = new ScanningBinaryDocValuesTermQuery("field", new BytesRef("hello"), SEPARATE_COUNT).createWeight(
                         searcher,
                         ScoreMode.COMPLETE_NO_SCORES,
                         1f

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesWildcardQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesWildcardQueryTests.java
@@ -34,6 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL;
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
 import static org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery.getContainsPattern;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -54,12 +56,21 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // Automaton wildcard "be*" matches "beta" and "best"; the all-null doc preceding "best" must not be matched.
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "be*", false, true)));
+                    assertEquals(
+                        2,
+                        searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "be*", false, ARRAY_ORDER_INLINE_NULL))
+                    );
                     // "*et*" rewrites to a contains query: with a multi-valued doc present in the segment the contains fast path is gated
                     // off and the per-value decode fallback runs, so only "beta" (which contains "et") matches — not "best".
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*et*", false, true)));
+                    assertEquals(
+                        1,
+                        searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*et*", false, ARRAY_ORDER_INLINE_NULL))
+                    );
                     // "*ph*" contains-matches "alpha" only.
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ph*", false, true)));
+                    assertEquals(
+                        1,
+                        searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ph*", false, ARRAY_ORDER_INLINE_NULL))
+                    );
                 }
             }
         }
@@ -101,7 +112,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
                         long count = searcher.count(
-                            new ScanningBinaryDocValuesWildcardQuery(fieldName, entry.getKey() + "*", false, false)
+                            new ScanningBinaryDocValuesWildcardQuery(fieldName, entry.getKey() + "*", false, SEPARATE_COUNT)
                         );
                         assertEquals(entry.getValue().longValue(), count);
                     }
@@ -119,7 +130,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, false);
+                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, SEPARATE_COUNT);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -144,7 +155,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, false);
+                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, SEPARATE_COUNT);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -188,7 +199,12 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     );
                     TopDocs baselineResults = searcher.search(baselineQuery, 32);
 
-                    Query contenderQuery = new ScanningBinaryDocValuesWildcardQuery("contender_field", randomWildcard, false, false);
+                    Query contenderQuery = new ScanningBinaryDocValuesWildcardQuery(
+                        "contender_field",
+                        randomWildcard,
+                        false,
+                        SEPARATE_COUNT
+                    );
                     TopDocs contenderResults = searcher.search(contenderQuery, 32);
 
                     assertThat(contenderResults.totalHits, equalTo(baselineResults.totalHits));
@@ -231,7 +247,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", false, false);
+                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", false, SEPARATE_COUNT);
                     Query rewritten = query.rewrite(searcher);
                     assertThat(rewritten, instanceOf(BinaryDocValuesContainsTermQuery.class));
                     assertEquals(3, searcher.count(rewritten));
@@ -251,7 +267,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ell*", false, false);
+                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ell*", false, SEPARATE_COUNT);
                     Query rewritten = query.rewrite(searcher);
                     assertThat(rewritten, instanceOf(BinaryDocValuesContainsTermQuery.class));
                     assertEquals(2, searcher.count(rewritten));
@@ -268,7 +284,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", true, false);
+                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", true, SEPARATE_COUNT);
                     Query rewritten = query.rewrite(searcher);
                     assertThat(rewritten, instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
                     assertEquals(1, searcher.count(rewritten));
@@ -286,13 +302,13 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
 
-                    Query prefixQuery = new ScanningBinaryDocValuesWildcardQuery(fieldName, "foo*", false, false);
+                    Query prefixQuery = new ScanningBinaryDocValuesWildcardQuery(fieldName, "foo*", false, SEPARATE_COUNT);
                     assertThat(prefixQuery.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
 
-                    Query multiWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*foo*bar*", false, false);
+                    Query multiWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*foo*bar*", false, SEPARATE_COUNT);
                     assertThat(multiWildcard.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
 
-                    Query singleCharWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*fo?*", false, false);
+                    Query singleCharWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*fo?*", false, SEPARATE_COUNT);
                     assertThat(singleCharWildcard.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
                 }
             }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -56,6 +56,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.StringBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.ArrayOrderBinaryDocValuesSyntheticFieldLoaderLayer;
+import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
@@ -73,7 +74,6 @@ import org.elasticsearch.index.mapper.TextFamilyFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader.ArrayOrderSource;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.search.FuzzyQueries;
@@ -328,6 +328,11 @@ public class WildcardFieldMapper extends FieldMapper {
          */
         boolean usesArrayOrderBinaryDocValues() {
             return arrayOrderBinaryDocValues;
+        }
+
+        /** Which framing a reader of this field's binary doc values has to decode. */
+        private BinaryDocValuesFormat binaryFormat() {
+            return arrayOrderBinaryDocValues ? BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL : BinaryDocValuesFormat.SEPARATE_COUNT;
         }
 
         @Override
@@ -1040,10 +1045,7 @@ public class WildcardFieldMapper extends FieldMapper {
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             if (hasDocValues()) {
                 if (indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
-                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(
-                        name(),
-                        arrayOrderBinaryDocValues ? ArrayOrderSource.INLINE : ArrayOrderSource.NONE
-                    );
+                    return new BytesRefsFromBinaryMultiSeparateCountBlockLoader(name(), binaryFormat());
                 }
                 return new BytesRefsFromCustomBinaryBlockLoader(name());
             }
@@ -1058,7 +1060,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 CoreValuesSourceType.KEYWORD,
                 WildcardDocValuesField::new,
                 indexVersion,
-                arrayOrderBinaryDocValues
+                binaryFormat()
             );
         }
 


### PR DESCRIPTION
Stacked on #157948, which has to merge first. This branch carries that PR's commit as its first commit, so until it merges the diff here shows both — **review the second commit only** ("Name the binary doc-values format once"). Once #157948 is in, this collapses to just its own change.

Collapses three spellings of one question into a single `BinaryDocValuesFormat`, in preparation for a third framing (the ColumNAR string payload, #157944).

Which framing a field's binary blobs use was passed as a `boolean arrayOrderInlineNull` to the doc-values queries, a `boolean arrayOrder` to fielddata and index sorting, and a two-valued `ArrayOrderSource` to the block loaders. All three ask the same thing, and all three name it after array order — which is a consequence of the framing, not the framing itself. They become one enum, one constant per framing, taken from the mapping everywhere. The mappers that keep their own boolean convert at the call.

Three parts worth a closer look:

`KeywordFieldType.DocValuesDiskFormat` now carries a `BinaryDocValuesFormat` rather than a `boolean binary`. `isBinary()` falls out of it, and the byte layout is written down in one place instead of being described in both enums — which matters because the third framing would otherwise have to be added to both. `KeywordFieldType.binaryFormat()` is `@Nullable` as a result: a sorted-set field has no framing, and answering `SEPARATE_COUNT` for it would be naming one a caller could act on. Every reader is already behind `usesBinaryDocValues()`, except the `LENGTH` block loader, which resolves the sorted-set column first and never reaches the branch that reads the framing.

`MultiValuedBinaryDocValuesSortField` persists the format into segment info, because Lucene rebuilds the sort field at merge time with no mapping in reach. It already wrote the boolean as an int, so it now writes an ordinal — `SEPARATE_COUNT` and `ARRAY_ORDER_INLINE_NULL` keep positions 0 and 1, which makes existing segments read back as themselves. `MultiValuedBinaryDocValuesSortFieldTests` pins those two ordinals, since appending is safe and reordering is not. An ordinal outside the enum — a damaged segment, or one from a newer node — is now a `CorruptIndexException` rather than an array index out of bounds raised from inside Lucene's read.

**The one behavior change:** the scanning queries compare the format in `equals`/`hashCode`. Only `ScanningBinaryDocValuesRangeQuery` did before, which also meant the field-type tests asserting on a constructed query couldn't actually tell the two framings apart. Two queries that differ in framing decode differently, so conflating them in the query cache was only ever safe because the framing is fixed per field — this makes that explicit rather than load-bearing. The keyed queries are left alone: theirs is fixed per class, so `sameClassAs` already separates them.
