### PR TITLE
[ESQL] Keep zero-overlap UBN files

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-union-by-name.csv-spec
+++ b/x-pack/plugin/esql-datasource-csv/qa/src/javaRestTest/resources/csv-union-by-name.csv-spec
@@ -67,6 +67,62 @@ charlie      | paris
 dave         | london
 ;
 
+// STATS BY a column missing from some files must still count those files' rows as the null group.
+multiFileUnionByNameCountByCity
+required_capability: dataset_in_from_command
+required_capability: external_csv_header_row_option
+required_capability: external_source_read_schema
+required_capability: datasource_file_readers_no_text_type
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"header_row": true, "schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| STATS c = COUNT(*) BY city
+| SORT city ASC;
+warningRegex:declared column \[city\] is not present in some source files
+
+c:long | city:keyword
+1      | london
+1      | paris
+2      | null
+;
+
+// KEEP a column missing from some files must still return those files' rows as null.
+multiFileUnionByNameProjectCityOnly
+required_capability: dataset_in_from_command
+required_capability: external_csv_header_row_option
+required_capability: external_source_read_schema
+required_capability: datasource_file_readers_no_text_type
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"header_row": true, "schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| KEEP city
+| SORT city ASC;
+warningRegex:declared column \[city\] is not present in some source files
+
+city:keyword
+london
+paris
+null
+null
+;
+
+// WHERE city IS NULL must match file A's rows (city is absent there, so every row is null).
+multiFileUnionByNameFilterCityIsNull
+required_capability: dataset_in_from_command
+required_capability: external_csv_header_row_option
+required_capability: external_source_read_schema
+required_capability: datasource_file_readers_no_text_type
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"header_row": true, "schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| WHERE city IS NULL
+| STATS count = COUNT(*);
+warningRegex:declared column \[city\] is not present in some source files
+
+count:long
+2
+;
+
 // =========================================================================================
 // UNION_BY_NAME × cross-file type drift — KEYWORD fallback end-to-end (issue esql-planning#794).
 //

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-multifile.csv-spec
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-multifile.csv-spec
@@ -159,6 +159,43 @@ count:long
 4
 ;
 
+// STATS BY a column missing from some files must still count those files' rows as the null group.
+// File A has no city: alice/bob land in city=null. File B contributes paris and london.
+parquetUbnCountByCity
+required_capability: dataset_in_from_command
+required_capability: external_source_read_schema
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| STATS c = COUNT(*) BY city
+| SORT city ASC;
+warningRegex:declared column \[city\] is not present in some source files
+
+c:long | city:keyword
+1      | london
+1      | paris
+2      | null
+;
+
+// KEEP a column missing from some files must still return those files' rows as null.
+// parquetUbnProjectPruning does not cover this: KEEP name, city overlaps file A on name.
+parquetUbnProjectCityOnly
+required_capability: dataset_in_from_command
+required_capability: external_source_read_schema
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| KEEP city
+| SORT city ASC;
+warningRegex:declared column \[city\] is not present in some source files
+
+city:keyword
+london
+paris
+null
+null
+;
+
 parquetUbnProjectPruning
 required_capability: dataset_in_from_command
 required_capability: external_source_read_schema
@@ -196,6 +233,22 @@ FROM employees_multifile_ubn_union
 
 name:keyword | city:keyword
 charlie      | paris
+;
+
+// WHERE city IS NULL must match file A's rows (city is absent there, so every row is null).
+// The overlap skip used to drop file A before the IS NULL carve-out, returning 0.
+parquetUbnFilterCityIsNull
+required_capability: dataset_in_from_command
+required_capability: external_source_read_schema
+dataset: employees_multifile_ubn_union: "{{employees_multifile_ubn}}" WITH {"schema_resolution": "union_by_name"}
+
+FROM employees_multifile_ubn_union
+| WHERE city IS NULL
+| STATS count = COUNT(*);
+warningRegex:declared column \[city\] is not present in some source files
+
+count:long
+2
 ;
 
 parquetUbnFilterOnFileBMissingColumn

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -326,7 +326,7 @@ public class FileSplitProvider implements SplitProvider {
         List<Expression> filterHints = context.filterHints();
         // Strip partition columns from the Query schema before per-file work: their values come
         // from the storage path, not from file bytes, so they don't participate in the file-read
-        // narrowing or in the no-overlap skip check.
+        // narrowing.
         ExternalSchema fileBackedQuerySchema = stripPartitionColumns(context.querySchema(), partitionInfo);
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = context.schemaMap();
 
@@ -365,10 +365,10 @@ public class FileSplitProvider implements SplitProvider {
 
             // Phase 1: sequential filtering — cheap, in-memory predicates applied per file to
             // build the list of FileTask items that need I/O (footer reads, boundary scans).
-            // Tracks whether any file was dropped by the row-count-unsafe no-column-overlap heuristic:
-            // such a file still contributes rows to COUNT(*), so an all-dropped result driven by it is
-            // NOT an exhaustive prune and must fall back to a full read (see SplitDiscoveryResult).
-            boolean droppedByColumnOverlap = false;
+            // certifiedSkips counts only row-count-preserving continues (partition prune,
+            // missing-column filter). A future skip that forgets to increment it cannot claim
+            // exhaustivelyPruned when every file is dropped; the coordinator falls back to a full read.
+            int certifiedSkips = 0;
             // Bytes of the files that will be cut at a stride, which are the only ones that cost probe reads and so
             // the only ones the probe budget is shared between. See strideBoundedByProbeBudget.
             long probedFileBytes = 0;
@@ -388,27 +388,19 @@ public class FileSplitProvider implements SplitProvider {
                 if (partitionValues.isEmpty() == false && filterHints.isEmpty() == false) {
                     if (matchesPartitionFilters(partitionValues, filterHints) == false) {
                         // Partition pruning: the path values alone disprove the filter, so the file is skipped unread.
+                        certifiedSkips++;
                         continue;
                     }
                 }
 
-                SchemaReconciliation.FileSchemaInfo fileSchemaInfo = schemaInfo != null ? schemaInfo.get(filePath) : null;
-
-                if (fileBackedQuerySchema.isEmpty() == false && fileSchemaInfo != null) {
-                    if (skipIfNoColumnOverlap(fileSchemaInfo.fileSchema(), fileBackedQuerySchema)) {
-                        // Row-count-unsafe: the file's rows still exist (they would be all-NULL for the query's
-                        // columns), so COUNT(*) and other row-count-sensitive queries need them. Skipping is a
-                        // best-effort optimization that relies on a full-read fallback when it empties the plan.
-                        droppedByColumnOverlap = true;
-                        continue;
-                    }
-                }
+                SchemaReconciliation.FileSchemaInfo fileSchemaInfo = schemaInfo.get(filePath);
 
                 if (filterHints.isEmpty() == false && fileSchemaInfo != null) {
                     Set<String> fileColumnNames = new LinkedHashSet<>(fileSchemaInfo.fileSchema().names());
                     // Partition columns are always available (values come from paths, not file data)
                     fileColumnNames.addAll(partitionValues.keySet());
                     if (skipIfFilterOnMissingColumns(filterHints, fileColumnNames)) {
+                        certifiedSkips++;
                         continue;
                     }
                 }
@@ -434,30 +426,27 @@ public class FileSplitProvider implements SplitProvider {
                 ColumnMapping columnMapping = null;
                 List<Attribute> readSchema = null;
                 Map<String, DataType> inferredFileTypes = null;
-                if (schemaInfo != null) {
-                    SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(filePath);
-                    if (info != null) {
-                        inferredFileTypes = info.inferredTypes();
-                        ColumnMapping mapping = info.mapping();
-                        if (mapping != null && unifiedSchema != null && fileBackedQuerySchema.isEmpty() == false) {
-                            // Fused narrowing: output dimension goes from Unified to Query, read
-                            // dimension goes from File to per-file Query projection. See the
-                            // four-schema doc on SchemaReconciliation. For Hive-partitioned sources
-                            // context.unifiedSchema() is the post-shadow data-only schema (partition
-                            // columns are appended only to the coordinator-facing schema, never here), so
-                            // its width matches each per-file mapping built by shadowPartitionCollisions and
-                            // satisfies pruneToPerFileQuery's unifiedSchema.size() == index.length assertion.
-                            mapping = mapping.pruneToPerFileQuery(unifiedSchema, info.fileSchema(), fileBackedQuerySchema);
-                        }
-                        if (mapping != null && mapping.isIdentity() == false) {
-                            columnMapping = mappingCache.computeIfAbsent(mapping, k -> k);
-                        }
-                        // Pin the reader to the coordinator's reconciled per-file read schema so it
-                        // doesn't re-infer at runtime and disagree with the planner's view of this file.
-                        // For text formats this schema already carries each widened column's reconciled
-                        // type (see SchemaReconciliation), so the reader reads at that type directly.
-                        readSchema = info.fileSchema().attributes();
+                if (fileSchemaInfo != null) {
+                    inferredFileTypes = fileSchemaInfo.inferredTypes();
+                    ColumnMapping mapping = fileSchemaInfo.mapping();
+                    if (mapping != null && unifiedSchema != null && fileBackedQuerySchema.isEmpty() == false) {
+                        // Fused narrowing: output dimension goes from Unified to Query, read
+                        // dimension goes from File to per-file Query projection. See the
+                        // four-schema doc on SchemaReconciliation. For Hive-partitioned sources
+                        // context.unifiedSchema() is the post-shadow data-only schema (partition
+                        // columns are appended only to the coordinator-facing schema, never here), so
+                        // its width matches each per-file mapping built by shadowPartitionCollisions and
+                        // satisfies pruneToPerFileQuery's unifiedSchema.size() == index.length assertion.
+                        mapping = mapping.pruneToPerFileQuery(unifiedSchema, fileSchemaInfo.fileSchema(), fileBackedQuerySchema);
                     }
+                    if (mapping != null && mapping.isIdentity() == false) {
+                        columnMapping = mappingCache.computeIfAbsent(mapping, k -> k);
+                    }
+                    // Pin the reader to the coordinator's reconciled per-file read schema so it
+                    // doesn't re-infer at runtime and disagree with the planner's view of this file.
+                    // For text formats this schema already carries each widened column's reconciled
+                    // type (see SchemaReconciliation), so the reader reads at that type directly.
+                    readSchema = fileSchemaInfo.fileSchema().attributes();
                 }
 
                 tasks.add(
@@ -482,10 +471,10 @@ public class FileSplitProvider implements SplitProvider {
             }
 
             if (tasks.isEmpty()) {
-                // Every file was dropped. Only a resolved, non-empty file list whose files were all removed by
-                // row-count-preserving filter contradictions (no no-overlap heuristic among them) is a true
-                // exhaustive prune the phase may trust to read nothing; otherwise fall back to a full read.
-                boolean exhaustivelyPruned = fileList.fileCount() > 0 && droppedByColumnOverlap == false;
+                // Exhaustive only when every file was dropped by a certified row-count-preserving skip.
+                // An unresolved or already-empty file list is not a prune (fileCount == 0). A skip that
+                // is not counted above leaves certifiedSkips < fileCount and falls back to a full read.
+                boolean exhaustivelyPruned = fileList.fileCount() > 0 && certifiedSkips == fileList.fileCount();
                 return new SplitDiscoveryResult(List.of(), 0, exhaustivelyPruned);
             }
 
@@ -2026,20 +2015,6 @@ public class FileSplitProvider implements SplitProvider {
             return querySchema;
         }
         return new ExternalSchema(filtered);
-    }
-
-    /**
-     * Returns {@code true} when the file's data columns have zero overlap with the query schema,
-     * meaning this file would produce only NULL rows for all needed columns.
-     */
-    static boolean skipIfNoColumnOverlap(ExternalSchema fileSchema, ExternalSchema querySchema) {
-        Set<String> queryNames = querySchema.names();
-        for (Attribute attr : fileSchema) {
-            if (queryNames.contains(attr.name())) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -314,8 +314,8 @@ public final class SplitDiscoveryPhase {
             // No splits because every file was eliminated by a row-count-preserving filter contradiction (see
             // SplitDiscoveryResult#exhaustivelyPruned). Swap in FileList.EMPTY so the read path scans nothing; a row
             // filter still runs downstream, so the answer is unchanged (0 rows). An empty result that is NOT an
-            // exhaustive prune (unresolved glob, SINGLE source, or a row-count-unsafe no-overlap drop) falls through
-            // to the whole read. Return before the stats increments below to keep honest zero scanned counts.
+            // exhaustive prune (unresolved glob, SINGLE source, empty file list) falls through to the whole read.
+            // Return before the stats increments below to keep honest zero scanned counts.
             if (result.exhaustivelyPruned()) {
                 return exec.withFileList(FileList.EMPTY);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryContext.java
@@ -25,7 +25,7 @@ import java.util.function.BooleanSupplier;
  * @param querySchema the post-prune Query schema (data attributes only, metadata stripped) the
  *        query actually materializes. Empty means either all columns are needed or the projection
  *        is unknown. Split providers use {@link ExternalSchema#names()} for membership tests when pruning
- *        per-file mappings or skipping files with no column overlap.
+ *        per-file mappings.
  * @param unifiedSchema the pre-prune Unified schema, or {@code null} when not available. Together
  *        with {@code querySchema} and each file's schema this lets split providers narrow per-file
  *        {@link org.elasticsearch.xpack.esql.datasources.ColumnMapping}s on the coordinator.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryResult.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitDiscoveryResult.java
@@ -23,13 +23,12 @@ import java.util.List;
  *
  * <p>{@code exhaustivelyPruned} is {@code true} only when {@link #splits()} is empty <em>because</em>
  * every file was eliminated by a row-count-preserving filter contradiction — a partition/metadata
- * predicate that evaluated to {@code false}, or a filter over a column absent from the file (both
- * make the {@code WHERE} unsatisfiable, so a full read would emit zero rows too). It is deliberately
- * {@code false} when the empty result is a best-effort heuristic that a downstream read would have
- * disagreed with (e.g. a file dropped for having no column overlap with the query still contributes
- * rows to {@code COUNT(*)}). Only the former is safe for {@code SplitDiscoveryPhase} to trust as
- * "read nothing"; the latter must fall back to a full read so the row filter runs. An empty result
- * from an unresolved or empty file list is not a prune and reports {@code false}.
+ * predicate that evaluated to {@code false}, or a missing-column filter that is unsatisfiable in
+ * {@code WHERE} (comparisons, {@code IN}, {@code IS NOT NULL}; {@code IS NULL} on a missing column
+ * matches every row and is not a prune). Those cases emit zero rows on a full read too, so
+ * {@code SplitDiscoveryPhase} may trust them as "read nothing". An empty result that is not a
+ * proven filter contradiction — unresolved glob, empty file list, or a provider that cannot certify
+ * the prune — reports {@code false} and must fall back to a full read.
  */
 public record SplitDiscoveryResult(List<ExternalSplit> splits, int filesScanned, boolean exhaustivelyPruned) {
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -205,6 +205,39 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     /**
+     * The other certified producer of {@code exhaustivelyPruned}: every file is dropped because a WHERE
+     * conjunct references a column absent from that file (UNKNOWN → FALSE). Same coordinator signal as
+     * {@link #testAllPartitionsPrunedYieldsNoSplitsAndExhaustivePrune}.
+     */
+    public void testAllFilesDroppedByMissingColumnFilterAreExhaustivePrune() {
+        StoragePath pathA = StoragePath.of("s3://b/a.parquet");
+        StoragePath pathB = StoragePath.of("s3://b/b.parquet");
+        FileList fileList = GlobExpander.fileListOf(
+            List.of(new StorageEntry(pathA, 100, Instant.EPOCH), new StorageEntry(pathB, 200, Instant.EPOCH)),
+            "s3://b/*.parquet"
+        );
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = new HashMap<>();
+        schemaInfo.put(pathA, new SchemaReconciliation.FileSchemaInfo(new ExternalSchema(List.of(refAttr("name"))), null, null));
+        schemaInfo.put(pathB, new SchemaReconciliation.FileSchemaInfo(new ExternalSchema(List.of(refAttr("id"))), null, null));
+        Expression filter = new GreaterThan(SRC, fieldAttr("price"), intLiteral(100), null);
+        // 7-arg ctor so schemaMap is populated; the 5-arg ctor would skip the missing-column check.
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(
+            null,
+            fileList,
+            schemaInfo,
+            Map.of(),
+            PartitionMetadata.EMPTY,
+            List.of(filter),
+            ExternalSchema.EMPTY
+        );
+        SplitDiscoveryResult result = provider.discoverSplits(ctx);
+
+        assertTrue("a missing-column filter contradiction must prune every file", result.splits().isEmpty());
+        assertEquals(0, result.filesScanned());
+        assertTrue("a missing-column prune of a resolved, non-empty fileList is exhaustive", result.exhaustivelyPruned());
+    }
+
+    /**
      * An unresolved or already-empty fileList yields zero splits, but that is NOT an exhaustive prune: there is
      * nothing to read anyway (empty) or the listing happens at runtime (unresolved), so the coordinator must not
      * treat it as "pruned to nothing" and swap in {@link FileList#EMPTY}.
@@ -3783,9 +3816,14 @@ public class FileSplitProviderTests extends ESTestCase {
         return registry;
     }
 
-    // -- UNION_BY_NAME file skipping --
+    // -- UNION_BY_NAME file retention --
 
-    public void testSkipsFileWithNoProjColumnOverlap() {
+    /**
+     * A file whose schema is disjoint from the query projection still contributes all-NULL rows
+     * (the null group under {@code STATS BY}, {@code IS NULL} matches, {@code SORT}/{@code LIMIT}
+     * positions). Keep it; the per-file mapping is a count-only / null-fill read, not a drop.
+     */
+    public void testKeepsFileWithNoProjColumnOverlap() {
         StoragePath pathA = StoragePath.of("s3://b/a.parquet");
         StoragePath pathB = StoragePath.of("s3://b/b.parquet");
         StoragePath pathC = StoragePath.of("s3://b/c.parquet");
@@ -3823,9 +3861,10 @@ public class FileSplitProviderTests extends ESTestCase {
         );
         List<ExternalSplit> splits = provider.discoverSplits(ctx).splits();
 
-        assertEquals(2, splits.size());
+        assertEquals(3, splits.size());
         assertEquals(pathA, ((FileSplit) splits.get(0)).path());
         assertEquals(pathB, ((FileSplit) splits.get(1)).path());
+        assertEquals(pathC, ((FileSplit) splits.get(2)).path());
     }
 
     public void testKeepsFileWithPartialOverlap() {
@@ -3965,7 +4004,7 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals("File without schema info entry is kept (conservative)", 2, splits.size());
     }
 
-    public void testSkippingWithPartitionPruningCombined() {
+    public void testPartitionPruneKeepsDisjointSchemaFile() {
         StoragePath pathA = StoragePath.of("s3://b/year=2024/a.parquet");
         StoragePath pathB = StoragePath.of("s3://b/year=2024/b.parquet");
         StoragePath pathC = StoragePath.of("s3://b/year=2023/c.parquet");
@@ -4005,9 +4044,11 @@ public class FileSplitProviderTests extends ESTestCase {
         );
         List<ExternalSplit> splits = provider.discoverSplits(ctx).splits();
 
-        // pathC pruned by partition filter (year=2023), pathB pruned by column skipping (only 'bonus')
-        assertEquals(1, splits.size());
+        // pathC pruned by partition filter (year=2023). pathB has no overlap with [id, name] but is
+        // kept: all-NULL rows still contribute.
+        assertEquals(2, splits.size());
         assertEquals(pathA, ((FileSplit) splits.get(0)).path());
+        assertEquals(pathB, ((FileSplit) splits.get(1)).path());
     }
 
     // -- filter-based file skipping --

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -254,8 +254,8 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
 
     /**
      * Empty splits are NOT enough to swap: when the provider reports the empty result is not an exhaustive prune
-     * (e.g. files were dropped by the row-count-unsafe no-column-overlap heuristic, whose rows a {@code COUNT(*)}
-     * still needs), the source must fall through unchanged to the whole read so the row filter runs.
+     * (unresolved glob, empty file list, or a provider that cannot certify a filter contradiction), the source
+     * must fall through unchanged to the whole read so the row filter runs.
      */
     public void testEmptySplitsNotExhaustivelyPrunedNotSwapped() {
         FileList fileList = createFileList(3); // resolved, non-empty


### PR DESCRIPTION
Files with no projected-column overlap still contribute all-NULL rows. Skipping them dropped the STATS BY null group and made IS NULL match nothing.