### PR TITLE
[9.4] Lower logs-elasticsearch.querylog@template priority to avoid conflicts (#158188)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/activitylog/logs-elasticsearch.querylog@template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": ["${xpack.stack.querylog.template.pattern}"],
-  "priority": 250,
+  "priority": 240,
   "data_stream": {
     "hidden": false
   },


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Lower logs-elasticsearch.querylog@template priority to avoid conflicts (#158188)