### PR TITLE
ESQL:DS: Infer unsigned long Hive partition values

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetector.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.DeclaredTypeCoercions;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -25,7 +26,8 @@ import java.util.Set;
 /**
  * Detects Hive-style partition columns from file paths (e.g., {@code /year=2024/month=06/file.parquet}).
  * Parses key=value segments, validates consistency across all files, and infers types
- * using Spark-style rules: try Integer, Long, Double, Boolean, fallback to keyword.
+ * using Spark-style rules extended for ES|QL: try Integer, Long, Unsigned Long, Double, Boolean,
+ * fallback to keyword.
  */
 public final class HivePartitionDetector implements PartitionDetector {
 
@@ -219,18 +221,31 @@ public final class HivePartitionDetector implements PartitionDetector {
 
     private static DataType tryAllIntegral(List<String> values) {
         boolean needsLong = false;
+        boolean needsUnsignedLong = false;
+        boolean hasNegative = false;
         for (String v : values) {
             if (v == null) {
                 continue;
             }
             try {
                 Number n = StringUtils.parseIntegral(v);
-                if (n instanceof Long) {
-                    needsLong = true;
+                if (n instanceof BigInteger) {
+                    needsUnsignedLong = true;
+                } else {
+                    if (n instanceof Long) {
+                        needsLong = true;
+                    }
+                    if (n.longValue() < 0) {
+                        hasNegative = true;
+                    }
                 }
             } catch (Exception e) {
                 return null;
             }
+        }
+        if (needsUnsignedLong) {
+            // A negative value and one above Long.MAX_VALUE have no exact common numeric type.
+            return hasNegative ? DataType.KEYWORD : DataType.UNSIGNED_LONG;
         }
         return needsLong ? DataType.LONG : DataType.INTEGER;
     }
@@ -270,6 +285,9 @@ public final class HivePartitionDetector implements PartitionDetector {
         }
         if (type == DataType.LONG) {
             return Long.parseLong(value);
+        }
+        if (type == DataType.UNSIGNED_LONG) {
+            return DeclaredTypeCoercions.coerceToUnsignedLong(value);
         }
         if (type == DataType.DOUBLE) {
             return Double.parseDouble(value);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/HivePartitionDetectorTests.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -45,6 +47,17 @@ public class HivePartitionDetectorTests extends ESTestCase {
 
     public void testTypeInferenceLong() {
         assertEquals(DataType.LONG, HivePartitionDetector.inferType(List.of("1", "9999999999")));
+        assertEquals(DataType.LONG, HivePartitionDetector.inferType(List.of(Long.toString(Long.MAX_VALUE))));
+    }
+
+    public void testTypeInferenceUnsignedLong() {
+        assertEquals(DataType.UNSIGNED_LONG, HivePartitionDetector.inferType(List.of("9223372036854775808", "18446744073709551615")));
+        assertEquals(DataType.UNSIGNED_LONG, HivePartitionDetector.inferType(List.of("1", "9999999999", "9223372036854775808")));
+    }
+
+    public void testTypeInferenceMixedNegativeAndUnsignedLongFallsBackToKeyword() {
+        assertEquals(DataType.KEYWORD, HivePartitionDetector.inferType(List.of("-1", "9223372036854775808")));
+        assertEquals(DataType.KEYWORD, HivePartitionDetector.inferType(List.of(Long.toString(Long.MIN_VALUE), "18446744073709551615")));
     }
 
     public void testTypeInferenceDouble() {
@@ -107,6 +120,43 @@ public class HivePartitionDetectorTests extends ESTestCase {
         assertEquals(true, result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=True/file1.parquet")).get("flag"));
         assertNull(
             result.filePartitionValues().get(StoragePath.of("s3://bucket/data/flag=__HIVE_DEFAULT_PARTITION__/file2.parquet")).get("flag")
+        );
+    }
+
+    public void testUnsignedLongPartitionFoldersInferAndCast() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/id=1/file1.parquet"),
+            entry("s3://bucket/data/id=9223372036854775808/file2.parquet"),
+            entry("s3://bucket/data/id=18446744073709551615/file3.parquet"),
+            entry("s3://bucket/data/id=__HIVE_DEFAULT_PARTITION__/file4.parquet")
+        );
+
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.UNSIGNED_LONG, result.partitionColumns().get("id"));
+        assertUnsignedLongPartitionValue(result, "s3://bucket/data/id=1/file1.parquet", "1");
+        assertUnsignedLongPartitionValue(result, "s3://bucket/data/id=9223372036854775808/file2.parquet", "9223372036854775808");
+        assertUnsignedLongPartitionValue(result, "s3://bucket/data/id=18446744073709551615/file3.parquet", "18446744073709551615");
+        assertNull(
+            result.filePartitionValues().get(StoragePath.of("s3://bucket/data/id=__HIVE_DEFAULT_PARTITION__/file4.parquet")).get("id")
+        );
+    }
+
+    public void testMixedNegativeAndUnsignedLongPartitionFoldersInferKeyword() {
+        List<StorageEntry> files = List.of(
+            entry("s3://bucket/data/id=-1/file1.parquet"),
+            entry("s3://bucket/data/id=9223372036854775808/file2.parquet")
+        );
+
+        PartitionMetadata result = HivePartitionDetector.INSTANCE.detect(files);
+
+        assertFalse(result.isEmpty());
+        assertEquals(DataType.KEYWORD, result.partitionColumns().get("id"));
+        assertEquals("-1", result.filePartitionValues().get(StoragePath.of("s3://bucket/data/id=-1/file1.parquet")).get("id"));
+        assertEquals(
+            "9223372036854775808",
+            result.filePartitionValues().get(StoragePath.of("s3://bucket/data/id=9223372036854775808/file2.parquet")).get("id")
         );
     }
 
@@ -333,6 +383,11 @@ public class HivePartitionDetectorTests extends ESTestCase {
         assertEquals(9999999999L, HivePartitionDetector.castValue("9999999999", DataType.LONG));
     }
 
+    public void testCastValueUnsignedLong() {
+        String value = "9999999999999999999";
+        assertEquals(NumericUtils.asLongUnsigned(new BigInteger(value)), HivePartitionDetector.castValue(value, DataType.UNSIGNED_LONG));
+    }
+
     public void testCastValueDouble() {
         assertEquals(3.14, HivePartitionDetector.castValue("3.14", DataType.DOUBLE));
     }
@@ -474,6 +529,7 @@ public class HivePartitionDetectorTests extends ESTestCase {
     public void testCastValueNullReturnsNull() {
         assertNull(HivePartitionDetector.castValue(null, DataType.INTEGER));
         assertNull(HivePartitionDetector.castValue(null, DataType.LONG));
+        assertNull(HivePartitionDetector.castValue(null, DataType.UNSIGNED_LONG));
         assertNull(HivePartitionDetector.castValue(null, DataType.DOUBLE));
         assertNull(HivePartitionDetector.castValue(null, DataType.BOOLEAN));
         assertNull(HivePartitionDetector.castValue(null, DataType.KEYWORD));
@@ -493,6 +549,13 @@ public class HivePartitionDetectorTests extends ESTestCase {
         );
 
         assertTrue("inconsistent key sets across files yield no partition columns", HivePartitionDetector.INSTANCE.detect(files).isEmpty());
+    }
+
+    private static void assertUnsignedLongPartitionValue(PartitionMetadata result, String path, String expected) {
+        Object value = result.filePartitionValues().get(StoragePath.of(path)).get("id");
+        assertTrue(value instanceof Long);
+        Number decoded = NumericUtils.unsignedLongAsNumber((Long) value);
+        assertEquals(new BigInteger(expected), new BigInteger(decoded.toString()));
     }
 
     private static StorageEntry entry(String path) {


### PR DESCRIPTION
Infer and correctly encode unsigned-long partitions, with exact fallback for mixed signed values and regression coverage. 

Closes https://github.com/elastic/esql-planning/issues/1324