### PR TITLE
ESQL:DS: Classify deferred external read failures

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFailures.java
@@ -19,8 +19,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Classifies a failure raised while reading an external data source into the exception the
- * {@code AsyncExternalSourceOperator} should surface, so that it maps to the right HTTP status. The
+ * Classifies a failure raised while reading an external data source into the exception an external-read
+ * operator should surface, so that it maps to the right HTTP status. The
  * companion {@link #surface} helper is used at the worker rethrow sites inside parallel coordinators and
  * page iterators to pre-type the failure: it wraps a raw {@link IOException} in an already-classified
  * {@link ExternalClientException} (400) so the read boundary's {@link #classify} sees a status-typed
@@ -28,12 +28,14 @@ import java.util.concurrent.ExecutionException;
  * {@link RuntimeException} wrapper; callers must therefore pass the <em>raw</em> stored throwable, not a
  * pre-wrapped one.
  * <p>
- * {@link #classify} is the single boundary where external-source reads turn into a user-visible error,
- * and it is reached only for external-source queries (the operator exists only for them), so index queries
- * are unaffected. It runs co-located with the throw, on the node that reads the external source, before
- * the failure is serialized back to the coordinator — so classification relies on the concrete
- * exception type while it is still available, and only the resulting {@code status()} needs to cross
- * the wire (see {@link org.elasticsearch.xpack.esql.datasources.spi.ExternalException}). The policy:
+ * {@link #classify} is the shared policy boundary where external-source reads turn into a user-visible
+ * error. Both eager reads in {@code AsyncExternalSourceOperator} and deferred reads in
+ * {@code ExternalFieldExtractOperator} invoke it at their local read boundary; neither operator exists
+ * for index queries, so those are unaffected. Classification runs co-located with the throw, on the node
+ * that reads the external source, before the failure is serialized back to the coordinator — so it relies
+ * on the concrete exception type while it is still available, and only the resulting public exception
+ * name and {@code status()} need to cross the wire (see
+ * {@link org.elasticsearch.xpack.esql.datasources.spi.ExternalException}). The policy:
  * <ul>
  *     <li>{@link Error} (assertion failures, OOM, …) is rethrown — a JVM/programming fault must stay
  *     fatal, never be downgraded to a request error.</li>
@@ -136,8 +138,8 @@ public final class ExternalFailures {
      *     after a worker thread was interrupted) becomes an {@link ExternalServerException} (500): we have
      *     no evidence it is the caller's fault, so we keep the bug visible.</li>
      * </ul>
-     * Calling {@code surface} at the worker rethrow site lets {@code AsyncExternalSourceOperator}'s
-     * {@link #classify} compose cleanly on the result: an {@link ExternalException} returned here passes
+     * Calling {@code surface} at the worker rethrow site lets a read-boundary {@link #classify} call
+     * compose cleanly on the result: an {@link ExternalException} returned here passes
      * straight through {@code classify} unchanged; a non-classified {@link RuntimeException} is the only
      * shape {@code classify} still actively re-wraps (into {@link ExternalServerException}, the same status
      * {@code surface} would have produced for an unrecognized worker fault).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperator.java
@@ -287,7 +287,14 @@ public class ExternalFieldExtractOperator implements Operator {
             }
         }
 
-        Block[] deferredBlocks = registry.materialize(refs, positions, deferredColumnNames, deferredColumnTypes, blockFactory);
+        final Block[] deferredBlocks;
+        try {
+            deferredBlocks = registry.materialize(refs, positions, deferredColumnNames, deferredColumnTypes, blockFactory);
+        } catch (Throwable t) {
+            // Deferred extraction performs external reads on the driver thread, so classify here
+            // while the concrete failure type is still available and before any transport hop.
+            throw ExternalFailures.classify(t);
+        }
         Block[] outBlocks = new Block[passThroughChannels.size() + deferredBlocks.length];
         try {
             int idx = 0;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceExtractors.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceExtractors.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -209,8 +208,10 @@ public final class SourceExtractors implements Releasable {
      *                    ({@code null} — the list or an entry — disables coercion for that column)
      * @param factory     block factory for memory accounting
      * @return one Block per column, each with exactly {@code count} rows; in caller-supplied order
+     * @throws IOException if an extractor fails while reading the requested columns
      */
-    public Block[] materialize(long[] encodedRefs, int count, List<String> columns, List<DataType> targetTypes, BlockFactory factory) {
+    public Block[] materialize(long[] encodedRefs, int count, List<String> columns, List<DataType> targetTypes, BlockFactory factory)
+        throws IOException {
         if (encodedRefs == null) {
             throw new IllegalArgumentException("encodedRefs must not be null");
         }
@@ -305,12 +306,7 @@ public final class SourceExtractors implements Releasable {
                 if (perIdCounts[id] == 0) {
                     continue;
                 }
-                Block[] perIdBlocks;
-                try {
-                    perIdBlocks = snapshot.get(id).extract(columnNames, targetTypesArray, localPositionsById[id], factory);
-                } catch (IOException e) {
-                    throw new UncheckedIOException("failed to materialize columns " + columns + " from extractor id [" + id + "]", e);
-                }
+                Block[] perIdBlocks = snapshot.get(id).extract(columnNames, targetTypesArray, localPositionsById[id], factory);
                 if (perIdBlocks == null || perIdBlocks.length != colCount) {
                     if (perIdBlocks != null) {
                         Releasables.closeExpectNoException(perIdBlocks);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalException.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.core.QlException;
  * Base type for failures raised while reading from an external data source — an object store, a
  * file in some columnar/row format, a remote HTTP endpoint, etc. Grouping every external-source
  * failure under one type lets callers catch them as a family ({@code catch (ExternalException)})
- * and lets {@code AsyncExternalSourceOperator} surface them with the correct HTTP status.
+ * and lets external-read operators surface them with the correct HTTP status.
  * <p>
  * The distinction between server- and client-class failures is carried by the concrete subtype, so
  * the right status falls out of the exception itself rather than from a downstream {@code instanceof}
@@ -32,14 +32,16 @@ import org.elasticsearch.xpack.esql.core.QlException;
  * <p>
  * <b>Transport behaviour.</b> Like every other ES|QL exception, these are not registered in
  * {@code ElasticsearchException}'s serialization registry, so crossing a node boundary turns them
- * into a {@code NotSerializableExceptionWrapper}. That wrapper <em>preserves {@link #status()}</em>
- * (it captures {@code ExceptionsHelper.status(this)} on the sending node and replays it on the
- * receiver), so the 400/500/503 distinction survives the data-node &rarr; coordinator hop and the
- * REST layer still maps it correctly. What does <em>not</em> survive is the concrete Java type: a
- * remote receiver cannot {@code instanceof}-check these. That is fine because classification happens
+ * into a {@code NotSerializableExceptionWrapper}. That wrapper preserves both the public exception
+ * name (for example, {@code external_client_exception}) and {@link #status()} (it captures
+ * {@code ExceptionsHelper.status(this)} on the sending node and replays it on the receiver), so the
+ * name and 400/500/503 distinction survive the data-node &rarr; coordinator hop and the REST layer
+ * still maps them correctly. What does <em>not</em> survive is the concrete Java type: a remote
+ * receiver cannot {@code instanceof}-check these. That is fine because classification happens
  * co-located with the throw — {@code ExternalFailures.classify} runs inside
- * {@code AsyncExternalSourceOperator}, which executes on the node that reads the external source,
- * before any serialization — so no remote consumer ever needs the concrete type, only the status.
+ * {@code AsyncExternalSourceOperator} for eager reads and {@code ExternalFieldExtractOperator} for
+ * deferred reads, on the node that reads the external source and before any serialization — so no
+ * remote consumer ever needs the concrete type.
  */
 public abstract class ExternalException extends QlException {
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
@@ -19,8 +21,10 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.test.ComputeTestCase;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -259,10 +263,55 @@ public class ExternalFieldExtractOperatorTests extends ComputeTestCase {
      * path, including {@link Error}s. Leak detection is {@link ComputeTestCase}'s teardown.
      */
     public void testMaterializeFailureReleasesPage() {
-        boolean throwError = randomBoolean();
+        CircuitBreakingException breaker = new CircuitBreakingException(
+            "simulated breaker trip during extraction",
+            CircuitBreaker.Durability.TRANSIENT
+        );
+        AssertionError error = new AssertionError("simulated error during extraction");
+        for (Throwable failure : List.of(breaker, error)) {
+            try (SourceExtractors registry = new SourceExtractors()) {
+                int id = registry.register(new ThrowingExtractor(failure));
+                Page page = newPage(new long[] { 1L }, new long[] { SourceExtractors.encode(id, 0) }, new int[] { 9 });
+
+                ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(
+                    1,
+                    List.of(0, 2),
+                    List.of("col"),
+                    List.of(DataType.INTEGER),
+                    registry,
+                    blockFactory
+                );
+                op.addInput(page);
+                try {
+                    if (failure instanceof CircuitBreakingException) {
+                        CircuitBreakingException thrown = expectThrows(CircuitBreakingException.class, op::getOutput);
+                        assertSame(failure, thrown);
+                        assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(thrown));
+                    } else {
+                        assertSame(failure, expectThrows(AssertionError.class, op::getOutput));
+                    }
+                } finally {
+                    op.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * A checked I/O failure during deferred extraction is an external-read failure, even though it
+     * occurs after TopN on the driver thread. The first extractor successfully allocates its block
+     * before the second fails, so leak tracking also verifies cleanup of partial registry output.
+     */
+    public void testIoFailureDuringMaterializationIsClassified() {
+        IOException failure = new IOException("Access denied reading object s3://bucket/hits.parquet");
         try (SourceExtractors registry = new SourceExtractors()) {
-            int id = registry.register(new ThrowingExtractor(throwError));
-            Page page = newPage(new long[] { 1L }, new long[] { SourceExtractors.encode(id, 0) }, new int[] { 9 });
+            int successfulId = registry.register(new IntListExtractor(new int[] { 10 }));
+            int failingId = registry.register(new ThrowingExtractor(failure));
+            Page page = newPage(
+                new long[] { 1L, 2L },
+                new long[] { SourceExtractors.encode(successfulId, 0), SourceExtractors.encode(failingId, 0) },
+                new int[] { 9, 10 }
+            );
 
             ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(
                 1,
@@ -273,9 +322,17 @@ public class ExternalFieldExtractOperatorTests extends ComputeTestCase {
                 blockFactory
             );
             op.addInput(page);
-            Class<? extends Throwable> expected = throwError ? AssertionError.class : CircuitBreakingException.class;
-            expectThrows(expected, op::getOutput);
-            op.close();
+            op.finish();
+            try {
+                ExternalClientException thrown = expectThrows(ExternalClientException.class, op::getOutput);
+                assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(thrown));
+                assertEquals("external_client_exception", ElasticsearchException.getExceptionName(thrown));
+                assertTrue(thrown.getMessage().startsWith("Failed to read external source: "));
+                assertTrue(thrown.getMessage().contains(failure.getMessage()));
+                assertSame(failure, thrown.getCause());
+            } finally {
+                op.close();
+            }
         }
     }
 
@@ -354,15 +411,14 @@ public class ExternalFieldExtractOperatorTests extends ComputeTestCase {
     }
 
     /**
-     * Extractor that allocates nothing and always throws: a {@link CircuitBreakingException}
-     * simulating a breaker trip mid-materialization, or an {@link AssertionError} to exercise
-     * the {@code Throwable} (not just {@code RuntimeException}) cleanup paths.
+     * Extractor that allocates nothing and rethrows a supplied checked exception, runtime
+     * exception, or error unchanged.
      */
     private static final class ThrowingExtractor implements ColumnExtractor {
-        private final boolean throwError;
+        private final Throwable failure;
 
-        ThrowingExtractor(boolean throwError) {
-            this.throwError = throwError;
+        ThrowingExtractor(Throwable failure) {
+            this.failure = failure;
         }
 
         @Override
@@ -371,11 +427,18 @@ public class ExternalFieldExtractOperatorTests extends ComputeTestCase {
         }
 
         @Override
-        public Block[] extract(String[] columnNames, DataType[] targetTypes, long[] localPositions, BlockFactory factory) {
-            if (throwError) {
-                throw new AssertionError("simulated error during extraction");
+        public Block[] extract(String[] columnNames, DataType[] targetTypes, long[] localPositions, BlockFactory factory)
+            throws IOException {
+            if (failure instanceof IOException ioException) {
+                throw ioException;
             }
-            throw new CircuitBreakingException("simulated breaker trip during extraction", CircuitBreaker.Durability.TRANSIENT);
+            if (failure instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (failure instanceof Error error) {
+                throw error;
+            }
+            throw new AssertionError("unsupported test failure", failure);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalFieldExtractOperatorTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnExtractor;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalServerException;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -330,6 +332,69 @@ public class ExternalFieldExtractOperatorTests extends ComputeTestCase {
                 assertTrue(thrown.getMessage().startsWith("Failed to read external source: "));
                 assertTrue(thrown.getMessage().contains(failure.getMessage()));
                 assertSame(failure, thrown.getCause());
+            } finally {
+                op.close();
+            }
+        }
+    }
+
+    /**
+     * A storage-layer 503 already carries the retryable status. Classification at this operator
+     * must leave it unchanged rather than re-wrapping it as a client or server exception.
+     */
+    public void testUnavailableExceptionDuringMaterializationStays503() {
+        ExternalUnavailableException failure = new ExternalUnavailableException("store 503", new IOException("connection reset"));
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id = registry.register(new ThrowingExtractor(failure));
+            Page page = newPage(new long[] { 1L }, new long[] { SourceExtractors.encode(id, 0) }, new int[] { 9 });
+
+            ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(
+                1,
+                List.of(0, 2),
+                List.of("col"),
+                List.of(DataType.INTEGER),
+                registry,
+                blockFactory
+            );
+            op.addInput(page);
+            op.finish();
+            try {
+                ExternalUnavailableException thrown = expectThrows(ExternalUnavailableException.class, op::getOutput);
+                assertSame(failure, thrown);
+                assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(thrown));
+                assertEquals("external_unavailable_exception", ElasticsearchException.getExceptionName(thrown));
+            } finally {
+                op.close();
+            }
+        }
+    }
+
+    /**
+     * Materializing against a closed registry is a broken invariant, not bad input. Classification
+     * at this operator must turn that {@link IllegalStateException} into a 500.
+     */
+    public void testClosedRegistryDuringMaterializationIsServerException() {
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int id = registry.register(new IntListExtractor(new int[] { 10 }));
+            Page page = newPage(new long[] { 1L }, new long[] { SourceExtractors.encode(id, 0) }, new int[] { 9 });
+
+            ExternalFieldExtractOperator op = new ExternalFieldExtractOperator(
+                1,
+                List.of(0, 2),
+                List.of("col"),
+                List.of(DataType.INTEGER),
+                registry,
+                blockFactory
+            );
+            op.addInput(page);
+            op.finish();
+            registry.close();
+            try {
+                ExternalServerException thrown = expectThrows(ExternalServerException.class, op::getOutput);
+                assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(thrown));
+                assertEquals("external_server_exception", ElasticsearchException.getExceptionName(thrown));
+                assertTrue(thrown.getCause() instanceof IllegalStateException);
+                assertEquals("SourceExtractors is closed", thrown.getCause().getMessage());
             } finally {
                 op.close();
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
@@ -153,7 +153,7 @@ public class SourceExtractorsTests extends ESTestCase {
         assertEquals("trailing closeable must run exactly once", 1, calls.get());
     }
 
-    public void testMaterializeEmptyCount() {
+    public void testMaterializeEmptyCount() throws IOException {
         try (SourceExtractors registry = new SourceExtractors()) {
             registry.register(new IntListExtractor(new int[] { 1, 2 }));
             Block[] result = registry.materialize(new long[0], 0, List.of("col"), null, blockFactory);
@@ -166,7 +166,7 @@ public class SourceExtractorsTests extends ESTestCase {
         }
     }
 
-    public void testMaterializeSingleSource() {
+    public void testMaterializeSingleSource() throws IOException {
         try (SourceExtractors registry = new SourceExtractors()) {
             int id = registry.register(new IntListExtractor(new int[] { 10, 20, 30, 40 }));
             // Request positions 3, 0, 2 — out of order and disjoint.
@@ -185,7 +185,7 @@ public class SourceExtractorsTests extends ESTestCase {
         }
     }
 
-    public void testMaterializeMultiSourceInterleaved() {
+    public void testMaterializeMultiSourceInterleaved() throws IOException {
         try (SourceExtractors registry = new SourceExtractors()) {
             int idA = registry.register(new IntListExtractor(new int[] { 100, 101, 102 }));
             int idB = registry.register(new IntListExtractor(new int[] { 200, 201 }));
@@ -214,7 +214,7 @@ public class SourceExtractorsTests extends ESTestCase {
         }
     }
 
-    public void testMaterializeBatchesPerExtractor() {
+    public void testMaterializeBatchesPerExtractor() throws IOException {
         // The dispatch must call extract once per id per materialize() call — proving the per-id
         // batching is real, not row-by-row, and that all requested columns flow through a single
         // extract invocation so the implementation can coalesce I/O across columns (F-2).
@@ -254,7 +254,7 @@ public class SourceExtractorsTests extends ESTestCase {
         assertEquals("single-column materialize must pass exactly one column to extract", 1, maxColumnsPerCall.get());
     }
 
-    public void testMaterializeMultipleColumnsBatchesAllColumnsPerExtractor() {
+    public void testMaterializeMultipleColumnsBatchesAllColumnsPerExtractor() throws IOException {
         // F-2 invariant: with N requested columns and K extractor ids, materialize() must invoke
         // each extractor's multi-column extract exactly once (passing all N columns), so the
         // implementation can issue a single coalesced I/O batch covering all N columns. A
@@ -292,7 +292,7 @@ public class SourceExtractorsTests extends ESTestCase {
         assertEquals("multi-column materialize must pass both columns in a single extract() call", 2, maxColsA.get());
     }
 
-    public void testMaterializeMultipleColumns() {
+    public void testMaterializeMultipleColumns() throws IOException {
         try (SourceExtractors registry = new SourceExtractors()) {
             int idA = registry.register(new TwoColumnExtractor(new int[] { 1, 2 }, new long[] { 10L, 20L }));
             int idB = registry.register(new TwoColumnExtractor(new int[] { 3, 4 }, new long[] { 30L, 40L }));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceExtractorsTests.java
@@ -315,6 +315,31 @@ public class SourceExtractorsTests extends ESTestCase {
         }
     }
 
+    /**
+     * {@link SourceExtractors#materialize} must rethrow the extractor's {@link IOException} as the
+     * same instance. Wrapping it (for example in {@code UncheckedIOException}) would hide the
+     * checked type from {@code ExternalFailures.classify} at the operator boundary.
+     */
+    public void testMaterializeRethrowsExtractIoFailure() {
+        IOException failure = new IOException("simulated extract I/O failure");
+        try (SourceExtractors registry = new SourceExtractors()) {
+            int successfulId = registry.register(new IntListExtractor(new int[] { 10 }));
+            int failingId = registry.register(new IntListExtractor(new int[] { 20 }) {
+                @Override
+                public Block[] extract(String[] columnNames, DataType[] targetTypes, long[] localPositions, BlockFactory factory)
+                    throws IOException {
+                    throw failure;
+                }
+            });
+            long[] refs = new long[] { SourceExtractors.encode(successfulId, 0), SourceExtractors.encode(failingId, 0) };
+            IOException thrown = expectThrows(
+                IOException.class,
+                () -> registry.materialize(refs, refs.length, List.of("col"), null, blockFactory)
+            );
+            assertSame(failure, thrown);
+        }
+    }
+
     public void testMaterializeRejectsUnknownExtractorId() {
         try (SourceExtractors registry = new SourceExtractors()) {
             registry.register(new IntListExtractor(new int[] { 1, 2 }));


### PR DESCRIPTION
Routes late-materialization failures through external error classification, preserving raw I/O causes and adding regression coverage for status, type, and cleanup.

Closes https://github.com/elastic/esql-planning/issues/1825