### PR TITLE
ES|QL|DS Fix wrong file stats

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -115,10 +115,14 @@ public final class SplitDiscoveryPhase {
      * split coalescing.
      *
      * @param plan          the split-enriched physical plan
-     * @param filesScanned  distinct files contributing splits (file-based sources only; {@code 0} otherwise)
-     * @param splitsScanned total number of discovered splits across all external sources
-     * @param bytesScanned  sum of {@link ExternalSplit#estimatedSizeInBytes()} over the discovered splits,
-     *                      ignoring splits that report an unknown ({@code < 0}) size
+     * @param filesScanned  distinct files contributing splits; a source that falls through to a whole-list read
+     *                      (empty splits, not an exhaustive prune) contributes every file in the resolved list
+     * @param splitsScanned total number of discovered splits across all external sources; a source that falls
+     *                      through to a whole-list read contributes one unit per file, matching how the runtime
+     *                      reads it
+     * @param bytesScanned  sum of {@link ExternalSplit#estimatedSizeInBytes()} over the discovered splits, or the
+     *                      listed file sizes for a whole-list fall-through; either way only positive sizes are
+     *                      summed
      */
     public record Result(PhysicalPlan plan, int filesScanned, int splitsScanned, long bytesScanned) {}
 
@@ -313,11 +317,26 @@ public final class SplitDiscoveryPhase {
         if (splits.isEmpty()) {
             // No splits because every file was eliminated by a row-count-preserving filter contradiction (see
             // SplitDiscoveryResult#exhaustivelyPruned). Swap in FileList.EMPTY so the read path scans nothing; a row
-            // filter still runs downstream, so the answer is unchanged (0 rows). An empty result that is NOT an
-            // exhaustive prune (unresolved glob, SINGLE source, empty file list) falls through to the whole read.
-            // Return before the stats increments below to keep honest zero scanned counts.
+            // filter still runs downstream, so the answer is unchanged (0 rows) and the scanned counts stay an
+            // honest zero. An empty result that is NOT an exhaustive prune (unresolved glob, SINGLE source, empty
+            // file list, or a provider that could not certify its prune) falls through to the whole read.
             if (result.exhaustivelyPruned()) {
                 return exec.withFileList(FileList.EMPTY);
+            }
+            // The fall-through reads every file in the resolved list, each as one unit, so the accounting must say
+            // that: reporting zeros here would describe a full-dataset read as no work at all. An unresolved list
+            // reports zero because its listing has not happened yet (the counts do not exist at this layer), and a
+            // file-less SINGLE source reports zero by contract (SplitDiscoveryResult).
+            if (fileList != null && fileList.isResolved() && fileList.isEmpty() == false) {
+                int fileCount = fileList.fileCount();
+                stats.filesScanned += fileCount;
+                stats.splitsScanned += fileCount;
+                for (int i = 0; i < fileCount; i++) {
+                    long sizeInBytes = fileList.size(i);
+                    if (sizeInBytes > 0) {
+                        stats.bytesScanned += sizeInBytes;
+                    }
+                }
             }
             return exec;
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -272,17 +272,9 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         assertSame("the resolved fileList must be preserved for the whole read", fileList, ((ExternalSourceExec) result).fileList());
     }
 
-    /**
-     * A non-exhaustive empty result on a resolved, non-empty fileList means the provider dropped every file without
-     * certifying the prune as row-count-preserving, so the source falls through unchanged and the runtime reads the
-     * whole list. The scan accounting must describe that read (every file scanned, one split unit per file, the
-     * listed bytes) or the query profile reports a full-dataset read as zero files and zero bytes.
-     */
     public void testNonExhaustiveEmptyResultAccountsWholeRead() {
-        // createFileList sizes file i as 100*(i+1); three files => 100 + 200 + 300 bytes.
         FileList fileList = createFileList(3);
         ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
-        // Zero splits, but explicitly NOT an exhaustive prune: the read still happens.
         Map<String, ExternalSourceFactory> factories = Map.of(
             "parquet",
             testFactory(new FixedSplitProvider(new SplitDiscoveryResult(List.of(), 0, false)))
@@ -300,11 +292,6 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         assertEquals("the whole read scans the listed bytes", 600L, result.bytesScanned());
     }
 
-    /**
-     * A listed file with an unknown size (listed as 0, see FileSplitProvider's unlisted-length convention) still
-     * counts as a scanned file and split unit on the whole-read fall-through, but contributes nothing to the byte
-     * sum, mirroring the positive-size guard on the discovered-splits path.
-     */
     public void testNonExhaustiveEmptyResultSkipsUnknownSizes() {
         FileList fileList = GlobExpander.fileListOf(
             List.of(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseTests.java
@@ -273,6 +273,65 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
     }
 
     /**
+     * A non-exhaustive empty result on a resolved, non-empty fileList means the provider dropped every file without
+     * certifying the prune as row-count-preserving, so the source falls through unchanged and the runtime reads the
+     * whole list. The scan accounting must describe that read (every file scanned, one split unit per file, the
+     * listed bytes) or the query profile reports a full-dataset read as zero files and zero bytes.
+     */
+    public void testNonExhaustiveEmptyResultAccountsWholeRead() {
+        // createFileList sizes file i as 100*(i+1); three files => 100 + 200 + 300 bytes.
+        FileList fileList = createFileList(3);
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        // Zero splits, but explicitly NOT an exhaustive prune: the read still happens.
+        Map<String, ExternalSourceFactory> factories = Map.of(
+            "parquet",
+            testFactory(new FixedSplitProvider(new SplitDiscoveryResult(List.of(), 0, false)))
+        );
+
+        SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
+
+        assertSame("a non-exhaustive empty result must fall through unchanged, not be swapped to EMPTY", exec, result.plan());
+        assertEquals("the whole read that follows scans every file in the resolved list", 3, result.filesScanned());
+        assertEquals("the whole read processes each file as one unit", 3, result.splitsScanned());
+        assertEquals("the whole read scans the listed bytes", 600L, result.bytesScanned());
+    }
+
+    /**
+     * A listed file with an unknown size (listed as 0, see FileSplitProvider's unlisted-length convention) still
+     * counts as a scanned file and split unit on the whole-read fall-through, but contributes nothing to the byte
+     * sum, mirroring the positive-size guard on the discovered-splits path.
+     */
+    public void testNonExhaustiveEmptyResultSkipsUnknownSizes() {
+        FileList fileList = GlobExpander.fileListOf(
+            List.of(
+                new StorageEntry(StoragePath.of("s3://bucket/data/a.parquet"), 100, Instant.EPOCH),
+                new StorageEntry(StoragePath.of("s3://bucket/data/b.parquet"), 0, Instant.EPOCH)
+            ),
+            "s3://bucket/data/*.parquet"
+        );
+        ExternalSourceExec exec = createExternalSourceExec(fileList, "parquet");
+        Map<String, ExternalSourceFactory> factories = Map.of(
+            "parquet",
+            testFactory(new FixedSplitProvider(new SplitDiscoveryResult(List.of(), 0, false)))
+        );
+
+        SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
+
+        assertSame(exec, result.plan());
+        assertEquals(2, result.filesScanned());
+        assertEquals(2, result.splitsScanned());
+        assertEquals("only the known size contributes to the byte sum", 100L, result.bytesScanned());
+    }
+
+    /**
      * An unresolved fileList (glob not yet expanded — resolved and read at runtime) must NOT be swapped when discovery
      * returns no splits: there is nothing to prune yet, and swapping to EMPTY would make the source read nothing at
      * all. It falls through unchanged to the runtime whole-fileList read.
@@ -308,9 +367,16 @@ public class SplitDiscoveryPhaseTests extends ESTestCase {
         ExternalSourceExec exec = createExternalSourceExec(FileList.EMPTY, "parquet");
         Map<String, ExternalSourceFactory> factories = Map.of("parquet", testFactory(new RecordingSplitProvider()));
 
-        PhysicalPlan result = SplitDiscoveryPhase.resolveExternalSplits(exec, factories);
+        SplitDiscoveryPhase.Result result = SplitDiscoveryPhase.resolveExternalSplitsWithStats(
+            exec,
+            factories,
+            SegmentableFormatReader.DEFAULT_MAX_RECORD_BYTES
+        );
 
-        assertSame("an already-empty glob needs no swap", exec, result);
+        assertSame("an already-empty glob needs no swap", exec, result.plan());
+        assertEquals("an already-empty glob reads nothing", 0, result.filesScanned());
+        assertEquals(0, result.splitsScanned());
+        assertEquals(0L, result.bytesScanned());
     }
 
     /** {@link ExternalRelation#withFileList} swaps only the fileList, preserving the rest of the relation. */


### PR DESCRIPTION
## Problem

When split discovery returns zero splits without an exhaustive prune, the source falls through to a whole-fileList read, but the exit returned before the scan accounting ran. The query profile then reported `files_scanned: 0` and `bytes_scanned: 0` for a full-dataset read, and any assertion that a pruned query scanned nothing would go green on the path where the engine read everything.

## Fix

- On the non-exhaustive fall-through in `SplitDiscoveryPhase`, when the exec carries a resolved, non-empty file list, account the read that follows: every file counts as scanned (one unit per file, matching the runtime read) and the listed file sizes sum into `bytes_scanned`.
- Unresolved and already-empty lists keep zero counters: the counts either do not exist at this layer or nothing is read.

## Tests

New unit tests in `SplitDiscoveryPhaseTests` pin the fall-through accounting (including the unknown-size guard) and the zero counters for empty lists; verified red before the fix. The fall-through branch is unreachable from a live query with today's providers, so coverage is necessarily at the phase level.

Closes https://github.com/elastic/esql-planning/issues/1751
