### PR TITLE
[9.4] Skip audit logging for protobuf endpoints (#157666)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
@@ -14,15 +14,20 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 public class AuditUtil {
+
+    private static final Logger logger = LogManager.getLogger(AuditUtil.class);
 
     // We need to expose this to allow-list as a header passed for cross cluster requests; see `CrossClusterAccessServerTransportFilter`
     public static final String AUDIT_REQUEST_ID = "_xpack_audit_request_id";
@@ -32,7 +37,8 @@ public class AuditUtil {
      * <p>
      * If {@code maxBytes > 0} and the rendered JSON length exceeds that limit, an
      * {@link ElasticsearchStatusException} with status 413 is thrown so the caller can reject
-     * the request before it is written to the audit log.
+     * the request before it is written to the audit log. If the request has no XContent type
+     * (e.g. a protobuf endpoint), a short diagnostic string is returned rather than throwing.
      *
      * @param maxBytes   maximum allowed length of the rendered JSON string, in characters; {@code 0} = unlimited
      * @param settingKey the cluster setting key to include in the error message; may be {@code null}
@@ -42,7 +48,13 @@ public class AuditUtil {
         if (request.hasContent()) {
             var content = request.content();
             try {
-                String json = XContentHelper.convertToJson(content, false, false, request.getXContentType());
+                final XContentType xContentType = request.getXContentType();
+                if (xContentType == null) {
+                    final var parsedContentType = request.getParsedContentType();
+                    final String mediaType = parsedContentType != null ? parsedContentType.mediaTypeWithoutParameters() : "unknown";
+                    return "Unrecognized content type [" + mediaType + "]";
+                }
+                String json = XContentHelper.convertToJson(content, false, false, xContentType);
                 if (maxBytes > 0 && json.length() > maxBytes) {
                     throw new ElasticsearchStatusException(
                         "Request body size [{}] exceeds the audit body size limit [{}]; "
@@ -57,6 +69,7 @@ public class AuditUtil {
             } catch (ElasticsearchStatusException e) {
                 throw e;
             } catch (Exception e) {
+                logger.warn(() -> Strings.format("failed to read body of REST request [%s] for auditing", request.uri()), e);
                 return "Invalid Format: " + content.utf8ToString();
             }
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditUtilTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditUtilTests.java
@@ -20,8 +20,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
@@ -61,6 +63,23 @@ public class AuditUtilTests extends ESTestCase {
             XContentType.JSON
         ).build();
         assertEquals(json, AuditUtil.restRequestContent(request, 0, null));
+    }
+
+    public void testRestRequestContentNullXContentType() {
+        // Protobuf handlers set XContentType to null; restRequestContent must return a placeholder, not throw.
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(new BytesArray(new byte[] { 0x0A, 0x02 }), null)
+            .withHeaders(Map.of("Content-Type", List.of("application/x-protobuf")))
+            .build();
+        assertThat(AuditUtil.restRequestContent(request, 0, null), containsString("Unrecognized content type"));
+    }
+
+    public void testRestRequestContentInvalidBodyReturnsInvalidFormat() {
+        // Malformed YAML body: convertToJson throws; must not propagate, must return "Invalid Format".
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray("key: [unclosed".getBytes(StandardCharsets.UTF_8)),
+            XContentType.YAML
+        ).build();
+        assertThat(AuditUtil.restRequestContent(request, 0, null), containsString("Invalid Format"));
     }
 
     // ── indices ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Skip audit logging for protobuf endpoints (#157666)