### PR TITLE
Fixed flaky BinaryFieldMapperTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -106,9 +106,6 @@ tests:
 - class: org.elasticsearch.upgrades.XpackSystemIndicesUpgradeIT
   method: testUpgradeSystemIndexAndDataStream {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/158123
-- class: org.elasticsearch.index.mapper.BinaryFieldMapperTests
-  method: testSyntheticSourceMany
-  issue: https://github.com/elastic/elasticsearch/issues/158124
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Put an outlier_detection job on the mixed cluster}
   issue: https://github.com/elastic/elasticsearch/issues/158132

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -215,7 +215,7 @@ public class BinaryFieldMapperTests extends MapperTestCase {
 
                 var outList = values.stream()
                     .map(Tuple::v2)
-                    .map(BytesCompareUnsigned::new)
+                    .map(BytesRef::new)
                     .collect(Collectors.toSet())
                     .stream()
                     .sorted()
@@ -247,13 +247,6 @@ public class BinaryFieldMapperTests extends MapperTestCase {
 
                 if (rarely()) {
                     b.field("store", false);
-                }
-            }
-
-            private record BytesCompareUnsigned(byte[] bytes) implements Comparable<BytesCompareUnsigned> {
-                @Override
-                public int compareTo(BytesCompareUnsigned o) {
-                    return Arrays.compareUnsigned(bytes, o.bytes);
                 }
             }
         };


### PR DESCRIPTION
`BytesRef`'s comparison methods are identical to this custom one. The problem was the lack of `equals` and `hashCode`, which `BytesRef` provides.

Closes https://github.com/elastic/elasticsearch/issues/158124