### PR TITLE
[9.5] Unified and faster calibration path (#153577)

### DIFF
--- a/docs/changelog/153577.yaml
+++ b/docs/changelog/153577.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 153577
+summary: Unified and faster calibration path
+type: enhancement

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -1466,6 +1466,57 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
 
     @Override
     public void dotProductBulk(float[] query, float[] v0, float[] v1, float[] v2, float[] v3, int distancesOffset, float[] distances) {
+        // split aligned vs remainder lengths into separate methods so HotSpot keeps independent vector API profiles.
+        if (FLOAT_SPECIES.loopBound(query.length) == query.length) {
+            dotProductBulkAligned(query, v0, v1, v2, v3, distancesOffset, distances);
+        } else {
+            dotProductBulkUnaligned(query, v0, v1, v2, v3, distancesOffset, distances);
+        }
+    }
+
+    private static void dotProductBulkAligned(
+        float[] query,
+        float[] v0,
+        float[] v1,
+        float[] v2,
+        float[] v3,
+        int distancesOffset,
+        float[] distances
+    ) {
+        int i = 0;
+        final int end = query.length;
+
+        FloatVector sv0 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv1 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv2 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv3 = FloatVector.zero(FLOAT_SPECIES);
+        for (; i < end; i += FLOAT_SPECIES.length()) {
+            FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i);
+            FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i);
+            FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i);
+            FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i);
+            FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i);
+            sv0 = fma(qv, dv0, sv0);
+            sv1 = fma(qv, dv1, sv1);
+            sv2 = fma(qv, dv2, sv2);
+            sv3 = fma(qv, dv3, sv3);
+        }
+
+        distances[distancesOffset] = sv0.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 1] = sv1.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 2] = sv2.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 3] = sv3.reduceLanes(VectorOperators.ADD);
+    }
+
+    private static void dotProductBulkUnaligned(
+        float[] query,
+        float[] v0,
+        float[] v1,
+        float[] v2,
+        float[] v3,
+        int distancesOffset,
+        float[] distances
+    ) {
         int i = 0;
         final int vectorEnd = FLOAT_SPECIES.loopBound(query.length);
 
@@ -1485,18 +1536,16 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
             sv3 = fma(qv, dv3, sv3);
         }
 
-        if (i < query.length) {
-            VectorMask<Float> mask = FLOAT_SPECIES.indexInRange(i, query.length);
-            FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i, mask);
-            FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i, mask);
-            FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i, mask);
-            FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i, mask);
-            FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i, mask);
-            sv0 = fma(qv, dv0, sv0);
-            sv1 = fma(qv, dv1, sv1);
-            sv2 = fma(qv, dv2, sv2);
-            sv3 = fma(qv, dv3, sv3);
-        }
+        VectorMask<Float> mask = FLOAT_SPECIES.indexInRange(i, query.length);
+        FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i, mask);
+        FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i, mask);
+        FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i, mask);
+        FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i, mask);
+        FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i, mask);
+        sv0 = fma(qv, dv0, sv0);
+        sv1 = fma(qv, dv1, sv1);
+        sv2 = fma(qv, dv2, sv2);
+        sv3 = fma(qv, dv3, sv3);
 
         distances[distancesOffset] = sv0.reduceLanes(VectorOperators.ADD);
         distances[distancesOffset + 1] = sv1.reduceLanes(VectorOperators.ADD);
@@ -1516,9 +1565,70 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
         float[] distances,
         int length
     ) {
+        // split aligned vs remainder lengths into separate methods so HotSpot keeps independent vector API profiles.
+        if (FLOAT_SPECIES.loopBound(length) == length) {
+            squareDistanceBulkAligned(query, vectorOffset, v0, v1, v2, v3, distancesOffset, distances, length);
+        } else {
+            squareDistanceBulkUnaligned(query, vectorOffset, v0, v1, v2, v3, distancesOffset, distances, length);
+        }
+    }
+
+    /** {@code length} is an exact multiple of {@link #FLOAT_SPECIES} lane count — no masked tail. */
+    private static void squareDistanceBulkAligned(
+        float[] query,
+        int vectorOffset,
+        float[] v0,
+        float[] v1,
+        float[] v2,
+        float[] v3,
+        int distancesOffset,
+        float[] distances,
+        int length
+    ) {
         int i = vectorOffset;
-        int vectorEnd = vectorOffset + FLOAT_SPECIES.loopBound(length);
-        int end = vectorOffset + length;
+        final int end = vectorOffset + length;
+
+        FloatVector sv0 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv1 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv2 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector sv3 = FloatVector.zero(FLOAT_SPECIES);
+        for (; i < end; i += FLOAT_SPECIES.length()) {
+            FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i);
+            FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i);
+            FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i);
+            FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i);
+            FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i);
+            FloatVector diff0 = qv.sub(dv0);
+            FloatVector diff1 = qv.sub(dv1);
+            FloatVector diff2 = qv.sub(dv2);
+            FloatVector diff3 = qv.sub(dv3);
+            sv0 = fma(diff0, diff0, sv0);
+            sv1 = fma(diff1, diff1, sv1);
+            sv2 = fma(diff2, diff2, sv2);
+            sv3 = fma(diff3, diff3, sv3);
+        }
+
+        distances[distancesOffset] = sv0.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 1] = sv1.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 2] = sv2.reduceLanes(VectorOperators.ADD);
+        distances[distancesOffset + 3] = sv3.reduceLanes(VectorOperators.ADD);
+    }
+
+    /** {@code length} has a non-empty remainder relative to {@link #FLOAT_SPECIES} — masked tail required. */
+    private static void squareDistanceBulkUnaligned(
+        float[] query,
+        int vectorOffset,
+        float[] v0,
+        float[] v1,
+        float[] v2,
+        float[] v3,
+        int distancesOffset,
+        float[] distances,
+        int length
+    ) {
+        int i = vectorOffset;
+        final int vectorEnd = vectorOffset + FLOAT_SPECIES.loopBound(length);
+        final int end = vectorOffset + length;
 
         FloatVector sv0 = FloatVector.zero(FLOAT_SPECIES);
         FloatVector sv1 = FloatVector.zero(FLOAT_SPECIES);
@@ -1540,22 +1650,20 @@ public sealed class PanamaESVectorUtilSupport implements ESVectorUtilSupport per
             sv3 = fma(diff3, diff3, sv3);
         }
 
-        if (i < end) {
-            VectorMask<Float> mask = FLOAT_SPECIES.indexInRange(i, end);
-            FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i, mask);
-            FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i, mask);
-            FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i, mask);
-            FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i, mask);
-            FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i, mask);
-            FloatVector diff0 = qv.sub(dv0);
-            FloatVector diff1 = qv.sub(dv1);
-            FloatVector diff2 = qv.sub(dv2);
-            FloatVector diff3 = qv.sub(dv3);
-            sv0 = fma(diff0, diff0, sv0);
-            sv1 = fma(diff1, diff1, sv1);
-            sv2 = fma(diff2, diff2, sv2);
-            sv3 = fma(diff3, diff3, sv3);
-        }
+        VectorMask<Float> mask = FLOAT_SPECIES.indexInRange(i, end);
+        FloatVector qv = FloatVector.fromArray(FLOAT_SPECIES, query, i, mask);
+        FloatVector dv0 = FloatVector.fromArray(FLOAT_SPECIES, v0, i, mask);
+        FloatVector dv1 = FloatVector.fromArray(FLOAT_SPECIES, v1, i, mask);
+        FloatVector dv2 = FloatVector.fromArray(FLOAT_SPECIES, v2, i, mask);
+        FloatVector dv3 = FloatVector.fromArray(FLOAT_SPECIES, v3, i, mask);
+        FloatVector diff0 = qv.sub(dv0);
+        FloatVector diff1 = qv.sub(dv1);
+        FloatVector diff2 = qv.sub(dv2);
+        FloatVector diff3 = qv.sub(dv3);
+        sv0 = fma(diff0, diff0, sv0);
+        sv1 = fma(diff1, diff1, sv1);
+        sv2 = fma(diff2, diff2, sv2);
+        sv3 = fma(diff3, diff3, sv3);
 
         distances[distancesOffset] = sv0.reduceLanes(VectorOperators.ADD);
         distances[distancesOffset + 1] = sv1.reduceLanes(VectorOperators.ADD);

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IvfAutoCalibration.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IvfAutoCalibration.java
@@ -170,8 +170,9 @@ public class IvfAutoCalibration {
 
     /**
      * On merge, attempts to reuse quantization metadata from input segments via {@link #selectFromMergeState}.
-     * When reuse is not possible, runs full calibration on merged vectors. Bounded (force-merge) merges
-     * skip metadata reuse and always calibrate.
+     * When reuse is not possible, runs calibration on the merged vectors. Bounded (force-merge) merges
+     * skip metadata reuse and always calibrate. Background and force merges share the same calibration
+     * path, so calibration semantics never depend on the merge kind.
      */
     public IvfSegmentConfig resolve(FieldInfo fieldInfo, MergeState mergeState, IvfSegmentConfig codecDefault) throws IOException {
         Objects.requireNonNull(mergeState, "mergeState");
@@ -189,6 +190,9 @@ public class IvfAutoCalibration {
             return codecDefault;
         }
 
+        // Background merges may short-circuit to reusing the input segments' agreed calibration metadata.
+        // Force merges always recalibrate. Either way, when a fresh fit is needed both merge kinds run the
+        // SAME single calibration path below — no per-merge-kind algorithmic divergence.
         if (isBoundedForceMerge(mergeState) == false) {
             IvfSegmentConfig reused = selectFromMergeState(fieldInfo, mergeState);
             if (reused != null) {
@@ -199,13 +203,6 @@ public class IvfAutoCalibration {
                 "Merge calibration: bounded force merge (inputSegments=[{}]), skipping metadata reuse",
                 mergeState.knnVectorsReaders == null ? 0 : mergeState.knnVectorsReaders.length
             );
-            try {
-                KMeansFloatVectorValues sampledVectors = CalibrationUtils.buildSampled(fieldInfo, mergeState, numVectors);
-                return calibrate(sampledVectors, similarityFunction, numVectors, CalibrationMode.FULL);
-            } catch (IOException e) {
-                logger.warn("calibration failed on bounded force merge, falling back to codec default encoding", e);
-                return codecDefault;
-            }
         }
 
         try {
@@ -468,7 +465,7 @@ public class IvfAutoCalibration {
         double invDim = manifold[1];
 
         if (mode == CalibrationMode.FAST) {
-            return sweepQuantizationCandidatesManifoldResiduals(similarityFunction, ctx.numVectors(), alpha, invDim, calibrationSource);
+            return sweepQuantizationCandidatesRealResiduals(similarityFunction, ctx.numVectors(), alpha, invDim, calibrationSource);
         } else {
             ErrorScalingFit scalingFit = ErrorModel.estimateErrorScalingFit(calibrationSource, vectorsPerCluster);
             return sweepQuantizationCandidates(similarityFunction, ctx.numVectors(), alpha, invDim, scalingFit, calibrationSource);
@@ -476,42 +473,40 @@ public class IvfAutoCalibration {
     }
 
     /**
-     * Sweeps (encoding, rerank) candidates using synthetic Gaussian residuals scaled to the
-     * manifold cluster radius: no k-means, no NN assignment. The slope {@code beta1 = invDim}
-     * is taken directly from the manifold; only the intercept {@code beta0} is measured via a
-     * single OSQ pass on random residuals. This is the cheapest calibration path.
-     * <p>
-     * TODO: the synthetic Gaussian residuals (and their squared norms) depend only on the manifold
-     * cluster radius, which is constant across candidates in a single sweep — only the OSQ
-     * quantization varies with (qbits, dbits). Generating them once and reusing across all candidates
-     * would avoid regenerating {@code nDocs * dim} Gaussians per candidate. See also the sort in
-     * {@code ErrorModel#quantizedRepErrorStd} which fully sorts to take only the top-5k.
+     * Sweeps (encoding, rerank) candidates using <em>real</em> corpus residuals: a single k-means clustering
+     * of a {@code ErrorModel#REAL_RESIDUAL_SAMPLE}-vector sample provides the actual per-cluster residuals,
+     * whose OSQ error is measured directly. Instead of re-clustering at multiple corpus sizes to learn how
+     * the residual error shrinks as the corpus grows (the full path's multi-sample scaling fit), the manifold
+     * slope {@code invDim} is used as a plug-in to extrapolate that single measurement from the sample size to
+     * the real corpus size (see {@link ErrorModel#estimateMagnitudeFromRealResiduals}).
      */
-    private SweepOutcome sweepQuantizationCandidatesManifoldResiduals(
+    private SweepOutcome sweepQuantizationCandidatesRealResiduals(
         VectorSimilarityFunction similarityFunction,
         int numVectors,
         double alpha,
         double invDim,
         CalibrationSource calibrationSource
     ) throws IOException {
+        ErrorModel.RealResidualState state = ErrorModel.newRealResidualState(calibrationSource);
         Map<EncKey, QuantizationErrorStdModel> errorModelCache = new HashMap<>();
         return sweepCandidates(similarityFunction, numVectors, alpha, invDim, (candidate, precondition) -> {
             EncKey key = new EncKey(candidate.qbits(), candidate.dbits(), precondition);
             QuantizationErrorStdModel errorModel = errorModelCache.get(key);
             if (errorModel == null) {
-                errorModel = ErrorModel.estimateMagnitudeFromManifoldResiduals(
-                    alpha,
+                errorModel = ErrorModel.estimateMagnitudeFromRealResiduals(
                     invDim,
                     calibrationSource,
                     precondition,
                     candidate.qbits(),
                     candidate.dbits(),
                     vectorsPerCluster,
-                    numVectors
+                    state
                 );
                 errorModelCache.put(key, errorModel);
             }
-            return errorModel.errorStd(vectorsPerCluster, numVectors);
+            // cap evaluation at the measured sample size to avoid extrapolating beyond its fitted range
+            int effectiveN = Math.min(numVectors, state.ndocs());
+            return errorModel.errorStd(vectorsPerCluster, effectiveN);
         });
     }
 
@@ -599,11 +594,12 @@ public class IvfAutoCalibration {
 
                 logger.debug(
                     () -> format(
-                        "Quantization recall((%d, %d) | %d, %s) = %.2f%%",
+                        "Quantization recall((%d, %d) | %d, %s) errorStd=%.5f = %.2f%%",
                         candidate.qbits(),
                         candidate.dbits(),
                         rerankVal,
                         precondition ? "precondition" : "no precondition",
+                        errorStd,
                         expected * 100.0
                     )
                 );

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/CalibrationUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/CalibrationUtils.java
@@ -36,7 +36,11 @@ import java.util.Random;
  */
 public final class CalibrationUtils {
 
-    static final int MAX_QUERY_SAMPLE = 1024;
+    // Query sample for calibration: a small query set (256) is sufficient to average rank distances and
+    // quantization-error statistics, and drives both the manifold fit and the residual error sweep, so it
+    // is the dominant lever on calibration cost. The corpus sample stays large (16384) to keep the manifold
+    // distance-scaling fit accurate.
+    static final int MAX_QUERY_SAMPLE = 256;
     static final int MAX_CORPUS_SAMPLE = 16384;
     static final long CALIBRATION_SEED = 215873873L;
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModel.java
@@ -24,7 +24,6 @@ import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Random;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -369,13 +368,32 @@ public final class ErrorModel {
             }
         }
 
-        Regression.OLSResult params = state.fit();
-        if (params == Regression.OLSResult.ZERO) {
+        Regression.OLSResult rawParams = state.fit();
+        if (rawParams == Regression.OLSResult.ZERO) {
             return new ErrorScalingFit(
                 new QuantizationErrorStdModel(Regression.OLSResult.ZERO),
                 warmStartDocCentroids,
                 warmStartQueryCentroids
             );
+        }
+
+        // Clamp to 0 so the error model degenerates to a constant (no corpus-size extrapolation) rather than
+        // producing unbounded estimates.
+        // This can happen when the k-means warm-start introduces non-monotone error steps
+        // over the narrow x-range of the sweep (~1.3 log-units for typical nDocsPerCluster).
+        Regression.OLSResult params;
+        if (rawParams.beta1() < 0) {
+            logger.debug(
+                () -> format(
+                    "Error scaling fit produced negative slope [%.4f] (R²=[%.4f]); "
+                        + "clamping to 0 (constant error model, no corpus-size extrapolation).",
+                    rawParams.beta1(),
+                    state.r2(rawParams)
+                )
+            );
+            params = new Regression.OLSResult(rawParams.beta0(), 0.0, 0, 0, 0, rawParams.sigmaSq());
+        } else {
+            params = rawParams;
         }
 
         double scalingSeconds = (System.nanoTime() - scalingStartNanos) / 1_000_000_000.0;
@@ -490,162 +508,83 @@ public final class ErrorModel {
         return new QuantizationErrorStdModel(params);
     }
 
+    /** Corpus sample size for the single-shot real-residual magnitude measurement. */
+    static final int REAL_RESIDUAL_SAMPLE = 2048;
+
     /**
-     * Estimates quantization error std for {@code (qbits, dbits)} using synthetic Gaussian
-     * residuals derived from the manifold model, requiring no k-means, no NN assignment.
-     * <p>
-     * The expected cluster radius R is computed analytically as
-     * {@code |expectedRankDistance(sim, alpha, invDim, numVectors, nDocsPerCluster/2)|}; then
-     * {@code nDocs} independent Gaussian residuals with per-dimension std {@code R/sqrt(dim)}
-     * are generated and quantized with OSQ against a zero centroid. Actual corpus vectors are
-     * used as queries (materialized via {@link CalibrationUtils#materializeCalibrationQuery})
-     * and also quantized against the zero centroid. The slope {@code beta1 = invDim} is taken
-     * directly from the manifold model; only the intercept {@code beta0} is fit from the
-     * single-point OSQ error measurement.
-     * <p>
-     * Cost: {@code O(nDocs × dim)} for residual generation + quantization plus the usual
-     * {@code O(nQueries × nDocs)} for the error measurement, avoid k-means pass.
+     * Opaque per-sweep state for the real-residual magnitude path: reusable OSQ scratch, a serial k-means
+     * instance, and the (encoding-independent) clustering from the first candidate, reused as a warm start
+     * for subsequent candidates so k-means is not recomputed from scratch per encoding. Construct once per
+     * calibration via {@link #newRealResidualState} and thread through every candidate.
      */
-    public static QuantizationErrorStdModel estimateMagnitudeFromManifoldResiduals(
-        double alpha,
+    public static final class RealResidualState {
+        private final QuantizedErrorScratch scratch;
+        private final HierarchicalKMeans<float[]> kmeans;
+        private final int nDocs;
+        private QuantizedErrorComputeResult shared;
+
+        private RealResidualState(CalibrationSource source) {
+            this.nDocs = Math.min(REAL_RESIDUAL_SAMPLE, source.corpusOrdinals().length);
+            this.kmeans = HierarchicalKMeans.ofSerial(CentroidOps.FLOAT, source.dim());
+            this.scratch = new QuantizedErrorScratch(
+                nDocs,
+                source.dim(),
+                source.cosine(),
+                source.similarityFunction() == VectorSimilarityFunction.EUCLIDEAN,
+                source.preconditioner() != null
+            );
+        }
+
+        public int ndocs() {
+            return nDocs;
+        }
+    }
+
+    /** Creates the shared state for a real-residual magnitude sweep over {@code source}. */
+    public static RealResidualState newRealResidualState(CalibrationSource source) {
+        return new RealResidualState(source);
+    }
+
+    /**
+     * Estimates the quantization error-std model for {@code (qbits, dbits)} from <em>real</em> corpus
+     * residuals. The clustering warm start is reused across candidates via {@code state} so k-means is
+     * not recomputed per encoding.
+     * <p>
+     * Measures OSQ error once at {@link #REAL_RESIDUAL_SAMPLE} and anchors the intercept at that sample
+     * size. The manifold slope {@code invDim} is used as the scaling exponent, so evaluating at the real corpus size {@code N}
+     * extrapolates as {@code errorStd = measuredStd × (REAL_RESIDUAL_SAMPLE / N)^invDim}.
+     */
+    public static QuantizationErrorStdModel estimateMagnitudeFromRealResiduals(
         double invDim,
         CalibrationSource source,
         boolean usePreconditionedQueries,
         int qbits,
         int dbits,
         int nDocsPerCluster,
-        int numVectors
+        RealResidualState state
     ) throws IOException {
-        VectorSimilarityFunction sim = source.similarityFunction();
-        int dim = source.dim();
-        boolean euclidean = sim == VectorSimilarityFunction.EUCLIDEAN;
-        int nSamples = source.corpusOrdinals().length;
-
-        int halfCluster = Math.max(1, nDocsPerCluster / 2);
-        double R = Math.abs(ManifoldModel.expectedRankDistance(sim, alpha, invDim, numVectors, halfCluster));
-        double perDimStd = R / Math.sqrt(dim);
-
-        int nDocs = Math.min(SAMPLE_SIZES_MAGNITUDE[0], nSamples);
-        float[] zeroCentroid = new float[dim];
-        float[] residualScratch = new float[dim];
-        int[] quantizeScratch = new int[dim];
-
-        OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(VectorSimilarityFunction.EUCLIDEAN);
-        Random rng = new Random(42L);
-
-        float[][] syntheticDocs = new float[nDocs][];
-        float[] docLower = new float[nDocs];
-        float[] docUpper = new float[nDocs];
-        int[] docL1 = new int[nDocs];
-        byte[][] docQuantized = new byte[nDocs][dim];
-        double[] docNormSq = euclidean ? new double[nDocs] : null;
-
-        for (int i = 0; i < nDocs; i++) {
-            float[] v = new float[dim];
-            for (int j = 0; j < dim; j++) {
-                v[j] = (float) (rng.nextGaussian() * perDimStd);
-            }
-            syntheticDocs[i] = v;
-            var qr = quantizer.scalarQuantize(v, residualScratch, quantizeScratch, (byte) dbits, zeroCentroid);
-            ESVectorUtil.packAsBytes(quantizeScratch, docQuantized[i], dim);
-            docLower[i] = qr.lowerInterval();
-            docUpper[i] = qr.upperInterval();
-            docL1[i] = qr.quantizedComponentSum();
-            if (docNormSq != null) {
-                docNormSq[i] = ESVectorUtil.dotProduct(v, v);
-            }
+        float[][] warmDoc = state.shared == null ? null : state.shared.docCentroids();
+        float[][] warmQuery = state.shared == null ? null : state.shared.queryCentroids();
+        QuantizedErrorComputeResult r = quantizedRepErrorStdWithCentroids(
+            source,
+            usePreconditionedQueries,
+            state.nDocs,
+            nDocsPerCluster,
+            qbits,
+            dbits,
+            state.kmeans,
+            warmDoc,
+            warmQuery,
+            state.scratch
+        );
+        if (state.shared == null) {
+            state.shared = r;
         }
-
-        WelfordVariance moments = new WelfordVariance();
-        double dScale = 1.0 / ((1 << dbits) - 1);
-        double qScale = 1.0 / ((1 << qbits) - 1);
-        double[] simOsq = new double[nDocs];
-        int[] order = new int[nDocs];
-        for (int i = 0; i < nDocs; i++) {
-            order[i] = i;
-        }
-        float[] queryScratch = new float[dim];
-        float[] preconditionScratch = source.preconditioner() != null ? new float[dim] : null;
-        byte[] queryQuantized = new byte[dim];
-        float[] bulkDistances = new float[4];
-
-        for (int queryOrdinal : source.queryOrdinals()) {
-            CalibrationUtils.materializeCalibrationQuery(
-                source.vectors(),
-                queryOrdinal,
-                source.baseDim(),
-                dim,
-                source.cosine(),
-                source.neyshabur(),
-                source.preconditioner(),
-                usePreconditionedQueries,
-                queryScratch,
-                preconditionScratch
-            );
-            var qqr = quantizer.scalarQuantize(queryScratch, residualScratch, quantizeScratch, (byte) qbits, zeroCentroid);
-            ESVectorUtil.packAsBytes(quantizeScratch, queryQuantized, dim);
-            double aq = qqr.lowerInterval();
-            double lq = qScale * (qqr.upperInterval() - qqr.lowerInterval());
-            int queryL1val = qqr.quantizedComponentSum();
-
-            // All docs share the single quantized query here, so score four docs per bulk SIMD call.
-            int d = 0;
-            int bulkLimit = nDocs - 3;
-            for (; d < bulkLimit; d += 4) {
-                ESVectorUtil.dotProductBulk(
-                    queryQuantized,
-                    docQuantized[d],
-                    docQuantized[d + 1],
-                    docQuantized[d + 2],
-                    docQuantized[d + 3],
-                    0,
-                    bulkDistances
-                );
-                for (int t = 0; t < 4; t++) {
-                    int di = d + t;
-                    double ad = docLower[di];
-                    double ld = dScale * (docUpper[di] - docLower[di]);
-                    double dotEst = ad * aq * dim + aq * ld * docL1[di] + ad * lq * queryL1val + ld * lq * Math.round(bulkDistances[t]);
-                    if (euclidean) {
-                        dotEst = 2.0 * dotEst;
-                        if (docNormSq != null) {
-                            dotEst -= docNormSq[di];
-                        }
-                    }
-                    simOsq[di] = dotEst;
-                }
-            }
-            for (; d < nDocs; d++) {
-                double ad = docLower[d];
-                double ld = dScale * (docUpper[d] - docLower[d]);
-                long intDot = (long) ESVectorUtil.dotProduct(docQuantized[d], queryQuantized);
-                double dotEst = ad * aq * dim + aq * ld * docL1[d] + ad * lq * queryL1val + ld * lq * intDot;
-                if (euclidean) {
-                    dotEst = 2.0 * dotEst;
-                    if (docNormSq != null) {
-                        dotEst -= docNormSq[d];
-                    }
-                }
-                simOsq[d] = dotEst;
-            }
-
-            int topN = Math.min(5 * source.k(), nDocs);
-            selectTopNDescending(simOsq, order, nDocs, topN);
-            for (int i = 0; i < topN; i++) {
-                int docIdx = order[i];
-                float[] doc = syntheticDocs[docIdx];
-                double exact;
-                if (euclidean) {
-                    exact = 2.0 * ESVectorUtil.dotProduct(queryScratch, doc) - (docNormSq != null ? docNormSq[docIdx] : 0.0);
-                } else {
-                    exact = ESVectorUtil.dotProduct(queryScratch, doc);
-                }
-                moments.add(exact - simOsq[docIdx]);
-            }
-        }
-
-        double errorStd = Math.sqrt(3.0 * moments.sampleVariance());
-        double beta0 = Math.log(Math.max(errorStd, 1e-38)) - invDim * (Math.log(nDocsPerCluster) - Math.log(numVectors));
+        // 1/d is negative for similarities like cosine, so use -invDim
+        double invDimEffective = ManifoldModel.isDotLike(source.similarityFunction()) ? -invDim : invDim;
+        // single measurement anchored at state.nDocs (not numVectors),
+        // so evaluating at N gives measuredStd × (state.nDocs / N)^invDim
+        double beta0 = Math.log(Math.max(r.std(), 1e-38)) - invDimEffective * (Math.log(nDocsPerCluster) - Math.log(state.nDocs));
         return new QuantizationErrorStdModel(new Regression.OLSResult(beta0, invDim, 0, 0, 0, 0));
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ManifoldModel.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ManifoldModel.java
@@ -293,7 +293,7 @@ public final class ManifoldModel {
         return Math.exp(alpha + (logK - logN) * invDim);
     }
 
-    static boolean isDotLike(VectorSimilarityFunction similarityFunction) {
+    public static boolean isDotLike(VectorSimilarityFunction similarityFunction) {
         return similarityFunction == VectorSimilarityFunction.DOT_PRODUCT
             || similarityFunction == VectorSimilarityFunction.COSINE
             || similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ErrorModelTests.java
@@ -21,10 +21,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 
 import static org.apache.lucene.util.VectorUtil.l2normalize;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 public class ErrorModelTests extends ESTestCase {
 
@@ -234,75 +236,198 @@ public class ErrorModelTests extends ESTestCase {
         assertThat(magnitudeModel.errorStd(128, 4096), greaterThan(0.0));
     }
 
-    public void testEstimateMagnitudeFromManifoldResidualsReturnsFiniteModel() throws IOException {
-        CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
-        double alpha = -1.5;
-        double invDim = 0.5;
-        QuantizationErrorStdModel model = ErrorModel.estimateMagnitudeFromManifoldResiduals(alpha, invDim, source, false, 4, 2, 128, 5000);
-        assertTrue(Double.isFinite(model.params().beta0()));
-        assertTrue(Double.isFinite(model.params().beta1()));
-        assertThat(model.errorStd(128, 5000), greaterThan(0.0));
-    }
-
-    public void testEstimateMagnitudeFromManifoldResidualsUsesInvDimAsSlope() throws IOException {
-        CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
-        double invDim = 0.42;
-        QuantizationErrorStdModel model = ErrorModel.estimateMagnitudeFromManifoldResiduals(-1.0, invDim, source, false, 4, 2, 128, 5000);
-        // slope beta1 is taken directly from invDim, not refit
-        assertEquals(invDim, model.params().beta1(), 0.0);
-    }
-
-    public void testEstimateMagnitudeFromManifoldResidualsWithDotProduct() throws IOException {
-        CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.DOT_PRODUCT, 10);
-        double invDim = 0.4;
-        QuantizationErrorStdModel model = ErrorModel.estimateMagnitudeFromManifoldResiduals(-1.2, invDim, source, false, 4, 1, 128, 5000);
-        assertTrue(Double.isFinite(model.params().beta0()));
-        assertEquals(invDim, model.params().beta1(), 0.0);
-        assertThat(model.errorStd(128, 5000), greaterThan(0.0));
-    }
-
-    public void testEstimateMagnitudeFromManifoldResidualsSmallCorpus() throws IOException {
-        // corpus smaller than SAMPLE_SIZES_MAGNITUDE[0]=2048 — nDocs is clamped to corpusOrdinals.length
-        float[][] rows = syntheticClusteredRows(600, 8, 4);
-        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, 8);
-        int[] queryOrdinals = new int[10];
-        int[] corpusOrdinals = new int[500];
-        for (int i = 0; i < queryOrdinals.length; i++) {
-            queryOrdinals[i] = i;
-        }
-        for (int i = 0; i < corpusOrdinals.length; i++) {
-            corpusOrdinals[i] = 10 + i;
-        }
+    /**
+     * Verifies that {@link ErrorModel#estimateMagnitudeFromRealResiduals} (fast single-shot path)
+     * approximates {@code ErrorModel#estimateMagnitudeModel} (full multi-sample sweep).
+     * <p>
+     * For a fair like-for-like comparison both models are given the <em>same slope</em> (from the
+     * scaling fit). The fast model is anchored at {@link ErrorModel#REAL_RESIDUAL_SAMPLE}, which is
+     * the measurement sample size, so at that evaluation point it should closely agree with the full
+     * model's OLS fit through {@code SAMPLE_SIZES_MAGNITUDE = [2048, 3072, 4096]}. At a second,
+     * larger evaluation point the extrapolated predictions are compared with the same 3× tolerance
+     * to account for the OLS safety margin included in the full path but absent in the fast path.
+     */
+    public void testEstimateMagnitudeFromRealResidualsApproximatesMagnitudeModel() throws IOException {
+        int dim = 1024;
+        int numQueries = 64;
+        int corpusSize = 6_000;
+        float[][] rows = randomNormalizedRows(numQueries + corpusSize, dim, 43L);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
         CalibrationSource source = new CalibrationSource(
             VectorSimilarityFunction.EUCLIDEAN,
-            8,
+            dim,
             fvv,
-            queryOrdinals,
-            8,
+            range(0, numQueries),
+            dim,
             false,
             false,
             null,
-            corpusOrdinals,
+            range(numQueries, corpusSize),
             10
         );
-        double invDim = 0.3;
-        QuantizationErrorStdModel model = ErrorModel.estimateMagnitudeFromManifoldResiduals(-1.0, invDim, source, false, 4, 2, 64, 500);
-        assertTrue(Double.isFinite(model.params().beta0()));
-        assertEquals(invDim, model.params().beta1(), 0.0);
+        int nDocsPerCluster = 128;
+
+        // Full path: sweeps [2048, 3072, 4096] and fits a plug-in OLS intercept with the scaling slope
+        ErrorScalingFit scalingFit = ErrorModel.estimateErrorScalingFit(source, nDocsPerCluster);
+        QuantizationErrorStdModel fullModel = ErrorModel.estimateMagnitudeModel(scalingFit, source, false, 4, 2, nDocsPerCluster);
+
+        // Fast path: single measurement; use the same slope for a direct comparison of the intercept
+        double sharedInvDim = scalingFit.scalingModel().params().beta1();
+        ErrorModel.RealResidualState state = ErrorModel.newRealResidualState(source);
+        QuantizationErrorStdModel fastModel = ErrorModel.estimateMagnitudeFromRealResiduals(
+            sharedInvDim,
+            source,
+            false,
+            4,
+            2,
+            nDocsPerCluster,
+            // anchor at the measurement sample size for correct semantics
+            state
+        );
+
+        // FULL path: beta1 is always fixed from the scaling fit (plug-in OLS)
+        assertEquals("full model must use the shared slope", sharedInvDim, fullModel.params().beta1(), 0.0);
+        assertTrue("fast model beta1 must be finite", Double.isFinite(fastModel.params().beta1()));
+
+        // At the anchor sample size the fast model is anchored; both should agree within the OLS safety margin
+        int anchor = ErrorModel.REAL_RESIDUAL_SAMPLE; // 2048
+        double fastAtAnchor = fastModel.errorStd(nDocsPerCluster, anchor);
+        double fullAtAnchor = fullModel.errorStd(nDocsPerCluster, anchor);
+        assertThat("fast estimate at anchor must be positive", fastAtAnchor, greaterThan(0.0));
+        assertThat("full estimate at anchor must be positive", fullAtAnchor, greaterThan(0.0));
+        double ratioAtAnchor = fastAtAnchor / fullAtAnchor;
+        assertThat(
+            "fast/full ratio at anchor must be < 1.15 (fast=" + fastAtAnchor + " full=" + fullAtAnchor + ")",
+            ratioAtAnchor,
+            lessThan(1.15)
+        );
+        assertThat(
+            "fast/full ratio at anchor must be > 0.85 (fast=" + fastAtAnchor + " full=" + fullAtAnchor + ")",
+            ratioAtAnchor,
+            greaterThan(0.85)
+        );
+
+        // At the largest magnitude sample size the slope extrapolation governs; check agreement there too
+        int largerSample = 4096;
+        double fastAtLarger = fastModel.errorStd(nDocsPerCluster, largerSample);
+        double fullAtLarger = fullModel.errorStd(nDocsPerCluster, largerSample);
+        assertThat("fast estimate at larger sample must be positive", fastAtLarger, greaterThan(0.0));
+        assertThat("full estimate at larger sample must be positive", fullAtLarger, greaterThan(0.0));
+        double ratioAtLarger = fastAtLarger / fullAtLarger;
+        assertThat(
+            "fast/full ratio at larger sample must be < 3 (fast=" + fastAtLarger + " full=" + fullAtLarger + ")",
+            ratioAtLarger,
+            lessThan(1.15)
+        );
+        assertThat(
+            "fast/full ratio at larger sample must be > 1/3 (fast=" + fastAtLarger + " full=" + fullAtLarger + ")",
+            ratioAtLarger,
+            greaterThan(0.85)
+        );
     }
 
-    public void testEstimateMagnitudeFromManifoldResidualsIsDeterministic() throws IOException {
-        CalibrationFixture fixture = newCalibrationFixture(8);
-        CalibrationSource source = fixture.toSource(VectorSimilarityFunction.EUCLIDEAN, 10);
-        double alpha = -1.5;
-        double invDim = 0.5;
-        QuantizationErrorStdModel first = ErrorModel.estimateMagnitudeFromManifoldResiduals(alpha, invDim, source, false, 4, 2, 128, 5000);
-        QuantizationErrorStdModel second = ErrorModel.estimateMagnitudeFromManifoldResiduals(alpha, invDim, source, false, 4, 2, 128, 5000);
-        assertEquals(first.params().beta0(), second.params().beta0(), 0.0);
-        assertEquals(first.params().beta1(), second.params().beta1(), 0.0);
+    /**
+     * Guards {@link CalibrationUtils#MAX_QUERY_SAMPLE}: reducing the query sample (256 vs 1024) must not
+     * materially change the real-residual error-std estimate, otherwise the parameter is set too low and
+     * would break estimation accuracy. Runs the same manifold + real-residual estimate at both query counts
+     * over an identical corpus and asserts the estimates stay close.
+     */
+    public void testErrorEstimateStableAcrossQuerySampleSize() throws IOException {
+        int dim = 1024;
+        float[][] rows = randomNormalizedRows(7000, dim, 42L);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
+        int[] corpus = range(1024, 5000); // disjoint from the 1024-vector query pool [0, 1024)
+        double errSmall = realResidualErrorStd(fvv, dim, range(0, 256), corpus);
+        double errLarge = realResidualErrorStd(fvv, dim, range(0, 1024), corpus);
+        assertThat(errSmall, greaterThan(0.0));
+        assertThat(errLarge, greaterThan(0.0));
+        double rel = Math.abs(errSmall - errLarge) / errLarge;
+        assertThat(
+            "error-std should be stable across query sample size 256 vs 1024, got " + errSmall + " vs " + errLarge,
+            rel,
+            lessThan(0.01)
+        );
+    }
+
+    /**
+     * Regression guard for the size-extrapolation fix. The real-residual error-std model must depend on
+     * corpus size: evaluating it at a larger corpus changes the prediction according to the model's own
+     * fitted slope. With a large enough corpus the model fits both intercept and slope from two actual
+     * measurements, so the ratio at a 10× larger sample size must equal {@code (1/10)^modelSlope} exactly.
+     */
+    public void testRealResidualErrorScalesWithCorpusSizeViaInvDim() throws IOException {
+        int dim = 1024;
+        float[][] rows = randomNormalizedRows(9000, dim, 7L);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
+        CalibrationSource source = new CalibrationSource(
+            VectorSimilarityFunction.EUCLIDEAN,
+            dim,
+            fvv,
+            range(0, 256),
+            dim,
+            false,
+            false,
+            null,
+            range(256, 8000),
+            10
+        );
+        double invDim = ManifoldModel.estimateManifoldParameters(source)[1];
+
+        ErrorModel.RealResidualState state = ErrorModel.newRealResidualState(source);
+        QuantizationErrorStdModel model = ErrorModel.estimateMagnitudeFromRealResiduals(invDim, source, false, 4, 2, 128, state);
+
+        // Use the model's own fitted slope (beta1) — with corpus ≥ REAL_RESIDUAL_SAMPLE this comes
+        // from a 2-point real-data fit rather than the manifold invDim proxy
+        double modelSlope = model.params().beta1();
+        assumeTrue("need a non-zero model slope to exercise extrapolation", Math.abs(modelSlope) > 1e-4);
+
+        int sample = Math.min(ErrorModel.REAL_RESIDUAL_SAMPLE, source.corpusOrdinals().length);
+        double atSample = model.errorStd(128, sample);
+        double atTenX = model.errorStd(128, sample * 10);
+        assertThat(atSample, greaterThan(0.0));
+        double ratio = atTenX / atSample;
+        // Self-consistency: the ratio must match the model's slope exactly
+        assertEquals("errorStd must scale as (sample/N)^modelSlope", Math.pow(0.1, modelSlope), ratio, 1e-3);
+        assertTrue("estimate must depend on corpus size (slope must not cancel)", Math.abs(ratio - 1.0) > 1e-3);
+    }
+
+    /** Real-residual error-std for encoding (4q,2d) at a given query set / corpus, extrapolated to the corpus size. */
+    private static double realResidualErrorStd(FloatVectorValues fvv, int dim, int[] queries, int[] corpus) throws IOException {
+        CalibrationSource source = new CalibrationSource(
+            VectorSimilarityFunction.DOT_PRODUCT,
+            dim,
+            fvv,
+            queries,
+            dim,
+            false,
+            false,
+            null,
+            corpus,
+            10
+        );
+        double invDim = ManifoldModel.estimateManifoldParameters(source)[1];
+        ErrorModel.RealResidualState state = ErrorModel.newRealResidualState(source);
+        return ErrorModel.estimateMagnitudeFromRealResiduals(invDim, source, false, 4, 2, 128, state).errorStd(128, corpus.length);
+    }
+
+    private static int[] range(int start, int count) {
+        int[] a = new int[count];
+        for (int i = 0; i < count; i++) {
+            a[i] = start + i;
+        }
+        return a;
+    }
+
+    private static float[][] randomNormalizedRows(int count, int dim, long seed) {
+        Random rng = new Random(seed);
+        float[][] rows = new float[count][dim];
+        for (int i = 0; i < count; i++) {
+            for (int d = 0; d < dim; d++) {
+                rows[i][d] = (float) rng.nextGaussian();
+            }
+            l2normalize(rows[i]);
+        }
+        return rows;
     }
 
     private record CalibrationFixture(FloatVectorValues fvv, int[] queryOrdinals, int[] corpusOrdinals, int dim) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ManifoldModelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/calibrate/ManifoldModelTests.java
@@ -268,6 +268,110 @@ public class ManifoldModelTests extends ESTestCase {
         assertThat(d100, lessThan(d1));
     }
 
+    /**
+     * Guards {@link CalibrationUtils#MAX_QUERY_SAMPLE}: the manifold parameters (log-alpha and invDim) fitted
+     * with 256 queries must agree within 25% of those fitted with 1024 queries on the same corpus. invDim drives
+     * the error-std extrapolation from the 2 048-doc sample to the full corpus, so large divergence here would
+     * cause encoding-selection errors without any signal at the error-model level.
+     * <p>
+     * The corpus is sized to {@link ManifoldModel#SAMPLE_SIZES} max (16,384) so all 25 sweep points are used.
+     * Both query sets share an identical corpus; only the number of query vectors differs. Random normalized
+     * vectors are used rather than the periodic synthetic-cluster rows, which produce duplicates that cause
+     * {@code log(0)} degenerate inputs to the OLS fit.
+     */
+    public void testManifoldParametersStableAcrossQuerySampleSizes() throws IOException {
+        int dim = 1024;
+        int corpusSize = 16_384; // enough for all ManifoldModel.SAMPLE_SIZES entries
+        int largeQueryCount = 1024;
+        int smallQueryCount = CalibrationUtils.MAX_QUERY_SAMPLE; // 256
+
+        // layout: rows [0, largeQueryCount) = query pool; [largeQueryCount, ...) = corpus
+        int totalRows = largeQueryCount + corpusSize;
+        float[][] rows = randomNormalizedRows(totalRows, dim, 31L);
+        FloatVectorValues fvv = KMeansFloatVectorValues.build(List.of(rows), null, dim);
+
+        int[] corpusOrdinals = new int[corpusSize];
+        for (int i = 0; i < corpusSize; i++) {
+            corpusOrdinals[i] = largeQueryCount + i;
+        }
+        int[] smallQueryOrdinals = new int[smallQueryCount];
+        for (int i = 0; i < smallQueryCount; i++) {
+            smallQueryOrdinals[i] = i;
+        }
+        int[] largeQueryOrdinals = new int[largeQueryCount];
+        for (int i = 0; i < largeQueryCount; i++) {
+            largeQueryOrdinals[i] = i;
+        }
+
+        CalibrationSource smallSource = new CalibrationSource(
+            VectorSimilarityFunction.EUCLIDEAN,
+            dim,
+            fvv,
+            smallQueryOrdinals,
+            dim,
+            false,
+            false,
+            null,
+            corpusOrdinals,
+            10
+        );
+        CalibrationSource largeSource = new CalibrationSource(
+            VectorSimilarityFunction.EUCLIDEAN,
+            dim,
+            fvv,
+            largeQueryOrdinals,
+            dim,
+            false,
+            false,
+            null,
+            corpusOrdinals,
+            10
+        );
+
+        double[] paramsSmall = ManifoldModel.estimateManifoldParameters(smallSource);
+        double[] paramsLarge = ManifoldModel.estimateManifoldParameters(largeSource);
+
+        double invDimSmall = paramsSmall[1];
+        double invDimLarge = paramsLarge[1];
+        double alphaSmall = paramsSmall[0];
+        double alphaLarge = paramsLarge[0];
+
+        assertTrue("invDim must be finite with 256 queries", Double.isFinite(invDimSmall));
+        assertTrue("invDim must be finite with 1024 queries", Double.isFinite(invDimLarge));
+        assertTrue("alpha must be finite with 256 queries", Double.isFinite(alphaSmall));
+        assertTrue("alpha must be finite with 1024 queries", Double.isFinite(alphaLarge));
+        assertThat("invDim must be positive with 256 queries", invDimSmall, greaterThan(0.0));
+        assertThat("invDim must be positive with 1024 queries", invDimLarge, greaterThan(0.0));
+
+        double invDimRelDiff = Math.abs(invDimSmall - invDimLarge) / Math.max(Math.abs(invDimSmall), Math.abs(invDimLarge));
+        assertThat(
+            "invDim must be stable across query sample sizes 256 vs 1024 (got " + invDimSmall + " vs " + invDimLarge + ")",
+            invDimRelDiff,
+            lessThan(0.01)
+        );
+
+        // alpha is log-scale and may be negative; compare deviation relative to the larger magnitude
+        double alphaDenom = Math.max(1e-6, Math.max(Math.abs(alphaSmall), Math.abs(alphaLarge)));
+        double alphaRelDiff = Math.abs(alphaSmall - alphaLarge) / alphaDenom;
+        assertThat(
+            "log-alpha must be stable across query sample sizes 256 vs 1024 (got " + alphaSmall + " vs " + alphaLarge + ")",
+            alphaRelDiff,
+            lessThan(0.01)
+        );
+    }
+
+    private static float[][] randomNormalizedRows(int count, int dim, long seed) {
+        java.util.Random rng = new java.util.Random(seed);
+        float[][] rows = new float[count][dim];
+        for (int i = 0; i < count; i++) {
+            for (int d = 0; d < dim; d++) {
+                rows[i][d] = (float) rng.nextGaussian();
+            }
+            l2normalize(rows[i]);
+        }
+        return rows;
+    }
+
     private static float[][] syntheticClusteredRows(int count, int dim, int numClusters) {
         float[][] centroids = new float[numClusters][dim];
         for (int c = 0; c < numClusters; c++) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Unified and faster calibration path (#153577)](https://github.com/elastic/elasticsearch/pull/153577)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)