### PR TITLE
[ESQL] Clear reminted parquet/orc filters

### DIFF
--- a/docs/changelog/158155.yaml
+++ b/docs/changelog/158155.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158155
+summary: Clear reminted parquet/orc filters
+type: bug

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -171,6 +171,12 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
 
     @Override
     public FormatReader withPushedFilter(Object pushedFilter) {
+        if (pushedFilter == null) {
+            if (this.pushedFilter == null && this.pushedExpressions == null) {
+                return this;
+            }
+            return new OrcFormatReader(blockFactory, null, null, dynamicThreshold, declaredDateFormats, declaredTypeColumns);
+        }
         if (pushedFilter instanceof SearchArgument sarg) {
             return new OrcFormatReader(this.blockFactory, sarg, null, dynamicThreshold, declaredDateFormats, declaredTypeColumns);
         }

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -60,6 +61,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.junit.After;
 import org.junit.Before;
@@ -842,6 +844,66 @@ public class OrcFormatReaderTests extends ESTestCase {
     public void testWithPushedFilterNullReturnsThis() {
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
         assertSame("withPushedFilter(null) must return same instance", reader, reader.withPushedFilter(null));
+    }
+
+    public void testWithPushedFilterNullClearsExistingFilter() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 5;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            for (int i = 0; i < 5; i++) {
+                idCol.vector[i] = i + 1;
+            }
+        });
+
+        SearchArgument sarg = SearchArgumentFactory.newBuilder()
+            .startNot()
+            .lessThanEquals("id", PredicateLeaf.Type.LONG, 100L)
+            .end()
+            .build();
+
+        OrcFormatReader filtered = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
+        StorageObject storageObject = createStorageObject(orcData);
+        try (CloseableIterator<Page> filteredIter = filtered.read(storageObject, null, 1024)) {
+            assertFalse("No rows should match the filter", filteredIter.hasNext());
+        }
+
+        FormatReader cleared = filtered.withPushedFilter(null);
+        assertNotSame("withPushedFilter(null) must fork when a filter is installed", filtered, cleared);
+        assertSame("second null is identity", cleared, cleared.withPushedFilter(null));
+        assertEquals(5, countRows((OrcFormatReader) cleared, storageObject, null, 1024));
+    }
+
+    public void testWithPushedFilterNullClearsPushedExpressions() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        byte[] orcData = createOrcFile(schema, batch -> {
+            batch.size = 5;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            for (int i = 0; i < 5; i++) {
+                idCol.vector[i] = i + 1;
+            }
+        });
+
+        OrcPushedExpressions pushed = new OrcPushedExpressions(
+            List.of(
+                new GreaterThan(
+                    Source.EMPTY,
+                    new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG),
+                    new Literal(Source.EMPTY, 100L, DataType.LONG),
+                    null
+                )
+            )
+        );
+        OrcFormatReader filtered = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(pushed);
+        StorageObject storageObject = createStorageObject(orcData);
+        try (CloseableIterator<Page> filteredIter = filtered.read(storageObject, null, 1024)) {
+            assertFalse("No rows should match the pushed expressions", filteredIter.hasNext());
+        }
+
+        FormatReader cleared = filtered.withPushedFilter(null);
+        assertNotSame("withPushedFilter(null) must fork when expressions are installed", filtered, cleared);
+        assertSame("second null is identity", cleared, cleared.withPushedFilter(null));
+        assertEquals(5, countRows((OrcFormatReader) cleared, storageObject, null, 1024));
     }
 
     public void testReadWithPushedFilterMatchingAll() throws Exception {

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-multifile.csv-spec
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/resources/parquet-multifile.csv-spec
@@ -7,8 +7,8 @@
 //                           rows: charlie(50, paris), dave(60, london)
 // The mixed-temporal (ts:date/date_nanos) and lossy-representation (code:integer/keyword) columns live in the
 // SEPARATE {{employees_multifile_temporal}} and {{employees_multifile_type_drift}} fixtures, used only by the
-// parquetUbnMixedTemporal* / parquetUbnMixedRepresentation tests below, so they do not perturb this fixture's
-// first-file-wins and widened-column tests.
+// parquetUbnMixedTemporal* / parquetUbnMixedRepresentation* / parquetUbnFilterTypeDriftedColumn tests below,
+// so they do not perturb this fixture's first-file-wins and widened-column tests.
 //
 // Authored as FROM <dataset>: each test declares its source via a `dataset:` directive. ParquetFormatSpecIT
 // registers the dataset on every storage backend and runs the FROM query verbatim. The dataset name encodes
@@ -130,6 +130,25 @@ warningRegex:Schema reconciliation widened columns to keyword due to cross-file 
 
 lo:keyword | hi:keyword
 10         | 9
+;
+
+// Filter on the type-drifted `code` column: INTEGER in A {2,9}, KEYWORD in B {10,11}, widened to
+// KEYWORD. UNION_BY_NAME remints withPushedFilter(null) on the INT file; that clear must stick so
+// FilterExec re-applies lexicographically on the unified page. "9" > "5"; "2"/"10"/"11" do not.
+parquetUbnFilterTypeDriftedColumn
+required_capability: external_command
+required_capability: external_source_read_schema
+dataset: employees_type_drift_union: "{{employees_multifile_type_drift}}" WITH {"schema_resolution": "union_by_name"}
+
+FROM employees_type_drift_union
+| WHERE code > "5"
+| KEEP id, code
+| SORT id ASC;
+warningRegex:Column \[code\] widened to keyword:.*distinct types: \[integer, keyword\]
+warningRegex:Schema reconciliation widened columns to keyword due to cross-file type disagreement.*
+
+id:integer | code:keyword
+2          | 9
 ;
 
 parquetUbnFilterWidenedColumn

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -316,6 +316,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
+        if (pushedFilter == null) {
+            if (pushedExpressions == null && FilterCompat.isFilteringRequired(this.pushedFilter) == false) {
+                return this;
+            }
+            return new ParquetFormatReader(
+                blockFactory,
+                FilterCompat.NOOP,
+                null,
+                forceBaselinePath,
+                optimizedReader,
+                dynamicThreshold,
+                declaredDateFormats,
+                declaredTypeColumns
+            );
+        }
         if (pushedFilter instanceof FilterCompat.Filter filter) {
             return new ParquetFormatReader(
                 blockFactory,

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetBloomFilterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetBloomFilterTests.java
@@ -27,9 +27,14 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
@@ -211,6 +216,42 @@ public class ParquetBloomFilterTests extends ESTestCase {
     }
 
     /**
+     * {@code withPushedFilter(null)} must drop a previously installed {@link FilterCompat.Filter}.
+     * Uses a predicate that matches no rows so the clear is observable as a full read.
+     */
+    public void testWithPushedFilterNullClearsExistingFilter() throws IOException {
+        byte[] parquetData = createParquetFileWithBloomFilter();
+        FilterPredicate filter = FilterApi.eq(FilterApi.longColumn("id"), 999999L);
+        ParquetFormatReader filtered = new ParquetFormatReader(blockFactory).withPushedFilter(FilterCompat.get(filter));
+        assertEquals(0, readAllRows(filtered, parquetData));
+
+        ParquetFormatReader cleared = filtered.withPushedFilter(null);
+        assertNotSame(filtered, cleared);
+        assertSame(cleared, cleared.withPushedFilter(null));
+        assertEquals(300, readAllRows(cleared, parquetData));
+    }
+
+    /**
+     * {@code withPushedFilter(null)} must drop previously installed {@link ParquetPushedExpressions},
+     * the opaque type the coordinator stamps at plan time and remints per file. Uses a LONG
+     * comparison that matches no rows so the clear is observable as a full read.
+     */
+    public void testWithPushedFilterNullClearsPushedExpressions() throws IOException {
+        byte[] parquetData = createParquetFileWithBloomFilter();
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(
+            List.of(new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 1000L, DataType.LONG), null))
+        );
+        ParquetFormatReader filtered = new ParquetFormatReader(blockFactory).withPushedFilter(pushed);
+        assertEquals(0, readAllRows(filtered, parquetData));
+
+        ParquetFormatReader cleared = filtered.withPushedFilter(null);
+        assertNotSame(filtered, cleared);
+        assertSame(cleared, cleared.withPushedFilter(null));
+        assertEquals(300, readAllRows(cleared, parquetData));
+    }
+
+    /**
      * Test that filterPushdownSupport returns non-null.
      */
     public void testFilterPushdownSupport() {
@@ -257,7 +298,10 @@ public class ParquetBloomFilterTests extends ESTestCase {
         if (filter != null) {
             reader = reader.withPushedFilter(FilterCompat.get(filter));
         }
+        return readAllRows(reader, parquetData);
+    }
 
+    private int readAllRows(ParquetFormatReader reader, byte[] parquetData) throws IOException {
         StorageObject storageObject = createStorageObject(parquetData);
         int totalRows = 0;
         try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(List.of("id", "value", "name"), 1000))) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -19,9 +19,10 @@ import java.util.function.Consumer;
  * Bundles all per-read execution parameters that were previously spread across 12+ method overloads.
  * <p>
  * Format-specific configuration (delimiter, encoding, etc.) lives on the reader instance via
- * {@link FormatReader#withConfig}. Per-query optimizer hints (pushed filters) live on the reader
- * instance via {@link FormatReader#withPushedFilter}. This context carries only the parameters
- * that may vary per file or per split within a single query execution.
+ * {@link FormatReader#withConfig}. Optimizer hints (pushed filters) live on the reader
+ * instance via {@link FormatReader#withPushedFilter} and are reminted per file. This context
+ * carries only the parameters that may vary per file or per split within a single query
+ * execution.
  *
  * @param projectedColumns columns to read. {@code null} means "no projection info available — read
  *                         every column" (backward compatibility default). An <em>empty</em> list

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReader.java
@@ -35,8 +35,9 @@ import java.util.concurrent.Executor;
  * which returns a unified {@link SourceMetadata} containing schema and source information.
  * <p>
  * Per-query format configuration (delimiter, encoding, etc.) is set on the reader instance
- * via {@link #withConfig(Map)}. Per-query optimizer hints (pushed filters for row-group
- * or stripe skipping) are set via {@link #withPushedFilter(Object)}. Per-read execution
+ * via {@link #withConfig(Map)}. Optimizer hints (pushed filters for row-group or stripe
+ * skipping) are set via {@link #withPushedFilter(Object)} from the plan and reminted per
+ * file. Per-read execution
  * parameters (projection, batch size, limit, error policy, split config) are bundled in
  * {@link FormatReadContext}.
  */
@@ -214,12 +215,19 @@ public interface FormatReader extends Closeable {
      * local physical optimization. Only format readers that support predicate pushdown
      * (e.g., Parquet row-group skipping, ORC stripe-level predicates) need to override this.
      * <p>
-     * The filter is per-query: it applies identically to every file/split in the query.
-     * Implementations should cast the filter to their expected type and return a new reader
-     * instance with the filter stored as an instance field.
+     * The filter is installed from the plan, then reminted per {@code FileSplit}: a file that
+     * cannot host the planned predicate (missing column, or a one-way widening with no safe
+     * inverse) is given {@code null} so the residual {@code FilterExec} re-applies on the
+     * unified page. {@code null} means this instance has no pushed filter — clear any filter a
+     * previous call installed. Unrecognized types return {@code this}.
+     * <p>
+     * Implementations should cast the filter to their expected type. Applying or clearing a
+     * recognized filter returns a new reader with the filter stored as an instance field;
+     * already-clear {@code null} and unrecognized types return {@code this}.
      *
-     * @param pushedFilter opaque filter object, or null if no filter was pushed
-     * @return a new reader with the filter applied, or {@code this} if the filter is not applicable
+     * @param pushedFilter opaque filter object, or {@code null} to clear
+     * @return a new reader with the filter applied or cleared, or {@code this} if the filter
+     *         is not applicable (unrecognized type, or already clear when {@code null})
      */
     default FormatReader withPushedFilter(Object pushedFilter) {
         return this;


### PR DESCRIPTION
The coordinator remints withPushedFilter(null) per file when a
predicate cannot be hosted. Parquet and ORC treated null as a
no-op, leaving the plan-time KEYWORD filter on INT files and
500ing. Honor null as a clear so FilterExec re-applies.