### PR TITLE
Fix stable plugin entitlement policy

### DIFF
--- a/docs/changelog/158079.yaml
+++ b/docs/changelog/158079.yaml
@@ -1,0 +1,6 @@
+area: Infra/Plugins
+issues:
+ - 157751
+pr: 158079
+summary: Fix stable plugin entitlement policy
+type: bug

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -67,6 +67,7 @@ public class EntitlementBootstrap {
     public static void bootstrap(
         Policy serverPolicyPatch,
         Map<String, Policy> pluginPolicies,
+        Map<String, String> pluginSyntheticModuleNames,
         Function<Class<?>, PolicyManager.PolicyScope> scopeResolver,
         Function<String, Stream<String>> settingResolver,
         Path[] dataDirs,
@@ -101,7 +102,14 @@ public class EntitlementBootstrap {
             pidFile,
             settingResolver
         );
-        PolicyManager policyManager = createPolicyManager(pluginPolicies, pathLookup, serverPolicyPatch, scopeResolver, pluginSourcePaths);
+        PolicyManager policyManager = createPolicyManager(
+            pluginPolicies,
+            pluginSyntheticModuleNames,
+            pathLookup,
+            serverPolicyPatch,
+            scopeResolver,
+            pluginSourcePaths
+        );
         PolicyChecker policyChecker = createPolicyChecker(suppressFailureLogPackages, policyManager, pathLookup);
         InternalInstrumentationRegistry instrumentationRegistry = new InstrumentationRegistryImpl(policyChecker);
         EntitlementInitialization.initializeArgs = new EntitlementInitialization.InitializeArgs(
@@ -183,6 +191,7 @@ public class EntitlementBootstrap {
 
     private static PolicyManager createPolicyManager(
         Map<String, Policy> pluginPolicies,
+        Map<String, String> pluginSyntheticModuleNames,
         PathLookup pathLookup,
         Policy serverPolicyPatch,
         Function<Class<?>, PolicyManager.PolicyScope> scopeResolver,
@@ -194,6 +203,7 @@ public class EntitlementBootstrap {
             HardcodedEntitlements.serverPolicy(pathLookup.pidFile(), serverPolicyPatch),
             HardcodedEntitlements.agentEntitlements(),
             pluginPolicies,
+            pluginSyntheticModuleNames,
             scopeResolver,
             pluginSourcePathsResolver::get,
             pathLookup

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -244,15 +244,21 @@ public class PolicyManager {
         Policy serverPolicy,
         List<Entitlement> apmAgentEntitlements,
         Map<String, Policy> pluginPolicies,
+        Map<String, String> pluginSyntheticModuleNames,
         Function<Class<?>, PolicyScope> scopeResolver,
         Function<String, Collection<Path>> pluginSourcePathsResolver,
         PathLookup pathLookup
     ) {
-        this.serverEntitlements = buildScopeEntitlementsMap(requireNonNull(serverPolicy));
+        this.serverEntitlements = buildScopeEntitlementsMap(requireNonNull(serverPolicy), null);
         this.apmAgentEntitlements = apmAgentEntitlements;
         this.pluginsEntitlements = requireNonNull(pluginPolicies).entrySet()
             .stream()
-            .collect(toUnmodifiableMap(Map.Entry::getKey, e -> buildScopeEntitlementsMap(e.getValue())));
+            .collect(
+                toUnmodifiableMap(
+                    Map.Entry::getKey,
+                    e -> buildScopeEntitlementsMap(e.getValue(), pluginSyntheticModuleNames.get(e.getKey()))
+                )
+            );
         this.scopeResolver = scopeResolver;
         this.pluginSourcePathsResolver = pluginSourcePathsResolver;
         this.pathLookup = requireNonNull(pathLookup);
@@ -277,8 +283,15 @@ public class PolicyManager {
         this.forbiddenPaths = createForbiddenPaths(pathLookup);
     }
 
-    private static Map<String, List<Entitlement>> buildScopeEntitlementsMap(Policy policy) {
-        return policy.scopes().stream().collect(toUnmodifiableMap(Scope::moduleName, Scope::entitlements));
+    private static Map<String, List<Entitlement>> buildScopeEntitlementsMap(Policy policy, String allUnnamedAlias) {
+        return policy.scopes()
+            .stream()
+            .collect(
+                toUnmodifiableMap(
+                    scope -> (allUnnamedAlias != null && ALL_UNNAMED.equals(scope.moduleName())) ? allUnnamedAlias : scope.moduleName(),
+                    Scope::entitlements
+                )
+            );
     }
 
     private static void validateEntitlementsPerModule(

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtils.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtils.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -46,7 +47,7 @@ public class PolicyUtils {
      * {@code pluginName} must be the descriptor {@code name=} value (not the install directory),
      * since the runtime entitlement lookup keys off the descriptor name.
      */
-    public record PluginData(Path pluginPath, String pluginName, boolean isModular, boolean isExternalPlugin) {
+    public record PluginData(Path pluginPath, String pluginName, boolean isModular, boolean isStable, boolean isExternalPlugin) {
         public PluginData {
             requireNonNull(pluginPath);
             requireNonNull(pluginName);
@@ -64,7 +65,7 @@ public class PolicyUtils {
         for (var entry : pluginData) {
             Path pluginRoot = entry.pluginPath();
             String pluginName = entry.pluginName();
-            final Set<String> moduleNames = getModuleNames(pluginRoot, entry.isModular());
+            final Set<String> moduleNames = getModuleNames(entry);
 
             var pluginPolicyPatch = parseEncodedPolicyIfExists(
                 pluginPolicyPatches.get(pluginName),
@@ -74,7 +75,11 @@ public class PolicyUtils {
                 moduleNames
             );
             var pluginPolicy = parsePolicyIfExists(pluginName, pluginRoot, entry.isExternalPlugin());
-            validatePolicyScopes(pluginName, pluginPolicy, moduleNames, pluginRoot.resolve(POLICY_FILE_NAME).toString());
+            // Stable non-modular plugins run in a synthetic named module, but the synthetic name is an
+            // implementation detail. They must use ALL-UNNAMED in their policy, just like any non-modular plugin.
+            // PolicyManager translates ALL-UNNAMED to the synthetic name at load time.
+            Set<String> validationModuleNames = (entry.isStable() && entry.isModular() == false) ? Set.of(ALL_UNNAMED) : moduleNames;
+            validatePolicyScopes(pluginName, pluginPolicy, validationModuleNames, pluginRoot.resolve(POLICY_FILE_NAME).toString());
 
             pluginPolicies.put(
                 pluginName,
@@ -154,15 +159,39 @@ public class PolicyUtils {
         return new Policy(pluginName, List.of());
     }
 
-    private static Set<String> getModuleNames(Path pluginRoot, boolean isModular) {
-        if (isModular) {
-            ModuleFinder moduleFinder = ModuleFinder.of(pluginRoot);
+    private static Set<String> getModuleNames(PluginData entry) {
+        if (entry.isModular()) {
+            ModuleFinder moduleFinder = ModuleFinder.of(entry.pluginPath());
             Set<ModuleReference> moduleReferences = moduleFinder.findAll();
 
             return moduleReferences.stream().map(mr -> mr.descriptor().name()).collect(Collectors.toUnmodifiableSet());
         }
+        if (entry.isStable()) {
+            // Stable plugins are loaded into a named synthetic module by PluginsLoader; mirror that module name here.
+            return Set.of(syntheticModuleName(entry.pluginName()));
+        }
         // When isModular == false we use the same "ALL-UNNAMED" constant as the JDK to indicate (any) unnamed module for this plugin
         return Set.of(ALL_UNNAMED);
+    }
+
+    /**
+     * Returns a map from plugin name to synthetic module name for stable non-modular plugins.
+     * Pass this to {@code PolicyManager} so it can translate {@code ALL-UNNAMED} scopes to the correct synthetic name.
+     */
+    public static Map<String, String> stablePluginSyntheticModuleNames(Collection<PluginData> pluginData) {
+        return pluginData.stream()
+            .filter(e -> e.isStable() && e.isModular() == false)
+            .collect(Collectors.toUnmodifiableMap(PluginData::pluginName, e -> syntheticModuleName(e.pluginName())));
+    }
+
+    /**
+     * Returns the full synthetic module name (including the {@code synthetic.} prefix) for a stable non-modular plugin.
+     * The name transformation mirrors {@code PluginsLoader.toModuleName}, which cannot be referenced here because it
+     * lives in {@code server}.
+     */
+    static String syntheticModuleName(String pluginName) {
+        return "synthetic."
+            + pluginName.replaceAll("\\W+", ".").replaceAll("(^[^A-Za-z_]*)", "").replaceAll("\\.$", "").toLowerCase(Locale.ROOT);
     }
 
     public static List<Scope> mergeScopes(List<Scope> mainScopes, List<Scope> additionalScopes) {

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -101,6 +101,7 @@ public class PolicyManagerTests extends ESTestCase {
             new Policy("server", List.of(new Scope("org.example.httpclient", List.of(new OutboundNetworkEntitlement())))),
             List.of(),
             Map.of("plugin1", new Policy("plugin1", List.of(new Scope("plugin.module1", List.of(new ExitVMEntitlement()))))),
+            Map.of(),
             c -> policyScope.get(),
             Map.of("plugin1", plugin1SourcePaths)::get,
             TEST_PATH_LOOKUP
@@ -181,6 +182,7 @@ public class PolicyManagerTests extends ESTestCase {
             createEmptyTestServerPolicy(),
             List.of(),
             Map.of(descriptorName, pluginPolicy),
+            Map.of(),
             c -> PolicyScope.plugin(descriptorName, PolicyManager.ALL_UNNAMED),
             name -> Collections.emptyList(),
             TEST_PATH_LOOKUP
@@ -198,6 +200,7 @@ public class PolicyManagerTests extends ESTestCase {
             createEmptyTestServerPolicy(),
             List.of(),
             Map.of(directoryName, pluginPolicy),
+            Map.of(),
             c -> PolicyScope.plugin(descriptorName, PolicyManager.ALL_UNNAMED),
             name -> Collections.emptyList(),
             TEST_PATH_LOOKUP
@@ -215,6 +218,7 @@ public class PolicyManagerTests extends ESTestCase {
         var policyManager = new PolicyManager(
             createEmptyTestServerPolicy(),
             List.of(new CreateClassLoaderEntitlement()),
+            Map.of(),
             Map.of(),
             c -> c.getPackageName().startsWith(TEST_AGENTS_PACKAGE_NAME)
                 ? PolicyScope.apmAgent("test.agent.module")
@@ -243,6 +247,7 @@ public class PolicyManagerTests extends ESTestCase {
                 ),
                 List.of(),
                 Map.of(),
+                Map.of(),
                 c -> PolicyScope.plugin("test", moduleName(c)),
                 name -> Collections.emptyList(),
                 TEST_PATH_LOOKUP
@@ -258,6 +263,7 @@ public class PolicyManagerTests extends ESTestCase {
             () -> new PolicyManager(
                 createEmptyTestServerPolicy(),
                 List.of(new CreateClassLoaderEntitlement(), new CreateClassLoaderEntitlement()),
+                Map.of(),
                 Map.of(),
                 c -> PolicyScope.plugin("test", moduleName(c)),
                 name -> Collections.emptyList(),
@@ -295,6 +301,7 @@ public class PolicyManagerTests extends ESTestCase {
                         )
                     )
                 ),
+                Map.of(),
                 c -> PolicyScope.plugin("plugin1", moduleName(c)),
                 Map.of("plugin1", List.of(Path.of("modules", "plugin1")))::get,
                 TEST_PATH_LOOKUP
@@ -345,6 +352,7 @@ public class PolicyManagerTests extends ESTestCase {
                         )
                     )
                 ),
+                Map.of(),
                 c -> PolicyScope.plugin("", moduleName(c)),
                 Map.of("plugin1", List.of(Path.of("modules", "plugin1")), "plugin2", List.of(Path.of("modules", "plugin2")))::get,
                 TEST_PATH_LOOKUP
@@ -396,6 +404,7 @@ public class PolicyManagerTests extends ESTestCase {
                         )
                     )
                 ),
+                Map.of(),
                 c -> PolicyScope.plugin("", moduleName(c)),
                 name -> Collections.emptyList(),
                 TEST_PATH_LOOKUP

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtilsTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtilsTests.java
@@ -47,7 +47,7 @@ public class PolicyUtilsTests extends ESTestCase {
             """);
 
         String descriptorName = "myPlugin";
-        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, true);
+        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, false, true);
 
         var result = PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(), "9.0.0");
 
@@ -74,12 +74,47 @@ public class PolicyUtilsTests extends ESTestCase {
                 - manage_threads
             """.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
 
-        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, true);
+        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, false, true);
         var result = PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(descriptorName, patch), "9.0.0");
 
         assertThat(result.keySet(), containsInAnyOrder(descriptorName));
         var entitlements = result.get(descriptorName).scopes().stream().flatMap(s -> s.entitlements().stream()).toList();
         assertThat(entitlements, containsInAnyOrder(new OutboundNetworkEntitlement(), new ManageThreadsEntitlement()));
+    }
+
+    /** Stable plugin authors must use ALL-UNNAMED; writing the synthetic name directly is rejected. */
+    public void testStablePluginPolicyWithSyntheticModuleNameIsRejected() throws Exception {
+        Path pluginDir = createTempDir("stable-plugin-synthetic-module");
+        Files.writeString(pluginDir.resolve(PolicyUtils.POLICY_FILE_NAME), """
+            synthetic.myplugin:
+              - manage_threads
+            """);
+
+        var pluginData = new PolicyUtils.PluginData(pluginDir, "myPlugin", false, true, true);
+
+        assertThrows(IllegalStateException.class, () -> PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(), "9.0.0"));
+    }
+
+    /** A stable plugin may use ALL-UNNAMED in its policy; validation accepts it as-is. */
+    public void testStablePluginPolicyWithAllUnnamedIsAccepted() throws Exception {
+        Path pluginDir = createTempDir("stable-plugin-all-unnamed");
+        Files.writeString(pluginDir.resolve(PolicyUtils.POLICY_FILE_NAME), """
+            ALL-UNNAMED:
+              - manage_threads
+            """);
+
+        var pluginData = new PolicyUtils.PluginData(pluginDir, "myPlugin", false, true, true);
+        var result = PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(), "9.0.0");
+
+        assertThat(result.keySet(), containsInAnyOrder("myPlugin"));
+        assertThat(result.get("myPlugin").scopes(), containsInAnyOrder(new Scope("ALL-UNNAMED", List.of(new ManageThreadsEntitlement()))));
+    }
+
+    /** The synthetic module name must mirror PluginsLoader.toModuleName's transformation, including the synthetic. prefix. */
+    public void testStablePluginSyntheticModuleName() {
+        assertThat(PolicyUtils.syntheticModuleName("my-stable-plugin"), equalTo("synthetic.my.stable.plugin"));
+        assertThat(PolicyUtils.syntheticModuleName("my_stable_plugin"), equalTo("synthetic.my_stable_plugin"));
+        assertThat(PolicyUtils.syntheticModuleName("42plugin"), equalTo("synthetic.plugin"));
     }
 
     public void testCreatePluginPolicyWithPatch() {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -243,6 +243,7 @@ class Elasticsearch {
                         bundle.getDir(),
                         bundle.pluginDescriptor().getName(),
                         bundle.pluginDescriptor().isModular(),
+                        bundle.pluginDescriptor().isStable(),
                         false
                     )
                 ),
@@ -252,6 +253,7 @@ class Elasticsearch {
                         bundle.getDir(),
                         bundle.pluginDescriptor().getName(),
                         bundle.pluginDescriptor().isModular(),
+                        bundle.pluginDescriptor().isStable(),
                         true
                     )
                 )
@@ -275,6 +277,7 @@ class Elasticsearch {
         EntitlementBootstrap.bootstrap(
             serverPolicyPatch,
             pluginPolicies,
+            PolicyUtils.stablePluginSyntheticModuleNames(pluginData),
             scopeResolver::resolveClassToScope,
             nodeEnv.settings()::getValues,
             nodeEnv.dataDirs(),

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsLoader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsLoader.java
@@ -458,7 +458,7 @@ public class PluginsLoader {
         String result = name.replaceAll("\\W+", ".") // replace non-alphanumeric character strings with dots
             .replaceAll("(^[^A-Za-z_]*)", "") // trim non-alpha or underscore characters from start
             .replaceAll("\\.$", "") // trim trailing dot
-            .toLowerCase(Locale.getDefault());
+            .toLowerCase(Locale.ROOT);
         assert ModuleSupport.isPackageName(result);
         return result;
     }

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
@@ -51,7 +51,7 @@ public class TestPolicyManager extends PolicyManager {
         Collection<Path> classpath,
         Collection<URI> testOnlyClasspath
     ) {
-        super(serverPolicy, apmAgentEntitlements, pluginPolicies, scopeResolver, name -> classpath, pathLookup);
+        super(serverPolicy, apmAgentEntitlements, pluginPolicies, Map.of(), scopeResolver, name -> classpath, pathLookup);
         this.classpath = classpath;
         this.testOnlyClasspath = testOnlyClasspath;
         resetAfterTest();


### PR DESCRIPTION
Stable non-modular plugins are loaded into a synthetic named module by
PluginsLoader (synthetic.<name>), but the entitlement policy lookup was
using ALL-UNNAMED for them, so no policy was ever applied. This fix
threads isStable through PluginData and Elasticsearch bootstrap so that
policy resolution uses the correct synthetic module name at runtime.

Like any non-modular plugin, stable plugin authors write ALL-UNNAMED in
their policy file — it is the standard sentinel for non-modular code and
the synthetic module name is an implementation detail that is rejected if
written directly. Validation accepts ALL-UNNAMED for stable non-modular
plugins, and PolicyManager translates it to the synthetic name when
building its internal entitlements map, using a new
pluginSyntheticModuleNames parameter passed from the bootstrap path.

The syntheticModuleName helper (mirroring PluginsLoader.toModuleName)
now includes the synthetic. prefix and uses Locale.ROOT for
deterministic lowercasing. Tests cover the ALL-UNNAMED acceptance and
translation, rejection of the synthetic name, and the name
transformation.

closes #157751
