### PR TITLE
[Inference API] Ignore elasticsearch service when disabled

### DIFF
--- a/docs/changelog/158218.yaml
+++ b/docs/changelog/158218.yaml
@@ -1,5 +1,0 @@
-area: Inference
-issues: []
-pr: 158218
-summary: "[Inference API] Ignore elasticsearch service when disabled"
-type: bug

--- a/docs/changelog/158218.yaml
+++ b/docs/changelog/158218.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 158218
+summary: "[Inference API] Ignore elasticsearch service when disabled"
+type: bug

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/GetInferenceModelMlDisabledIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/GetInferenceModelMlDisabledIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.integration;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
+import org.elasticsearch.xpack.core.inference.results.ModelStoreResponse;
+import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
+import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Integration test that verifies {@code GET _inference/_all} (and related paths) behave correctly
+ * when ML is disabled and endpoints persisted with {@code "service": "elasticsearch"} or the
+ * pre-8.13 alias {@code "service": "elser"} are present in the index.
+ *
+ * <p>The node starts with {@code xpack.ml.enabled=false}, so {@link ElasticsearchInternalService}
+ * is never registered. Models are written directly to the registry (bypassing the PUT API, which
+ * would reject an unregistered service) to simulate a cluster that had ML enabled in the past.
+ */
+public class GetInferenceModelMlDisabledIT extends ESSingleNodeTestCase {
+
+    private static final String ES_ENDPOINT_ID = "es-endpoint";
+    private static final String ELSER_ENDPOINT_ID = "elser-endpoint";
+    private static final String TEST_ENDPOINT_ID = "test-endpoint";
+
+    @Override
+    protected boolean resetNodeAfterTest() {
+        return true;
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false).build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(ReindexPlugin.class, LocalStateInferencePlugin.class);
+    }
+
+    public void testGetAllModels_SkipsElasticsearchAndElserEndpoints() {
+        var registry = modelRegistry();
+        storeModel(registry, esModel());
+        storeModel(registry, elserModel());
+        storeModel(registry, testServiceModel());
+
+        var response = executeGetAll();
+
+        assertThat(response.getEndpoints(), hasSize(1));
+        assertThat(response.getEndpoints().get(0).getInferenceEntityId(), equalTo(TEST_ENDPOINT_ID));
+    }
+
+    public void testGetAllModels_ReturnsEmpty_WhenOnlyElasticsearchEndpointsExist() {
+        // Regression test for the empty-GroupedActionListener bug: when every persisted endpoint
+        // belongs to the skipped elasticsearch service, the response must be empty, not a 500.
+        var registry = modelRegistry();
+        storeModel(registry, esModel());
+        storeModel(registry, elserModel());
+
+        var response = executeGetAll();
+
+        assertThat(response.getEndpoints(), empty());
+    }
+
+    public void testGetModel_ByIdStillFails_ForElasticsearchEndpoint() {
+        // The single-endpoint path does NOT apply the skip — asking for a specific id should surface
+        // the problem rather than succeed silently.
+        storeModel(modelRegistry(), esModel());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        client().execute(GetInferenceModelAction.INSTANCE, new GetInferenceModelAction.Request(ES_ENDPOINT_ID, TaskType.ANY), future);
+
+        expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+    }
+
+    // -------------------- helpers --------------------
+
+    private ModelRegistry modelRegistry() {
+        return node().injector().getInstance(ModelRegistry.class);
+    }
+
+    private void storeModel(ModelRegistry registry, org.elasticsearch.inference.Model model) {
+        var future = new TestPlainActionFuture<List<ModelStoreResponse>>();
+        registry.storeModels(List.of(model), false, future, TimeValue.THIRTY_SECONDS);
+        future.actionGet(TEST_REQUEST_TIMEOUT);
+    }
+
+    private GetInferenceModelAction.Response executeGetAll() {
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        client().execute(GetInferenceModelAction.INSTANCE, new GetInferenceModelAction.Request("_all", TaskType.ANY, false), future);
+        return future.actionGet(TEST_REQUEST_TIMEOUT);
+    }
+
+    /**
+     * A model persisted with {@code "service": "elasticsearch"} — as created by the pre-change code
+     * on a cluster with ML enabled.
+     */
+    private static org.elasticsearch.inference.Model esModel() {
+        return ModelRegistryIT.createModel(ES_ENDPOINT_ID, TaskType.SPARSE_EMBEDDING, ElasticsearchInternalService.NAME);
+    }
+
+    /**
+     * A model persisted with {@code "service": "elser"} — as created before the 8.13 service rename.
+     */
+    private static org.elasticsearch.inference.Model elserModel() {
+        return ModelRegistryIT.createModel(
+            ELSER_ENDPOINT_ID,
+            TaskType.SPARSE_EMBEDDING,
+            ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME
+        );
+    }
+
+    /**
+     * A model whose service ({@code test_service}) IS registered in {@link LocalStateInferencePlugin}.
+     */
+    private static org.elasticsearch.inference.Model testServiceModel() {
+        return new TestSparseInferenceServiceExtension.TestSparseModel(
+            TEST_ENDPOINT_ID,
+            new TestSparseInferenceServiceExtension.TestServiceSettings("test-model", null, false)
+        );
+    }
+}

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/GetInferenceModelMlDisabledIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/GetInferenceModelMlDisabledIT.java
@@ -95,8 +95,6 @@ public class GetInferenceModelMlDisabledIT extends ESSingleNodeTestCase {
         expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
     }
 
-    // -------------------- helpers --------------------
-
     private ModelRegistry modelRegistry() {
         return node().injector().getInstance(ModelRegistry.class);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -68,7 +68,6 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackPlugin;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.inference.action.DeleteCCMConfigurationAction;
 import org.elasticsearch.xpack.core.inference.action.DeleteInferenceEndpointAction;
@@ -727,7 +726,7 @@ public class InferencePlugin extends Plugin
         factories.add(context -> new Ai21Service(httpFactory.get(), serviceComponents.get(), context));
         factories.add(context -> new OpenShiftAiService(httpFactory.get(), serviceComponents.get(), context));
         factories.add(context -> new NvidiaService(httpFactory.get(), serviceComponents.get(), context));
-        if (XPackSettings.MACHINE_LEARNING_ENABLED.get(settings) && XPackSettings.NLP_ENABLED.get(settings)) {
+        if (ElasticsearchInternalService.isSupported(settings)) {
             factories.add(ElasticsearchInternalService::new);
         }
         factories.add(context -> new CustomService(httpFactory.get(), serviceComponents.get(), context));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -149,7 +149,8 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
                         continue;
                     }
 
-                    throw serviceNotFoundException(unparsedModel.service(), unparsedModel.inferenceEntityId());
+                    listener.onFailure(serviceNotFoundException(unparsedModel.service(), unparsedModel.inferenceEntityId()));
+                    return;
                 }
                 var list = parsedModelsByService.computeIfAbsent(service.get().name(), s -> new ArrayList<>());
                 list.add(service.get().parsePersistedConfig(unparsedModel));
@@ -189,7 +190,7 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     }
 
     private ElasticsearchStatusException serviceNotFoundException(String service, String inferenceId) {
-        throw new ElasticsearchStatusException(
+        return new ElasticsearchStatusException(
             "Unknown service [{}] for inference endpoint [{}].",
             RestStatus.INTERNAL_SERVER_ERROR,
             service,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.Model;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.common.InferenceExceptions;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -42,6 +44,7 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     private final ModelRegistry modelRegistry;
     private final InferenceServiceRegistry serviceRegistry;
     private final Executor executor;
+    private final Settings settings;
 
     @Inject
     public TransportGetInferenceModelAction(
@@ -49,7 +52,8 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
         ActionFilters actionFilters,
         ThreadPool threadPool,
         ModelRegistry modelRegistry,
-        InferenceServiceRegistry serviceRegistry
+        InferenceServiceRegistry serviceRegistry,
+        Settings settings
     ) {
         super(
             GetInferenceModelAction.NAME,
@@ -61,6 +65,7 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
         this.modelRegistry = modelRegistry;
         this.serviceRegistry = serviceRegistry;
         this.executor = threadPool.executor(InferencePlugin.UTILITY_THREAD_POOL_NAME);
+        this.settings = settings;
     }
 
     @Override
@@ -138,10 +143,21 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
             for (var unparsedModel : unparsedModels) {
                 var service = serviceRegistry.getService(unparsedModel.service());
                 if (service.isEmpty()) {
+                    // If the ml plugin or the nlp functionality is disabled the elasticsearch service will not be registered so ignore
+                    // this failure
+                    if (shouldIgnoreElasticsearchInternalServiceMissing(unparsedModel.service())) {
+                        continue;
+                    }
+
                     throw serviceNotFoundException(unparsedModel.service(), unparsedModel.inferenceEntityId());
                 }
                 var list = parsedModelsByService.computeIfAbsent(service.get().name(), s -> new ArrayList<>());
                 list.add(service.get().parsePersistedConfig(unparsedModel));
+            }
+
+            if (parsedModelsByService.isEmpty()) {
+                listener.onResponse(new GetInferenceModelAction.Response(List.of()));
+                return;
             }
 
             var groupedListener = new GroupedActionListener<List<Model>>(
@@ -166,6 +182,10 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    private boolean shouldIgnoreElasticsearchInternalServiceMissing(String service) {
+        return ElasticsearchInternalService.isServiceNameOrAlias(service) && ElasticsearchInternalService.isSupported(settings) == false;
     }
 
     private ElasticsearchStatusException serviceNotFoundException(String service, String inferenceId) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -56,7 +56,6 @@ import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInt
 import org.elasticsearch.xpack.inference.services.validation.ModelValidationResult;
 import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuilder;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -415,7 +414,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
     }
 
     private boolean isInClusterService(String name) {
-        return List.of(ElasticsearchInternalService.NAME, ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME).contains(name);
+        return ElasticsearchInternalService.isServiceNameOrAlias(name);
     }
 
     private String getDeploymentIdForInClusterEndpoint(Model model) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.EmbeddingRequestChunker;
 import org.elasticsearch.xpack.core.inference.chunking.RerankRequestChunker;
@@ -156,6 +157,14 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 Strings.format("Error parsing request config, model id is missing for inference id: %s", inferenceEntityId)
             );
         }
+    }
+
+    public static boolean isSupported(Settings settings) {
+        return XPackSettings.MACHINE_LEARNING_ENABLED.get(settings) && XPackSettings.NLP_ENABLED.get(settings);
+    }
+
+    public static boolean isServiceNameOrAlias(String name) {
+        return name.equals(ElasticsearchInternalService.NAME) || name.equals(ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME);
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelActionTests.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TestPlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.inference.InferenceService;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.UnparsedModel;
+import org.elasticsearch.plugins.Platforms;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.elasticsearch.xpack.core.XPackSettings.MACHINE_LEARNING_ENABLED;
+import static org.elasticsearch.xpack.core.XPackSettings.ML_NATIVE_CODE_PLATFORMS;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportGetInferenceModelActionTests extends ESTestCase {
+
+    private static final String ES_ENDPOINT_ID = "es-endpoint-id";
+    private static final String ELSER_ENDPOINT_ID = "elser-endpoint-id";
+    private static final String TEST_ENDPOINT_ID = "test-endpoint-id";
+    private static final String TEST_ENDPOINT_ID_2 = "zzz-test-endpoint-id";
+    private static final String OTHER_TEST_ENDPOINT_ID = "aaa-other-test-endpoint-id";
+    private static final String TEST_SERVICE_NAME = "test-service";
+    private static final String OTHER_TEST_SERVICE_NAME = "other-test-service";
+    private static final String UNKNOWN_SERVICE_NAME = "unknown-service";
+
+    private static final Settings ML_DISABLED_SETTINGS = Settings.builder().put(MACHINE_LEARNING_ENABLED.getKey(), false).build();
+
+    private ThreadPool threadPool;
+    private ModelRegistry mockModelRegistry;
+    private InferenceServiceRegistry mockInferenceServiceRegistry;
+
+    @Before
+    public void setUpMocks() throws Exception {
+        super.setUp();
+        threadPool = createThreadPool(inferenceUtilityExecutors());
+        mockModelRegistry = mock(ModelRegistry.class);
+        mockInferenceServiceRegistry = mock(InferenceServiceRegistry.class);
+    }
+
+    @After
+    public void terminateThreadPool() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
+    }
+
+    // -------------------- get-all tests --------------------
+
+    public void testGetAllModels_SkipsElasticsearchEndpoint_WhenMlDisabled() {
+        var esEndpoint = unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME);
+        var testEndpoint = unparsedModel(TEST_ENDPOINT_ID, TEST_SERVICE_NAME);
+        mockGetAllModels(List.of(esEndpoint, testEndpoint));
+
+        registerService(TEST_SERVICE_NAME);
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.empty());
+
+        var response = executeGetAll(ML_DISABLED_SETTINGS);
+
+        assertThat(response.getEndpoints(), hasSize(1));
+        assertThat(response.getEndpoints().get(0).getInferenceEntityId(), is(TEST_ENDPOINT_ID));
+    }
+
+    public void testGetAllModels_SkipsElserAliasEndpoint_WhenMlDisabled() {
+        // An endpoint persisted before 8.13 will have "service": "elser" rather than "elasticsearch"
+        var elserEndpoint = unparsedModel(ELSER_ENDPOINT_ID, ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME);
+        var testEndpoint = unparsedModel(TEST_ENDPOINT_ID, TEST_SERVICE_NAME);
+        mockGetAllModels(List.of(elserEndpoint, testEndpoint));
+
+        registerService(TEST_SERVICE_NAME);
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME)).thenReturn(Optional.empty());
+
+        var response = executeGetAll(ML_DISABLED_SETTINGS);
+
+        assertThat(response.getEndpoints(), hasSize(1));
+        assertThat(response.getEndpoints().get(0).getInferenceEntityId(), is(TEST_ENDPOINT_ID));
+    }
+
+    public void testGetAllModels_ReturnsEmptyResponse_WhenAllEndpointsAreSkipped() {
+        // Regression test: if every persisted endpoint is skipped, parsedModelsByService is empty.
+        // GroupedActionListener rejects a group size of 0, so we must short-circuit before building it.
+        mockGetAllModels(
+            List.of(
+                unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME),
+                unparsedModel(ELSER_ENDPOINT_ID, ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME)
+            )
+        );
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.empty());
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME)).thenReturn(Optional.empty());
+
+        var response = executeGetAll(ML_DISABLED_SETTINGS);
+
+        assertThat(response.getEndpoints(), empty());
+    }
+
+    public void testGetAllModels_ReturnsEmptyResponse_WhenRegistryReturnsNoModels() {
+        mockGetAllModels(List.of());
+
+        var response = executeGetAll(ML_DISABLED_SETTINGS);
+
+        assertThat(response.getEndpoints(), empty());
+    }
+
+    public void testGetAllModels_ThrowsUnknownService_ForOtherMissingService() {
+        // The skip only applies to the elasticsearch service/alias; other missing services must still throw.
+        mockGetAllModels(List.of(unparsedModel(TEST_ENDPOINT_ID, UNKNOWN_SERVICE_NAME)));
+        when(mockInferenceServiceRegistry.getService(UNKNOWN_SERVICE_NAME)).thenReturn(Optional.empty());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(ML_DISABLED_SETTINGS).doExecute(mock(Task.class), getAllRequest(), future);
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(exception.getMessage(), containsString("Unknown service [" + UNKNOWN_SERVICE_NAME + "]"));
+    }
+
+    public void testGetAllModels_ThrowsUnknownService_ForElasticsearchService_WhenMlEnabled() {
+        // The skip must NOT apply when ML is enabled — a missing elasticsearch service is then an error.
+        assumeTrue("ML native code required", ML_NATIVE_CODE_PLATFORMS.contains(Platforms.PLATFORM_NAME));
+
+        mockGetAllModels(List.of(unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME)));
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.empty());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(Settings.EMPTY).doExecute(mock(Task.class), getAllRequest(), future);
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(exception.getMessage(), containsString("Unknown service [" + ElasticsearchInternalService.NAME + "]"));
+    }
+
+    public void testGetAllModels_ThrowsUnknownService_ForElserAlias_WhenMlEnabled() {
+        // Same as above for the elser alias.
+        assumeTrue("ML native code required", ML_NATIVE_CODE_PLATFORMS.contains(Platforms.PLATFORM_NAME));
+
+        mockGetAllModels(List.of(unparsedModel(ELSER_ENDPOINT_ID, ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME)));
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME)).thenReturn(Optional.empty());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(Settings.EMPTY).doExecute(mock(Task.class), getAllRequest(), future);
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(exception.getMessage(), containsString("Unknown service [" + ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME + "]"));
+    }
+
+    public void testGetAllModels_SortsResultsByInferenceEntityId() {
+        // Endpoints from two services come back sorted by entity id, not grouped by service.
+        mockGetAllModels(
+            List.of(unparsedModel(TEST_ENDPOINT_ID_2, TEST_SERVICE_NAME), unparsedModel(OTHER_TEST_ENDPOINT_ID, OTHER_TEST_SERVICE_NAME))
+        );
+        registerService(TEST_SERVICE_NAME);
+        registerService(OTHER_TEST_SERVICE_NAME);
+
+        var response = executeGetAll(ML_DISABLED_SETTINGS);
+
+        assertThat(response.getEndpoints(), hasSize(2));
+        assertThat(response.getEndpoints().get(0).getInferenceEntityId(), is(OTHER_TEST_ENDPOINT_ID));
+        assertThat(response.getEndpoints().get(1).getInferenceEntityId(), is(TEST_ENDPOINT_ID_2));
+    }
+
+    // -------------------- get-by-task-type tests --------------------
+
+    public void testGetModelsByTaskType_SkipsElasticsearchEndpoint_WhenMlDisabled() {
+        var esEndpoint = unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME);
+        var testEndpoint = unparsedModel(TEST_ENDPOINT_ID, TEST_SERVICE_NAME);
+        mockGetModelsByTaskType(List.of(esEndpoint, testEndpoint));
+
+        registerService(TEST_SERVICE_NAME);
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.empty());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(ML_DISABLED_SETTINGS).doExecute(
+            mock(Task.class),
+            new GetInferenceModelAction.Request("_all", TaskType.SPARSE_EMBEDDING, false),
+            future
+        );
+        var response = future.actionGet(TEST_REQUEST_TIMEOUT);
+
+        assertThat(response.getEndpoints(), hasSize(1));
+        assertThat(response.getEndpoints().get(0).getInferenceEntityId(), is(TEST_ENDPOINT_ID));
+    }
+
+    // -------------------- single-model tests --------------------
+
+    public void testGetSingleModel_ThrowsUnknownService_ForElasticsearchService_WhenMlDisabled() {
+        // The single-endpoint path (GET _inference/<id>) intentionally does NOT skip the error —
+        // asking for one specific endpoint by id should surface the problem rather than succeed silently.
+        mockGetModel(unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME));
+        when(mockInferenceServiceRegistry.getService(ElasticsearchInternalService.NAME)).thenReturn(Optional.empty());
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(ML_DISABLED_SETTINGS).doExecute(
+            mock(Task.class),
+            new GetInferenceModelAction.Request(ES_ENDPOINT_ID, TaskType.ANY),
+            future
+        );
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(exception.getMessage(), containsString("Unknown service [" + ElasticsearchInternalService.NAME + "]"));
+    }
+
+    public void testGetSingleModel_ThrowsMismatchedTaskType() {
+        registerService(TEST_SERVICE_NAME);
+        var unparsed = new UnparsedModel(TEST_ENDPOINT_ID, TaskType.SPARSE_EMBEDDING, TEST_SERVICE_NAME, Map.of(), Map.of());
+        mockGetModel(unparsed);
+        // No need to stub parsePersistedConfig — the task type mismatch check fires before it is called
+
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(ML_DISABLED_SETTINGS).doExecute(
+            mock(Task.class),
+            new GetInferenceModelAction.Request(TEST_ENDPOINT_ID, TaskType.TEXT_EMBEDDING),
+            future
+        );
+
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
+    }
+
+    // -------------------- helpers --------------------
+
+    private TransportGetInferenceModelAction createAction(Settings settings) {
+        return new TransportGetInferenceModelAction(
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            threadPool,
+            mockModelRegistry,
+            mockInferenceServiceRegistry,
+            settings
+        );
+    }
+
+    private GetInferenceModelAction.Request getAllRequest() {
+        return new GetInferenceModelAction.Request("_all", TaskType.ANY, false);
+    }
+
+    private GetInferenceModelAction.Response executeGetAll(Settings settings) {
+        var future = new TestPlainActionFuture<GetInferenceModelAction.Response>();
+        createAction(settings).doExecute(mock(Task.class), getAllRequest(), future);
+        return future.actionGet(TEST_REQUEST_TIMEOUT);
+    }
+
+    private void mockGetAllModels(List<UnparsedModel> models) {
+        doAnswer(invocation -> {
+            ActionListener<List<UnparsedModel>> listener = invocation.getArgument(1);
+            listener.onResponse(models);
+            return null;
+        }).when(mockModelRegistry).getAllModels(anyBoolean(), any());
+    }
+
+    private void mockGetModelsByTaskType(List<UnparsedModel> models) {
+        doAnswer(invocation -> {
+            ActionListener<List<UnparsedModel>> listener = invocation.getArgument(1);
+            listener.onResponse(models);
+            return null;
+        }).when(mockModelRegistry).getModelsByTaskType(any(), any());
+    }
+
+    private void mockGetModel(UnparsedModel model) {
+        doAnswer(invocation -> {
+            ActionListener<UnparsedModel> listener = invocation.getArgument(1);
+            listener.onResponse(model);
+            return null;
+        }).when(mockModelRegistry).getModel(anyString(), any());
+    }
+
+    /**
+     * Registers a mock service under {@code name}. The mock stubs {@code parsePersistedConfig} to return
+     * a model whose {@code inferenceEntityId} matches the entity id of the {@link UnparsedModel} passed to it,
+     * and stubs {@code updateModelsWithDynamicFields} to echo models back to the listener.
+     *
+     * Note: {@code updateModelsWithDynamicFields} is a default interface method; Mockito does not run
+     * default methods, so it must be explicitly stubbed or the listener will never complete.
+     */
+    private InferenceService registerService(String name) {
+        var service = mock(InferenceService.class);
+        when(service.name()).thenReturn(name);
+        when(service.parsePersistedConfig(any())).thenAnswer(invocation -> {
+            UnparsedModel unparsed = invocation.getArgument(0);
+            return mockModel(unparsed.inferenceEntityId(), name);
+        });
+        doAnswer(invocation -> {
+            List<Model> models = invocation.getArgument(0);
+            ActionListener<List<Model>> listener = invocation.getArgument(1);
+            listener.onResponse(models);
+            return null;
+        }).when(service).updateModelsWithDynamicFields(anyList(), any());
+        when(mockInferenceServiceRegistry.getService(name)).thenReturn(Optional.of(service));
+        return service;
+    }
+
+    private static UnparsedModel unparsedModel(String inferenceEntityId, String service) {
+        return new UnparsedModel(inferenceEntityId, TaskType.SPARSE_EMBEDDING, service, Map.of(), Map.of());
+    }
+
+    private static Model mockModel(String inferenceEntityId, String serviceName) {
+        var model = mock(Model.class);
+        var configs = mock(ModelConfigurations.class);
+        when(configs.getInferenceEntityId()).thenReturn(inferenceEntityId);
+        when(configs.getService()).thenReturn(serviceName);
+        when(model.getInferenceEntityId()).thenReturn(inferenceEntityId);
+        when(model.getConfigurations()).thenReturn(configs);
+        return model;
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelActionTests.java
@@ -80,8 +80,6 @@ public class TransportGetInferenceModelActionTests extends ESTestCase {
         terminate(threadPool);
     }
 
-    // -------------------- get-all tests --------------------
-
     public void testGetAllModels_SkipsElasticsearchEndpoint_WhenMlDisabled() {
         var esEndpoint = unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME);
         var testEndpoint = unparsedModel(TEST_ENDPOINT_ID, TEST_SERVICE_NAME);
@@ -194,8 +192,6 @@ public class TransportGetInferenceModelActionTests extends ESTestCase {
         assertThat(response.getEndpoints().get(1).getInferenceEntityId(), is(TEST_ENDPOINT_ID_2));
     }
 
-    // -------------------- get-by-task-type tests --------------------
-
     public void testGetModelsByTaskType_SkipsElasticsearchEndpoint_WhenMlDisabled() {
         var esEndpoint = unparsedModel(ES_ENDPOINT_ID, ElasticsearchInternalService.NAME);
         var testEndpoint = unparsedModel(TEST_ENDPOINT_ID, TEST_SERVICE_NAME);
@@ -215,8 +211,6 @@ public class TransportGetInferenceModelActionTests extends ESTestCase {
         assertThat(response.getEndpoints(), hasSize(1));
         assertThat(response.getEndpoints().get(0).getInferenceEntityId(), is(TEST_ENDPOINT_ID));
     }
-
-    // -------------------- single-model tests --------------------
 
     public void testGetSingleModel_ThrowsUnknownService_ForElasticsearchService_WhenMlDisabled() {
         // The single-endpoint path (GET _inference/<id>) intentionally does NOT skip the error —
@@ -252,8 +246,6 @@ public class TransportGetInferenceModelActionTests extends ESTestCase {
         var exception = expectThrows(ElasticsearchStatusException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
         assertThat(exception.status(), is(RestStatus.BAD_REQUEST));
     }
-
-    // -------------------- helpers --------------------
 
     private TransportGetInferenceModelAction createAction(Settings settings) {
         return new TransportGetInferenceModelAction(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -50,12 +50,14 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
 import org.elasticsearch.inference.telemetry.InferenceStats;
+import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
@@ -120,6 +122,7 @@ import java.util.function.Consumer;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.inference.InferenceStringTests.createRandomUsingDataTypes;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xpack.core.XPackSettings.ML_NATIVE_CODE_PLATFORMS;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction.Response.RESULTS_FIELD;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterService;
@@ -2646,6 +2649,50 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     Strings.format("The [%s] service does not support task type [%s]", ElasticsearchInternalService.NAME, TaskType.ANY)
                 )
             );
+        }
+    }
+
+    public void testIsSupported_ReturnsFalse_WhenMlDisabled() {
+        var settings = Settings.builder().put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false).build();
+        assertFalse(ElasticsearchInternalService.isSupported(settings));
+    }
+
+    public void testIsSupported_ReturnsFalse_WhenNlpDisabled() {
+        var settings = Settings.builder().put(XPackSettings.NLP_ENABLED.getKey(), false).build();
+        assertFalse(ElasticsearchInternalService.isSupported(settings));
+    }
+
+    public void testIsSupported_ReturnsTrue_WhenMlAndNlpEnabled() {
+        assumeTrue("ML native code required", ML_NATIVE_CODE_PLATFORMS.contains(Platforms.PLATFORM_NAME));
+        assertTrue(ElasticsearchInternalService.isSupported(Settings.EMPTY));
+    }
+
+    public void testIsServiceNameOrAlias_ReturnsTrue_ForServiceName() {
+        assertTrue(ElasticsearchInternalService.isServiceNameOrAlias(ElasticsearchInternalService.NAME));
+    }
+
+    public void testIsServiceNameOrAlias_ReturnsTrue_ForElserAlias() {
+        assertTrue(ElasticsearchInternalService.isServiceNameOrAlias(ElasticsearchInternalService.OLD_ELSER_SERVICE_NAME));
+    }
+
+    public void testIsServiceNameOrAlias_ReturnsFalse_ForOtherService() {
+        assertFalse(ElasticsearchInternalService.isServiceNameOrAlias("some-other-service"));
+        assertFalse(ElasticsearchInternalService.isServiceNameOrAlias("elasticsearch "));
+        assertFalse(ElasticsearchInternalService.isServiceNameOrAlias("ELASTICSEARCH"));
+    }
+
+    public void testIsServiceNameOrAlias_MatchesEveryDeclaredAlias() throws IOException {
+        // Guard: if aliases() is ever extended, isServiceNameOrAlias must be updated too.
+        // When the service is unregistered its alias map is empty, so isServiceNameOrAlias is the
+        // only code standing in for aliases() on that path.
+        try (var service = createService(mock(Client.class))) {
+            assertTrue(ElasticsearchInternalService.isServiceNameOrAlias(service.name()));
+            for (var alias : service.aliases()) {
+                assertTrue(
+                    "alias [" + alias + "] not covered by isServiceNameOrAlias",
+                    ElasticsearchInternalService.isServiceNameOrAlias(alias)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue where a 500 is thrown if the ML plugin or NLP feature is disabled and the inference endpoints are attempted to be retrieved.

## Testing
Disable either the ML plugin, or the NLP feature

```
GET _inference/_all
```

Without the fix you should see something like:

```
org.elasticsearch.ElasticsearchStatusException: Unknown service [elasticsearch] for inference endpoint [.elser-2-elasticsearch].
	at org.elasticsearch.inference@9.6.0/org.elasticsearch.xpack.inference.action.TransportGetInferenceModelAction.serviceNotFoundException(TransportGetInferenceModelAction.java:172)
	at org.elasticsearch.inference@9.6.0/org.elasticsearch.xpack.inference.action.TransportGetInferenceModelAction.parseModels(TransportGetInferenceModelAction.java:141)
	at org.elasticsearch.inference@9.6.0/org.elasticsearch.xpack.inference.action.TransportGetInferenceModelAction.lambda$getAllModels$2(TransportGetInferenceModelAction.java:119)
	at org.elasticsearch.server@9.6.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:1125)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1516)
```

With the fix it should either return no endpoints (if all you have are defaults) or the endpoints you have created or EIS has created.