### PR TITLE
[8.16.x] [Build] Cache spotless p2 dependencies when baking ci image (#118523) (#118591)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -17,8 +17,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
 
 /**
  * This plugin configures formatting for Java source using Spotless
@@ -66,8 +64,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 java.importOrderFile(new File(elasticsearchWorkspace, importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-                java.eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/"))
-                    .configFile(new File(elasticsearchWorkspace, formatterConfigPath));
+                java.eclipse().configFile(new File(elasticsearchWorkspace, formatterConfigPath));
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep

--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,10 @@ allprojects {
     if (project.path.contains(":distribution:docker")) {
       enabled = false
     }
-
+    if (project.path.contains(":libs:cli")) {
+      // ensure we resolve p2 dependencies for the spotless eclipse formatter
+      dependsOn "spotlessJavaCheck"
+    }
   }
 
   ext.withReleaseBuild = { Closure config ->


### PR DESCRIPTION
Backport of #118591 to 8.16.x.

Removes the broken UMD Eclipse P2 mirror (`mirror.umd.edu`) from the Spotless formatter configuration and pre-resolves Spotless P2 dependencies during CI image baking. This fixes CI failures where Spotless cannot download the Eclipse JDT formatter:

```
Could not determine the dependencies of task ':benchmarks:spotlessApply'
> Failed to load eclipse jdt formatter: ... mirror.umd.edu/eclipse/eclipse/updates/4.29/ ...
```

This backport was already present on 8.17+ but was never merged to 8.16.