### PR TITLE
[9.4] [ML] Reject blank job id on close request (#158020)

### DIFF
--- a/docs/changelog/158020.yaml
+++ b/docs/changelog/158020.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 158020
+summary: Reject blank job id on close request
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CloseJobAction.java
@@ -6,9 +6,11 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -163,6 +165,16 @@ public class CloseJobAction extends ActionType<CloseJobAction.Response> {
                 }
             }
             return false;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            if (Strings.isNullOrBlank(jobId)) {
+                ActionRequestValidationException e = new ActionRequestValidationException();
+                e.addValidationError(Job.ID.getPreferredName() + " cannot be empty");
+                return e;
+            }
+            return super.validate();
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CloseJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CloseJobActionRequestTests.java
@@ -6,11 +6,15 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction.Request;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 public class CloseJobActionRequestTests extends AbstractXContentSerializingTestCase<Request> {
 
@@ -42,5 +46,15 @@ public class CloseJobActionRequestTests extends AbstractXContentSerializingTestC
     @Override
     protected Request doParseInstance(XContentParser parser) {
         return Request.parseRequest(null, parser);
+    }
+
+    public void testValidate_rejectsBlankJobId() {
+        for (String blank : new String[] { "", "   " }) {
+            Request request = new Request(blank);
+            ActionRequestValidationException e = request.validate();
+            assertNotNull("expected validation error for job_id=[" + blank + "]", e);
+            assertThat(e.validationErrors(), hasSize(1));
+            assertThat(e.validationErrors().get(0), containsString("job_id"));
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ML] Reject blank job id on close request (#158020)