### PR TITLE
ESQL:DS: Preserve datasource warnings across nodes

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/Clusters.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.qa.parquet;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.xpack.esql.datasources.Federation;
 import org.elasticsearch.xpack.esql.datasources.FixtureUtils;
@@ -29,7 +30,7 @@ public class Clusters {
     /**
      * Installs the project-encryption-key (PEK) secure settings so data-source secrets can be encrypted
      * when a data source is registered via {@code PUT /_query/data_source}. Mirrors the single-node esql
-     * qa datasource-CRUD cluster config. Applied only by {@link #testClusterWithEncryption}.
+     * qa datasource-CRUD cluster config. Applied only by the encryption-enabled cluster helpers.
      */
     private static final LocalClusterConfigProvider DATASET_ENCRYPTION_CONFIG = builder -> builder.keystore(
         "cluster.state.encryption.password." + ENCRYPTION_PASSWORD_ID,
@@ -59,9 +60,25 @@ public class Clusters {
     }
 
     public static ElasticsearchCluster testCluster(Supplier<String> s3EndpointSupplier, LocalClusterConfigProvider configProvider) {
+        return clusterBuilder(s3EndpointSupplier, configProvider).shared(true).build();
+    }
+
+    /**
+     * A non-shared, {@code nodeCount}-node variant of {@link #testClusterWithEncryption(Supplier)}. Needed by suites
+     * whose subject is <em>where</em> an external read runs: the
+     * shared single-node cluster collapses the coordinator and the data node onto one JVM, so it cannot distinguish a
+     * coordinator-local scan from one shipped to another node.
+     */
+    public static ElasticsearchCluster multiNodeTestClusterWithEncryption(Supplier<String> s3EndpointSupplier, int nodeCount) {
+        return clusterBuilder(s3EndpointSupplier, DATASET_ENCRYPTION_CONFIG).nodes(nodeCount).build();
+    }
+
+    private static LocalClusterSpecBuilder<ElasticsearchCluster> clusterBuilder(
+        Supplier<String> s3EndpointSupplier,
+        LocalClusterConfigProvider configProvider
+    ) {
         return ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .shared(true)
             .plugin("inference-service-test")
             // Enable S3 repository plugin for S3 access
             .module("repository-s3")
@@ -95,8 +112,7 @@ public class Clusters {
             // This must be set as a JVM arg to take effect before any Arrow classes are loaded
             .jvmArg("-Darrow.allocation.manager.type=Unsafe")
             // Apply any additional configuration
-            .apply(() -> configProvider)
-            .build();
+            .apply(() -> configProvider);
     }
 
     public static ElasticsearchCluster testCluster(Supplier<String> s3EndpointSupplier) {

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetNullListElementWarningIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetNullListElementWarningIT.java
@@ -46,8 +46,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.WAREHOUSE;
@@ -59,16 +61,16 @@ import static org.hamcrest.Matchers.hasItem;
  * every external distribution mode.
  *
  * <p>An ES|QL multivalue cannot hold null, so a list element that is null is dropped on read and the reader announces
- * the loss with one {@code Warning} per affected column (elastic/esql-planning#1799). The notice travels a different
- * route depending on where the scan runs: a coordinator-local scan writes it into the REST request's own
- * {@code ThreadContext}, while a scan shipped to another node has to get it back across the wire. The existing
- * coverage — {@code ListColumnParityTests} at the decoder and the parquet csv-spec suites on a single-node cluster —
- * exercises neither split, because on one node the coordinator <em>is</em> the data node.
+ * the loss with one {@code Warning} per affected column (elastic/esql-planning#1799). The notice must travel through
+ * the driver's warning channel: a scan node's own response headers do not reach the client when the scan was shipped
+ * away from the coordinator. The existing coverage — {@code ListColumnParityTests} at the decoder and the parquet
+ * csv-spec suites on a single-node cluster — exercises neither placement, because on one node the coordinator
+ * <em>is</em> the data node.
  *
- * <p>So this suite runs the identical read under {@code coordinator_only} (never leaves the coordinator),
- * {@code round_robin} (always shipped to an eligible data node) and {@code adaptive} (production's default, which for
- * this one-row-group file stays local), and requires the notice in all three. A mode that returns the right values
- * with no notice is the silent-loss regression the notice exists to prevent.
+ * <p>So this suite runs the identical read under {@code coordinator_only}, {@code round_robin}, and {@code adaptive}
+ * from every coordinator, verifies from the profiles that at least one round-robin assignment differs from its
+ * coordinator-only counterpart, and requires the notice in every response. A mode that returns the right values with
+ * no notice is the silent-loss regression the notice exists to prevent.
  */
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubqueryRestTestCase {
@@ -124,11 +126,12 @@ public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubquery
 
         // Every combination is run before anything is asserted, so a failure report names all of them rather than
         // stopping at the first. Each mode is issued once per node: under a distributing mode the one split lands on a
-        // fixed node, so sweeping the coordinator across the cluster is what guarantees the shipped-elsewhere case is
-        // covered instead of leaving it to which node the client happened to pick.
+        // fixed node, so sweeping the coordinator across the cluster gives the assignment a chance to differ. The
+        // profile assertion below proves that it actually did rather than assuming placement from the pragma alone.
         Map<String, QueryOutcome> outcomes = new LinkedHashMap<>();
+        Map<String, RestClient> coordinators = perNodeClients();
         for (String mode : DISTRIBUTION_MODES) {
-            for (Map.Entry<String, RestClient> coordinator : perNodeClients().entrySet()) {
+            for (Map.Entry<String, RestClient> coordinator : coordinators.entrySet()) {
                 outcomes.put(mode + " @ " + coordinator.getKey(), runQueryWithMode(coordinator.getValue(), query, mode));
             }
         }
@@ -138,6 +141,23 @@ public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubquery
         });
         Map<String, String> report = new LinkedHashMap<>();
         outcomes.forEach((label, outcome) -> report.put(label, "scan on " + outcome.scanNodes() + " warnings " + outcome.warnings()));
+        outcomes.forEach(
+            (label, outcome) -> assertFalse(
+                "[" + label + "] profile names no external scan node; per run: " + report,
+                outcome.scanNodes().isEmpty()
+            )
+        );
+        boolean observedOffCoordinatorAssignment = coordinators.keySet()
+            .stream()
+            .anyMatch(
+                coordinator -> outcomes.get("coordinator_only @ " + coordinator)
+                    .scanNodes()
+                    .equals(outcomes.get("round_robin @ " + coordinator).scanNodes()) == false
+            );
+        assertTrue(
+            "round_robin never changed the external scan node relative to coordinator_only for the same coordinator; per run: " + report,
+            observedOffCoordinatorAssignment
+        );
         outcomes.forEach((label, outcome) -> {
             assertThat("[" + label + "] summary notice; per run: " + report, outcome.warnings(), hasItem(SUMMARY_WARNING));
             assertThat("[" + label + "] per-column notice; per run: " + report, outcome.warnings(), hasItem(COLUMN_WARNING));
@@ -189,12 +209,12 @@ public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubquery
          * the warnings so a failure says where the read happened rather than only that the notice went missing.
          */
         @SuppressWarnings("unchecked")
-        List<String> scanNodes() {
+        Set<String> scanNodes() {
             Map<String, Object> profile = (Map<String, Object>) body.get("profile");
             if (profile == null) {
-                return List.of("<no profile>");
+                return Set.of();
             }
-            List<String> nodes = new ArrayList<>();
+            Set<String> nodes = new LinkedHashSet<>();
             for (Map<String, Object> driver : (List<Map<String, Object>>) profile.get("drivers")) {
                 for (Map<String, Object> operator : (List<Map<String, Object>>) driver.get("operators")) {
                     if (String.valueOf(operator.get("operator")).contains("ExternalDataSourceOperator")) {
@@ -215,7 +235,7 @@ public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubquery
     private static QueryOutcome runQueryWithMode(RestClient coordinator, String query, String mode) throws IOException {
         Request req = new Request("POST", "/_query");
         try (XContentBuilder b = jsonBuilder()) {
-            b.startObject().field("query", query).field("profile", true);
+            b.startObject().field("query", query).field("profile", true).field("accept_pragma_risks", true);
             b.startObject("pragma").field("external_distribution", mode).endObject();
             b.endObject();
             req.setJsonEntity(Strings.toString(b));

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetNullListElementWarningIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetNullListElementWarningIT.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.parquet;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.http.HttpHost;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.WarningsHandler;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.test.AzureReactorThreadFilter;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.datasources.AbstractFromDatasetSubqueryRestTestCase;
+import org.elasticsearch.xpack.esql.datasources.BackendFixture;
+import org.elasticsearch.xpack.esql.datasources.S3BackendFixture;
+import org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.DataSourcesS3HttpFixture;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.esql.datasources.S3FixtureUtils.WAREHOUSE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Pins the dropped-null-element notice of a Parquet {@code LIST} read to the response, on a multi-node cluster, for
+ * every external distribution mode.
+ *
+ * <p>An ES|QL multivalue cannot hold null, so a list element that is null is dropped on read and the reader announces
+ * the loss with one {@code Warning} per affected column (elastic/esql-planning#1799). The notice travels a different
+ * route depending on where the scan runs: a coordinator-local scan writes it into the REST request's own
+ * {@code ThreadContext}, while a scan shipped to another node has to get it back across the wire. The existing
+ * coverage — {@code ListColumnParityTests} at the decoder and the parquet csv-spec suites on a single-node cluster —
+ * exercises neither split, because on one node the coordinator <em>is</em> the data node.
+ *
+ * <p>So this suite runs the identical read under {@code coordinator_only} (never leaves the coordinator),
+ * {@code round_robin} (always shipped to an eligible data node) and {@code adaptive} (production's default, which for
+ * this one-row-group file stays local), and requires the notice in all three. A mode that returns the right values
+ * with no notice is the silent-loss regression the notice exists to prevent.
+ */
+@ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
+public class ParquetNullListElementWarningIT extends AbstractFromDatasetSubqueryRestTestCase {
+
+    private static final String DATA_SOURCE = "null_list_elem_s3_ds";
+    private static final String DATASET = "null_list_elem_s3";
+    private static final String BLOB_KEY = WAREHOUSE + "/standalone/null_list_elements.parquet";
+
+    /** Every external distribution mode {@code QueryPragmas#EXTERNAL_DISTRIBUTION} accepts. */
+    private static final List<String> DISTRIBUTION_MODES = List.of("coordinator_only", "round_robin", "adaptive");
+
+    private static final String SUMMARY_WARNING =
+        "Parquet lists with null elements were read with those elements omitted; an ES|QL multivalued field cannot hold null";
+    private static final String COLUMN_WARNING = "Parquet list column [ints] contains lists with null elements; "
+        + "the column returns fewer values than the file holds";
+
+    /** The benign notice ES|QL adds for a query without an explicit {@code LIMIT}; not the subject here. */
+    private static final String DEFAULT_LIMIT_WARNING = "No limit defined, adding default limit of [1000]";
+
+    public static DataSourcesS3HttpFixture s3Fixture = new DataSourcesS3HttpFixture();
+    /**
+     * Two nodes so a distributed assignment has somewhere to go: with one node every strategy resolves to the same
+     * JVM and the placement axis this suite is about disappears.
+     */
+    public static ElasticsearchCluster cluster = Clusters.multiNodeTestClusterWithEncryption(() -> s3Fixture.getAddress(), 2);
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(s3Fixture).around(cluster);
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @AfterClass
+    public static void cleanupRegistry() throws IOException {
+        deleteIgnoringMissing("/_query/dataset/" + DATASET);
+        deleteIgnoringMissing("/_query/data_source/" + DATA_SOURCE);
+    }
+
+    /**
+     * {@code ints} holds {@code [1,2,3]}, {@code [null,1]}, {@code [4]}: six elements, five of them non-null. The
+     * value assertions pin the drop semantics (the read returns five) and the warning assertion pins that the drop is
+     * announced.
+     */
+    public void testDroppedNullElementIsAnnouncedInEveryDistributionMode() throws Exception {
+        BackendFixture s3Backend = new S3BackendFixture(s3Fixture);
+        s3Backend.uploadBlob(BLOB_KEY, nullListElementParquetBytes());
+        putDataSource(DATA_SOURCE, s3Backend.dataSourceType(), s3Backend.dataSourceSettings());
+        putDataset(DATASET, DATA_SOURCE, s3Backend.resourceUri(BLOB_KEY), Map.of());
+
+        String query = "FROM " + DATASET + " | STATS rows = COUNT(*), elements = SUM(MV_COUNT(ints))";
+
+        // Every combination is run before anything is asserted, so a failure report names all of them rather than
+        // stopping at the first. Each mode is issued once per node: under a distributing mode the one split lands on a
+        // fixed node, so sweeping the coordinator across the cluster is what guarantees the shipped-elsewhere case is
+        // covered instead of leaving it to which node the client happened to pick.
+        Map<String, QueryOutcome> outcomes = new LinkedHashMap<>();
+        for (String mode : DISTRIBUTION_MODES) {
+            for (Map.Entry<String, RestClient> coordinator : perNodeClients().entrySet()) {
+                outcomes.put(mode + " @ " + coordinator.getKey(), runQueryWithMode(coordinator.getValue(), query, mode));
+            }
+        }
+        outcomes.forEach((label, outcome) -> {
+            assertThat("[" + label + "] rows", outcome.longValue("rows"), equalTo(3L));
+            assertThat("[" + label + "] elements (the null element is dropped)", outcome.longValue("elements"), equalTo(5L));
+        });
+        Map<String, String> report = new LinkedHashMap<>();
+        outcomes.forEach((label, outcome) -> report.put(label, "scan on " + outcome.scanNodes() + " warnings " + outcome.warnings()));
+        outcomes.forEach((label, outcome) -> {
+            assertThat("[" + label + "] summary notice; per run: " + report, outcome.warnings(), hasItem(SUMMARY_WARNING));
+            assertThat("[" + label + "] per-column notice; per run: " + report, outcome.warnings(), hasItem(COLUMN_WARNING));
+        });
+    }
+
+    /**
+     * One client per cluster node, each pinned to that node so it is the coordinator for every request it carries.
+     * The shared {@code client()} spreads requests over all nodes, which would leave the placement being tested to
+     * chance. Built once per suite and closed in {@link #closePerNodeClients()}.
+     */
+    private Map<String, RestClient> perNodeClients() throws IOException {
+        if (perNodeClients == null) {
+            Map<String, RestClient> clients = new LinkedHashMap<>();
+            for (String address : cluster.getHttpAddresses().split(",")) {
+                HttpHost host = HttpHost.create(address.startsWith("http") ? address : "http://" + address);
+                clients.put(address, buildClient(restClientSettings(), new HttpHost[] { host }));
+            }
+            perNodeClients = clients;
+        }
+        return perNodeClients;
+    }
+
+    private Map<String, RestClient> perNodeClients;
+
+    @After
+    public void closePerNodeClients() throws IOException {
+        if (perNodeClients != null) {
+            IOUtils.close(perNodeClients.values());
+            perNodeClients = null;
+        }
+    }
+
+    /** A single {@code _query} result: the response body plus the {@code Warning} headers it carried. */
+    private record QueryOutcome(Map<String, Object> body, List<String> warnings) {
+        @SuppressWarnings("unchecked")
+        long longValue(String columnName) {
+            List<Map<String, Object>> columns = (List<Map<String, Object>>) body.get("columns");
+            for (int i = 0; i < columns.size(); i++) {
+                if (columnName.equals(columns.get(i).get("name"))) {
+                    return ((Number) ((List<List<Object>>) body.get("values")).get(0).get(i)).longValue();
+                }
+            }
+            throw new AssertionError("column [" + columnName + "] not in response " + body);
+        }
+
+        /**
+         * The names of the nodes that actually ran the external scan, read off the request profile. Reported alongside
+         * the warnings so a failure says where the read happened rather than only that the notice went missing.
+         */
+        @SuppressWarnings("unchecked")
+        List<String> scanNodes() {
+            Map<String, Object> profile = (Map<String, Object>) body.get("profile");
+            if (profile == null) {
+                return List.of("<no profile>");
+            }
+            List<String> nodes = new ArrayList<>();
+            for (Map<String, Object> driver : (List<Map<String, Object>>) profile.get("drivers")) {
+                for (Map<String, Object> operator : (List<Map<String, Object>>) driver.get("operators")) {
+                    if (String.valueOf(operator.get("operator")).contains("ExternalDataSourceOperator")) {
+                        nodes.add(String.valueOf(driver.get("node_name")));
+                        break;
+                    }
+                }
+            }
+            return nodes;
+        }
+    }
+
+    /**
+     * Runs {@code query} with {@code external_distribution} pinned to {@code mode}, returning the body together with
+     * the engine warnings minus the ambient no-limit notice. Warnings are collected rather than asserted by the
+     * client, because their presence is what the test measures.
+     */
+    private static QueryOutcome runQueryWithMode(RestClient coordinator, String query, String mode) throws IOException {
+        Request req = new Request("POST", "/_query");
+        try (XContentBuilder b = jsonBuilder()) {
+            b.startObject().field("query", query).field("profile", true);
+            b.startObject("pragma").field("external_distribution", mode).endObject();
+            b.endObject();
+            req.setJsonEntity(Strings.toString(b));
+        }
+        req.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE));
+        Response r = coordinator.performRequest(req);
+        assertThat(r.getStatusLine().getStatusCode(), equalTo(200));
+        List<String> warnings = new ArrayList<>(r.getWarnings());
+        warnings.remove(DEFAULT_LIMIT_WARNING);
+        return new QueryOutcome(entityAsMap(r), warnings);
+    }
+
+    /**
+     * A three-row, one-row-group file with a single 3-level {@code LIST} column of optional {@code int64} elements.
+     * The middle row's leading element is null: {@link Group#addGroup} with nothing appended writes a present list
+     * entry whose value is absent, which is exactly the definition level the reader recognises as a droppable
+     * element (as opposed to a null or empty list).
+     */
+    private static byte[] nullListElementParquetBytes() throws IOException {
+        MessageType schema = new MessageType(
+            "null_list_elements",
+            Types.optionalList().optionalElement(PrimitiveType.PrimitiveTypeName.INT64).named("ints")
+        );
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(byteArrayOutputFile(baos))
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            writer.write(listRow(factory, 1L, 2L, 3L));
+            writer.write(listRow(factory, null, 1L));
+            writer.write(listRow(factory, 4L));
+        }
+        return baos.toByteArray();
+    }
+
+    private static Group listRow(SimpleGroupFactory factory, Long... elements) {
+        Group row = factory.newGroup();
+        Group list = row.addGroup("ints");
+        for (Long element : elements) {
+            Group entry = list.addGroup("list");
+            if (element != null) {
+                entry.append("element", element);
+            }
+        }
+        return row;
+    }
+
+    private static OutputFile byteArrayOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return positionOutputStream(baos);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+
+    private static PositionOutputStream positionOutputStream(ByteArrayOutputStream baos) {
+        return new PositionOutputStream() {
+            private long position = 0;
+
+            @Override
+            public long getPos() {
+                return position;
+            }
+
+            @Override
+            public void write(int b) {
+                baos.write(b);
+                position++;
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                baos.write(b, off, len);
+                position += len;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -129,10 +129,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
     /** See {@link #nullListElementWarnings()}. */
     private SkipWarnings nullListElementWarnings;
     /**
-     * Relay for this eager read's per-value coercion warnings, or {@code null} to fall back to
-     * emitting directly via {@code HeaderWarning}. This iterator
-     * runs on a background reader thread under the async source, so a non-null sink (the source
-     * buffer relay) is required for the warnings to reach the response; see {@link #coercionWarnings()}.
+     * Relay for this eager read's informational warnings, or {@code null} to fall back to emitting directly via
+     * {@code HeaderWarning}. This iterator runs on a background reader thread under the async source, so a non-null
+     * sink (the source buffer relay) is required for the warnings to reach the response; see
+     * {@link #coercionWarnings()}.
      */
     @Nullable
     private final Consumer<String> warningSink;
@@ -1958,7 +1958,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
-                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], null, coercionWarnings());
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], null, coercionWarnings(), warningSink);
             }
         }
         // Sink intentionally not armed: see Javadoc above.
@@ -1987,7 +1987,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
-                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], survivorRowRanges, coercionWarnings());
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], survivorRowRanges, coercionWarnings(), warningSink);
             }
         }
         // Sink intentionally not armed: see Javadoc above.
@@ -2041,7 +2041,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             if (columnInfos[i] != null && columnInfos[i].isRowPosition() == false && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
-                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], currentRowRanges, coercionWarnings());
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], currentRowRanges, coercionWarnings(), warningSink);
             }
         }
         // Arm the sink only when this batch will be processed by nextStandard, which is the only
@@ -2979,6 +2979,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 attributes.get(colIndex).name(),
                 coercionWarnings(),
                 listColumnSink,
+                warningSink,
                 nullListElementWarnings()
             );
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -45,6 +45,7 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
 /**
@@ -105,9 +106,12 @@ final class PageColumnReader implements Releasable {
     private final ColumnDescriptor descriptor;
     private final ColumnInfo info;
     private final RowRanges rowRanges;
-    /** Per-value declared-coercion failure sink ({@code null} = strict); see the 5-arg constructor. */
+    /** Per-value declared-coercion failure sink ({@code null} = strict); see the 6-arg constructor. */
     @Nullable
     private final SkipWarnings coercionWarnings;
+    /** Relay for unconditional read-time notices that must survive execution away from the coordinator. */
+    @Nullable
+    private final Consumer<String> informationalWarningSink;
     /**
      * Per-batch row-drop sink for {@code skip_row} mode ({@code null} = not in skip_row mode).
      * Positions reported are relative to the current batch (0-based within {@link #readBatch}'s
@@ -164,26 +168,30 @@ final class PageColumnReader implements Releasable {
     private long pendingPrejumped;
 
     PageColumnReader(PageReader pageReader, ColumnDescriptor descriptor, ColumnInfo info, RowRanges rowRanges) {
-        this(pageReader, descriptor, info, rowRanges, null);
+        this(pageReader, descriptor, info, rowRanges, null, null);
     }
 
     /**
      * @param coercionWarnings sink for per-value declared-coercion failures (nulled cell +
      *                         response Warning header), shared across the read so the warning cap
      *                         is per read. {@code null} = strict: a coercion failure propagates.
+     * @param informationalWarningSink relay for unconditional read-time notices, or {@code null} to emit directly
+     *                                 to the current thread's response headers
      */
     PageColumnReader(
         PageReader pageReader,
         ColumnDescriptor descriptor,
         ColumnInfo info,
         RowRanges rowRanges,
-        @Nullable SkipWarnings coercionWarnings
+        @Nullable SkipWarnings coercionWarnings,
+        @Nullable Consumer<String> informationalWarningSink
     ) {
         this.pageReader = pageReader;
         this.descriptor = descriptor;
         this.info = info;
         this.rowRanges = rowRanges;
         this.coercionWarnings = coercionWarnings;
+        this.informationalWarningSink = informationalWarningSink;
         this.maxDefLevel = descriptor.getMaxDefinitionLevel();
         this.columnExhausted = false;
         this.rowPositionInRowGroup = 0;
@@ -1800,7 +1808,7 @@ final class PageColumnReader implements Releasable {
                 if (needsShrinking(produced, maxRows)) values = Arrays.copyOf(values, produced);
                 return blockFactory.newLongArrayVector(values, produced).asBlock();
             }
-            ParquetColumnDecoding.warnTimestampOutOfRange(info);
+            ParquetColumnDecoding.warnTimestampOutOfRange(info, informationalWarningSink);
             Block allNull = ConstantBlockDetection.tryAllNull(overflow.toBitSet(), produced, blockFactory);
             if (allNull != null) {
                 return allNull;
@@ -1829,7 +1837,7 @@ final class PageColumnReader implements Releasable {
         }
         boolean anyOverflow = scaleDateNanosMasked(values, produced, micros, nulls);
         if (anyOverflow) {
-            ParquetColumnDecoding.warnTimestampOutOfRange(info);
+            ParquetColumnDecoding.warnTimestampOutOfRange(info, informationalWarningSink);
         }
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -253,20 +253,26 @@ final class ParquetColumnDecoding {
     }
 
     /**
-     * Emits a response {@code Warning} header noting that a Parquet timestamp column carried instants
-     * outside the representable {@code date_nanos} range and those values were returned as null. The
-     * message is column-scoped and constant, so the response-header machinery deduplicates it to a
-     * single entry per affected column regardless of how many values or batches triggered it.
+     * Reports that a Parquet timestamp column carried instants outside the representable {@code date_nanos} range and
+     * those values were returned as null. When supplied, {@code warningSink} relays the message through the external
+     * driver's warning channel so it survives a scan on another node; the {@code null} fallback writes directly to
+     * the current thread's response headers for tests and synchronous callers.
+     *
+     * <p>The message is column-scoped and constant, so both the production informational-warning budget and response
+     * headers deduplicate it regardless of how many values or batches triggered it.
      */
-    static void warnTimestampOutOfRange(ColumnInfo info) {
+    static void warnTimestampOutOfRange(ColumnInfo info, @Nullable Consumer<String> warningSink) {
         ColumnDescriptor descriptor = info.descriptor();
         String column = descriptor == null ? "<unknown>" : String.join(".", descriptor.getPath());
-        HeaderWarning.addWarning(
-            "Parquet timestamp column ["
-                + column
-                + "] contains values outside the representable date_nanos range (~1677-09-21 to 2262-04-11); "
-                + "such values are returned as null"
-        );
+        String warning = "Parquet timestamp column ["
+            + column
+            + "] contains values outside the representable date_nanos range (~1677-09-21 to 2262-04-11); "
+            + "such values are returned as null";
+        if (warningSink != null) {
+            warningSink.accept(warning);
+        } else {
+            HeaderWarning.addWarning(warning);
+        }
     }
 
     /** Converts a date32 value (days since epoch) to epoch milliseconds. */
@@ -1003,8 +1009,10 @@ final class ParquetColumnDecoding {
      *                   pairs: the list decodes at the file's own element type, then
      *                   {@link DeclaredTypeCoercions#castBlock} coerces each element. {@code null} = strict, the
      *                   coercion failure propagates
-     * @param lossWarnings always-live collector for the dropped-null-element notice; required, since a
-     *                     {@code null} here would silently restore the pre-fix silence
+     * @param informationalWarningSink relay for unconditional read-time notices such as out-of-range timestamps, or
+     *                                 {@code null} to emit directly to the current thread's response headers
+     * @param lossWarnings always-live collector for the dropped-null-element notice; required, since a {@code null}
+     *                     here would silently restore the pre-fix silence
      */
     static Block readListColumn(
         ListColumnReader input,
@@ -1014,6 +1022,7 @@ final class ParquetColumnDecoding {
         String columnName,
         @Nullable SkipWarnings warnings,
         @Nullable IntConsumer failedPositionSink,
+        @Nullable Consumer<String> informationalWarningSink,
         SkipWarnings lossWarnings
     ) {
         DataType declared = info.esqlType();
@@ -1024,7 +1033,17 @@ final class ParquetColumnDecoding {
             && DeclaredTypeCoercions.supports(fileElementType, declared)) {
             // The recursion decodes at the file's own element type and owns the drop notice for this read; this
             // frame deliberately keeps no tally of its own, since it never reaches the row loops below.
-            Block physical = readListColumn(input, info.fileTyped(), rows, blockFactory, columnName, null, null, lossWarnings);
+            Block physical = readListColumn(
+                input,
+                info.fileTyped(),
+                rows,
+                blockFactory,
+                columnName,
+                null,
+                null,
+                informationalWarningSink,
+                lossWarnings
+            );
             try {
                 return DeclaredTypeCoercions.castBlock(
                     physical,
@@ -1060,7 +1079,7 @@ final class ParquetColumnDecoding {
             case BOOLEAN -> readListBooleanColumn(input, maxDef, rows, blockFactory, tally);
             case KEYWORD, TEXT -> readListBytesRefColumn(input, info, rows, blockFactory, tally);
             case DATETIME -> readListDatetimeColumn(input, info, rows, blockFactory, columnName, warnings, failedPositionSink, tally);
-            case DATE_NANOS -> readListDateNanosColumn(input, info, rows, blockFactory, tally);
+            case DATE_NANOS -> readListDateNanosColumn(input, info, rows, blockFactory, tally, informationalWarningSink);
             default -> {
                 skipListValues(input, rows);
                 yield blockFactory.newConstantNullBlock(rows);
@@ -1370,8 +1389,8 @@ final class ParquetColumnDecoding {
      * {@code LongBlock} of epoch-nanoseconds. {@code MICROS} elements whose scaled value would overflow the
      * representable {@code date_nanos} range are dropped from their list (mirroring how the generic list reader
      * already skips null elements); a list whose elements <em>all</em> overflow becomes a null position. A single
-     * deduplicated warning header is emitted when any element was dropped. This uses a lazy {@code beginPositionEntry}
-     * so an all-overflow defined list never triggers the empty-position assertion in {@link Block.Builder}.
+     * deduplicated warning is reported when any element was dropped. This uses a lazy {@code beginPositionEntry} so
+     * an all-overflow defined list never triggers the empty-position assertion in {@link Block.Builder}.
      *
      * <p>Overflow and null-element drops are announced separately — they are different losses with different
      * remedies — so this loop feeds both {@code anyOverflow} and {@code tally}.
@@ -1381,7 +1400,8 @@ final class ParquetColumnDecoding {
         ColumnInfo info,
         int rows,
         BlockFactory blockFactory,
-        NullElementTally tally
+        NullElementTally tally,
+        @Nullable Consumer<String> informationalWarningSink
     ) {
         int maxDef = info.maxDefLevel();
         LogicalTypeAnnotation logical = info.logicalType();
@@ -1392,7 +1412,7 @@ final class ParquetColumnDecoding {
                 readDateNanosListRow(input, maxDef, micros, logical, builder, anyOverflow, tally);
             }
             if (anyOverflow[0]) {
-                warnTimestampOutOfRange(info);
+                warnTimestampOutOfRange(info, informationalWarningSink);
             }
             return builder.build();
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -125,7 +125,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      */
     private final long[] rowGroupOffsets;
     /**
-     * Relay for per-value declared-coercion warnings, or {@code null} to fall back to emitting directly via
+     * Relay for read-time informational warnings, or {@code null} to fall back to emitting directly via
      * {@code HeaderWarning}. Production always supplies one: it is the budget-gated wrapper that caps the whole
      * source and ends in {@code DriverContext#addWarning}. Running on the driver thread is not enough to make the
      * fallback correct — when the scan runs on a node other than the coordinator that thread's response headers do
@@ -155,7 +155,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      * @param errorPolicy   the read's error policy, inherited from the iterator that produced the
      *                      row identities so the deferred columns fail (or warn+null) exactly like
      *                      the eagerly scanned ones
-     * @param warningSink   where per-value coercion warnings are relayed (budget-gated, ending in the driver's
+     * @param warningSink   where read-time informational warnings are relayed (budget-gated, ending in the driver's
      *                      warning sink), or {@code null} for direct {@code HeaderWarning} emission
      */
     ParquetColumnExtractor(
@@ -770,13 +770,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      * the row-group rows in source order, alternating skips and reads to produce exactly the
      * surviving rows.
      */
-    private static Block decodeFlat(
-        Bucket bucket,
-        ColumnInfo info,
-        PrefetchedPageReadStore store,
-        int rgRowCount,
-        BlockFactory blockFactory
-    ) {
+    private Block decodeFlat(Bucket bucket, ColumnInfo info, PrefetchedPageReadStore store, int rgRowCount, BlockFactory blockFactory) {
         PageReader pr = store.getPageReader(info.descriptor());
         try (
             PageColumnReader pageReader = new PageColumnReader(
@@ -785,7 +779,9 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                 info,
                 // RowRanges.all() lets every page through loadNextPage()'s page-skip check; the
                 // sparse loop drives skip/read by in-group position from there.
-                RowRanges.all(rgRowCount)
+                RowRanges.all(rgRowCount),
+                null,
+                warningSink
             )
         ) {
             return pageReader.readBatchSparse(rgRowCount, blockFactory, bucket.uniquePositions, bucket.uniqueCount);
@@ -859,6 +855,7 @@ final class ParquetColumnExtractor implements ColumnExtractor {
                         columnName,
                         null,
                         null,
+                        warningSink,
                         nullListElementWarnings()
                     )
                 );

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnExtractor.java
@@ -125,18 +125,20 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      */
     private final long[] rowGroupOffsets;
     /**
-     * Relay for per-value declared-coercion warnings, or {@code null} to fall back to emitting
-     * directly via {@code HeaderWarning}. The extractor runs on the
-     * driver thread, so direct emission is correct; a non-null sink is the budget-gated wrapper that
-     * caps the whole source. See {@link #coercionWarnings()}.
+     * Relay for per-value declared-coercion warnings, or {@code null} to fall back to emitting directly via
+     * {@code HeaderWarning}. Production always supplies one: it is the budget-gated wrapper that caps the whole
+     * source and ends in {@code DriverContext#addWarning}. Running on the driver thread is not enough to make the
+     * fallback correct — when the scan runs on a node other than the coordinator that thread's response headers do
+     * not reach the client (elastic/esql-planning#1837) — so the {@code null} case is for tests only.
+     * See {@link #coercionWarnings()}.
      */
     @Nullable
     private final Consumer<String> warningSink;
 
     /**
      * Delegates to {@link #ParquetColumnExtractor(StorageObject, ParquetFormatReader, ParquetMetadata, ErrorPolicy, Consumer)}
-     * with no warning sink, so coercion warnings emit directly via {@code HeaderWarning} (per-instance
-     * cap only). Used by tests and any on-driver-thread caller that does not centrally cap the channel.
+     * with no warning sink, so coercion warnings emit directly via {@code HeaderWarning} (per-instance cap only, and
+     * only visible when the scan happens to run on the coordinator). Tests only; production hands in a sink.
      */
     ParquetColumnExtractor(StorageObject storageObject, ParquetFormatReader reader, ParquetMetadata ownedFooter, ErrorPolicy errorPolicy) {
         this(storageObject, reader, ownedFooter, errorPolicy, null);
@@ -153,9 +155,8 @@ final class ParquetColumnExtractor implements ColumnExtractor {
      * @param errorPolicy   the read's error policy, inherited from the iterator that produced the
      *                      row identities so the deferred columns fail (or warn+null) exactly like
      *                      the eagerly scanned ones
-     * @param warningSink   where per-value coercion warnings are relayed (budget-gated direct
-     *                      emission on the driver thread), or {@code null} for direct
-     *                      {@code HeaderWarning} emission
+     * @param warningSink   where per-value coercion warnings are relayed (budget-gated, ending in the driver's
+     *                      warning sink), or {@code null} for direct {@code HeaderWarning} emission
      */
     ParquetColumnExtractor(
         StorageObject storageObject,

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -2964,10 +2964,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
         @Nullable
         private final ColumnarRowDropHelper rowDropHelper;
         /**
-         * Relay for this read's per-value coercion warnings, or {@code null} to fall back to emitting
-         * directly via {@code HeaderWarning}. Under the async source
-         * this iterator runs on a background reader thread, so a non-null sink (the source buffer
-         * relay) is required for the warnings to reach the response; see {@link #coercionWarnings()}.
+         * Relay for this read's informational warnings, or {@code null} to fall back to emitting directly via
+         * {@code HeaderWarning}. Under the async source this iterator runs on a background reader thread, so a
+         * non-null sink (the source buffer relay) is required for the warnings to reach the response; see
+         * {@link #coercionWarnings()}.
          */
         @Nullable
         private final Consumer<String> warningSink;
@@ -3172,7 +3172,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                         ColumnInfo ci = columnInfos[i];
                         if (ci != null && ci.isRowPosition() == false && ci.maxRepLevel() == 0) {
                             PageReader pageReader = rowGroup.getPageReader(ci.descriptor());
-                            pageColumnReaders[i] = new PageColumnReader(pageReader, ci.descriptor(), ci, allRows, coercionWarnings());
+                            pageColumnReaders[i] = new PageColumnReader(
+                                pageReader,
+                                ci.descriptor(),
+                                ci,
+                                allRows,
+                                coercionWarnings(),
+                                warningSink
+                            );
                         }
                     }
                     if (rowDropHelper != null) {
@@ -3436,6 +3443,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                     attributes.get(colIndex).name(),
                     coercionWarnings(),
                     failedPositionSink,
+                    warningSink,
                     nullListElementWarnings()
                 );
             }
@@ -3706,7 +3714,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
          * Reads an INT64 {@code TIMESTAMP(MICROS|NANOS)} column into a {@code DATE_NANOS} block of epoch-nanoseconds.
          * {@code NANOS} passes through; {@code MICROS} is scaled ×1_000. A {@code MICROS} value whose scaled instant
          * would fall outside the representable {@code date_nanos} range (~1677-2262) has no nanosecond representation,
-         * so it is emitted as null (with a single deduplicated response warning) rather than silently wrapping around.
+         * so it is emitted as null (with a single deduplicated warning) rather than silently wrapping around.
          */
         private Block readDateNanosColumn(ColumnReader cr, ColumnInfo info, int rows) {
             LogicalTypeAnnotation logical = info.logicalType();
@@ -3735,7 +3743,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader, NoConfigForm
                 cr.consume();
             }
             if (anyOverflow) {
-                ParquetColumnDecoding.warnTimestampOutOfRange(info);
+                ParquetColumnDecoding.warnTimestampOutOfRange(info, warningSink);
             }
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull, false);
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -2269,7 +2269,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
     /**
      * A timestamp[us] value beyond the representable date_nanos range (~year 2262) has no nanosecond
      * representation, so it is returned as null rather than silently wrapping around. A defined in-range
-     * value in the same column is unaffected.
+     * value in the same column is unaffected. The warning must use the supplied relay rather than the scan thread's
+     * response headers so it survives execution on another node.
      */
     public void testReadTimestampMicrosOutOfRangeReturnsNull() throws Exception {
         MessageType schema = Types.buildMessage()
@@ -2291,19 +2292,35 @@ public class ParquetFormatReaderTests extends ESTestCase {
             return List.of(g1, g2);
         });
 
-        StorageObject storageObject = createStorageObject(parquetData);
-        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        String expectedWarning = timestampOutOfRangeWarning("ts");
+        for (ParquetFormatReader reader : List.of(
+            new ParquetFormatReader(blockFactory),
+            new ParquetFormatReader(blockFactory).withBaselinePath()
+        )) {
+            StorageObject storageObject = createStorageObject(parquetData);
+            SourceMetadata metadata = reader.metadata(storageObject);
+            assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
 
-        SourceMetadata metadata = reader.metadata(storageObject);
-        assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
-
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
-            assertTrue(iterator.hasNext());
-            Page page = iterator.next();
-            LongBlock block = (LongBlock) page.getBlock(0);
-            assertFalse("in-range value must be present", block.isNull(0));
-            assertEquals(inRangeMicros * 1_000, block.getLong(0));
-            assertTrue("out-of-range value must be null", block.isNull(1));
+            List<String> warnings = new ArrayList<>();
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    storageObject,
+                    FormatReadContext.builder().batchSize(10).informationalWarningSink(warnings::add).build()
+                )
+            ) {
+                assertTrue(iterator.hasNext());
+                Page page = iterator.next();
+                try {
+                    LongBlock block = (LongBlock) page.getBlock(0);
+                    assertFalse("in-range value must be present", block.isNull(0));
+                    assertEquals(inRangeMicros * 1_000, block.getLong(0));
+                    assertTrue("out-of-range value must be null", block.isNull(1));
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+            assertThat("the reader must relay its warning", warnings, contains(expectedWarning));
+            assertThat("the warning must not leak to the scan thread's response headers", drainWarnings(), empty());
         }
     }
 
@@ -3203,8 +3220,8 @@ public class ParquetFormatReaderTests extends ESTestCase {
 
     /**
      * A LIST of timestamp[us] resolves to a DATE_NANOS multivalue column: each element is scaled to epoch-nanos with
-     * full precision, null lists stay null, and null elements within a list are dropped (multivalue blocks have no
-     * per-element null slot). Both reader paths route list columns through the same shared decoder.
+     * full precision, null lists stay null, null elements within a list are dropped, and values outside the nanos
+     * range are dropped with a relayed warning. Both reader paths route list columns through the same shared decoder.
      */
     private void assertReadListOfDateNanosColumn(ParquetFormatReader reader) throws Exception {
         Type listType = Types.optionalList()
@@ -3216,11 +3233,13 @@ public class ParquetFormatReaderTests extends ESTestCase {
         long micros1 = 946728000000L * 1_000 + 111; // sub-millisecond fraction .000111 ms
         long micros2 = 946728000000L * 1_000 + 222;
         long micros3 = 946728000000L * 1_000 + 333;
+        long outOfRangeMicros = 20_000_000_000_000_000L;
         byte[] parquetData = createParquetFile(schema, factory -> {
-            // Row 0: [micros1, micros2]
+            // Row 0: [micros1, out-of-range, micros2]
             Group g1 = factory.newGroup();
             Group list1 = g1.addGroup("values");
             list1.addGroup("list").append("element", micros1);
+            list1.addGroup("list").append("element", outOfRangeMicros);
             list1.addGroup("list").append("element", micros2);
 
             // Row 1: null list
@@ -3239,29 +3258,41 @@ public class ParquetFormatReaderTests extends ESTestCase {
         SourceMetadata metadata = reader.metadata(storageObject);
         assertEquals(DataType.DATE_NANOS, metadata.schema().get(0).dataType());
 
-        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
+        List<String> warnings = new ArrayList<>();
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                storageObject,
+                FormatReadContext.builder().batchSize(10).informationalWarningSink(warnings::add).build()
+            )
+        ) {
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
-            assertEquals(3, page.getPositionCount());
+            try {
+                assertEquals(3, page.getPositionCount());
 
-            LongBlock block = (LongBlock) page.getBlock(0);
-            // Row 0: [micros1, micros2] scaled to nanos with full precision
-            assertFalse(block.isNull(0));
-            assertEquals(2, block.getValueCount(0));
-            int start0 = block.getFirstValueIndex(0);
-            assertEquals(micros1 * 1_000, block.getLong(start0));
-            assertEquals(micros2 * 1_000, block.getLong(start0 + 1));
+                LongBlock block = (LongBlock) page.getBlock(0);
+                // Row 0: the in-range values are scaled to nanos; the out-of-range value is dropped.
+                assertFalse(block.isNull(0));
+                assertEquals(2, block.getValueCount(0));
+                int start0 = block.getFirstValueIndex(0);
+                assertEquals(micros1 * 1_000, block.getLong(start0));
+                assertEquals(micros2 * 1_000, block.getLong(start0 + 1));
 
-            // Row 1: null list
-            assertTrue(block.isNull(1));
+                // Row 1: null list
+                assertTrue(block.isNull(1));
 
-            // Row 2: [micros3]; the null element is dropped
-            assertFalse(block.isNull(2));
-            assertEquals(1, block.getValueCount(2));
-            assertEquals(micros3 * 1_000, block.getLong(block.getFirstValueIndex(2)));
+                // Row 2: [micros3]; the null element is dropped
+                assertFalse(block.isNull(2));
+                assertEquals(1, block.getValueCount(2));
+                assertEquals(micros3 * 1_000, block.getLong(block.getFirstValueIndex(2)));
+            } finally {
+                page.releaseBlocks();
+            }
         }
-        // Row 2's dropped element is announced, from the date_nanos loop's own row walk.
-        assertThat(drainWarnings(), contains(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY, droppedElementsNotice("values")));
+        assertThat(warnings, hasItem(timestampOutOfRangeWarning("values.list.element")));
+        assertThat(warnings, hasItem(ParquetColumnDecoding.NULL_LIST_ELEMENTS_SUMMARY));
+        assertThat(warnings, hasItem(droppedElementsNotice("values")));
+        assertThat("both notices must use the supplied relay", drainWarnings(), empty());
     }
 
     // --- LIST-under-STRUCT tests (elastic/esql-planning#1055) ---
@@ -5075,6 +5106,13 @@ public class ParquetFormatReaderTests extends ESTestCase {
     /** The per-column detail line for a LIST read that dropped null elements. */
     private static String droppedElementsNotice(String column) {
         return ParquetColumnDecoding.nullListElementsMessage(column);
+    }
+
+    private static String timestampOutOfRangeWarning(String column) {
+        return "Parquet timestamp column ["
+            + column
+            + "] contains values outside the representable date_nanos range (~1677-09-21 to 2262-04-11); "
+            + "such values are returned as null";
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetListCorruptionTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetListCorruptionTests.java
@@ -295,7 +295,7 @@ public class ParquetListCorruptionTests extends ESTestCase {
      * notices the read paths pass in.
      */
     private Block readList(ParquetColumnDecoding.ListColumnReader input, ColumnInfo info, int rows) {
-        return ParquetColumnDecoding.readListColumn(input, info, rows, blockFactory, "x", null, null, SkipWarnings.NOOP);
+        return ParquetColumnDecoding.readListColumn(input, info, rows, blockFactory, "x", null, null, null, SkipWarnings.NOOP);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -107,7 +107,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         } catch (Exception e) {
             completionListener.onFailure(e);
         }
-        return new AsyncExternalSourceOperator(buffer);
+        return new AsyncExternalSourceOperator(buffer, driverContext);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -97,11 +97,11 @@ public final class AsyncExternalSourceBuffer {
      * {@code FormatReadContext#informationalWarningSink()} / {@code RangeReadContext#informationalWarningSink()}),
      * which do not necessarily imply a dropped record. See {@link #recordWarning} vs {@link
      * #recordInformationalWarning}. Producer / parse-worker threads append here off the driver thread;
-     * {@link AsyncExternalSourceOperator#close()} drains and re-emits them via {@link
-     * org.elasticsearch.common.logging.HeaderWarning} on the driver thread, whose response headers
-     * {@code DriverRunner} collects into the client response. Emitting from the forked worker thread
-     * directly would land the header on that worker's {@code ThreadContext}, which is never merged
-     * back into the response — so the warning would be invisible to the client.
+     * {@link AsyncExternalSourceOperator#close()} drains them into the driver's
+     * {@link org.elasticsearch.compute.operator.DriverContext} sink, which {@code DriverCompletionInfo} carries back
+     * from whatever node ran the scan for the coordinator to re-emit. Depositing from the forked worker thread
+     * directly is not an option: that thread's sink is not this driver's, and the {@code ThreadContext} alternative
+     * only reaches the client when the scan happens to run on the coordinator.
      */
     private final Queue<String> pendingWarnings = new ConcurrentLinkedQueue<>();
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
@@ -45,6 +46,12 @@ public class AsyncExternalSourceOperator extends SourceOperator {
     private static final TransportVersion ESQL_CAPTURED_SOURCE_METADATA = TransportVersion.fromName("esql_captured_source_metadata");
 
     private final AsyncExternalSourceBuffer buffer;
+    /**
+     * This driver's warning sink, where {@link #emitPendingWarnings()} deposits what the producer recorded. Owning the
+     * context rather than reaching for {@code HeaderWarning} is what makes the warnings survive a scan that runs
+     * anywhere but the coordinator; see {@link #emitPendingWarnings()}.
+     */
+    private final DriverContext driverContext;
     /** Node telemetry sink; {@link ExternalSourceMetrics#NOOP} when none is wired (tests, connector factory path). */
     private final ExternalSourceMetrics externalSourceMetrics;
     /** Low-cardinality storage scheme dimension for this scan's histograms; {@code null} when unknown (connector path). */
@@ -60,12 +67,18 @@ public class AsyncExternalSourceOperator extends SourceOperator {
     private long rowsEmitted;
     private long processNanos;
 
-    public AsyncExternalSourceOperator(AsyncExternalSourceBuffer buffer) {
-        this(buffer, ExternalSourceMetrics.NOOP, null);
+    public AsyncExternalSourceOperator(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
+        this(buffer, driverContext, ExternalSourceMetrics.NOOP, null);
     }
 
-    public AsyncExternalSourceOperator(AsyncExternalSourceBuffer buffer, ExternalSourceMetrics externalSourceMetrics, String scheme) {
-        this.buffer = buffer;
+    public AsyncExternalSourceOperator(
+        AsyncExternalSourceBuffer buffer,
+        DriverContext driverContext,
+        ExternalSourceMetrics externalSourceMetrics,
+        String scheme
+    ) {
+        this.buffer = Objects.requireNonNull(buffer, "buffer");
+        this.driverContext = Objects.requireNonNull(driverContext, "driverContext");
         this.externalSourceMetrics = externalSourceMetrics == null ? ExternalSourceMetrics.NOOP : externalSourceMetrics;
         this.scheme = scheme;
     }
@@ -159,18 +172,20 @@ public class AsyncExternalSourceOperator extends SourceOperator {
     }
 
     /**
-     * Drains the buffer's recorded partial-results warnings and re-emits them via {@link HeaderWarning}.
-     * The driver invokes {@link #close()} on its own thread during teardown — the same thread whose
-     * response headers {@code DriverRunner} collects into the client response. The producer records these
-     * off a forked reader / parse-worker thread whose own response headers are never merged back, so the
-     * re-emission must happen here, on the driver thread, for the warning to reach the client (see #835).
-     * This mirrors how {@link org.elasticsearch.compute.operator.AsyncOperator} flushes a
-     * {@code ResponseHeadersCollector} from its {@code close()}.
+     * Drains the buffer's recorded warnings into this driver's {@link DriverContext} sink. The producer records them
+     * off a forked reader / parse-worker thread, so the hand-off has to happen here: the driver calls {@link #close()}
+     * on its own thread during teardown, before {@code DriverContext#finish} snapshots the sink (see #835).
+     * <p>
+     * The sink is {@link DriverContext#addWarning}, not {@link HeaderWarning}, because a driver's
+     * {@code ThreadContext} response headers only reach the client when the driver happens to run on the coordinator.
+     * {@code DriverCompletionInfo} ships this sink's contents back from whatever node ran the scan and the coordinator
+     * re-emits them once, which is how every other ES|QL warning already travels. A read shipped to a data node
+     * (elastic/esql-planning#1837) otherwise returned the right values with no warning at all.
      */
     private void emitPendingWarnings() {
         String warning;
         while ((warning = buffer.pollWarning()) != null) {
-            HeaderWarning.addWarning(warning);
+            driverContext.addWarning(warning);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
@@ -949,7 +948,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 }
             }
 
-            return new AsyncExternalSourceOperator(buffer, externalSourceMetrics, path.scheme());
+            return new AsyncExternalSourceOperator(buffer, driverContext, externalSourceMetrics, path.scheme());
         } catch (Exception e) {
             releaseOperator();
             throw e;
@@ -1027,7 +1026,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * {@link Builder#build} time.
      */
     private int registerExtractorFromProducer(ColumnExtractorProducer producer, DriverContext driverContext) throws IOException {
-        ColumnExtractor extractor = producer.createColumnExtractor(driverThreadInformationalWarningSink());
+        ColumnExtractor extractor = producer.createColumnExtractor(driverThreadInformationalWarningSink(driverContext));
         return sourceExtractorsFor(driverContext).register(extractor);
     }
 
@@ -1048,17 +1047,18 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     /**
-     * Budget-gated informational-warning sink for the deferred (TopN) extractor, which runs on the
-     * driver thread and therefore emits directly to {@link HeaderWarning}. It must not route through
-     * the source buffer: {@code Driver} closes the source operator (draining the buffer's pending
-     * warnings) as soon as it finishes, which can happen before the paired extract operator runs, so
-     * a buffered extractor warning would never be drained.
+     * Budget-gated informational-warning sink for the deferred (TopN) extractor, which runs on the driver thread and
+     * therefore deposits straight into that driver's {@link DriverContext} sink — the channel
+     * {@code DriverCompletionInfo} carries back from whatever node ran the scan, so the warning reaches the client
+     * whether or not that node is the coordinator. It must not route through the source buffer: {@code Driver} closes
+     * the source operator (draining the buffer's pending warnings) as soon as it finishes, which can happen before the
+     * paired extract operator runs, so a buffered extractor warning would never be drained.
      */
-    private Consumer<String> driverThreadInformationalWarningSink() {
+    private Consumer<String> driverThreadInformationalWarningSink(DriverContext driverContext) {
         return warning -> {
             String toRecord = informationalWarningBudget.accept(warning);
             if (toRecord != null) {
-                HeaderWarning.addWarning(toRecord);
+                driverContext.addWarning(toRecord);
             }
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ColumnExtractorProducer.java
@@ -56,12 +56,13 @@ public interface ColumnExtractorProducer {
      * range-restricted footer) at construction time.
      *
      * @param driverThreadWarningSink where the extractor relays per-value declared-coercion warnings
-     *                                (see {@link SkipWarnings}). The extractor runs on the driver
-     *                                thread, so this sink emits directly to the response headers; it
-     *                                is budget-gated so the whole source stays within one cap. May be
-     *                                {@code null}, in which case the extractor falls back to emitting
-     *                                warnings directly (per-instance cap only): the on-driver-thread
-     *                                default used by tests and benchmarks.
+     *                                (see {@link SkipWarnings}). The extractor invokes this sink on the driver
+     *                                thread; production binds it to {@code DriverContext#addWarning} so
+     *                                {@code DriverCompletionInfo} can carry warnings back from a remote scan. It is
+     *                                budget-gated so the whole source stays within one cap. May be {@code null}, in
+     *                                which case the extractor falls back to direct response-header emission
+     *                                (per-instance cap only). That fallback is for tests and benchmarks only because
+     *                                it is not transport-safe when the driver runs away from the coordinator.
      */
     ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) throws IOException;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -34,6 +34,14 @@ import java.util.function.Consumer;
  * is relayed and re-emitted on the correct thread instead of being silently dropped. Instances are
  * stateful and not thread-safe: create one per reader iterator or decoder.
  * <p>
+ * A correctly bound thread is necessary but not sufficient: a scan the planner ships to another node runs its
+ * drivers there, and that node's response headers reach the client only by chance, so a read-time notice written
+ * straight to {@link HeaderWarning} from a driver thread is still lost (elastic/esql-planning#1837). Read paths
+ * therefore relay to a sink that ends in {@code DriverContext#addWarning}, the channel
+ * {@code DriverCompletionInfo} carries back for the coordinator to emit. Direct {@link HeaderWarning} writes
+ * remain right for plan-time work — schema resolution, split discovery — which already runs on the coordinator's
+ * own request thread.
+ * <p>
  * Callers working against an {@link ErrorPolicy} should use {@link #of(ErrorPolicy, String)} (or the
  * sink-aware {@link #of(ErrorPolicy, String, Consumer)}) to obtain either a live collector or the
  * shared {@link #NOOP} sink, so that call sites never have to null-guard subsequent {@link #add(String)}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryDeferredExtractionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -36,6 +37,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.NoConfigFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.PassThroughRowPositionStrategy;
 import org.elasticsearch.xpack.esql.datasources.spi.RowPositionStrategy;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -45,12 +47,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -158,6 +164,78 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
             }
             operator.close();
         }
+    }
+
+    /**
+     * The deferred extractor's warning sink must deposit into the driver's {@link DriverContext}, which
+     * {@code DriverCompletionInfo} ships back from whatever node ran the scan, rather than into the emitting
+     * thread's {@code ThreadContext} — the latter only reaches the client when the scan runs on the coordinator
+     * (elastic/esql-planning#1837). The sink stays budget-gated, so a flood still collapses to the cap plus one
+     * overflow marker.
+     */
+    public void testDeferredExtractorWarningSinkFeedsTheDriverSinkUnderTheBudget() throws Exception {
+        AtomicInteger readCount = new AtomicInteger();
+        AtomicInteger extractorsCreated = new AtomicInteger();
+        List<Consumer<String>> capturedSinks = Collections.synchronizedList(new ArrayList<>());
+        FormatReader_RowPositionEmitting reader = new FormatReader_RowPositionEmitting(
+            readCount,
+            extractorsCreated,
+            /* rowsPerFile = */ 1,
+            capturedSinks
+        );
+
+        StoragePath path = StoragePath.of("s3://bucket/data/f1.parquet");
+        FileList fileList = GlobExpander.fileListOf(List.of(new StorageEntry(path, 100, Instant.EPOCH)), "s3://bucket/data/*.parquet");
+        List<Attribute> attributes = List.of(field("value", DataType.INTEGER), field(ColumnExtractor.ROW_POSITION_COLUMN, DataType.LONG));
+
+        // A real context, since the sink under test writes into it; a mock would swallow every message.
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, BLOCK_FACTORY, null);
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            new StubStorageProvider(),
+            reader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        ).fileList(fileList).deferredExtraction(true).build();
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        try {
+            while (operator.isFinished() == false) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                }
+            }
+            assertThat("the extractor handshake must hand out a sink", capturedSinks, hasSize(1));
+            Consumer<String> sink = capturedSinks.get(0);
+
+            // One distinct message per call, so the budget counts each rather than deduplicating them, and the
+            // count deliberately overshoots the cap.
+            int offered = SkipWarnings.MAX_ADDED_WARNINGS + 5;
+            for (int i = 0; i < offered; i++) {
+                sink.accept("extractor notice " + i);
+            }
+        } finally {
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        }
+
+        driverContext.finish();
+        List<String> warnings = driverContext.warnings();
+        assertThat(
+            "the cap admits MAX_ADDED_WARNINGS payloads plus one overflow marker",
+            warnings,
+            hasSize(SkipWarnings.MAX_ADDED_WARNINGS + 1)
+        );
+        assertThat(warnings.get(0), equalTo("extractor notice 0"));
+        assertThat(warnings, hasItem(SkipWarnings.overflowMessage()));
+        Releasables.close(driverContext.getSnapshot());
     }
 
     public void testEmptyDataProjectionWithDeferredExtractionAndNonIdentityMapping() throws Exception {
@@ -826,11 +904,23 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         private final AtomicInteger readCount;
         private final AtomicInteger extractorsCreated;
         private final int rowsPerFile;
+        /** Sinks handed to {@link ColumnExtractorProducer#createColumnExtractor}; empty unless a test wants them. */
+        private final List<Consumer<String>> capturedSinks;
 
         FormatReader_RowPositionEmitting(AtomicInteger readCount, AtomicInteger extractorsCreated, int rowsPerFile) {
+            this(readCount, extractorsCreated, rowsPerFile, Collections.synchronizedList(new ArrayList<>()));
+        }
+
+        FormatReader_RowPositionEmitting(
+            AtomicInteger readCount,
+            AtomicInteger extractorsCreated,
+            int rowsPerFile,
+            List<Consumer<String>> capturedSinks
+        ) {
             this.readCount = readCount;
             this.extractorsCreated = extractorsCreated;
             this.rowsPerFile = rowsPerFile;
+            this.capturedSinks = capturedSinks;
         }
 
         @Override
@@ -841,7 +931,7 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         @Override
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
             int idx = readCount.getAndIncrement();
-            return new ProducerIterator(idx, extractorsCreated, rowsPerFile);
+            return new ProducerIterator(idx, extractorsCreated, rowsPerFile, capturedSinks);
         }
 
         @Override
@@ -867,13 +957,15 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         private final int fileIndex;
         private final AtomicInteger extractorsCreated;
         private final int rowsPerFile;
+        private final List<Consumer<String>> capturedSinks;
         private boolean emitted = false;
         private long rowPositionEncodingHighBits = -1L;
 
-        ProducerIterator(int fileIndex, AtomicInteger extractorsCreated, int rowsPerFile) {
+        ProducerIterator(int fileIndex, AtomicInteger extractorsCreated, int rowsPerFile, List<Consumer<String>> capturedSinks) {
             this.fileIndex = fileIndex;
             this.extractorsCreated = extractorsCreated;
             this.rowsPerFile = rowsPerFile;
+            this.capturedSinks = capturedSinks;
         }
 
         @Override
@@ -906,6 +998,9 @@ public class AsyncExternalSourceOperatorFactoryDeferredExtractionTests extends E
         @Override
         public ColumnExtractor createColumnExtractor(@Nullable Consumer<String> driverThreadWarningSink) {
             extractorsCreated.incrementAndGet();
+            if (driverThreadWarningSink != null) {
+                capturedSinks.add(driverThreadWarningSink);
+            }
             return new InMemoryColumnExtractor(rowsPerFile);
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -67,6 +68,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
@@ -688,10 +690,9 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             new SchemaReconciliation.FileSchemaInfo(fileSchema, mapping, null)
         );
 
-        DriverContext driverContext = mock(DriverContext.class);
-        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
-        doAnswer(inv -> null).when(driverContext).addAsyncAction();
-        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+        // A real context rather than this suite's usual mock: the absent-column warning is delivered into its warning
+        // sink, which a stub would swallow, leaving the assertion at the end of this method nothing to read.
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
 
         AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
@@ -726,8 +727,9 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             }
             operator.close();
         }
-        // Absent-column warnings are buffered on the producer thread and re-emitted from operator.close().
-        assertWarnings(SkipWarnings.absentDeclaredColumnMessage("city"));
+        driverContext.finish();
+        assertThat(driverContext.warnings(), contains(SkipWarnings.absentDeclaredColumnMessage("city")));
+        Releasables.close(driverContext.getSnapshot());
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorTelemetryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorTelemetryTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.telemetry.InstrumentType;
 import org.elasticsearch.telemetry.Measurement;
 import org.elasticsearch.telemetry.RecordingMeterRegistry;
@@ -37,6 +38,11 @@ public class AsyncExternalSourceOperatorTelemetryTests extends ESTestCase {
     private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
         .breaker(new NoopCircuitBreaker("none"))
         .build();
+
+    /** A real {@link DriverContext} because {@link AsyncExternalSourceOperator#close()} deposits into its sink. */
+    private static DriverContext driverContext() {
+        return new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, BLOCK_FACTORY, null);
+    }
 
     private static Page createTestPage(int numColumns, int numRows) {
         IntBlock[] blocks = new IntBlock[numColumns];
@@ -72,7 +78,7 @@ public class AsyncExternalSourceOperatorTelemetryTests extends ESTestCase {
         // at close and records it as the parse.duration observation.
         buffer.recordFormatReaderStatus(new NdJsonReaderStatus(5L, 0L, TimeUnit.MILLISECONDS.toNanos(42L), 0L));
 
-        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, metrics, "s3a");
+        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, driverContext(), metrics, "s3a");
 
         Page page = operator.getOutput();
         assertNotNull("the buffered page must be emitted", page);
@@ -126,7 +132,7 @@ public class AsyncExternalSourceOperatorTelemetryTests extends ESTestCase {
         buffer.incSplitsProcessed();
         buffer.addPage(createTestPage(1, 1));
 
-        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, metrics, "s3");
+        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, driverContext(), metrics, "s3");
         Page page = operator.getOutput();
         assertNotNull(page);
         page.releaseBlocks();
@@ -151,7 +157,7 @@ public class AsyncExternalSourceOperatorTelemetryTests extends ESTestCase {
         buffer.setSplitsTotal(10);
         buffer.finish(true);
 
-        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, metrics, "s3");
+        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, driverContext(), metrics, "s3");
         assertNull(operator.getOutput());
         operator.close();
 
@@ -171,7 +177,7 @@ public class AsyncExternalSourceOperatorTelemetryTests extends ESTestCase {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
         buffer.finish(true);
 
-        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, metrics, "s3");
+        AsyncExternalSourceOperator operator = new AsyncExternalSourceOperator(buffer, driverContext(), metrics, "s3");
         assertNull(operator.getOutput());
         operator.close();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorWarningsTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceMetrics;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Pins the channel {@link AsyncExternalSourceOperator} hands the producer's warnings to.
+ *
+ * <p>They have to land in the driver's {@link DriverContext} sink, which {@code DriverCompletionInfo} ships back from
+ * whatever node ran the scan for the coordinator to re-emit. The earlier route — {@code HeaderWarning} on the driver
+ * thread — only reached the client when the scan happened to run on the coordinator, so a read the planner shipped to
+ * a data node returned the right values with no warning at all (elastic/esql-planning#1837).
+ */
+public class AsyncExternalSourceOperatorWarningsTests extends ESTestCase {
+
+    private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("none"))
+        .build();
+
+    /**
+     * Both warning kinds the buffer accumulates reach the sink: the informational ones a format reader relays through
+     * {@code FormatReadContext#informationalWarningSink} and the partial-results one the streaming truncation path
+     * records. Neither is emitted by the producer itself, so {@code close()} is the only hand-off point.
+     */
+    public void testCloseDepositsBufferedWarningsIntoTheDriverSink() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        buffer.recordInformationalWarning("column [ints] returned fewer values than the file holds");
+        buffer.recordWarning("a record exceeded external_max_record_size and was truncated");
+
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, BLOCK_FACTORY, null);
+        new AsyncExternalSourceOperator(buffer, driverContext, ExternalSourceMetrics.NOOP, "s3").close();
+
+        driverContext.finish();
+        assertThat(
+            driverContext.warnings(),
+            containsInAnyOrder(
+                "column [ints] returned fewer values than the file holds",
+                "a record exceeded external_max_record_size and was truncated"
+            )
+        );
+        assertThat("the buffer is drained, so a second close cannot double-report", buffer.pollWarning(), nullValue());
+    }
+
+    /** A read that recorded nothing must leave the sink empty rather than depositing an empty or null entry. */
+    public void testCloseWithoutWarningsLeavesTheDriverSinkEmpty() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, BLOCK_FACTORY, null);
+        new AsyncExternalSourceOperator(new AsyncExternalSourceBuffer(1024), driverContext, ExternalSourceMetrics.NOOP, "s3").close();
+
+        driverContext.finish();
+        assertThat(driverContext.warnings(), empty());
+    }
+}


### PR DESCRIPTION
Route external-source warnings through the driver warning channel so remote scans return them reliably. Add unit and multi-node Parquet coverage.

Related https://github.com/elastic/esql-planning/issues/1799
Closes https://github.com/elastic/esql-planning/issues/1837