### PR TITLE
ESQL:DS: Make strict NDJSON reconciliation name-based

### DIFF
--- a/docs/changelog/158110.yaml
+++ b/docs/changelog/158110.yaml
@@ -1,5 +1,0 @@
-area: ES|QL
-issues: []
-pr: 158110
-summary: "ESQL:DS: Make strict NDJSON reconciliation name-based"
-type: enhancement

--- a/docs/changelog/158110.yaml
+++ b/docs/changelog/158110.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158110
+summary: "ESQL:DS: Make strict NDJSON reconciliation name-based"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrerTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrerTests.java
@@ -39,6 +39,17 @@ public class NdJsonSchemaInferrerTests extends ESTestCase {
             """, field("name", DataType.KEYWORD), field("age", DataType.INTEGER));
     }
 
+    public void testInferredOrderFollowsFirstAppearance() throws IOException {
+        check("""
+            {"ts": "2026-01-01T00:00:00Z", "error_code": 7, "level": "INFO"}
+            {"ts": "2026-01-01T00:00:01Z", "error_code": 3, "level": "WARN"}
+            """, field("ts", DataType.DATETIME), field("error_code", DataType.INTEGER), field("level", DataType.KEYWORD));
+        check("""
+            {"ts": "2026-01-01T00:00:02Z", "level": "INFO"}
+            {"ts": "2026-01-01T00:00:03Z", "error_code": 5, "level": "ERROR"}
+            """, field("ts", DataType.DATETIME), field("level", DataType.KEYWORD), field("error_code", DataType.INTEGER, true));
+    }
+
     /**
      * Test case: Verifies the schema inference properly handles nested JSON objects.
      */

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonStrictSchemaResolutionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalNdJsonStrictSchemaResolutionIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * End-to-end coverage for strict schema resolution when sparse NDJSON records make identical
+ * logical schemas appear in different inferred column orders across files.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class ExternalNdJsonStrictSchemaResolutionIT extends AbstractExternalDataSourceIT {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> formatPlugins() {
+        return List.of(NdJsonDataSourcePlugin.class);
+    }
+
+    public void testStrictMapsSparseFilesByColumnName() throws Exception {
+        Path dir = createTempDir().resolve("strict_ndjson_sparse");
+        Files.createDirectories(dir);
+        Files.writeString(
+            dir.resolve("a.ndjson"),
+            "{\"id\":1,\"error_code\":10,\"level\":\"INFO\"}\n" + "{\"id\":2,\"error_code\":20,\"level\":\"DEBUG\"}\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            dir.resolve("b.ndjson"),
+            "{\"id\":3,\"level\":\"WARN\"}\n" + "{\"id\":4,\"error_code\":40,\"level\":\"ERROR\"}\n",
+            StandardCharsets.UTF_8
+        );
+
+        String glob = StoragePath.fileUri(dir) + "/*.ndjson";
+        String dataset = registerDataset("strict_ndjson_sparse", glob, Map.of("schema_resolution", "strict"));
+
+        try (var response = run(syncEsqlQueryRequest("FROM " + dataset + " | SORT id | KEEP error_code, level"))) {
+            assertThat(
+                getValuesList(response),
+                contains(List.of(10, "INFO"), List.of(20, "DEBUG"), Arrays.asList(null, "WARN"), List.of(40, "ERROR"))
+            );
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliation.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * Supports three strategies:
  * <ul>
  *   <li>{@code FIRST_FILE_WINS} — use the first file's schema (existing behavior, no reconciliation)</li>
- *   <li>{@code STRICT} — validate all files share the exact same schema</li>
+ *   <li>{@code STRICT} — validate all files share the exact same schema (NDJSON column order is ignored)</li>
  *   <li>{@code UNION_BY_NAME} — merge schemas by column name with safe type widening</li>
  * </ul>
  * <p>
@@ -74,7 +74,8 @@ import java.util.Set;
  *   <dt><b>Unified schema</b> (one for the whole table)</dt>
  *   <dd>The cross-file harmonized schema. Produced here as {@link Result#unifiedSchema()}:
  *       FFW takes the anchor file's schema, STRICT validates a common schema, UBN takes the
- *       column-name union with type widening. Becomes {@code ExternalSourceExec.attributes}
+ *       column-name union with type widening. NDJSON STRICT preserves the anchor's inferred
+ *       order while mapping other files' columns by name. Becomes {@code ExternalSourceExec.attributes}
  *       at first, before the optimizer's projection pruning rewrites that field.</dd>
  *
  *   <dt><b>Query schema</b> (unified shape; same for every file in the query)</dt>
@@ -84,8 +85,9 @@ import java.util.Set;
  *
  *   <dt><b>Per-file query schema</b> (per-file, file shape — what the reader actually produces)</dt>
  *   <dd>{@code Query schema} ∩ this file's columns, ordered to match the file's natural layout.
- *       Derived per file at split-construction time and at read time. Under FFW and STRICT it
- *       collapses to the Query schema because every file has every projected column.</dd>
+ *       Derived per file at split-construction time and at read time. Under FFW and ordered-format
+ *       STRICT it collapses to the Query schema because every file has every projected column;
+ *       NDJSON STRICT may retain a different inferred order and is mapped by name.</dd>
  * </dl>
  *
  * <h3>Worked example (UNION_BY_NAME)</h3>
@@ -208,7 +210,9 @@ public final class SchemaReconciliation {
 
     /**
      * STRICT reconciliation: validate all files share the exact same schema.
-     * Nullability differences are tolerated; all other differences produce an error.
+     * Nullability differences are tolerated. NDJSON column order is also ignored because its
+     * inferred order only records when each field first appeared in the sample; ordered formats
+     * retain positional schema identity.
      *
      * @param referenceFile path of the first (reference) file
      * @param fileMetadata ordered map of file path → metadata (first entry is the reference)
@@ -221,6 +225,7 @@ public final class SchemaReconciliation {
             throw new IllegalArgumentException("Reference file not found in metadata: " + referenceFile);
         }
         List<Attribute> refSchema = refMeta.schema();
+        boolean compareByName = fileMetadata.values().stream().allMatch(meta -> "ndjson".equals(meta.sourceType()));
 
         Map<StoragePath, FileSchemaInfo> perFileInfo = new LinkedHashMap<>();
 
@@ -233,14 +238,20 @@ public final class SchemaReconciliation {
             validateNoDuplicateColumns(filePath, fileSchema);
 
             if (filePath.equals(referenceFile) == false) {
-                validateStrictMatch(referenceFile, refSchema, filePath, fileSchema);
+                validateStrictMatch(referenceFile, refSchema, filePath, fileSchema, compareByName);
             }
 
-            int[] identity = new int[refSchema.size()];
-            for (int i = 0; i < identity.length; i++) {
-                identity[i] = i;
+            ColumnMapping mapping;
+            if (compareByName) {
+                mapping = computeMapping(refSchema, fileSchema);
+            } else {
+                int[] identity = new int[refSchema.size()];
+                for (int i = 0; i < identity.length; i++) {
+                    identity[i] = i;
+                }
+                mapping = new ColumnMapping(identity, null);
             }
-            perFileInfo.put(filePath, new FileSchemaInfo(new ExternalSchema(fileSchema), new ColumnMapping(identity, null), stats));
+            perFileInfo.put(filePath, new FileSchemaInfo(new ExternalSchema(fileSchema), mapping, stats));
         }
 
         return new Result(new ExternalSchema(refSchema), Map.copyOf(perFileInfo));
@@ -250,7 +261,8 @@ public final class SchemaReconciliation {
         StoragePath refPath,
         List<Attribute> refSchema,
         StoragePath filePath,
-        List<Attribute> fileSchema
+        List<Attribute> fileSchema,
+        boolean compareByName
     ) {
         if (refSchema.size() != fileSchema.size()) {
             throw new IllegalArgumentException(
@@ -265,6 +277,10 @@ public final class SchemaReconciliation {
                     + " columns."
                     + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
             );
+        }
+        if (compareByName) {
+            validateStrictMatchByName(refPath, refSchema, filePath, fileSchema);
+            return;
         }
         for (int i = 0; i < refSchema.size(); i++) {
             Attribute refAttr = refSchema.get(i);
@@ -285,22 +301,54 @@ public final class SchemaReconciliation {
                         + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
                 );
             }
-            if (refAttr.dataType() != fileAttr.dataType()) {
+            validateStrictTypeMatch(refPath, refAttr, filePath, fileAttr);
+        }
+    }
+
+    private static void validateStrictMatchByName(
+        StoragePath refPath,
+        List<Attribute> refSchema,
+        StoragePath filePath,
+        List<Attribute> fileSchema
+    ) {
+        Map<String, Attribute> fileAttributes = new HashMap<>();
+        for (Attribute fileAttr : fileSchema) {
+            fileAttributes.put(fileAttr.name(), fileAttr);
+        }
+        for (Attribute refAttr : refSchema) {
+            Attribute fileAttr = fileAttributes.get(refAttr.name());
+            if (fileAttr == null) {
                 throw new IllegalArgumentException(
                     "Schema mismatch in ["
                         + filePath
                         + "]: column ["
-                        + fileAttr.name()
-                        + "] has type ["
-                        + fileAttr.dataType().typeName()
-                        + "] but reference file ["
+                        + refAttr.name()
+                        + "] from reference file ["
                         + refPath
-                        + "] has type ["
-                        + refAttr.dataType().typeName()
-                        + "]."
+                        + "] is missing."
                         + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
                 );
             }
+            validateStrictTypeMatch(refPath, refAttr, filePath, fileAttr);
+        }
+    }
+
+    private static void validateStrictTypeMatch(StoragePath refPath, Attribute refAttr, StoragePath filePath, Attribute fileAttr) {
+        if (refAttr.dataType() != fileAttr.dataType()) {
+            throw new IllegalArgumentException(
+                "Schema mismatch in ["
+                    + filePath
+                    + "]: column ["
+                    + fileAttr.name()
+                    + "] has type ["
+                    + fileAttr.dataType().typeName()
+                    + "] but reference file ["
+                    + refPath
+                    + "] has type ["
+                    + refAttr.dataType().typeName()
+                    + "]."
+                    + " Hint: use schema_resolution = \"union_by_name\" to automatically merge different schemas."
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SchemaReconciliationTests.java
@@ -186,6 +186,85 @@ public class SchemaReconciliationTests extends ESTestCase {
         assertThat(result.unifiedSchema().size(), equalTo(1));
     }
 
+    public void testStrictNdJsonPermutedColumnsMappedByName() {
+        List<Attribute> dense = List.of(
+            attr("ts", DataType.DATETIME),
+            attr("error_code", DataType.INTEGER),
+            attr("level", DataType.KEYWORD)
+        );
+        List<Attribute> sparse = List.of(
+            attr("ts", DataType.DATETIME),
+            attr("level", DataType.KEYWORD),
+            attr("error_code", DataType.INTEGER)
+        );
+        StoragePath f1 = path("s3://logs/day=1/app.ndjson");
+        StoragePath f2 = path("s3://logs/day=2/app.ndjson");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(dense, "ndjson"), f2, meta(sparse, "ndjson"));
+        SchemaReconciliation.Result result = SchemaReconciliation.reconcileStrict(f1, metadata);
+
+        assertThat(result.unifiedSchema().attributes(), equalTo(dense));
+        assertThat(result.perFileInfo().get(f1).mapping(), equalTo(new ColumnMapping(new int[] { 0, 1, 2 }, null)));
+        assertThat(result.perFileInfo().get(f2).mapping(), equalTo(new ColumnMapping(new int[] { 0, 2, 1 }, null)));
+    }
+
+    public void testStrictNdJsonTypeMismatchRejectedByName() {
+        List<Attribute> dense = List.of(
+            attr("ts", DataType.DATETIME),
+            attr("error_code", DataType.INTEGER),
+            attr("level", DataType.KEYWORD)
+        );
+        List<Attribute> sparse = List.of(attr("level", DataType.KEYWORD), attr("ts", DataType.DATETIME), attr("error_code", DataType.LONG));
+        StoragePath f1 = path("s3://logs/day=1/app.ndjson");
+        StoragePath f2 = path("s3://logs/day=2/app.ndjson");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(dense, "ndjson"), f2, meta(sparse, "ndjson"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+
+        assertThat(e.getMessage(), containsString("column [error_code]"));
+        assertThat(e.getMessage(), containsString("long"));
+        assertThat(e.getMessage(), containsString("integer"));
+    }
+
+    public void testStrictNdJsonDifferentNameSetRejected() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("level", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.INTEGER), attr("message", DataType.KEYWORD));
+        StoragePath f1 = path("s3://logs/day=1/app.ndjson");
+        StoragePath f2 = path("s3://logs/day=2/app.ndjson");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, "ndjson"), f2, meta(schema2, "ndjson"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+
+        assertThat(e.getMessage(), containsString("column [level]"));
+        assertThat(e.getMessage(), containsString("is missing"));
+    }
+
+    public void testStrictNdJsonColumnCountMismatchRejected() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("level", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.INTEGER));
+        StoragePath f1 = path("s3://logs/day=1/app.ndjson");
+        StoragePath f2 = path("s3://logs/day=2/app.ndjson");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, "ndjson"), f2, meta(schema2, "ndjson"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+
+        assertThat(e.getMessage(), containsString("expected 2 columns"));
+        assertThat(e.getMessage(), containsString("found 1 columns"));
+    }
+
+    public void testStrictOrderedFormatRejectsPermutedColumns() {
+        List<Attribute> schema1 = List.of(attr("id", DataType.INTEGER), attr("level", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("level", DataType.KEYWORD), attr("id", DataType.INTEGER));
+        StoragePath f1 = path("s3://logs/day=1/app.csv");
+        StoragePath f2 = path("s3://logs/day=2/app.csv");
+
+        Map<StoragePath, SourceMetadata> metadata = orderedMap(f1, meta(schema1, "csv"), f2, meta(schema2, "csv"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SchemaReconciliation.reconcileStrict(f1, metadata));
+
+        assertThat(e.getMessage(), containsString("column 0 is [level]"));
+        assertThat(e.getMessage(), containsString("has [id]"));
+    }
+
     // === UNION_BY_NAME reconciliation tests ===
 
     public void testUnionByNameIdenticalSchemas() {


### PR DESCRIPTION
Strict NDJSON reconciliation now ignores inferred column order while preserving exact name/type validation. Added unit and end-to-end coverage; all focused tests pass.

Closes https://github.com/elastic/esql-planning/issues/1823