### PR TITLE
Fix nested doc iterator in phrase queries with stored source

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -102,6 +102,25 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
      * than the empty source that a plain stored-source loader returns for nested child doc IDs.
      */
     public void testPhraseQueryInsideNestedObject() throws IOException {
+        assertNestedPhraseQueries(false, "the quick brown fox", "the slow lazy dog", "quick brown");
+    }
+
+    /**
+     * Reproduces #156803: the per-query cached source-loader leaf shares forward-only child iterators across searches, so the
+     * second search re-reads the segment at a LOWER nested-child doc id and threw "Cannot find object path for document" before
+     * the fix in NestedDocuments.findObjectPath. The first phrase matches the child at the higher doc id, advancing the shared
+     * iterators past the lower one; both docs must land in one segment for the leaf to be shared, hence the force-merge.
+     */
+    public void testPhraseQueryInsideNestedObjectBackwardDocAccess() throws IOException {
+        assertNestedPhraseQueries(true, "the slow lazy dog", "the quick brown fox", "quick brown", "lazy dog");
+    }
+
+    /**
+     * Indexes two root documents, each with one nested child holding the given text, then runs each phrase query against
+     * children.text on one shared SearchExecutionContext and asserts exactly one hit per phrase.
+     */
+    private void assertNestedPhraseQueries(boolean forceMerge, String firstChildText, String secondChildText, String... phrases)
+        throws IOException {
         MapperService mapperService = createMapperService(mapping(b -> {
             b.startObject("children");
             b.field("type", "nested");
@@ -111,45 +130,33 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
 
-        try (Directory directory = newDirectory()) {
-            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
-
-            // First root document: has a nested child containing the target phrase.
-            ParsedDocument doc1 = mapperService.documentMapper().parse(source(b -> {
-                b.startArray("children");
-                b.startObject().field("text", "the quick brown fox").endObject();
-                b.endArray();
-            }));
-            iw.addDocuments(doc1.docs());
-
-            // Second root document: nested child does not contain the target phrase.
-            ParsedDocument doc2 = mapperService.documentMapper().parse(source(b -> {
-                b.startArray("children");
-                b.startObject().field("text", "the slow lazy dog").endObject();
-                b.endArray();
-            }));
-            iw.addDocuments(doc2.docs());
-
-            iw.close();
-
-            try (
-                DirectoryReader reader = ElasticsearchDirectoryReader.wrap(
-                    DirectoryReader.open(directory),
-                    new ShardId(mapperService.index(), 0)
-                )
-            ) {
-                // Pass false to avoid random reader re-wrapping (e.g. SlowCompositeReaderWrapper) that would break
-                // the ElasticsearchLeafReader chain needed by BitsetFilterCache to resolve the shard ID.
-                SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(reader, false));
+        withLuceneIndex(mapperService, iw -> {
+            for (String childText : new String[] { firstChildText, secondChildText }) {
+                ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+                    b.startArray("children");
+                    b.startObject().field("text", childText).endObject();
+                    b.endArray();
+                }));
+                iw.addDocuments(doc.docs());
+            }
+            if (forceMerge) {
+                iw.forceMerge(1);
+            }
+        }, reader -> {
+            DirectoryReader wrapped = ElasticsearchDirectoryReader.wrap(reader, new ShardId(mapperService.index(), 0));
+            // Pass false to avoid random reader re-wrapping (e.g. SlowCompositeReaderWrapper) that would break
+            // the ElasticsearchLeafReader chain needed by BitsetFilterCache to resolve the shard ID.
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(wrapped, false));
+            for (String phrase : phrases) {
                 NestedQueryBuilder query = new NestedQueryBuilder(
                     "children",
-                    new MatchPhraseQueryBuilder("children.text", "quick brown"),
+                    new MatchPhraseQueryBuilder("children.text", phrase),
                     ScoreMode.None
                 );
                 TopDocs docs = context.searcher().search(query.toQuery(context), 10);
-                assertThat(docs.totalHits.value(), equalTo(1L));
+                assertThat("phrase [" + phrase + "]", docs.totalHits.value(), equalTo(1L));
             }
-        }
+        });
     }
 
     private void assertPhraseQuery(MapperService mapperService) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/NestedDocuments.java
+++ b/server/src/main/java/org/elasticsearch/search/NestedDocuments.java
@@ -150,6 +150,13 @@ public class NestedDocuments {
             String path = null;
             for (Map.Entry<String, Scorer> objectFilter : childScorers.entrySet()) {
                 DocIdSetIterator it = objectFilter.getValue().iterator();
+                if (it.docID() > doc) {
+                    // Callers are not required to advance in doc id order: a SourceLoader reading stored source during the query phase may
+                    // re-read the segment from the top for a second query clause (see ConcurrentSegmentSourceProvider).
+                    // DocIdSetIterators are forward-only, so pull a fresh scorer to rewind.
+                    objectFilter.setValue(getNestedChildWeight(ctx, objectFilter.getKey()).scorer(ctx));
+                    it = objectFilter.getValue().iterator();
+                }
                 if (it.docID() == doc || it.docID() < doc && it.advance(doc) == doc) {
                     if (path == null || path.length() > objectFilter.getKey().length()) {
                         path = objectFilter.getKey();

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedStoredSourceLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedStoredSourceLoaderTests.java
@@ -9,14 +9,19 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.join.QueryBitSetProducer;
+import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.NestedDocuments;
 import org.elasticsearch.search.lookup.Source;
 
@@ -206,6 +211,59 @@ public class NestedStoredSourceLoaderTests extends MapperServiceTestCase {
 
             // All three nested docs share the same root (doc 3): root source loaded exactly once.
             assertEquals(1, storedFieldReads.get());
+        });
+    }
+
+    /**
+     * Runtime field queries visit every doc in the segment, including nested children, and source-backed runtime fields read
+     * _source per doc through the per-query cached SourceProvider. A second query on the same context re-reads the segment from
+     * doc 0, which threw "Cannot find object path for document" before the fix in NestedDocuments.findObjectPath (#156803).
+     * The runtime field is unrelated to the nested object - the nested field merely existing in the mapping is enough.
+     */
+    public void testRuntimeFieldQueryWithNestedMappingBackwardDocAccess() throws IOException {
+        MapperService mapperService = createMapperService("""
+            {
+                "_doc": {
+                    "runtime": {
+                        "rt": { "type": "keyword" }
+                    },
+                    "properties": {
+                        "children": {
+                            "type": "nested",
+                            "properties": {
+                                "value": { "type": "keyword" }
+                            }
+                        }
+                    }
+                }
+            }
+            """);
+
+        String firstValue = randomAlphaOfLength(8);
+        String secondValue = randomValueOtherThan(firstValue, () -> randomAlphaOfLength(8));
+
+        withLuceneIndex(mapperService, iw -> {
+            for (String value : new String[] { firstValue, secondValue }) {
+                ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+                    b.field("rt", value);
+                    b.startArray("children");
+                    b.startObject().field("value", randomAlphaOfLength(5)).endObject();
+                    b.endArray();
+                }));
+                iw.addDocuments(doc.docs());
+            }
+            // Force a single segment so both root docs' children share one cached source-loader leaf.
+            iw.forceMerge(1);
+        }, reader -> {
+            DirectoryReader wrapped = ElasticsearchDirectoryReader.wrap(reader, new ShardId(mapperService.index(), 0));
+            // Pass false to avoid random reader re-wrapping that would break the ElasticsearchLeafReader chain
+            // needed by BitsetFilterCache to resolve the shard ID.
+            SearchExecutionContext context = createSearchExecutionContext(mapperService, newSearcher(wrapped, false));
+
+            // Pass 1 visits all docs (children at doc ids 0 and 2), advancing the shared child iterators to doc 2.
+            assertEquals(1L, context.searcher().search(new TermQueryBuilder("rt", secondValue).toQuery(context), 10).totalHits.value());
+            // Pass 2 starts over at doc 0 with the child iterators still parked at doc 2.
+            assertEquals(1L, context.searcher().search(new TermQueryBuilder("rt", firstValue).toQuery(context), 10).totalHits.value());
         });
     }
 


### PR DESCRIPTION
### Problem

Search queries fail with: `java.lang.IllegalStateException: Cannot find object path for document <docid>`, thrown from `NestedDocuments.findObjectPath`, on indices that have a nested field in their mapping.

This happens because the `NestedDocuments.findObjectsPath` uses `DocIdSetIterator`s, which are forward-only. The query-phase source provider (`ConcurrentSegmentSourceProvider`) caches one source-loader leaf per segment for the whole query and, for stored source, deliberately permits random / backward doc access — stored fields support it. When a query performs more than one collection pass over a segment (ex. two positional clauses), the second pass re-reads the segment from the top. The cached child iterators are already positioned past the lower doc ID, so `findObjectPath` finds no matching path, and it throws.

### Fix

Make `NestedDocuments.findObjectPath` tolerate non-monotonic doc access. When a path's cached iterator has already advanced past the requested doc, pull a fresh scorer from the (cached, reusable) child `Weight` and retry — a `DocIdSetIterator` cannot rewind, so we replace it. This is the exact idiom [loadNestedIdentity](https://github.com/elastic/elasticsearch/blob/81f70e8e283c2261691b6ffd640be81cd8e98e96/server/src/main/java/org/elasticsearch/search/NestedDocuments.java#L172-L174) already uses a few lines below for the same reason.

Closes https://github.com/elastic/elasticsearch/issues/157718