### PR TITLE
[9.5] Fix NaN handling in PromqlHistogramQuantileTestHelpers (#157474)

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PromqlHistogramQuantileTestHelpers.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PromqlHistogramQuantileTestHelpers.java
@@ -148,7 +148,8 @@ final class PromqlHistogramQuantileTestHelpers {
         Bucket previous = buckets.getFirst();
         for (int i = 1; i < buckets.size(); i++) {
             Bucket bucket = buckets.get(i);
-            if (bucket.upperBound() == previous.upperBound()) {
+            if (bucket.upperBound() == previous.upperBound()
+                || (Double.isNaN(bucket.upperBound()) && Double.isNaN(previous.upperBound()))) {
                 previous = new Bucket(previous.upperBound(), previous.count() + bucket.count());
             } else {
                 result.add(previous);


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix NaN handling in PromqlHistogramQuantileTestHelpers (#157474)