### PR TITLE
ESQL: Make warning cap test order independent

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -316,9 +316,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
   method: test {csv-spec:scoring.testMatchAndQueryStringFunctionsWithScore}
   issue: https://github.com/elastic/elasticsearch/issues/153614
-- class: org.elasticsearch.xpack.esql.datasources.AsyncExternalSourceBufferTests
-  method: testRecordInformationalWarningAppliesOneGlobalCapAcrossManyCallers
-  issue: https://github.com/elastic/elasticsearch/issues/153652
 - class: org.elasticsearch.xpack.esql.parser.ParamsParserTests
   method: testMixedSingleDoubleParams
   issue: https://github.com/elastic/elasticsearch/issues/153746

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -403,7 +403,13 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
             maxInformationalWarnings,
             drained.size()
         );
-        assertTrue("the last line must note suppression", drained.get(drained.size() - 1).contains("further reader warnings suppressed"));
+        // Producers reserve cap slots before enqueueing, so the queue cannot preserve counter order across threads.
+        // The contract is the bounded line count plus one suppression notice, not that the notice is the last item.
+        assertEquals(
+            "exactly one line must note suppression",
+            1L,
+            drained.stream().filter(warning -> warning.contains("further reader warnings suppressed")).count()
+        );
         assertFalse(buffer.isPartial());
     }
 


### PR DESCRIPTION
## Summary

Concurrent producers reserve warning-cap slots before enqueueing their messages, so the suppression notice is not guaranteed to be the final queue item. Assert the actual contract—bounded output with exactly one suppression notice—and restore the test to CI.

Closes #153652

## Test plan

- [x] Targeted test, 1,000 iterations
- [x] `AsyncExternalSourceBufferTests` (19 tests)
- [x] `:x-pack:plugin:esql:spotlessJavaCheck`

The original CI failure is intermittent and did not reproduce with its seed or 100 pre-change iterations locally. The ordering race remains reachable from the separate counter-reservation and queue-insertion steps; no production behavior changes here. The 9.5 mute will need the same backport.

Made with [Cursor](https://cursor.com)