### PR TITLE
[9.4] Fix SmokeTestWatcherTestSuiteIT#testMonitorClusterHealth (#151446)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -161,9 +161,6 @@ tests:
 - class: org.elasticsearch.xpack.ccr.RestartIT
   method: testRestart {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/155609
-- class: org.elasticsearch.smoketest.SmokeTestWatcherTestSuiteIT
-  method: testMonitorClusterHealth
-  issue: https://github.com/elastic/elasticsearch/issues/158202
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:string.base64DecodeMixedMvExpand}
   issue: https://github.com/elastic/elasticsearch/issues/158225

--- a/x-pack/plugin/watcher/src/javaRestTest/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
+++ b/x-pack/plugin/watcher/src/javaRestTest/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
@@ -107,8 +107,11 @@ public class SmokeTestWatcherTestSuiteIT extends WatcherRestTestCase {
             indexWatch(watchId, builder);
         }
 
-        // check watch count
-        assertWatchCount(1);
+        // check watch count — wrap in assertBusy because when the .watches index is created for the
+        // first time, the WatcherLifeCycleService detects the new shard allocation and triggers a
+        // reload (pauseExecution + async reloadInner). During the pause window the watch count is 0;
+        // it becomes 1 once reloadInner finishes loading watches from the index.
+        assertBusy(() -> assertWatchCount(1));
 
         // check watch history
         ObjectPath objectPath = getWatchHistoryEntry(watchId);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix SmokeTestWatcherTestSuiteIT#testMonitorClusterHealth (#151446)](https://github.com/elastic/elasticsearch/pull/151446)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #158202