### PR TITLE
[ML][Backport 9.5] Reject blank datafeed ID in stop datafeed request

### DIFF
--- a/docs/changelog/157929.yaml
+++ b/docs/changelog/157929.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 157929
+summary: Reject blank datafeed ID in stop datafeed request
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -157,6 +158,11 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
 
         @Override
         public ActionRequestValidationException validate() {
+            if (Strings.isNullOrBlank(datafeedId)) {
+                ActionRequestValidationException e = new ActionRequestValidationException();
+                e.addValidationError(DatafeedConfig.ID.getPreferredName() + " cannot be empty");
+                return e;
+            }
             return null;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -158,7 +158,7 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
 
         @Override
         public ActionRequestValidationException validate() {
-            if (Strings.isNullOrBlank(datafeedId)) {
+            if (Strings.hasText(datafeedId) == false) {
                 ActionRequestValidationException e = new ActionRequestValidationException();
                 e.addValidationError(DatafeedConfig.ID.getPreferredName() + " cannot be empty");
                 return e;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedActionRequestTests.java
@@ -6,11 +6,15 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction.Request;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 public class StopDatafeedActionRequestTests extends AbstractXContentSerializingTestCase<Request> {
 
@@ -48,5 +52,15 @@ public class StopDatafeedActionRequestTests extends AbstractXContentSerializingT
     @Override
     protected Request doParseInstance(XContentParser parser) {
         return Request.parseRequest(null, parser);
+    }
+
+    public void testValidate_rejectsBlankDatafeedId() {
+        for (String blank : new String[] { "", "   " }) {
+            Request request = new Request(blank);
+            ActionRequestValidationException e = request.validate();
+            assertNotNull("expected validation error for datafeed_id=[" + blank + "]", e);
+            assertThat(e.validationErrors(), hasSize(1));
+            assertThat(e.validationErrors().get(0), containsString("datafeed_id"));
+        }
     }
 }


### PR DESCRIPTION
Backport of #157929 to 9.5.

**Fix:** `Strings.isNullOrBlank` is not available on 9.5; replaced with `Strings.hasText(datafeedId) == false` which is semantically identical and available on all backport branches.