### PR TITLE
Add missing bits and flat_index_threshold to dense-vector docs

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -579,6 +579,9 @@ $$$dense-vector-index-options$$$
 `ef_construction`
 :   (Optional, integer) The number of candidates to track while assembling the list of nearest neighbors for each new node. Defaults to `100`. Only applicable to `hnsw`, `int8_hnsw`, `int4_hnsw` and `bbq_hnsw` index types.
 
+`flat_index_threshold` {applies_to}`stack: ga 9.4`
+:   (Optional, integer) The segment document count threshold below which graph or IVF construction is skipped in favor of brute-force flat search. `-1` (default) defers to format-specific defaults. `0` always builds the graph or IVF structure. A positive value overrides the format default. Only applicable to `hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`, and `bbq_disk` index types.
+
 `default_visit_percentage` {applies_to}`stack: ga 9.2`
 :   (Optional, integer) Only applicable to `bbq_disk`. Must be between 0 and 100.  0 will default to using `num_candidates` for calculating the percent visited. Increasing `default_visit_percentage` tends to improve the accuracy of the final results. Defaults to ~1% per shard for every 1 million vectors.
 
@@ -587,6 +590,9 @@ $$$dense-vector-index-options$$$
 
 `cluster_size` {applies_to}`stack: ga 9.2`
 :   (Optional, integer) Only applicable to `bbq_disk`.  The number of vectors per cluster.  Smaller cluster sizes increases accuracy at the cost of performance. Defaults to `384`. Must be a value between `64` and `65536`.
+
+`bits` {applies_to}`stack: ga 9.4`
+:   (Optional, integer) Only applicable to `bbq_disk`. The number of bits per dimension for quantization encoding. Valid values are `1` (default), `2`, `4`, or `7`. Higher values increase fidelity at the cost of slightly more disk space and slower queries. When no `rescore_vector` is specified, `bits` automatically adjusts the default oversampling: `1` uses 3.0x, `2` uses 1.5x, `4` and `7` disable oversampling. This setting can be changed without reindexing. Refer to [Quantize bits](/reference/elasticsearch/mapping-reference/bbq.md#bbq-bits) for details.
 
 `rescore_vector` {applies_to}`stack: preview =9.0, ga 9.1+`
 :   (Optional, object) An optional section that configures automatic vector rescoring on knn queries for the given field. Only applicable to quantized index types.


### PR DESCRIPTION
## Summary

Adds two missing parameters to the `index_options` properties dropdown in the dense-vector mapping reference documentation.

### `bits` (GA 9.4)

The `bits` parameter for `bbq_disk` was documented in `bbq.md` under [Quantize bits](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/bbq#bbq-bits) but was missing from the canonical `index_options` properties listing in `dense-vector.md`. All other `bbq_disk`-specific parameters (`cluster_size`, `default_visit_percentage`, `precondition`, `auto_calibrate`) were already listed there.

### `flat_index_threshold` (GA 9.4)

The `flat_index_threshold` parameter is parsed by the server for all HNSW types and `bbq_disk` (`DenseVectorFieldMapper.java` lines 1849, 1886, 1922, 2050, 2139) and was present in the elasticsearch-specification, but was not documented in the dense-vector mapping reference.

### Related

- Companion spec PR: https://github.com/elastic/elasticsearch-specification/pull/6583