### PR TITLE
Add a LuceneLongColumn spec and (spec) builder

### DIFF
--- a/server/src/main/java/org/elasticsearch/escf/LuceneLongColumn.java
+++ b/server/src/main/java/org/elasticsearch/escf/LuceneLongColumn.java
@@ -9,7 +9,14 @@
 
 package org.elasticsearch.escf;
 
+import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatField;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.column.Column;
 import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.document.column.LongTupleCursor;
@@ -21,16 +28,161 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.sourcebatch.LuceneColumn;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A {@link LongColumn} backed by an {@link EscfLongColumn} (single-value) or {@link EscfArrayColumn}
  * (multi-value). Multi-value columns always use {@link Density#SPARSE}.
  */
 public final class LuceneLongColumn extends LongColumn implements LuceneColumn {
+
+    private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE = SortedNumericDocValuesField.TYPE;
+    private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
+        .fieldType();
+    private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE_STORED = storedVariant(SORTED_NUMERIC_DV_FIELD_TYPE);
+    private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE_STORED = storedVariant(
+        SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE
+    );
+
+    // BKD + DV combined field types, one per NumericKind. Used by Builder to select the indexed field type.
+    private static final IndexableFieldType LONG_INDEXED_FIELD_TYPE = new LongField("_sentinel", 0L, Field.Store.NO).fieldType();
+    private static final IndexableFieldType INT_INDEXED_FIELD_TYPE = new IntField("_sentinel", 0, Field.Store.NO).fieldType();
+    private static final IndexableFieldType FLOAT_INDEXED_FIELD_TYPE = new FloatField("_sentinel", 0f, Field.Store.NO).fieldType();
+    private static final IndexableFieldType DOUBLE_INDEXED_FIELD_TYPE = new DoubleField("_sentinel", 0.0, Field.Store.NO).fieldType();
+
+    // Stored-only field types (no doc values, no BKD), one per NumericKind.
+    private static final IndexableFieldType LONG_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0L).fieldType();
+    private static final IndexableFieldType INT_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0).fieldType();
+    private static final IndexableFieldType FLOAT_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0f).fieldType();
+    private static final IndexableFieldType DOUBLE_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0.0).fieldType();
+
+    private static IndexableFieldType storedVariant(IndexableFieldType base) {
+        FieldType ft = new FieldType(base);
+        ft.setStored(true);
+        ft.freeze();
+        return ft;
+    }
+
+    /**
+     * Returns a new {@link Builder} for constructing a {@link Spec}: a pre-computed column factory
+     * that captures all static configuration ({@code name}, field type, {@link LongColumn.NumericKind})
+     * at mapper construction time. Only the batch data is needed at {@link Spec#build} time.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A pre-computed column factory produced by {@link Builder#build()}. Holds the static column
+     * configuration ({@code name}, {@link IndexableFieldType}, {@link LongColumn.NumericKind})
+     * so that {@link #build(EscfColumnData)} only needs the per-batch data.
+     */
+    public static final class Spec {
+        private final String name;
+        private final IndexableFieldType fieldType;
+        private final LongColumn.NumericKind numericKind;
+
+        private Spec(String name, IndexableFieldType fieldType, LongColumn.NumericKind numericKind) {
+            this.name = name;
+            this.fieldType = fieldType;
+            this.numericKind = numericKind;
+        }
+
+        /** Creates a {@link LuceneLongColumn} from the pre-computed configuration and the given batch data. */
+        public LuceneLongColumn build(EscfColumnData data) {
+            return LuceneLongColumn.of(data, name, fieldType, numericKind);
+        }
+    }
+
+    /**
+     * Builder for {@link Spec}. Captures all static column configuration at mapper construction
+     * time and selects the appropriate {@link IndexableFieldType} from the combination of
+     * {@link IndexType}, {@code indexed}, {@code stored}, and {@link LongColumn.NumericKind}.
+     *
+     * <p>The field-type selection follows the same logic as the row-major path:
+     * <ul>
+     *   <li>If {@link IndexType#hasDocValuesSkipper()}: a {@code SortedNumericDocValuesField} with
+     *       a doc-values-skipper index, optionally with {@code stored}.</li>
+     *   <li>Else if {@code indexed}: a combined BKD + DV field ({@code LongField}, {@code IntField},
+     *       etc., derived from {@link LongColumn.NumericKind}), optionally with {@code stored}.</li>
+     *   <li>Otherwise: a plain {@code SortedNumericDocValuesField}, optionally with {@code stored}.</li>
+     * </ul>
+     */
+    public static final class Builder {
+        private String name;
+        private IndexType indexType;
+        private boolean indexed;
+        private boolean stored;
+        private LongColumn.NumericKind numericKind = LongColumn.NumericKind.LONG;
+
+        private Builder() {}
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder indexType(IndexType indexType) {
+            this.indexType = indexType;
+            return this;
+        }
+
+        public Builder indexed(boolean indexed) {
+            this.indexed = indexed;
+            return this;
+        }
+
+        public Builder stored(boolean stored) {
+            this.stored = stored;
+            return this;
+        }
+
+        public Builder numericKind(LongColumn.NumericKind numericKind) {
+            this.numericKind = numericKind;
+            return this;
+        }
+
+        /**
+         * Selects the field type and returns the immutable {@link Spec}.
+         *
+         * <p>When {@link #indexType} is set, the field type is chosen from the combination of
+         * {@link IndexType#hasDocValuesSkipper()}, {@code indexed}, and {@code stored}, covering
+         * the full DV (and optionally BKD) range. When {@link #indexType} is absent, a
+         * stored-only field type (no doc values, no BKD) is selected from {@link LongColumn.NumericKind},
+         * and {@code stored} must be {@code true}.
+         */
+        public Spec build() {
+            Objects.requireNonNull(name, "name");
+            final IndexableFieldType fieldType;
+            if (indexType == null) {
+                assert stored : "builder without indexType must have stored(true)";
+                fieldType = switch (numericKind) {
+                    case LONG -> LONG_STORED_ONLY_FIELD_TYPE;
+                    case INT -> INT_STORED_ONLY_FIELD_TYPE;
+                    case FLOAT -> FLOAT_STORED_ONLY_FIELD_TYPE;
+                    case DOUBLE -> DOUBLE_STORED_ONLY_FIELD_TYPE;
+                };
+            } else if (indexType.hasDocValuesSkipper()) {
+                fieldType = stored ? SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE_STORED : SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE;
+            } else if (indexed) {
+                IndexableFieldType base = switch (numericKind) {
+                    case LONG -> LONG_INDEXED_FIELD_TYPE;
+                    case INT -> INT_INDEXED_FIELD_TYPE;
+                    case FLOAT -> FLOAT_INDEXED_FIELD_TYPE;
+                    case DOUBLE -> DOUBLE_INDEXED_FIELD_TYPE;
+                };
+                fieldType = stored ? storedVariant(base) : base;
+            } else {
+                fieldType = stored ? SORTED_NUMERIC_DV_FIELD_TYPE_STORED : SORTED_NUMERIC_DV_FIELD_TYPE;
+            }
+            return new Spec(name, fieldType, numericKind);
+        }
+    }
 
     private final EscfColumn data;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -14,14 +14,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.document.column.LongTupleCursor;
 import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -118,15 +115,6 @@ public final class DateFieldMapper extends FieldMapper {
     ).withLocale(DEFAULT_LOCALE);
     private static final DateFormatter EPOCH_MILLIS_FORMATTER = DateFormatter.forPattern("epoch_millis").withLocale(DEFAULT_LOCALE);
     private static final DateMathParser EPOCH_MILLIS_PARSER = EPOCH_MILLIS_FORMATTER.toDateMathParser();
-    // FieldType constants for the Lucene field variants emitted by the columnar parse path.
-    // The compat harness compares frozen FieldType, so the column must carry exactly the same type
-    // as the corresponding field produced by the row-major path.
-    private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE = SortedNumericDocValuesField.TYPE;
-    private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
-        .fieldType();
-    private static final IndexableFieldType LONG_FIELD_TYPE = new LongField("_sentinel", 0L, Field.Store.NO).fieldType();
-    // Stored-only variant: matches the separate StoredField(name, timestamp) emitted by the row path.
-    private static final IndexableFieldType LONG_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0L).fieldType();
 
     public enum Resolution {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE, DateMillisDocValuesField::new) {
@@ -1176,6 +1164,8 @@ public final class DateFieldMapper extends FieldMapper {
 
     private final boolean stored;
     private final boolean indexed;
+    private final LuceneLongColumn.Spec columnSpec;
+    private final LuceneLongColumn.Spec storedSpec;
     private final DocValuesParameter.Values docValuesParameters;
     private final DocValuesFieldFactory dvFactory;
     private final Locale locale;
@@ -1207,6 +1197,12 @@ public final class DateFieldMapper extends FieldMapper {
         super(leafName, mappedFieldType, builderParams);
         this.stored = builder.store.getValue();
         this.indexed = builder.index.getValue();
+        this.columnSpec = LuceneLongColumn.builder()
+            .name(mappedFieldType.name())
+            .indexType(mappedFieldType.indexType())
+            .indexed(this.indexed)
+            .build();
+        this.storedSpec = LuceneLongColumn.builder().name(mappedFieldType.name()).stored(true).build();
         this.docValuesParameters = builder.docValuesParameters.getValue();
         this.dvFactory = new DocValuesFieldFactory(
             docValuesParameters.multiValue(),
@@ -1289,17 +1285,9 @@ public final class DateFieldMapper extends FieldMapper {
                 )
             );
         };
-        final IndexableFieldType columnFieldType;
-        if (fieldType().hasDocValuesSkipper()) {
-            columnFieldType = SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE;
-        } else if (indexed) {
-            columnFieldType = LONG_FIELD_TYPE;
-        } else {
-            columnFieldType = SORTED_NUMERIC_DV_FIELD_TYPE;
-        }
-        ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), columnFieldType, LongColumn.NumericKind.LONG));
+        ctx.addColumn(columnSpec.build(outData));
         if (stored) {
-            ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), LONG_STORED_ONLY_FIELD_TYPE, LongColumn.NumericKind.LONG));
+            ctx.addColumn(storedSpec.build(outData));
         }
         // Publish the timestamp ESCF column on the context so that postColumnarParse hooks
         // (DataStreamTimestampFieldMapper, TsidExtractingIdFieldMapper) can read per-document

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -19,7 +19,6 @@ import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.index.DocValuesType;
@@ -2742,6 +2741,8 @@ public class NumberFieldMapper extends FieldMapper {
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
     private final boolean stored;
+    private final LuceneLongColumn.Spec columnSpec;
+    private final LuceneLongColumn.Spec storedSpec;
     private final Explicit<Boolean> ignoreMalformed;
     private final Explicit<Boolean> coerce;
     private final Number nullValue;
@@ -2774,7 +2775,6 @@ public class NumberFieldMapper extends FieldMapper {
         super(simpleName, mappedFieldType, builderParams);
         this.type = builder.type;
         this.indexed = builder.indexed.getValue();
-        this.docValuesParameters = builder.docValuesParameters.getValue();
         this.stored = builder.stored.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.coerce = builder.coerce.getValue();
@@ -2795,6 +2795,16 @@ public class NumberFieldMapper extends FieldMapper {
 
         // this is basically just an inlined version of `(NumberFieldType) super.fieldType()`
         this.fieldType = (NumberFieldType) mappedFieldType;
+        // half_float uses a separate HalfFloatPoint column for BKD; the main column is always DV-only
+        final LongColumn.NumericKind kind = numericKind(this.type);
+        this.columnSpec = LuceneLongColumn.builder()
+            .name(mappedFieldType.name())
+            .indexType(mappedFieldType.indexType())
+            .numericKind(kind)
+            .indexed(this.indexed && this.type != NumberType.HALF_FLOAT)
+            .build();
+        this.storedSpec = LuceneLongColumn.builder().name(mappedFieldType.name()).numericKind(kind).stored(true).build();
+        this.docValuesParameters = builder.docValuesParameters.getValue();
         this.dvFactory = new DocValuesFieldFactory(
             docValuesParameters.multiValue(),
             fieldType.indexType.hasDocValuesSkipper(),
@@ -2856,25 +2866,8 @@ public class NumberFieldMapper extends FieldMapper {
         return fieldType.type.typeName();
     }
 
-    // FieldType constants for the Lucene field variants emitted by the columnar parse path.
-    // The compat harness compares frozen FieldType, so the column must carry exactly the same type
-    // as the corresponding field produced by the row-major path.
-    private static final IndexableFieldType SORTED_NUMERIC_DV_FIELD_TYPE = SortedNumericDocValuesField.TYPE;
-    private static final IndexableFieldType SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE = SortedNumericDocValuesField.indexedField("_sentinel", 0L)
-        .fieldType();
-    // Match the field types produced by the indexed+DV branches in addLongFields / NumberType.addFields.
-    private static final IndexableFieldType LONG_FIELD_TYPE = new LongField("_sentinel", 0L, Field.Store.NO).fieldType();
-    private static final IndexableFieldType INT_FIELD_TYPE = new IntField("_sentinel", 0, Field.Store.NO).fieldType();
-    private static final IndexableFieldType FLOAT_FIELD_TYPE = new FloatField("_sentinel", 0f, Field.Store.NO).fieldType();
-    private static final IndexableFieldType DOUBLE_FIELD_TYPE = new DoubleField("_sentinel", 0.0, Field.Store.NO).fieldType();
-    // half_float uses a separate HalfFloatPoint (2-byte BKD points) alongside its doc-values column;
-    // LuceneHalfFloatPointColumn emits this type for the points column.
+    // half_float uses a separate HalfFloatPoint (2-byte BKD points) alongside its doc-values column.
     private static final IndexableFieldType HALF_FLOAT_POINT_FIELD_TYPE = new HalfFloatPoint("_sentinel", 0f).fieldType();
-    // Stored-only variants: match the separate StoredField(name, value) emitted by the row path.
-    private static final IndexableFieldType INT_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0).fieldType();
-    private static final IndexableFieldType LONG_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0L).fieldType();
-    private static final IndexableFieldType FLOAT_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0f).fieldType();
-    private static final IndexableFieldType DOUBLE_STORED_ONLY_FIELD_TYPE = new StoredField("_sentinel", 0.0).fieldType();
 
     @Override
     public boolean supportsColumnarParse(IndexSettings indexSettings) {
@@ -2904,59 +2897,32 @@ public class NumberFieldMapper extends FieldMapper {
                 )
             );
         }
+
         Long nullSortableLong = nullValue != null ? type.toSortableLong(nullValue) : null;
         EscfColumnData outData = NumberColumnTransform.toSortableLongColumn(source, type, coerce(), ctx.recycler(), nullSortableLong);
-        if (fieldType().indexType().hasDocValuesSkipper()) {
-            ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), SORTED_NUMERIC_DV_INDEXED_FIELD_TYPE, numericKind(type)));
-        } else if (indexed) {
-            if (type == NumberType.HALF_FLOAT) {
-                // half_float's BKD index uses a separate 2-byte HalfFloatPoint; other numeric types combine DV and BKD into one field.
-                ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), SORTED_NUMERIC_DV_FIELD_TYPE, LongColumn.NumericKind.FLOAT));
+        ctx.addColumn(columnSpec.build(outData));
+
+        if (type == NumberType.HALF_FLOAT) {
+            if (indexed) {
+                // half_float uses separate HalfFloatPoint (2-byte BKD) and SortedNumericDocValuesField,
+                // unlike other numeric types which use a combined field. Send one column for each.
                 EscfColumnData halfFloatPointData = NumberColumnTransform.toHalfFloatPointBinaryColumn(
                     EscfColumn.from(outData),
                     ctx.recycler()
                 );
                 ctx.addColumn(LuceneBinaryColumn.of(halfFloatPointData, fieldType().name(), HALF_FLOAT_POINT_FIELD_TYPE));
-            } else {
-                ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), indexableFieldType(type), numericKind(type)));
             }
-        } else {
-            ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), SORTED_NUMERIC_DV_FIELD_TYPE, numericKind(type)));
-        }
-        if (stored) {
-            if (type == NumberType.HALF_FLOAT) {
+            if (stored) {
                 // half_float DV encodes as sortable shorts, but stored fields need sortable float ints for FLOAT-kind decoding.
                 EscfColumnData halfFloatStoredData = NumberColumnTransform.toHalfFloatStoredLongColumn(
                     EscfColumn.from(outData),
                     ctx.recycler()
                 );
-                ctx.addColumn(
-                    LuceneLongColumn.of(halfFloatStoredData, fieldType().name(), FLOAT_STORED_ONLY_FIELD_TYPE, LongColumn.NumericKind.FLOAT)
-                );
-            } else {
-                ctx.addColumn(LuceneLongColumn.of(outData, fieldType().name(), storedOnlyFieldType(type), numericKind(type)));
+                ctx.addColumn(storedSpec.build(halfFloatStoredData));
             }
+        } else if (stored) {
+            ctx.addColumn(storedSpec.build(outData));
         }
-    }
-
-    private static IndexableFieldType storedOnlyFieldType(NumberType type) {
-        return switch (type) {
-            case BYTE, SHORT, INTEGER -> INT_STORED_ONLY_FIELD_TYPE;
-            case FLOAT -> FLOAT_STORED_ONLY_FIELD_TYPE;
-            case LONG -> LONG_STORED_ONLY_FIELD_TYPE;
-            case DOUBLE -> DOUBLE_STORED_ONLY_FIELD_TYPE;
-            case HALF_FLOAT -> throw new AssertionError("unreachable: indexed half_float is handled separately");
-        };
-    }
-
-    private static IndexableFieldType indexableFieldType(NumberType type) {
-        return switch (type) {
-            case BYTE, SHORT, INTEGER -> INT_FIELD_TYPE;
-            case FLOAT -> FLOAT_FIELD_TYPE;
-            case LONG -> LONG_FIELD_TYPE;
-            case DOUBLE -> DOUBLE_FIELD_TYPE;
-            case HALF_FLOAT -> throw new AssertionError("unreachable: indexed half_float is handled separately");
-        };
     }
 
     private static LongColumn.NumericKind numericKind(NumberType type) {

--- a/server/src/test/java/org/elasticsearch/escf/LuceneLongColumnBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/escf/LuceneLongColumnBuilderTests.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.escf;
+
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatField;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.LongColumn;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableFieldType;
+import org.elasticsearch.index.mapper.IndexType;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.BytesRefRecycler;
+
+/**
+ * Unit tests for {@link LuceneLongColumn.Builder} and {@link LuceneLongColumn.Spec}. Verifies that
+ * the builder selects the correct {@link IndexableFieldType} for every combination of
+ * {@link IndexType}, {@code indexed}, {@code stored}, and {@link LongColumn.NumericKind}.
+ */
+public class LuceneLongColumnBuilderTests extends ESTestCase {
+
+    /** A minimal one-doc long column — just enough to call {@link LuceneLongColumn.Spec#build}. */
+    private static EscfColumnData minimalLongData() {
+        EscfColumnBuilder builder = new EscfColumnBuilder(EscfColumnBuilder.CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        builder.setLong(0, 42L);
+        return builder.finish(1);
+    }
+
+    /** Returns a stored variant of {@code base} — mirrors the private helper in {@link LuceneLongColumn}. */
+    private static IndexableFieldType storedVariant(IndexableFieldType base) {
+        FieldType ft = new FieldType(base);
+        ft.setStored(true);
+        ft.freeze();
+        return ft;
+    }
+
+    // ---- name and null-check ----
+
+    public void testNamePropagates() {
+        LuceneLongColumn col = LuceneLongColumn.builder()
+            .name("my_field")
+            .indexType(IndexType.docValuesOnly())
+            .build()
+            .build(minimalLongData());
+        assertEquals("my_field", col.name());
+    }
+
+    public void testMissingNameThrows() {
+        expectThrows(NullPointerException.class, () -> LuceneLongColumn.builder().indexType(IndexType.docValuesOnly()).build());
+    }
+
+    // ---- numericKind ----
+
+    public void testNumericKindDefaultsToLong() {
+        LuceneLongColumn col = LuceneLongColumn.builder().name("f").indexType(IndexType.docValuesOnly()).build().build(minimalLongData());
+        assertEquals(LongColumn.NumericKind.LONG, col.numericKind());
+    }
+
+    public void testNumericKindPropagates() {
+        for (LongColumn.NumericKind kind : LongColumn.NumericKind.values()) {
+            LuceneLongColumn col = LuceneLongColumn.builder()
+                .name("f")
+                .indexType(IndexType.docValuesOnly())
+                .numericKind(kind)
+                .build()
+                .build(minimalLongData());
+            assertEquals(kind, col.numericKind());
+        }
+    }
+
+    // ---- stored-only path (indexType == null) ----
+
+    public void testStoredOnlyLong() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.LONG)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new StoredField("_", 0L).fieldType(), ft);
+        assertStoredOnly(ft);
+    }
+
+    public void testStoredOnlyInt() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.INT)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new StoredField("_", 0).fieldType(), ft);
+        assertStoredOnly(ft);
+    }
+
+    public void testStoredOnlyFloat() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.FLOAT)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new StoredField("_", 0f).fieldType(), ft);
+        assertStoredOnly(ft);
+    }
+
+    public void testStoredOnlyDouble() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.DOUBLE)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new StoredField("_", 0.0).fieldType(), ft);
+        assertStoredOnly(ft);
+    }
+
+    // ---- doc-values-skipper path (indexType.hasDocValuesSkipper() == true) ----
+
+    public void testDocValuesSkipperNotStored() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.skippers())
+            .stored(false)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(SortedNumericDocValuesField.indexedField("_", 0L).fieldType(), ft);
+        assertFalse(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertNotEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(0, ft.pointDimensionCount());
+    }
+
+    public void testDocValuesSkipperStored() {
+        IndexableFieldType expected = storedVariant(SortedNumericDocValuesField.indexedField("_", 0L).fieldType());
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.skippers())
+            .stored(true)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(expected, ft);
+        assertTrue(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertNotEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(0, ft.pointDimensionCount());
+    }
+
+    // ---- indexed (BKD + DV) path ----
+
+    public void testIndexedLong() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .numericKind(LongColumn.NumericKind.LONG)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new LongField("_", 0L, Field.Store.NO).fieldType(), ft);
+        assertFalse(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Long.BYTES, ft.pointNumBytes());
+    }
+
+    public void testIndexedInt() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .numericKind(LongColumn.NumericKind.INT)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new IntField("_", 0, Field.Store.NO).fieldType(), ft);
+        assertFalse(ft.stored());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Integer.BYTES, ft.pointNumBytes());
+    }
+
+    public void testIndexedFloat() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .numericKind(LongColumn.NumericKind.FLOAT)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new FloatField("_", 0f, Field.Store.NO).fieldType(), ft);
+        assertFalse(ft.stored());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Integer.BYTES, ft.pointNumBytes());
+    }
+
+    public void testIndexedDouble() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .numericKind(LongColumn.NumericKind.DOUBLE)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(new DoubleField("_", 0.0, Field.Store.NO).fieldType(), ft);
+        assertFalse(ft.stored());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Long.BYTES, ft.pointNumBytes());
+    }
+
+    public void testIndexedLongStored() {
+        IndexableFieldType expected = storedVariant(new LongField("_", 0L, Field.Store.NO).fieldType());
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.LONG)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(expected, ft);
+        assertTrue(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Long.BYTES, ft.pointNumBytes());
+    }
+
+    public void testIndexedIntStored() {
+        IndexableFieldType expected = storedVariant(new IntField("_", 0, Field.Store.NO).fieldType());
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.points(true, true))
+            .indexed(true)
+            .stored(true)
+            .numericKind(LongColumn.NumericKind.INT)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(expected, ft);
+        assertTrue(ft.stored());
+        assertEquals(1, ft.pointDimensionCount());
+        assertEquals(Integer.BYTES, ft.pointNumBytes());
+    }
+
+    // ---- doc-values-only path (indexed=false, no DV skipper) ----
+
+    public void testDocValuesOnly() {
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.docValuesOnly())
+            .indexed(false)
+            .stored(false)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(SortedNumericDocValuesField.TYPE, ft);
+        assertFalse(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(0, ft.pointDimensionCount());
+    }
+
+    public void testDocValuesOnlyStored() {
+        IndexableFieldType expected = storedVariant(SortedNumericDocValuesField.TYPE);
+        IndexableFieldType ft = LuceneLongColumn.builder()
+            .name("f")
+            .indexType(IndexType.docValuesOnly())
+            .indexed(false)
+            .stored(true)
+            .build()
+            .build(minimalLongData())
+            .fieldType();
+        assertEquals(expected, ft);
+        assertTrue(ft.stored());
+        assertEquals(DocValuesType.SORTED_NUMERIC, ft.docValuesType());
+        assertEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(0, ft.pointDimensionCount());
+    }
+
+    // ---- Spec reuse ----
+
+    /** The same {@link LuceneLongColumn.Spec} can be called multiple times without side effects. */
+    public void testSpecIsReusable() {
+        LuceneLongColumn.Spec spec = LuceneLongColumn.builder()
+            .name("reused")
+            .indexType(IndexType.docValuesOnly())
+            .numericKind(LongColumn.NumericKind.LONG)
+            .build();
+        LuceneLongColumn col1 = spec.build(minimalLongData());
+        LuceneLongColumn col2 = spec.build(minimalLongData());
+        assertEquals(col1.name(), col2.name());
+        assertEquals(col1.fieldType(), col2.fieldType());
+        assertEquals(col1.numericKind(), col2.numericKind());
+    }
+
+    private static void assertStoredOnly(IndexableFieldType ft) {
+        assertTrue(ft.stored());
+        assertEquals(DocValuesType.NONE, ft.docValuesType());
+        assertEquals(DocValuesSkipIndexType.NONE, ft.docValuesSkipIndexType());
+        assertEquals(0, ft.pointDimensionCount());
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/157913

The spec is intended to capture all the details at mapper construction time -- it closes over the `String` field name, as well as the `IndexableFieldType`, and `LongColumn.NumericKind`. With that closure, then, you can pass in a `EscfColumnData` per batch and get out a `LuceneLongColumn`. As a consequence, a bunch of the constants from `NumberFieldMapper` and `DateFieldMapper` fall away, as does a bunch of their gnarly if/else conditional logic. (Note: IMHO it's easier to review those classes side by side rather than with inline diffs, but you can do as you'd like.)

The `LuceneLongColumnBuilderTests` are rather trivial, but the `NumberFieldMapper` and `DateFieldMapper` tests continuing to pass after this PR is the more interesting fact.

This is still somewhat flexible code (i.e. I expect it to evolve more as we get further into the various columnar mapper changes that we're writing). I don't think I've fully solved anything, but it seemed like a useful step in the right direction.