### PR TITLE
[9.4] Fix test failure in MixedClusterClientYamlTestSuiteIT (#157424)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -161,9 +161,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
   method: testFailedDeploymentStats
   issue: https://github.com/elastic/elasticsearch/issues/157341
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=snapshot.restore/10_basic/Create a snapshot and then restore single index from it}
-  issue: https://github.com/elastic/elasticsearch/issues/157984
 
 # Examples:
 #

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -78,6 +78,9 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot_2
         wait_for_completion: true
+        body:
+          "index_settings":
+            "index.routing.rebalance.enable": "none"
 
   - match: { snapshot.snapshot: test_snapshot_2 }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix test failure in MixedClusterClientYamlTestSuiteIT (#157424)](https://github.com/elastic/elasticsearch/pull/157424)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)