### PR TITLE
[9.5] DataStreamAutoShardingService.calculate() works on stale data [#134505] (#157634)

### DIFF
--- a/docs/changelog/157634.yaml
+++ b/docs/changelog/157634.yaml
@@ -1,0 +1,6 @@
+area: Data streams
+issues:
+ - 134505
+pr: 157634
+summary: "`DataStreamAutoShardingService.calculate()` works on stale data [#134505]"
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
@@ -14,9 +14,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexWriteLoad;
+import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -35,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -387,7 +390,7 @@ public class DataStreamAutoShardingService {
             return NOT_APPLICABLE_RESULT;
         }
 
-        if (dataStream.getIndexMode() == IndexMode.LOOKUP) {
+        if (isLookupIndexMode(state.metadata(), dataStream)) {
             logger.debug("Data stream [{}] has indexing mode LOOKUP; auto-sharding is not applicable.", dataStream.getName());
             return NOT_APPLICABLE_RESULT;
         }
@@ -423,6 +426,20 @@ public class DataStreamAutoShardingService {
         Decision decision = innerCalculate(state.metadata(), dataStream, inputs);
         decisionLogger.accept(decision);
         return decision.result();
+    }
+
+    /**
+     * Attempt to resolve the expected values after rollover or, if that's not possible,
+     * just use the current value from the datastream settings
+     */
+    private static boolean isLookupIndexMode(ProjectMetadata project, DataStream dataStream) {
+        return Optional.ofNullable(MetadataIndexTemplateService.findV2Template(project, dataStream.getName(), false))
+            .map(templateName -> project.templatesV2().get(templateName))
+            .map(template -> {
+                ComposableIndexTemplate templateWithSettings = template.mergeSettings(dataStream.getSettings());
+                return project.retrieveIndexModeFromTemplate(templateWithSettings) == IndexMode.LOOKUP;
+            })
+            .orElse(dataStream.getIndexMode() == IndexMode.LOOKUP);
     }
 
     private static double sumLoadMetrics(IndexStats stats, Function<IndexingStats.Stats, Double> loadMetric) {

--- a/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingS
 import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingService.WriteLoadMetric;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAutoShardingEvent;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -25,6 +26,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadataStats;
 import org.elasticsearch.cluster.metadata.IndexWriteLoad;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -1368,6 +1370,87 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
         AutoShardingResult autoShardingResult = service.calculate(state.projectState(projectId), dataStream, null);
         assertThat(autoShardingResult, is(NOT_APPLICABLE_RESULT));
         assertThat(decisionsLogged, hasSize(0));
+    }
+
+    /**
+     * Regression test for https://github.com/elastic/elasticsearch/issues/134505.
+     * When a data stream's stored indexMode is stale (null) but the matching composable template declares
+     * {@code index.mode: lookup}, auto-sharding must return NOT_APPLICABLE rather than recommending a shard
+     * increase that would then cause rollover to fail.
+     */
+    public void testCalculateReturnsNotApplicableWhenTemplateHasLookupIndexMode() {
+        var projectId = randomProjectIdOrDefault();
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(projectId);
+
+        // Build the data stream with a null (stale) indexMode.
+        DataStream dataStream = createDataStream(
+            builder,
+            dataStreamName,
+            1,
+            now,
+            List.of(now - 3000, now - 2000, now - 1000),
+            getWriteLoad(1, 2.0, 2.0, 2.0),
+            null
+        );
+        assert dataStream.getIndexMode() == null : "test assumes null (stale) indexMode on the data stream";
+
+        // Register a composable template matching the data stream's name that declares lookup mode.
+        var lookupTemplate = new Template(Settings.builder().put("index.mode", "lookup").build(), null, null);
+        var composableTemplate = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(dataStreamName + "*"))
+            .template(lookupTemplate)
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .build();
+        builder.put(dataStreamName + "_template", composableTemplate);
+
+        ClusterState state = createClusterStateWithDataStream(builder);
+
+        // With real stats: should be NOT_APPLICABLE because the effective mode is LOOKUP.
+        AutoShardingResult withStats = service.calculate(state.projectState(projectId), dataStream, createIndexStats(1, 1.0, 1.0, 1.0));
+        assertThat(withStats, is(NOT_APPLICABLE_RESULT));
+        assertThat(decisionsLogged, hasSize(0));
+
+        // With null stats: same guard should fire before the null-stats check.
+        AutoShardingResult withNullStats = service.calculate(state.projectState(projectId), dataStream, null);
+        assertThat(withNullStats, is(NOT_APPLICABLE_RESULT));
+        assertThat(decisionsLogged, hasSize(0));
+    }
+
+    /**
+     * Ensures that the template-fallback logic in {@link DataStreamAutoShardingService} does not interfere when the
+     * matching template has no index mode set (the common, non-LOOKUP case).
+     */
+    public void testCalculateProducesNormalResultWhenTemplateHasNoIndexMode() {
+        var projectId = randomProjectIdOrDefault();
+        ProjectMetadata.Builder builder = ProjectMetadata.builder(projectId);
+
+        // Build a data stream whose write index has a high load, so auto-sharding would recommend an increase.
+        DataStream dataStream = createDataStream(
+            builder,
+            dataStreamName,
+            1,
+            now,
+            List.of(now - 3000, now - 2000, now - 1000),
+            getWriteLoad(1, 2.0, 2.0, 2.0),
+            null
+        );
+
+        // Template present but with no index.mode setting — should not trigger the LOOKUP guard.
+        var composableTemplate = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(dataStreamName + "*"))
+            .template(new Template(null, null, null))
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .build();
+        builder.put(dataStreamName + "_template", composableTemplate);
+
+        ClusterState state = createClusterStateWithDataStream(builder);
+
+        AutoShardingResult result = service.calculate(
+            state.projectState(projectId),
+            dataStream,
+            createIndexStats(1, 9999.0, 9999.0, 9999.0)
+        );
+        assertThat(result.type(), is(INCREASE_SHARDS));
     }
 
     private DataStream createLookupModeDataStream(ProjectMetadata.Builder builder) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - DataStreamAutoShardingService.calculate() works on stale data [#134505] (#157634)