### PR TITLE
[9.5] Audit: reject oversized request bodies (#157760)

### DIFF
--- a/docs/changelog/157760.yaml
+++ b/docs/changelog/157760.yaml
@@ -1,0 +1,5 @@
+area: Audit
+issues: []
+pr: 157760
+summary: "Audit: reject oversized request bodies"
+type: enhancement

--- a/docs/reference/elasticsearch/configuration-reference/auding-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/auding-settings.md
@@ -68,7 +68,10 @@ $$$xpack-sa-lf-events-emit-request$$$
     Be advised that sensitive data may be audited in plain text when including the request body in audit events, even though all the security APIs, such as those that change the user’s password, have the credentials filtered out when audited.
     ::::
 
+$$$xpack-sa-lf-events-max-request-body-size$$$
 
+`xpack.security.audit.logfile.events.max_request_body_size` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+:   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) Maximum rendered JSON body size (in characters) that may be included in audit events when [`xpack.security.audit.logfile.events.emit_request_body`](#xpack-sa-lf-events-emit-request) is `true`. The limit is applied to the JSON representation of the request body (after format conversion), so it correctly accounts for formats that expand when converted to JSON. Requests whose rendered body exceeds this limit are rejected with HTTP 413 (Request Entity Too Large), ensuring the audit log is always a complete record of accepted requests. The default value is `2147483647b` (`Integer.MAX_VALUE`). Set to `0` to disable the limit entirely. Lower this value on nodes with limited available memory as needed.
 
 ## Local Node Info Settings [node-audit-settings]
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
@@ -23,6 +23,13 @@ public interface AuditTrail {
 
     String name();
 
+    /**
+     * Records a successful authentication for the given REST request.
+     *
+     * @throws org.elasticsearch.ElasticsearchStatusException with status 413 if the request body
+     *     exceeds the configured audit body size limit
+     *     ({@link org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail#MAX_REQUEST_BODY_SIZE})
+     */
     void authenticationSuccess(RestRequest request);
 
     void authenticationSuccess(String requestId, Authentication authentication, String action, TransportRequest transportRequest);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
@@ -6,16 +6,18 @@
  */
 package org.elasticsearch.xpack.security.audit;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.TransportRequest;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,12 +27,36 @@ public class AuditUtil {
     // We need to expose this to allow-list as a header passed for cross cluster requests; see `CrossClusterAccessServerTransportFilter`
     public static final String AUDIT_REQUEST_ID = "_xpack_audit_request_id";
 
-    public static String restRequestContent(RestRequest request) {
+    /**
+     * Renders the body of {@code request} as a JSON string for inclusion in audit log events.
+     * <p>
+     * If {@code maxBytes > 0} and the rendered JSON length exceeds that limit, an
+     * {@link ElasticsearchStatusException} with status 413 is thrown so the caller can reject
+     * the request before it is written to the audit log.
+     *
+     * @param maxBytes   maximum allowed length of the rendered JSON string, in characters; {@code 0} = unlimited
+     * @param settingKey the cluster setting key to include in the error message; may be {@code null}
+     *                   when {@code maxBytes} is {@code 0}
+     */
+    public static String restRequestContent(RestRequest request, int maxBytes, String settingKey) {
         if (request.hasContent()) {
             var content = request.content();
             try {
-                return XContentHelper.convertToJson(content, false, false, request.getXContentType());
-            } catch (IOException ioe) {
+                String json = XContentHelper.convertToJson(content, false, false, request.getXContentType());
+                if (maxBytes > 0 && json.length() > maxBytes) {
+                    throw new ElasticsearchStatusException(
+                        "Request body size [{}] exceeds the audit body size limit [{}]; "
+                            + "adjust the [{}] setting to increase the limit or set it to 0 to disable",
+                        RestStatus.REQUEST_ENTITY_TOO_LARGE,
+                        ByteSizeValue.ofBytes(json.length()),
+                        ByteSizeValue.ofBytes(maxBytes),
+                        settingKey
+                    );
+                }
+                return json;
+            } catch (ElasticsearchStatusException e) {
+                throw e;
+            } catch (Exception e) {
                 return "Invalid Format: " + content.utf8ToString();
             }
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
@@ -288,6 +289,28 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         Property.NodeScope,
         Property.Dynamic
     );
+    /**
+     * Maximum rendered JSON length (in characters) that may be included in audit events when
+     * {@link #INCLUDE_REQUEST_BODY} is {@code true}. The limit is applied to the output of
+     * {@link org.elasticsearch.common.xcontent.XContentHelper#convertToJson} rather than the raw
+     * request bytes, so it accounts for format differences (e.g. SMILE expanding to JSON).
+     * Requests whose rendered body exceeds this limit are rejected with HTTP 413 to keep the
+     * audit log a complete record of every accepted request.
+     * <p>
+     * {@code 0} disables the limit (no rejection); use with caution on endpoints that may receive
+     * large bodies such as OTLP or Prometheus remote-write ingestion endpoints.
+     * <p>
+     * The default is {@link Integer#MAX_VALUE} bytes (the maximum representable value), which
+     * effectively imposes no limit beyond what the JVM can address in a single buffer.
+     */
+    public static final Setting<ByteSizeValue> MAX_REQUEST_BODY_SIZE = Setting.byteSizeSetting(
+        setting("audit.logfile.events.max_request_body_size"),
+        ByteSizeValue.ofBytes(Integer.MAX_VALUE),
+        ByteSizeValue.ZERO,
+        ByteSizeValue.ofBytes(Integer.MAX_VALUE),
+        Property.NodeScope,
+        Property.Dynamic
+    );
     // actions (and their requests) that are audited as "security change" events
     public static final Set<String> SECURITY_CHANGE_ACTIONS = Set.of(
         PutUserAction.NAME,
@@ -355,6 +378,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     // package for testing
     volatile EnumSet<AuditLevel> events;
     volatile boolean includeRequestBody;
+    /** Maximum bytes for {@code request.body}; {@code 0} means unlimited. Package-private for testing. */
+    volatile int maxRequestBodyBytes;
     // fields that all entries have in common
     EntryCommonFields entryCommonFields;
 
@@ -371,6 +396,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         this.logger = logger;
         this.events = parse(INCLUDE_EVENT_SETTINGS.get(settings), EXCLUDE_EVENT_SETTINGS.get(settings));
         this.includeRequestBody = INCLUDE_REQUEST_BODY.get(settings);
+        this.maxRequestBodyBytes = (int) MAX_REQUEST_BODY_SIZE.get(settings).getBytes();
         this.threadContext = threadContext;
         this.securityContext = new SecurityContext(settings, threadContext);
         this.entryCommonFields = new EntryCommonFields(settings, null, clusterService);
@@ -379,9 +405,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(newSettings -> {
             this.entryCommonFields = this.entryCommonFields.withNewSettings(newSettings);
             this.includeRequestBody = INCLUDE_REQUEST_BODY.get(newSettings);
+            this.maxRequestBodyBytes = (int) MAX_REQUEST_BODY_SIZE.get(newSettings).getBytes();
             // `events` is a volatile field! Keep `events` write last so that
-            // `entryCommonFields` and `includeRequestBody` writes happen-before! `events` is
-            // always read before `entryCommonFields` and `includeRequestBody`.
+            // `entryCommonFields`, `includeRequestBody`, and `maxRequestBodyBytes` writes happen-before!
+            // `events` is always read before `entryCommonFields` and `includeRequestBody`.
             this.events = parse(INCLUDE_EVENT_SETTINGS.get(newSettings), EXCLUDE_EVENT_SETTINGS.get(newSettings));
         },
             Arrays.asList(
@@ -393,7 +420,8 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 EMIT_CLUSTER_UUID_SETTING,
                 INCLUDE_EVENT_SETTINGS,
                 EXCLUDE_EVENT_SETTINGS,
-                INCLUDE_REQUEST_BODY
+                INCLUDE_REQUEST_BODY,
+                MAX_REQUEST_BODY_SIZE
             )
         );
         clusterService.getClusterSettings()
@@ -1083,6 +1111,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         return includeRequestBody;
     }
 
+    public int maxRequestBodyBytes() {
+        return maxRequestBodyBytes;
+    }
+
     private LogEntryBuilder securityChangeLogEntryBuilder(String requestId) {
         return new LogEntryBuilder(false).with(EVENT_TYPE_FIELD_NAME, SECURITY_CHANGE_ORIGIN_FIELD_VALUE).withRequestId(requestId);
     }
@@ -1639,7 +1671,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
 
         LogEntryBuilder withRequestBody(RestRequest request) {
             if (includeRequestBody) {
-                final String requestContent = restRequestContent(request);
+                final String requestContent = restRequestContent(request, maxRequestBodyBytes, MAX_REQUEST_BODY_SIZE.getKey());
                 if (Strings.hasLength(requestContent)) {
                     logEntry.with(REQUEST_BODY_FIELD_NAME, requestContent);
                 }
@@ -1811,6 +1843,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         settings.add(INCLUDE_EVENT_SETTINGS);
         settings.add(EXCLUDE_EVENT_SETTINGS);
         settings.add(INCLUDE_REQUEST_BODY);
+        settings.add(MAX_REQUEST_BODY_SIZE);
         settings.add(FILTER_POLICY_IGNORE_PRINCIPALS);
         settings.add(FILTER_POLICY_IGNORE_INDICES);
         settings.add(FILTER_POLICY_IGNORE_ROLES);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.rest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestChannel;
@@ -83,7 +84,12 @@ public class SecurityRestFilter implements RestInterceptor {
         // RestRequest might have stream content, in some cases we need to aggregate request content, for example audit logging.
         final Consumer<RestRequest> aggregationCallback = (aggregatedRestRequest) -> {
             final RestRequest wrappedRequest = maybeWrapRestRequest(aggregatedRestRequest, targetHandler);
-            auditTrailService.get().authenticationSuccess(wrappedRequest);
+            try {
+                auditTrailService.get().authenticationSuccess(wrappedRequest);
+            } catch (ElasticsearchStatusException e) {
+                handleException(aggregatedRestRequest, e, listener);
+                return;
+            }
             secondaryAuthenticator.authenticateAndAttachToContext(wrappedRequest, ActionListener.wrap(secondaryAuthentication -> {
                 if (secondaryAuthentication != null) {
                     logger.trace(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditUtilTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditUtilTests.java
@@ -6,21 +6,64 @@
  */
 package org.elasticsearch.xpack.security.audit;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.MockIndicesRequest;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.xcontent.XContentType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Unit tests for the audit utils class
  */
 public class AuditUtilTests extends ESTestCase {
+
+    // ── restRequestContent with JSON-length size limit ────────────────────────
+
+    public void testRestRequestContentExceedsLimitThrows() {
+        String json = "{\"key\":\"value\"}";
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON
+        ).build();
+        ElasticsearchStatusException ex = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> AuditUtil.restRequestContent(request, json.length() - 1, "xpack.security.audit.logfile.events.max_request_body_size")
+        );
+        assertThat(ex.status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    public void testRestRequestContentWithinLimitReturnsJson() {
+        String json = "{\"key\":\"value\"}";
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON
+        ).build();
+        assertEquals(json, AuditUtil.restRequestContent(request, json.length(), "setting.key"));
+    }
+
+    public void testRestRequestContentZeroLimitIsUnlimited() {
+        String json = "{\"key\":\"value\"}";
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON
+        ).build();
+        assertEquals(json, AuditUtil.restRequestContent(request, 0, null));
+    }
+
+    // ── indices ───────────────────────────────────────────────────────────────
 
     public void testIndicesRequest() {
         assertNull(AuditUtil.indices(new MockIndicesRequest(null, (String[]) null)));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -327,6 +327,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 LoggingAuditTrail.INCLUDE_EVENT_SETTINGS,
                 LoggingAuditTrail.EXCLUDE_EVENT_SETTINGS,
                 LoggingAuditTrail.INCLUDE_REQUEST_BODY,
+                LoggingAuditTrail.MAX_REQUEST_BODY_SIZE,
                 LoggingAuditTrail.FILTER_POLICY_IGNORE_PRINCIPALS,
                 LoggingAuditTrail.FILTER_POLICY_IGNORE_REALMS,
                 LoggingAuditTrail.FILTER_POLICY_IGNORE_ROLES,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.util.StandardCharset;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -26,6 +27,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestRequestFilter;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.TestMatchers;
@@ -58,6 +60,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
@@ -73,6 +76,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -422,6 +426,66 @@ public class SecurityRestFilterTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    /**
+     * When {@code AuditUtil.restRequestContent} detects an oversized body during auditing, it
+     * throws {@link ElasticsearchStatusException} with status 413. {@link SecurityRestFilter}
+     * must catch that exception and reject the request without processing it further.
+     */
+    public void testRejectsOversizedBodyWhenBodyAuditingEnabled() throws Exception {
+        FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withContent(
+            new BytesArray(randomByteArrayOfLength(20)),
+            XContentType.JSON
+        ).build();
+
+        AuditTrail auditTrail = mock(AuditTrail.class);
+        AuditTrailService auditTrailService = mock(AuditTrailService.class);
+        when(auditTrailService.get()).thenReturn(auditTrail);
+        doThrow(new ElasticsearchStatusException("body exceeds audit limit", RestStatus.REQUEST_ENTITY_TOO_LARGE)).when(auditTrail)
+            .authenticationSuccess(any());
+
+        SecurityRestFilter testFilter = new SecurityRestFilter(
+            true,
+            true,
+            threadContext,
+            secondaryAuthenticator,
+            auditTrailService,
+            NOOP_OPERATOR_PRIVILEGES_SERVICE
+        );
+
+        PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        testFilter.intercept(restRequest, channel, restHandler, future);
+
+        ExecutionException ex = expectThrows(ExecutionException.class, future::get);
+        assertTrue(ex.getCause() instanceof ElasticsearchStatusException);
+        assertThat(((ElasticsearchStatusException) ex.getCause()).status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    /** When {@code authenticationSuccess} does not throw, the request proceeds normally. */
+    public void testAcceptsBodyWithinAuditLimit() throws Exception {
+        FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withContent(
+            new BytesArray(randomByteArrayOfLength(5)),
+            XContentType.JSON
+        ).build();
+        when(channel.request()).thenReturn(restRequest);
+
+        AuditTrail auditTrail = mock(AuditTrail.class);
+        AuditTrailService auditTrailService = mock(AuditTrailService.class);
+        when(auditTrailService.get()).thenReturn(auditTrail);
+
+        SecurityRestFilter testFilter = new SecurityRestFilter(
+            true,
+            true,
+            threadContext,
+            secondaryAuthenticator,
+            auditTrailService,
+            NOOP_OPERATOR_PRIVILEGES_SERVICE
+        );
+
+        PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        testFilter.intercept(restRequest, channel, restHandler, future);
+        assertThat(future.get(), is(Boolean.TRUE));
     }
 
     private interface FilteredRestHandler extends RestHandler, RestRequestFilter {}


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Audit: reject oversized request bodies (#157760)