### PR TITLE
[9.5] Clarify shutdown logging on reindex cancel timeout (#157877)

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -199,18 +199,24 @@ public class ShutdownPrepareService {
         @Nullable Consumer<Task> taskNotifier,
         @Nullable Consumer<List<Task>> onTimeout
     ) {
-        return awaitTasksCompleteInternal(timeout, sleeper, taskName, taskManager, taskNotifier, onTimeout);
+        return awaitTasksCompleteInternal(timeout, sleeper, taskName, "finish", taskManager, taskNotifier, onTimeout);
+    }
+
+    protected boolean awaitTasksCancellation(TimeValue timeout, Sleeper sleeper, String taskName, TaskManager taskManager) {
+        return awaitTasksCompleteInternal(timeout, sleeper, taskName, "complete", taskManager, null, null);
     }
 
     /// Repeatedly polls the `taskManager` to list tasks whose action name is `taskName`, invoking `sleeper` to sleep for
     /// [#AWAIT_TASKS_POLL_INTERVAL] between each poll, until either no matching tasks are returned or the total time waited reaches
     /// `timeout`. Invokes `taskNotifier` exactly once for each matching task encountered. Returns true if it found no matching tasks, false
-    /// if it timed out or was interrupted.
+    /// if it timed out or was interrupted. The `waitFor` parameter gives a verb describing what we're waiting for the task to do, to use in
+    /// logging, e.g. `finish` or `cancel`.
     // package-private for testing
     static boolean awaitTasksCompleteInternal(
         TimeValue timeout,
         Sleeper sleeper,
         String taskName,
+        String waitFor,
         TaskManager taskManager,
         @Nullable Consumer<Task> taskNotifier,
         @Nullable Consumer<List<Task>> onTimeout
@@ -235,23 +241,30 @@ public class ShutdownPrepareService {
                 // literally just want to wait and not take up resources on this thread for now.
                 millisWaited += AWAIT_TASKS_POLL_INTERVAL.millis();
                 if (TimeValue.ZERO.equals(timeout) == false && millisWaited >= timeout.millis()) {
-                    logger.warn("timed out after waiting [{}] for [{}] {} tasks to finish", timeout, tasksRemaining.size(), taskName);
+                    logger.warn("timed out after waiting [{}] for [{}] {} tasks to {}", timeout, tasksRemaining.size(), taskName, waitFor);
                     if (onTimeout != null) {
                         onTimeout.accept(tasksRemaining);
                     }
                     return false;
                 }
                 logger.debug(
-                    "waiting for [{}] {} tasks to finish, next poll in [{}]",
+                    "waiting for [{}] {} tasks to {}, next poll in [{}]",
                     tasksRemaining.size(),
                     taskName,
+                    waitFor,
                     AWAIT_TASKS_POLL_INTERVAL
                 );
                 try {
                     sleeper.sleep(AWAIT_TASKS_POLL_INTERVAL);
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
-                    logger.warn("interrupted while waiting [{}] for [{}] {} tasks to finish", timeout, tasksRemaining.size(), taskName);
+                    logger.warn(
+                        "interrupted while waiting [{}] for [{}] {} tasks to {}",
+                        timeout,
+                        tasksRemaining.size(),
+                        taskName,
+                        waitFor
+                    );
                     return false;
                 }
             }
@@ -295,7 +308,7 @@ public class ShutdownPrepareService {
                         assert false : "Expected reindex tasks to be cancellable";
                     }
                 });
-                awaitTasksComplete(REINDEXING_CANCELLATION_TIMEOUT, sleeper, ReindexAction.NAME, taskManager, null, null);
+                awaitTasksCancellation(REINDEXING_CANCELLATION_TIMEOUT, sleeper, ReindexAction.NAME, taskManager);
             }
         );
     }

--- a/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/node/ShutdownPrepareServiceTests.java
@@ -50,6 +50,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,
+            "finish",
             taskManager,
             null,
             null
@@ -84,6 +85,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,
+            "finish",
             taskManager,
             null,
             null
@@ -141,6 +143,7 @@ public class ShutdownPrepareServiceTests extends ESTestCase {
             timeValueMillis(ShutdownPrepareService.AWAIT_TASKS_POLL_INTERVAL.millis() * 3),
             mock(),
             actionName,
+            "finish",
             taskManager,
             notified::add,
             null

--- a/test/framework/src/main/java/org/elasticsearch/node/ListenableShutdownPrepareService.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/ListenableShutdownPrepareService.java
@@ -60,12 +60,25 @@ public class ListenableShutdownPrepareService extends ShutdownPrepareService {
         @Nullable Consumer<Task> taskNotifier,
         @Nullable Consumer<List<Task>> onTimeout
     ) {
-        return awaitTasksCompleteInternal(timeout, sleeper, taskName, taskManager, taskNotifier, tasks -> {
+        return awaitTasksCompleteInternal(timeout, sleeper, taskName, "finish", taskManager, taskNotifier, tasks -> {
             notifyTaskTimeout(taskName, tasks);
             if (onTimeout != null) {
                 onTimeout.accept(tasks);
             }
         });
+    }
+
+    @Override
+    protected boolean awaitTasksCancellation(TimeValue timeout, Sleeper sleeper, String taskName, TaskManager taskManager) {
+        return awaitTasksCompleteInternal(
+            timeout,
+            sleeper,
+            taskName,
+            "cancel",
+            taskManager,
+            null,
+            tasks -> notifyTaskTimeout(taskName, tasks)
+        );
     }
 
     private void notifyTaskTimeout(String taskName, List<Task> tasks) {


### PR DESCRIPTION
Backports the following commits to 9.5:
 - Clarify shutdown logging on reindex cancel timeout (#157877)