### PR TITLE
[8.19] Fix IndexingSlowLogTests (multiple slow loggers) (#157615)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
@@ -49,6 +49,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -176,19 +177,25 @@ public class IndexingSlowLogTests extends ESTestCase {
     }
 
     public void testMultipleSlowLoggersUseSingleLog4jLogger() {
-        LoggerContext context = (LoggerContext) LogManager.getContext(false);
-
         IndexSettings index1Settings = new IndexSettings(createIndexMetadata("index1", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
         IndexingSlowLog log1 = new IndexingSlowLog(index1Settings, mock(SlowLogFields.class));
 
-        int numberOfLoggersBefore = context.getLoggers().size();
+        int numberOfLoggersBefore = numberOfLoggers();
 
         IndexSettings index2Settings = new IndexSettings(createIndexMetadata("index2", settings(UUIDs.randomBase64UUID())), Settings.EMPTY);
         IndexingSlowLog log2 = new IndexingSlowLog(index2Settings, mock(SlowLogFields.class));
-        context = (LoggerContext) LogManager.getContext(false);
 
-        int numberOfLoggersAfter = context.getLoggers().size();
-        assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore));
+        int numberOfLoggersAfter = numberOfLoggers();
+        assertThat(
+            numberOfLoggersAfter,
+            // number of loggers here might be smaller: log4j logger registry expunges stale entries on every getLoggers() call
+            lessThanOrEqualTo(numberOfLoggersBefore)
+        );
+    }
+
+    private static int numberOfLoggers() {
+        var context = (LoggerContext) LogManager.getContext(false);
+        return context.getLoggers().size();
     }
 
     private IndexMetadata createIndexMetadata(String index, Settings build) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix IndexingSlowLogTests (multiple slow loggers) (#157615)](https://github.com/elastic/elasticsearch/pull/157615)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)