### PR TITLE
Fix relocated PIT context leak when closed before first search

### DIFF
--- a/docs/changelog/158159.yaml
+++ b/docs/changelog/158159.yaml
@@ -1,4 +1,4 @@
-area: "Distributed, Search"
+area: Search
 issues:
  - 157873
 pr: 158159

--- a/docs/changelog/158159.yaml
+++ b/docs/changelog/158159.yaml
@@ -1,0 +1,6 @@
+area: "Distributed, Search"
+issues:
+ - 157873
+pr: 158159
+summary: Fix relocated PIT context leak when closed before first search
+type: bug

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/SearchEngine.java
@@ -1703,7 +1703,7 @@ public class SearchEngine extends Engine {
     private class RelocatedPITReaderTracker implements Closeable {
 
         private final Set<RelocatedPITReader> trackedReaders = new HashSet<>();
-        private boolean closed = false;
+        private boolean trackerClosed = false;
 
         RelocatedPITReaderTracker() {}
 
@@ -1716,17 +1716,30 @@ public class SearchEngine extends Engine {
                 // waiting for the shard to transition to STARTED. If the shard is never started
                 // (e.g. recovery fails), no searcher is ever acquired.
                 private SearcherSupplier delegate = null;
-                private boolean closed = false;
+                private boolean supplierClosed = false;
 
                 @Override
                 protected synchronized void doClose() {
-                    closed = true;
-                    IOUtils.closeWhileHandlingException(delegate);
+                    supplierClosed = true;
+                    if (delegate != null) {
+                        IOUtils.closeWhileHandlingException(delegate);
+                    } else {
+                        // The lazy delegate (the real searcher) was never acquired.
+                        // Its storeRef and PITCommitHandle are still owned by the RelocatedPITReader
+                        // in trackedReaders — remove and close it now so those resources are not
+                        // held until engine close.
+                        synchronized (RelocatedPITReaderTracker.this) {
+                            if (trackerClosed == false) {
+                                trackedReaders.remove(relocatedPITReader);
+                                IOUtils.closeWhileHandlingException(relocatedPITReader);
+                            }
+                        }
+                    }
                 }
 
                 @Override
                 protected synchronized Searcher acquireSearcherInternal(String source) {
-                    if (closed) {
+                    if (supplierClosed) {
                         throw new AlreadyClosedException("SearcherSupplier was closed");
                     }
 
@@ -1784,17 +1797,17 @@ public class SearchEngine extends Engine {
 
         private void ensureOpen() {
             assert Thread.holdsLock(this);
-            if (closed) {
+            if (trackerClosed) {
                 throw new AlreadyClosedException("RelocatedPITReaderTracker is closed");
             }
         }
 
         @Override
         public synchronized void close() {
-            if (closed) {
+            if (trackerClosed) {
                 return;
             }
-            closed = true;
+            trackerClosed = true;
             IOUtils.closeWhileHandlingException(trackedReaders);
         }
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/SearchEngineTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/SearchEngineTests.java
@@ -920,6 +920,80 @@ public class SearchEngineTests extends AbstractEngineTestCase {
         );
     }
 
+    /**
+     * Verifies that closing a relocated PIT {@link SearcherSupplier} before any search is issued
+     * ("unprimed") releases the store reference and shared commit reader that were acquired during
+     * {@link SearchEngine#acquireSearcherForCommit}.
+     *
+     * <p>{@link SearchEngine#acquireSearcherForCommit} registers a {@code RelocatedPITReader} in
+     * {@code SearchEngine.RelocatedPITReaderTracker} and returns a lazy-initialisation wrapper
+     * {@link SearcherSupplier}: the real underlying supplier (the {@code delegate}) is only acquired
+     * on the first {@code acquireSearcher} call, deferring the Lucene searcher open until a search
+     * actually arrives. Until then the supplier is "unprimed" — {@code delegate} is {@code null}.
+     * The supplier is handed to {@code PITRelocationService}, which registers it with
+     * {@code SearchService} once the shard reaches STARTED. When the {@code SearchService.Reaper}
+     * expires a context before any search is issued, it closes the supplier while {@code delegate}
+     * is still {@code null}. Closing an unprimed supplier must remove the {@code RelocatedPITReader}
+     * from {@code SearchEngine.RelocatedPITReaderTracker.trackedReaders} and release its
+     * {@code storeRef} and {@code PITCommitHandle}, because those resources are not owned by anyone
+     * else at that point.
+     */
+    public void testUnprimedRelocatedPITSearcherSupplierReleasesResourcesOnClose() throws IOException {
+        final var indexConfig = indexConfig();
+        final var searchTaskQueue = new DeterministicTaskQueue();
+
+        try (
+            var indexEngine = newIndexEngine(indexConfig);
+            var searchEngine = newSearchEngineFromIndexEngine(indexEngine, searchTaskQueue)
+        ) {
+            indexEngine.index(randomDoc("1"));
+            indexEngine.flush();
+            notifyCommits(indexEngine, searchEngine);
+            searchTaskQueue.runAllRunnableTasks();
+
+            Engine.IndexCommitRef commit = searchEngine.acquireLastIndexCommit(false);
+            final String segmentsFileName = commit.getIndexCommit().getSegmentsFileName();
+            final Map<String, BlobFileRanges> metadata;
+            try (DirectoryReader reader = DirectoryReader.open(commit.getIndexCommit())) {
+                SearchDirectory searchDirectory = SearchDirectory.unwrapDirectory(reader.directory());
+                metadata = searchDirectory.getBlobFileRangesForFiles(commit.getIndexCommit().getFileNames());
+            }
+            IOUtils.close(commit);
+
+            final var store = searchEngine.config().getStore();
+            final int refCountBefore = store.refCount();
+            final int sharedReaderCountBefore = searchEngine.getSharedPITCommitReaderCount();
+
+            var supplierFuture = new PlainActionFuture<SearcherSupplier>();
+            searchEngine.acquireSearcherForCommit(
+                segmentsFileName,
+                metadata,
+                Function.identity(),
+                null,
+                SplitShardCountSummary.IRRELEVANT,
+                supplierFuture
+            );
+            searchTaskQueue.runAllRunnableTasks();
+            SearcherSupplier supplier = supplierFuture.actionGet(TimeValue.timeValueSeconds(5));
+
+            assertThat(store.refCount(), equalTo(refCountBefore + 1));
+            assertThat(searchEngine.getSharedPITCommitReaderCount(), equalTo(sharedReaderCountBefore + 1));
+
+            // Simulate closing the context before any search: close the supplier
+            // without ever calling acquireSearcher(), leaving the internal delegate null.
+            supplier.close();
+
+            // Closing an unprimed supplier must release the storeRef and PITCommitHandle
+            // that are still owned by the RelocatedPITReader in trackedReaders.
+            assertThat(store.refCount(), equalTo(refCountBefore));
+            assertThat(searchEngine.getSharedPITCommitReaderCount(), equalTo(sharedReaderCountBefore));
+        }
+        assertWarnings(
+            "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch and will be removed in a future release. "
+                + "See the breaking changes documentation for the next major version."
+        );
+    }
+
     public void testSegmentGenerationListenerNotLeakedOnConcurrentClose() throws Exception {
         var indexConfig = indexConfig();
         var searchTaskQueue = new DeterministicTaskQueue();


### PR DESCRIPTION
When a PIT is relocated to a search-tier node, SearchEngine registers a
RelocatedPITReader in RelocatedPITReaderTracker and returns a lazily-initialised
SearcherSupplier — the real underlying searcher is only opened on the first
search. If the SearchService.Reaper expires the context before any search
arrives, it closes the supplier while the delegate is still null, which was a
no-op: the store reference and PITCommitHandle held by the RelocatedPITReader
stayed stranded in trackedReaders until engine close.

The fix adds a check in SearcherSupplier.doClose(): when the delegate was never
initialised, the RelocatedPITReader is removed from trackedReaders and closed
immediately under the tracker lock, guarded against a race with concurrent
engine close.

Also adds a unit test in SearchEngineTests that acquires a SearcherSupplier via
acquireSearcherForCommit, closes it without issuing a search, and asserts that
the store ref count and shared commit reader count return to their
pre-acquisition baselines.

Closes #157873