### PR TITLE
Fixed flaky FallbackSyntheticSourceBlockLoaderTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -152,12 +152,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.LookupJoinTypesIT
   method: testLookupJoinOthers {p0=EQ}
   issue: https://github.com/elastic/elasticsearch/issues/157452
-- class: org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoaderTests
-  method: testCanReuseAcrossBinaryBlocks
-  issue: https://github.com/elastic/elasticsearch/issues/157945
-- class: org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoaderTests
-  method: testCanReuseTracksLastReadDoc
-  issue: https://github.com/elastic/elasticsearch/issues/157946
 - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
   method: testFailedDeploymentStats
   issue: https://github.com/elastic/elasticsearch/issues/157341

--- a/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoaderTests.java
@@ -114,6 +114,12 @@ public class FallbackSyntheticSourceBlockLoaderTests extends MapperServiceTestCa
 
     private void withIndex(int numDocs, int valueLength, CheckedBiConsumer<MapperService, LeafReaderContext, IOException> test)
         throws IOException {
+        // The DOC_VALUES_IGNORED_SOURCE format these tests exercise is only selected when this feature flag is enabled, which is the
+        // default in snapshot builds but off in release builds.
+        assumeTrue(
+            "requires ignored_source_as_doc_values feature flag enabled",
+            IgnoredSourceFieldMapper.IGNORED_SOURCE_AS_DOC_VALUES_FF.isEnabled()
+        );
         var settings = Settings.builder()
             .put("index.mapping.source.mode", "synthetic")
             // DOC_VALUES_IGNORED_SOURCE requires the TSDB doc values format to be enabled


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/157946
Closes https://github.com/elastic/elasticsearch/issues/157945