### PR TITLE
[9.5] Fix FLS field names term state filtering (#157889)

### DIFF
--- a/docs/changelog/157889.yaml
+++ b/docs/changelog/157889.yaml
@@ -1,0 +1,5 @@
+area: Authorization
+issues: []
+pr: 157889
+summary: Fix FLS field names term state filtering
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FilterIterator;
+import org.apache.lucene.util.IOBooleanSupplier;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -723,6 +724,12 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
         @Override
         public boolean seekExact(BytesRef term) throws IOException {
             return accept(term) && in.seekExact(term);
+        }
+
+        @Override
+        public IOBooleanSupplier prepareSeekExact(BytesRef term) throws IOException {
+            // TermStates uses this method before seekExact(term, state), so the field filter must be applied at both stages.
+            return accept(term) ? in.prepareSeekExact(term) : null;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -47,6 +48,8 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TermsEnum.SeekStatus;
 import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -1249,6 +1252,47 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
 
         TestUtil.checkReader(ir);
         IOUtils.close(ir, iw, dir);
+    }
+
+    public void testFieldNamesTermStateForDeniedParentWithAllowedMultiField() throws Exception {
+        DocumentMapper mapper = createMapperService(mapping(b -> {
+            b.startObject("my_field");
+            b.field("type", "text");
+            b.field("norms", false);
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").field("doc_values", false).endObject();
+            b.endObject();
+            b.endObject();
+        })).documentMapper();
+
+        try (
+            Directory directory = newDirectory();
+            StandardAnalyzer analyzer = new StandardAnalyzer();
+            IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer))
+        ) {
+            ParsedDocument document = mapper.parse(source(b -> b.field("my_field", "test")));
+            writer.addDocuments(document.docs());
+
+            Automaton automaton = Automatons.patterns(List.of("my_field.keyword", FieldNamesFieldMapper.NAME));
+            try (
+                DirectoryReader reader = FieldSubsetReader.wrap(
+                    DirectoryReader.open(writer),
+                    new CharacterRunAutomaton(automaton),
+                    IgnoredSourceFieldMapper.IgnoredSourceFormat.NO_IGNORED_SOURCE,
+                    fieldName -> false
+                )
+            ) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                TermQuery parentExistsQuery = new TermQuery(new Term(FieldNamesFieldMapper.NAME, "my_field"));
+
+                assertEquals(1, searcher.count(new TermQuery(new Term("my_field.keyword", "test"))));
+                assertEquals(1, searcher.count(new TermQuery(new Term(FieldNamesFieldMapper.NAME, "my_field.keyword"))));
+                assertEquals(0, searcher.count(parentExistsQuery));
+                assertEquals(0L, searcher.search(parentExistsQuery, 10).totalHits.value());
+
+                TestUtil.checkReader(reader);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Fix FLS field names term state filtering (#157889)