### PR TITLE
Don't block reshard target recovery upon max retries

### DIFF
--- a/docs/changelog/158078.yaml
+++ b/docs/changelog/158078.yaml
@@ -1,0 +1,6 @@
+area: Stateless
+issues:
+  - 157917
+pr: 158078
+summary: Don't block reshard target recovery upon max retries
+type: bug

--- a/docs/changelog/158078.yaml
+++ b/docs/changelog/158078.yaml
@@ -1,4 +1,4 @@
-area: Stateless
+area: Allocation
 issues:
   - 157917
 pr: 158078

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
+import org.elasticsearch.cluster.routing.RecoverySource.ReshardSplitRecoverySource;
 import org.elasticsearch.cluster.routing.RelocationFailureInfo;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -44,10 +45,16 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
 
     private static final Decision YES_SIMULATING = Decision.single(Decision.Type.YES, NAME, "previous failures ignored when simulating");
 
+    private static final Decision YES_RESHARD_SPLIT = Decision.single(Decision.Type.YES, NAME, "reshard split target shard");
+
     @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
         if (allocation.isSimulating()) {
             return YES_SIMULATING;
+        }
+
+        if (shardRouting.recoverySource() instanceof ReshardSplitRecoverySource) {
+            return YES_RESHARD_SPLIT;
         }
 
         final int maxRetries = SETTING_ALLOCATION_MAX_RETRY.get(allocation.metadata().indexMetadata(shardRouting.index()).getSettings());

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -3440,7 +3440,8 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
         );
 
         final var indexName = randomIndexName();
-        createIndex(indexName, 1, 0);
+        // test that allocator max retry doesn't block target shard recovery
+        createIndex(indexName, indexSettings(1, 0).put(SETTING_ALLOCATION_MAX_RETRY.getKey(), 0).build());
         ensureGreen(indexName);
 
         // allow placement on target node after shard 0 has been placed on source node


### PR DESCRIPTION
When the source shard relocates, the clone task is cancelled, and the target shard fails. It's possible for the target recovery to be blocked when `index.allocation.max_retries` (5) is hit.

We do internal retries for `InitiateSplitWithSourceShardAction`, but it's not enough to retry upon task cancellation since the target will continuously send to the old node. We would have to update the `Split` in `SplitTargetService` which contains `sourceNode`. There are potentially other issues too, as we check `split.equals(splitFromRequest)` when accepting handoff which would fail if we updated the split.

One solution is to always allow allocation for target shards.

Resolves #157917