### PR TITLE
[Docs][Columnar source] Documented way uses deprecated path

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
@@ -325,12 +325,12 @@ PUT my-columnar-index
 {
   "settings": {
     "index": {
+      "mapping": {
+        "source": {
+          "mode": "columnar_stored"
+        }
+      },
       "mode": "columnar"
-    }
-  },
-  "mappings": {
-    "_source": {
-      "mode": "columnar_stored"
     }
   }
 }


### PR DESCRIPTION
Removed the '_source' mapping configuration and replaced it with the `index.mapping.source.mode` setting.

If you use the current way, it returns a deprecation warning (helpfully visible in Kibana Dev Tools):

> #! Configuring source mode in mappings is deprecated and will be removed in future versions. Use [index.mapping.source.mode] index setting instead.