### PR TITLE
Give foreign-library modules their own test build-info

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
@@ -9,9 +9,12 @@
 
 package org.elasticsearch.gradle.internal.foreign;
 
+import org.elasticsearch.gradle.plugin.GenerateTestBuildInfoTask;
+import org.elasticsearch.gradle.test.TestBuildInfoPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -83,6 +86,8 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
         mainSourceSet.getOutput().dir(processAnnotations.flatMap(JavaCompile::getDestinationDirectory));
 
         swapModuleInfoInJar(project, augmentModuleInfo);
+
+        registerTestBuildInfoTask(project, processAnnotations);
 
         // All non-main source sets get the same annotation processing, but no module-info augmentation
         // and no jar swap: they are non-modular and run on the classpath.
@@ -161,6 +166,35 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
             task.getJavaLauncher().set(javaToolchains.launcherFor(spec -> spec.getLanguageVersion().set(PROCESSOR_TOOLCHAIN)));
             task.getOutputModuleInfo()
                 .set(project.getLayout().getBuildDirectory().file(AUGMENTED_MODULE_INFO_DIR + "/" + MODULE_INFO_CLASS));
+        });
+    }
+
+    /**
+     * Make a foreign-library module represent itself to the entitlement test-scope resolver.
+     *
+     * <p>Foreign-library modules live in {@code libs} and are part of the server trust boundary, but — unlike
+     * plugins and the server itself — nothing generates their entitlement test-build-info. On a module's own
+     * test classpath, the annotation processor's {@code <Library>$Impl}/{@code $Provider} classes (which issue
+     * the native downcalls) sit in the sibling {@code generated-foreign-library-classes} directory that no other
+     * build-info records, so they resolve to {@code component [(unknown)]} and fail native-library entitlement
+     * checks. Applying {@link TestBuildInfoPlugin} registers a {@code generateTestBuildInfo} task that emits a
+     * {@code lib-test-build-info.json} enumerating both its main classes directory and that generated directory
+     * (see {@link org.elasticsearch.gradle.plugin.GenerateTestBuildInfoTask}); the test framework reads these
+     * and maps both to the module's scope.
+     */
+    private void registerTestBuildInfoTask(Project project, TaskProvider<JavaCompile> processAnnotations) {
+        project.getPluginManager().apply(TestBuildInfoPlugin.class);
+        project.getTasks().named("generateTestBuildInfo", GenerateTestBuildInfoTask.class).configure(task -> {
+            task.getComponentName().set(project.getName());
+            task.getOutputFile().set(project.getLayout().getBuildDirectory().file("generated-build-info/lib-test-build-info.json"));
+            // Add the annotation processor's generated-foreign-library-classes directory so the generated
+            // $Impl/$Provider classes get their own location. Its build dependency is the processor task, not
+            // processResources, so — unlike the source set's full output — it introduces no task cycle (the
+            // build-info feeds processResources). get() extracts the collection TestBuildInfoPlugin already set,
+            // so the derived value does not reference the property being assigned.
+            FileCollection codeLocations = task.getCodeLocations().get();
+            task.getCodeLocations()
+                .set(codeLocations.plus(project.files(processAnnotations.flatMap(JavaCompile::getDestinationDirectory))));
         });
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/foreign/ForeignLibraryPlugin.java
@@ -170,17 +170,9 @@ public class ForeignLibraryPlugin implements Plugin<Project> {
     }
 
     /**
-     * Make a foreign-library module represent itself to the entitlement test-scope resolver.
-     *
-     * <p>Foreign-library modules live in {@code libs} and are part of the server trust boundary, but — unlike
-     * plugins and the server itself — nothing generates their entitlement test-build-info. On a module's own
-     * test classpath, the annotation processor's {@code <Library>$Impl}/{@code $Provider} classes (which issue
-     * the native downcalls) sit in the sibling {@code generated-foreign-library-classes} directory that no other
-     * build-info records, so they resolve to {@code component [(unknown)]} and fail native-library entitlement
-     * checks. Applying {@link TestBuildInfoPlugin} registers a {@code generateTestBuildInfo} task that emits a
-     * {@code lib-test-build-info.json} enumerating both its main classes directory and that generated directory
-     * (see {@link org.elasticsearch.gradle.plugin.GenerateTestBuildInfoTask}); the test framework reads these
-     * and maps both to the module's scope.
+     * Applies {@link TestBuildInfoPlugin} and configures it to emit a {@code lib-test-build-info.json} covering
+     * both the main classes directory and the annotation processor's generated directory, so the generated
+     * {@code $Impl}/{@code $Provider} classes are resolved to this module's scope at test time.
      */
     private void registerTestBuildInfoTask(Project project, TaskProvider<JavaCompile> processAnnotations) {
         project.getPluginManager().apply(TestBuildInfoPlugin.class);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GenerateTestBuildInfoTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GenerateTestBuildInfoTask.java
@@ -123,17 +123,19 @@ public abstract class GenerateTestBuildInfoTask extends DefaultTask {
      */
     private List<Location> buildLocationList() throws IOException {
         List<Location> locations = new ArrayList<>();
+        List<File> directories = new ArrayList<>();
         for (File file : getCodeLocations().get().getFiles()) {
             if (file.exists()) {
                 if (file.getName().endsWith(JAR_DESCRIPTOR_SUFFIX)) {
                     extractLocationsFromJar(file, locations);
                 } else if (file.isDirectory()) {
-                    extractLocationsFromDirectory(file, locations);
+                    directories.add(file);
                 } else {
                     throw new IllegalArgumentException("unrecognized classpath entry: " + file);
                 }
             }
         }
+        extractLocationsFromDirectories(directories, locations);
         return List.copyOf(locations);
     }
 
@@ -276,50 +278,88 @@ public abstract class GenerateTestBuildInfoTask extends DefaultTask {
     }
 
     /**
-     * find the first class and module when the class path entry is a directory
+     * Emit a {@link Location} for each directory code location. All of a task's directory code locations
+     * belong to the single Gradle project being described, and so to the single Java module that project
+     * declares. Only the main classes directory carries a {@code module-info.class}; sibling output
+     * directories — most notably the foreign-library annotation processor's
+     * {@code generated-foreign-library-classes}, which holds the {@code $Impl}/{@code $Provider} classes
+     * that issue the native downcalls — do not, but still belong to that same module. Resolve the module
+     * once from whichever directory declares it (falling back to {@link #getModuleName()}) and attribute
+     * every directory location to it.
      */
-    private void extractLocationsFromDirectory(File dir, List<Location> locations) throws IOException {
-        String className = extractClassNameFromDirectory(dir);
-        String moduleName = extractModuleNameFromDirectory(dir);
-
-        if (className != null && moduleName != null) {
-            locations.add(new Location(moduleName, className));
+    private void extractLocationsFromDirectories(List<File> directories, List<Location> locations) throws IOException {
+        String moduleName = getModuleName().getOrNull();
+        for (File dir : directories) {
+            String declared = extractDeclaredModuleName(dir);
+            if (declared != null) {
+                moduleName = declared;
+                break;
+            }
+        }
+        if (moduleName == null) {
+            return;
+        }
+        for (File dir : directories) {
+            String className = extractClassNameFromDirectory(dir);
+            if (className != null) {
+                locations.add(new Location(moduleName, className));
+            }
         }
     }
 
     /**
-     * look through the directory to find the first unique class that isn't
-     * module-info.class (which may not be unique) and avoid anonymous classes
+     * look through the directory to find a class to use as this location's representative. Prefer a
+     * top-level class (its file name has no {@code $}); a module-info is never unique and is skipped.
+     * Fall back to a named nested class (e.g. the foreign-library {@code <Library>$Impl}/{@code $Provider}
+     * generated output, which populates a directory with nothing else) — still unique and loadable —
+     * while skipping anonymous/local classes, whose names are not stable across compilations.
      */
     private String extractClassNameFromDirectory(File dir) throws IOException {
         var visitor = new SimpleFileVisitor<Path>() {
             String result = null;
+            String nestedFallback = null;
 
             @Override
             public @NotNull FileVisitResult visitFile(@NotNull Path candidate, @NotNull BasicFileAttributes attrs) {
                 String name = candidate.getFileName().toString(); // Just the part after the last dir separator
-                if (name.endsWith(".class") && (name.equals("module-info.class") || name.contains("$")) == false) {
-                    result = candidate.toAbsolutePath()
-                        .toString()
-                        .substring(dir.getAbsolutePath().length() + 1)
-                        .replace(File.separatorChar, '/');
-                    return TERMINATE;
-                } else {
+                if (name.endsWith(".class") == false || name.equals("module-info.class")) {
                     return CONTINUE;
                 }
+                if (name.contains("$") == false) {
+                    result = relativize(candidate);
+                    return TERMINATE;
+                }
+                if (nestedFallback == null && isAnonymousOrLocal(name) == false) {
+                    nestedFallback = relativize(candidate);
+                }
+                return CONTINUE;
+            }
+
+            private String relativize(Path candidate) {
+                return candidate.toAbsolutePath().toString().substring(dir.getAbsolutePath().length() + 1).replace(File.separatorChar, '/');
             }
         };
         Files.walkFileTree(dir.toPath(), visitor);
-        return visitor.result;
+        return visitor.result != null ? visitor.result : visitor.nestedFallback;
     }
 
     /**
-     * look through the directory to find the module name in either module-info.class
-     * if it exists or the preset one derived from the jar task
+     * Whether a {@code .class} file name denotes an anonymous or local class, i.e. the segment right
+     * after the last {@code $} begins with a digit (e.g. {@code Outer$1.class}, {@code Outer$1Local.class}).
+     * Such names are not stable across compilations and must not be used as a representative class.
      */
-    private String extractModuleNameFromDirectory(File dir) throws IOException {
+    private static boolean isAnonymousOrLocal(String fileName) {
+        int dollar = fileName.lastIndexOf('$');
+        return dollar >= 0 && dollar + 1 < fileName.length() && Character.isDigit(fileName.charAt(dollar + 1));
+    }
+
+    /**
+     * look through the directory for a {@code module-info.class} and return the module name it declares,
+     * or {@code null} if the directory has none.
+     */
+    private String extractDeclaredModuleName(File dir) throws IOException {
         var visitor = new SimpleFileVisitor<Path>() {
-            private String result = getModuleName().getOrNull();
+            private String result = null;
 
             @Override
             public @NotNull FileVisitResult visitFile(@NotNull Path candidate, @NotNull BasicFileAttributes attrs) throws IOException {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GenerateTestBuildInfoTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/GenerateTestBuildInfoTask.java
@@ -278,14 +278,9 @@ public abstract class GenerateTestBuildInfoTask extends DefaultTask {
     }
 
     /**
-     * Emit a {@link Location} for each directory code location. All of a task's directory code locations
-     * belong to the single Gradle project being described, and so to the single Java module that project
-     * declares. Only the main classes directory carries a {@code module-info.class}; sibling output
-     * directories — most notably the foreign-library annotation processor's
-     * {@code generated-foreign-library-classes}, which holds the {@code $Impl}/{@code $Provider} classes
-     * that issue the native downcalls — do not, but still belong to that same module. Resolve the module
-     * once from whichever directory declares it (falling back to {@link #getModuleName()}) and attribute
-     * every directory location to it.
+     * Emits a {@link Location} for each directory. All directories belong to the same module, but only the
+     * main classes directory carries a {@code module-info.class}; the module name is resolved once (falling
+     * back to {@link #getModuleName()}) and attributed to every directory.
      */
     private void extractLocationsFromDirectories(List<File> directories, List<Location> locations) throws IOException {
         String moduleName = getModuleName().getOrNull();
@@ -308,11 +303,8 @@ public abstract class GenerateTestBuildInfoTask extends DefaultTask {
     }
 
     /**
-     * look through the directory to find a class to use as this location's representative. Prefer a
-     * top-level class (its file name has no {@code $}); a module-info is never unique and is skipped.
-     * Fall back to a named nested class (e.g. the foreign-library {@code <Library>$Impl}/{@code $Provider}
-     * generated output, which populates a directory with nothing else) — still unique and loadable —
-     * while skipping anonymous/local classes, whose names are not stable across compilations.
+     * Returns a representative class name from the directory: prefers a top-level class, falls back to a
+     * named nested class (skipping anonymous/local classes), returns {@code null} if the directory has none.
      */
     private String extractClassNameFromDirectory(File dir) throws IOException {
         var visitor = new SimpleFileVisitor<Path>() {
@@ -344,9 +336,8 @@ public abstract class GenerateTestBuildInfoTask extends DefaultTask {
     }
 
     /**
-     * Whether a {@code .class} file name denotes an anonymous or local class, i.e. the segment right
-     * after the last {@code $} begins with a digit (e.g. {@code Outer$1.class}, {@code Outer$1Local.class}).
-     * Such names are not stable across compilations and must not be used as a representative class.
+     * True if the class file name denotes an anonymous or local class (the segment after the last
+     * {@code $} begins with a digit, e.g. {@code Outer$1.class}).
      */
     private static boolean isAnonymousOrLocal(String fileName) {
         int dollar = fileName.lastIndexOf('$');

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/TestBuildInfoParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/TestBuildInfoParser.java
@@ -108,12 +108,9 @@ public class TestBuildInfoParser {
     }
 
     /**
-     * Parse the server build-info and fold in the locations of every self-representing library on the classpath.
-     * Foreign-library modules ({@code libs/zstd}, {@code libs/native}, {@code libs/simdvec}) emit a
-     * {@code lib-test-build-info.json} so their annotation-processor generated {@code $Impl}/{@code $Provider}
-     * classes — which no other build-info records — get a location; see {@code ForeignLibraryPlugin}. These
-     * libraries are part of the server trust boundary and are entitled through server scopes keyed on their module
-     * name, so their locations join the server build-info and are resolved with server scope.
+     * Parses the server build-info and folds in locations from any {@code lib-test-build-info.json} files on
+     * the classpath. Foreign-library modules emit these so their generated {@code $Impl}/{@code $Provider}
+     * classes are resolved with server scope.
      */
     public static TestBuildInfo parseServerAndLibTestBuildInfo() throws IOException {
         var serverTestBuildInfo = parseServerTestBuildInfo();

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/TestBuildInfoParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/TestBuildInfoParser.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class TestBuildInfoParser {
 
     private static final String PLUGIN_TEST_BUILD_INFO_RESOURCES = "META-INF/plugin-test-build-info.json";
+    private static final String LIB_TEST_BUILD_INFO_RESOURCES = "META-INF/lib-test-build-info.json";
     private static final String SERVER_TEST_BUILD_INFO_RESOURCE = "META-INF/server-test-build-info.json";
 
     private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("test_build_info", Builder::new);
@@ -76,18 +77,22 @@ public class TestBuildInfoParser {
     }
 
     public static List<TestBuildInfo> parseAllPluginTestBuildInfo() throws IOException {
+        return parseAll(PLUGIN_TEST_BUILD_INFO_RESOURCES);
+    }
+
+    private static List<TestBuildInfo> parseAll(String resourceName) throws IOException {
         var xContent = XContentFactory.xContent(XContentType.JSON);
-        List<TestBuildInfo> pluginsTestBuildInfos = new ArrayList<>();
-        var resources = TestBuildInfoParser.class.getClassLoader().getResources(PLUGIN_TEST_BUILD_INFO_RESOURCES);
+        List<TestBuildInfo> testBuildInfos = new ArrayList<>();
+        var resources = TestBuildInfoParser.class.getClassLoader().getResources(resourceName);
         while (resources.hasMoreElements()) {
             try (
                 var stream = getStream(resources.nextElement());
                 var parser = xContent.createParser(XContentParserConfiguration.EMPTY, stream)
             ) {
-                pluginsTestBuildInfos.add(fromXContent(parser));
+                testBuildInfos.add(fromXContent(parser));
             }
         }
-        return pluginsTestBuildInfos;
+        return testBuildInfos;
     }
 
     public static TestBuildInfo parseServerTestBuildInfo() throws IOException {
@@ -100,6 +105,30 @@ public class TestBuildInfoParser {
         try (var stream = getStream(resource); var parser = xContent.createParser(XContentParserConfiguration.EMPTY, stream)) {
             return fromXContent(parser);
         }
+    }
+
+    /**
+     * Parse the server build-info and fold in the locations of every self-representing library on the classpath.
+     * Foreign-library modules ({@code libs/zstd}, {@code libs/native}, {@code libs/simdvec}) emit a
+     * {@code lib-test-build-info.json} so their annotation-processor generated {@code $Impl}/{@code $Provider}
+     * classes — which no other build-info records — get a location; see {@code ForeignLibraryPlugin}. These
+     * libraries are part of the server trust boundary and are entitled through server scopes keyed on their module
+     * name, so their locations join the server build-info and are resolved with server scope.
+     */
+    public static TestBuildInfo parseServerAndLibTestBuildInfo() throws IOException {
+        var serverTestBuildInfo = parseServerTestBuildInfo();
+        if (serverTestBuildInfo == null) {
+            return null;
+        }
+        var libsTestBuildInfo = parseAll(LIB_TEST_BUILD_INFO_RESOURCES);
+        if (libsTestBuildInfo.isEmpty()) {
+            return serverTestBuildInfo;
+        }
+        List<TestBuildInfoLocation> locations = new ArrayList<>(serverTestBuildInfo.locations());
+        for (var libTestBuildInfo : libsTestBuildInfo) {
+            locations.addAll(libTestBuildInfo.locations());
+        }
+        return new TestBuildInfo(serverTestBuildInfo.component(), locations);
     }
 
     @SuppressForbidden(reason = "URLs from class loader")

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/bootstrap/TestEntitlementBootstrap.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/bootstrap/TestEntitlementBootstrap.java
@@ -95,7 +95,7 @@ public class TestEntitlementBootstrap {
 
     private static TestPolicyManager createPolicyManager(PathLookup pathLookup) throws IOException {
         var pluginsTestBuildInfo = TestBuildInfoParser.parseAllPluginTestBuildInfo();
-        var serverTestBuildInfo = TestBuildInfoParser.parseServerTestBuildInfo();
+        var serverTestBuildInfo = TestBuildInfoParser.parseServerAndLibTestBuildInfo();
         List<String> pluginNames = pluginsTestBuildInfo.stream().map(TestBuildInfo::component).toList();
 
         var pluginDescriptors = parsePluginsDescriptors(pluginNames);


### PR DESCRIPTION
Foreign-library modules live in libs and are part of the server trust
boundary, but nothing generated their entitlement test-build-info: they
free-rode on server-test-build-info for scope resolution. That left the
annotation processor's generated $Impl/$Provider classes, which sit in a
sibling generated-foreign-library-classes directory that no build-info
recorded, resolving to component [(unknown)] and failing native-library
entitlement checks in a module's own tests.

Have the foreign-library plugin generate a lib-test-build-info.json for
such modules, enumerating both the main classes directory and the
generated directory, and have the test entitlement bootstrap fold those
locations into the server build-info. The build-info task now emits a
location for a directory of only generated nested classes and attributes
a project's output directories to the single module it declares.
