### PR TITLE
[TEST] Improve cross-index-mode MV comparison

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/CrossIndexModeGenerativeIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/CrossIndexModeGenerativeIT.java
@@ -12,7 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.elasticsearch.xpack.esql.qa.rest.generative.CrossIndexModeGenerativeRestTest;
+import org.elasticsearch.xpack.esql.qa.rest.generative.CrossIndexModeGenerativeRestRunner;
 import org.junit.ClassRule;
 
 /**
@@ -24,7 +24,7 @@ import org.junit.ClassRule;
  */
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 @TestLogging(value = "org.elasticsearch.xpack.esql.plugin.ComputeService", reason = "see query plans on failure")
-public class CrossIndexModeGenerativeIT extends CrossIndexModeGenerativeRestTest {
+public class CrossIndexModeGenerativeIT extends CrossIndexModeGenerativeRestRunner {
 
     @ClassRule
     public static ElasticsearchCluster cluster = Clusters.testCluster();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
@@ -80,9 +80,9 @@ import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.availableDatasetsF
  * of known behavioral differences between {@code standard} and {@code columnar} mode that informed
  * {@link #EXCLUDED_DATASETS} and {@link #ALLOWED_MODE_DIFFERENCES}.
  */
-public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTest {
+public abstract class CrossIndexModeGenerativeRestRunner extends GenerativeRestTest {
 
-    private static final Logger logger = LogManager.getLogger(CrossIndexModeGenerativeRestTest.class);
+    private static final Logger logger = LogManager.getLogger(CrossIndexModeGenerativeRestRunner.class);
 
     /** Name prefix for reference-side indices (plain {@code standard} mode by default). */
     public static final String REF_PREFIX = "ref_";
@@ -120,14 +120,15 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
         // "POINT (116.072 5.975)" on columnar — a known encoding precision difference.
         "airports",
         "airports_web",
-        // Mapping designed to be type-incompatible with the standard employees dataset; its CSV
-        // data contains deliberate duplicates in boolean MV fields (e.g. [false,true,true]).
-        // SortedSetDocValues deduplicates those in standard mode while columnar may preserve them,
-        // producing spurious divergences that are not meaningful correctness signals.
+        // Mapping designed to be type-incompatible with the standard employees dataset; combining
+        // ref_employees_incompatible (with its altered field types) and ref_employees under a wildcard
+        // pattern produces type conflicts that cause schema divergences between the two modes.
         "employees_incompatible",
         // Multi-value double fields (rows carry [1.1], [1.1,2.2], …, [1.1,…,5.5]) cause COUNT to
         // diverge: standard mode counts individual MV values whereas columnar mode counts documents.
-        // Excluded until the COUNT-on-MV behaviour is reconciled between the two modes.
+        // Root cause: columnar mode disables point indexing for numeric fields, so
+        // SearchContextStats#detectSingleValue mis-detects them as single-valued and PushStatsToSource
+        // pushes COUNT down to a Lucene document count instead of a per-value count.
         "all_types_mv",
         // The all_types family uses mapping-all-types.json which contains `semantic_text` and
         // `dense_vector` field types. These types appear in field_caps for standard mode but are
@@ -176,7 +177,8 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
         "voyager",
         // Multi-value date fields (rows carry [1952,1962] and [2003,1998]) cause COUNT to diverge:
         // standard mode counts individual MV values while columnar mode counts documents. Same root
-        // cause as all_types_mv. Excluded until COUNT-on-MV behaviour is reconciled.
+        // cause as all_types_mv (SearchContextStats#detectSingleValue + PushStatsToSource push
+        // COUNT down to a document count for point-index-disabled fields).
         "mv_decades",
         // Cartesian multi-polygon shape data fails to bulk-index in columnar mode (the cartesian_shape
         // field cannot be stored via doc_values for synthetic source), leaving cand_cartesian_multipolygons
@@ -334,7 +336,7 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
      */
     @Before
     public void setupCrossModeIndices() throws IOException {
-        synchronized (CrossIndexModeGenerativeRestTest.class) {
+        synchronized (CrossIndexModeGenerativeRestRunner.class) {
             if (crossModeSetupDone) {
                 return;
             }
@@ -566,11 +568,13 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
             || cmdText.contains(": \"")) {
             return false;
         }
-        // Order-sensitive MV functions: standard mode returns multi-value fields in original
-        // insertion order; columnar mode (synthetic source from doc values) returns them in sorted
-        // order. These functions either select, slice, concatenate, or compute differences between
-        // consecutive elements in field order — all produce different output when the input ordering
-        // differs.
+        // Order-sensitive MV functions: columnar mode preserves the original source-insertion order
+        // of multi-value fields (via the array-order block loader), while standard mode returns them
+        // in ascending doc-values order (SortedNumericDocValues / SortedSetDocValues). These
+        // functions either select, slice, concatenate, or compute differences between consecutive
+        // elements in field order — all produce different output when the input ordering differs.
+        // See also: ints.csv-spec:795+, string.csv-spec:696+, mv_expand.csv-spec:104+
+        // (skip_columnar markers that document the same ordering divergence for each function).
         if (cmdText.contains("MV_SLICE(")
             || cmdText.contains("MV_FIRST(")
             || cmdText.contains("MV_LAST(")
@@ -584,27 +588,15 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
         if (cmdText.contains("LEAST(") || cmdText.contains("GREATEST(")) {
             return false;
         }
-        // FIRST() / LAST() aggregation functions pick a value from the row with the minimum or
-        // maximum sort-column value. They can be non-deterministic when there are ties in the sort
-        // column. Additionally, columnar mode has a known issue where FIRST() returns null for
-        // boolean MV fields instead of the correct multi-value boolean.
+        // FIRST() aggregation function picks a value from the row with the minimum sort-column
+        // value. It can be non-deterministic when there are ties. Additionally, columnar mode has a
+        // known issue where FIRST() returns null for boolean MV fields instead of the correct
+        // multi-value boolean. Note: contains("FIRST(") also matches MV_FIRST(, and
+        // contains("LAST(") matches MV_LAST(; both are correctly gated since the aggregate and the
+        // scalar function share the same ordering-sensitivity rationale.
+        // (The generator never emits a bare last(...) aggregate; LAST( here catches only MV_LAST(.)
         // TODO: remove once the columnar FIRST/LAST boolean bug is fixed.
         if (cmdText.contains("FIRST(") || cmdText.contains("LAST(")) {
-            return false;
-        }
-        // VARIANCE / STD_DEV are computed with Welford's algorithm, whose parallel-merge step
-        // (WelfordAlgorithm#add(mean, m2, count)) is not associative in floating point: it
-        // recombines the mean as (mean*count + meanValue*countValue)/(count+countValue), which
-        // rounds for non-power-of-two partial counts and leaves a residual delta. The streaming
-        // add(double) is exact for a constant column, so the result depends on how a group's rows
-        // are split across partial states and on the order those partials are merged — and that
-        // order is page arrival order out of ExchangeBuffer (a ConcurrentLinkedQueue), which is
-        // not pinned by the data. For a group whose values are all equal the true result is 0,
-        // but one side can return 0.0 while the other returns ~1e-32 — a difference that the
-        // 6-significant-figure rounding in canonicalValue cannot absorb, because relative rounding
-        // is meaningless at zero.
-        // See: https://github.com/elastic/elasticsearch/issues/156988
-        if (cmdText.contains("VARIANCE(") || cmdText.contains("STD_DEV(")) {
             return false;
         }
         // DISSECT and GROK applied to multi-value string fields: standard mode expands each element
@@ -629,19 +621,19 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
             || (("inline_stats".equals(cmdName) || "stats".equals(cmdName)) && cmdText.contains(" BY ") == false)) {
             return false;
         }
-        // DEDUP deduplicates rows by all column values. Multi-value fields are returned in
-        // insertion order in standard mode but in sorted order in columnar mode (synthetic source
-        // from doc values). Two rows that appear identical in columnar (both MV cells normalised
-        // to sorted order) may differ in standard (one cell [a,b], another [b,a]), so DEDUP can
-        // remove a different number of rows in each mode. Close the gate once DEDUP appears to
-        // prevent false-positive row-count divergences.
+        // DEDUP deduplicates rows by all column values. Columnar mode preserves MV fields in
+        // source-insertion order, while standard mode returns them in ascending doc-values order.
+        // Two rows that appear identical under standard-mode ordering (both MV cells sorted) may
+        // differ in columnar (one cell [a,b], another [b,a]), so DEDUP can remove a different
+        // number of rows in each mode. Close the gate once DEDUP appears to prevent false-positive
+        // row-count divergences.
         if ("dedup".equals(cmdName)) {
             return false;
         }
         // HIGHLIGHT returns a highlighted snippet from stored source (standard mode) versus
         // synthetic source / doc-values (columnar mode). For MV fields the highlighted value
-        // is selected by position — insertion order in standard, sorted order in columnar —
-        // so the returned snippet can legitimately differ between the two modes.
+        // is selected by position — doc-values order (sorted) in standard, source-insertion order
+        // in columnar — so the returned snippet can legitimately differ between the two modes.
         if ("highlight".equals(cmdName)) {
             return false;
         }
@@ -851,27 +843,52 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
      *       that no fixed significant-figure rounding can reconcile without becoming too coarse to
      *       catch real bugs.</li>
      *   <li>{@code flattened}: object values contain nested arrays (e.g. {@code host.ip}) whose
-     *       element order differs between stored source (original insertion order) and synthetic
-     *       source (doc-values order). Skipping prevents false-positive failures while schema
-     *       divergence (missing or renamed column) is still caught by the schema check.</li>
+     *       element order differs between columnar mode (source-insertion order, via the array-order
+     *       block loader) and standard mode (ascending doc-values order). Skipping prevents
+     *       false-positive failures while schema divergence (missing or renamed column) is still
+     *       caught by the schema check.</li>
      * </ul>
      */
     private static final Set<String> SKIP_VALUE_COLUMN_TYPES = Set.of("geo_point", "cartesian_point", "flattened");
 
     /**
+     * Column types backed by {@code SortedSetDocValues} in standard mode: ES|QL loads these via
+     * an ordinality-based block loader that returns values in ascending sorted order and drops
+     * duplicates. In columnar mode the array-order block loader is used instead, returning values
+     * in source-insertion order with duplicates preserved.
+     *
+     * <p>When comparing MV cells of these types the two sides can therefore differ in both ordering
+     * and cardinality: a keyword field stored as {@code ["b","a","a"]} yields {@code ["a","b"]} in
+     * standard mode but {@code ["b","a","a"]} in columnar mode. The canonical form renders such
+     * cells as a sorted, distinct (set-like) list so both representations compare equal.
+     *
+     * <p>Numeric and boolean types use {@code SortedNumericDocValues}, which sorts but does
+     * <em>not</em> deduplicate — the two sides differ only in ordering, which is already absorbed
+     * by the element-sort in {@link #toCanonical}. Those types are therefore <em>not</em> listed
+     * here; collapsing their duplicates would mask a real data-loss bug.
+     *
+     * <p>References: {@code keyword.md:137} ("may sort keyword fields and remove duplicates"),
+     * {@code ip.md:130}, {@code version.md:51}, and
+     * {@link org.elasticsearch.index.mapper.KeywordFieldMapper} {@code preservesArrayOrder()}.
+     */
+    static final Set<String> SORTED_SET_BACKED_TYPES = Set.of("keyword", "text", "ip", "version", "wildcard");
+
+    /**
      * Converts a result set to a list of canonical row strings for order-insensitive comparison.
      *
      * <p>Each cell is rendered by {@link #canonicalValue}. List-valued cells (multi-value fields)
-     * have their elements sorted before rendering to absorb ordering differences between stored and
-     * synthetic source — e.g. a keyword MV stored as {@code ["b","a"]} in the standard index and
-     * returned as {@code ["a","b"]} in the columnar (synthetic-source) index will compare equal.
+     * have their elements sorted before rendering to absorb the ordering difference: columnar mode
+     * returns MV fields in source-insertion order while standard mode returns them in ascending
+     * doc-values order. For types in {@link #SORTED_SET_BACKED_TYPES} (e.g. {@code keyword}),
+     * standard mode also deduplicates; cells of those types are additionally deduplicated here so
+     * that e.g. columnar's {@code ["b","a","a"]} and standard's {@code ["a","b"]} compare equal.
      *
      * <p>Columns whose type is in {@link #SKIP_VALUE_COLUMN_TYPES} are replaced by a constant
      * placeholder so that inherent precision differences (stored vs synthetic source coordinate
      * encoding) do not produce false-positive failures.
      */
     @SuppressWarnings("unchecked")
-    private static List<String> toCanonical(List<List<Object>> rows, List<Column> schema) {
+    static List<String> toCanonical(List<List<Object>> rows, List<Column> schema) {
         List<String> result = new ArrayList<>(rows.size());
         for (List<Object> row : rows) {
             StringBuilder sb = new StringBuilder();
@@ -891,6 +908,12 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
                         strs.add(canonicalValue(v));
                     }
                     Collections.sort(strs);
+                    if (SORTED_SET_BACKED_TYPES.contains(colType)) {
+                        // Deduplicate after sorting: standard mode's SortedSetDocValues removes
+                        // duplicates, while columnar mode preserves them. Collapsing them here lets
+                        // ["a","b"] (standard) == ["b","a","a"] (columnar) after sort+dedup.
+                        strs = strs.stream().distinct().toList();
+                    }
                     sb.append(strs);
                 } else {
                     sb.append(canonicalValue(val));
@@ -905,7 +928,13 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
      * Renders a single cell value as a canonical string.
      *
      * <p>Doubles are rounded to 6 significant figures to absorb tiny floating-point differences
-     * that arise when re-encoding values through doc values in columnar mode.
+     * that arise when re-encoding values through doc values in columnar mode. Additionally, values
+     * whose absolute magnitude is below {@code 1e-9} are snapped to {@code 0.0} to absorb the
+     * Welford parallel-merge residual that can leave one side at {@code 0.0} and the other at
+     * {@code ~1e-32} when the true result is zero (see
+     * <a href="https://github.com/elastic/elasticsearch/issues/156988">#156988</a>). The threshold
+     * is many orders of magnitude above the residual ({@code ~1e-32}) and many orders of magnitude
+     * below any meaningful small result in the CSV test datasets.
      *
      * <p>Strings that look like WKT geometry ({@code POINT (…)}, {@code POLYGON (…)}, etc.) have
      * their coordinate numbers rounded to the same 6 significant figures. Doc-values-based
@@ -913,10 +942,14 @@ public abstract class CrossIndexModeGenerativeRestTest extends GenerativeRestTes
      * example a stored {@code POINT (5.0 5.0)} can come back as
      * {@code POINT (4.999999953433871 4.999999995343387)} in columnar mode.
      */
-    private static String canonicalValue(Object val) {
+    static String canonicalValue(Object val) {
         if (val instanceof Double d) {
             if (Double.isNaN(d) || Double.isInfinite(d)) {
                 return String.valueOf(d);
+            }
+            // Snap near-zero values before relative rounding, which is meaningless at zero.
+            if (Math.abs(d) < 1e-9) {
+                return "0.0";
             }
             return String.valueOf(new BigDecimal(d).round(new MathContext(6, RoundingMode.HALF_DOWN)).doubleValue());
         }

--- a/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunnerTests.java
+++ b/x-pack/plugin/esql/qa/server/src/test/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunnerTests.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.rest.generative;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.generator.Column;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.qa.rest.generative.CrossIndexModeGenerativeRestRunner.SORTED_SET_BACKED_TYPES;
+import static org.elasticsearch.xpack.esql.qa.rest.generative.CrossIndexModeGenerativeRestRunner.canonicalValue;
+import static org.elasticsearch.xpack.esql.qa.rest.generative.CrossIndexModeGenerativeRestRunner.toCanonical;
+
+/**
+ * Unit tests for the canonicalisation helpers in {@link CrossIndexModeGenerativeRestRunner}.
+ *
+ * <p>These cover the type-aware MV cell comparison ({@code toCanonical}) and the near-zero
+ * double snap ({@code canonicalValue}). The helpers are package-private so this test can live
+ * in the same package without requiring reflection or changes to production accessibility.
+ */
+public class CrossIndexModeGenerativeRestRunnerTests extends ESTestCase {
+
+    // -----------------------------------------------------------------------
+    // SORTED_SET_BACKED_TYPES coverage
+    // -----------------------------------------------------------------------
+
+    public void testSortedSetBackedTypesContainsExpected() {
+        assertTrue(SORTED_SET_BACKED_TYPES.contains("keyword"));
+        assertTrue(SORTED_SET_BACKED_TYPES.contains("text"));
+        assertTrue(SORTED_SET_BACKED_TYPES.contains("ip"));
+        assertTrue(SORTED_SET_BACKED_TYPES.contains("version"));
+        assertTrue(SORTED_SET_BACKED_TYPES.contains("wildcard"));
+
+        // Numeric and boolean types must NOT be in this set: they use SortedNumericDocValues
+        // which sorts but does not deduplicate. Collapsing their duplicates would mask real bugs.
+        assertFalse(SORTED_SET_BACKED_TYPES.contains("long"));
+        assertFalse(SORTED_SET_BACKED_TYPES.contains("integer"));
+        assertFalse(SORTED_SET_BACKED_TYPES.contains("double"));
+        assertFalse(SORTED_SET_BACKED_TYPES.contains("boolean"));
+        assertFalse(SORTED_SET_BACKED_TYPES.contains("date"));
+    }
+
+    // -----------------------------------------------------------------------
+    // toCanonical — keyword MV: order + dedup absorbed
+    // -----------------------------------------------------------------------
+
+    /**
+     * Standard mode returns keyword MVs sorted and deduplicated (SortedSetDocValues).
+     * Columnar mode returns them in source-insertion order with duplicates.
+     * After canonicalisation both should compare equal.
+     */
+    public void testKeywordMvDeduplicatedEqualsColumnarMvWithDuplicates() {
+        // schema: one keyword column
+        List<Column> schema = List.of(new Column("kw", "keyword", List.of()));
+
+        // Standard: ["a","b"] (sorted + deduped from ["b","a","a"])
+        List<List<Object>> stdRows = List.of(List.of(List.of("a", "b")));
+        // Columnar: ["b","a","a"] (source order)
+        List<List<Object>> colRows = List.of(List.of(List.of("b", "a", "a")));
+
+        List<String> stdCanon = toCanonical(stdRows, schema);
+        List<String> colCanon = toCanonical(colRows, schema);
+
+        assertEquals("Standard and columnar keyword MV should canonicalise equal", stdCanon, colCanon);
+    }
+
+    /** Single-value keyword cells should also compare equal regardless of representation. */
+    public void testKeywordSingleValueEqual() {
+        List<Column> schema = List.of(new Column("kw", "keyword", List.of()));
+        List<List<Object>> rows = List.of(List.of("hello"));
+        List<String> canon = toCanonical(rows, schema);
+        assertEquals(List.of("hello"), canon);
+    }
+
+    // -----------------------------------------------------------------------
+    // toCanonical — long MV: order absorbed, duplicates retained
+    // -----------------------------------------------------------------------
+
+    /**
+     * Standard mode returns long MVs sorted with duplicates kept (SortedNumericDocValues).
+     * Columnar mode returns them in source-insertion order with duplicates.
+     * Sorting on both sides should make them equal.
+     */
+    public void testLongMvOrderAbsorbed() {
+        List<Column> schema = List.of(new Column("n", "long", List.of()));
+
+        // Standard: [1,1,2] (sorted, dups kept)
+        List<List<Object>> stdRows = List.of(List.of(List.of(1L, 1L, 2L)));
+        // Columnar: [2,1,1] (source order)
+        List<List<Object>> colRows = List.of(List.of(List.of(2L, 1L, 1L)));
+
+        assertEquals(toCanonical(stdRows, schema), toCanonical(colRows, schema));
+    }
+
+    /**
+     * Duplicate loss in long MV (one side has [1,1,2], other has [1,2]) must NOT be masked:
+     * these should canonicalise differently because long does not dedup.
+     */
+    public void testLongMvDuplicateLossDetected() {
+        List<Column> schema = List.of(new Column("n", "long", List.of()));
+
+        List<List<Object>> withDups = List.of(List.of(List.of(1L, 1L, 2L)));
+        List<List<Object>> withoutDup = List.of(List.of(List.of(1L, 2L)));
+
+        assertNotEquals(toCanonical(withDups, schema), toCanonical(withoutDup, schema));
+    }
+
+    // -----------------------------------------------------------------------
+    // toCanonical — boolean MV: order absorbed, duplicates retained
+    // -----------------------------------------------------------------------
+
+    /** Boolean MV: sorting absorbs order difference; duplicate retention is verified. */
+    public void testBooleanMvOrderAbsorbed() {
+        List<Column> schema = List.of(new Column("b", "boolean", List.of()));
+
+        // Standard: [false,true,true] (sorted, SortedNumericDocValues — dups kept)
+        List<List<Object>> stdRows = List.of(List.of(List.of(false, true, true)));
+        // Columnar: [true,false,true] (source order)
+        List<List<Object>> colRows = List.of(List.of(List.of(true, false, true)));
+
+        assertEquals(toCanonical(stdRows, schema), toCanonical(colRows, schema));
+    }
+
+    /** Boolean MV duplicate loss must be detected (boolean does not dedup in standard mode). */
+    public void testBooleanMvDuplicateLossDetected() {
+        List<Column> schema = List.of(new Column("b", "boolean", List.of()));
+
+        List<List<Object>> withDup = List.of(List.of(List.of(false, true, true)));
+        List<List<Object>> withoutDup = List.of(List.of(List.of(false, true)));
+
+        assertNotEquals(toCanonical(withDup, schema), toCanonical(withoutDup, schema));
+    }
+
+    // -----------------------------------------------------------------------
+    // toCanonical — SKIP_VALUE_COLUMN_TYPES placeholder
+    // -----------------------------------------------------------------------
+
+    /** geo_point columns are replaced by "~" regardless of value. */
+    public void testGeoPointColumnSkipped() {
+        List<Column> schema = List.of(new Column("loc", "geo_point", List.of()));
+        List<List<Object>> rows = List.of(List.of("POINT (1.0 2.0)"));
+        List<String> canon = toCanonical(rows, schema);
+        assertEquals(List.of("~"), canon);
+    }
+
+    // -----------------------------------------------------------------------
+    // canonicalValue — near-zero double snap
+    // -----------------------------------------------------------------------
+
+    /** Welford residual ~1e-32 must snap to "0.0". */
+    public void testNearZeroDoubleSnappedToZero() {
+        assertEquals("0.0", canonicalValue(1e-32));
+        assertEquals("0.0", canonicalValue(-1e-32));
+        assertEquals("0.0", canonicalValue(1e-10));
+        assertEquals("0.0", canonicalValue(0.0));
+    }
+
+    /** Values at or above 1e-9 must NOT be snapped. */
+    public void testSmallButMeaningfulDoubleNotSnapped() {
+        // 1e-9 is right at the boundary — we snap values strictly below 1e-9
+        String canon = canonicalValue(1e-3);
+        assertFalse("1e-3 should not snap to 0.0", canon.equals("0.0"));
+
+        String canon2 = canonicalValue(0.001);
+        assertFalse("0.001 should not snap to 0.0", canon2.equals("0.0"));
+    }
+
+    /** NaN and Infinity are returned as-is without snapping. */
+    public void testSpecialDoublesNotSnapped() {
+        assertEquals("NaN", canonicalValue(Double.NaN));
+        assertEquals("Infinity", canonicalValue(Double.POSITIVE_INFINITY));
+        assertEquals("-Infinity", canonicalValue(Double.NEGATIVE_INFINITY));
+    }
+
+    // -----------------------------------------------------------------------
+    // canonicalValue — 6-significant-figure rounding
+    // -----------------------------------------------------------------------
+
+    /** Non-trivial double is rounded to 6 significant figures. */
+    public void testDoubleRoundedToSixSigFigs() {
+        // 1.23456789 → 1.23457 (6 sig figs, HALF_DOWN)
+        String canon = canonicalValue(1.23456789);
+        assertFalse("Should be rounded, not full precision", canon.equals(String.valueOf(1.23456789)));
+    }
+
+    // -----------------------------------------------------------------------
+    // canonicalValue — WKT geometry coordinate normalisation
+    // -----------------------------------------------------------------------
+
+    public void testWktCoordinatesNormalised() {
+        String raw = "POINT (4.999999953433871 4.999999995343387)";
+        String canon = canonicalValue(raw);
+        // Both coordinates should round to something near 5.0
+        assertTrue("Expected normalised WKT, got: " + canon, canon.startsWith("POINT (5.0 5.0)"));
+    }
+
+    // -----------------------------------------------------------------------
+    // toCanonical — row ordering is multiset (rows sorted after canonicalisation)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Two result sets with the same rows in different order should produce the same canonical list
+     * after the caller sorts them (toCanonical itself does not sort rows — the caller does).
+     */
+    public void testCanonicalRowsCanBeSortedToCompare() {
+        List<Column> schema = List.of(new Column("x", "long", List.of()));
+
+        List<List<Object>> rowsA = List.of(List.of(1L), List.of(2L));
+        List<List<Object>> rowsB = List.of(List.of(2L), List.of(1L));
+
+        List<String> canonA = toCanonical(rowsA, schema);
+        List<String> canonB = toCanonical(rowsB, schema);
+
+        java.util.Collections.sort(canonA);
+        java.util.Collections.sort(canonB);
+
+        assertEquals(canonA, canonB);
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -104,7 +104,7 @@ public class CsvColumnarIT extends CsvIT {
      * Datasets excluded from the columnar variant because they either fail index creation in
      * columnar mode or produce legitimately different results by design. Each entry has a comment
      * naming the reason, cross-referenced to the catalogue in
-     * {@code CrossIndexModeGenerativeRestTest.EXCLUDED_DATASETS} and
+     * {@code CrossIndexModeGenerativeRestRunner.EXCLUDED_DATASETS} and
      * {@code LogsDbSubobjectsFalseVersusLogsDbColumnarRestIT} where applicable.
      *
      * <p>Note: several entries in the generative-test catalogue
@@ -125,7 +125,7 @@ public class CsvColumnarIT extends CsvIT {
         "airports_not_indexed_nor_doc_values",
         // geo_point fields are stored at different precision in columnar mode: to_string() returns
         // slightly different coordinates (e.g. "POINT (116.072 5.975)" vs "POINT (116.073 5.975)").
-        // See CrossIndexModeGenerativeRestTest.EXCLUDED_DATASETS.
+        // See CrossIndexModeGenerativeRestRunner.EXCLUDED_DATASETS.
         "airports",
         "airports_web",
         // Mapping designed to be type-incompatible with the standard employees dataset; its CSV


### PR DESCRIPTION
## Summary

`CrossIndexModeGenerativeRestRunner` (renamed from `CrossIndexModeGenerativeRestTest`) is the differential oracle that runs the same randomly-generated ES|QL pipeline against `ref_*` (standard) and `cand_*` (columnar) indices and compares results. The determinism gate was previously closed by many multi-value constructs because standard and columnar modes disagree on MV ordering and cardinality.

This PR makes the comparison smarter rather than giving up on value checking:

- **Type-aware MV cell canonicalization**: `keyword`, `text`, `ip`, `version`, and `wildcard` columns are backed by `SortedSetDocValues` in standard mode, which sorts _and_ deduplicates. Columnar mode preserves source-insertion order with duplicates. `toCanonical` now sorts and deduplicates MV cells for these types so `["b","a","a"]` (columnar) == `["a","b"]` (standard). Numeric/boolean types sort only — their duplicates are kept — so real duplicate-loss bugs are still caught.

- **Near-zero double snap**: Values with magnitude below 1e-9 are snapped to `"0.0"` before the 6-sig-fig relative rounding. This absorbs the Welford parallel-merge residual (~1e-32) that caused `VARIANCE`/`STD_DEV` to diverge when the true result is 0, allowing that gate to be removed.

- **Comment corrections**: Five comment blocks had standard/columnar MV ordering direction backwards (claimed standard=insertion order, columnar=sorted — exactly wrong). All corrected and cross-referenced to mapper code and docs. Added root-cause notes to `all_types_mv` and `mv_decades` exclusions.

- **Unit tests**: `CrossIndexModeGenerativeRestRunnerTests` covers type-aware MV dedup, duplicate retention for numeric types, near-zero snap, WKT normalization, and skip-column placeholders.

## Verification

- Unit tests: pass
- 100-iteration soak (`-Dtests.timeoutSuite=7200000!`): pass (27m 31s)
- `spotlessJavaCheck`: pass