### PR TITLE
Use effective manifold dimensionality for error std in auto calibration

### DIFF
--- a/docs/changelog/158158.yaml
+++ b/docs/changelog/158158.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 158158
+summary: Use effective manifold dimensionality for error std in auto calibration
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
@@ -546,8 +546,8 @@ public final class ErrorModel {
      * not recomputed per encoding.
      * <p>
      * Measures OSQ error once at {@link #REAL_RESIDUAL_SAMPLE} and anchors the intercept at that sample
-     * size. The manifold slope {@code invDim} is used as the scaling exponent, so evaluating at the real corpus size {@code N}
-     * extrapolates as {@code errorStd = measuredStd × (REAL_RESIDUAL_SAMPLE / N)^invDim}.
+     * size. The manifold slope is used as the scaling exponent, sign-corrected for dot-like similarities, so evaluating at the
+     * real corpus size {@code N} extrapolates as {@code errorStd = measuredStd × (REAL_RESIDUAL_SAMPLE / N)^invDimEffective}.
      */
     public static QuantizationErrorStdModel estimateMagnitudeFromRealResiduals(
         double invDim,
@@ -577,10 +577,9 @@ public final class ErrorModel {
         }
         // 1/d is negative for similarities like cosine, so use -invDim
         double invDimEffective = ManifoldModel.isDotLike(source.similarityFunction()) ? -invDim : invDim;
-        // single measurement anchored at state.nDocs (not numVectors),
-        // so evaluating at N gives measuredStd × (state.nDocs / N)^invDim
+        // single measurement anchored at state.nDocs, so evaluating at N gives measuredStd × (state.nDocs / N)^invDimEffective
         double beta0 = Math.log(Math.max(r.std(), 1e-38)) - invDimEffective * (Math.log(nDocsPerCluster) - Math.log(state.nDocs));
-        return new QuantizationErrorStdModel(new Regression.OLSResult(beta0, invDim, 0, 0, 0, 0));
+        return new QuantizationErrorStdModel(new Regression.OLSResult(beta0, invDimEffective, 0, 0, 0, 0));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ExpectedRecall.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ExpectedRecall.java
@@ -129,14 +129,16 @@ public final class ExpectedRecall {
      * @return the cumulative probability that the rank is lower than the rank threshold
      */
     static double probabilityRankLessThanN(double[] rankDistances, double errorStd, int rankThreshold, double x) {
-        double mu = 0, stddevSq = 0;
+        double mu = 0;
+        double variance = 0;
         int limit = Math.min(RERANK_WINDOW_RANK_MULTIPLIER * rankThreshold, rankDistances.length);
         for (int i = 0; i < limit; i++) {
             double fx = normalCdf(x, rankDistances[i], errorStd);
             mu += fx;
-            stddevSq += fx * fx;
+            // variance of a sum of independent Bernoulli terms.
+            variance += fx * (1.0 - fx);
         }
-        double stddev = Math.sqrt(Math.max(1e-5, mu - stddevSq)); // avoid divide-by-zero
+        double stddev = Math.sqrt(Math.max(1e-5, variance)); // avoid divide-by-zero
         return normalCdf(rankThreshold, mu, stddev);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
@@ -132,7 +132,7 @@ public class ErrorModelTests extends ESTestCase {
 
     public void testEstimateQuantizationErrorStdModelReturnsFiniteModel() throws IOException {
         CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
+        CalibrationSource source = fixture.toSource(randomFrom(VectorSimilarityFunction.values()), 10);
         QuantizationErrorStdModel model = ErrorModel.estimateErrorScalingFit(source, 128).scalingModel();
         assertTrue(Double.isFinite(model.params().beta0()));
         assertTrue(Double.isFinite(model.params().beta1()));
@@ -141,7 +141,7 @@ public class ErrorModelTests extends ESTestCase {
 
     public void testEstimateMagnitudeModelReturnsFiniteModel() throws IOException {
         CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
+        CalibrationSource source = fixture.toSource(randomFrom(VectorSimilarityFunction.values()), 10);
         ErrorScalingFit scalingFit = ErrorModel.estimateErrorScalingFit(source, 128);
         QuantizationErrorStdModel magnitudeModel = ErrorModel.estimateMagnitudeModel(scalingFit, source, true, 4, 2, 128);
         assertTrue(Double.isFinite(magnitudeModel.params().beta0()));
@@ -151,7 +151,7 @@ public class ErrorModelTests extends ESTestCase {
 
     public void testEstimateMagnitudeModelReusesScalingSlope() throws IOException {
         CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
+        CalibrationSource source = fixture.toSource(randomFrom(VectorSimilarityFunction.values()), 10);
         ErrorScalingFit scalingFit = ErrorModel.estimateErrorScalingFit(source, 128);
         QuantizationErrorStdModel magnitudeModel = ErrorModel.estimateMagnitudeModel(scalingFit, source, true, 4, 2, 128);
         assertEquals(scalingFit.scalingModel().params().beta1(), magnitudeModel.params().beta1(), 0.0);
@@ -163,7 +163,7 @@ public class ErrorModelTests extends ESTestCase {
         int[] queryOrdinals = { 0, 1, 2, 3 };
         int[] corpusOrdinals = { 4, 5, 6, 7, 8, 9, 10, 11 };
         CalibrationSource source = new CalibrationSource(
-            VectorSimilarityFunction.EUCLIDEAN,
+            randomFrom(VectorSimilarityFunction.values()),
             8,
             fvv,
             queryOrdinals,
@@ -185,7 +185,7 @@ public class ErrorModelTests extends ESTestCase {
 
     public void testGrowingCorpusSweepReusesWarmStartCentroids() throws IOException {
         CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
+        CalibrationSource source = fixture.toSource(randomFrom(VectorSimilarityFunction.values()), 10);
         HierarchicalKMeans<float[]> kmeans = HierarchicalKMeans.ofSerial(CentroidOps.FLOAT, 8);
         float[][] docWarmStart = null;
         float[][] queryWarmStart = null;
@@ -230,7 +230,7 @@ public class ErrorModelTests extends ESTestCase {
 
     public void testMagnitudeFitReusesScalingFitClusteringState() throws IOException {
         CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
+        CalibrationSource source = fixture.toSource(randomFrom(VectorSimilarityFunction.values()), 10);
         ErrorScalingFit scalingFit = ErrorModel.estimateErrorScalingFit(source, 128);
         QuantizationErrorStdModel magnitudeModel = ErrorModel.estimateMagnitudeModel(scalingFit, source, true, 4, 2, 128);
         assertTrue(Double.isFinite(magnitudeModel.params().beta0()));
@@ -255,7 +255,7 @@ public class ErrorModelTests extends ESTestCase {
         float[][] rows = randomNormalizedRows(numQueries + corpusSize, dim, 43L);
         FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
         CalibrationSource source = new CalibrationSource(
-            VectorSimilarityFunction.EUCLIDEAN,
+            randomFrom(VectorSimilarityFunction.values()),
             dim,
             fvv,
             range(0, numQueries),
@@ -362,7 +362,7 @@ public class ErrorModelTests extends ESTestCase {
         float[][] rows = randomNormalizedRows(9000, dim, 7L);
         FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
         CalibrationSource source = new CalibrationSource(
-            VectorSimilarityFunction.EUCLIDEAN,
+            randomFrom(VectorSimilarityFunction.values()),
             dim,
             fvv,
             range(0, 256),


### PR DESCRIPTION
Fix the correct sign of the 1/d plugin for error standard deviation, for cosine / dot / max-inner-product.
It also includes a minor fix to keep every term non-negative in `ExpectedRecall#probabilityRankLessThanN`.