### PR TITLE
[8.19] Migrate more xpack:qa:rolling-upgrade-legacy tests (#156288)

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -17,12 +18,18 @@ smartRetry.pruneIndividualTests.set(false)
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation(project(':x-pack:qa'))
+  javaRestTestImplementation(testArtifact(project(':server')))
+  javaRestTestImplementation(testArtifact(project(xpackModule('inference'))))
 }
 
 buildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      systemProperty 'tests.ml.skip', 'true'
+    }
   }
 }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractXpackRollingUpgradeTestCase.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.upgrades;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.test.ParameterizedRollingUpgradeTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
@@ -16,6 +17,10 @@ import org.elasticsearch.test.cluster.util.Version;
 import java.util.function.UnaryOperator;
 
 public abstract class AbstractXpackRollingUpgradeTestCase extends ParameterizedRollingUpgradeTestCase {
+
+    static final org.elasticsearch.Version UPGRADE_FROM_VERSION = org.elasticsearch.Version.fromString(
+        System.getProperty("tests.upgrade_from_version")
+    );
 
     public AbstractXpackRollingUpgradeTestCase(int upgradedNodes) {
         super(upgradedNodes);
@@ -39,5 +44,9 @@ public abstract class AbstractXpackRollingUpgradeTestCase extends ParameterizedR
         }
 
         return customizer.apply(builder).build();
+    }
+
+    protected static boolean isOriginalClusterCurrent() {
+        return getOldClusterVersion().equals(Build.current().version());
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ApiKeyBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/ApiKeyBackwardsCompatibilityIT.java
@@ -55,8 +55,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class ApiKeyBackwardsCompatibilityIT extends AbstractXpackRollingUpgradeWithSecurityTestCase {
 
-    private static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
-
     public ApiKeyBackwardsCompatibilityIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
     }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Build;
@@ -20,14 +22,13 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matchers;
 
@@ -40,13 +41,16 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.upgrades.IndexingIT.assertCount;
 import static org.hamcrest.Matchers.equalTo;
 
-public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
+public class DataStreamsUpgradeIT extends AbstractXpackRollingUpgradeWithSecurityTestCase {
+
+    public DataStreamsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
 
     public void testDataStreams() throws IOException {
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             String requestBody = """
                 {
                   "index_patterns": [ "logs-*" ],
@@ -79,7 +83,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             bulk.setJsonEntity(b.toString());
             Response response = client().performRequest(bulk);
             assertEquals("{\"errors\":false}", EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
-        } else if (CLUSTER_TYPE == ClusterType.MIXED) {
+        } else if (isMixedCluster()) {
             long nowMillis = System.currentTimeMillis();
             Request rolloverRequest = new Request("POST", "/logs-foobar/_rollover");
             client().performRequest(rolloverRequest);
@@ -87,7 +91,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             Request index = new Request("POST", "/logs-foobar/_doc");
             index.addParameter("refresh", "true");
             index.addParameter("filter_path", "_index");
-            if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
+            if (isFirstMixedCluster()) {
                 // include legacy name and date-named indices with today +/-1 in case of clock skew
                 var expectedIndices = List.of(
                     "{\"_index\":\"" + DataStreamTestHelper.getLegacyDefaultBackingIndexName("logs-foobar", 2) + "\"}",
@@ -113,15 +117,15 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         }
 
         final int expectedCount;
-        if (CLUSTER_TYPE.equals(ClusterType.OLD)) {
+        if (isOldCluster()) {
             expectedCount = 1000;
-        } else if (CLUSTER_TYPE.equals(ClusterType.MIXED)) {
-            if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
+        } else if (isMixedCluster()) {
+            if (isFirstMixedCluster()) {
                 expectedCount = 1001;
             } else {
                 expectedCount = 1002;
             }
-        } else if (CLUSTER_TYPE.equals(ClusterType.UPGRADED)) {
+        } else if (isUpgradedCluster()) {
             expectedCount = 1002;
         } else {
             throw new AssertionError("unexpected cluster type");
@@ -130,7 +134,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     public void testDataStreamValidationDoesNotBreakUpgrade() throws Exception {
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             String requestBody = """
                 {
                   "index_patterns": [ "logs-*" ],
@@ -167,13 +171,13 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             Request rolloverRequest = new Request("POST", "/logs-barbaz-2021.01.13/_rollover");
             client().performRequest(rolloverRequest);
         } else {
-            if (CLUSTER_TYPE == ClusterType.MIXED) {
+            if (isMixedCluster()) {
                 ensureHealth((request -> {
                     request.addParameter("timeout", "70s");
                     request.addParameter("wait_for_nodes", "3");
                     request.addParameter("wait_for_status", "yellow");
                 }));
-            } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+            } else if (isUpgradedCluster()) {
                 // Wait for the cluster to recover to yellow at least before checking index status
                 ensureHealth((request -> {
                     request.addParameter("timeout", "30s");
@@ -208,10 +212,10 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             stopILM();
         }
 
-        if (CLUSTER_TYPE == ClusterType.OLD) {
+        if (isOldCluster()) {
             createAndRolloverDataStream(dataStreamName, numRollovers, hasILMPolicy, ilmEnabled);
             createDataStreamFromNonDataStreamIndices(dataStreamFromNonDataStreamIndices);
-        } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+        } else if (isUpgradedCluster()) {
             Map<String, Map<String, Object>> oldIndicesMetadata = getIndicesMetadata(dataStreamName);
             upgradeDataStream(dataStreamName, numRollovers, numRollovers + 1, 0, ilmEnabled);
             upgradeDataStream(dataStreamFromNonDataStreamIndices, 0, 1, 0, ilmEnabled);
@@ -330,7 +334,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void compareMappings(Map<?, ?> oldMappings, Map<?, ?> upgradedMappings) {
-        boolean ignoreSource = Version.fromString(UPGRADE_FROM_VERSION).before(Version.V_8_19_0);
+        boolean ignoreSource = UPGRADE_FROM_VERSION.before(Version.V_8_19_0);
         if (ignoreSource) {
             Map<?, ?> doc = (Map<?, ?>) oldMappings.get("_doc");
             if (doc != null) {
@@ -743,11 +747,7 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
      * for 8.6 and 8.17, but false for 7.17 and 8.18.
      */
     private boolean isOriginalClusterSameMajorVersionAsCurrent() {
-        /*
-         * Since data stream reindex is specifically about upgrading a data stream from one major version to the next, it's ok to use the
-         * deprecated Version.fromString here
-         */
-        return Version.fromString(UPGRADE_FROM_VERSION).major == Version.fromString(Build.current().version()).major;
+        return Version.fromString(getOldClusterVersion()).major == Version.fromString(Build.current().version()).major;
     }
 
     private static void bulkLoadData(String dataStreamName) throws IOException {
@@ -825,5 +825,15 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
         configureClient(builder, Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build());
         builder.setStrictDeprecationMode(true);
         return builder.build();
+    }
+
+    private static void assertCount(String index, int count) throws IOException {
+        Request searchTestIndexRequest = new Request("POST", "/" + index + "/_search");
+        searchTestIndexRequest.addParameter("rest_total_hits_as_int", "true");
+        searchTestIndexRequest.addParameter("filter_path", "hits.total");
+        Response searchTestIndexResponse = client().performRequest(searchTestIndexRequest);
+        assertEquals(Strings.format("""
+            {"hits":{"total":%s}}\
+            """, count), EntityUtils.toString(searchTestIndexResponse.getEntity(), StandardCharsets.UTF_8));
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -6,11 +6,13 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,37 +21,38 @@ import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_A
 
 /**
  * Basic test that indexed documents survive the rolling restart.
- * <p>
- * This test is an almost exact copy of <code>IndexingIT</code> in the
- * oss rolling restart tests. We should work on a way to remove this
- * duplication but for now we have no real way to share code.
  */
-public class IndexingIT extends AbstractUpgradeTestCase {
+public class IndexingIT extends AbstractXpackRollingUpgradeTestCase {
+
+    @org.junit.ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public IndexingIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     public void testIndexing() throws IOException {
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                break;
-            case MIXED:
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                break;
-            case UPGRADED:
-                ensureHealth("test_index,index_with_replicas,empty_index", (request -> {
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "green");
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("level", "shards");
-                }));
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isMixedCluster()) {
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+        } else if (isUpgradedCluster()) {
+            ensureHealth("test_index,index_with_replicas,empty_index", (request -> {
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "green");
+                request.addParameter("timeout", "70s");
+                request.addParameter("level", "shards");
+            }));
         }
 
-        if (CLUSTER_TYPE == ClusterType.OLD) {
-
+        if (isOldCluster()) {
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("""
                 {"settings": {"index.number_of_replicas": 0}}""");
@@ -70,31 +73,23 @@ public class IndexingIT extends AbstractUpgradeTestCase {
             bulk("index_with_replicas", "_OLD", 5);
         }
 
-        int expectedCount;
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                expectedCount = 5;
-                break;
-            case MIXED:
-                if (Booleans.parseBoolean(System.getProperty("tests.first_round"))) {
-                    expectedCount = 5;
-                } else {
-                    expectedCount = 10;
-                }
-                break;
-            case UPGRADED:
-                expectedCount = 15;
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        final int expectedCount;
+        if (isOldCluster()) {
+            expectedCount = 5;
+        } else if (isMixedCluster()) {
+            expectedCount = isFirstMixedCluster() ? 5 : 10;
+        } else {
+            assert isUpgradedCluster();
+            expectedCount = 15;
         }
 
         assertCount("test_index", expectedCount);
         assertCount("index_with_replicas", 5);
         assertCount("empty_index", 0);
 
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            bulk("test_index", "_" + CLUSTER_TYPE, 5);
+        if (isOldCluster() == false) {
+            String suffix = isMixedCluster() ? "_MIXED" : "_UPGRADED";
+            bulk("test_index", suffix, 5);
             Request toBeDeleted = new Request("PUT", "/test_index/_doc/to_be_deleted");
             toBeDeleted.addParameter("refresh", "true");
             toBeDeleted.setJsonEntity("{\"f1\": \"delete-me\"}");

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -7,15 +7,20 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,7 +35,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
+public class MLModelDeploymentsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     // See PyTorchModelIT for how this model was created
     static final String BASE_64_ENCODED_MODEL =
@@ -59,6 +66,18 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     static final long RAW_MODEL_SIZE; // size of the model before base64 encoding
     static {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MLModelDeploymentsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @BeforeClass
@@ -98,58 +117,52 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     public void testTrainedModelDeployment() throws Exception {
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
+        var originalClusterAtLeastV8 = UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0);
         // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
         assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
 
         final String modelId = "upgrade-deployment-test";
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                setupDeployment(modelId);
+        if (isOldCluster()) {
+            setupDeployment(modelId);
+            assertInfer(modelId);
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted(modelId);
+            // attempt inference on new and old nodes multiple times
+            for (int i = 0; i < 10; i++) {
                 assertInfer(modelId);
             }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted(modelId);
-                // attempt inference on new and old nodes multiple times
-                for (int i = 0; i < 10; i++) {
-                    assertInfer(modelId);
-                }
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
 
-                waitForDeploymentStarted(modelId);
-                assertInfer(modelId);
-                assertNewInfer(modelId);
-                stopDeployment(modelId);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+            waitForDeploymentStarted(modelId);
+            assertInfer(modelId);
+            assertNewInfer(modelId);
+            stopDeployment(modelId);
         }
     }
 
     public void testTrainedModelDeploymentStopOnMixedCluster() throws Exception {
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
+        var originalClusterAtLeastV8 = UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0);
         // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
         assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
 
         final String modelId = "upgrade-deployment-test-stop-mixed-cluster";
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                setupDeployment(modelId);
-                assertInfer(modelId);
-            }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                stopDeployment(modelId);
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                assertThatTrainedModelAssignmentMetadataIsEmpty(modelId);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            setupDeployment(modelId);
+            assertInfer(modelId);
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            stopDeployment(modelId);
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            assertThatTrainedModelAssignmentMetadataIsEmpty(modelId);
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -15,7 +17,9 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,7 +33,7 @@ import static org.elasticsearch.client.WarningsHandler.PERMISSIVE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
+public class MlAssignmentPlannerUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
 
     private static final boolean IS_SINGLE_PROCESSOR_TEST = Boolean.parseBoolean(
         System.getProperty("tests.configure_test_clusters_with_one_processor", "false")
@@ -66,56 +70,64 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101926")
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlAssignmentPlannerUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     public void testMlAssignmentPlannerUpgrade() throws Exception {
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
+        var originalClusterAtLeastV8 = UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0);
         // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
         assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
         assumeFalse("This test deploys multiple models which cannot be accommodated on a single processor", IS_SINGLE_PROCESSOR_TEST);
 
         logger.info("Starting testMlAssignmentPlannerUpgrade, model size {}", RAW_MODEL_SIZE);
 
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                // setup deployments using old and new memory format
-                setupDeployments();
+        if (isOldCluster()) {
+            // setup deployments using old and new memory format
+            setupDeployments();
 
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
 
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
-                if (clusterHasFeature(RestTestLegacyFeatures.ML_NEW_MEMORY_FORMAT)) {
-                    assertNewMemoryFormat("new_memory_format");
-                } else {
-                    assertOldMemoryFormat("new_memory_format");
-                }
-            }
-            case MIXED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
-
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
-                if (clusterHasFeature(RestTestLegacyFeatures.ML_NEW_MEMORY_FORMAT)) {
-                    assertNewMemoryFormat("new_memory_format");
-                } else {
-                    assertOldMemoryFormat("new_memory_format");
-                }
-
-            }
-            case UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                waitForDeploymentStarted("old_memory_format");
-                waitForDeploymentStarted("new_memory_format");
-
-                // assert correct memory format is used
-                assertOldMemoryFormat("old_memory_format");
+            // assert correct memory format is used
+            assertOldMemoryFormat("old_memory_format");
+            if (clusterHasFeature(RestTestLegacyFeatures.ML_NEW_MEMORY_FORMAT)) {
                 assertNewMemoryFormat("new_memory_format");
-
-                cleanupDeployments();
+            } else {
+                assertOldMemoryFormat("new_memory_format");
             }
+        }
+        if (isMixedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
+
+            // assert correct memory format is used
+            assertOldMemoryFormat("old_memory_format");
+            if (clusterHasFeature(RestTestLegacyFeatures.ML_NEW_MEMORY_FORMAT)) {
+                assertNewMemoryFormat("new_memory_format");
+            } else {
+                assertOldMemoryFormat("new_memory_format");
+            }
+        }
+        if (isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            waitForDeploymentStarted("old_memory_format");
+            waitForDeploymentStarted("new_memory_format");
+
+            // assert correct memory format is used
+            assertOldMemoryFormat("old_memory_format");
+            assertNewMemoryFormat("new_memory_format");
+
+            cleanupDeployments();
         }
     }
 
@@ -143,7 +155,11 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         Long expectedMemoryUsage = ByteSizeValue.ofMb(memoryOverheadMb).getBytes() + RAW_MODEL_SIZE * 2;
         Integer actualMemoryUsage = (Integer) XContentMapValues.extractValue("model_size_stats.required_native_memory_bytes", stat);
         assertThat(
-            Strings.format("Memory usage mismatch for the model %s in cluster state %s", modelId, CLUSTER_TYPE.toString()),
+            Strings.format(
+                "Memory usage mismatch for the model %s in cluster state %s",
+                modelId,
+                isOldCluster() ? "old" : isMixedCluster() ? "mixed" : "updated"
+            ),
             actualMemoryUsage,
             equalTo(expectedMemoryUsage.intValue())
         );

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -6,31 +6,33 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -39,23 +41,41 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
+public class MlJobSnapshotUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     private static final String JOB_ID = "ml-snapshots-upgrade-job";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlJobSnapshotUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
 
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     protected static void waitForPendingUpgraderTasks() throws Exception {
@@ -71,32 +91,32 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
         adjustLoggingLevels.setJsonEntity("""
             {"persistent": {"logger.org.elasticsearch.xpack.ml": "trace"}}""");
         client().performRequest(adjustLoggingLevels);
-        switch (CLUSTER_TYPE) {
-            case OLD -> createJobAndSnapshots();
-            case MIXED -> {
-                assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
-                assumeTrue(
-                    "Older versions could not always reliably determine if we were in a mixed cluster state",
-                    Version.fromString(UPGRADE_FROM_VERSION).after(Version.V_8_19_6)
-                );
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                testSnapshotUpgradeFailsOnMixedCluster();
-            }
-            case UPGRADED -> {
-                assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
-                ensureHealth((request -> {
-                    request.addParameter("timeout", "70s");
-                    request.addParameter("wait_for_nodes", "3");
-                    request.addParameter("wait_for_status", "yellow");
-                }));
-                testSnapshotUpgrade();
-                waitForPendingUpgraderTasks();
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+
+        if (isOldCluster()) {
+            createJobAndSnapshots();
+        }
+        if (isMixedCluster()) {
+            assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
+            assumeTrue(
+                "Older versions could not always reliably determine if we were in a mixed cluster state",
+                UPGRADE_FROM_VERSION.after(org.elasticsearch.Version.V_8_19_6)
+            );
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+            testSnapshotUpgradeFailsOnMixedCluster();
+        }
+        if (isUpgradedCluster()) {
+            assumeTrue("We should only test if old cluster is before new cluster", isOriginalClusterCurrent() == false);
+            ensureHealth((request -> {
+                request.addParameter("timeout", "70s");
+                request.addParameter("wait_for_nodes", "3");
+                request.addParameter("wait_for_status", "yellow");
+            }));
+            testSnapshotUpgrade();
+            waitForPendingUpgraderTasks();
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
@@ -14,21 +16,21 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.test.rest.IndexMappingTemplateAsserter;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
 import org.elasticsearch.xpack.test.rest.XPackRestTestHelper;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
 import static org.hamcrest.Matchers.anyOf;
@@ -40,24 +42,42 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
+public class MlMappingsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     private static final String JOB_ID = "ml-mappings-upgrade-job";
     private static final String RESULTS_INDEX_NAME = "mappings-upgrade-test";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlMappingsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
 
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     /**
@@ -66,34 +86,23 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
      */
     public void testMappingsUpgrade() throws Exception {
 
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                createAndOpenTestJob();
-                break;
-            case MIXED:
-                // We don't know whether the job is on an old or upgraded node, so cannot assert that the mappings have been upgraded
-                break;
-            case UPGRADED:
-                assertUpgradedResultsMappings();
-                assertUpgradedAnnotationsMappings();
-                closeAndReopenTestJob();
-                assertUpgradedConfigMappings();
-                assertMlLegacyTemplatesDeleted();
-                IndexMappingTemplateAsserter.assertMlMappingsMatchTemplates(client());
-                assertLegacyIndicesRollover();
-                assertAnomalyIndicesRollover();
-                assertNotificationsIndexAliasCreated();
-                assertBusy(
-                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
-                        client(),
-                        ".ml-anomalies-",
-                        10000005,
-                        List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*")
-                    )
-                );
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            createAndOpenTestJob();
+        }
+
+        // On mixed clusters, we don't know whether the job is on an old or upgraded node, so cannot assert that the mappings have been
+        // upgraded
+
+        if (isUpgradedCluster()) {
+            assertUpgradedResultsMappings();
+            assertUpgradedAnnotationsMappings();
+            closeAndReopenTestJob();
+            assertUpgradedConfigMappings();
+            assertMlLegacyTemplatesDeleted();
+            IndexMappingTemplateAsserter.assertMlMappingsMatchTemplates(client());
+            assertLegacyIndicesRollover();
+            assertAnomalyIndicesRollover();
+            assertNotificationsIndexAliasCreated();
         }
     }
 
@@ -265,7 +274,7 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void assertLegacyIndicesRollover() throws Exception {
-        if (isOriginalClusterVersionAtLeast(Version.V_8_0_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) {
             // not a legacy index
             return;
         }
@@ -296,7 +305,7 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void assertAnomalyIndicesRollover() throws Exception {
-        if (isOriginalClusterVersionAtLeast(Version.V_8_0_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) {
             // not a legacy index
             return;
         }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlRolloverLegacyIndicesIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlRolloverLegacyIndicesIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
@@ -14,20 +16,21 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT.generateData;
 import static org.hamcrest.Matchers.anyOf;
@@ -39,7 +42,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
+public class MlRolloverLegacyIndicesIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     private static final String JOB_ID = "ml-rollover-legacy-job";
     private static final String CUSTOM_INDEX_JOB_ID = "ml-rollover-legacy-custom-job";
@@ -48,19 +53,35 @@ public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
     private static final String UPGRADED_CUSTOM_INDEX_CLUSTER_JOB_ID = "ml-rollover-upgraded-custom-job";
     private static final int NUM_BUCKETS = 10;
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlRolloverLegacyIndicesIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     /**
@@ -69,27 +90,20 @@ public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
      * custom results indices.
      */
     public void testRolloverLegacyIndices() throws Exception {
-
-        switch (CLUSTER_TYPE) {
-            case OLD:
-                createAndRunJob(JOB_ID, false);
-                createAndRunJob(CUSTOM_INDEX_JOB_ID, true);
-                break;
-            case MIXED:
-                break;
-            case UPGRADED:
-                assertLegacyIndicesRollover();
-                assertAnomalyIndicesRollover();
-                assertNotificationsIndexAliasCreated();
-                createAndRunJob(UPGRADED_CLUSTER_JOB_ID, false);
-                closeJob(UPGRADED_CLUSTER_JOB_ID);
-                createAndRunJob(UPGRADED_CUSTOM_INDEX_CLUSTER_JOB_ID, true);
-                closeJob(UPGRADED_CUSTOM_INDEX_CLUSTER_JOB_ID);
-                assertResultsInNewIndex(false);
-                assertResultsInNewIndex(true);
-                break;
-            default:
-                throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            createAndRunJob(JOB_ID, false);
+            createAndRunJob(CUSTOM_INDEX_JOB_ID, true);
+        }
+        if (isUpgradedCluster()) {
+            assertLegacyIndicesRollover();
+            assertAnomalyIndicesRollover();
+            assertNotificationsIndexAliasCreated();
+            createAndRunJob(UPGRADED_CLUSTER_JOB_ID, false);
+            closeJob(UPGRADED_CLUSTER_JOB_ID);
+            createAndRunJob(UPGRADED_CUSTOM_INDEX_CLUSTER_JOB_ID, true);
+            closeJob(UPGRADED_CUSTOM_INDEX_CLUSTER_JOB_ID);
+            assertResultsInNewIndex(false);
+            assertResultsInNewIndex(true);
         }
     }
 
@@ -173,7 +187,7 @@ public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void assertLegacyIndicesRollover() throws Exception {
-        if (isOriginalClusterVersionAtLeast(Version.V_8_0_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) {
             // not a legacy index
             return;
         }
@@ -204,7 +218,7 @@ public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     private void assertAnomalyIndicesRollover() throws Exception {
-        if (isOriginalClusterVersionAtLeast(Version.V_8_0_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) {
             // not a legacy index
             return;
         }
@@ -281,7 +295,7 @@ public class MlRolloverLegacyIndicesIT extends AbstractUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     public void assertResultsInNewIndex(boolean checkCustomIndex) throws Exception {
-        if (isOriginalClusterVersionAtLeast(Version.V_8_0_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0)) {
             // not a legacy index
             return;
         }

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -7,28 +7,34 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.test.rest.XPackRestTestConstants;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
+public class MlTrainedModelsUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
+    private static final boolean SKIP_ML_TESTS = Booleans.parseBoolean(System.getProperty("tests.ml.skip", "false"));
 
     static final String BOOLEAN_FIELD = "boolean-field";
     static final String NUMERICAL_FIELD = "numerical-field";
@@ -40,41 +46,54 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
     static final List<String> KEYWORD_FIELD_VALUES = List.of("cat", "dog");
     static final String INDEX_NAME = "created_index";
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public MlTrainedModelsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
     @BeforeClass
     public static void maybeSkip() {
         assumeFalse("Skip ML tests on unsupported glibc versions", SKIP_ML_TESTS);
     }
 
-    @Override
-    protected Collection<String> templatesToWaitFor() {
-        // We shouldn't wait for ML templates during the upgrade - production won't
-        if (CLUSTER_TYPE != ClusterType.OLD) {
-            return super.templatesToWaitFor();
+    @Before
+    public void waitForMlTemplates() throws Exception {
+        // We shouldn't wait for ML templates during the upgrade - production won't.
+        // On the old cluster, wait for the ML index templates to be installed before running tests.
+        if (isOldCluster()) {
+            for (String templateName : XPackRestTestConstants.ML_POST_V7120_TEMPLATES) {
+                assertBusy(() -> {
+                    Request request = new Request("GET", "/_index_template/" + templateName);
+                    assertOK(client().performRequest(request));
+                });
+            }
         }
-        return Stream.concat(XPackRestTestConstants.ML_POST_V7120_TEMPLATES.stream(), super.templatesToWaitFor().stream())
-            .collect(Collectors.toSet());
     }
 
     public void testTrainedModelInference() throws Exception {
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                createIndexWithName(INDEX_NAME);
-                indexData(INDEX_NAME, 1000);
-                createAndRunClassificationJob("classification-upgrade-job");
-                createAndRunRegressionJob();
-                List<String> oldModels = getTrainedModels();
-                createPipelines(oldModels);
-                testInfer(oldModels);
-            }
-            case MIXED, UPGRADED -> {
-                ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
-                List<String> modelIds = getTrainedModels();
-                // Test that stats are serializable and can be gathered
-                getTrainedModelStats();
-                // Verify that the pipelines still work and inference is possible
-                testInfer(modelIds);
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            createIndexWithName(INDEX_NAME);
+            indexData(INDEX_NAME, 1000);
+            createAndRunClassificationJob("classification-upgrade-job");
+            createAndRunRegressionJob();
+            List<String> oldModels = getTrainedModels();
+            createPipelines(oldModels);
+            testInfer(oldModels);
+        }
+        if (isMixedCluster() || isUpgradedCluster()) {
+            ensureYellowAndNoInitializingShards(".ml-inference-*,.ml-config*", "120s");
+            List<String> modelIds = getTrainedModels();
+            // Test that stats are serializable and can be gathered
+            getTrainedModelStats();
+            // Verify that the pipelines still work and inference is possible
+            testInfer(modelIds);
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.upgrades;
 
+import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.search.join.ScoreMode;
@@ -28,6 +29,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -36,6 +38,7 @@ import org.elasticsearch.xpack.core.ml.search.SparseVectorQueryBuilder;
 import org.elasticsearch.xpack.inference.mapper.SemanticTextField;
 import org.elasticsearch.xpack.inference.model.TestModel;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,17 +47,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests.addSemanticTextInferenceResults;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.randomSemanticText;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
-public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
+public class SemanticTextUpgradeIT extends AbstractXpackRollingUpgradeTestCase {
+
     private static final String INDEX_BASE_NAME = "semantic_text_test_index";
     private static final String SPARSE_FIELD = "sparse_field";
     private static final String DENSE_FIELD = "dense_field";
-    private static final Version UPGRADE_FROM_VERSION_PARSED = Version.fromString(UPGRADE_FROM_VERSION);
 
     private static final String DOC_1_ID = "doc_1";
     private static final String DOC_2_ID = "doc_2";
@@ -70,6 +74,9 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
 
     private final boolean useLegacyFormat;
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
     @BeforeClass
     public static void beforeClass() {
         SPARSE_MODEL = TestModel.createRandomInstance(TaskType.SPARSE_EMBEDDING);
@@ -77,27 +84,35 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         DENSE_MODEL = TestModel.createRandomInstance(TaskType.TEXT_EMBEDDING, List.of(SimilarityMeasure.DOT_PRODUCT));
     }
 
-    public SemanticTextUpgradeIT(boolean useLegacyFormat) {
+    public SemanticTextUpgradeIT(@Name("upgradedNodes") int upgradedNodes, @Name("useLegacyFormat") boolean useLegacyFormat) {
+        super(upgradedNodes);
         this.useLegacyFormat = useLegacyFormat;
     }
 
-    @ParametersFactory
+    @ParametersFactory(shuffle = false)
     public static Iterable<Object[]> parameters() {
-        List<Object[]> parameters = new ArrayList<>();
-        parameters.add(new Object[] { true });
-        if (UPGRADE_FROM_VERSION_PARSED.onOrAfter(Version.V_8_18_0)) {
-            // New semantic text format added in 8.18
-            parameters.add(new Object[] { false });
-        }
-        return parameters;
+        return IntStream.rangeClosed(0, NODE_NUM).boxed().flatMap(n -> {
+            List<Object[]> parameters = new ArrayList<>();
+            parameters.add(new Object[] { n, true });
+            if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_18_0)) {
+                // New semantic text format added in 8.18
+                parameters.add(new Object[] { n, false });
+            }
+            return parameters.stream();
+        }).toList();
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     public void testSemanticTextOperations() throws Exception {
-        assumeTrue("Upgrade from version supports semantic text", UPGRADE_FROM_VERSION_PARSED.onOrAfter(Version.V_8_15_0));
-        switch (CLUSTER_TYPE) {
-            case OLD -> createAndPopulateIndex();
-            case MIXED, UPGRADED -> performIndexQueryHighlightOps();
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        assumeTrue("Upgrade from version supports semantic text", UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_15_0));
+        if (isOldCluster()) {
+            createAndPopulateIndex();
+        } else {
+            performIndexQueryHighlightOps();
         }
     }
 
@@ -119,7 +134,7 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
             """, SPARSE_FIELD, SPARSE_MODEL.getInferenceEntityId(), DENSE_FIELD, DENSE_MODEL.getInferenceEntityId());
 
         Settings.Builder settingsBuilder = Settings.builder();
-        if (UPGRADE_FROM_VERSION_PARSED.onOrAfter(Version.V_8_18_0)) {
+        if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_18_0)) {
             settingsBuilder.put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), useLegacyFormat);
         }
 
@@ -248,7 +263,7 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
             assertThat(id, notNullValue());
             docIds.add(id);
 
-            if (UPGRADE_FROM_VERSION_PARSED.onOrAfter(Version.V_8_18_0) || CLUSTER_TYPE == ClusterType.UPGRADED) {
+            if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_18_0) || isUpgradedCluster()) {
                 // Semantic highlighting only functions reliably on clusters where all nodes are 8.18.0 or later
                 List<String> expectedHighlight = DOC_VALUES.get(id);
                 assertThat(expectedHighlight, notNullValue());

--- a/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
@@ -4,7 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 package org.elasticsearch.upgrades;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
@@ -16,10 +19,11 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -41,7 +45,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
+public class TransformSurvivesUpgradeIT extends AbstractXpackRollingUpgradeWithSecurityTestCase {
 
     private static final String TRANSFORM_ENDPOINT = "/_transform/";
     private static final String CONTINUOUS_TRANSFORM_ID = "continuous-transform-upgrade-job";
@@ -52,8 +56,16 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         .map(TimeValue::timeValueMinutes)
         .collect(Collectors.toList());
 
-    protected static void waitForPendingTransformTasks() throws Exception {
-        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TRANSFORM_TASK_NAME) == false);
+    @ClassRule
+    public static ElasticsearchCluster cluster = buildCluster();
+
+    public TransformSurvivesUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
     }
 
     @Override
@@ -64,11 +76,14 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         return builder.build();
     }
 
+    protected static void waitForPendingTransformTasks() throws Exception {
+        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TRANSFORM_TASK_NAME) == false);
+    }
+
     /**
      * The purpose of this test is to ensure that when a transform is running through a rolling upgrade it
      * keeps working and does not fail
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84283")
     public void testTransformRollingUpgrade() throws Exception {
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
         adjustLoggingLevels.setJsonEntity("""
@@ -83,26 +98,18 @@ public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         Request waitForYellow = new Request("GET", "/_cluster/health");
         waitForYellow.addParameter("wait_for_nodes", "3");
         waitForYellow.addParameter("wait_for_status", "yellow");
-        switch (CLUSTER_TYPE) {
-            case OLD -> {
-                client().performRequest(waitForYellow);
-                createAndStartContinuousTransform();
-            }
-            case MIXED -> {
-                client().performRequest(waitForYellow);
-                long lastCheckpoint = 1;
-                if (Booleans.parseBoolean(System.getProperty("tests.first_round")) == false) {
-                    lastCheckpoint = 2;
-                }
-                verifyContinuousTransformHandlesData(lastCheckpoint);
-            }
-            case UPGRADED -> {
-                client().performRequest(waitForYellow);
-                verifyContinuousTransformHandlesData(3);
-                verifyUpgrade();
-                cleanUpTransforms();
-            }
-            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        if (isOldCluster()) {
+            client().performRequest(waitForYellow);
+            createAndStartContinuousTransform();
+        } else if (isMixedCluster()) {
+            client().performRequest(waitForYellow);
+            long lastCheckpoint = isFirstMixedCluster() ? 1 : 2;
+            verifyContinuousTransformHandlesData(lastCheckpoint);
+        } else if (isUpgradedCluster()) {
+            client().performRequest(waitForYellow);
+            verifyContinuousTransformHandlesData(3);
+            verifyUpgrade();
+            cleanUpTransforms();
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate more xpack:qa:rolling-upgrade-legacy tests (#156288)](https://github.com/elastic/elasticsearch/pull/156288)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)