### PR TITLE
Remove S3 repo docs regarding obsolete versions

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/s3-repository-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/s3-repository-settings.md
@@ -113,13 +113,6 @@ The following list contains the available S3 client settings. Those that must be
 `s3.client.CLIENT_NAME.path_style_access`
 :   Whether to force the use of the path style access pattern. If `true`, the path style access pattern will be used. If `false`, the access pattern will be automatically determined by the AWS Java SDK (See [AWS documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setPathStyleAccessEnabled-java.lang.Boolean-) for details). Defaults to `false`.
 
-::::{note}
-:name: repository-s3-path-style-deprecation
-
-In versions `7.0`, `7.1`, `7.2` and `7.3` all bucket operations used the [now-deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) path style access pattern. If your deployment requires the path style access pattern then you should set this setting to `true` when upgrading.
-::::
-
-
 `s3.client.CLIENT_NAME.disable_chunked_encoding`
 :   Whether chunked encoding should be disabled or not. If `false`, chunked encoding is enabled and will be used where appropriate. If `true`, chunked encoding is disabled and will not be used, which may mean that snapshot operations consume more resources and take longer to complete. It should only be set to `true` if you are using a storage service that does not support chunked encoding. See the [AWS Java SDK documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details. Defaults to `false`.
 


### PR DESCRIPTION
There's a note in the S3 repo docs specifically about versions 7.0
through 7.3, but these docs relate to 9.x versions only and the 7.x
versions in question have been unmaintained and unsupported for many
years. This commit removes these obsolete docs.