### PR TITLE
Pin transport version in IgnoreNullMetrics dimension test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -595,9 +595,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecBucketIncludeEmptyBucketsIT
   method: test {csv-spec:bucket_include_empty_buckets.Large number of buckets doesn't OOM - stats}
   issue: https://github.com/elastic/elasticsearch/issues/156356
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.IgnoreNullMetricsTests
-  method: testDimensionsAreNotFiltered
-  issue: https://github.com/elastic/elasticsearch/issues/156380
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecChangePointIT
   method: test {csv-spec:change_point.null keys}
   issue: https://github.com/elastic/elasticsearch/issues/156397

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestOptimizer.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/TestOptimizer.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -100,6 +101,15 @@ public class TestOptimizer {
     // =======================================
     // Below this is delegates to TestAnalyzer
     // =======================================
+
+    /**
+     * Pins the negotiated minimum transport version used during analysis and optimization. By default the analyzer picks a random
+     * compatible version, which makes version-gated plan shapes nondeterministic. Pin it when a test asserts on such a shape.
+     */
+    public TestOptimizer minimumTransportVersion(TransportVersion minimumTransportVersion) {
+        analyzer.minimumTransportVersion(minimumTransportVersion);
+        return this;
+    }
 
     /**
      * Adds an index resolution by loading the mapping from a resource file.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/IgnoreNullMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/IgnoreNullMetricsTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.logical.local;
 
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.PackDimsAgg;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.optimizer.AbstractLocalLogicalPlanOptimizerTests;
@@ -21,6 +22,7 @@ import org.elasticsearch.xpack.esql.plan.logical.PackDims;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.UnpackDims;
 
+import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -60,7 +62,10 @@ public class IgnoreNullMetricsTests extends AbstractLocalLogicalPlanOptimizerTes
     }
 
     public void testDimensionsAreNotFiltered() {
-        LogicalPlan actual = metrics().localPlan("""
+        // Dimension packing has two representations: a standalone PackDims/UnpackDims pair (older versions) or a PACKDIMSAGG aggregate
+        // folded into the time-series aggregate (pack_dims_agg and later). The analyzer picks a random compatible version by default, so
+        // pin to the version just below pack_dims_agg to assert the standalone PackDims/UnpackDims shape deterministically.
+        LogicalPlan actual = metrics().minimumTransportVersion(getPreviousVersion(PackDimsAgg.PACK_DIMS_AGG_VERSION)).localPlan("""
             TS test
             | STATS max(max_over_time(metric_1)) BY dimension_1
             | LIMIT 10


### PR DESCRIPTION
testDimensionsAreNotFiltered asserted the standalone PackDims/UnpackDims plan shape, but the analyzer picks a random compatible transport version. When it selected pack_dims_agg or later, PackDims is folded into the time-series aggregate as PACKDIMSAGG and the assertions failed intermittently.

Pin the minimum transport version to the one just below pack_dims_agg so the standalone shape is produced deterministically, add a minimumTransportVersion passthrough to TestOptimizer, and unmute the test.

Closes #156380
