### PR TITLE
ESQL:DS: make pushdown row-drop opt-in

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -789,6 +789,23 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         return new OrcFilterPushdownSupport();
     }
 
+    /**
+     * ORC keeps dropping rows for {@code skip_row} with a SearchArgument pushed into it, so it opts into the
+     * pushdown the SPI withholds by default.
+     * <p>
+     * Two properties earn that: the reader has a single decode path — {@code convertToPage} always runs
+     * {@code ColumnarRowDropHelper#filterBlocks} — and it never calls {@code OrcFile.ReaderOptions#setRowFilter},
+     * so a SearchArgument prunes whole stripes and row-index ranges but never individual rows inside a batch.
+     * Batch coordinates therefore stay intact and the positions the coercion reports still address the blocks
+     * the helper compacts. A future row-level ORC predicate path would break both and must revisit this
+     * answer; {@code OrcFormatReaderTests#testDropsRowsUnderPushedFilter} demonstrates the drop under a real
+     * pushed SearchArgument rather than leaving it asserted.
+     */
+    @Override
+    public boolean dropsRowsUnderPushedFilter() {
+        return true;
+    }
+
     @Override
     public AggregatePushdownSupport aggregatePushdownSupport() {
         return new OrcAggregatePushdownSupport();

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -1975,8 +1975,8 @@ public class OrcFormatReaderTests extends ESTestCase {
         }
         drainWarnings();
 
-        // ...which is why the reader may advertise the capability. Pinned so a future row-level ORC predicate path
-        // cannot quietly inherit "true" and start null-filling instead of dropping.
+        // ...which is why the reader may opt into the capability the SPI withholds by default. Pinned so a future
+        // row-level ORC predicate path cannot keep the now-stale "true" and start null-filling instead of dropping.
         assertTrue(new OrcFormatReader(blockFactory).dropsRowsUnderPushedFilter());
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -412,8 +412,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
     }
 
     /**
-     * Parquet cannot drop rows once a filter is pushed into it. A pushed
-     * {@link ParquetPushedExpressions} turns on late materialization in
+     * Parquet cannot drop rows once a filter is pushed into it. This restates the SPI default rather than
+     * relying on it: Parquet is the concrete reason the default is the conservative one, so the reasoning
+     * belongs where the decode paths it names live.
+     * <p>
+     * A pushed {@link ParquetPushedExpressions} turns on late materialization in
      * {@link OptimizedParquetColumnIterator}, whose {@code nextWithLateMaterialization} /
      * {@code nextTwoPhaseBatch} paths emit their pages without going through
      * {@code ColumnarRowDropHelper#filterBlocks} — a coercion failure there would null the cell and keep

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
@@ -295,8 +295,8 @@ public final class ColumnMapping implements Writeable {
      *       both layers share, which is a wider change than the drop itself.</li>
      * </ul>
      * Reachable only when cross-file unification actually widens a column (a multi-file glob whose files drift), so
-     * it does not affect the single-declared-type reads {@code skip_row} is normally used with. Tracked separately;
-     * until then this is the documented behaviour rather than an oversight.
+     * it does not affect the single-declared-type reads {@code skip_row} is normally used with. Tracked as
+     * elastic/esql-planning#1824; until then this is the documented behaviour rather than an oversight.
      */
     Page mapPage(
         Page filePage,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
@@ -132,6 +132,14 @@ final class CompressionDelegatingFormatReader implements FormatReader {
     }
 
     @Override
+    public boolean dropsRowsUnderPushedFilter() {
+        // Inert today (the text readers this wraps offer no filter pushdown), but forwarded so the wrapper stays
+        // transparent: wrapping a reader that had opted into the pushdown would otherwise silently answer the
+        // interface default and cost it every pushed filter.
+        return inner.dropsRowsUnderPushedFilter();
+    }
+
+    @Override
     public RowPositionStrategy rowPositionStrategy() {
         return inner.rowPositionStrategy();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnarRowDropHelper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnarRowDropHelper.java
@@ -54,9 +54,10 @@ import java.util.Arrays;
  * in the current batch, and where the batch is exactly as wide as {@link #beginBatch} was told. A caller
  * on a path that pre-filters rows (late materialization, two-phase predicate evaluation) would have to
  * transform its post-predicate positions back into batch coordinates first; none does today, which is
- * why {@code FormatReader#dropsRowsUnderPushedFilter} lets such a reader decline the pushdown outright
- * rather than silently mixing the two spaces. Both ends are checked: {@link #markFailed} rejects an
- * out-of-range position and {@link #filterBlocks} asserts each block's width.
+ * why {@code FormatReader#dropsRowsUnderPushedFilter} declines the pushdown by default rather than let a
+ * reader silently mix the two spaces — a reader claims the pushdown only by overriding it. Both ends are
+ * checked: {@link #markFailed} rejects an out-of-range position and {@link #filterBlocks} asserts each
+ * block's width.
  *
  * <h2>Exception contract</h2>
  * Budget-exceeded failures surface as {@link ParsingException} (an HTTP 400 client-data error), matching

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -79,7 +79,7 @@ public record ErrorPolicy(Mode mode, long maxErrors, double maxErrorRatio, boole
          * Honoured by the row-oriented (text) readers and, via {@code ColumnarRowDropHelper}, by the columnar ones.
          * One coercion site is exempt and null-fills instead: the cross-file schema-unification cast in
          * {@code ColumnMapping#mapPage}, which runs above the reader and outside its error budget — see the
-         * "Known gap" note there.
+         * "Known gap" note there, tracked as elastic/esql-planning#1824.
          */
         SKIP_ROW,
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -367,17 +367,23 @@ public interface FormatReader extends Closeable {
      * coercion across the batch and compacting every block at the page emit point. A reader that evaluates
      * a pushed predicate on a <em>separate</em> decode path (late materialization, two-phase decode) may
      * never reach that emit point, in which case the failed cell is merely nulled and the row survives —
-     * silently serving {@code null_field} semantics for a {@code skip_row} read. Such readers must return
-     * {@code false} so {@code PushFiltersToSource} withholds the pushdown and leaves the predicate in a
-     * {@code FilterExec} above the source; results stay correct (the filter still runs, just one level up)
-     * and every batch stays on the path that drops rows.
+     * silently serving {@code null_field} semantics for a {@code skip_row} read.
+     * <p>
+     * The default is therefore {@code false}: a reader is assumed <em>not</em> to drop rows once filtered
+     * until it declares that it does, so a new reader is correct while silent and only an explicit
+     * override can trade correctness for speed. On {@code false}, {@code PushFiltersToSource} withholds the
+     * pushdown and leaves the predicate in a {@code FilterExec} above the source; results stay correct on
+     * both counts (the filter still runs, just one level up, and every batch stays on the path that drops
+     * rows) and the only cost is the row-group / page-index skipping the pushdown would have bought.
+     * Overriding to {@code true} is a promise about a specific decode path and has to be demonstrated —
+     * see {@code OrcFormatReaderTests#testDropsRowsUnderPushedFilter}.
      * <p>
      * Only consulted when the read actually combines {@code skip_row} with declared-type columns — see
      * {@code DeclaredReadSpec#dropsRowsOnCoercionFailure}. With no declared types there is nothing to
      * coerce, hence no row to drop, and pushdown is always allowed.
      */
     default boolean dropsRowsUnderPushedFilter() {
-        return true;
+        return false;
     }
 
     default boolean supportsNativeAsync() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSourceTests.java
@@ -113,6 +113,16 @@ public class PushFiltersToSourceTests extends ESTestCase {
         assertSame("the filter must stay above the source, unpushed", filterExec, result);
     }
 
+    /**
+     * The stub above reaches {@code false} by saying nothing, which is the point: the SPI default is the conservative
+     * answer, so a reader written without a thought for {@code skip_row} loses the pushdown rather than the row-drop.
+     * Pinned separately from the rule so a flip of the default is a failure here and not only a silent correctness
+     * regression in whichever reader forgot to opt out.
+     */
+    public void testReaderSilentAboutRowDropTakesTheConservativeDefault() {
+        assertFalse(new StubReader().dropsRowsUnderPushedFilter());
+    }
+
     /** The same read on a reader that does drop rows on its filtered path (ORC) keeps the pushdown. */
     public void testPushesWhenReaderDropsRowsUnderPushedFilter() {
         FilterExec filterExec = filterOverExternalSource("skip_row", Set.of("salary"));
@@ -183,27 +193,19 @@ public class PushFiltersToSourceTests extends ESTestCase {
 
     private static FormatReaderRegistry registry(boolean dropsRowsUnderPushedFilter) {
         FormatReaderRegistry registry = new FormatReaderRegistry(null);
-        registry.registerLazy("parquet", (settings, blockFactory) -> new StubReader(dropsRowsUnderPushedFilter), null, null);
+        FormatReader reader = dropsRowsUnderPushedFilter ? new DroppingStubReader() : new StubReader();
+        registry.registerLazy("parquet", (settings, blockFactory) -> reader, null, null);
         return registry;
     }
 
     /**
      * Reader stub whose only interesting behaviour is the pair the rule consults: it always offers pushdown (via a
-     * support object that swallows every conjunct) and answers {@link FormatReader#dropsRowsUnderPushedFilter()} as
-     * configured. The remaining {@link NoConfigFormatReader} methods stay unimplemented so accidental use during a
-     * rule pass is loud.
+     * support object that swallows every conjunct) and says nothing at all about
+     * {@link FormatReader#dropsRowsUnderPushedFilter()} — the shape a newly written reader has, so it takes the SPI
+     * default. The remaining {@link NoConfigFormatReader} methods stay unimplemented so accidental use during a rule
+     * pass is loud.
      */
-    private static final class StubReader implements NoConfigFormatReader {
-        private final boolean dropsRows;
-
-        StubReader(boolean dropsRows) {
-            this.dropsRows = dropsRows;
-        }
-
-        @Override
-        public boolean dropsRowsUnderPushedFilter() {
-            return dropsRows;
-        }
+    private static class StubReader implements NoConfigFormatReader {
 
         @Override
         public FilterPushdownSupport filterPushdownSupport() {
@@ -237,5 +239,13 @@ public class PushFiltersToSourceTests extends ESTestCase {
 
         @Override
         public void close() {}
+    }
+
+    /** The opt-in half: a reader that does declare the row-drop on its filtered path, as ORC does. */
+    private static final class DroppingStubReader extends StubReader {
+        @Override
+        public boolean dropsRowsUnderPushedFilter() {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Review follow-ups to #157602.

FormatReader#dropsRowsUnderPushedFilter now defaults to false, so a reader that says nothing loses the filter pushdown rather than the skip_row row-drop; claiming the pushdown takes an explicit override. ORC opts in (single decode path, no setRowFilter); Parquet keeps its false. CompressionDelegatingFormatReader forwards the flag.
