### PR TITLE
[9.5] Fix test failure in MixedClusterClientYamlTestSuiteIT (#157424)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -78,6 +78,9 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot_2
         wait_for_completion: true
+        body:
+          "index_settings":
+            "index.routing.rebalance.enable": "none"
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix test failure in MixedClusterClientYamlTestSuiteIT (#157424)](https://github.com/elastic/elasticsearch/pull/157424)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)