### PR TITLE
ESQL:DS: warn when a Parquet LIST read drops nulls

### DIFF
--- a/docs/reference/query-languages/esql/esql-data-federation-querying.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-querying.md
@@ -120,7 +120,7 @@ The following search functions are available for datasets:
 :::{include} _snippets/data-federation/experimental-warning.md
 :::
 
-The operations below require structures that only exist in an {{es}} index, such as the inverted index, doc values, or time series metadata. Each fails with a clear error rather than wrong results.
+The limitations below include operations that require structures available only in an {{es}} index, such as the inverted index, doc values, or time series metadata, as well as unsupported data shapes. Unsupported operations fail with a clear error; representation limitations are described in the table.
 
 | Operation | Reason | Error |
 |---|---|---|
@@ -134,6 +134,7 @@ The operations below require structures that only exist in an {{es}} index, such
 | [Cross-cluster search](/reference/query-languages/esql/esql-cross-clusters.md) | Datasets on a remote cluster cannot be queried. Only local datasets are supported. | `ES\|QL queries with remote datasets are not supported. Matched [...]` |
 | Snapshot and restore | Data sources and datasets cannot be snapshotted or restored. | |
 | Parquet MAP and nested LIST | These complex types are not currently supported and return null. STRUCT is supported and flattened to dot-notation column names (for example, `address.city`). | |
+| `null` elements inside a Parquet LIST | An {{esql}} multivalued field cannot hold `null`, so a `null` element inside a list is omitted and the column returns fewer values than the file holds. A list of `[1, null, 2]` reads as `[1, 2]`, and a list whose elements are all `null` reads as `null`. The response includes a warning naming the affected columns. | |
 
 ## Troubleshooting
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -119,6 +119,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     private final String fileLocation;
     /** See {@link #coercionWarnings()}. */
     private SkipWarnings coercionWarnings;
+    /** See {@link #nullListElementWarnings()}. */
+    private SkipWarnings nullListElementWarnings;
     /**
      * Relay for this eager read's per-value coercion warnings, or {@code null} to fall back to
      * emitting directly via {@code HeaderWarning}. This iterator
@@ -2600,7 +2602,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 blockFactory,
                 attributes.get(colIndex).name(),
                 coercionWarnings(),
-                listColumnSink
+                listColumnSink,
+                nullListElementWarnings()
             );
         }
         ParquetColumnDecoding.skipValues(cr, rowsToRead);
@@ -2627,6 +2630,23 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             );
         }
         return coercionWarnings;
+    }
+
+    /**
+     * The sink for the notice that a LIST column returned fewer values than the file holds, because its lists carry
+     * null elements an ES|QL multivalue cannot represent. Lazily created and shared by every column and row group of
+     * this iterator, so {@link SkipWarnings#addOnce} deduplicates one column's notice across every batch of the read.
+     * <p>
+     * Deliberately NOT policy-gated like {@link #coercionWarnings()}: that gate is correct there because coercion
+     * warn+null only <em>happens</em> under a lenient policy, whereas this drop is forced by the Block representation
+     * and therefore happens under every {@code error_mode} — including the default {@code fail_fast}. A notice that
+     * appeared only under a lenient policy would leave the default configuration silent, which is the bug.
+     */
+    private SkipWarnings nullListElementWarnings() {
+        if (nullListElementWarnings == null) {
+            nullListElementWarnings = new SkipWarnings(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, warningSink);
+        }
+        return nullListElementWarnings;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -578,41 +578,123 @@ final class ParquetColumnDecoding {
     // ---- List column reading ----
 
     /**
-     * Reads a LIST column using repetition levels to determine list boundaries,
-     * producing multi-valued ESQL blocks. Dispatches to the appropriate typed reader
-     * based on the ESQL element type. Handles null lists, empty lists, and null
-     * elements within lists correctly. Unsupported types are skipped and returned
-     * as a constant null block.
+     * The summary header accompanying {@link #nullListElementsMessage}. Names no file on purpose: the loss follows
+     * from the Block representation rather than from anything about one file, so a file-scoped summary would emit
+     * one non-deduplicable line per file on a glob read. Shared with the read paths that own the collector so the
+     * text has one source of truth.
      */
-    static Block readListColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
-        return readListColumn(cr, info, rows, blockFactory, null, null);
+    static final String NULL_LIST_ELEMENTS_SUMMARY = "Parquet lists with null elements were read with those elements "
+        + "omitted; an ES|QL multivalued field cannot hold null";
+
+    /**
+     * The per-column detail for a LIST read that dropped null elements. {@code columnName} is the attribute name the
+     * query used, not the physical leaf path — for a LIST the descriptor path is {@code ints.list.element} while the
+     * user wrote {@code ints}.
+     *
+     * <p>Constant per column by design: the drop is rediscovered on every batch, and each layer that caps this
+     * channel ({@link SkipWarnings#addOnce}, {@code InformationalWarningBudget}, {@code ThreadContext}'s
+     * response-header dedup) collapses repeats by exact text, so one column costs the client one line however many
+     * batches, row groups, or files hit it.
+     */
+    static String nullListElementsMessage(String columnName) {
+        return "Parquet list column ["
+            + columnName
+            + "] contains lists with null elements; the column returns fewer values than the file holds";
     }
 
     /**
-     * As {@link #readListColumn(ColumnReader, ColumnInfo, int, BlockFactory)}, coercing a
-     * declared element type beyond the fused pairs: the list decodes at the file's own element
-     * type, then {@link DeclaredTypeCoercions#castBlock} coerces each element to the declared
-     * type ({@code warnings} carries the per-value failure sink; {@code null} = strict).
+     * The definition level a LIST element carries when its list entry exists but the element itself is null, or
+     * {@code -1} when this column can have no such element ({@code -1} matches no real definition level).
+     *
+     * <p>Definition levels are prefix-defined, so {@code maxDefLevel - 1} means "every nullable node on the path is
+     * defined except the deepest one". When the leaf primitive is {@code OPTIONAL} that deepest node <em>is</em> the
+     * leaf, so the level reads "the repeated list entry is there, the value in it is null" — the element this decode
+     * cannot represent and therefore drops. When the leaf is {@code REQUIRED} (a 3-level LIST of required elements)
+     * or {@code REPEATED} (a legacy 2-level list, or a bare top-level {@code repeated} primitive, which
+     * {@code buildColumnInfos} binds by {@code path[0]} and the iterators route here on {@code maxRepLevel > 0}) no
+     * null element is representable at all, and {@code maxDefLevel - 1} instead means "the list is empty" — matching
+     * it there would report a lossless read of every empty list.
+     *
+     * <p>Exact — never silent, never a false alarm — for every LIST-annotated column, which is what this reader is
+     * for, and for a flattened repeated group whose leaf is its repeated node's direct child. Two boundaries worth
+     * knowing:
+     * <ul>
+     *   <li>A nested LIST would put an inner empty list on a lower level and defeat a single comparison, but cannot
+     *       reach here: {@code convertGroupTypeToEsql} types a non-primitive element {@code UNSUPPORTED} and
+     *       {@code buildColumnInfos} skips it.</li>
+     *   <li>An <em>un-annotated</em> {@code repeated} group with more than one nullable node beneath it (the
+     *       Hive-era "2-level list of struct of struct", e.g. {@code repeated addr { optional geo { optional lat } }},
+     *       which {@code collectAttributes} flattens to a {@code maxRepLevel == 1} leaf) has a second droppable
+     *       level: {@code def == 1} there means the {@code addr} entry exists but {@code geo} is null, which loses a
+     *       value this comparison does not catch. Recognising it exactly needs the definition level of the innermost
+     *       repeated node — a schema walk, so a {@link ColumnInfo} field — which is deliberately out of scope for the
+     *       LIST fix. The consequence is a residual silence on that one shape, never a wrong warning on any shape.</li>
+     * </ul>
+     */
+    private static int nullElementDefLevel(ColumnInfo info) {
+        ColumnDescriptor descriptor = info.descriptor();
+        if (descriptor == null || descriptor.getPrimitiveType().getRepetition() != Type.Repetition.OPTIONAL) {
+            return -1;
+        }
+        return info.maxDefLevel() - 1;
+    }
+
+    /**
+     * Per-column tally of list elements dropped because an ES|QL multivalue has no representation for null. Carries
+     * the definition level such an element has (see {@link #nullElementDefLevel}) so every row loop recognises one
+     * with a single comparison, plus the flag they raise on a drop; {@link #readListColumn} turns a raised flag into
+     * one response {@code Warning}. Mutable and single-threaded — one instance per {@code readListColumn} call.
+     */
+    private static final class NullElementTally {
+        private final int nullElementDef;
+        private boolean dropped;
+
+        NullElementTally(ColumnInfo info) {
+            this.nullElementDef = nullElementDefLevel(info);
+        }
+
+        /**
+         * Raises the flag when {@code def} — the level of an element the caller is about to skip — is that of a null
+         * element inside a list that exists. A lower level means the list itself is null or empty, which loses no
+         * element and must not be reported.
+         */
+        void recordIfNullElement(int def) {
+            if (def == nullElementDef) {
+                dropped = true;
+            }
+        }
+    }
+
+    /**
+     * Reads a LIST column using repetition levels to determine list boundaries, producing multi-valued ESQL blocks.
+     * Dispatches to the appropriate typed reader based on the ESQL element type. Null lists and empty lists become
+     * null positions. Unsupported types are skipped and returned as a constant null block.
+     *
+     * <p>A null element <em>inside</em> a list is dropped, because an ES|QL multivalue cannot hold null (a null lives
+     * at position granularity: {@code Block.isNull} is per position and {@code AbstractBlockBuilder.appendNull}
+     * closes any open position entry). The value cannot be preserved, so the read announces itself instead: any
+     * dropped element emits one {@code Warning} through {@code lossWarnings} naming the column. That notice is
+     * unconditional — unlike {@code warnings} below it must not be policy-gated, since the drop happens under every
+     * {@code error_mode}.
+     *
+     * @param columnName the attribute name the query used for this column; names the column in both notices, so
+     *                   unlike the coercion helpers downstream this one requires it
+     * @param warnings   per-value declared-coercion failure sink, for a declared element type beyond the fused
+     *                   pairs: the list decodes at the file's own element type, then
+     *                   {@link DeclaredTypeCoercions#castBlock} coerces each element. {@code null} = strict, the
+     *                   coercion failure propagates
+     * @param lossWarnings always-live collector for the dropped-null-element notice; required, since a
+     *                     {@code null} here would silently restore the pre-fix silence
      */
     static Block readListColumn(
         ColumnReader cr,
         ColumnInfo info,
         int rows,
         BlockFactory blockFactory,
-        @Nullable String columnName,
-        @Nullable SkipWarnings warnings
-    ) {
-        return readListColumn(cr, info, rows, blockFactory, columnName, warnings, null);
-    }
-
-    static Block readListColumn(
-        ColumnReader cr,
-        ColumnInfo info,
-        int rows,
-        BlockFactory blockFactory,
-        @Nullable String columnName,
+        String columnName,
         @Nullable SkipWarnings warnings,
-        @Nullable IntConsumer failedPositionSink
+        @Nullable IntConsumer failedPositionSink,
+        SkipWarnings lossWarnings
     ) {
         DataType declared = info.esqlType();
         DataType fileElementType = info.fileEsqlType();
@@ -620,7 +702,9 @@ final class ParquetColumnDecoding {
             && declared != fileElementType
             && DeclaredTypeCoercions.fusedInDecode(fileElementType, declared, info.dateFormatter() != null) == false
             && DeclaredTypeCoercions.supports(fileElementType, declared)) {
-            Block physical = readListColumn(cr, info.fileTyped(), rows, blockFactory);
+            // The recursion decodes at the file's own element type and owns the drop notice for this read; this
+            // frame deliberately keeps no tally of its own, since it never reaches the row loops below.
+            Block physical = readListColumn(cr, info.fileTyped(), rows, blockFactory, columnName, null, null, lossWarnings);
             try {
                 return DeclaredTypeCoercions.castBlock(
                     physical,
@@ -638,29 +722,35 @@ final class ParquetColumnDecoding {
         }
         DataType elementType = info.esqlType();
         int maxDef = info.maxDefLevel();
-        return switch (elementType) {
-            case INTEGER -> readListIntColumn(cr, maxDef, rows, blockFactory);
+        NullElementTally tally = new NullElementTally(info);
+        Block block = switch (elementType) {
+            case INTEGER -> readListIntColumn(cr, maxDef, rows, blockFactory, tally);
             case LONG -> {
                 if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
                     // TIME_MILLIS: physical INT32 widened to long (raw ms value, no unit conversion)
-                    yield readListInt32AsLongColumn(cr, maxDef, rows, blockFactory);
+                    yield readListInt32AsLongColumn(cr, maxDef, rows, blockFactory, tally);
                 }
                 long multiplier = info.logicalType() instanceof LogicalTypeAnnotation.TimeLogicalTypeAnnotation time
                     ? timeNanoMultiplier(time)
                     : 1L;
-                yield readListLongColumn(cr, maxDef, rows, blockFactory, multiplier);
+                yield readListLongColumn(cr, maxDef, rows, blockFactory, multiplier, tally);
             }
-            case UNSIGNED_LONG -> readListUnsignedLongColumn(cr, maxDef, rows, blockFactory);
-            case DOUBLE -> readListDoubleColumn(cr, maxDef, rows, blockFactory);
-            case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory);
-            case KEYWORD, TEXT -> readListBytesRefColumn(cr, info, rows, blockFactory);
-            case DATETIME -> readListDatetimeColumn(cr, info, rows, blockFactory, columnName, warnings, failedPositionSink);
-            case DATE_NANOS -> readListDateNanosColumn(cr, info, rows, blockFactory);
+            case UNSIGNED_LONG -> readListUnsignedLongColumn(cr, maxDef, rows, blockFactory, tally);
+            case DOUBLE -> readListDoubleColumn(cr, maxDef, rows, blockFactory, tally);
+            case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory, tally);
+            case KEYWORD, TEXT -> readListBytesRefColumn(cr, info, rows, blockFactory, tally);
+            case DATETIME -> readListDatetimeColumn(cr, info, rows, blockFactory, columnName, warnings, failedPositionSink, tally);
+            case DATE_NANOS -> readListDateNanosColumn(cr, info, rows, blockFactory, tally);
             default -> {
                 skipListValues(cr, rows);
                 yield blockFactory.newConstantNullBlock(rows);
             }
         };
+        // Only after the block is built: a read that threw produced no answer, so it has nothing to caveat.
+        if (tally.dropped) {
+            lossWarnings.addOnce(nullListElementsMessage(columnName));
+        }
+        return block;
     }
 
     /**
@@ -672,30 +762,41 @@ final class ParquetColumnDecoding {
      * <p>The caller must have positioned the column reader at the start of the row.
      * After this method returns, the reader is positioned at the start of the next row
      * (repetition level == 0).
+     *
+     * <p>An element whose definition level is below {@code maxDef} has no value to append and is skipped; when it is
+     * a null element of a list that exists (rather than the level of a null or empty list) that is a lossy read, so
+     * it is recorded on {@code tally} for the caller to announce.
      */
-    private static void readListRow(ColumnReader cr, int maxDef, Block.Builder builder, Runnable appender) {
+    private static void readListRow(ColumnReader cr, int maxDef, Block.Builder builder, Runnable appender, NullElementTally tally) {
         int def = cr.getCurrentDefinitionLevel();
         if (def >= maxDef) {
             builder.beginPositionEntry();
             appender.run();
             cr.consume();
             while (cr.getCurrentRepetitionLevel() > 0) {
-                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                int elementDef = cr.getCurrentDefinitionLevel();
+                if (elementDef >= maxDef) {
                     appender.run();
+                } else {
+                    tally.recordIfNullElement(elementDef);
                 }
                 cr.consume();
             }
             builder.endPositionEntry();
         } else {
+            tally.recordIfNullElement(def);
             cr.consume();
             boolean hasValues = false;
             while (cr.getCurrentRepetitionLevel() > 0) {
-                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                int elementDef = cr.getCurrentDefinitionLevel();
+                if (elementDef >= maxDef) {
                     if (hasValues == false) {
                         builder.beginPositionEntry();
                         hasValues = true;
                     }
                     appender.run();
+                } else {
+                    tally.recordIfNullElement(elementDef);
                 }
                 cr.consume();
             }
@@ -707,33 +808,46 @@ final class ParquetColumnDecoding {
         }
     }
 
-    private static Block readListIntColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListIntColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory, NullElementTally tally) {
         try (var builder = blockFactory.newIntBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendInt(cr.getInteger());
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
     }
 
-    private static Block readListLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory, long multiplier) {
+    private static Block readListLongColumn(
+        ColumnReader cr,
+        int maxDef,
+        int rows,
+        BlockFactory blockFactory,
+        long multiplier,
+        NullElementTally tally
+    ) {
         try (var builder = blockFactory.newLongBlockBuilder(rows)) {
             Runnable appender = multiplier == 1
                 ? () -> builder.appendLong(cr.getLong())
                 : () -> builder.appendLong(cr.getLong() * multiplier);
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
     }
 
-    private static Block readListInt32AsLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListInt32AsLongColumn(
+        ColumnReader cr,
+        int maxDef,
+        int rows,
+        BlockFactory blockFactory,
+        NullElementTally tally
+    ) {
         try (var builder = blockFactory.newLongBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendLong(cr.getInteger());
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
@@ -744,37 +858,49 @@ final class ParquetColumnDecoding {
      * Each element is sign-flip-encoded ({@code value ^ 2^63}) on the way in, mirroring the scalar read path and the
      * indexing path, so the always-decoding output edge produces the true unsigned value.
      */
-    private static Block readListUnsignedLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListUnsignedLongColumn(
+        ColumnReader cr,
+        int maxDef,
+        int rows,
+        BlockFactory blockFactory,
+        NullElementTally tally
+    ) {
         try (var builder = blockFactory.newLongBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendLong(encodeUnsignedLong(cr.getLong()));
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
     }
 
-    private static Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory, NullElementTally tally) {
         try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendDouble(cr.getDouble());
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
     }
 
-    private static Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+    private static Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory, NullElementTally tally) {
         try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
             Runnable appender = () -> builder.appendBoolean(cr.getBoolean());
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
     }
 
-    private static Block readListBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+    private static Block readListBytesRefColumn(
+        ColumnReader cr,
+        ColumnInfo info,
+        int rows,
+        BlockFactory blockFactory,
+        NullElementTally tally
+    ) {
         int maxDef = info.maxDefLevel();
         // UUID-annotated bytes are raw 16-byte payloads: format them as hex (matching the scalar path)
         // rather than sanitizing, which would mangle valid UUID bytes into replacement characters.
@@ -784,7 +910,7 @@ final class ParquetColumnDecoding {
                 ? () -> builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())))
                 : () -> builder.appendBytesRef(Utf8Sanitizer.sanitize(new BytesRef(cr.getBinary().getBytes())));
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
@@ -797,20 +923,21 @@ final class ParquetColumnDecoding {
         BlockFactory blockFactory,
         @Nullable String columnName,
         @Nullable SkipWarnings warnings,
-        @Nullable IntConsumer failedPositionSink
+        @Nullable IntConsumer failedPositionSink,
+        NullElementTally tally
     ) {
         // Declared string->datetime coercion for LIST<string> columns: parse each element via the shared
         // scalar with the column's declared format (ISO default), mirroring the flat decode paths. A parse
         // failure follows castBlock's bulk semantics (whole position nulls, or propagates when strict), so
         // this arm gathers each row before appending.
         if (info.parquetType() == PrimitiveType.PrimitiveTypeName.BINARY) {
-            return readListStringDatetimeColumn(cr, info, rows, blockFactory, columnName, warnings, failedPositionSink);
+            return readListStringDatetimeColumn(cr, info, rows, blockFactory, columnName, warnings, failedPositionSink, tally);
         }
         try (var builder = blockFactory.newLongBlockBuilder(rows)) {
             int maxDef = info.maxDefLevel();
             Runnable appender = () -> builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
             for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, appender);
+                readListRow(cr, maxDef, builder, appender, tally);
             }
             return builder.build();
         }
@@ -824,7 +951,8 @@ final class ParquetColumnDecoding {
      * instead of leaving a half-built entry. On failure the remaining elements are still
      * materialised (not parsed) so the column reader's data cursor stays in lock-step with its
      * level cursor for the rows that follow. {@code warnings} carries the per-position failure
-     * sink; {@code null} = strict, the failure propagates.
+     * sink; {@code null} = strict, the failure propagates. A skipped null element is recorded on
+     * {@code tally} for {@link #readListColumn} to announce, exactly as in {@link #readListRow}.
      */
     private static Block readListStringDatetimeColumn(
         ColumnReader cr,
@@ -832,19 +960,9 @@ final class ParquetColumnDecoding {
         int rows,
         BlockFactory blockFactory,
         @Nullable String columnName,
-        @Nullable SkipWarnings warnings
-    ) {
-        return readListStringDatetimeColumn(cr, info, rows, blockFactory, columnName, warnings, null);
-    }
-
-    private static Block readListStringDatetimeColumn(
-        ColumnReader cr,
-        ColumnInfo info,
-        int rows,
-        BlockFactory blockFactory,
-        @Nullable String columnName,
         @Nullable SkipWarnings warnings,
-        @Nullable IntConsumer failedPositionSink
+        @Nullable IntConsumer failedPositionSink,
+        NullElementTally tally
     ) {
         int maxDef = info.maxDefLevel();
         DateFormatter dateFormatter = info.dateFormatter();
@@ -856,7 +974,10 @@ final class ParquetColumnDecoding {
                 boolean failed = false;
                 boolean rowDone = false;
                 while (rowDone == false) {
-                    if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                    int elementDef = cr.getCurrentDefinitionLevel();
+                    if (elementDef < maxDef) {
+                        tally.recordIfNullElement(elementDef);
+                    } else {
                         // Always read the value so the data cursor advances even after a failure.
                         String value = cr.getBinary().toStringUsingUTF8();
                         if (failed == false) {
@@ -906,15 +1027,24 @@ final class ParquetColumnDecoding {
      * already skips null elements); a list whose elements <em>all</em> overflow becomes a null position. A single
      * deduplicated warning header is emitted when any element was dropped. This uses a lazy {@code beginPositionEntry}
      * so an all-overflow defined list never triggers the empty-position assertion in {@link Block.Builder}.
+     *
+     * <p>Overflow and null-element drops are announced separately — they are different losses with different
+     * remedies — so this loop feeds both {@code anyOverflow} and {@code tally}.
      */
-    private static Block readListDateNanosColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+    private static Block readListDateNanosColumn(
+        ColumnReader cr,
+        ColumnInfo info,
+        int rows,
+        BlockFactory blockFactory,
+        NullElementTally tally
+    ) {
         int maxDef = info.maxDefLevel();
         LogicalTypeAnnotation logical = info.logicalType();
         boolean micros = isMicrosTimestamp(logical);
         boolean[] anyOverflow = { false };
         try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(rows)) {
             for (int row = 0; row < rows; row++) {
-                readDateNanosListRow(cr, maxDef, micros, logical, builder, anyOverflow);
+                readDateNanosListRow(cr, maxDef, micros, logical, builder, anyOverflow, tally);
             }
             if (anyOverflow[0]) {
                 warnTimestampOutOfRange(info);
@@ -934,13 +1064,23 @@ final class ParquetColumnDecoding {
         boolean micros,
         LogicalTypeAnnotation logical,
         LongBlock.Builder builder,
-        boolean[] anyOverflow
+        boolean[] anyOverflow,
+        NullElementTally tally
     ) {
-        boolean open = cr.getCurrentDefinitionLevel() >= maxDef && appendDateNanosElement(cr, logical, micros, builder, false, anyOverflow);
+        int def = cr.getCurrentDefinitionLevel();
+        boolean open = false;
+        if (def >= maxDef) {
+            open = appendDateNanosElement(cr, logical, micros, builder, false, anyOverflow);
+        } else {
+            tally.recordIfNullElement(def);
+        }
         cr.consume();
         while (cr.getCurrentRepetitionLevel() > 0) {
-            if (cr.getCurrentDefinitionLevel() >= maxDef) {
+            int elementDef = cr.getCurrentDefinitionLevel();
+            if (elementDef >= maxDef) {
                 open = appendDateNanosElement(cr, logical, micros, builder, open, anyOverflow);
+            } else {
+                tally.recordIfNullElement(elementDef);
             }
             cr.consume();
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -403,6 +403,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                             bucket,
                             block,
                             infos[c],
+                            columnNames[c],
                             perColumnSchemas[c],
                             perColumnProjections[c],
                             prefetchedResult.chunks(),
@@ -619,6 +620,29 @@ final class ParquetColumnExtractor implements ColumnExtractor {
         return coercionWarnings;
     }
 
+    /** See {@link #nullListElementWarnings()}. */
+    private SkipWarnings nullListElementWarnings;
+
+    /**
+     * The sink for the notice that a LIST column returned fewer values than the file holds, because its lists carry
+     * null elements an ES|QL multivalue cannot represent. Lazily created and shared by every column and
+     * {@link #extract} call of this extractor, so {@link SkipWarnings#addOnce} deduplicates one column's notice
+     * across every sparse run the deferred pass decodes.
+     * <p>
+     * Like {@link #coercionWarnings()} — and unlike {@link #castBlockWarnings()} — this is always live: the drop is
+     * forced by the Block representation, so it happens under every {@code error_mode} and must be announced under
+     * every {@code error_mode}. This keeps the deferred pass agreeing with the eager scan of the same file, which is
+     * the invariant the whole extractor is built around — with one honest asymmetry: the notice caveats the rows this
+     * pass actually returned, and {@link #skipListRows} walks past the others without inspecting their definition
+     * levels, so a file whose null elements all sit in rows a TopN discarded warns on the eager scan and not here.
+     */
+    private SkipWarnings nullListElementWarnings() {
+        if (nullListElementWarnings == null) {
+            nullListElementWarnings = new SkipWarnings(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, warningSink);
+        }
+        return nullListElementWarnings;
+    }
+
     /**
      * The per-value coercion-failure sink handed to {@code castBlock}, or {@code null} under
      * {@code fail_fast} so the failure propagates — identical to the eager iterators'
@@ -702,6 +726,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
         Bucket bucket,
         BlockMetaData block,
         ColumnInfo info,
+        String columnName,
         MessageType projectedSchema,
         Set<String> projection,
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetched,
@@ -726,7 +751,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
             if (info.maxRepLevel() == 0) {
                 return decodeFlat(bucket, info, store, rgRowCount, blockFactory);
             }
-            return decodeList(bucket, info, store, projectedSchema, rgRowCount, createdBy, blockFactory);
+            return decodeList(bucket, info, columnName, store, projectedSchema, rgRowCount, createdBy, blockFactory);
         }
     }
 
@@ -768,6 +793,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
     private Block decodeList(
         Bucket bucket,
         ColumnInfo info,
+        String columnName,
         PrefetchedPageReadStore store,
         MessageType projectedSchema,
         int rgRowCount,
@@ -805,7 +831,20 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                     runEnd++;
                 }
                 int runLength = runEnd - runStart;
-                chunks.add(ParquetColumnDecoding.readListColumn(cr, info, runLength, blockFactory));
+                // The extractor always decodes at the file's own type, so no coercion sink is in play here; the
+                // dropped-null-element notice is unconditional and needs one regardless.
+                chunks.add(
+                    ParquetColumnDecoding.readListColumn(
+                        cr,
+                        info,
+                        runLength,
+                        blockFactory,
+                        columnName,
+                        null,
+                        null,
+                        nullListElementWarnings()
+                    )
+                );
                 cursor += runLength;
                 runStart = runEnd;
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -2929,6 +2929,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
          * cap is per read, not per column chunk.
          */
         private SkipWarnings coercionWarnings;
+        /** See {@link #nullListElementWarnings()}. */
+        private SkipWarnings nullListElementWarnings;
         /** The read's error policy; strict ({@code fail_fast}) makes {@link #coercionWarnings()} return {@code null}. */
         private final ErrorPolicy errorPolicy;
         /**
@@ -2974,6 +2976,27 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 );
             }
             return coercionWarnings;
+        }
+
+        /**
+         * The sink for the notice that a LIST column returned fewer values than the file holds, because its lists
+         * carry null elements an ES|QL multivalue cannot represent. Lazily created and shared by every column and
+         * row group of this iterator, so {@link SkipWarnings#addOnce} deduplicates one column's notice across every
+         * batch of the read.
+         * <p>
+         * Deliberately NOT policy-gated like {@link #coercionWarnings()}: that gate is correct there because
+         * coercion warn+null only <em>happens</em> under a lenient policy, whereas this drop is forced by the Block
+         * representation and therefore happens under every {@code error_mode} — including the default
+         * {@code fail_fast}. A notice that appeared only under a lenient policy would leave the default
+         * configuration silent, which is the bug. It follows that {@code fail_fast} warns here rather than failing:
+         * the loss is a representation limit, not malformed input, so failing would make every null-bearing LIST
+         * column unreadable by default.
+         */
+        private SkipWarnings nullListElementWarnings() {
+            if (nullListElementWarnings == null) {
+                nullListElementWarnings = new SkipWarnings(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, warningSink);
+            }
+            return nullListElementWarnings;
         }
 
         private void emitAbsentColumnWarningsOnce() {
@@ -3345,7 +3368,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                     blockFactory,
                     attributes.get(colIndex).name(),
                     coercionWarnings(),
-                    failedPositionSink
+                    failedPositionSink,
+                    nullListElementWarnings()
                 );
             }
             // WARNING: the dispatching logic below is duplicated in PageColumnReader#readBatch

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ListColumnParityTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ListColumnParityTests.java
@@ -45,6 +45,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -54,6 +56,10 @@ import static org.hamcrest.Matchers.equalTo;
  * parquet-mr's {@code ColumnReader}, but page parsing, decompression, and offsets all flow
  * through our custom code. Verify that decoded values match the baseline path bit-for-bit across
  * codec / writer-version / nullability axes.
+ * <p>
+ * The nullable parameterizations also plant null elements inside lists, which no ES|QL multivalue can hold. Both
+ * paths therefore drop them and announce the loss, so this test pins the notices as well as the values: a reader
+ * that decodes identically but reports the loss differently is still a parity break.
  */
 public class ListColumnParityTests extends ESTestCase {
 
@@ -108,16 +114,41 @@ public class ListColumnParityTests extends ESTestCase {
         ParquetFormatReader baseline = new ParquetFormatReader(blockFactory, false);
         ParquetFormatReader optimized = new ParquetFormatReader(blockFactory, true);
 
+        // Both paths drop null list elements (a multivalue cannot hold null) and announce it. Capture the notices
+        // per read instead of letting them reach this thread's HeaderWarning context, so they can be compared:
+        // warning parity between the two paths belongs in a parity test just as much as value parity does.
+        List<String> baselineWarnings = new ArrayList<>();
         List<Page> baselinePages;
-        try (CloseableIterator<Page> iter = baseline.read(storageObject, FormatReadContext.of(null, 64))) {
+        try (CloseableIterator<Page> iter = baseline.read(storageObject, readContext(baselineWarnings))) {
             baselinePages = collect(iter);
         }
+        List<String> optimizedWarnings = new ArrayList<>();
         List<Page> optimizedPages;
-        try (CloseableIterator<Page> iter = optimized.read(storageObject, FormatReadContext.of(null, 64))) {
+        try (CloseableIterator<Page> iter = optimized.read(storageObject, readContext(optimizedWarnings))) {
             optimizedPages = collect(iter);
         }
 
         assertPagesEqual(baselinePages, optimizedPages, description);
+        assertThat(description + ": warning parity", optimizedWarnings, equalTo(baselineWarnings));
+        if (nullable) {
+            // writeFile plants null elements in `ints` and `strs` only, and `longs` never. Exactly one notice per
+            // affected column across all four batches, so this also pins the per-read deduplication.
+            assertThat(
+                description + ": dropped-element notices",
+                baselineWarnings,
+                containsInAnyOrder(
+                    ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY,
+                    ParquetColumnDecoding.nullListElementsMessage("ints"),
+                    ParquetColumnDecoding.nullListElementsMessage("strs")
+                )
+            );
+        } else {
+            assertThat(description + ": a null-free file loses nothing and must not warn", baselineWarnings, empty());
+        }
+    }
+
+    private static FormatReadContext readContext(List<String> warningSink) {
+        return FormatReadContext.builder().batchSize(64).informationalWarningSink(warningSink::add).build();
     }
 
     private byte[] writeFile(MessageType schema) throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractorTests.java
@@ -62,6 +62,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * Unit tests for {@link ParquetColumnExtractor}: random-access reads of single columns by
@@ -453,6 +454,43 @@ public class ParquetColumnExtractorTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    /**
+     * The deferred sparse-lookup path drops null list elements for the same reason the eager scan does — an ES|QL
+     * multivalue cannot hold null — so it must announce the loss for the same reason too. Without this the answer a
+     * query gets would depend on whether extraction was deferred, which is the one thing the extractor exists to
+     * rule out. The notice must also name the attribute the query used, not the physical leaf path
+     * {@code vals.list.element}.
+     */
+    public void testExtractListColumnAnnouncesDroppedNullElements() throws IOException {
+        org.apache.parquet.schema.Type intList = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("vals");
+        byte[] data = writeFile(new MessageType("ints_list", intList), factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Group g = factory.newGroup();
+                Group vals = g.addGroup("vals");
+                vals.addGroup("list").append("element", i);
+                vals.addGroup("list"); // null element
+                groups.add(g);
+            }
+            return groups;
+        }, 64 * 1024 * 1024L);
+        StorageObject so = createStorageObject(data);
+        try (ColumnExtractor extractor = newFullFileExtractor(so)) {
+            // Non-adjacent positions so decodeList makes several readListColumn calls: the notice is still one line.
+            try (Block block = extractor.extract("vals", new long[] { 1, 4, 9 }, blockFactory)) {
+                IntBlock ints = (IntBlock) block;
+                assertEquals(3, ints.getPositionCount());
+                for (int slot = 0; slot < 3; slot++) {
+                    assertEquals("the null element is dropped", 1, ints.getValueCount(slot));
+                }
+            }
+        }
+        List<String> warnings = drainWarnings();
+        assertThat(warnings, hasItem(ParquetColumnDecoding.nullListElementsMessage("vals")));
+        assertThat(warnings, hasItem(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY));
+        assertEquals("one summary + one detail, not one per decoded run: " + warnings, 2, warnings.size());
     }
 
     public void testExtractListAcrossRowGroupsWithDuplicates() throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -119,7 +120,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
@@ -3000,6 +3003,9 @@ public class ParquetFormatReaderTests extends ESTestCase {
             // independent of the unsigned encoding, asserted here to document it for the unsigned_long path.
             assertTrue(block.isNull(3));
         }
+        // Row 2's dropped element is announced. Asserted here rather than left to the class's warning-stashing
+        // @After so the notice is visible behaviour of this arm, not an invisible side effect.
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("values")));
     }
 
     public void testReadListOfDateNanosColumn() throws Exception {
@@ -3069,6 +3075,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
             assertEquals(1, block.getValueCount(2));
             assertEquals(micros3 * 1_000, block.getLong(block.getFirstValueIndex(2)));
         }
+        // Row 2's dropped element is announced, from the date_nanos loop's own row walk.
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("values")));
     }
 
     // --- LIST-under-STRUCT tests (elastic/esql-planning#1055) ---
@@ -4872,6 +4880,286 @@ public class ParquetFormatReaderTests extends ESTestCase {
             assertEquals("null element is dropped, not decoded as epoch 0", 1, longs.getValueCount(0));
             assertEquals(ts, longs.getLong(longs.getFirstValueIndex(0)));
         }
+        // Dropping the element is forced by the Block representation, but doing it silently is not: the read
+        // announces that it returned fewer values than the file holds.
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("events")));
+    }
+
+    // --- Dropped-null-element notices (esql-planning#1799) ---
+
+    /** The per-column detail line for a LIST read that dropped null elements. */
+    private static String droppedElementsNotice(String column) {
+        return ParquetColumnDecoding.nullListElementsMessage(column);
+    }
+
+    /**
+     * The file from the issue report: {@code int64_list} holds {@code [1, 2, 3]}, {@code [NULL, 1]}, {@code [4]} —
+     * six elements, five of them non-null. It is a mirror of {@code list_columns.parquet} in apache/parquet-testing.
+     */
+    private byte[] nullBearingIntListFixture() throws IOException {
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT64).named("int64_list");
+        return createParquetFile(new MessageType("test_schema", listType), factory -> {
+            Group g1 = factory.newGroup();
+            Group list1 = g1.addGroup("int64_list");
+            list1.addGroup("list").append("element", 1L);
+            list1.addGroup("list").append("element", 2L);
+            list1.addGroup("list").append("element", 3L);
+            Group g2 = factory.newGroup();
+            Group list2 = g2.addGroup("int64_list");
+            list2.addGroup("list"); // leading null element
+            list2.addGroup("list").append("element", 1L);
+            Group g3 = factory.newGroup();
+            g3.addGroup("int64_list").addGroup("list").append("element", 4L);
+            return List.of(g1, g2, g3);
+        });
+    }
+
+    /** Total values across every position of a block — what {@code SUM(MV_COUNT(col))} counts. */
+    private static int totalValueCount(Block block) {
+        int total = 0;
+        for (int pos = 0; pos < block.getPositionCount(); pos++) {
+            total += block.getValueCount(pos);
+        }
+        return total;
+    }
+
+    public void testListNullElementsAnnounceTheDroppedValues() throws Exception {
+        // The engine cannot preserve a null list element (an ES|QL multivalue has no representation for one), so
+        // the file's six elements necessarily read as five. What it must not do is stay quiet about it: a user
+        // cross-checking against DuckDB or ClickHouse would otherwise see a different count with no signal from us.
+        // Cover both decode paths — the optimized iterator and the baseline row-at-a-time reader.
+        byte[] parquetData = nullBearingIntListFixture();
+        for (ParquetFormatReader reader : List.of(
+            new ParquetFormatReader(blockFactory),
+            new ParquetFormatReader(blockFactory).withBaselinePath()
+        )) {
+            try (CloseableIterator<Page> it = reader.read(createStorageObject(parquetData), null, 10)) {
+                Page page = it.next();
+                assertEquals(3, page.getPositionCount());
+                LongBlock values = (LongBlock) page.getBlock(0);
+                assertEquals("the file's six elements read as five", 5, totalValueCount(values));
+                assertEquals("[NULL, 1] comes back as the single-element [1]", 1, values.getValueCount(1));
+                assertEquals(1L, values.getLong(values.getFirstValueIndex(1)));
+                page.releaseBlocks();
+            }
+            List<String> warnings = drainWarnings();
+            assertThat(
+                "the lossy read must announce itself",
+                warnings,
+                contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("int64_list"))
+            );
+            // The notice names the column the query used, not the physical leaf path int64_list.list.element.
+            assertThat(warnings.get(1), not(containsString("list.element")));
+        }
+    }
+
+    public void testListNullElementNoticeIsNotPolicyGated() throws Exception {
+        // The trap this guards: the per-value coercion sink threaded into the same readListColumn call is
+        // deliberately dead under fail_fast, because coercion warn+null only happens under a lenient policy. This
+        // drop happens under EVERY policy, so a notice riding that sink would leave the DEFAULT error_mode silent.
+        // fail_fast also warns rather than fails here on purpose: the loss is a representation limit, not malformed
+        // input, so failing would make every null-bearing LIST column unreadable by default.
+        byte[] parquetData = nullBearingIntListFixture();
+        for (ErrorPolicy policy : List.of(ErrorPolicy.STRICT, ErrorPolicy.PERMISSIVE)) {
+            try (
+                CloseableIterator<Page> it = new ParquetFormatReader(blockFactory).read(
+                    createStorageObject(parquetData),
+                    FormatReadContext.of(null, 10).withErrorPolicy(policy)
+                )
+            ) {
+                Page page = it.next();
+                assertEquals("the read succeeds under " + policy.mode(), 3, page.getPositionCount());
+                assertEquals(5, totalValueCount(page.getBlock(0)));
+                page.releaseBlocks();
+            }
+            assertThat(
+                "policy [" + policy.mode() + "] must still see the notice",
+                drainWarnings(),
+                contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("int64_list"))
+            );
+        }
+    }
+
+    public void testListNullElementNoticeRoutesToSuppliedSink() throws Exception {
+        // Under the async external source the decode loop runs on a background reader thread whose ThreadContext is
+        // never merged into the client response, so a notice emitted there via HeaderWarning is silently lost —
+        // exactly the silence being fixed. When the caller supplies a sink, every notice must go through it.
+        byte[] parquetData = nullBearingIntListFixture();
+        List<String> sink = new ArrayList<>();
+        try (
+            CloseableIterator<Page> it = new ParquetFormatReader(blockFactory).read(
+                createStorageObject(parquetData),
+                FormatReadContext.builder().batchSize(10).informationalWarningSink(sink::add).build()
+            )
+        ) {
+            while (it.hasNext()) {
+                it.next().releaseBlocks();
+            }
+        }
+        assertThat(sink, contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("int64_list")));
+        assertThat("nothing may leak to this thread's response headers when a sink is supplied", drainWarnings(), empty());
+    }
+
+    public void testListNullElementNoticeEmittedOncePerColumnAcrossBatches() throws Exception {
+        // The drop is rediscovered on every batch, but the notice is constant per column, so it must be emitted
+        // once. A plain SkipWarnings#add would instead count each repeat against MAX_ADDED_WARNINGS and eventually
+        // emit "further warnings suppressed" — telling the client warnings were dropped when none were.
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("vals");
+        int rows = SkipWarnings.MAX_ADDED_WARNINGS * 3;
+        byte[] parquetData = createParquetFile(new MessageType("test_schema", listType), factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                Group g = factory.newGroup();
+                Group list = g.addGroup("vals");
+                list.addGroup("list").append("element", r);
+                list.addGroup("list"); // one dropped null element in every single row
+                groups.add(g);
+            }
+            return groups;
+        });
+        // batchSize 1 maximises the number of readListColumn calls, and therefore of rediscoveries.
+        try (CloseableIterator<Page> it = new ParquetFormatReader(blockFactory).read(createStorageObject(parquetData), null, 1)) {
+            int seen = 0;
+            while (it.hasNext()) {
+                Page page = it.next();
+                seen += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            assertEquals(rows, seen);
+        }
+        assertThat(
+            "one notice per column per read, however many batches rediscover the drop",
+            drainWarnings(),
+            contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("vals"))
+        );
+    }
+
+    /**
+     * Every list shape whose below-{@code maxDefLevel} definition level is NOT a dropped element. A reader that
+     * keyed the notice on "definition level below maxDefLevel" alone, or on {@code maxDefLevel - 1} without
+     * checking the leaf's repetition, would cry loss over each of these:
+     * <ul>
+     *   <li>optional element, every element present: null lists and empty lists lose nothing;</li>
+     *   <li>required element: no null element is representable, so {@code maxDefLevel - 1} IS the empty-list
+     *       level;</li>
+     *   <li>bare top-level {@code repeated} primitive (the legacy un-annotated list, still accepted by
+     *       {@code ParquetFormatReader#isTopLevelListLeaf}): {@code maxDefLevel} is 1, so
+     *       {@code maxDefLevel - 1} is "zero occurrences" and every empty row would warn.</li>
+     * </ul>
+     */
+    public void testLosslessListShapesDoNotWarn() throws Exception {
+        MessageType schema = new MessageType(
+            "test_schema",
+            Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT32).named("optional_element"),
+            Types.optionalList().requiredElement(PrimitiveType.PrimitiveTypeName.INT32).named("required_element"),
+            Types.repeated(PrimitiveType.PrimitiveTypeName.INT32).named("bare_repeated")
+        );
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            // Row 0: populated lists. Row 1: empty lists. Row 2: absent (null) lists.
+            Group populated = factory.newGroup();
+            populated.addGroup("optional_element").addGroup("list").append("element", 1);
+            populated.addGroup("required_element").addGroup("list").append("element", 2);
+            populated.append("bare_repeated", 3);
+            Group emptyLists = factory.newGroup();
+            emptyLists.addGroup("optional_element");
+            emptyLists.addGroup("required_element");
+            Group absent = factory.newGroup();
+            return List.of(populated, emptyLists, absent);
+        });
+        try (CloseableIterator<Page> it = new ParquetFormatReader(blockFactory).read(createStorageObject(parquetData), null, 10)) {
+            Page page = it.next();
+            assertEquals(3, page.getPositionCount());
+            for (int b = 0; b < page.getBlockCount(); b++) {
+                assertEquals("only row 0 holds a value in block " + b, 1, totalValueCount(page.getBlock(b)));
+            }
+            page.releaseBlocks();
+        }
+        assertThat("a read that lost nothing must not claim it did", drainWarnings(), empty());
+    }
+
+    public void testListDateNanosNullElementAnnouncesTheDrop() throws Exception {
+        // The date_nanos list loop is its own row walk (it scales each element and drops MICROS overflows), so it
+        // needs the null-element tally wired separately from the generic readListRow.
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .named("events");
+        long nanos = 971211336000L * 1_000_000L;
+        byte[] parquetData = createParquetFile(new MessageType("test_schema", listType), factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("events");
+            list.addGroup("list").append("element", nanos);
+            list.addGroup("list"); // null element
+            return List.of(g);
+        });
+        try (CloseableIterator<Page> it = new ParquetFormatReader(blockFactory).read(createStorageObject(parquetData), null, 10)) {
+            Page page = it.next();
+            LongBlock values = (LongBlock) page.getBlock(0);
+            assertEquals(1, values.getValueCount(0));
+            assertEquals(nanos, values.getLong(values.getFirstValueIndex(0)));
+            page.releaseBlocks();
+        }
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("events")));
+    }
+
+    public void testListNullElementNoticeSurvivesCoerceAfterDecode() throws Exception {
+        // A declared element type beyond the fused pairs makes readListColumn recurse: it decodes at the file's own
+        // element type and then coerces the block. Only the inner frame walks the row loops, so the notice has to
+        // travel down with the recursion and be emitted exactly once — not twice (a tally in the outer frame too)
+        // and not never (the sink not forwarded). LIST<int64> declared `integer` narrows through castBlock, which is
+        // a supports() pair that fusedInDecode rejects, so it takes that branch.
+        Type listType = Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT64).named("vals");
+        byte[] parquetData = createParquetFile(new MessageType("test_schema", listType), factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("vals");
+            list.addGroup("list").append("element", 7L);
+            list.addGroup("list"); // null element
+            return List.of(g);
+        });
+        List<Attribute> plannerTypes = List.of(new ReferenceAttribute(Source.EMPTY, "vals", DataType.INTEGER));
+        try (
+            CloseableIterator<Page> it = declaredReader("vals").readRange(
+                createStorageObject(parquetData),
+                new RangeReadContext(List.of("vals"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.PERMISSIVE)
+            )
+        ) {
+            Page page = it.next();
+            IntBlock values = (IntBlock) page.getBlock(0);
+            assertEquals(1, values.getValueCount(0));
+            assertEquals(7, values.getInt(values.getFirstValueIndex(0)));
+            page.releaseBlocks();
+        }
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("vals")));
+    }
+
+    public void testListStringDeclaredDatetimeNullElementAnnouncesTheDrop() throws Exception {
+        // The string->datetime list arm gathers each row into a scratch before appending (so a mid-row parse
+        // failure can null the whole position), which makes it a third row walk needing the tally.
+        Type listType = Types.optionalList()
+            .optionalElement(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("vals");
+        byte[] parquetData = createParquetFile(new MessageType("test_schema", listType), factory -> {
+            Group g = factory.newGroup();
+            Group list = g.addGroup("vals");
+            list.addGroup("list").append("element", "2000-10-10T20:55:36Z");
+            list.addGroup("list"); // null element
+            return List.of(g);
+        });
+        List<Attribute> plannerTypes = List.of(new ReferenceAttribute(Source.EMPTY, "vals", DataType.DATETIME));
+        try (
+            CloseableIterator<Page> it = declaredReader("vals").readRange(
+                createStorageObject(parquetData),
+                new RangeReadContext(List.of("vals"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.PERMISSIVE)
+            )
+        ) {
+            Page page = it.next();
+            LongBlock values = (LongBlock) page.getBlock(0);
+            assertEquals(1, values.getValueCount(0));
+            assertEquals(971211336000L, values.getLong(values.getFirstValueIndex(0)));
+            page.releaseBlocks();
+        }
+        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("vals")));
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.core.Nullable;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -77,6 +79,12 @@ public class SkipWarnings {
     public static final SkipWarnings NOOP = new SkipWarnings("") {
         @Override
         public void add(String detail) {}
+
+        // Also overridden (rather than left to delegate to the no-op add) because NOOP is a shared
+        // static: letting it populate an instance dedup set would accumulate unbounded state across
+        // every reader in the JVM, and from several threads at once.
+        @Override
+        public void addOnce(String detail) {}
     };
 
     private final String summary;
@@ -91,6 +99,9 @@ public class SkipWarnings {
     private int added;
     private boolean summaryEmitted;
     private boolean overflowEmitted;
+    /** Details already emitted through {@link #addOnce(String)}; {@code null} until that method is first used. */
+    @Nullable
+    private Set<String> emittedOnce;
 
     public SkipWarnings(String summary) {
         this(summary, null);
@@ -141,6 +152,29 @@ public class SkipWarnings {
         } else if (overflowEmitted == false) {
             emit(overflowMessage());
             overflowEmitted = true;
+        }
+    }
+
+    /**
+     * Records a skip/null-fill event whose detail is constant for the affected column rather than distinct per
+     * value, emitting each distinct message at most once. A decode loop that rediscovers such a condition on
+     * every batch must use this rather than {@link #add(String)}, because {@code add} counts duplicates against
+     * {@link #MAX_ADDED_WARNINGS}: after that many batches one self-repeating column would emit
+     * {@link #overflowMessage()}, telling the client warnings were dropped when in fact every distinct message
+     * had already been delivered, and with enough such columns it would spend the whole budget on the first one.
+     * Downstream value-dedup does not prevent that — the overflow line is itself a distinct message.
+     */
+    public void addOnce(String detail) {
+        if (overflowEmitted) {
+            // The cap has already been reported, so add() would emit nothing: returning here keeps the dedup set
+            // from growing without bound for a caller whose details are numerous rather than few-and-repeated.
+            return;
+        }
+        if (emittedOnce == null) {
+            emittedOnce = new HashSet<>();
+        }
+        if (emittedOnce.add(detail)) {
+            add(detail);
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
@@ -64,7 +64,54 @@ public class SkipWarningsTests extends ESTestCase {
     public void testNoopDropsEverything() {
         SkipWarnings.NOOP.add("first");
         SkipWarnings.NOOP.add("second");
+        // NOOP overrides addOnce too, so it never populates a dedup set on the shared static. That state is not
+        // observable from here — this only pins that nothing is emitted, which the add() override alone would give.
+        SkipWarnings.NOOP.addOnce("third");
         assertNull(threadContext.getResponseHeaders().get("Warning"));
+    }
+
+    /**
+     * {@link SkipWarnings#addOnce} exists for details that are constant per affected column but rediscovered per
+     * batch (e.g. the Parquet list reader dropping null elements). Repeats must not reach the client, and — the
+     * reason a plain {@code add} will not do — must not be counted against the cap either.
+     */
+    public void testAddOnceEmitsOneLinePerDistinctDetail() {
+        SkipWarnings warnings = new SkipWarnings("the summary");
+        warnings.addOnce("column [a] lost values");
+        warnings.addOnce("column [a] lost values");
+        warnings.addOnce("column [b] lost values");
+        warnings.addOnce("column [a] lost values");
+
+        assertEquals(List.of("the summary", "column [a] lost values", "column [b] lost values"), drain());
+    }
+
+    public void testAddOnceRepeatsDoNotSpendTheDetailCap() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = new SkipWarnings("summary", sunk::add);
+        // Far more repeats than the cap: with plain add() this would emit the overflow notice, telling the client
+        // warnings were dropped when in fact the one distinct detail had already been delivered.
+        for (int i = 0; i < SkipWarnings.MAX_ADDED_WARNINGS * 3; i++) {
+            warnings.addOnce("the only detail");
+        }
+        assertEquals(List.of("summary", "the only detail"), sunk);
+    }
+
+    public void testAddOnceAndAddShareTheSameCap() {
+        List<String> sunk = new ArrayList<>();
+        SkipWarnings warnings = new SkipWarnings("summary", sunk::add);
+        // Interleave the two so the assertion pins one shared counter rather than two: half the distinct details
+        // arrive through add, half through addOnce, and the cap still lands after MAX_ADDED_WARNINGS of them.
+        for (int i = 0; i < SkipWarnings.MAX_ADDED_WARNINGS + 5; i++) {
+            if (i % 2 == 0) {
+                warnings.add("detail " + i);
+            } else {
+                warnings.addOnce("detail " + i);
+            }
+        }
+        // 1 summary + MAX_ADDED_WARNINGS details + 1 overflow notice: distinct details are capped as usual, so
+        // addOnce suppresses repeats without weakening the bound on how many lines one collector can emit.
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS + 2, sunk.size());
+        assertEquals(SkipWarnings.overflowMessage(), sunk.get(sunk.size() - 1));
     }
 
     public void testOfStrictPolicyReturnsNoop() {


### PR DESCRIPTION
A Parquet LIST column containing null elements returned fewer values than the file holds, silently: [1,2,3], [NULL,1], [4] read back as 5 elements where DuckDB and ClickHouse read 6. The drop is forced by the Block representation — an ES|QL multivalue has no slot for a null element — so this announces the loss rather than preventing it: each affected column now emits one response Warning naming it.

The notice uses a separate always-live SkipWarnings collector, not the per-value coercion sink already passed to readListColumn: that one is dead under fail_fast (the default error_mode), while this drop happens under every policy. It is built with each read's existing relay sink so async reads on a background thread deliver it. All three read paths are covered — both eager iterators and the deferred extractor — including the coerce-after-decode recursion.

New SkipWarnings.addOnce emits the constant per-column message once per read, so a drop rediscovered every batch doesn't exhaust the detail cap. Docs gain a limitations row; ListColumnParityTests now pins warning parity alongside value parity.

Closes https://github.com/elastic/esql-planning/issues/1799