### PR TITLE
[8.19] Move ParameterizedRollingUpgradeTestCase to test-framework (#155762)

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeTestCase.java
@@ -12,6 +12,7 @@ package org.elasticsearch.upgrades;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
@@ -14,6 +14,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
 
+  // optional dependency
+  compileOnly project(":test:test-clusters")
+
   annotationProcessor "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ParameterizedRollingUpgradeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ParameterizedRollingUpgradeTestCase.java
@@ -7,11 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.upgrades;
+package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
@@ -45,12 +46,16 @@ import static org.hamcrest.Matchers.notNullValue;
  * <pre>{@code smartRetry.pruneIndividualTests.set(false)}</pre>
  */
 public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase {
+
     protected static final int NODE_NUM = 3;
+
+    private static final String CURRENT_ES_VERSION = Build.current().version();
     protected static final String OLD_CLUSTER_VERSION = System.getProperty("tests.old_cluster_version");
     private static final Set<Integer> upgradedNodes = new HashSet<>();
     private static TestFeatureService oldClusterTestFeatureService = null;
     private static boolean upgradeFailed = false;
     private static IndexVersion oldIndexVersion;
+
     private final int requestedUpgradedNodes;
 
     protected ParameterizedRollingUpgradeTestCase(@Name("upgradedNodes") int upgradedNodes) {
@@ -62,7 +67,11 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
         return IntStream.rangeClosed(0, NODE_NUM).boxed().map(n -> new Object[] { n }).toList();
     }
 
-    protected abstract ElasticsearchCluster getUpgradeCluster();
+    protected void beforeUpgrade() {
+        if (getOldClusterVersion().endsWith("-SNAPSHOT")) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
+    }
 
     @Before
     public void upgradeNode() throws Exception {
@@ -106,6 +115,8 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
         // Skip remaining tests if upgrade failed
         assumeFalse("Cluster upgrade failed", upgradeFailed);
 
+        beforeUpgrade();
+
         // finally, upgrade node
         if (upgradedNodes.size() < requestedUpgradedNodes) {
             closeClients();
@@ -113,12 +124,9 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
             for (int n = 0; n < requestedUpgradedNodes; n++) {
                 if (upgradedNodes.add(n)) {
                     try {
-                        Version upgradeVersion = System.getProperty("tests.new_cluster_version") == null
-                            ? Version.CURRENT
-                            : Version.fromString(System.getProperty("tests.new_cluster_version"));
-
-                        logger.info("Upgrading node {} to version {}", n, upgradeVersion);
-                        getUpgradeCluster().upgradeNodeToVersion(n, upgradeVersion);
+                        String newClusterVersion = System.getProperty("tests.new_cluster_version", CURRENT_ES_VERSION);
+                        logger.info("Upgrading node {} to version {}", n, newClusterVersion);
+                        getUpgradeCluster().upgradeNodeToVersion(n, Version.fromString(newClusterVersion));
                     } catch (Exception e) {
                         upgradeFailed = true;
                         throw e;
@@ -127,6 +135,13 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
             }
             initClient();
         }
+    }
+
+    protected abstract ElasticsearchCluster getUpgradeCluster();
+
+    @Override
+    protected String getTestRestCluster() {
+        return getUpgradeCluster().getHttpAddresses();
     }
 
     @AfterClass
@@ -160,7 +175,7 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
         return Version.fromString(OLD_CLUSTER_VERSION);
     }
 
-    protected static boolean isOldClusterVersion(String nodeVersion) {
+    public static boolean isOldClusterVersion(String nodeVersion) {
         return OLD_CLUSTER_VERSION.equals(nodeVersion);
     }
 
@@ -178,11 +193,6 @@ public abstract class ParameterizedRollingUpgradeTestCase extends ESRestTestCase
 
     protected static boolean isUpgradedCluster() {
         return upgradedNodes.size() == NODE_NUM;
-    }
-
-    @Override
-    protected String getTestRestCluster() {
-        return getUpgradeCluster().getHttpAddresses();
     }
 
     @Override

--- a/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -20,7 +19,6 @@ smartRetry.pruneIndividualTests.set(false)
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation project(path: xpackModule('inference'))
-  javaRestTestImplementation(testArtifact(project(":qa:rolling-upgrade"), "javaRestTest"))
 }
 
 // Inference API added in 8.11
@@ -31,4 +29,3 @@ buildParams.bwcVersions.withWireCompatible(v -> v.after("8.11.0")) { bwcVersion,
     maxParallelForks = 1
   }
 }
-

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/InferenceUpgradeTestCase.java
@@ -13,10 +13,10 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.http.MockWebServer;
-import org.elasticsearch.upgrades.ParameterizedRollingUpgradeTestCase;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -31,10 +31,6 @@ public class InferenceUpgradeTestCase extends ParameterizedRollingUpgradeTestCas
 
     static final String MODELS_RENAMED_TO_ENDPOINTS = "8.15.0";
 
-    public InferenceUpgradeTestCase(@Name("upgradedNodes") int upgradedNodes) {
-        super(upgradedNodes);
-    }
-
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
@@ -43,6 +39,10 @@ public class InferenceUpgradeTestCase extends ParameterizedRollingUpgradeTestCas
         .setting("xpack.security.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .build();
+
+    public InferenceUpgradeTestCase(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
 
     @Override
     protected ElasticsearchCluster getUpgradeCluster() {

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -5,167 +5,23 @@
  * 2.0.
  */
 
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
-apply plugin: 'elasticsearch.rest-resources'
 
 // Each suite is parameterized over the upgrade phases and an earlier phase sets up the cluster state a later phase asserts on,
 // so a phase that passed must still run when a later phase is retried.
 smartRetry.pruneIndividualTests.set(false)
 
-dependencies {
-  testImplementation project(':x-pack:qa')
-}
-
-restResources {
-  restApi {
-    include '*'
-  }
-}
-
-tasks.named("forbiddenPatterns").configure {
-  exclude '**/system_key'
-}
-
-def buildDirectory = layout.buildDirectory
-String outputDir = "${buildDirectory.file("generated-resources/${project.name}").get().asFile}"
-
-tasks.register("copyTestNodeKeyMaterial", Copy) {
-  from project(':x-pack:plugin:core').files('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
-    'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt')
-  into outputDir
-}
-
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
-  String oldVersion = bwcVersion.toString()
-
-  // SearchableSnapshotsRollingUpgradeIT uses a specific repository to not interfere with other tests
-  String searchableSnapshotRepository = "${buildDirectory.file("cluster/shared/searchable-snapshots-repo/${baseName}").get().asFile}"
-  File repoFolder = buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile
-  def baseCluster = testClusters.register(baseName) {
-    testDistribution = "DEFAULT"
-    versions = [oldVersion, project.version]
-    numberOfNodes = 3
-
-    setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-    setting 'path.repo', "['${repoFolder}', '${searchableSnapshotRepository}']"
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'xpack.security.enabled', 'true'
-    setting 'xpack.security.transport.ssl.enabled', 'true'
-    setting 'xpack.security.authc.token.enabled', 'true'
-    setting 'xpack.security.authc.token.timeout', '60m'
-    setting 'xpack.security.authc.api_key.enabled', 'true'
-    setting 'xpack.security.audit.enabled', 'true'
-    setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-    setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-    keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-
-    if (bwcVersion.onOrAfter('7.0.0')) {
-      setting 'xpack.security.authc.realms.file.file1.order', '0'
-      setting 'xpack.security.authc.realms.native.native1.order', '1'
-    } else {
-      setting 'xpack.security.authc.realms.file1.type', 'file'
-      setting 'xpack.security.authc.realms.file1.order', '0'
-      setting 'xpack.security.authc.realms.native1.type', 'native'
-      setting 'xpack.security.authc.realms.native1.order', '1'
-    }
-    if (bwcVersion.onOrAfter('6.6.0')) {
-      setting 'ccr.auto_follow.wait_for_metadata_timeout', '1s'
-    }
-    if (bwcVersion.onOrAfter('7.11.0')) {
-      extraConfigFile 'operator_users.yml', file("${project.projectDir}/src/test/resources/operator_users.yml")
-      setting 'xpack.security.operator_privileges.enabled', "true"
-      user username: "non_operator", password: 'x-pack-test-password', role: "superuser"
-    }
-
-    user username: "test_user", password: "x-pack-test-password"
-
-    extraConfigFile 'testnode.pem', file("$outputDir/testnode.pem")
-    extraConfigFile 'testnode.crt', file("$outputDir/testnode.crt")
-
-    keystore 'xpack.watcher.encryption_key', file("${project.projectDir}/src/test/resources/system_key")
-    setting 'xpack.watcher.encrypt_sensitive_data', 'true'
-
-    // Old versions of the code contain an invalid assertion that trips
-    // during tests.  Versions 5.6.9 and 6.2.4 have been fixed by removing
-    // the assertion, but this is impossible for released versions.
-    // However, released versions run without assertions, so end users won't
-    // be suffering the effects.  This argument effectively removes the
-    // incorrect assertion from the older versions used in the BWC tests.
-    if (bwcVersion.before('5.6.9') || (bwcVersion.onOrAfter('6.0.0') && bwcVersion.before('6.2.4'))) {
-      jvmArgs '-da:org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk'
-    }
-    setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
-
-    if (bwcVersion.onOrAfter('7.12.0')) {
-      setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
-      setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
-    }
+  tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.old_cluster_version", bwcVersion)
   }
+}
 
-  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
-    useCluster baseCluster
-    mustRunAfter("precommit")
-    dependsOn "copyTestNodeKeyMaterial"
-    def repoDir = buildDirectory.file("cluster/shared/repo/${baseName}").get().asFile
-    doFirst {
-      delete(repoDir)
-      delete("${searchableSnapshotRepository}")
-    }
-    systemProperty 'tests.rest.suite', 'old_cluster'
-    systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.clustername', baseName)
-  }
-
-  tasks.register("${baseName}#oneThirdUpgradedTest", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#oldClusterTest"
-    useCluster baseCluster
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(baseCluster)
-    }
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.clustername', baseName)
-    systemProperty 'tests.rest.suite', 'mixed_cluster'
-    systemProperty 'tests.first_round', 'true'
-    systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-  }
-
-  tasks.register("${baseName}#twoThirdsUpgradedTest", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#oneThirdUpgradedTest"
-    useCluster baseCluster
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(baseCluster)
-    }
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.clustername', baseName)
-    systemProperty 'tests.rest.suite', 'mixed_cluster'
-    systemProperty 'tests.first_round', 'false'
-    systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-  }
-
-  tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
-    dependsOn "${baseName}#twoThirdsUpgradedTest"
-    useCluster baseCluster
-    doFirst {
-      getRegistry().get().nextNodeToNextVersion(baseCluster)
-    }
-    nonInputProperties.systemProperty('tests.rest.cluster', getClusterInfo(baseName).map { it.allHttpSocketURI.join(",") })
-    nonInputProperties.systemProperty('tests.clustername', baseName)
-    systemProperty 'tests.rest.suite', 'upgraded_cluster'
-    systemProperty 'tests.upgrade_from_version', oldVersion
-    systemProperty 'tests.path.searchable.snapshots.repo', searchableSnapshotRepository
-  }
-
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn "${baseName}#upgradedClusterTest"
-  }
+tasks.withType(Test).configureEach {
+  // CI doesn't like it when there's multiple clusters running at once
+  maxParallelForks = 1
 }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -15,7 +15,6 @@ apply plugin: 'elasticsearch.bwc-test'
 smartRetry.pruneIndividualTests.set(false)
 
 dependencies {
-  javaRestTestImplementation(testArtifact(project(":qa:rolling-upgrade"), "javaRestTest"))
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(project(':x-pack:qa'))
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
@@ -7,60 +7,37 @@
 
 package org.elasticsearch.upgrades;
 
-import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
-import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
 
-import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 public abstract class AbstractXpackRollingUpgradeTestCase extends ParameterizedRollingUpgradeTestCase {
 
-    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+    public AbstractXpackRollingUpgradeTestCase(int upgradedNodes) {
+        super(upgradedNodes);
+    }
 
-    private static final ElasticsearchCluster cluster = buildCluster();
+    protected static ElasticsearchCluster buildCluster() {
+        return buildCluster(b -> b);
+    }
 
-    @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
-
-    private static ElasticsearchCluster buildCluster() {
+    protected static ElasticsearchCluster buildCluster(UnaryOperator<LocalClusterSpecBuilder<ElasticsearchCluster>> customizer) {
         var builder = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
             .version(getOldClusterVersion())
             .nodes(NODE_NUM)
             .setting("xpack.license.self_generated.type", "trial")
-            .setting("xpack.security.enabled", "false")
-            .systemProperty("ingest.geoip.downloader.enabled.default", "true")
-            .systemProperty("ingest.geoip.downloader.endpoint.default", "http://invalid.endpoint")
-            .setting("ingest.geoip.downloader.endpoint", "http://invalid.endpoint")
-            .setting("path.repo", new Supplier<>() {
-                @Override
-                @SuppressForbidden(reason = "TemporaryFolder only has io.File methods, not nio.File")
-                public String get() {
-                    return repoDirectory.getRoot().getPath();
-                }
-            })
-            .setting("xpack.searchable.snapshot.shared_cache.size", "16MB")
-            .setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB");
+            .setting("xpack.security.enabled", "false");
 
         if (getOldClusterTestVersion().before(Version.fromString("8.18.0"))) {
             builder.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             builder.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }
 
-        return builder.build();
-    }
-
-    public AbstractXpackRollingUpgradeTestCase(int upgradedNodes) {
-        super(upgradedNodes);
-    }
-
-    @Override
-    protected ElasticsearchCluster getUpgradeCluster() {
-        return cluster;
+        return customizer.apply(builder).build();
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeWithSecurityTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeWithSecurityTestCase.java
@@ -17,8 +17,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
-import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.junit.ClassRule;
 
@@ -29,47 +27,41 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.notNullValue;
 
-public abstract class AbstractXpackRollingUpgradeWithSecurityTestCase extends ParameterizedRollingUpgradeTestCase {
+public abstract class AbstractXpackRollingUpgradeWithSecurityTestCase extends AbstractXpackRollingUpgradeTestCase {
 
     protected static final String USER = "test_user";
     protected static final String PASS = "x-pack-test-password";
 
-    private static final ElasticsearchCluster cluster = buildCluster();
-
     @ClassRule
-    public static ElasticsearchCluster clusterRule = cluster;
+    public static ElasticsearchCluster cluster = buildClusterWithSecurity();
 
-    private static ElasticsearchCluster buildCluster() {
-        var builder = ElasticsearchCluster.local()
-            .distribution(DistributionType.DEFAULT)
-            .version(getOldClusterVersion())
-            .nodes(NODE_NUM)
-            .user(USER, PASS)
-            .setting("xpack.license.self_generated.type", "trial")
-            .setting("xpack.security.enabled", "true")
-            .setting("xpack.security.autoconfiguration.enabled", "false")
-            .setting("xpack.security.transport.ssl.enabled", "true")
-            .setting("xpack.security.transport.ssl.key", "testnode.pem")
-            .setting("xpack.security.transport.ssl.certificate", "testnode.crt")
-            .setting("xpack.security.authc.token.enabled", "true")
-            .setting("xpack.security.authc.token.timeout", "60m")
-            .setting("xpack.security.authc.api_key.enabled", "true")
-            .setting("xpack.security.audit.enabled", "true")
-            .setting("xpack.security.authc.realms.file.file1.order", "0")
-            .setting("xpack.security.authc.realms.native.native1.order", "1")
-            .setting("xpack.watcher.encrypt_sensitive_data", "true")
-            .setting("logger.org.elasticsearch.xpack.watcher", "DEBUG")
-            .configFile("testnode.pem", Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
-            .configFile("testnode.crt", Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"))
-            .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")
-            .keystore("xpack.watcher.encryption_key", Resource.fromClasspath("system_key"));
-
-        if (getOldClusterTestVersion().before(Version.fromString("8.18.0"))) {
-            builder.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
-            builder.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
-        }
-
-        return builder.build();
+    protected static ElasticsearchCluster buildClusterWithSecurity() {
+        return buildCluster(
+            b -> b.user(USER, PASS)
+                .setting("xpack.security.enabled", "true")
+                .setting("xpack.security.autoconfiguration.enabled", "false")
+                .setting("xpack.security.transport.ssl.enabled", "true")
+                .setting("xpack.security.transport.ssl.key", "testnode.pem")
+                .setting("xpack.security.transport.ssl.certificate", "testnode.crt")
+                .setting("xpack.security.authc.token.enabled", "true")
+                .setting("xpack.security.authc.token.timeout", "60m")
+                .setting("xpack.security.authc.api_key.enabled", "true")
+                .setting("xpack.security.audit.enabled", "true")
+                .setting("xpack.security.authc.realms.file.file1.order", "0")
+                .setting("xpack.security.authc.realms.native.native1.order", "1")
+                .setting("xpack.watcher.encrypt_sensitive_data", "true")
+                .setting("logger.org.elasticsearch.xpack.watcher", "DEBUG")
+                .configFile(
+                    "testnode.pem",
+                    Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem")
+                )
+                .configFile(
+                    "testnode.crt",
+                    Resource.fromClasspath("org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt")
+                )
+                .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")
+                .keystore("xpack.watcher.encryption_key", Resource.fromClasspath("system_key"))
+        );
     }
 
     protected AbstractXpackRollingUpgradeWithSecurityTestCase(@Name("upgradedNodes") int upgradedNodes) {
@@ -131,5 +123,4 @@ public abstract class AbstractXpackRollingUpgradeWithSecurityTestCase extends Pa
             assertTrue(Integer.parseInt(responseVersion) >= version);
         });
     }
-
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
@@ -12,14 +12,28 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.hamcrest.Matchers;
+import org.junit.ClassRule;
 
 import java.nio.charset.StandardCharsets;
 
 public class GeoIpUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster(
+        b -> b.systemProperty("ingest.geoip.downloader.enabled.default", "true")
+            .systemProperty("ingest.geoip.downloader.endpoint.default", "http://invalid.endpoint")
+            .setting("ingest.geoip.downloader.endpoint", "http://invalid.endpoint")
+    );
+
     public GeoIpUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     public void testGeoIpDownloader() throws Exception {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ILMHistoryManagedTemplateUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ILMHistoryManagedTemplateUpgradeIT.java
@@ -12,7 +12,9 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ObjectPath;
+import org.junit.ClassRule;
 
 import java.util.List;
 import java.util.Map;
@@ -22,8 +24,16 @@ import static org.hamcrest.Matchers.is;
 
 public class ILMHistoryManagedTemplateUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
     public ILMHistoryManagedTemplateUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodeInfo.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodeInfo.java
@@ -10,6 +10,7 @@ package org.elasticsearch.upgrades;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 
 import java.io.IOException;

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SLMHistoryManagedTemplateUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SLMHistoryManagedTemplateUpgradeIT.java
@@ -12,7 +12,9 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ObjectPath;
+import org.junit.ClassRule;
 
 import java.util.List;
 import java.util.Map;
@@ -22,8 +24,16 @@ import static org.hamcrest.Matchers.is;
 
 public class SLMHistoryManagedTemplateUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
     public SLMHistoryManagedTemplateUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SearchableSnapshotsRollingUpgradeIT.java
@@ -17,14 +17,21 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.hamcrest.Matcher;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,8 +40,27 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SearchableSnapshotsRollingUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster cluster = buildCluster(b -> b.setting("path.repo", new Supplier<>() {
+        @Override
+        @SuppressForbidden(reason = "TemporaryFolder only has io.File methods, not nio.File")
+        public String get() {
+            return repoDirectory.getRoot().getPath();
+        }
+    }).setting("xpack.searchable.snapshot.shared_cache.size", "16MB").setting("xpack.searchable.snapshot.shared_cache.region_size", "256KB")
+    );
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+
     public SearchableSnapshotsRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     public enum Storage {

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/WatcherRestartIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/WatcherRestartIT.java
@@ -13,6 +13,8 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.junit.ClassRule;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -24,8 +26,16 @@ import static org.hamcrest.Matchers.not;
 
 public class WatcherRestartIT extends AbstractXpackRollingUpgradeTestCase {
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
     public WatcherRestartIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     public void testWatcherRestart() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Move ParameterizedRollingUpgradeTestCase to test-framework (#155762)](https://github.com/elastic/elasticsearch/pull/155762)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)