### PR TITLE
Add 8.19.21 connector release notes

### DIFF
--- a/docs/reference/connector/docs/connectors-release-notes.asciidoc
+++ b/docs/reference/connector/docs/connectors-release-notes.asciidoc
@@ -10,6 +10,19 @@ Prior to version *8.16.0*, the connector release notes were published as part of
 ====
 
 [discrete]
+[[es-connectors-release-notes-8-19-21]]
+=== 8.19.21
+
+[discrete]
+[[es-connectors-release-notes-8-19-21-bug-fixes]]
+===== Bug fixes
+
+* Fixed long-running syncs being falsely marked as idle when Elasticsearch was temporarily slow or refresh calls timed out. The connector service no longer forces an index refresh on every job status check, keeps the ingestion heartbeat alive through transient errors, and retries job status checks during active syncs.
+See: https://github.com/elastic/connectors/pull/4369[*PR 4369*]
+* Fixed long-running syncs failing permanently on transient non-JSON Elasticsearch bulk responses, such as `Client Closed Request`. Failed concurrent bulk tasks are no longer silently dropped.
+See: https://github.com/elastic/connectors/pull/4387[*PR 4387*]
+
+[discrete]
 [[es-connectors-release-notes-8-19-20]]
 === 8.19.20
 

--- a/docs/reference/connector/docs/connectors-release-notes.asciidoc
+++ b/docs/reference/connector/docs/connectors-release-notes.asciidoc
@@ -21,6 +21,8 @@ Prior to version *8.16.0*, the connector release notes were published as part of
 See: https://github.com/elastic/connectors/pull/4369[*PR 4369*]
 * Fixed long-running syncs failing permanently on transient non-JSON Elasticsearch bulk responses, such as `Client Closed Request`. Failed concurrent bulk tasks are no longer silently dropped.
 See: https://github.com/elastic/connectors/pull/4387[*PR 4387*]
+* Fixed the SharePoint Online connector to recover from expired drive delta tokens (`410 Gone`) with one restart from `root/delta` per drive, and to fail the sync with a clear drive-id message if recovery does not succeed.
+See: https://github.com/elastic/connectors/pull/4383[*PR 4383*]
 
 [discrete]
 [[es-connectors-release-notes-8-19-20]]


### PR DESCRIPTION
Adds the 8.19.21 connector release notes. Covers elastic/connectors#4369 (backport of #4345, fixes elastic/connectors#4311) and elastic/connectors#4387 (backport of #4384). The ssl.verification_mode fix (elastic/connectors#4395) is not yet merged into 8.19 and is excluded.