### PR TITLE
Bump es-native-cross-toolchain to :4 for shared native builds

### DIFF
--- a/libs/simdvec/README.md
+++ b/libs/simdvec/README.md
@@ -69,7 +69,8 @@ The native kernels cover single-pair and bulk scoring for:
 
 The native library is built via the `Makefile` in `native/`. For
 cross-compilation of all three platform binaries (darwin-aarch64,
-linux-aarch64, linux-x64), use the Docker-based toolchain:
+linux-aarch64, linux-x64), use the shared Docker-based toolchain image
+(`es-native-cross-toolchain`, also used by `libs/simdjson`):
 
 ```bash
 # Build the cross-compilation toolchain image

--- a/libs/simdvec/native/Dockerfile.cross-toolchain
+++ b/libs/simdvec/native/Dockerfile.cross-toolchain
@@ -7,16 +7,18 @@
 # License v3.0 only", or the "Server Side Public License, v 1".
 #
 
-# Cross-compilation toolchain image for libvec.
+# Cross-compilation toolchain image for Elasticsearch native libraries (libvec,
+# libsimdjson, and future native modules).
 # Contains clang-21 (all targets: Darwin, Linux x64, Linux aarch64).
-# No macOS SDK required — Darwin builds use a minimal C++ std library
-# (tinystd) bundled in the source tree, with clang's freestanding headers.
+#
+# libvec: Darwin builds use a minimal C++ std library (tinystd) bundled in the
+# source tree; Linux cross builds use libstdc++-14-dev-*-cross (default sysroot).
+#
+# libsimdjson: Linux cross builds pin libstdc++ to GCC 8 (GLIBCXX_3.4.25) via
+# the archived buster packages below; Makefiles select headers with -nostdinc++.
 #
 # To build and push (see also build_cross_toolchain_image.sh):
-#   docker build \
-#     -f Dockerfile.cross-toolchain \
-#     -t docker.elastic.co/es-dev/es-native-cross-toolchain:3 .
-#   docker push docker.elastic.co/es-dev/es-native-cross-toolchain:3
+#   ./build_cross_toolchain_image.sh
 
 FROM debian:trixie-slim
 
@@ -37,10 +39,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         make \
+        curl \
+        xz-utils \
+        bzip2 \
         clang-21 \
         lld-21 \
         llvm-21 \
         llvm-21-tools \
         libstdc++-14-dev-arm64-cross \
         libstdc++-14-dev-amd64-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+# GCC 8 libstdc++ cross packages are no longer in current Debian releases;
+# pull them from the archived buster suite. libsimdjson selects these via
+# Makefile flags (-nostdinc++); libvec continues to use libstdc++-14 above.
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian buster main" \
+        > /etc/apt/sources.list.d/buster-libstdcxx8-archive.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libstdc++-8-dev-arm64-cross \
+        libstdc++-8-dev-amd64-cross \
+        linux-libc-dev-arm64-cross \
+        linux-libc-dev-amd64-cross \
     && rm -rf /var/lib/apt/lists/*

--- a/libs/simdvec/native/build_cross_toolchain_image.sh
+++ b/libs/simdvec/native/build_cross_toolchain_image.sh
@@ -8,7 +8,8 @@
 # License v3.0 only", or the "Server Side Public License, v 1".
 #
 
-# Builds and pushes the cross-compilation toolchain image for libvec.
+# Builds and pushes the cross-compilation toolchain image for Elasticsearch
+# native libraries (libvec, libes_simdjson, and future native modules).
 # Run this script when compiler versions need updating.
 # No Mac or macOS SDK required — can be run on any machine with Docker.
 #
@@ -27,7 +28,7 @@ case "${1:-}" in
   *)       echo "Usage: $0 [--local]" >&2; exit 1 ;;
 esac
 
-VERSION=3
+VERSION=4
 HOST=docker.elastic.co
 REPOSITORY=elasticsearch-infra/es-native-cross-toolchain
 IMAGE=$HOST/$REPOSITORY:$VERSION

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -47,7 +47,7 @@ if [ "$UPLOAD" = true ] && [ -z "${ARTIFACTORY_API_KEY:-}" ]; then
   exit 1;
 fi
 
-TOOLCHAIN_IMAGE="docker.elastic.co/elasticsearch-infra/es-native-cross-toolchain:3"
+TOOLCHAIN_IMAGE="docker.elastic.co/elasticsearch-infra/es-native-cross-toolchain:4"
 if [ "$LOCAL" = true ]; then
   TOOLCHAIN_IMAGE="es-native-cross-toolchain:local"
 fi


### PR DESCRIPTION
This commit bumps the shared es-native-cross-toolchain Docker image from `:3` to `:4` so we have one cross-compilation container for Elasticsearch native libraries instead of per-module images.

@ldematte flagged this on the simdjson PR: the simdjson-specific image was just es-native-cross-toolchain:3 plus a few extra packages. Moving those packages into the base image keeps maintenance in one place and makes it easier to update compilers and sysroots.

What :4 adds:
 * GCC 8 libstdc++ cross headers and libraries from archived Debian buster, so libes_simdjson can pin to GLIBCXX_3.4.25 and run on RHEL 8 / glibc 2.28
 * curl, xz-utils, and bzip2 for macOS SDK fetch during cross builds

What stays the same for libvec:
 * libstdc++-14-dev cross packages remain; vec's Makefile is unchanged and still uses the default cross sysroot

Each library's Makefile continues to select its own stdlib. Only the container infra is unified.

Follow-up: once this merges and :4 is published, the simdjson PR can drop its own Dockerfile and build script and point publish_simdjson_binaries.sh at es-native-cross-toolchain:4.
