### PR TITLE
Make /_cat/shards cancellable (#158024)

### DIFF
--- a/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/CatShardsRestCancellationIT.java
+++ b/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/CatShardsRestCancellationIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.http;
+
+import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
+import org.elasticsearch.common.settings.Settings;
+
+public class CatShardsRestCancellationIT extends BlockedSearcherRestCancellationTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // disable internal cluster info service to avoid internal indices stats calls
+            .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    public void testCatShardsRestCancellation() throws Exception {
+        runTest(new Request(HttpGet.METHOD_NAME, "/_cat/shards"), IndicesStatsAction.NAME);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -45,6 +45,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
@@ -88,9 +89,10 @@ public class RestShardsAction extends AbstractCatAction {
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices).indicesOptions(IndicesOptions.strictExpandHidden());
 
         return channel -> {
+            final var cancellableClient = new RestCancellableNodeClient(client, request.getHttpChannel());
             final var clusterStateFuture = new ListenableFuture<ClusterStateResponse>();
-            client.admin().cluster().state(clusterStateRequest, clusterStateFuture);
-            client.admin()
+            cancellableClient.admin().cluster().state(clusterStateRequest, clusterStateFuture);
+            cancellableClient.admin()
                 .indices()
                 .stats(
                     new IndicesStatsRequest().all().indices(indices).indicesOptions(IndicesOptions.strictExpandHidden()),


### PR DESCRIPTION
Change `/_cat/shards` so its transport calls go through `RestCancellableNodeClient`, same as other cancellable REST endpoints. When the HTTP channel closes, the related tasks should be cancelled.

This solves issue #158024