### PR TITLE
Cap min_hash filter params

### DIFF
--- a/docs/changelog/158211.yaml
+++ b/docs/changelog/158211.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 158211
+summary: Cap `min_hash` filter params to prevent overflow and OOM
+type: bug

--- a/docs/changelog/158211.yaml
+++ b/docs/changelog/158211.yaml
@@ -1,5 +1,5 @@
 area: Analysis
 issues: []
 pr: 158211
-summary: Cap `min_hash` filter params to prevent overflow and OOM
+summary: Cap `min_hash` filter params
 type: bug

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MinHashTokenFilterFactory.java
@@ -26,6 +26,16 @@ import java.util.Map;
  */
 public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
 
+    /**
+     * Hard upper bounds for the {@code hash_count}, {@code bucket_count}, and {@code hash_set_size}
+     * parameters. No legitimate MinHash configuration needs values anywhere near these limits (typical
+     * values are in the single digits to low hundreds). The caps exist to prevent integer overflow in
+     * the product check below and to block resource-exhaustion attacks via the {@code _analyze} API.
+     */
+    static final int MAX_HASH_COUNT = 10_000;
+    static final int MAX_BUCKET_COUNT = 10_000;
+    static final int MAX_HASH_SET_SIZE = 10_000;
+
     private final MinHashFilterFactory minHashFilterFactory;
 
     MinHashTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
@@ -33,6 +43,9 @@ public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
         int hashCount = settings.getAsInt("hash_count", MinHashFilter.DEFAULT_HASH_COUNT);
         int bucketCount = settings.getAsInt("bucket_count", MinHashFilter.DEFAULT_BUCKET_COUNT);
         int hashSetSize = settings.getAsInt("hash_set_size", MinHashFilter.DEFAULT_HASH_SET_SIZE);
+        validateParamBound("hash_count", hashCount, MAX_HASH_COUNT, settings);
+        validateParamBound("bucket_count", bucketCount, MAX_BUCKET_COUNT, settings);
+        validateParamBound("hash_set_size", hashSetSize, MAX_HASH_SET_SIZE, settings);
         // Only validate when the user explicitly configured parameters; eager instantiation with
         // default settings (empty Settings) is skipped so that an unrelated low max_token_count
         // on an index that doesn't use min_hash does not cause index creation to fail.
@@ -58,6 +71,12 @@ public class MinHashTokenFilterFactory extends AbstractTokenFilterFactory {
             }
         }
         minHashFilterFactory = new MinHashFilterFactory(convertSettings(settings));
+    }
+
+    private static void validateParamBound(String paramName, int value, int maxValue, Settings settings) {
+        if (settings.hasValue(paramName) && value > maxValue) {
+            throw new IllegalArgumentException("[" + paramName + "] must not exceed [" + maxValue + "] but was [" + value + "]");
+        }
     }
 
     @Override

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MinHashFilterFactoryTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisTestsHelper;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.test.ESTestCase;
@@ -23,6 +22,7 @@ import java.io.IOException;
 import java.io.StringReader;
 
 import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.assertStreamHasNumberOfTokens;
+import static org.hamcrest.Matchers.containsString;
 
 public class MinHashFilterFactoryTests extends ESTokenStreamTestCase {
     public void testDefault() throws IOException {
@@ -112,7 +112,64 @@ public class MinHashFilterFactoryTests extends ESTokenStreamTestCase {
             IllegalArgumentException.class,
             () -> AnalysisTestsHelper.createTestAnalysisFromSettings(settings, new CommonAnalysisPlugin())
         );
-        assertThat(e.getMessage(), org.hamcrest.Matchers.containsString(IndexSettings.MAX_TOKEN_COUNT_SETTING.getKey()));
+        assertThat(e.getMessage(), containsString("must not exceed"));
+    }
+
+    public void testIndividualParameterCapEnforced() {
+        // Each parameter should be independently rejected when it exceeds its cap
+        String[][] paramsAndLimits = {
+            { "hash_count", Integer.toString(MinHashTokenFilterFactory.MAX_HASH_COUNT + 1) },
+            { "bucket_count", Integer.toString(MinHashTokenFilterFactory.MAX_BUCKET_COUNT + 1) },
+            { "hash_set_size", Integer.toString(MinHashTokenFilterFactory.MAX_HASH_SET_SIZE + 1) } };
+        for (String[] entry : paramsAndLimits) {
+            String param = entry[0];
+            String overLimit = entry[1];
+            Settings settings = Settings.builder()
+                .put("index.analysis.filter.test_min_hash.type", "min_hash")
+                .put("index.analysis.filter.test_min_hash." + param, overLimit)
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+                .build();
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> AnalysisTestsHelper.createTestAnalysisFromSettings(settings, new CommonAnalysisPlugin())
+            );
+            assertThat(e.getMessage(), containsString("[" + param + "] must not exceed"));
+        }
+    }
+
+    public void testOverflowBypassRejected() {
+        // Regression test: three values whose mathematical product wraps to zero in long arithmetic
+        // should still be rejected by the per-parameter cap. This is the bypass described in
+        // elastic/security#12881 where hash_set_size was raised to force a long overflow.
+        Settings settings = Settings.builder()
+            .put("index.analysis.filter.test_min_hash.type", "min_hash")
+            .put("index.analysis.filter.test_min_hash.hash_count", "2097152")
+            .put("index.analysis.filter.test_min_hash.bucket_count", "2097152")
+            .put("index.analysis.filter.test_min_hash.hash_set_size", "4194304")
+            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+            .build();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> AnalysisTestsHelper.createTestAnalysisFromSettings(settings, new CommonAnalysisPlugin())
+        );
+        assertThat(e.getMessage(), containsString("must not exceed"));
+    }
+
+    public void testMaxParamValueAllowed() throws IOException {
+        // Boundary test: exactly the maximum should pass the per-parameter cap (but may still
+        // be rejected by the product check against max_token_count).
+        int maxBucketCount = MinHashTokenFilterFactory.MAX_BUCKET_COUNT;
+        Settings settings = Settings.builder()
+            .put("index.analysis.filter.test_min_hash.type", "min_hash")
+            .put("index.analysis.filter.test_min_hash.hash_count", "1")
+            .put("index.analysis.filter.test_min_hash.bucket_count", maxBucketCount)
+            .put("index.analysis.filter.test_min_hash.hash_set_size", "1")
+            .put("index.analyze.max_token_count", maxBucketCount)
+            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
+            .build();
+        // Should not throw — product is 1 * 10000 * 1 = 10000, which equals max_token_count
+        ESTestCase.TestAnalysis analysis = AnalysisTestsHelper.createTestAnalysisFromSettings(settings, new CommonAnalysisPlugin());
+        assertNotNull(analysis.tokenFilter.get("test_min_hash"));
     }
 
 }


### PR DESCRIPTION
Adds per-parameter upper bounds (10,000) on `hash_count`, `bucket_count`, and `hash_set_size` in `MinHashTokenFilterFactory`. The caps fire before the existing product check against `max_token_count`, preventing `long` arithmetic overflow (extending what was added in #154480).

No legitimate MinHash configuration needs values anywhere near these limits — typical values are single digits to low hundreds (defaults: `hash_count=1`, `bucket_count=512`, `hash_set_size=1`). With all three capped at 10,000, the maximum product is 10^12, well within `long` range.

**Tests added:**
- `testIndividualParameterCapEnforced` — each parameter independently rejected above its cap
- `testOverflowBypassRejected` — regression test using the exact values from the reported bypass
- `testMaxParamValueAllowed` — boundary test confirming the cap value itself is accepted