### PR TITLE
Support columnar batch indexing for more field types

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -11,10 +11,12 @@ package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
@@ -24,6 +26,7 @@ import org.apache.lucene.queries.intervals.Intervals;
 import org.apache.lucene.queries.intervals.IntervalsSource;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiTermQuery;
@@ -33,6 +36,7 @@ import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
@@ -42,6 +46,14 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnData;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.EscfColumnTransforms;
+import org.elasticsearch.escf.LuceneBinaryColumn;
+import org.elasticsearch.escf.LuceneLongColumn;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
@@ -60,12 +72,14 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.ArrayOrderBinaryDocValuesSyntheticFieldLoaderLayer;
+import org.elasticsearch.index.mapper.BatchMappingContext;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.CustomDocValuesField;
 import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldArrayContext;
@@ -105,6 +119,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentString;
@@ -1179,6 +1194,183 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     @Override
     protected FieldMapper.DocValuesParameter.Values.OnFailure onFailureBehavior() {
         return docValuesParameters.onFailure();
+    }
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // usesBinaryDocValues() requires doc_values to be enabled and implies strict-columnar mode's
+        // array-order-vs-single-value invariant (see mapColumnBatch); the SORTED_SET (low-cardinality)
+        // and no-doc-values encodings are not supported by the columnar batch path.
+        return indexSettings.getMode().isStrictColumnar()
+            && fieldType().usesBinaryDocValues()
+            && copyTo().copyToFields().isEmpty()
+            && multiFieldsSupportColumnarParse(indexSettings);
+    }
+
+    // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
+    private static EscfColumnBuilder mergeStringColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.STRING);
+        return b;
+    }
+
+    private static EscfColumnBuilder mergeLongColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.LONG);
+        return b;
+    }
+
+    /**
+     * Maps a batch of documents for this field from the supplied ESCF source column. match_only_text has no
+     * {@code ignore_above}/{@code null_value}/normalizer, so this is a simplified version of
+     * {@link KeywordFieldMapper#mapColumnBatch}: only the indexed (tokenized) field and the binary doc-values
+     * encoding need reproducing.
+     */
+    @Override
+    public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+        final boolean emitTerms = indexed;
+        final boolean emitDvs = docValuesParameters.enabled();
+        if (emitTerms || emitDvs) {
+            if (fieldType().usesArrayOrderBinaryDocValues()) {
+                mapColumnBatchArrayOrder(ctx, source, emitTerms, emitDvs);
+            } else {
+                mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs);
+            }
+        }
+        mapColumnBatchToMultiFields(ctx, source);
+    }
+
+    private void mapColumnBatchArrayOrder(BatchMappingContext ctx, EscfColumn source, boolean emitTerms, boolean emitDvs) {
+        final int docCount = ctx.docCount();
+
+        // retainValues=false: each value is appended to the document blob before the cursor advances, so no
+        // value has to outlive the nextDoc() that moves past it.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
+        final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
+        final EscfColumnBuilder dvCounts = emitDvs ? mergeLongColumn() : null;
+
+        int currentDoc = -1;
+        // Buffer null when not emitted. Each document's slots are appended as they are read and the finished
+        // blob is handed to binaryDvs.setString, which copies it out immediately, so the buffer is free to be
+        // rewritten.
+        final BytesRefBuilder docBlob = emitDvs ? new BytesRefBuilder() : null;
+        int pos = 0;
+        int docSlotCount = 0;
+        int lastValueLength = 0;
+        // True when the current doc has at least one non-null slot; gates binary dv blob emission.
+        boolean hasNonNull = false;
+
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc != currentDoc) {
+                // Flush the completed doc's elements. All-null docs write counts (matching
+                // ArrayOrderInlineNull.recordNull) but no blob.
+                if (binaryDvs != null && docSlotCount > 0) {
+                    dvCounts.setLong(currentDoc, docSlotCount);
+                    if (hasNonNull) {
+                        final int length = docSlotCount == 1 ? lastValueLength : pos;
+                        binaryDvs.setString(currentDoc, docBlob.bytes(), pos - length, length);
+                    }
+                    pos = 0;
+                    docSlotCount = 0;
+                    hasNonNull = false;
+                }
+                if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                    break;
+                }
+                currentDoc = nextDoc;
+            }
+
+            final BytesRef value = cursor.value();
+
+            // match_only_text has no null_value: an explicit JSON null records a null slot only, mirroring the
+            // row path's textOrNull() == null check.
+            if (value == null) {
+                if (binaryDvs != null) {
+                    pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, null);
+                    docSlotCount++;
+                    // hasNonNull stays false: null slots do not produce a binary dv blob.
+                }
+                continue;
+            }
+
+            if (terms != null) {
+                terms.setString(currentDoc, value);
+            }
+            if (binaryDvs != null) {
+                pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, value);
+                lastValueLength = value.length;
+                docSlotCount++;
+                hasNonNull = true;
+            }
+        }
+
+        // Attach output columns. Terms, binary-dv blob, and counts are each emitted independently.
+        // All-null docs emit counts but no binary blob, so binaryDvs and dvCounts are decoupled.
+        if (terms != null && terms.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(terms.finish(docCount), fieldType().name(), fieldType));
+        }
+        if (binaryDvs != null && binaryDvs.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(binaryDvs.finish(docCount), fieldType().name(), CustomDocValuesField.TYPE));
+        }
+        if (dvCounts != null && dvCounts.isEmpty() == false) {
+            ctx.addColumn(LuceneLongColumn.counts(dvCounts.finish(docCount), fieldType().name()));
+        }
+    }
+
+    private void mapColumnBatchSingleValue(BatchMappingContext ctx, EscfColumn source, boolean emitTerms, boolean emitDvs) {
+        final int docCount = ctx.docCount();
+        boolean valuesProduced = false;
+
+        // retainValues=false: every value is consumed within one loop iteration, before the cursor advances.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        EscfColumnBuilder values = source.leafValueKind() != EscfColumnKind.STRING && (emitTerms || emitDvs) ? mergeStringColumn() : null;
+
+        int currentDoc = -1;
+        boolean valueSeenThisDoc = false;
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                break;
+            }
+            if (nextDoc != currentDoc) {
+                currentDoc = nextDoc;
+                valueSeenThisDoc = false;
+            }
+            final BytesRef value = cursor.value();
+            if (value == null) {
+                // match_only_text has no null_value: JSON null -> absent, matching the row path's
+                // textOrNull() == null check.
+                continue;
+            }
+
+            if (valueSeenThisDoc) {
+                // multi_value=false violation: bail so ShardBatchMapper falls back to the row path,
+                // which raises the correct per-doc error (on_failure=FAIL).
+                throw new UnsupportedOperationException(
+                    "mapColumnBatch: multi_value=false field [" + fullPath() + "] has more than one value for doc [" + currentDoc + "]"
+                );
+            }
+            valueSeenThisDoc = true;
+            valuesProduced = true;
+
+            if (values != null) {
+                values.setString(currentDoc, value);
+            }
+        }
+
+        // Emit one indexed (tokenized) column and one plain binary DV column — no .counts sidecar. Both
+        // columns share the same finished EscfColumnData (one serialization, two field-type wrappers).
+        if (valuesProduced) {
+            final EscfColumnData data = values != null ? values.finish(docCount) : source.columnData();
+            if (emitTerms) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), fieldType));
+            }
+            if (emitDvs) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), BinaryDocValuesField.TYPE));
+            }
+        }
     }
 
     @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperColumnarCompatibilityTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperColumnarCompatibilityTests.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.extras;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.AbstractColumnarMapperCompatibilityTestCase;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Parity tests for {@link MatchOnlyTextFieldMapper#mapColumnBatch} against the row path.
+ * The {@link AbstractColumnarMapperCompatibilityTestCase} harness drives leaf mappers automatically
+ * via {@code EscfEncoder}; no subclass override is needed.
+ */
+public class MatchOnlyTextFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
+
+    private static final String FIELD = "f";
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MapperExtrasPlugin());
+    }
+
+    private static Settings columnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    public void testSingleValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("single value", 1L, doc("d1", 1L, "{\"f\":\"hello world\"}"))
+        );
+    }
+
+    public void testMultiValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("multi-value", 1L, doc("d1", 1L, "{\"f\":[\"hello\",\"world\"]}"))
+        );
+    }
+
+    public void testAbsentDocsMixed() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("absent docs mixed", 1L, doc("d1", 1L, "{\"f\":\"alpha\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"gamma\"}"))
+        );
+    }
+
+    public void testArrayValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch(
+                "array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"solo\"]}"),
+                doc("d2", 2L, "{\"f\":[\"alpha\",\"beta\",\"gamma\"]}"),
+                doc("d3", 3L, "{\"f\":[]}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testArrayValuesWithNull() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("array values with null", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testMixedBatch() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch(
+                "mixed batch",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":[\"b\",\"c\"]}"),
+                doc("d4", 4L, "{\"f\":\"d\"}")
+            )
+        );
+    }
+
+    public void testLongValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch(
+                "long values",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":-7}"),
+                doc("d3", 3L, "{\"f\":9876543210}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testDoubleValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch(
+                "double values",
+                1L,
+                doc("d1", 1L, "{\"f\":3.14}"),
+                doc("d2", 2L, "{\"f\":1.5}"),
+                doc("d3", 3L, "{\"f\":-2.5}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testBooleanValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("boolean values", 1L, doc("d1", 1L, "{\"f\":true}"), doc("d2", 2L, "{\"f\":false}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testNestedArray() throws IOException {
+        // Nested arrays are flattened, matching the row-path behaviour in DocumentParser.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").endObject()),
+            columnarSettings(),
+            batch("nested array", 1L, doc("d1", 1L, "{\"f\":[[\"a\",\"b\"],[\"c\"]]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testNoIndexDocValuesOnly() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "match_only_text").field("index", false).endObject()),
+            columnarSettings(),
+            batch("no-index single value", 1L, doc("d1", 1L, "{\"f\":\"only_dv\"}"))
+        );
+    }
+
+    public void testSingleValueMultiValueFalse() throws IOException {
+        // One string value, one absent doc, and an empty string.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single value multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"\"}")
+            )
+        );
+    }
+
+    public void testAbsentAndNullMultiValueFalse() throws IOException {
+        // Present value, absent doc ({}), and explicit JSON null -> absent (match_only_text has no null_value).
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "absent and null multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"alpha\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":null}")
+            )
+        );
+    }
+
+    public void testIndexedAndDocValuesMultiValueFalse() throws IOException {
+        // Default index:true — both an indexed (tokenized) column and a binary DV column are emitted.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "indexed and dv multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"indexed\"}"),
+                doc("d2", 2L, "{\"f\":\"also indexed\"}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testScalarCoercionsMultiValueFalse() throws IOException {
+        // Numeric and boolean scalars are stringified by utf8Cursor, matching the row path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "scalar coercions multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":3.14}"),
+                doc("d3", 3L, "{\"f\":true}")
+            )
+        );
+    }
+
+    public void testAllPresentDenseMultiValueFalse() throws IOException {
+        // Every doc has a string value; no absent docs. Exercises the dense (validity==null) wrap in the fast path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "all present dense multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{\"f\":\"b\"}"),
+                doc("d3", 3L, "{\"f\":\"c\"}")
+            )
+        );
+    }
+
+    public void testManyMixedPresentAbsentMultiValueFalse() throws IOException {
+        // Larger interleaved present/absent batch to stress the SPARSE wrap.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "many mixed present absent multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"v1\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"v3\"}"),
+                doc("d4", 4L, "{}"),
+                doc("d5", 5L, "{\"f\":\"v5\"}"),
+                doc("d6", 6L, "{\"f\":\"v6\"}"),
+                doc("d7", 7L, "{}")
+            )
+        );
+    }
+
+    public void testSingleElementArrayMultiValueFalse() throws IOException {
+        // A single-element array {"f":["a"]} is a legal value for a multi_value=false field.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single element array multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"a\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    // ---- multi-fields ---------------------------------------------------------------------------
+
+    public void testMultiFieldSingleValue() throws IOException {
+        // match_only_text with a keyword multi-field, the common real-world pairing.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field single value",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Hello World\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"Another Value\"}")
+            )
+        );
+    }
+
+    public void testMultiFieldArrayValues() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"alpha beta\",\"gamma\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testMultiFieldTwoMultiFields() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.startObject("other").field("type", "keyword").field("ignore_above", 3).endObject();
+            b.endObject();
+            b.endObject();
+        }), columnarSettings(), batch("multi-field two multi-fields", 1L, doc("d1", 1L, "{\"f\":\"abcd\"}"), doc("d2", 2L, "{}")));
+    }
+
+    public void testMultiFieldNotIndexedParent() throws IOException {
+        // The parent is not indexed (doc values only) while its multi-field is fully indexed.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text").field("index", false);
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("multi-field not-indexed parent", 1L, doc("d1", 1L, "{\"f\":\"only_dv_and_multifield\"}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testMultiFieldWithColumnarCapableKeywordIsSupported() throws IOException {
+        MapperService ms = createMapperService(columnarSettings(), mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        var mapper = ms.mappingLookup().getMapper(FIELD);
+        assertTrue(mapper instanceof MatchOnlyTextFieldMapper);
+        assertTrue(((MatchOnlyTextFieldMapper) mapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+
+    public void testMultiFieldWithNonColumnarTextFallsBack() throws IOException {
+        // A "text" multi-field never supports columnar parse, so the parent must fall back too.
+        MapperService ms = createMapperService(columnarSettings(), mapping(b -> {
+            b.startObject(FIELD).field("type", "match_only_text");
+            b.startObject("fields");
+            b.startObject("full").field("type", "text").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        var mapper = ms.mappingLookup().getMapper(FIELD);
+        assertTrue(mapper instanceof MatchOnlyTextFieldMapper);
+        assertFalse(((MatchOnlyTextFieldMapper) mapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+}

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperColumnarCompatibilityTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperColumnarCompatibilityTests.java
@@ -369,11 +369,12 @@ public class MatchOnlyTextFieldMapperColumnarCompatibilityTests extends Abstract
     }
 
     public void testMultiFieldWithNonColumnarTextFallsBack() throws IOException {
-        // A "text" multi-field never supports columnar parse, so the parent must fall back too.
+        // A text multi-field with index_phrases=true writes a companion phrase field outside the
+        // batch dispatch and is not supported on the columnar path, so the parent must fall back too.
         MapperService ms = createMapperService(columnarSettings(), mapping(b -> {
             b.startObject(FIELD).field("type", "match_only_text");
             b.startObject("fields");
-            b.startObject("full").field("type", "text").endObject();
+            b.startObject("full").field("type", "text").field("index_phrases", true).endObject();
             b.endObject();
             b.endObject();
         }));

--- a/server/src/main/java/org/elasticsearch/escf/EscfColumnTransforms.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfColumnTransforms.java
@@ -12,6 +12,7 @@ package org.elasticsearch.escf;
 import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.sourcebatch.ArrayReader;
 import org.elasticsearch.sourcebatch.SourceValueType;
 import org.elasticsearch.xcontent.XContentString;
@@ -223,5 +224,47 @@ public final class EscfColumnTransforms {
                 return currentValue;
             }
         };
+    }
+
+    /**
+     * Merges {@code columns} — schema leaves that alias the same mapped field via different dotted/nested
+     * spellings within one batch (for example {@code "a.b"} and {@code {"a": {"b": ...}}}) — into a single,
+     * row-aligned column. Each present value is replayed positionally, in {@code columns} order; two values
+     * landing on the same row become a multi-valued output via {@link EscfColumnBuilder}'s
+     * {@link EscfColumnBuilder.CollisionPolicy#MERGE} policy, exactly as a naturally multi-valued source
+     * column already would be. A row absent from every input column stays absent in the result.
+     *
+     * @throws UnsupportedOperationException if any column's kind is not one of {@code LONG}, {@code DOUBLE},
+     *         {@code STRING}, or {@code BINARY} — the v1 support matrix for leaf aliasing
+     *         ({@code ShardBatchMapper#resolveMappers}). The caller catches this and falls back to the row
+     *         path for the chunk, the same safety net {@code NumberFieldMapper#mapColumnBatch} relies on for
+     *         its own unsupported-kind switch.
+     */
+    public static EscfColumn mergeAliasedLeaves(EscfColumn[] columns, int docCount, Recycler<BytesRef> recycler) {
+        for (EscfColumn column : columns) {
+            switch (column.kind()) {
+                case EscfColumnKind.LONG, EscfColumnKind.DOUBLE, EscfColumnKind.STRING, EscfColumnKind.BINARY -> {
+                    // supported
+                }
+                default -> throw new UnsupportedOperationException(
+                    "mergeAliasedLeaves: ESCF column kind [" + EscfColumnKind.name(column.kind()) + "] is not yet supported"
+                );
+            }
+        }
+        final EscfColumnBuilder builder = new EscfColumnBuilder(EscfColumnBuilder.CollisionPolicy.MERGE, recycler);
+        for (int row = 0; row < docCount; row++) {
+            for (EscfColumn column : columns) {
+                if (column.isPresent(row) == false) {
+                    continue;
+                }
+                switch (column.kind()) {
+                    case EscfColumnKind.LONG -> builder.setLong(row, column.getLongValue(row));
+                    case EscfColumnKind.DOUBLE -> builder.setDouble(row, column.getDoubleValue(row));
+                    case EscfColumnKind.STRING -> builder.setString(row, column.getBinaryValue(row));
+                    case EscfColumnKind.BINARY -> builder.setBinary(row, column.getBinaryValue(row));
+                }
+            }
+        }
+        return EscfColumn.from(builder.finish(docCount));
     }
 }

--- a/server/src/main/java/org/elasticsearch/escf/EscfRowBuffer.java
+++ b/server/src/main/java/org/elasticsearch/escf/EscfRowBuffer.java
@@ -97,6 +97,7 @@ public final class EscfRowBuffer {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = SourceValueType.KEY_VALUE;
         scratchVar[colIdx] = BytesRef.EMPTY_BYTES;
+        schema.noteEmptyObject(colIdx);
         return colIdx;
     }
 
@@ -105,6 +106,7 @@ public final class EscfRowBuffer {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) ? SourceValueType.INT : SourceValueType.LONG;
         scratchNumeric[colIdx] = value;
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 
@@ -114,6 +116,7 @@ public final class EscfRowBuffer {
         float fval = (float) value;
         scratchType[colIdx] = ((double) fval == value) ? SourceValueType.FLOAT : SourceValueType.DOUBLE;
         scratchNumeric[colIdx] = Double.doubleToRawLongBits(value);
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 
@@ -122,6 +125,7 @@ public final class EscfRowBuffer {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = SourceValueType.STRING;
         scratchVar[colIdx] = value;
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 
@@ -134,6 +138,7 @@ public final class EscfRowBuffer {
     public int booleanField(String name, boolean value) {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = value ? SourceValueType.TRUE : SourceValueType.FALSE;
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 
@@ -141,6 +146,7 @@ public final class EscfRowBuffer {
     public int nullField(String name) {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = SourceValueType.NULL;
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 
@@ -152,6 +158,7 @@ public final class EscfRowBuffer {
         int colIdx = addLeaf(name);
         scratchType[colIdx] = arrayType;
         scratchVar[colIdx] = packed;
+        schema.noteRealValue(colIdx);
         return colIdx;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -281,6 +281,33 @@ public abstract class FieldMapper extends Mapper {
     }
 
     /**
+     * Whether every multi-field attached to this field also supports the columnar batch path. A field with multi-fields can only take
+     * the columnar path itself if all of its multi-fields can too, since each multi-field parses the same source values and produces
+     * its own output columns from them. Intended for use by {@link #supportsColumnarParse(IndexSettings)} overrides on mappers that
+     * support multi-fields on the columnar path.
+     */
+    protected final boolean multiFieldsSupportColumnarParse(IndexSettings indexSettings) {
+        for (FieldMapper multiField : multiFields()) {
+            if (multiField.supportsColumnarParse(indexSettings) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Dispatches {@link #mapColumnBatch} to every multi-field attached to this field, over the same source column. Multi-fields parse
+     * the same raw values as their parent field — mirroring how {@link #doParseMultiFields} replays the same parser value on the row
+     * path — so the parent's already-materialized {@code source} column is reused verbatim rather than re-derived. Intended for use by
+     * {@link #mapColumnBatch(BatchMappingContext, EscfColumn)} overrides on mappers that support multi-fields on the columnar path.
+     */
+    protected final void mapColumnBatchToMultiFields(BatchMappingContext ctx, EscfColumn source) {
+        for (FieldMapper multiField : multiFields()) {
+            multiField.mapColumnBatch(ctx, source);
+        }
+    }
+
+    /**
      * Whether this mapper consumes the whole group of schema leaves rooted at its own path rather than a single leaf of its own. Mappers
      * whose source value is an object that the columnar encoder explodes into one dotted leaf per key — {@code flattened} is the first —
      * cannot be resolved leaf by leaf, because no mapper exists at those descendant paths. A mapper returning {@code true} receives every

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -14,6 +14,7 @@ import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.LongColumn;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.index.DocValuesType;
@@ -33,6 +34,11 @@ import org.elasticsearch.common.geo.SimpleVectorTileFormatter;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.LuceneBinaryColumn;
+import org.elasticsearch.escf.LuceneLongColumn;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.index.IndexMode;
@@ -85,6 +91,21 @@ import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPrefere
 public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoint> {
 
     public static final String CONTENT_TYPE = "geo_point";
+
+    /** Field type for the SORTED_NUMERIC doc-values channel of a geo_point column (no BKD points). */
+    private static final FieldType GEO_DV_ONLY_FIELD_TYPE;
+    /** Field type for the 2D BKD-points channel of a geo_point column (no doc values). */
+    private static final FieldType GEO_BKD_ONLY_FIELD_TYPE;
+
+    static {
+        GEO_DV_ONLY_FIELD_TYPE = new FieldType();
+        GEO_DV_ONLY_FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
+        GEO_DV_ONLY_FIELD_TYPE.freeze();
+
+        GEO_BKD_ONLY_FIELD_TYPE = new FieldType();
+        GEO_BKD_ONLY_FIELD_TYPE.setDimensions(2, Integer.BYTES);
+        GEO_BKD_ONLY_FIELD_TYPE.freeze();
+    }
 
     private static Builder builder(FieldMapper in) {
         return toType(in).builder;
@@ -379,6 +400,86 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     @Override
     protected String contentType() {
         return CONTENT_TYPE;
+    }
+
+    @Override
+    public boolean resolvesColumnGroup() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // At least one output channel must be active; stored-field and script channels are not yet handled.
+        return indexSettings.getMode().isStrictColumnar()
+            && (indexed || fieldType().hasDocValues())
+            && fieldType().isStored() == false
+            && hasScript() == false
+            && copyTo().copyToFields().isEmpty()
+            && multiFields().iterator().hasNext() == false;
+    }
+
+    /**
+     * Handles a batch of geo_point documents encoded as separate {@code lat} and {@code lon} sub-columns.
+     * Emits a SORTED_NUMERIC doc-values column (packed long: latEncoded shifted left 32 bits OR-ed with lonEncoded)
+     * when {@code doc_values} is enabled, and a 2D BKD-points column (8 sortable bytes: lat then lon)
+     * when {@code index} is enabled. Documents missing either coordinate are silently skipped.
+     */
+    @Override
+    public void mapColumnGroupBatch(BatchMappingContext ctx, EscfColumn[] columns, String[] relativeKeys) {
+        assert columns.length == relativeKeys.length;
+        int latIdx = -1;
+        int lonIdx = -1;
+        for (int k = 0; k < relativeKeys.length; k++) {
+            switch (relativeKeys[k]) {
+                case "lat" -> latIdx = k;
+                case "lon" -> lonIdx = k;
+            }
+        }
+        if (latIdx == -1 || lonIdx == -1) {
+            throw new UnsupportedOperationException(
+                "mapColumnGroupBatch: geo_point field [" + fullPath() + "] requires both [lat] and [lon] sub-fields"
+            );
+        }
+        final int docCount = ctx.docCount();
+        final EscfColumn latCol = columns[latIdx];
+        final EscfColumn lonCol = columns[lonIdx];
+        final boolean hasDv = fieldType().hasDocValues();
+        final EscfColumnBuilder dvBuilder = hasDv ? new EscfColumnBuilder(EscfColumnBuilder.CollisionPolicy.SPLIT) : null;
+        final EscfColumnBuilder bkdBuilder = indexed ? new EscfColumnBuilder(EscfColumnBuilder.CollisionPolicy.SPLIT) : null;
+        final byte[] bkdBytes = indexed ? new byte[8] : null;
+        for (int doc = 0; doc < docCount; doc++) {
+            if (latCol.isPresent(doc) == false || lonCol.isPresent(doc) == false) {
+                continue;
+            }
+            final double lat = readGeoCoordinate(latCol, doc);
+            final double lon = readGeoCoordinate(lonCol, doc);
+            final int latEnc = GeoEncodingUtils.encodeLatitude(lat);
+            final int lonEnc = GeoEncodingUtils.encodeLongitude(lon);
+            if (hasDv) {
+                dvBuilder.setLong(doc, (((long) latEnc) << 32) | (lonEnc & 0xFFFFFFFFL));
+            }
+            if (indexed) {
+                NumericUtils.intToSortableBytes(latEnc, bkdBytes, 0);
+                NumericUtils.intToSortableBytes(lonEnc, bkdBytes, Integer.BYTES);
+                bkdBuilder.setBinary(doc, new BytesRef(bkdBytes));
+            }
+        }
+        if (hasDv) {
+            ctx.addColumn(LuceneLongColumn.of(dvBuilder.finish(docCount), fullPath(), GEO_DV_ONLY_FIELD_TYPE, LongColumn.NumericKind.LONG));
+        }
+        if (indexed) {
+            ctx.addColumn(LuceneBinaryColumn.of(bkdBuilder.finish(docCount), fullPath(), GEO_BKD_ONLY_FIELD_TYPE));
+        }
+    }
+
+    private static double readGeoCoordinate(EscfColumn col, int doc) {
+        return switch (col.kind()) {
+            case EscfColumnKind.DOUBLE -> col.getDoubleValue(doc);
+            case EscfColumnKind.LONG -> (double) col.getLongValue(doc);
+            default -> throw new UnsupportedOperationException(
+                "mapColumnGroupBatch: unsupported ESCF column kind [" + EscfColumnKind.name(col.kind()) + "] for geo_point coordinate"
+            );
+        };
     }
 
     public static class GeoPointFieldType extends AbstractPointFieldType<GeoPoint> implements GeoShapeQueryable {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1618,7 +1618,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             && supportsColumnarDocValues()
             && hasScript() == false
             && copyTo().copyToFields().isEmpty()
-            && multiFields().iterator().hasNext() == false
+            && multiFieldsSupportColumnarParse(indexSettings)
             && normalizerName == null
             && fieldType().isDimension() == false;
     }
@@ -1659,9 +1659,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         final boolean emitTerms = fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored();
         final boolean emitFallback = storeIgnoredValuesForSyntheticSource();
         final boolean emitDvs = fieldType().hasDocValues();
-        if (emitTerms == false && emitDvs == false && emitFallback == false) {
-            return;
-        }
 
         // These paths build a scan cursor that converts all ESCF column kinds to BytesRef strings:
         // longs/doubles via canonical toString, booleans as "true"/"false", strings as-is, arrays
@@ -1672,12 +1669,17 @@ public final class KeywordFieldMapper extends FieldMapper {
         // source characters (which the row path preserves via parser.getText()).
         // In order to support the original string representations we would need to keep the columns as
         // strings. This is possible as an eventual user option.
-
-        if (fieldType().storesArrayOrderInline()) {
-            mapColumnBatchArrayOrder(ctx, source, emitTerms, emitDvs, emitFallback);
-        } else {
-            mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
+        if (emitTerms || emitDvs || emitFallback) {
+            if (fieldType().storesArrayOrderInline()) {
+                mapColumnBatchArrayOrder(ctx, source, emitTerms, emitDvs, emitFallback);
+            } else {
+                mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs, emitFallback);
+            }
         }
+        // Multi-fields parse the same raw source values as this field; a fully disabled parent
+        // (index:false, doc_values:false, store:false) can still have multi-fields that do index, so
+        // this must run regardless of whether the branch above emitted anything.
+        mapColumnBatchToMultiFields(ctx, source);
     }
 
     private void mapColumnBatchArrayOrder(

--- a/server/src/main/java/org/elasticsearch/index/mapper/ShardBatchMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ShardBatchMapper.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.escf.EscfBatch;
 import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnTransforms;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineBatch;
@@ -29,7 +30,9 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.sourcebatch.SourceBatch;
 import org.elasticsearch.sourcebatch.SourceSchema;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -68,7 +71,35 @@ public final class ShardBatchMapper {
      * <p>{@code columnGroups} holds one entry per group mapper (e.g. {@code flattened}), ordered by the
      * first schema leaf that mapped to that group.
      */
-    public record BatchMapperResolution(FieldMapper[] columnMappers, ColumnGroupResolution[] columnGroups) {}
+    public record BatchMapperResolution(
+        FieldMapper[] columnMappers,
+        ColumnGroupResolution[] columnGroups,
+        AliasedLeafResolution[] aliasedLeaves
+    ) {}
+
+    /**
+     * A per-leaf-mapper field spelled two or more ways in one batch (for example {@code "a.b"} and
+     * {@code {"a": {"b": ...}}}), which the ESCF encoder keeps as separate schema leaves. Every leaf here
+     * is bound to the same {@link FieldMapper}; {@link #mapColumnBatch} merges their source columns into
+     * one via {@link EscfColumnTransforms#mergeAliasedLeaves} before invoking that mapper once per chunk.
+     * Only built when the index mode is {@link IndexSettings#getMode() strictly columnar} — see the
+     * mode-gating note in {@link #resolveMappers}.
+     *
+     * @param leafIndexes indexes into the batch's column array, in the order the leaves were encountered
+     */
+    public record AliasedLeafResolution(FieldMapper mapper, int[] leafIndexes) {}
+
+    private static final AliasedLeafResolution[] EMPTY_ALIASED_LEAVES = new AliasedLeafResolution[0];
+
+    /** Accumulates per-leaf-mapper aliasing groups, keyed by full path, in first-seen order. */
+    private static final class AliasedLeafGroup {
+        private final FieldMapper mapper;
+        private final List<Integer> leafIndexes = new ArrayList<>();
+
+        AliasedLeafGroup(FieldMapper mapper) {
+            this.mapper = mapper;
+        }
+    }
 
     /**
      * Resolve each schema leaf to a {@link FieldMapper}. Returns {@code null} if any scenario
@@ -123,9 +154,13 @@ public final class ShardBatchMapper {
         final int leafCount = schema.leafCount();
         final FieldMapper[] columnMappers = new FieldMapper[leafCount];
         ColumnGroupResolver.Builder groupBuilder = null;
-        // Full paths of leaves bound to a per-leaf mapper, used to detect dotted/nested aliasing. Allocated lazily
-        // because most batches resolve every leaf to a group or to nothing at all.
-        HashSet<String> mappedPaths = null;
+        // Full paths of leaves bound to a per-leaf mapper, mapped to the first leaf index seen for that path.
+        // Used to detect dotted/nested aliasing. Allocated lazily because most batches resolve every leaf to a
+        // group or to nothing at all.
+        HashMap<String, Integer> mappedPaths = null;
+        // Aliasing groups accumulated for strictly-columnar indices; see the mode-gating note below. Allocated
+        // lazily since aliasing is rare.
+        LinkedHashMap<String, AliasedLeafGroup> aliasedLeafGroups = null;
 
         for (int leaf = 0; leaf < leafCount; leaf++) {
             final String fullPath = schema.getFullPath(leaf);
@@ -222,22 +257,57 @@ public final class ShardBatchMapper {
             }
             // Two schema leaves can share a full path when a batch mixes the dotted and nested spellings of the same
             // field ({"a.b":1} and {"a":{"b":1}}); the encoder keeps them as separate columns. Per-leaf mappers are
-            // dispatched one column at a time, so a document carrying both spellings would emit two independent
-            // outputs where the sequential path emits one merged multi-valued field. Group mappers are immune —
-            // mapColumnGroupBatch receives all of a group's columns at once — so only the per-leaf columns are
-            // checked here.
+            // dispatched one column at a time, so on its own a document carrying both spellings would emit two
+            // independent outputs where the sequential path emits one merged multi-valued field. Group mappers are
+            // immune — mapColumnGroupBatch receives all of a group's columns at once — so only the per-leaf columns
+            // are checked here.
             if (mappedPaths == null) {
-                mappedPaths = new HashSet<>(leafCount);
+                mappedPaths = new HashMap<>(leafCount);
             }
-            if (mappedPaths.add(fullPath) == false) {
-                logger.debug("batch indexing disabled: [{}] is spelled both dotted and nested in this batch", fullPath);
-                return null;
+            final Integer firstLeaf = mappedPaths.putIfAbsent(fullPath, leaf);
+            if (firstLeaf != null) {
+                // This merge is only sound because strictly-columnar index modes guarantee subobjects:false as
+                // part of the mode's contract (IndexMode#isStrictColumnar javadoc): there is no real ObjectMapper
+                // tree, so both spellings are guaranteed to resolve through this same flat leaf FieldMapper with no
+                // intervening per-object mapping concerns. That guarantee does not extend to every mode that can
+                // reach this method (e.g. time_series), so leave those on the original whole-batch fallback.
+                if (indexSettings.getMode().isStrictColumnar() == false) {
+                    logger.debug("batch indexing disabled: [{}] is spelled both dotted and nested in this batch", fullPath);
+                    return null;
+                }
+                if (aliasedLeafGroups == null) {
+                    aliasedLeafGroups = new LinkedHashMap<>();
+                }
+                AliasedLeafGroup group = aliasedLeafGroups.get(fullPath);
+                if (group == null) {
+                    group = new AliasedLeafGroup(fieldMapper);
+                    group.leafIndexes.add(firstLeaf);
+                    aliasedLeafGroups.put(fullPath, group);
+                    columnMappers[firstLeaf] = null;
+                }
+                group.leafIndexes.add(leaf);
+                columnMappers[leaf] = null;
+                continue;
             }
             columnMappers[leaf] = fieldMapper;
         }
 
         final ColumnGroupResolution[] columnGroups = groupBuilder != null ? groupBuilder.build() : ColumnGroupResolver.EMPTY;
-        return new BatchMapperResolution(columnMappers, columnGroups);
+        final AliasedLeafResolution[] aliasedLeaves;
+        if (aliasedLeafGroups == null) {
+            aliasedLeaves = EMPTY_ALIASED_LEAVES;
+        } else {
+            aliasedLeaves = new AliasedLeafResolution[aliasedLeafGroups.size()];
+            int i = 0;
+            for (AliasedLeafGroup group : aliasedLeafGroups.values()) {
+                final int[] indexes = new int[group.leafIndexes.size()];
+                for (int j = 0; j < indexes.length; j++) {
+                    indexes[j] = group.leafIndexes.get(j);
+                }
+                aliasedLeaves[i++] = new AliasedLeafResolution(group.mapper, indexes);
+            }
+        }
+        return new BatchMapperResolution(columnMappers, columnGroups, aliasedLeaves);
     }
 
     /**
@@ -385,6 +455,17 @@ public final class ShardBatchMapper {
                         groupColumns[i] = escfChunk.column(leafIndexes[i]);
                     }
                     group.mapper().mapColumnGroupBatch(context, groupColumns, group.relativeKeys());
+                }
+                // Dispatch per-leaf-mapper fields spelled two or more ways in this batch: merge their source
+                // columns into one before invoking the mapper, once, per chunk.
+                for (AliasedLeafResolution aliased : resolution.aliasedLeaves()) {
+                    final int[] leafIndexes = aliased.leafIndexes();
+                    final EscfColumn[] toMerge = new EscfColumn[leafIndexes.length];
+                    for (int i = 0; i < leafIndexes.length; i++) {
+                        toMerge[i] = escfChunk.column(leafIndexes[i]);
+                    }
+                    final EscfColumn merged = EscfColumnTransforms.mergeAliasedLeaves(toMerge, escfChunk.docCount(), recycler);
+                    aliased.mapper().mapColumnBatch(context, merged);
                 }
             } else {
                 throw new IllegalStateException("unexpected batch mapping - only use escf currently");

--- a/server/src/main/java/org/elasticsearch/index/mapper/ShardBatchMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ShardBatchMapper.java
@@ -211,6 +211,14 @@ public final class ShardBatchMapper {
                     logger.debug("batch indexing disabled: runtime-field shadow at [{}]", fullPath);
                     return null;
                 }
+                // Empty-object leaves carry no indexable data. The sequential path also produces no
+                // index writes for empty objects under subobjects:DISABLED (DocumentParser exits
+                // parseObjectOrNested immediately when the object has no children, creating no mapper
+                // and indexing nothing). Skip such leaves rather than falling back.
+                if (schema.isAlwaysEmptyObject(leaf)) {
+                    columnMappers[leaf] = null;
+                    continue;
+                }
                 final ObjectMapper.Dynamic parentDynamic = findNearestParentDynamic(fullPath, lookup);
                 if (parentDynamic == ObjectMapper.Dynamic.FALSE) {
                     // The sequential path rejects an unmapped field that matches routing_path rather than dropping it,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -18,10 +18,12 @@ import org.apache.lucene.analysis.shingle.FixedShingleFilter;
 import org.apache.lucene.analysis.tokenattributes.BytesTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
@@ -38,6 +40,7 @@ import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -50,6 +53,7 @@ import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
@@ -60,6 +64,14 @@ import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnData;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.EscfColumnTransforms;
+import org.elasticsearch.escf.LuceneBinaryColumn;
+import org.elasticsearch.escf.LuceneLongColumn;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
@@ -98,6 +110,7 @@ import org.elasticsearch.script.field.TextDocValuesField;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -1850,6 +1863,186 @@ public final class TextFieldMapper extends FieldMapper {
     public boolean isNullable() {
         // Text fields have no null_value parameter, so nullability is governed solely by the doc_values nullability setting.
         return docValuesParameters.nullability();
+    }
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // usesBinaryDocValues() requires doc_values to be enabled; this also makes
+        // needsFallbackStorageForSyntheticSource() a no-op (it returns false whenever hasDocValues() is true) and
+        // excludes the SORTED_SET (low-cardinality)/no-doc-values MAX_TERM_LENGTH fallback path - see mapColumnBatch.
+        // index_phrases/index_prefixes write extra companion Lucene fields outside this dispatch and are not yet
+        // supported on the columnar batch path.
+        return indexSettings.getMode().isStrictColumnar()
+            && fieldType().usesBinaryDocValues()
+            && prefixFieldInfo == null
+            && phraseFieldInfo == null
+            && copyTo().copyToFields().isEmpty()
+            && multiFieldsSupportColumnarParse(indexSettings);
+    }
+
+    // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
+    private static EscfColumnBuilder mergeStringColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.STRING);
+        return b;
+    }
+
+    private static EscfColumnBuilder mergeLongColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.LONG);
+        return b;
+    }
+
+    /**
+     * Maps a batch of documents for this field from the supplied ESCF source column. text has no
+     * {@code ignore_above}/{@code null_value}/normalizer, so this is a simplified version of
+     * {@link KeywordFieldMapper#mapColumnBatch}: only the indexed (tokenized) field and the binary doc-values
+     * encoding need reproducing.
+     */
+    @Override
+    public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+        final boolean emitTerms = fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored();
+        final boolean emitDvs = docValuesParameters.enabled();
+        if (emitTerms || emitDvs) {
+            if (fieldType().usesArrayOrderBinaryDocValues()) {
+                mapColumnBatchArrayOrder(ctx, source, emitTerms, emitDvs);
+            } else {
+                mapColumnBatchSingleValue(ctx, source, emitTerms, emitDvs);
+            }
+        }
+        mapColumnBatchToMultiFields(ctx, source);
+    }
+
+    private void mapColumnBatchArrayOrder(BatchMappingContext ctx, EscfColumn source, boolean emitTerms, boolean emitDvs) {
+        final int docCount = ctx.docCount();
+
+        // retainValues=false: each value is appended to the document blob before the cursor advances, so no
+        // value has to outlive the nextDoc() that moves past it.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        final EscfColumnBuilder terms = emitTerms ? mergeStringColumn() : null;
+        final EscfColumnBuilder binaryDvs = emitDvs ? mergeStringColumn() : null;
+        final EscfColumnBuilder dvCounts = emitDvs ? mergeLongColumn() : null;
+
+        int currentDoc = -1;
+        // Buffer null when not emitted. Each document's slots are appended as they are read and the finished
+        // blob is handed to binaryDvs.setString, which copies it out immediately, so the buffer is free to be
+        // rewritten.
+        final BytesRefBuilder docBlob = emitDvs ? new BytesRefBuilder() : null;
+        int pos = 0;
+        int docSlotCount = 0;
+        int lastValueLength = 0;
+        // True when the current doc has at least one non-null slot; gates binary dv blob emission.
+        boolean hasNonNull = false;
+
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc != currentDoc) {
+                // Flush the completed doc's elements. All-null docs write counts (matching
+                // ArrayOrderInlineNull.recordNull) but no blob.
+                if (binaryDvs != null && docSlotCount > 0) {
+                    dvCounts.setLong(currentDoc, docSlotCount);
+                    if (hasNonNull) {
+                        final int length = docSlotCount == 1 ? lastValueLength : pos;
+                        binaryDvs.setString(currentDoc, docBlob.bytes(), pos - length, length);
+                    }
+                    pos = 0;
+                    docSlotCount = 0;
+                    hasNonNull = false;
+                }
+                if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                    break;
+                }
+                currentDoc = nextDoc;
+            }
+
+            final BytesRef value = cursor.value();
+
+            // text has no null_value: an explicit JSON null records a null slot only, mirroring the row path's
+            // textOrNull() == null check.
+            if (value == null) {
+                if (binaryDvs != null) {
+                    pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, null);
+                    docSlotCount++;
+                    // hasNonNull stays false: null slots do not produce a binary dv blob.
+                }
+                continue;
+            }
+
+            if (terms != null) {
+                terms.setString(currentDoc, value);
+            }
+            if (binaryDvs != null) {
+                pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, value);
+                lastValueLength = value.length;
+                docSlotCount++;
+                hasNonNull = true;
+            }
+        }
+
+        // Attach output columns. Terms, binary-dv blob, and counts are each emitted independently.
+        // All-null docs emit counts but no binary blob, so binaryDvs and dvCounts are decoupled.
+        if (terms != null && terms.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(terms.finish(docCount), fieldType().name(), fieldType));
+        }
+        if (binaryDvs != null && binaryDvs.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(binaryDvs.finish(docCount), fieldType().name(), CustomDocValuesField.TYPE));
+        }
+        if (dvCounts != null && dvCounts.isEmpty() == false) {
+            ctx.addColumn(LuceneLongColumn.counts(dvCounts.finish(docCount), fieldType().name()));
+        }
+    }
+
+    private void mapColumnBatchSingleValue(BatchMappingContext ctx, EscfColumn source, boolean emitTerms, boolean emitDvs) {
+        final int docCount = ctx.docCount();
+        boolean valuesProduced = false;
+
+        // retainValues=false: every value is consumed within one loop iteration, before the cursor advances.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        EscfColumnBuilder values = source.leafValueKind() != EscfColumnKind.STRING && (emitTerms || emitDvs) ? mergeStringColumn() : null;
+
+        int currentDoc = -1;
+        boolean valueSeenThisDoc = false;
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                break;
+            }
+            if (nextDoc != currentDoc) {
+                currentDoc = nextDoc;
+                valueSeenThisDoc = false;
+            }
+            final BytesRef value = cursor.value();
+            if (value == null) {
+                // text has no null_value: JSON null -> absent, matching the row path's textOrNull() == null check.
+                continue;
+            }
+
+            if (valueSeenThisDoc) {
+                // multi_value=false violation: bail so ShardBatchMapper falls back to the row path,
+                // which raises the correct per-doc error (on_failure=FAIL).
+                throw new UnsupportedOperationException(
+                    "mapColumnBatch: multi_value=false field [" + fullPath() + "] has more than one value for doc [" + currentDoc + "]"
+                );
+            }
+            valueSeenThisDoc = true;
+            valuesProduced = true;
+
+            if (values != null) {
+                values.setString(currentDoc, value);
+            }
+        }
+
+        // Emit one indexed (tokenized) column and one plain binary DV column — no .counts sidecar. Both
+        // columns share the same finished EscfColumnData (one serialization, two field-type wrappers).
+        if (valuesProduced) {
+            final EscfColumnData data = values != null ? values.finish(docCount) : source.columnData();
+            if (emitTerms) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), fieldType));
+            }
+            if (emitDvs) {
+                ctx.addColumn(LuceneBinaryColumn.of(data, fieldType().name(), BinaryDocValuesField.TYPE));
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/sourcebatch/SourceSchema.java
+++ b/server/src/main/java/org/elasticsearch/sourcebatch/SourceSchema.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.UnicodeUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -42,6 +43,18 @@ public final class SourceSchema {
 
     private final FieldLevel nonLeaves;
     private final FieldLevel leaves;
+
+    /**
+     * Tracks leaves that have been written at least once as an empty object
+     * ({@link org.elasticsearch.escf.EscfRowBuffer#emptyObject}).
+     */
+    private final BitSet emptyObjectSeen = new BitSet();
+    /**
+     * Tracks leaves that have been written at least once as a real value (non-empty-object).
+     * A leaf is considered "always empty-object" iff {@link #emptyObjectSeen} is set and
+     * {@link #realValueSeen} is not — meaning the sequential path would also index no data for it.
+     */
+    private final BitSet realValueSeen = new BitSet();
 
     /**
      * Creates a new schema with root automatically added as non-leaf index 0.
@@ -147,6 +160,35 @@ public final class SourceSchema {
             sb.append('.');
         }
         sb.append(nonLeaves.getName(nonLeafIdx));
+    }
+
+    /**
+     * Records that {@code leafIdx} was written as an empty-object leaf in at least one row.
+     * Called from {@link org.elasticsearch.escf.EscfRowBuffer#emptyObject}.
+     */
+    public void noteEmptyObject(int leafIdx) {
+        emptyObjectSeen.set(leafIdx);
+    }
+
+    /**
+     * Records that {@code leafIdx} was written as a non-empty-object leaf in at least one row.
+     * Called from all value-writing methods in {@link org.elasticsearch.escf.EscfRowBuffer} except
+     * {@link org.elasticsearch.escf.EscfRowBuffer#emptyObject}.
+     */
+    public void noteRealValue(int leafIdx) {
+        realValueSeen.set(leafIdx);
+    }
+
+    /**
+     * Returns {@code true} if {@code leafIdx} has only ever been written as an empty-object leaf
+     * (i.e. {@link #noteEmptyObject} was called and {@link #noteRealValue} was never called).
+     *
+     * <p>This lets {@link org.elasticsearch.index.mapper.ShardBatchMapper} skip unmapped empty-object
+     * leaves rather than falling back to sequential indexing — the sequential path also produces no
+     * index writes for empty objects under {@code subobjects: DISABLED}.
+     */
+    public boolean isAlwaysEmptyObject(int leafIdx) {
+        return emptyObjectSeen.get(leafIdx) && realValueSeen.get(leafIdx) == false;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperParseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperParseTests.java
@@ -249,6 +249,118 @@ public class ShardBatchMapperParseTests extends IndexShardTestCase {
         }
     }
 
+    private static final String NESTED_KEYWORD_MAPPING = """
+        {
+          "dynamic": "strict",
+          "properties": {
+            "a": {
+              "properties": {
+                "b": { "type": "keyword" }
+              }
+            }
+          }
+        }""";
+
+    /**
+     * A per-leaf-mapper field spelled two ways in one document ({@code {"a":{"b":"x"},"a.b":"y"}}) merges into one
+     * multi-valued doc-values blob with a 2-slot counts sidecar — matching what the sequential path would produce
+     * for the same document (two independent {@code IndexableField} instances for "a.b").
+     */
+    public void testAliasedPerLeafColumnsMergeWithinOneDocument() throws IOException {
+        IndexShard shard = newShardWithMapping(NESTED_KEYWORD_MAPPING, COLUMNAR_SETTINGS);
+        try {
+            final BulkItemRequest[] items = { new BulkItemRequest(0, indexRequest("doc1")) };
+            try (
+                SourceBatch batch = EscfEncoder.encode(List.of(new BytesArray("{\"a\":{\"b\":\"x\"},\"a.b\":\"y\"}")), XContentType.JSON)
+            ) {
+                EngineBatch result = mapBatch(shard, items, batch);
+                assertNotNull("expected columnar path to succeed for aliased per-leaf keyword field", result);
+
+                final MappedColumns mc = result.columns();
+                mc.fillPrimaryTerm(1L);
+                mc.setSeqNo(0, 1L);
+                mc.setVersion(0, 1L);
+
+                final MappedColumns.RowCursor cursor = mc.rowCursor();
+                cursor.advance();
+                final List<IndexableField> fields = cursor.fields();
+
+                assertTrue(
+                    "a.b binary DV should be present",
+                    fields.stream().anyMatch(f -> "a.b".equals(f.name()) && f.binaryValue() != null)
+                );
+                final long counts = fields.stream()
+                    .filter(f -> "a.b.counts".equals(f.name()))
+                    .mapToLong(f -> f.numericValue().longValue())
+                    .findFirst()
+                    .orElseThrow();
+                assertEquals("both spellings' values should be merged into one 2-slot doc", 2L, counts);
+            }
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /** The same merge applies when the two spellings come from different documents in the batch. */
+    public void testAliasedPerLeafColumnsMergeAcrossDocuments() throws IOException {
+        IndexShard shard = newShardWithMapping(NESTED_KEYWORD_MAPPING, COLUMNAR_SETTINGS);
+        try {
+            final BulkItemRequest[] items = { new BulkItemRequest(0, indexRequest("doc1")), new BulkItemRequest(1, indexRequest("doc2")) };
+            try (
+                SourceBatch batch = EscfEncoder.encode(
+                    List.of(new BytesArray("{\"a\":{\"b\":\"x\"}}"), new BytesArray("{\"a.b\":\"y\"}")),
+                    XContentType.JSON
+                )
+            ) {
+                EngineBatch result = mapBatch(shard, items, batch);
+                assertNotNull("expected columnar path to succeed", result);
+
+                final MappedColumns mc = result.columns();
+                mc.fillPrimaryTerm(1L);
+                mc.setSeqNo(0, 1L);
+                mc.setSeqNo(1, 2L);
+                mc.setVersion(0, 1L);
+                mc.setVersion(1, 1L);
+
+                final MappedColumns.RowCursor cursor = mc.rowCursor();
+                cursor.advance();
+                assertTrue(
+                    "doc0: a.b binary DV present",
+                    cursor.fields().stream().anyMatch(f -> "a.b".equals(f.name()) && f.binaryValue() != null)
+                );
+                cursor.advance();
+                assertTrue(
+                    "doc1: a.b binary DV present",
+                    cursor.fields().stream().anyMatch(f -> "a.b".equals(f.name()) && f.binaryValue() != null)
+                );
+            }
+        } finally {
+            closeShards(shard);
+        }
+    }
+
+    /**
+     * An aliased leaf whose value is a JSON array (already multi-valued on its own, an ARRAY-kind source column)
+     * falls outside the v1 merge support matrix ({@code EscfColumnTransforms#mergeAliasedLeaves}); the chunk falls
+     * back to the row path rather than crashing.
+     */
+    public void testAliasedPerLeafColumnsWithArrayKindFallsBack() throws IOException {
+        IndexShard shard = newShardWithMapping(NESTED_KEYWORD_MAPPING, COLUMNAR_SETTINGS);
+        try {
+            final BulkItemRequest[] items = { new BulkItemRequest(0, indexRequest("doc1")) };
+            try (
+                SourceBatch batch = EscfEncoder.encode(
+                    List.of(new BytesArray("{\"a\":{\"b\":[\"x\",\"y\"]},\"a.b\":\"z\"}")),
+                    XContentType.JSON
+                )
+            ) {
+                assertNull("array-kind aliased leaf is outside v1 merge support and must fall back", mapBatch(shard, items, batch));
+            }
+        } finally {
+            closeShards(shard);
+        }
+    }
+
     // TODO(columnar): bring back once the corresponding field mappers support columnar parsing:
     // - testSupportedMapperTypes (date, long, double — keyword already covered above)
     // - testNumberMapperReceivesStringValue (long/double with a string source value)

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -223,12 +223,26 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         assertThat(resolution.columnMappers()[0], instanceOf(IpFieldMapper.class));
     }
 
-    public void testKeywordWithMultiFieldsFallsBack() throws IOException {
+    public void testKeywordWithColumnarCapableMultiFieldIsSupported() throws IOException {
         MapperService ms = mapper(mapping(b -> {
             b.startObject("host");
             b.field("type", "keyword");
             b.startObject("fields");
             b.startObject("lower").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("host"), ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertThat(resolution.columnMappers()[0], instanceOf(KeywordFieldMapper.class));
+    }
+
+    public void testKeywordWithNonColumnarMultiFieldFallsBack() throws IOException {
+        MapperService ms = mapper(mapping(b -> {
+            b.startObject("host");
+            b.field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("text").field("type", "text").endObject();
             b.endObject();
             b.endObject();
         }));

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ShardBatchMapper;
 import org.elasticsearch.index.mapper.ShardBatchMapper.BatchMapperResolution;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.sourcebatch.SourceSchema;
@@ -196,8 +197,15 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         // redundant with the per-mapper guard, so this test is intentionally narrow).
     }
 
-    public void testTextMapperNotSupported() throws IOException {
+    public void testTextMapperIsSupported() throws IOException {
         MapperService ms = mapper(mapping(b -> { b.startObject("t").field("type", "text").endObject(); }));
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("t"), ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertThat(resolution.columnMappers()[0], instanceOf(TextFieldMapper.class));
+    }
+
+    public void testTextMapperWithIndexPhrasesFallsBack() throws IOException {
+        MapperService ms = mapper(mapping(b -> { b.startObject("t").field("type", "text").field("index_phrases", true).endObject(); }));
         BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schemaOf("t"), ms.mappingLookup(), indexSettings);
         assertNull(resolution);
     }
@@ -242,7 +250,7 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
             b.startObject("host");
             b.field("type", "keyword");
             b.startObject("fields");
-            b.startObject("text").field("type", "text").endObject();
+            b.startObject("phrases").field("type", "text").field("index_phrases", true).endObject();
             b.endObject();
             b.endObject();
         }));

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -881,6 +881,44 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         assertNull(resolution.columnMappers()[schema.findLeaf(" ", 0)]);
     }
 
+    /**
+     * An empty-object leaf (e.g. {@code {"json":{}}}) must not force a batch fallback. The sequential path also
+     * produces no index writes for empty objects under {@code subobjects: DISABLED} — {@code DocumentParser}
+     * exits immediately when the object value has no children, creating no mapper and indexing nothing.
+     * <p>
+     * This is the root cause of the elastic/logs rally track logsdb_columnar regression: the k8-application
+     * corpus always has {@code "json": {}} in its documents, creating an always-empty-object schema leaf that
+     * was previously forcing every batch to fall back.
+     */
+    public void testEmptyObjectLeafIsSkippedNotFallback() throws IOException {
+        // No mapping for "json" — the sequential path also creates none for an empty object.
+        MapperService ms = mapper(mapping(b -> b.startObject("host").field("type", "keyword").endObject()));
+
+        // All rows have "json" as an empty object.
+        SourceSchema schema = schemaOfJson("{\"host\":\"srv\",\"json\":{}}", "{\"host\":\"srv2\",\"json\":{}}");
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings);
+        assertNotNull("an always-empty-object leaf must be skipped, not cause a batch fallback", resolution);
+        // The empty-object leaf has a null column mapper (skip, same as dynamic:false).
+        assertNull(resolution.columnMappers()[schema.findLeaf("json", 0)]);
+        // Other mapped leaves are resolved normally.
+        assertThat(resolution.columnMappers()[schema.findLeaf("host", 0)], instanceOf(KeywordFieldMapper.class));
+    }
+
+    /**
+     * If even one row writes a field as a real value (not empty object), the leaf is no longer "always empty-object"
+     * and must still fall back so the sequential path can index and map it.
+     */
+    public void testMixedEmptyObjectAndRealValueLeafFallsBack() throws IOException {
+        MapperService ms = mapper(mapping(b -> b.startObject("host").field("type", "keyword").endObject()));
+
+        // First row has "json" as empty object; second has it as a string — not always-empty-object.
+        SourceSchema schema = schemaOfJson("{\"host\":\"srv\",\"json\":{}}", "{\"host\":\"srv2\",\"json\":\"value\"}");
+        assertNull(
+            "a leaf that is sometimes a real value must still fall back for dynamic mapping",
+            ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings)
+        );
+    }
+
     /** Control for the two tests above: the same mapping without the nested object resolves normally. */
     public void testPlainObjectWithSameShapeResolves() throws IOException {
         MapperService ms = mapper(mapping(b -> {

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.mapper.ColumnGroupResolver;
 import org.elasticsearch.index.mapper.ColumnGroupResolver.ColumnGroupLookup;
 import org.elasticsearch.index.mapper.ColumnGroupResolver.ColumnGroupResolution;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -915,6 +916,50 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         SourceSchema schema = schemaOfJson("{\"host\":\"srv\",\"json\":{}}", "{\"host\":\"srv2\",\"json\":\"value\"}");
         assertNull(
             "a leaf that is sometimes a real value must still fall back for dynamic mapping",
+            ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings)
+        );
+    }
+
+    /**
+     * geo_point fields encoded as {@code {"lat": ..., "lon": ...}} objects produce sub-leaves that previously
+     * caused a {@link ColumnGroupLookup.Conflict} fallback. With {@link GeoPointFieldMapper#resolvesColumnGroup()}
+     * returning true, they are owned by the geo_point group mapper and the batch proceeds on the columnar path.
+     * This is the root cause of the elastic/logs k8-application corpus logsdb_columnar regression.
+     */
+    public void testGeoPointObjectFormatIsSupported() throws IOException {
+        MapperService ms = mapper(mapping(b -> b.startObject("location").field("type", "geo_point").endObject()));
+        SourceSchema schema = schemaOfJson("{\"location\":{\"lat\":40.7,\"lon\":-74.0}}");
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings);
+        assertNotNull("geo_point in {lat, lon} object format should not cause a batch fallback", resolution);
+
+        final int locationNonLeaf = schema.findNonLeaf("location", 0);
+        final int latLeaf = schema.findLeaf("lat", locationNonLeaf);
+        final int lonLeaf = schema.findLeaf("lon", locationNonLeaf);
+
+        assertNull("lat leaf should be owned by the geo_point group, not an individual leaf mapper", resolution.columnMappers()[latLeaf]);
+        assertNull("lon leaf should be owned by the geo_point group, not an individual leaf mapper", resolution.columnMappers()[lonLeaf]);
+
+        assertEquals(1, resolution.columnGroups().length);
+        assertThat(resolution.columnGroups()[0].mapper(), instanceOf(GeoPointFieldMapper.class));
+        assertArrayEquals(new String[] { "lat", "lon" }, resolution.columnGroups()[0].relativeKeys());
+    }
+
+    /**
+     * geo_point multi-fields receive the geohash string on the row path, which the columnar path does not generate.
+     * So geo_point with multi-fields must fall back to preserve correctness.
+     */
+    public void testGeoPointWithMultiFieldFallsBack() throws IOException {
+        MapperService ms = mapper(mapping(b -> {
+            b.startObject("location");
+            b.field("type", "geo_point");
+            b.startObject("fields");
+            b.startObject("geohash").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        SourceSchema schema = schemaOfJson("{\"location\":{\"lat\":40.7,\"lon\":-74.0}}");
+        assertNull(
+            "geo_point with multi-fields should fall back (multi-fields receive geohash, incompatible with columnar path)",
             ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings)
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/ShardBatchMapperResolveTests.java
@@ -525,11 +525,14 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
 
     /**
      * A per-leaf mapper gets one {@code mapColumnBatch} call per column, so a document spelling the same field both
-     * ways ({@code {"a":{"b":1},"a.b":3}}) would emit two independent outputs where the sequential path emits one
-     * merged multi-valued field — for a keyword, two doc-value blobs and two count entries instead of one of each.
-     * The batch must fall back.
+     * ways ({@code {"a":{"b":1},"a.b":3}}) can't be resolved as two independent leaf mappers the way group mappers
+     * are — the two schema leaves are merged into one {@link ShardBatchMapper.AliasedLeafResolution} and dispatched
+     * through a single {@code mapColumnBatch} call instead. This is only safe because {@code indexSettings} here is
+     * strictly columnar, which guarantees {@code subobjects: false} (see the mode-gating note on
+     * {@code ShardBatchMapper#resolveMappers}); {@link #testAliasedPerLeafColumnsFallBackOutsideStrictColumnar}
+     * covers the other modes.
      */
-    public void testAliasedPerLeafColumnsFallBack() throws IOException {
+    public void testAliasedPerLeafColumnsMergeIntoOneMapper() throws IOException {
         MapperService ms = mapper(mapping(b -> {
             b.startObject("a");
             b.startObject("properties");
@@ -542,16 +545,22 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
         assertEquals("a.b", schema.getFullPath(0));
         assertEquals("a.b", schema.getFullPath(1));
 
-        assertNull(ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings));
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertNull("both leaves are dispatched via aliasedLeaves, not as individual columns", resolution.columnMappers()[0]);
+        assertNull("both leaves are dispatched via aliasedLeaves, not as individual columns", resolution.columnMappers()[1]);
+        assertEquals(1, resolution.aliasedLeaves().length);
+        assertTrue(resolution.aliasedLeaves()[0].mapper() instanceof KeywordFieldMapper);
+        assertArrayEquals(new int[] { 0, 1 }, resolution.aliasedLeaves()[0].leafIndexes());
     }
 
     /**
      * The aliasing check is batch-wide rather than per-document, so it also trips when the two spellings come from
-     * different documents. That case would in fact be safe — neither document carries both columns — but detecting it
-     * needs per-row inspection, and {@code resolveMappers} runs once per batch. Falling back costs a slow path on a
-     * rare input.
+     * different documents. The merge handles this correctly with no special casing: a row where only one leaf is
+     * present simply contributes nothing from the other side, which is exactly what {@code testAliasedPerLeafColumnsMergeIntoOneMapper}
+     * already produces for a row that has both.
      */
-    public void testAliasedPerLeafColumnsAcrossDocumentsAlsoFallBack() throws IOException {
+    public void testAliasedPerLeafColumnsAcrossDocumentsAlsoMerge() throws IOException {
         MapperService ms = mapper(mapping(b -> {
             b.startObject("a");
             b.startObject("properties");
@@ -560,7 +569,63 @@ public class ShardBatchMapperResolveTests extends MapperServiceTestCase {
             b.endObject();
         }));
         SourceSchema schema = schemaOfJson("{\"a\":{\"b\":\"x\"}}", "{\"a.b\":\"y\"}");
-        assertNull(ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings));
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertEquals(1, resolution.aliasedLeaves().length);
+        assertArrayEquals(new int[] { 0, 1 }, resolution.aliasedLeaves()[0].leafIndexes());
+    }
+
+    /**
+     * Three distinct spellings of the same path in one batch — dotted-at-root, nested-under-dotted, and
+     * fully-nested — all fold into a single {@link ShardBatchMapper.AliasedLeafResolution}, not just pairs.
+     */
+    public void testThreeWayAliasedPerLeafColumnsMergeIntoOneGroup() throws IOException {
+        MapperService ms = mapper(mapping(b -> {
+            b.startObject("a");
+            b.startObject("properties");
+            b.startObject("b");
+            b.startObject("properties");
+            b.startObject("c").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        SourceSchema schema = schemaOfJson("{\"a.b.c\":\"x\"}", "{\"a\":{\"b.c\":\"y\"}}", "{\"a\":{\"b\":{\"c\":\"z\"}}}");
+        BatchMapperResolution resolution = ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), indexSettings);
+        assertNotNull(resolution);
+        assertEquals(1, resolution.aliasedLeaves().length);
+        assertEquals(3, resolution.aliasedLeaves()[0].leafIndexes().length);
+    }
+
+    /**
+     * The per-leaf merge relies on strictly-columnar index modes guaranteeing {@code subobjects: false} (no real
+     * {@code ObjectMapper} tree for "a"), a guarantee {@link org.elasticsearch.index.IndexMode#TIME_SERIES} does not
+     * make. Outside strictly-columnar mode the aliasing collision still falls back to the row path, unchanged from
+     * before this merge support was added. Uses a {@code long} field rather than {@code keyword}:
+     * {@code KeywordFieldMapper#supportsColumnarParse} requires strictly-columnar mode outright, so a keyword field
+     * would already fall back before reaching the aliasing check and wouldn't exercise this mode gate;
+     * {@code NumberFieldMapper#supportsColumnarParse} accepts {@code isTsdb()} too, so it reaches the check.
+     */
+    public void testAliasedPerLeafColumnsFallBackOutsideStrictColumnar() throws IOException {
+        final Settings.Builder tsdbSettings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "uid")
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false);
+        MapperService ms = createMapperService(tsdbSettings.build(), mapping(b -> {
+            b.startObject("a");
+            b.startObject("properties");
+            b.startObject("b").field("type", "long").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        final IndexSettings tsdbIndexSettings = new IndexSettings(
+            new IndexMetadata.Builder("index").settings(indexSettings(IndexVersion.current(), 1, 0).put(tsdbSettings.build()).build())
+                .build(),
+            Settings.EMPTY
+        );
+        SourceSchema schema = schemaOfJson("{\"a\":{\"b\":1},\"a.b\":2}");
+        assertNull(ShardBatchMapper.resolveMappers(schema, ms.mappingLookup(), tsdbIndexSettings));
     }
 
     /** Control: a single spelling repeated across documents is one column and must not trip the aliasing check. */

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperColumnarCompatibilityTests.java
@@ -401,4 +401,109 @@ public class KeywordFieldMapperColumnarCompatibilityTests extends AbstractColumn
             )
         );
     }
+
+    // ---- multi-fields ---------------------------------------------------------------------------
+
+    public void testMultiFieldSingleValue() throws IOException {
+        // The parent and its keyword multi-field both parse the same raw source values.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("lower").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field single value",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"World\"}")
+            )
+        );
+    }
+
+    public void testMultiFieldArrayValues() throws IOException {
+        // Multi-valued source arrays replay independently through the parent and its multi-field.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"alpha\",\"beta\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testMultiFieldDivergingIgnoreAbove() throws IOException {
+        // The parent and multi-field have different ignore_above limits, so a value can trip one
+        // field's ignore_above-fallback path without tripping the other's.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("ignore_above", 4);
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("multi-field diverging ignore_above", 1L, doc("d1", 1L, "{\"f\":\"toolong\"}"), doc("d2", 2L, "{\"f\":\"ok\"}"))
+        );
+    }
+
+    public void testMultiFieldTwoMultiFields() throws IOException {
+        // Two multi-fields under the same parent produce independent output columns.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.startObject("other").field("type", "keyword").field("ignore_above", 3).endObject();
+            b.endObject();
+            b.endObject();
+        }), columnarSettings(), batch("multi-field two multi-fields", 1L, doc("d1", 1L, "{\"f\":\"abcd\"}"), doc("d2", 2L, "{}")));
+    }
+
+    public void testMultiFieldNotIndexedParent() throws IOException {
+        // The parent is not indexed (doc values only) while its multi-field is fully indexed;
+        // mapColumnBatch must dispatch to the multi-field regardless of the parent's own emit flags.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword").field("index", false);
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("multi-field not-indexed parent", 1L, doc("d1", 1L, "{\"f\":\"only_dv_and_multifield\"}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testMultiFieldMultiValueFalse() throws IOException {
+        // The parent is multi_value=false while its multi-field keeps the default multi_value=true.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field parent multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"solo\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"solo2\"}")
+            )
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperColumnarCompatibilityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperColumnarCompatibilityTests.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+
+import java.io.IOException;
+
+/**
+ * Parity tests for {@link TextFieldMapper#mapColumnBatch} against the row path.
+ * The {@link AbstractColumnarMapperCompatibilityTestCase} harness drives leaf mappers automatically
+ * via {@code EscfEncoder}; no subclass override is needed.
+ */
+public class TextFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
+
+    private static final String FIELD = "f";
+
+    private static Settings columnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    public void testSingleValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("single value", 1L, doc("d1", 1L, "{\"f\":\"hello world\"}"))
+        );
+    }
+
+    public void testMultiValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("multi-value", 1L, doc("d1", 1L, "{\"f\":[\"hello\",\"world\"]}"))
+        );
+    }
+
+    public void testAbsentDocsMixed() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("absent docs mixed", 1L, doc("d1", 1L, "{\"f\":\"alpha\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"gamma\"}"))
+        );
+    }
+
+    public void testArrayValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch(
+                "array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"solo\"]}"),
+                doc("d2", 2L, "{\"f\":[\"alpha\",\"beta\",\"gamma\"]}"),
+                doc("d3", 3L, "{\"f\":[]}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testArrayValuesWithNull() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("array values with null", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testMixedBatch() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch(
+                "mixed batch",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":[\"b\",\"c\"]}"),
+                doc("d4", 4L, "{\"f\":\"d\"}")
+            )
+        );
+    }
+
+    public void testLongValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch(
+                "long values",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":-7}"),
+                doc("d3", 3L, "{\"f\":9876543210}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testDoubleValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch(
+                "double values",
+                1L,
+                doc("d1", 1L, "{\"f\":3.14}"),
+                doc("d2", 2L, "{\"f\":1.5}"),
+                doc("d3", 3L, "{\"f\":-2.5}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testBooleanValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("boolean values", 1L, doc("d1", 1L, "{\"f\":true}"), doc("d2", 2L, "{\"f\":false}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testNestedArray() throws IOException {
+        // Nested arrays are flattened, matching the row-path behaviour in DocumentParser.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").endObject()),
+            columnarSettings(),
+            batch("nested array", 1L, doc("d1", 1L, "{\"f\":[[\"a\",\"b\"],[\"c\"]]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testNoIndexDocValuesOnly() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").field("index", false).endObject()),
+            columnarSettings(),
+            batch("no-index single value", 1L, doc("d1", 1L, "{\"f\":\"only_dv\"}"))
+        );
+    }
+
+    public void testTermVectors() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").field("term_vector", "with_positions_offsets").endObject()),
+            columnarSettings(),
+            batch("term vectors", 1L, doc("d1", 1L, "{\"f\":\"hello world\"}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testNormsEnabled() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "text").field("norms", true).endObject()),
+            columnarSettings(),
+            batch("norms enabled", 1L, doc("d1", 1L, "{\"f\":\"hello world\"}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testSingleValueMultiValueFalse() throws IOException {
+        // One string value, one absent doc, and an empty string.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single value multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"\"}")
+            )
+        );
+    }
+
+    public void testAbsentAndNullMultiValueFalse() throws IOException {
+        // Present value, absent doc ({}), and explicit JSON null -> absent (text has no null_value).
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "absent and null multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"alpha\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":null}")
+            )
+        );
+    }
+
+    public void testIndexedAndDocValuesMultiValueFalse() throws IOException {
+        // Default index:true — both an indexed (tokenized) column and a binary DV column are emitted.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "indexed and dv multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"indexed\"}"),
+                doc("d2", 2L, "{\"f\":\"also indexed\"}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testScalarCoercionsMultiValueFalse() throws IOException {
+        // Numeric and boolean scalars are stringified by utf8Cursor, matching the row path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "scalar coercions multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":3.14}"),
+                doc("d3", 3L, "{\"f\":true}")
+            )
+        );
+    }
+
+    public void testAllPresentDenseMultiValueFalse() throws IOException {
+        // Every doc has a string value; no absent docs. Exercises the dense (validity==null) wrap in the fast path.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "all present dense multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{\"f\":\"b\"}"),
+                doc("d3", 3L, "{\"f\":\"c\"}")
+            )
+        );
+    }
+
+    public void testManyMixedPresentAbsentMultiValueFalse() throws IOException {
+        // Larger interleaved present/absent batch to stress the SPARSE wrap.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "many mixed present absent multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":\"v1\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"v3\"}"),
+                doc("d4", 4L, "{}"),
+                doc("d5", 5L, "{\"f\":\"v5\"}"),
+                doc("d6", 6L, "{\"f\":\"v6\"}"),
+                doc("d7", 7L, "{}")
+            )
+        );
+    }
+
+    public void testSingleElementArrayMultiValueFalse() throws IOException {
+        // A single-element array {"f":["a"]} is a legal value for a multi_value=false field.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("doc_values").field("multi_value", false).endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "single element array multi_value=false",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"a\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    // ---- multi-fields ---------------------------------------------------------------------------
+
+    public void testMultiFieldSingleValue() throws IOException {
+        // text with a keyword multi-field: the most common real-world mapping pattern (dynamic mapping's
+        // default "text" + ".keyword").
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field single value",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Hello World\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"Another Value\"}")
+            )
+        );
+    }
+
+    public void testMultiFieldArrayValues() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"alpha beta\",\"gamma\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testMultiFieldTwoMultiFields() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.startObject("other").field("type", "keyword").field("ignore_above", 3).endObject();
+            b.endObject();
+            b.endObject();
+        }), columnarSettings(), batch("multi-field two multi-fields", 1L, doc("d1", 1L, "{\"f\":\"abcd\"}"), doc("d2", 2L, "{}")));
+    }
+
+    public void testMultiFieldNotIndexedParent() throws IOException {
+        // The parent is not indexed (doc values only) while its multi-field is fully indexed.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "text").field("index", false);
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("multi-field not-indexed parent", 1L, doc("d1", 1L, "{\"f\":\"only_dv_and_multifield\"}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    // ---- fields not yet supported: verify correct fallback ---------------------------------------
+
+    public void testIndexPhrasesFallsBack() throws IOException {
+        MapperService ms = createMapperService(
+            columnarSettings(),
+            mapping(b -> b.startObject(FIELD).field("type", "text").field("index_phrases", true).endObject())
+        );
+        Mapper mapper = ms.mappingLookup().getMapper(FIELD);
+        assertTrue(mapper instanceof TextFieldMapper);
+        assertFalse(((TextFieldMapper) mapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+
+    public void testIndexPrefixesFallsBack() throws IOException {
+        MapperService ms = createMapperService(columnarSettings(), mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("index_prefixes").endObject();
+            b.endObject();
+        }));
+        Mapper mapper = ms.mappingLookup().getMapper(FIELD);
+        assertTrue(mapper instanceof TextFieldMapper);
+        assertFalse(((TextFieldMapper) mapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+
+    public void testMultiFieldWithNonColumnarMultiFieldFallsBack() throws IOException {
+        // A multi-field that is itself disqualified from columnar parse (here, a "text" multi-field with
+        // index_phrases) must disqualify the parent too - recursion via multiFieldsSupportColumnarParse.
+        MapperService ms = createMapperService(columnarSettings(), mapping(b -> {
+            b.startObject(FIELD).field("type", "text");
+            b.startObject("fields");
+            b.startObject("phrases").field("type", "text").field("index_phrases", true).endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        Mapper mapper = ms.mappingLookup().getMapper(FIELD);
+        assertTrue(mapper instanceof TextFieldMapper);
+        assertFalse(((TextFieldMapper) mapper).supportsColumnarParse(ms.getIndexSettings()));
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -17,6 +17,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.column.ObjectTupleCursor;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
@@ -24,6 +25,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -35,6 +37,7 @@ import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
@@ -46,7 +49,15 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.escf.EscfColumn;
+import org.elasticsearch.escf.EscfColumnBuilder;
+import org.elasticsearch.escf.EscfColumnBuilder.CollisionPolicy;
+import org.elasticsearch.escf.EscfColumnKind;
+import org.elasticsearch.escf.EscfColumnTransforms;
+import org.elasticsearch.escf.LuceneBinaryColumn;
+import org.elasticsearch.escf.LuceneLongColumn;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -56,10 +67,12 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.StringBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.ArrayOrderBinaryDocValuesSyntheticFieldLoaderLayer;
+import org.elasticsearch.index.mapper.BatchMappingContext;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BinaryDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.CustomDocValuesField;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
@@ -78,6 +91,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomB
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.wildcard.WildcardDocValuesField;
@@ -1134,6 +1148,171 @@ public class WildcardFieldMapper extends FieldMapper {
     @Override
     public WildcardFieldType fieldType() {
         return (WildcardFieldType) super.fieldType();
+    }
+
+    @Override
+    public boolean supportsColumnarParse(IndexSettings indexSettings) {
+        // wildcard is always indexed and always has doc values (IndexType.terms(true, true), no index/doc_values
+        // toggle), and arrayOrderBinaryDocValues is unconditionally true in strict columnar mode - see
+        // Builder#build. So mapColumnBatch only needs the array-order shape, unlike KeywordFieldMapper#mapColumnBatch.
+        return indexSettings.getMode().isStrictColumnar()
+            && storeIgnoredFieldsInBinaryDocValues
+            && copyTo().copyToFields().isEmpty()
+            && multiFieldsSupportColumnarParse(indexSettings);
+    }
+
+    // TODO: make the batch supply a recycler to wire up recycling instead of NON_RECYCLING_INSTANCE.
+    private static EscfColumnBuilder mergeStringColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.STRING);
+        return b;
+    }
+
+    private static EscfColumnBuilder mergeLongColumn() {
+        EscfColumnBuilder b = new EscfColumnBuilder(CollisionPolicy.MERGE, BytesRefRecycler.NON_RECYCLING_INSTANCE);
+        b.lockScalar(EscfColumnKind.LONG);
+        return b;
+    }
+
+    /**
+     * The indexed ngram field wraps every value with {@link #TOKEN_START_OR_END_CHAR} markers (see
+     * {@link #addLineEndChars}). {@link #TOKEN_START_OR_END_CHAR} is {@code (char) 0}, a single UTF-8 byte, so the
+     * wrap can be done directly on the UTF-8 bytes without a String round-trip.
+     */
+    private static BytesRef addLineEndBytes(BytesRef value) {
+        byte[] bytes = new byte[value.length + 3];
+        bytes[0] = 0;
+        System.arraycopy(value.bytes, value.offset, bytes, 1, value.length);
+        bytes[value.length + 1] = 0;
+        bytes[value.length + 2] = 0;
+        return new BytesRef(bytes);
+    }
+
+    /**
+     * Maps a batch of documents for this field from the supplied ESCF source column. Unlike
+     * {@link KeywordFieldMapper#mapColumnBatch}, this only has one shape to build (see
+     * {@link #supportsColumnarParse}), and the indexed ngram field carries a different value (wrapped with
+     * line-end markers via {@link #addLineEndBytes}) than the doc-values field (the raw value), so a dedicated
+     * terms builder is always required - there is no zero-copy path.
+     *
+     * @throws UnsupportedOperationException when a document has more than one ignore_above-exceeded value
+     *         (causes {@link org.elasticsearch.index.mapper.ShardBatchMapper} to fall back to the row path)
+     */
+    @Override
+    public void mapColumnBatch(BatchMappingContext ctx, EscfColumn source) {
+        final int docCount = ctx.docCount();
+        final boolean emitFallback = storeIgnored;
+
+        // retainValues=false: each value is appended to the document blob (or the terms/fallback builders)
+        // before the cursor advances, so no value has to outlive the nextDoc() that moves past it.
+        final ObjectTupleCursor<BytesRef> cursor = EscfColumnTransforms.utf8Cursor(source, false);
+        final EscfColumnBuilder terms = mergeStringColumn();
+        final EscfColumnBuilder binaryDvs = mergeStringColumn();
+        final EscfColumnBuilder dvCounts = mergeLongColumn();
+        final EscfColumnBuilder fallback = emitFallback ? mergeStringColumn() : null;
+        final EscfColumnBuilder fallbackCounts = emitFallback ? mergeLongColumn() : null;
+        final BytesRef nullValueBytes = nullValue == null ? null : new BytesRef(nullValue);
+
+        int currentDoc = -1;
+        boolean ignoredThisDoc = false;
+        // Buffer for the in-order binary doc-values blob. Each document's slots are appended as they are read
+        // and the finished blob is handed to binaryDvs.setString, which copies it out immediately, so the
+        // buffer is free to be rewritten.
+        final BytesRefBuilder docBlob = new BytesRefBuilder();
+        int pos = 0;
+        int docSlotCount = 0;
+        int lastValueLength = 0;
+        // True when the current doc has at least one non-null slot; gates binary dv blob emission.
+        boolean hasNonNull = false;
+
+        while (true) {
+            final int nextDoc = cursor.nextDoc();
+            if (nextDoc != currentDoc) {
+                // Flush the completed doc's elements. All-null docs write counts (matching
+                // ArrayOrderInlineNull.recordNull) but no blob; docs with only ignore_above-exceeded values
+                // write neither, matching the row path (createFields is never called for them).
+                if (docSlotCount > 0) {
+                    dvCounts.setLong(currentDoc, docSlotCount);
+                    if (hasNonNull) {
+                        final int length = docSlotCount == 1 ? lastValueLength : pos;
+                        binaryDvs.setString(currentDoc, docBlob.bytes(), pos - length, length);
+                    }
+                    pos = 0;
+                    docSlotCount = 0;
+                    hasNonNull = false;
+                }
+                if (nextDoc == DocIdSetIterator.NO_MORE_DOCS) {
+                    break;
+                }
+                currentDoc = nextDoc;
+                ignoredThisDoc = false;
+            }
+
+            BytesRef value = cursor.value();
+
+            // Explicit JSON null: apply null_value substitution if configured; otherwise record a null
+            // doc-values slot (no ngram field, no ignore_above check), mirroring the row path's
+            // ArrayOrderInlineNull.recordNull for an absent value with no null_value.
+            if (value == null) {
+                if (nullValueBytes != null) {
+                    value = nullValueBytes;
+                    // Fall through to normal value processing below.
+                } else {
+                    pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, null);
+                    docSlotCount++;
+                    // hasNonNull stays false: null slots do not produce a binary dv blob.
+                    continue;
+                }
+            }
+
+            // ignore_above: record _ignored once per doc; the value records no slot at all, matching the row
+            // path where createFields (and therefore ArrayOrderInlineNull.recordValue) is never called for it.
+            if (ignoreAbove.isIgnored(value)) {
+                if (ignoredThisDoc == false) {
+                    ctx.addIgnoredFieldColumnar(currentDoc, fullPath());
+                    if (fallback != null) {
+                        fallback.setString(currentDoc, value);
+                        fallbackCounts.setLong(currentDoc, 1L);
+                    }
+                    ignoredThisDoc = true;
+                } else if (fallback != null) {
+                    // TODO: support multiple ignore_above-exceeded values per doc (multi-valued fallback
+                    // requires SeparateCount vint-length encoding across multiple values).
+                    throw new UnsupportedOperationException(
+                        "mapColumnBatch: more than one ignore_above-exceeded value in field ["
+                            + fullPath()
+                            + "] for doc ["
+                            + currentDoc
+                            + "]; multi-valued synthetic-source fallback is not yet supported"
+                    );
+                }
+                continue;
+            }
+
+            terms.setString(currentDoc, addLineEndBytes(value));
+            pos = MultiValuedBinaryDocValuesField.ArrayOrderInlineNull.appendSlot(docBlob, pos, value);
+            lastValueLength = value.length;
+            docSlotCount++;
+            hasNonNull = true;
+        }
+
+        // Attach output columns. Terms, binary-dv blob, and counts are each emitted independently.
+        // All-null docs emit counts but no binary blob, so binaryDvs and dvCounts are decoupled.
+        if (terms.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(terms.finish(docCount), fieldType().name(), NGRAM_FIELD_TYPE));
+        }
+        if (binaryDvs.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(binaryDvs.finish(docCount), fieldType().name(), CustomDocValuesField.TYPE));
+        }
+        if (dvCounts.isEmpty() == false) {
+            ctx.addColumn(LuceneLongColumn.counts(dvCounts.finish(docCount), fieldType().name()));
+        }
+        if (emitFallback && fallback != null && fallback.isEmpty() == false) {
+            ctx.addColumn(LuceneBinaryColumn.of(fallback.finish(docCount), originalName(), CustomDocValuesField.TYPE));
+            ctx.addColumn(LuceneLongColumn.counts(fallbackCounts.finish(docCount), originalName()));
+        }
+
+        mapColumnBatchToMultiFields(ctx, source);
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperColumnarCompatibilityTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperColumnarCompatibilityTests.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.AbstractColumnarMapperCompatibilityTestCase;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.wildcard.Wildcard;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Parity tests for {@link WildcardFieldMapper#mapColumnBatch} against the row path.
+ * The {@link AbstractColumnarMapperCompatibilityTestCase} harness drives leaf mappers automatically
+ * via {@code EscfEncoder}; no subclass override is needed.
+ */
+public class WildcardFieldMapperColumnarCompatibilityTests extends AbstractColumnarMapperCompatibilityTestCase {
+
+    private static final String FIELD = "f";
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return Collections.singleton(new Wildcard());
+    }
+
+    private static Settings columnarSettings() {
+        return Settings.builder()
+            .put(IndexSettings.MODE.getKey(), IndexMode.COLUMNAR.getName())
+            .put(RecoverySettings.INDICES_RECOVERY_SOURCE_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    public void testSingleValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("single value", 1L, doc("d1", 1L, "{\"f\":\"hello\"}"))
+        );
+    }
+
+    public void testMultiValue() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("multi-value", 1L, doc("d1", 1L, "{\"f\":[\"hello\",\"world\"]}"))
+        );
+    }
+
+    public void testAbsentDocsMixed() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("absent docs mixed", 1L, doc("d1", 1L, "{\"f\":\"alpha\"}"), doc("d2", 2L, "{}"), doc("d3", 3L, "{\"f\":\"gamma\"}"))
+        );
+    }
+
+    public void testArrayValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch(
+                "array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"solo\"]}"),
+                doc("d2", 2L, "{\"f\":[\"alpha\",\"beta\",\"gamma\"]}"),
+                doc("d3", 3L, "{\"f\":[]}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testArrayValuesWithNull() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("array values with null", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testMixedBatch() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch(
+                "mixed batch",
+                1L,
+                doc("d1", 1L, "{\"f\":\"a\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":[\"b\",\"c\"]}"),
+                doc("d4", 4L, "{\"f\":\"d\"}")
+            )
+        );
+    }
+
+    public void testLongValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch(
+                "long values",
+                1L,
+                doc("d1", 1L, "{\"f\":42}"),
+                doc("d2", 2L, "{\"f\":-7}"),
+                doc("d3", 3L, "{\"f\":9876543210}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testDoubleValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch(
+                "double values",
+                1L,
+                doc("d1", 1L, "{\"f\":3.14}"),
+                doc("d2", 2L, "{\"f\":1.5}"),
+                doc("d3", 3L, "{\"f\":-2.5}"),
+                doc("d4", 4L, "{}")
+            )
+        );
+    }
+
+    public void testBooleanValues() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("boolean values", 1L, doc("d1", 1L, "{\"f\":true}"), doc("d2", 2L, "{\"f\":false}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testNestedArray() throws IOException {
+        // Nested arrays are flattened, matching the row-path behaviour in DocumentParser.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("nested array", 1L, doc("d1", 1L, "{\"f\":[[1,2],[3]]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testNullValueSubstitution() throws IOException {
+        // An explicit JSON null is substituted with the configured null_value.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").field("null_value", "NULL").endObject()),
+            columnarSettings(),
+            batch("null_value substitution", 1L, doc("d1", 1L, "{\"f\":null}"), doc("d2", 2L, "{\"f\":\"a\"}"), doc("d3", 3L, "{}"))
+        );
+    }
+
+    public void testArrayWithNull() throws IOException {
+        // An array containing an explicit null element produces a null slot in the doc-values blob.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").endObject()),
+            columnarSettings(),
+            batch("array with null element", 1L, doc("d1", 1L, "{\"f\":[\"a\",null,\"b\"]}"), doc("d2", 2L, "{}"))
+        );
+    }
+
+    public void testIgnoreAbove() throws IOException {
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").field("ignore_above", 8).endObject()),
+            columnarSettings(),
+            batch("ignore_above value", 1L, doc("d1", 1L, "{\"f\":\"toolongvalue\"}"), doc("d2", 2L, "{\"f\":\"short\"}"))
+        );
+    }
+
+    public void testIgnoreAboveWithOtherValuesInDoc() throws IOException {
+        // The ignored value records neither a term nor a doc-values slot, but a non-ignored sibling in the same
+        // array still gets one.
+        assertColumnarMatchesXContent(
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").field("ignore_above", 8).endObject()),
+            columnarSettings(),
+            batch("ignore_above with sibling values", 1L, doc("d1", 1L, "{\"f\":[\"short\",\"toolongvalue\"]}"))
+        );
+    }
+
+    public void testIgnoreAboveTwoValuesInDocFallsBack() throws IOException {
+        // Two ignore_above-exceeded values in the same doc are not yet supported on the columnar batch path.
+        MapperService ms = createMapperService(
+            columnarSettings(),
+            mapping(b -> b.startObject(FIELD).field("type", "wildcard").field("ignore_above", 4).endObject())
+        );
+        expectThrows(UnsupportedOperationException.class, () -> mapColumnarLeaf(ms, FIELD, "{\"f\":[\"toolong1\",\"toolong2\"]}"));
+    }
+
+    // ---- multi-fields ---------------------------------------------------------------------------
+
+    public void testMultiFieldSingleValue() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "wildcard");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field single value",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"World\"}")
+            )
+        );
+    }
+
+    public void testMultiFieldArrayValues() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "wildcard");
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "multi-field array values",
+                1L,
+                doc("d1", 1L, "{\"f\":[\"alpha\",\"beta\"]}"),
+                doc("d2", 2L, "{\"f\":[]}"),
+                doc("d3", 3L, "{}")
+            )
+        );
+    }
+
+    public void testMultiFieldDivergingIgnoreAbove() throws IOException {
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "wildcard").field("ignore_above", 4);
+            b.startObject("fields");
+            b.startObject("raw").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch("multi-field diverging ignore_above", 1L, doc("d1", 1L, "{\"f\":\"toolong\"}"), doc("d2", 2L, "{\"f\":\"ok\"}"))
+        );
+    }
+
+    public void testKeywordParentWithWildcardMultiField() throws IOException {
+        // The reverse pairing: a keyword field with a wildcard multi-field.
+        assertColumnarMatchesXContent(mapping(b -> {
+            b.startObject(FIELD).field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("wc").field("type", "wildcard").endObject();
+            b.endObject();
+            b.endObject();
+        }),
+            columnarSettings(),
+            batch(
+                "keyword parent with wildcard multi-field",
+                1L,
+                doc("d1", 1L, "{\"f\":\"Hello\"}"),
+                doc("d2", 2L, "{}"),
+                doc("d3", 3L, "{\"f\":\"World\"}")
+            )
+        );
+    }
+}


### PR DESCRIPTION
This is a draft PR's purpose is to investigate what changes are needed to fully utilize columnar batching indexing with the elastic/logs Rally track.

Extends the columnar batch indexing path (`ShardBatchMapper`) to support additional field types and cases encountered when running the elastic/logs rally track in `logsdb_columnar` mode with columnar batch indexing enabled:

- Support columnar batch indexing for keyword multi-fields
- Support columnar batch indexing for `match_only_text` fields
- Support columnar batch indexing for `text` fields
- Support columnar batch indexing for `wildcard` fields
- Support columnar batch indexing for `geo_point` fields (fixes `source.geo.location` in `{"lat": ..., "lon": ...}` format from GeoIP enrichment)
- Merge dotted/nested spelling aliases in columnar batch indexing. The rally track's dataset contains field with dots using object notation.
- Skip always-empty-object leaves in columnar batch indexing (fixes `"json": {}` in k8-application corpus). The rally track datasets contain some empty object fields that are not mapped, triggering sequential path.

With these changes `ShardBatchMapper#resolveMappers(...)` doesn't fall back to the sequential path.
Without these changes this method almost always falls back to the sequential path, because multi_fields, text fields etc. are very common in the dataset.

The PR is a prototype and will not be merged. Instead each commit of this PR should be its own change.