### PR TITLE
fix(mapper): handle missing counts in contains query

### DIFF
--- a/docs/changelog/158187.yaml
+++ b/docs/changelog/158187.yaml
@@ -1,0 +1,5 @@
+area: Mapping
+issues: []
+pr: 158187
+summary: "Fix(mapper): handle missing counts in contains query"
+type: bug

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -10,124 +10,56 @@
 package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.DocValuesSkipper;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.search.ConstantScoreScorerSupplier;
-import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryVisitor;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.mapper.BinaryDocValuesFormat;
 import org.elasticsearch.index.mapper.BlockLoader;
-import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
 
 /**
- * A query that matches documents whose binary doc values contain a specific term. Only works with binary doc values
- * encoded using {@link org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.SeparateCount}.
+ * A query that matches documents whose binary doc values contain a specific term. It adds the whole-blob
+ * {@code tryContainsIterator} fast path on top of the {@link AbstractBinaryDocValuesQuery} scanning path.
  */
-public final class BinaryDocValuesContainsTermQuery extends Query {
-    final String fieldName;
-    final BytesRef containsTerm;
-    // Selects the decoder for the multi-valued fallback path; see BinaryDocValuesFormat.
-    final BinaryDocValuesFormat binaryFormat;
+public final class BinaryDocValuesContainsTermQuery extends AbstractBinaryDocValuesQuery {
+
+    private final BytesRef containsTerm;
 
     BinaryDocValuesContainsTermQuery(String fieldName, BytesRef containsTerm, BinaryDocValuesFormat binaryFormat) {
-        this.fieldName = Objects.requireNonNull(fieldName);
+        super(fieldName, bytes -> contains(bytes, containsTerm), binaryFormat);
         this.containsTerm = Objects.requireNonNull(containsTerm);
-        this.binaryFormat = Objects.requireNonNull(binaryFormat);
     }
 
     @Override
-    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-        float matchCost = matchCost();
-        // Captured for the binary doc values decode checkpoint below. This query is reached via rewrite() so it gets its own weight and
-        // must establish the breaker itself.
-        final CircuitBreaker breaker = ContextIndexSearcher.circuitBreakerOrNull(searcher);
-        return new ConstantScoreWeight(this, boost) {
-
-            @Override
-            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-                final FieldInfo fi = context.reader().getFieldInfos().fieldInfo(fieldName);
-                if (fi == null || fi.getDocValuesType() != DocValuesType.BINARY) {
-                    return null;
-                }
-                return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
-                    @Override
-                    public long cost() {
-                        return context.reader().maxDoc();
-                    }
-
-                    @Override
-                    public DocIdSetIterator iterator(long leadCost) throws IOException {
-                        // Checkpoint before opening: the probe is 0-byte heap sampling, so
-                        // checking before the allocation skips it entirely when under pressure.
-                        ContextIndexSearcher.checkBinaryDvDecodeBreaker(breaker);
-                        final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
-                        if (values == null) {
-                            return DocIdSetIterator.empty();
-                        }
-
-                        // The optimized path returns a TwoPhaseIterator-backed iterator (see the contract
-                        // on tryContainsIterator). ConstantScoreScorerSupplier unwraps the TwoPhase so Lucene's
-                        // BulkScorer drives approximation.advance(min) + matches() within [min, max), giving
-                        // linear scaling under sub-segment slicing (DataPartitioning.DOC).
-                        String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
-                        DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
-
-                        // tryContainsIterator scans the whole doc blob (including the multi-valued length-prefix framing), so it is only
-                        // correct for single-valued fields where no length prefixes exist.
-                        final DocIdSetIterator containsIter = (countsSkipper == null || countsSkipper.maxValue() == 1)
-                            && values instanceof BlockLoader.OptionalColumnAtATimeReader direct
-                                ? direct.tryContainsIterator(containsTerm)
-                                : null;
-
-                        if (containsIter != null) {
-                            return containsIter;
-                        }
-                        Predicate<BytesRef> predicate = bytes -> contains(bytes, containsTerm);
-                        final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
-                        return binaryFormat == BinaryDocValuesFormat.ARRAY_ORDER_INLINE_NULL
-                            ? AbstractBinaryDocValuesQuery.arrayOrderInlineNullIterator(values, counts, predicate, matchCost())
-                            : AbstractBinaryDocValuesQuery.multiValuedIterator(values, counts, predicate, matchCost());
-                    }
-                };
+    protected DocIdSetIterator getDocIdSetIterator(LeafReaderContext context, float matchCost) throws IOException {
+        final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
+        if (values == null) {
+            return null;
+        }
+        // tryContainsIterator scans the whole doc blob including the multi-valued length-prefix framing, so it is only
+        // correct for single-valued fields where no length prefixes exist.
+        final DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(fieldName + COUNT_FIELD_SUFFIX);
+        if ((countsSkipper == null || countsSkipper.maxValue() == 1) && values instanceof BlockLoader.OptionalColumnAtATimeReader direct) {
+            final DocIdSetIterator containsIter = direct.tryContainsIterator(containsTerm);
+            if (containsIter != null) {
+                return containsIter;
             }
-
-            @Override
-            public boolean isCacheable(LeafReaderContext ctx) {
-                return DocValues.isCacheable(ctx, fieldName);
-            }
-        };
+        }
+        return super.getDocIdSetIterator(context, matchCost);
     }
 
-    float matchCost() {
+    @Override
+    protected float matchCost() {
         return 10;
     }
 
     @Override
-    public void visit(QueryVisitor visitor) {
-        if (visitor.acceptField(fieldName)) {
-            visitor.visitLeaf(this);
-        }
-    }
-
     public String toString(String field) {
         return "BinaryDocValuesContainsTermQuery(fieldName=" + field + ",containsTerm=" + containsTerm + ")";
     }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesContainsTermQuery.java
@@ -61,7 +61,7 @@ public final class BinaryDocValuesContainsTermQuery extends AbstractBinaryDocVal
 
     @Override
     public String toString(String field) {
-        return "BinaryDocValuesContainsTermQuery(fieldName=" + field + ",containsTerm=" + containsTerm + ")";
+        return "BinaryDocValuesContainsTermQuery(fieldName=" + fieldName + ",containsTerm=" + containsTerm + ")";
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesScanningQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesScanningQueryTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.lucene.queries;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.elasticsearch.index.mapper.BinaryDocValuesFormat.SEPARATE_COUNT;
+
+/**
+ * Runs every binary doc-values scanning query over one single-valued corpus and checks the match counts. The corpus is
+ * written once with the {@code .counts} companion and once without (the {@code writeCounts} parameter), so the same
+ * assertions cover both encodings the scanning queries must read as single-valued. It is sparse (some documents have no
+ * value) so the whole-blob fast paths are disabled and every query goes through the shared scanning path.
+ */
+public class BinaryDocValuesScanningQueryTests extends ESTestCase {
+
+    private static final String FIELD = "field";
+
+    private final boolean writeCounts;
+
+    /**
+     * @param writeCounts whether each indexed value is written with its {@code .counts} companion, so the queries are
+     *                    exercised against both the counts-present and counts-absent single-valued encodings
+     */
+    public BinaryDocValuesScanningQueryTests(@Name("writeCounts") boolean writeCounts) {
+        this.writeCounts = writeCounts;
+    }
+
+    /** Runs the suite twice: once writing the {@code .counts} companion for each value and once omitting it. */
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        return List.of(new Object[] { true }, new Object[] { false });
+    }
+
+    public void testTermQuery() throws IOException {
+        assertMatchCount(new ScanningBinaryDocValuesTermQuery(FIELD, new BytesRef("research"), SEPARATE_COUNT), 1);
+    }
+
+    public void testPrefixQuery() throws IOException {
+        assertMatchCount(new ScanningBinaryDocValuesPrefixQuery(FIELD, "re", false, SEPARATE_COUNT), 1);
+    }
+
+    public void testWildcardQuery() throws IOException {
+        assertMatchCount(new ScanningBinaryDocValuesWildcardQuery(FIELD, "resea*", false, SEPARATE_COUNT), 1);
+    }
+
+    public void testRegexpQuery() throws IOException {
+        assertMatchCount(
+            new ScanningBinaryDocValuesRegexpQuery(
+                FIELD,
+                "re.*",
+                RegExp.ALL,
+                0,
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                SEPARATE_COUNT,
+                null
+            ),
+            1
+        );
+    }
+
+    public void testTermInSetQuery() throws IOException {
+        assertMatchCount(
+            new ScanningBinaryDocValuesTermInSetQuery(FIELD, List.of(new BytesRef("kibana"), new BytesRef("research")), SEPARATE_COUNT),
+            2
+        );
+    }
+
+    public void testContainsQuery() throws IOException {
+        assertMatchCount(new BinaryDocValuesContainsTermQuery(FIELD, new BytesRef("search"), SEPARATE_COUNT), 3);
+    }
+
+    private void assertMatchCount(Query query, int expected) throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newIndexWriter(dir)) {
+                indexValue(writer, "elasticsearch");
+                writer.addDocument(new Document());
+                indexValue(writer, "kibana");
+                indexValue(writer, "research");
+                writer.addDocument(new Document());
+                indexValue(writer, "logstash");
+                indexValue(writer, "searching");
+                try (IndexReader reader = writer.getReader()) {
+                    final IndexSearcher searcher = newSearcher(reader);
+                    assertEquals(expected, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    private void indexValue(RandomIndexWriter writer, String value) throws IOException {
+        final Document document = new Document();
+        final MultiValuedBinaryDocValuesField.SeparateCount field = new MultiValuedBinaryDocValuesField.SeparateCount(
+            FIELD,
+            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+        );
+        field.add(new BytesRef(value.getBytes(StandardCharsets.UTF_8)));
+        document.add(field);
+        if (writeCounts) {
+            document.add(NumericDocValuesField.indexedField(FIELD + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX, 1));
+        }
+        writer.addDocument(document);
+    }
+
+    private static RandomIndexWriter newIndexWriter(Directory dir) throws IOException {
+        final IndexWriterConfig iwc = newIndexWriterConfig();
+        iwc.setCodec(TestUtil.alwaysDocValuesFormat(new ES819TSDBDocValuesFormat()));
+        return new RandomIndexWriter(random(), dir, iwc);
+    }
+}


### PR DESCRIPTION
## TL;DR

`BinaryDocValuesContainsTermQuery` threw a shard-level `NullPointerException` when run over a single-valued binary doc-values keyword field that has no `.counts` companion. It was the only binary doc-values scanning query that did not fall back to single-valued handling when `.counts` is absent. This PR makes it reuse the shared scanning fallback that its siblings already use, and adds coverage for the whole family with and without the `.counts` companion. Because the fix removes the duplicated scanning path that had drifted from the shared base, it deletes more production code than it adds while pinning down more behavior in tests. It also takes the opportunity to correct the query's `toString`, which printed the passed field argument instead of its own field.

## Summary

Binary doc-values keyword fields (no inverted index) are searched by a family of scanning queries in `org.elasticsearch.lucene.queries`. For the `SEPARATE_COUNT` format they read a companion `.counts` numeric doc values field for each document's value count. A multi-valued field always writes `.counts`, so an absent `.counts` denotes a single-valued field and must be read as one.

`AbstractBinaryDocValuesQuery.getDocIdSetIterator`, shared by the `term` (`==`), `prefix`, `wildcard`, `regexp`, and `term-in-set` queries, already handles this: for `SEPARATE_COUNT` it falls back to `singleValuedIterator` when `counts` is null. `BinaryDocValuesContainsTermQuery` instead re-implemented the scanning path and always called `multiValuedIterator`, which builds a `TwoPhaseIterator` over the null `counts` and throws. This is why `==` on such a field worked while a `LIKE "*term*"` predicate (a wildcard rewritten to a contains query) failed. The fix makes the contains query extend `AbstractBinaryDocValuesQuery`, keeping only the `tryContainsIterator` fast path and delegating the scanning path to `super.getDocIdSetIterator`, so value-count handling lives in one place.

When a search spans multiple shards, a per-shard `NullPointerException` does not fail the request. It is returned as a partial result: the response still comes back successfully, the failing shard's contribution is simply missing, and the failure is buried in the per-shard failures rather than surfaced as an error. A hit count or a `STATS COUNT(*)` is then silently too low. Unless the caller inspects the partial-results flag or disables partial results, the wrong answer looks like a normal one, so the defect can go unnoticed.

## Changes

- `BinaryDocValuesContainsTermQuery`: extend `AbstractBinaryDocValuesQuery`, keep only the `tryContainsIterator` fast path, and delegate the scanning path to `super.getDocIdSetIterator`, which already reads an absent `.counts` as single-valued.
- `BinaryDocValuesScanningQueryTests`: runs every binary doc-values scanning query over a single-valued corpus, parameterized to write each value with and without its `.counts` companion, since a single-valued field can be stored either way and the queries must read both. The contains query threw before this change in the without-counts case, while the other queries already passed.
- `BinaryDocValuesContainsTermQuery.toString`: print the query's own `fieldName` rather than the passed default-field argument, matching the sibling scanning queries.

## Testing

```bash
./gradlew :server:test --tests "org.elasticsearch.lucene.queries.BinaryDocValuesScanningQueryTests"
```
