### PR TITLE
[ESQL] Skip type inference for all-null casts

### DIFF
--- a/docs/changelog/157985.yaml
+++ b/docs/changelog/157985.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 157985
+summary: Skip type inference for all-null casts
+type: enhancement

--- a/docs/changelog/157985.yaml
+++ b/docs/changelog/157985.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
 pr: 157985
-summary: Skip type inference for all-null casts
-type: enhancement
+summary: Skip type inference for all-null casts when the file type is unknown
+type: bug

--- a/docs/changelog/157985.yaml
+++ b/docs/changelog/157985.yaml
@@ -1,5 +1,0 @@
-area: ES|QL
-issues: []
-pr: 157985
-summary: Skip type inference for all-null casts when the file type is unknown
-type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
@@ -439,6 +439,15 @@ public final class ColumnMapping implements Writeable {
      * A pair outside {@link DeclaredTypeCoercions#supports} means the mapping was built against
      * types reconciliation can never produce — fail loud (an ill-formed mapping must not limp
      * along), matching this method's historical contract.
+     * <p>
+     * All-null sources skip type inference and return a constant-null block. {@code
+     * ConstantNullBlock} implements every typed block interface, so {@link #resolveSourceType}'s
+     * {@code instanceof} chain would otherwise bind {@link IntBlock} first and reject targets
+     * {@code BOOLEAN} and {@code IP} ({@link DeclaredTypeCoercions#supports} is false for
+     * {@code INTEGER} → those types) before the engine's own all-null short-circuit can run. A
+     * typed all-null array block still reports {@link Block#areAllValuesNull()} without being a
+     * {@code ConstantNullBlock}, so the guard is the flag, not the class. Does not close
+     * {@code source}: {@link #mapPage} does not take ownership of file-page blocks.
      *
      * @param sourceType file-side ES|QL type, or {@code null} when unknown. Required to
      *                   disambiguate {@link LongBlock} sources for KEYWORD casts (DATETIME vs
@@ -452,6 +461,9 @@ public final class ColumnMapping implements Writeable {
         @Nullable String columnName,
         @Nullable SkipWarnings warnings
     ) {
+        if (source.areAllValuesNull()) {
+            return bf.newConstantNullBlock(source.getPositionCount());
+        }
         DataType from = resolveSourceType(source, sourceType, targetType);
         if (DeclaredTypeCoercions.supports(from, targetType) == false) {
             throw new UnsupportedOperationException(
@@ -468,7 +480,8 @@ public final class ColumnMapping implements Writeable {
      * ES|QL types (LONG, DATETIME, DATE_NANOS). Under a DATE_NANOS target the source is DATETIME
      * (the only pair reconciliation widens into DATE_NANOS); under a KEYWORD target the three
      * stringify differently, so the type must come from the read schema — the assertion tripwires
-     * any caller that forgets to thread it.
+     * any caller that forgets to thread it. All-null sources never reach this method:
+     * {@link #castBlock} short-circuits them before inference.
      */
     private static DataType resolveSourceType(Block source, @Nullable DataType sourceType, DataType targetType) {
         if (sourceType != null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ConstantNullBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -440,13 +441,15 @@ public final class ColumnMapping implements Writeable {
      * types reconciliation can never produce — fail loud (an ill-formed mapping must not limp
      * along), matching this method's historical contract.
      * <p>
-     * All-null sources skip type inference and return a constant-null block. {@code
-     * ConstantNullBlock} implements every typed block interface, so {@link #resolveSourceType}'s
-     * {@code instanceof} chain would otherwise bind {@link IntBlock} first and reject targets
-     * {@code BOOLEAN} and {@code IP} ({@link DeclaredTypeCoercions#supports} is false for
-     * {@code INTEGER} → those types) before the engine's own all-null short-circuit can run. A
-     * typed all-null array block still reports {@link Block#areAllValuesNull()} without being a
-     * {@code ConstantNullBlock}, so the guard is the flag, not the class. Does not close
+     * When {@code sourceType} is unknown and the batch is all-null, skip inference. The reachable
+     * case is an all-null {@link LongBlock} under KEYWORD: {@link #resolveSourceType} asserts a
+     * source type to disambiguate DATETIME / DATE_NANOS / LONG even though all-null data makes
+     * the stringifier moot. {@code ConstantNullBlock} implements every typed interface, so the
+     * {@code instanceof} chain binds {@link IntBlock} first; BOOLEAN/IP targets are not produced
+     * by reconciliation ({@link CastType} cannot encode them) and are covered only defensively.
+     * A known {@code sourceType} still runs {@link DeclaredTypeCoercions#supports} and then the
+     * engine's own all-null short-circuit. An incoming {@code ConstantNullBlock} is
+     * {@code incRef}'d and reused; a typed all-null array block is replaced. Does not close
      * {@code source}: {@link #mapPage} does not take ownership of file-page blocks.
      *
      * @param sourceType file-side ES|QL type, or {@code null} when unknown. Required to
@@ -461,7 +464,11 @@ public final class ColumnMapping implements Writeable {
         @Nullable String columnName,
         @Nullable SkipWarnings warnings
     ) {
-        if (source.areAllValuesNull()) {
+        if (sourceType == null && source.areAllValuesNull()) {
+            if (source instanceof ConstantNullBlock) {
+                source.incRef();
+                return source;
+            }
             return bf.newConstantNullBlock(source.getPositionCount());
         }
         DataType from = resolveSourceType(source, sourceType, targetType);
@@ -480,8 +487,8 @@ public final class ColumnMapping implements Writeable {
      * ES|QL types (LONG, DATETIME, DATE_NANOS). Under a DATE_NANOS target the source is DATETIME
      * (the only pair reconciliation widens into DATE_NANOS); under a KEYWORD target the three
      * stringify differently, so the type must come from the read schema — the assertion tripwires
-     * any caller that forgets to thread it. All-null sources never reach this method:
-     * {@link #castBlock} short-circuits them before inference.
+     * any caller that forgets to thread it. All-null sources with a null {@code sourceType} never
+     * reach this method: {@link #castBlock} short-circuits them before inference.
      */
     private static DataType resolveSourceType(Block source, @Nullable DataType sourceType, DataType targetType) {
         if (sourceType != null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ConstantNullBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -667,6 +668,72 @@ public class ColumnMappingTests extends ESTestCase {
             );
         } finally {
             filePage.releaseBlocks();
+        }
+    }
+
+    // ===== all-null cast short-circuit =====
+    //
+    // ConstantNullBlock implements every typed block interface, so resolveSourceType's
+    // instanceof chain binds IntBlock first (INTEGER). supports(INTEGER, BOOLEAN|IP) is
+    // false, and that throw used to run before DeclaredTypeCoercions.castBlock's all-null
+    // short-circuit. Two-arg mapPage (null fileColumnTypes) is the path that infers from
+    // the block class.
+
+    public void testCastConstantNullBlockToAnyTargetWithoutSourceType() {
+        // LONG/DOUBLE/DATE_NANOS/KEYWORD happen to be supported from INTEGER; BOOLEAN and
+        // IP are the cells that threw on main.
+        DataType[] targets = { DataType.LONG, DataType.DOUBLE, DataType.DATE_NANOS, DataType.KEYWORD, DataType.BOOLEAN, DataType.IP };
+        int n = randomIntBetween(1, 8);
+        for (DataType target : targets) {
+            ColumnMapping mapping = new ColumnMapping(new int[] { 0 }, new DataType[] { target });
+            Block src = blockFactory.newConstantNullBlock(n);
+            Page filePage = new Page(n, new Block[] { src });
+            try {
+                Page out = mapping.mapPage(filePage, blockFactory);
+                try {
+                    Block result = out.getBlock(0);
+                    assertTrue("all-null ConstantNullBlock must cast to " + target, result.areAllValuesNull());
+                    assertEquals("position count preserved for " + target, n, result.getPositionCount());
+                } finally {
+                    out.releaseBlocks();
+                }
+            } finally {
+                filePage.releaseBlocks();
+            }
+        }
+    }
+
+    public void testCastAllNullIntArrayBlockToBooleanAndIpWithoutSourceType() {
+        // IntBlock.Builder.build() does not collapse an all-null build to ConstantNullBlock —
+        // the result is an IntArrayBlock whose elementType is still INT. Narrowing the
+        // short-circuit to instanceof ConstantNullBlock would throw on BOOLEAN/IP the same
+        // way main did for ConstantNullBlock.
+        DataType[] targets = { DataType.BOOLEAN, DataType.IP };
+        int n = randomIntBetween(1, 8);
+        for (DataType target : targets) {
+            ColumnMapping mapping = new ColumnMapping(new int[] { 0 }, new DataType[] { target });
+            IntBlock src;
+            try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(n)) {
+                for (int i = 0; i < n; i++) {
+                    b.appendNull();
+                }
+                src = b.build();
+            }
+            assertTrue("IntBlock.Builder must not collapse all-null to ConstantNullBlock", src instanceof ConstantNullBlock == false);
+            assertTrue(src.areAllValuesNull());
+            Page filePage = new Page(n, new Block[] { src });
+            try {
+                Page out = mapping.mapPage(filePage, blockFactory);
+                try {
+                    Block result = out.getBlock(0);
+                    assertTrue("all-null IntArrayBlock must cast to " + target, result.areAllValuesNull());
+                    assertEquals("position count preserved for " + target, n, result.getPositionCount());
+                } finally {
+                    out.releaseBlocks();
+                }
+            } finally {
+                filePage.releaseBlocks();
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.ConstantNullBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -673,15 +674,15 @@ public class ColumnMappingTests extends ESTestCase {
 
     // ===== all-null cast short-circuit =====
     //
-    // ConstantNullBlock implements every typed block interface, so resolveSourceType's
-    // instanceof chain binds IntBlock first (INTEGER). supports(INTEGER, BOOLEAN|IP) is
-    // false, and that throw used to run before DeclaredTypeCoercions.castBlock's all-null
-    // short-circuit. Two-arg mapPage (null fileColumnTypes) is the path that infers from
-    // the block class.
+    // Two-arg mapPage (null fileColumnTypes) infers from the block class. An all-null LongBlock
+    // under KEYWORD trips resolveSourceType's DATETIME/DATE_NANOS/LONG assert on main — that is
+    // the reachable UBN mapping. ConstantNullBlock implements every typed interface so the
+    // instanceof chain binds IntBlock first; BOOLEAN/IP targets are not a CastType and are
+    // covered only defensively.
 
     public void testCastConstantNullBlockToAnyTargetWithoutSourceType() {
-        // LONG/DOUBLE/DATE_NANOS/KEYWORD happen to be supported from INTEGER; BOOLEAN and
-        // IP are the cells that threw on main.
+        // LONG/DOUBLE/DATE_NANOS/KEYWORD are supported from INTEGER and already short-circuit
+        // in DeclaredTypeCoercions; BOOLEAN and IP are defensive (CastType cannot encode them).
         DataType[] targets = { DataType.LONG, DataType.DOUBLE, DataType.DATE_NANOS, DataType.KEYWORD, DataType.BOOLEAN, DataType.IP };
         int n = randomIntBetween(1, 8);
         for (DataType target : targets) {
@@ -692,7 +693,9 @@ public class ColumnMappingTests extends ESTestCase {
                 Page out = mapping.mapPage(filePage, blockFactory);
                 try {
                     Block result = out.getBlock(0);
+                    assertSame("ConstantNullBlock is incRef'd, not copied, for " + target, src, result);
                     assertTrue("all-null ConstantNullBlock must cast to " + target, result.areAllValuesNull());
+                    assertEquals("short-circuit yields ElementType.NULL for " + target, ElementType.NULL, result.elementType());
                     assertEquals("position count preserved for " + target, n, result.getPositionCount());
                 } finally {
                     out.releaseBlocks();
@@ -706,8 +709,9 @@ public class ColumnMappingTests extends ESTestCase {
     public void testCastAllNullIntArrayBlockToBooleanAndIpWithoutSourceType() {
         // IntBlock.Builder.build() does not collapse an all-null build to ConstantNullBlock —
         // the result is an IntArrayBlock whose elementType is still INT. Narrowing the
-        // short-circuit to instanceof ConstantNullBlock would throw on BOOLEAN/IP the same
-        // way main did for ConstantNullBlock.
+        // short-circuit to instanceof ConstantNullBlock would throw on BOOLEAN/IP. Those
+        // targets are defensive (not a CastType); the reachable typed-array case is the
+        // LongBlock → KEYWORD sibling below.
         DataType[] targets = { DataType.BOOLEAN, DataType.IP };
         int n = randomIntBetween(1, 8);
         for (DataType target : targets) {
@@ -719,7 +723,7 @@ public class ColumnMappingTests extends ESTestCase {
                 }
                 src = b.build();
             }
-            assertTrue("IntBlock.Builder must not collapse all-null to ConstantNullBlock", src instanceof ConstantNullBlock == false);
+            assumeFalse("IntBlock.Builder collapsed all-null to ConstantNullBlock", src instanceof ConstantNullBlock);
             assertTrue(src.areAllValuesNull());
             Page filePage = new Page(n, new Block[] { src });
             try {
@@ -727,6 +731,7 @@ public class ColumnMappingTests extends ESTestCase {
                 try {
                     Block result = out.getBlock(0);
                     assertTrue("all-null IntArrayBlock must cast to " + target, result.areAllValuesNull());
+                    assertEquals("short-circuit yields ElementType.NULL for " + target, ElementType.NULL, result.elementType());
                     assertEquals("position count preserved for " + target, n, result.getPositionCount());
                 } finally {
                     out.releaseBlocks();
@@ -734,6 +739,54 @@ public class ColumnMappingTests extends ESTestCase {
             } finally {
                 filePage.releaseBlocks();
             }
+        }
+    }
+
+    public void testCastAllNullLongBlockToKeywordWithoutSourceType() {
+        // Reachable UBN mapping: KEYWORD is a CastType, and an all-null LongBlock with no
+        // sourceType trips resolveSourceType's DATETIME/DATE_NANOS/LONG assert on main.
+        int n = randomIntBetween(1, 8);
+        ColumnMapping mapping = new ColumnMapping(new int[] { 0 }, new DataType[] { DataType.KEYWORD });
+        LongBlock src;
+        try (LongBlock.Builder b = blockFactory.newLongBlockBuilder(n)) {
+            for (int i = 0; i < n; i++) {
+                b.appendNull();
+            }
+            src = b.build();
+        }
+        assumeFalse("LongBlock.Builder collapsed all-null to ConstantNullBlock", src instanceof ConstantNullBlock);
+        assertTrue(src.areAllValuesNull());
+        Page filePage = new Page(n, new Block[] { src });
+        try {
+            Page out = mapping.mapPage(filePage, blockFactory);
+            try {
+                Block result = out.getBlock(0);
+                assertTrue(result.areAllValuesNull());
+                assertEquals(ElementType.NULL, result.elementType());
+                assertEquals(n, result.getPositionCount());
+            } finally {
+                out.releaseBlocks();
+            }
+        } finally {
+            filePage.releaseBlocks();
+        }
+    }
+
+    public void testAllNullUnsupportedCastStillThrowsWhenSourceTypeKnown() {
+        // Gating the short-circuit on sourceType == null keeps supports() fail-loud for an
+        // ill-formed mapping even when the page happens to be all-null.
+        ColumnMapping mapping = new ColumnMapping(new int[] { 0 }, new DataType[] { DataType.LONG });
+        Block src = blockFactory.newConstantNullBlock(2);
+        Page filePage = new Page(2, new Block[] { src });
+        try {
+            RuntimeException e = expectThrows(
+                RuntimeException.class,
+                () -> mapping.mapPage(filePage, blockFactory, new DataType[] { DataType.BOOLEAN })
+            );
+            assertTrue("wrapped under mapPage's catch", e.getMessage() != null && e.getMessage().contains("Failed to map page"));
+            assertTrue("underlying cause surfaces", e.getCause() instanceof UnsupportedOperationException);
+        } finally {
+            filePage.releaseBlocks();
         }
     }
 


### PR DESCRIPTION
An all-null LongBlock under a KEYWORD cast with no file type trips resolveSourceType's DATETIME/DATE_NANOS/LONG assert, even though all-null data makes the stringifier moot. Skip inference in that case. BOOLEAN/IP targets are not a CastType and are covered only defensively.