### PR TITLE
Un-exclude json_logs/voyager from columnar tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/CrossIndexModeGenerativeRestRunner.java
@@ -168,13 +168,6 @@ public abstract class CrossIndexModeGenerativeRestRunner extends GenerativeRestT
         // addresses_text: ref_employees (keyword) and ref_employees_gender_text (text) produce a
         // type conflict under ref_* wildcards, while cand_* consistently sees keyword in columnar.
         "employees_gender_text",
-        // Contains a `payload: text` field that survives columnar index creation (other fields
-        // provide doc_values) but causes the server to crash when queried in columnar mode.
-        // Until root-caused, exclude to prevent cluster instability during the generative test run.
-        "json_logs",
-        // Contains a `notes: text` field with the same issue as json_logs: cand_voyager creates
-        // successfully but querying it in columnar mode crashes the server.
-        "voyager",
         // Multi-value date fields (rows carry [1952,1962] and [2003,1998]) cause COUNT to diverge:
         // standard mode counts individual MV values while columnar mode counts documents. Same root
         // cause as all_types_mv (SearchContextStats#detectSingleValue + PushStatsToSource push

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvColumnarIT.java
@@ -152,10 +152,6 @@ public class CsvColumnarIT extends CsvIT {
         // Contains a plain txt:text field with no doc_values; fails index creation in columnar
         // mode because text without doc_values cannot be reconstructed from doc values.
         "text_state_mapped",
-        // Contains a plain text field; querying in columnar mode crashes the server.
-        // TODO: file an issue and reference it here.
-        "json_logs",
-        "voyager",
         // cartesian_shape field cannot be stored via doc_values for synthetic source, so bulk
         // indexing fails in columnar mode (zero documents indexed).
         "cartesian_multipolygons",


### PR DESCRIPTION
Both datasets were excluded from CrossIndexModeGenerativeRestRunner and CsvColumnarIT with a note that querying their text field (payload/notes) in columnar mode crashes the server. That crash does not reproduce on current main.

Verified no crash and full parity:
- Generative CrossIndexModeGenerativeIT creates and queries cand_json_logs and cand_voyager via FROM cand_*; multiple seeded runs pass with no hs_err JVM crash files and no value divergence.
- CsvColumnarIT runs the full csv-spec corpus (6504 tests) against columnar indices with these datasets included, including the FROM voyager FIRST/LAST tests and json_extract tests on json_logs: 0 failures.

Removing the stale exclusions regains text-in-columnar coverage.