### PR TITLE
Fixing RestoreOverOpenIndexIT.testOverlappingRestoreTransitionsDoNotCorruptTheSecondRestore() race condition

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -755,9 +755,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetTestingIT
   method: testParquetFile {bad_ARROW-GH-43605}
   issue: https://github.com/elastic/elasticsearch/issues/157747
-- class: org.elasticsearch.snapshots.RestoreOverOpenIndexIT
-  method: testOverlappingRestoreTransitionsDoNotCorruptTheSecondRestore
-  issue: https://github.com/elastic/elasticsearch/issues/157793
 - class: org.elasticsearch.index.mapper.SyntheticVersusColumnarStoredSourceIT
   method: testFallbackMultiValueViolationRestoredIdenticallyAcrossSourceModes
   issue: https://github.com/elastic/elasticsearch/issues/157799

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreOverOpenIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreOverOpenIndexIT.java
@@ -257,10 +257,13 @@ public class RestoreOverOpenIndexIT extends AbstractSnapshotIntegTestCase {
                 historyUuidAfterFirstTransition,
                 notNullValue()
             );
+            // The recovery is blocked on the repository, so the first restore cannot have completed: its shard has not STARTED. We do
+            // not assert the exact routing state, because a blocked recovery may show up as INITIALIZING or, briefly, as UNASSIGNED
+            // between allocation attempts (both are valid mid-flight states); asserting INITIALIZING specifically is racy (see #157793).
             assertThat(
-                "the first restore's shard must still be initializing (blocked on the repository) when the second transition publishes",
+                "the first restore must still be in flight (its shard not yet started) when the second transition publishes",
                 primaryShardRouting().state(),
-                equalTo(ShardRoutingState.INITIALIZING)
+                not(equalTo(ShardRoutingState.STARTED))
             );
 
             // publish a second transition over the same, still-recovering shard


### PR DESCRIPTION
RestoreOverOpenIndexIT.testOverlappingRestoreTransitionsDoNotCorruptTheSecondRestore() was occasionally failing. Since we're blocking recovery, we usually observe the shard state as INITIALIZING, but occasionally we catch it while it is UNASSIGNED and the test fails. All we really care about though is that it is not STARTED. So this PR changes the check to make sure we are not STARTED instead.
Closes #157793
Relates #156969