### PR TITLE
[9.5] Fix composite agg on doc values skipper fields

### DIFF
--- a/docs/changelog/158060.yaml
+++ b/docs/changelog/158060.yaml
@@ -1,0 +1,6 @@
+area: Mapping
+issues:
+ - 158008
+pr: 158060
+summary: Fix composite agg on doc values skipper fields
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/30_composite_agg.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/30_composite_agg.yml
@@ -6,7 +6,7 @@
   # field, so both of these fall back to a SortedDocsProducer, which reads the absent points index or terms
   # dictionary and silently collects nothing.
   - requires:
-      test_runner_features: [capabilities, cluster_features]
+      test_runner_features: [capabilities]
       cluster_features: ["search.aggs.composite.doc_values_skipper_fix"]
       capabilities:
         - method: PUT

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/30_composite_agg.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/30_composite_agg.yml
@@ -1,0 +1,91 @@
+---
+"composite aggregation on fields backed only by a doc values skipper":
+  # In a logsdb index that does not sort on @timestamp first, @timestamp gets a doc values skipper and no
+  # points index, and a non-indexed keyword gets a skipper and no terms dictionary. The composite
+  # aggregation only takes the index sort shortcut when the leading source matches the leading index sort
+  # field, so both of these fall back to a SortedDocsProducer, which reads the absent points index or terms
+  # dictionary and silently collects nothing.
+  - requires:
+      test_runner_features: [capabilities, cluster_features]
+      cluster_features: ["search.aggs.composite.doc_values_skipper_fix"]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [logsdb_index_mode]
+      reason: "Fix for composite aggregation silently returning zero buckets on doc-values-skipper fields required"
+
+  - do:
+      indices.create:
+        index: test-composite
+        body:
+          settings:
+            index:
+              mode: logsdb
+              number_of_shards: 1
+              number_of_replicas: 0
+              sort.field: [ "host.name", "@timestamp" ]
+              sort.order: [ "asc", "desc" ]
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              host.name:
+                type: keyword
+              service:
+                type: keyword
+                index: false
+
+  - do:
+      bulk:
+        index: test-composite
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:00:00Z", "host.name": "foo", "service": "a" }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:16:00Z", "host.name": "bar", "service": "b" }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:31:00Z", "host.name": "foo", "service": "c" }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:46:00Z", "host.name": "bar", "service": "a" }
+
+  - do:
+      search:
+        index: test-composite
+        body:
+          size: 0
+          aggs:
+            c:
+              composite:
+                size: 100
+                sources:
+                  - d:
+                      date_histogram:
+                        field: "@timestamp"
+                        fixed_interval: 15m
+
+  - length: { aggregations.c.buckets: 4 }
+  - match: { aggregations.c.buckets.0.key.d: 1707732000000 }
+  - match: { aggregations.c.buckets.0.doc_count: 1 }
+  - match: { aggregations.c.buckets.3.key.d: 1707734700000 }
+  - match: { aggregations.c.buckets.3.doc_count: 1 }
+
+  - do:
+      search:
+        index: test-composite
+        body:
+          size: 0
+          aggs:
+            c:
+              composite:
+                size: 100
+                sources:
+                  - s:
+                      terms:
+                        field: service
+
+  - length: { aggregations.c.buckets: 3 }
+  - match: { aggregations.c.buckets.0.key.s: "a" }
+  - match: { aggregations.c.buckets.0.doc_count: 2 }
+  - match: { aggregations.c.buckets.1.key.s: "b" }
+  - match: { aggregations.c.buckets.2.key.s: "c" }

--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -96,6 +96,14 @@ public final class SearchFeatures implements FeatureSpecification {
     public static final NodeFeature FETCH_FIELDS_EXCLUDES_NON_METADATA_TYPE = new NodeFeature(
         "search.fetch_fields.excludes_non_metadata_type"
     );
+    /**
+     * Composite aggregation no longer silently returns zero buckets when the leading source is a field
+     * backed only by a doc values skipper (no points index for dates, no terms dictionary for
+     * non-indexed keywords). Previously, {@code checkIfSortedDocsIsApplicable} accepted any index-sort
+     * shortcut and built a {@code SortedDocsProducer} against the absent BKD tree or terms dictionary,
+     * which collected nothing and reported success.
+     */
+    public static final NodeFeature COMPOSITE_AGG_DOC_VALUES_SKIPPER_FIX = new NodeFeature("search.aggs.composite.doc_values_skipper_fix");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -130,7 +138,8 @@ public final class SearchFeatures implements FeatureSpecification {
             DATE_HISTOGRAM_HARD_BOUNDS_OUTSIDE_DATA_FIX,
             COUNT_STATS_PARAMETER,
             FETCH_FIELDS_EXCLUDES_NON_METADATA_TYPE,
-            NESTED_KNN_INNER_HITS_MATCH_QUERY_PHASE_SCORING
+            NESTED_KNN_INNER_HITS_MATCH_QUERY_PHASE_SCORING,
+            COMPOSITE_AGG_DOC_VALUES_SKIPPER_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -261,7 +261,11 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
         query = extractQuery(query);
-        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
+        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false
+            // Number fields with index_terms=true use inverted index and PointsSortedDocsProducer needs bkd tree / points.
+            // If index_terms=true, we need to bail here, otherwise composite agg always return zero buckets.
+            || fieldType.indexType().hasPoints() == false
+            || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
             return null;
         }
         final byte[] lowerPoint;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -261,11 +261,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     SortedDocsProducer createSortedDocsProducerOrNull(IndexReader reader, Query query) {
         query = extractQuery(query);
-        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false
-            // Number fields with index_terms=true use inverted index and PointsSortedDocsProducer needs bkd tree / points.
-            // If index_terms=true, we need to bail here, otherwise composite agg always return zero buckets.
-            || fieldType.indexType().hasPoints() == false
-            || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
+        if (checkIfSortedDocsIsApplicable(reader, fieldType) == false || checkMatchAllOrRangeQuery(query, fieldType.name()) == false) {
             return null;
         }
         final byte[] lowerPoint;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
@@ -143,8 +143,11 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
     /**
      * Returns true if a {@link SortedDocsProducer} should be used to optimize the execution.
      */
+    // TODO: Implementing mayDynamicallyPrune(IndexReader)/getUniqueValueCount() on other subclasses than just GlobalOrdinalValuesSource
+    // would let CompositeAggregator#getLeafCollector return inner.competitiveIterator() for numeric and date sources too.
+    // This matters for logsdb and tsdb, where @timestamp is always skipper backed.
     protected boolean checkIfSortedDocsIsApplicable(IndexReader reader, MappedFieldType fieldType) {
-        if (fieldType == null || (missingBucket && afterValue == null) || fieldType.indexType().supportsSortShortcuts() == false ||
+        if (fieldType == null || (missingBucket && afterValue == null) || fieldType.indexType().hasDenseIndex() == false ||
         // inverse of the natural order
             reverseMul == -1) {
             return false;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -9,7 +9,11 @@
 
 package org.elasticsearch.search.aggregations.bucket.composite;
 
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Term;
@@ -20,12 +24,16 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -256,6 +264,200 @@ public class SingleDimensionValuesSourceTests extends ESTestCase {
                 }
             assertNull(source.createSortedDocsProducerOrNull(mockIndexReader(100, 49), null));
         }
+    }
+
+    /**
+     * A field that is only backed by a doc values skipper has no BKD tree, so building a
+     * {@link PointsSortedDocsProducer} for it would silently collect nothing. This is the shape that
+     * {@code @timestamp} takes in a logsdb or tsdb index that sorts on it, and it regressed when
+     * {@code IndexType#supportsSortShortcuts} started accepting doc values skippers.
+     */
+    public void testSkipperBackedFieldsDoNotProduceAPointsProducer() {
+        IndexReader reader = mockIndexReader(1, 1);
+
+        MappedFieldType skipperDate = dateFieldType("@timestamp", IndexType.skippers());
+        assertNull(longSource(skipperDate).createSortedDocsProducerOrNull(reader, null));
+        assertNull(longSource(skipperDate).createSortedDocsProducerOrNull(reader, Queries.ALL_DOCS_INSTANCE));
+        assertNull(longSource(skipperDate).createSortedDocsProducerOrNull(reader, new FieldExistsQuery("@timestamp")));
+
+        MappedFieldType skipperLong = new NumberFieldMapper.NumberFieldType(
+            "number",
+            NumberFieldMapper.NumberType.LONG,
+            IndexType.skippers(),
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            null,
+            false,
+            null,
+            null,
+            false,
+            false,
+            false
+        );
+        assertNull(longSource(skipperLong).createSortedDocsProducerOrNull(reader, null));
+        assertNull(longSource(skipperLong).createSortedDocsProducerOrNull(reader, Queries.ALL_DOCS_INSTANCE));
+
+        // an [index_terms] numeric has a dense index, but it is an inverted index rather than a BKD tree
+        MappedFieldType indexTermsLong = new NumberFieldMapper.NumberFieldType(
+            "number",
+            NumberFieldMapper.NumberType.LONG,
+            IndexType.terms(true, true),
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            null,
+            false,
+            null,
+            null,
+            false,
+            false,
+            true
+        );
+        assertTrue(indexTermsLong.indexType().hasDenseIndex());
+        assertFalse(indexTermsLong.indexType().hasPoints());
+        assertNull(longSource(indexTermsLong).createSortedDocsProducerOrNull(reader, null));
+
+        // a legacy archived date exposes points metadata derived from doc values, but still has no BKD tree
+        MappedFieldType archivedDate = dateFieldType("@timestamp", IndexType.archivedPoints());
+        assertTrue(archivedDate.indexType().hasPointsMetadata());
+        assertFalse(archivedDate.indexType().hasPoints());
+        assertNull(longSource(archivedDate).createSortedDocsProducerOrNull(reader, null));
+
+        // the same fields keep the optimization when they do have a points index
+        MappedFieldType indexedDate = new DateFieldMapper.DateFieldType("@timestamp");
+        assertNotNull(longSource(indexedDate).createSortedDocsProducerOrNull(reader, null));
+        MappedFieldType indexedLong = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
+        assertNotNull(longSource(indexedLong).createSortedDocsProducerOrNull(reader, null));
+    }
+
+    /**
+     * The terms equivalent of {@link #testSkipperBackedFieldsDoNotProduceAPointsProducer()}. A keyword that is
+     * only backed by a doc values skipper has no terms dictionary, so {@link TermsSortedDocsProducer} finds a
+     * null {@link org.apache.lucene.index.Terms} and collects nothing. This is the shape that {@code host.name}
+     * takes in logsdb, and that any {@code index: false} keyword takes once doc values skippers are enabled.
+     */
+    public void testSkipperBackedKeywordDoesNotProduceATermsProducer() {
+        IndexReader reader = mockIndexReader(1, 1);
+        MappedFieldType skipperKeyword = skipperBackedKeyword("keyword");
+
+        assertNull(globalOrdinalsSource(skipperKeyword).createSortedDocsProducerOrNull(reader, null));
+        assertNull(globalOrdinalsSource(skipperKeyword).createSortedDocsProducerOrNull(reader, Queries.ALL_DOCS_INSTANCE));
+        assertNull(binarySource(skipperKeyword).createSortedDocsProducerOrNull(reader, null));
+        assertNull(binarySource(skipperKeyword).createSortedDocsProducerOrNull(reader, Queries.ALL_DOCS_INSTANCE));
+    }
+
+    /**
+     * An indexed keyword keeps the terms optimization, so the assertions above are about the missing terms
+     * dictionary rather than about keywords in general. This guards against the terms fix over-reaching.
+     */
+    public void testIndexedKeywordStillProducesATermsProducer() {
+        IndexReader reader = mockIndexReader(1, 1);
+        MappedFieldType keyword = new KeywordFieldMapper.KeywordFieldType("keyword");
+
+        assertNotNull(globalOrdinalsSource(keyword).createSortedDocsProducerOrNull(reader, null));
+        assertNotNull(binarySource(keyword).createSortedDocsProducerOrNull(reader, null));
+    }
+
+    /**
+     * {@code missing_bucket: true} disables the optimization only while there is no after key, so on an affected
+     * build it masks the defect on the first page of a composite aggregation and then returns nothing once the
+     * caller pages with the after key it was just handed. The skipper check has to hold in both states.
+     */
+    public void testSkipperBackedDateIsRejectedWhenPaginatingWithMissingBucket() {
+        IndexReader reader = mockIndexReader(1, 1);
+        MappedFieldType skipperDate = dateFieldType("@timestamp", IndexType.skippers());
+        MappedFieldType indexedDate = new DateFieldMapper.DateFieldType("@timestamp");
+
+        // with no after key, missing_bucket alone is enough to skip the optimization for either field
+        assertNull(longSource(skipperDate, true).createSortedDocsProducerOrNull(reader, null));
+        assertNull(longSource(indexedDate, true).createSortedDocsProducerOrNull(reader, null));
+
+        // an after key re-enables it, so only the missing points index keeps the skipper backed field out
+        LongValuesSource skipperWithAfter = longSource(skipperDate, true);
+        skipperWithAfter.setAfter(100L);
+        assertNull(skipperWithAfter.createSortedDocsProducerOrNull(reader, null));
+
+        LongValuesSource indexedWithAfter = longSource(indexedDate, true);
+        indexedWithAfter.setAfter(100L);
+        assertNotNull(indexedWithAfter.createSortedDocsProducerOrNull(reader, null));
+    }
+
+    private static MappedFieldType dateFieldType(String name, IndexType indexType) {
+        return new DateFieldMapper.DateFieldType(
+            name,
+            indexType,
+            false,
+            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
+            DateFieldMapper.Resolution.MILLISECONDS,
+            null,
+            null,
+            Collections.emptyMap()
+        );
+    }
+
+    /**
+     * Builds a keyword field type with doc values and a doc values skipper but no inverted index, which is what
+     * {@code index: false} produces once {@code index.mapping.use_doc_values_skipper} is on.
+     */
+    private static MappedFieldType skipperBackedKeyword(String name) {
+        FieldType fieldType = new FieldType();
+        fieldType.setIndexOptions(IndexOptions.NONE);
+        fieldType.setDocValuesType(DocValuesType.SORTED_SET);
+        fieldType.setDocValuesSkipIndexType(DocValuesSkipIndexType.RANGE);
+        fieldType.freeze();
+        MappedFieldType keyword = new KeywordFieldMapper.KeywordFieldType(name, fieldType, false);
+        assertTrue(keyword.indexType().hasDocValuesSkipper());
+        assertFalse(keyword.indexType().hasTerms());
+        return keyword;
+    }
+
+    private static LongValuesSource longSource(MappedFieldType fieldType) {
+        return longSource(fieldType, false);
+    }
+
+    private static LongValuesSource longSource(MappedFieldType fieldType, boolean missingBucket) {
+        return new LongValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            fieldType,
+            context -> null,
+            value -> value,
+            DocValueFormat.RAW,
+            missingBucket,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
+    }
+
+    private static GlobalOrdinalValuesSource globalOrdinalsSource(MappedFieldType fieldType) {
+        return new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            fieldType,
+            0L,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
+    }
+
+    private static BinaryValuesSource binarySource(MappedFieldType fieldType) {
+        return new BinaryValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            breaker -> {},
+            fieldType,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
     }
 
     private static IndexReader mockIndexReader(int maxDoc, int numDocs) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -293,32 +293,10 @@ public class SingleDimensionValuesSourceTests extends ESTestCase {
             null,
             null,
             false,
-            false,
             false
         );
         assertNull(longSource(skipperLong).createSortedDocsProducerOrNull(reader, null));
         assertNull(longSource(skipperLong).createSortedDocsProducerOrNull(reader, Queries.ALL_DOCS_INSTANCE));
-
-        // an [index_terms] numeric has a dense index, but it is an inverted index rather than a BKD tree
-        MappedFieldType indexTermsLong = new NumberFieldMapper.NumberFieldType(
-            "number",
-            NumberFieldMapper.NumberType.LONG,
-            IndexType.terms(true, true),
-            false,
-            false,
-            null,
-            Collections.emptyMap(),
-            null,
-            false,
-            null,
-            null,
-            false,
-            false,
-            true
-        );
-        assertTrue(indexTermsLong.indexType().hasDenseIndex());
-        assertFalse(indexTermsLong.indexType().hasPoints());
-        assertNull(longSource(indexTermsLong).createSortedDocsProducerOrNull(reader, null));
 
         // a legacy archived date exposes points metadata derived from doc values, but still has no BKD tree
         MappedFieldType archivedDate = dateFieldType("@timestamp", IndexType.archivedPoints());


### PR DESCRIPTION
Backport #158060 to 9.5 branch.

A composite aggregation silently returned zero buckets when its leading source was a field backed only by a doc values skipper. In a `logsdb` or `time_series` index that does not sort on @timestamp first, @timestamp gets a skipper and no points index, so a date_histogram source built a PointsSortedDocsProducer against an absent BKD tree, which collects nothing and reports success. The same happens for a non-indexed keyword, whose TermsSortedDocsProducer finds no terms dictionary.

The `SortedDocsProducer` logic is only reachable when the leading source does not match the leading index sort field, which is why the default `logs-*-*` sort on host.name exposes it and an @timestamp first sort does not.

checkIfSortedDocsIsApplicable now requires a dense index rather than any sort shortcut, since a skipper prunes by value but cannot be iterated in value order. `LongValuesSource` requires an additional points index check, because a number based field mapper might have `index_terms` enabled, which replaces bkd tree for inverted index and `LongValuesSource` only support bkd tree.