### PR TITLE
ESQL: use latestSupported() in compute gen processors

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
@@ -52,7 +52,7 @@ public class AggregatorProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_21;
+        return SourceVersion.latestSupported();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/ConsumeProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/ConsumeProcessor.java
@@ -54,7 +54,7 @@ public class ConsumeProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_21;
+        return SourceVersion.latestSupported();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorProcessor.java
@@ -44,7 +44,7 @@ public class EvaluatorProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_21;
+        return SourceVersion.latestSupported();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/MarkerAnnotationProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/MarkerAnnotationProcessor.java
@@ -44,7 +44,7 @@ public class MarkerAnnotationProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_21;
+        return SourceVersion.latestSupported();
     }
 
     @Override


### PR DESCRIPTION
## Summary

The ESQL `compute/gen` annotation processors (`AggregatorProcessor`, `EvaluatorProcessor`, `ConsumeProcessor`, `MarkerAnnotationProcessor`) pin `getSupportedSourceVersion()` to `SourceVersion.RELEASE_21`. These processors only inspect annotations, not language constructs, so there is no reason to tie them to a specific source version. Hardcoding it makes `javac` emit a "supported source version RELEASE_21 ... less than -source" warning as soon as the compiler runs a newer release.

This returns `SourceVersion.latestSupported()` instead, matching what `benchmarks` `ExtraParamProcessor` already does.

- Behavior-neutral on the current JDK 21 toolchain: `latestSupported()` resolves to `RELEASE_21`.
- Future-proofs the processors for newer compiler JDKs and removes the warning.

Extracted from #156773 (JDK 25 baseline), where it is otherwise a baseline-specific change; it stands on its own here.

## Test plan

- [ ] `:x-pack:plugin:esql:compute:gen:compileJava` and dependent codegen build green
- [ ] CI

Made with [Cursor](https://cursor.com)