### PR TITLE
ESQL:DS: Retry transient S3 resolution failures during planning

### DIFF
--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProvider.java
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.esql.datasource.nettycommons.PooledRecvByteBufAll
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceSettings;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.StorageIterator;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
@@ -474,6 +475,10 @@ public class S3StorageProvider implements StorageProvider {
             if (e instanceof S3Exception s3e && s3e.statusCode() == 403) {
                 return existsViaRangeGet(bucket, key, path);
             }
+            ExternalUnavailableException unavailable = mapResolveFailure(path, e);
+            if (unavailable != null) {
+                throw unavailable;
+            }
             throw new IOException("Failed to check existence of " + path + ": " + S3FailureDetail.of(e) + credentialHint(), e);
         }
     }
@@ -487,6 +492,10 @@ public class S3StorageProvider implements StorageProvider {
         } catch (NoSuchKeyException e) {
             return false;
         } catch (Exception e) {
+            ExternalUnavailableException unavailable = mapResolveFailure(path, e);
+            if (unavailable != null) {
+                throw unavailable;
+            }
             throw new IOException(
                 "Failed to check existence of "
                     + path
@@ -496,6 +505,32 @@ public class S3StorageProvider implements StorageProvider {
                 e
             );
         }
+    }
+
+    /**
+     * Types retryable S3 statuses before resolution code can erase the vendor status inside an
+     * {@link IOException}. The returned exception is both the HTTP 503 surfaced to the caller and
+     * the marker consumed by the storage retry policy.
+     */
+    private static ExternalUnavailableException mapResolveFailure(StoragePath path, Exception cause) {
+        if (cause instanceof S3Exception s3 && ExternalUnavailableException.isRetryableStatus(s3.statusCode())) {
+            boolean throttling = ExternalUnavailableException.isThrottlingStatus(s3.statusCode());
+            long retryAfterMs = 0L;
+            if (throttling && s3.awsErrorDetails() != null && s3.awsErrorDetails().sdkHttpResponse() != null) {
+                retryAfterMs = ExternalUnavailableException.parseRetryAfterMs(
+                    s3.awsErrorDetails().sdkHttpResponse().firstMatchingHeader("Retry-After").orElse(null)
+                );
+            }
+            return new ExternalUnavailableException(
+                throttling,
+                retryAfterMs,
+                cause,
+                "S3 store unavailable resolving [{}] (HTTP {})",
+                path,
+                s3.statusCode()
+            );
+        }
+        return null;
     }
 
     @Override
@@ -627,6 +662,10 @@ public class S3StorageProvider implements StorageProvider {
                 continuationToken = response.nextContinuationToken();
                 hasMorePages = response.isTruncated();
             } catch (Exception e) {
+                ExternalUnavailableException unavailable = mapResolveFailure(baseDirectory, e);
+                if (unavailable != null) {
+                    throw unavailable;
+                }
                 String msg = (e instanceof S3Exception s3e && s3e.statusCode() == 403)
                     ? "Access denied listing objects in bucket ["
                         + bucket

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
@@ -92,24 +92,27 @@ public class S3AnonymousAccessTests extends ESTestCase {
     }
 
     /**
-     * When the suffix-range GET fails with a non-403 S3 error, falls back to HEAD.
-     * A retryable HEAD status (500) maps like a retryable GET: {@link ExternalUnavailableException}
-     * (HTTP 503), not a client-class {@link IOException}.
+     * When the suffix-range GET fails with a retryable S3 status, metadata resolution falls back to HEAD.
+     * A retryable HEAD status maps like a retryable GET: {@link ExternalUnavailableException} (HTTP 503),
+     * not a client-class {@link IOException}.
      */
-    public void testHeadNon403ErrorPropagates() {
-        when(mockS3Client.getObject(any(GetObjectRequest.class))).thenThrow(
-            S3Exception.builder().statusCode(500).message("Internal Server Error").build()
-        );
-        when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(
-            S3Exception.builder().statusCode(500).message("Internal Server Error").build()
-        );
+    public void testRetryableMetadataStatusIsUnavailable() {
+        for (int status : new int[] { 429, 500, 502, 503, 504 }) {
+            S3Client client = mock(S3Client.class);
+            when(client.getObject(any(GetObjectRequest.class))).thenThrow(
+                S3Exception.builder().statusCode(status).message("Retryable failure").build()
+            );
+            when(client.headObject(any(HeadObjectRequest.class))).thenThrow(
+                S3Exception.builder().statusCode(status).message("Retryable failure").build()
+            );
 
-        S3StorageObject obj = new S3StorageObject(mockS3Client, BUCKET, KEY, PATH);
+            S3StorageObject obj = new S3StorageObject(client, BUCKET, KEY, PATH);
+            ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::length);
 
-        ExternalUnavailableException eue = expectThrows(ExternalUnavailableException.class, obj::length);
-        assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
-        assertThat(eue.getMessage(), containsString("HTTP 500"));
-        assertFalse(eue.throttling());
+            assertEquals(RestStatus.SERVICE_UNAVAILABLE, ExceptionsHelper.status(eue));
+            assertThat(eue.getMessage(), containsString("HTTP " + status));
+            assertEquals(ExternalUnavailableException.isThrottlingStatus(status), eue.throttling());
+        }
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProviderFailureTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageProviderFailureTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.StorageIterator;
+import org.elasticsearch.xpack.esql.datasources.StorageProviderRegistry;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3StorageProviderFailureTests extends ESTestCase {
+
+    private static final StoragePath PATH = StoragePath.of("s3://test-bucket/data/file.parquet");
+    private static final StoragePath PREFIX = StoragePath.of("s3://test-bucket/data");
+
+    public void testExistsTypesEveryRetryableStatus() {
+        for (int status : new int[] { 429, 500, 502, 503, 504 }) {
+            S3Client client = mock(S3Client.class);
+            S3Exception failure = s3Failure(status, status == 503 ? "3" : null);
+            when(client.headObject(any(HeadObjectRequest.class))).thenThrow(failure);
+
+            S3StorageProvider provider = S3StorageProvider.forTesting(client, null);
+            ExternalUnavailableException thrown = expectThrows(ExternalUnavailableException.class, () -> provider.exists(PATH));
+
+            assertSame(failure, thrown.getCause());
+            assertEquals(RestStatus.SERVICE_UNAVAILABLE, thrown.status());
+            assertEquals(ExternalUnavailableException.isThrottlingStatus(status), thrown.throttling());
+            assertEquals(status == 503 ? 3000L : 0L, thrown.retryAfterMs());
+        }
+    }
+
+    public void testExistsRangeFallbackTypesRetryableFailure() {
+        S3Client client = mock(S3Client.class);
+        when(client.headObject(any(HeadObjectRequest.class))).thenThrow(s3Failure(403, null));
+        S3Exception unavailable = s3Failure(503, null);
+        when(client.getObject(any(GetObjectRequest.class))).thenThrow(unavailable);
+
+        S3StorageProvider provider = S3StorageProvider.forTesting(client, null);
+        ExternalUnavailableException thrown = expectThrows(ExternalUnavailableException.class, () -> provider.exists(PATH));
+
+        assertSame(unavailable, thrown.getCause());
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, thrown.status());
+        assertTrue(thrown.throttling());
+    }
+
+    public void testLazyListingTypesEveryRetryableStatus() throws IOException {
+        for (int status : new int[] { 429, 500, 502, 503, 504 }) {
+            S3Client client = mock(S3Client.class);
+            S3Exception failure = s3Failure(status, null);
+            when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(failure);
+
+            S3StorageProvider provider = S3StorageProvider.forTesting(client, null);
+            try (StorageIterator iterator = provider.listObjects(PREFIX, true)) {
+                ExternalUnavailableException thrown = expectThrows(ExternalUnavailableException.class, iterator::hasNext);
+                assertSame(failure, thrown.getCause());
+                assertEquals(RestStatus.SERVICE_UNAVAILABLE, thrown.status());
+                assertEquals(ExternalUnavailableException.isThrottlingStatus(status), thrown.throttling());
+            }
+        }
+    }
+
+    public void testLazyListingRetriesMappedFailureOnSameIterator() throws IOException {
+        S3Client client = mock(S3Client.class);
+        when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(s3Failure(500, null))
+            .thenReturn(ListObjectsV2Response.builder().contents(java.util.List.of()).isTruncated(false).build());
+
+        try (StorageProviderRegistry registry = new StorageProviderRegistry(Settings.EMPTY)) {
+            registry.registerFactory("s3", StorageProviderFactory.noConfigKeys(() -> S3StorageProvider.forTesting(client, null)));
+            StorageProvider provider = registry.provider(PREFIX);
+            try (StorageIterator iterator = provider.listObjects(PREFIX, true)) {
+                assertFalse(iterator.hasNext());
+            }
+        }
+
+        verify(client, times(2)).listObjectsV2(any(ListObjectsV2Request.class));
+    }
+
+    private static S3Exception s3Failure(int status, String retryAfter) {
+        SdkHttpResponse.Builder response = SdkHttpResponse.builder().statusCode(status);
+        if (retryAfter != null) {
+            response.appendHeader("Retry-After", retryAfter);
+        }
+        return (S3Exception) S3Exception.builder()
+            .statusCode(status)
+            .message("S3 failure")
+            .awsErrorDetails(AwsErrorDetails.builder().sdkHttpResponse(response.build()).build())
+            .build();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -513,12 +513,8 @@ public class FileSplitProvider implements SplitProvider {
                         planResults.add(processFileForSplits(task, hoistedProvider, strideBytes, isCancelled));
                     }
                 }
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to discover splits", e);
-            } catch (RuntimeException e) {
-                throw e;
             } catch (Exception e) {
-                throw new RuntimeException("Failed to discover splits", e);
+                throw ExternalFailures.surface(e, "Failed to discover splits");
             }
 
             // Phase 3: probe the deferred files' record boundaries. Every deferred file's stride offsets go into one
@@ -902,10 +898,8 @@ public class FileSplitProvider implements SplitProvider {
                 throw new TaskCancelledException(RecordBoundaryProbe.CANCELLED_MESSAGE);
             }
             return outcomesByFile;
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to discover splits", e);
+            throw ExternalFailures.surface(e, "Failed to discover splits");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
@@ -12,8 +12,10 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 /**
@@ -82,7 +84,9 @@ class RetryableStorageProvider implements StorageProvider {
 
     @Override
     public StorageIterator listObjects(StoragePath prefix, boolean recursive) throws IOException {
-        return policyFor(prefix).execute(() -> delegate.listObjects(prefix, recursive), "listObjects", prefix);
+        RetryPolicy policy = policyFor(prefix);
+        StorageIterator iterator = policy.execute(() -> delegate.listObjects(prefix, recursive), "listObjects", prefix);
+        return new RetryableStorageIterator(iterator, policy, prefix);
     }
 
     @Override
@@ -103,5 +107,45 @@ class RetryableStorageProvider implements StorageProvider {
     @Override
     public void close() throws IOException {
         delegate.close();
+    }
+
+    /**
+     * Applies retries where lazy storage iterators actually fetch their next page. Iterator creation remains
+     * covered by {@link #listObjects}; this wrapper keeps the same iterator and continuation state across retries.
+     */
+    private static final class RetryableStorageIterator implements StorageIterator {
+        private final StorageIterator delegate;
+        private final RetryPolicy retryPolicy;
+        private final StoragePath prefix;
+
+        private RetryableStorageIterator(StorageIterator delegate, RetryPolicy retryPolicy, StoragePath prefix) {
+            this.delegate = delegate;
+            this.retryPolicy = retryPolicy;
+            this.prefix = prefix;
+        }
+
+        @Override
+        public boolean hasNext() {
+            try {
+                return retryPolicy.execute(delegate::hasNext, "listObjects.hasNext", prefix);
+            } catch (IOException e) {
+                // StorageIterator exposes lazy I/O through unchecked failures, so preserve that boundary contract.
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public StorageEntry next() {
+            if (hasNext() == false) {
+                throw new NoSuchElementException();
+            }
+            // Do not retry next() itself: an arbitrary iterator may already have advanced before throwing.
+            return delegate.next();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhase.java
@@ -302,6 +302,13 @@ public final class SplitDiscoveryPhase {
                 e
             );
         } catch (Exception e) {
+            RuntimeException surfaced = ExternalFailures.surface(
+                e,
+                "failed to discover splits for external source [" + exec.sourcePath() + "] of type [" + exec.sourceType() + "]"
+            );
+            if (surfaced != e) {
+                throw surfaced;
+            }
             throw new ElasticsearchException(
                 "failed to discover splits for external source [{}] of type [{}]",
                 e,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.esql.datasource.csv.CsvFormatReader;
 import org.elasticsearch.xpack.esql.datasource.ndjson.NdJsonFormatReader;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
@@ -748,6 +749,39 @@ public class FileSplitProviderTests extends ESTestCase {
 
     public void testNewlineAlignedCsvMacroSplitsAreDisjointAndMarked() throws IOException {
         assertNewlineAlignedMacroSplitsDisjointAndMarked(".csv", "csv-macro-test", "a,b,c\n", "s3://b/*.csv");
+    }
+
+    public void testSplitProbeIoFailureIsClientError() throws IOException {
+        SegmentableFormatReader mockReader = mock(SegmentableFormatReader.class);
+        when(mockReader.rowPositionStrategy()).thenReturn(PassThroughRowPositionStrategy.INSTANCE);
+        when(mockReader.minimumSegmentSize()).thenReturn(1L);
+        RecordSplitter mockSplitter = mock(RecordSplitter.class);
+        when(mockReader.recordSplitter(anyInt())).thenReturn(mockSplitter);
+        when(mockSplitter.supportsStridedProbing()).thenReturn(true);
+        when(mockSplitter.findNextRecordBoundary(any())).thenThrow(new IOException("injected split probe failure"));
+
+        FormatReaderRegistry formatRegistry = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        formatRegistry.registerLazy("ndjson-probe-failure", (s, bf) -> mockReader, Settings.EMPTY, null);
+        formatRegistry.registerExtension(".ndjson", "ndjson-probe-failure");
+        formatRegistry.byName("ndjson-probe-failure");
+
+        byte[] payload = new byte[4096];
+        FileSplitProvider splitter = new FileSplitProvider(
+            1024,
+            new DecompressionCodecRegistry(),
+            createPayloadStorageRegistry(payload),
+            formatRegistry,
+            Settings.EMPTY
+        );
+        StoragePath path = StoragePath.of("s3://b/data.ndjson");
+        FileList fileList = GlobExpander.fileListOf(List.of(new StorageEntry(path, payload.length, Instant.EPOCH)), "s3://b/*.ndjson");
+        SplitDiscoveryContext context = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
+
+        ExternalClientException e = expectThrows(ExternalClientException.class, () -> splitter.discoverSplits(context));
+
+        assertEquals(RestStatus.BAD_REQUEST, e.status());
+        assertThat(e.getMessage(), containsString("Failed to discover splits"));
+        assertThat(e.getMessage(), containsString("injected split probe failure"));
     }
 
     private void assertNewlineAlignedMacroSplitsDisjointAndMarked(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProviderTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
@@ -24,6 +25,7 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -97,6 +99,58 @@ public class RetryableStorageProviderTests extends ESTestCase {
         StorageIterator iter = provider.listObjects(StoragePath.of("s3://bucket/prefix"), true);
         assertFalse(iter.hasNext());
         assertEquals(2, calls.get());
+    }
+
+    public void testLazyListObjectsRetriesPagesWithoutRecreatingOrDuplicatingIterator() throws IOException {
+        StorageEntry first = new StorageEntry(StoragePath.of("s3://bucket/prefix/first.csv"), 10, Instant.EPOCH);
+        StorageEntry second = new StorageEntry(StoragePath.of("s3://bucket/prefix/second.csv"), 20, Instant.EPOCH);
+        AtomicInteger listCalls = new AtomicInteger();
+        AtomicInteger nextCalls = new AtomicInteger();
+        StorageProvider delegate = new StubStorageProvider() {
+            @Override
+            public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
+                listCalls.incrementAndGet();
+                return new StorageIterator() {
+                    private int index;
+                    private boolean firstPageFailed;
+                    private boolean secondPageFailed;
+
+                    @Override
+                    public boolean hasNext() {
+                        if (index == 0 && firstPageFailed == false) {
+                            firstPageFailed = true;
+                            throw new ExternalUnavailableException("first page unavailable", (Throwable) null);
+                        }
+                        if (index == 1 && secondPageFailed == false) {
+                            secondPageFailed = true;
+                            throw new ExternalUnavailableException("second page unavailable", (Throwable) null);
+                        }
+                        return index < 2;
+                    }
+
+                    @Override
+                    public StorageEntry next() {
+                        nextCalls.incrementAndGet();
+                        return index++ == 0 ? first : second;
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+            }
+        };
+        RetryableStorageProvider provider = new RetryableStorageProvider(delegate, new RetryPolicy(3, 1, 10));
+
+        List<StorageEntry> entries = new ArrayList<>();
+        try (StorageIterator iterator = provider.listObjects(StoragePath.of("s3://bucket/prefix"), true)) {
+            while (iterator.hasNext()) {
+                entries.add(iterator.next());
+            }
+        }
+
+        assertEquals(List.of(first, second), entries);
+        assertEquals("page retries must preserve the original iterator and continuation state", 1, listCalls.get());
+        assertEquals("each entry must be consumed exactly once", 2, nextCalls.get());
     }
 
     public void testExistsRetriesOnTransientFailure() throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitDiscoveryPhaseErrorTests.java
@@ -17,7 +17,9 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalClientException;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalUnavailableException;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryResult;
@@ -39,15 +41,16 @@ public class SplitDiscoveryPhaseErrorTests extends ESTestCase {
 
     private static final Source SRC = Source.EMPTY;
 
-    public void testUncheckedIOExceptionWrappedWithContext() {
+    public void testUncheckedIOExceptionIsClientErrorWithContext() {
         ExternalSourceExec exec = createExternalSourceExec("s3://bucket/data/*.parquet", "parquet");
         SplitProvider failingProvider = ctx -> { throw new UncheckedIOException(new IOException("connection reset by peer")); };
 
-        ElasticsearchException e = expectThrows(
-            ElasticsearchException.class,
+        ExternalClientException e = expectThrows(
+            ExternalClientException.class,
             () -> SplitDiscoveryPhase.resolveExternalSplits(exec, Map.of("parquet", testFactory(failingProvider)))
         );
 
+        assertEquals(RestStatus.BAD_REQUEST, e.status());
         assertThat(e.getMessage(), containsString("s3://bucket/data/*.parquet"));
         assertThat(e.getMessage(), containsString("parquet"));
         assertThat(e.getCause(), instanceOf(UncheckedIOException.class));
@@ -183,6 +186,20 @@ public class SplitDiscoveryPhaseErrorTests extends ESTestCase {
         );
 
         assertSame(original, e);
+    }
+
+    public void testUnavailableExceptionKeepsServiceUnavailableStatus() {
+        ExternalSourceExec exec = createExternalSourceExec("s3://bucket/data/*.parquet", "parquet");
+        ExternalUnavailableException original = new ExternalUnavailableException(true, "S3 store unavailable");
+        SplitProvider failingProvider = ctx -> { throw original; };
+
+        ExternalUnavailableException e = expectThrows(
+            ExternalUnavailableException.class,
+            () -> SplitDiscoveryPhase.resolveExternalSplits(exec, Map.of("parquet", testFactory(failingProvider)))
+        );
+
+        assertSame(original, e);
+        assertEquals(RestStatus.SERVICE_UNAVAILABLE, e.status());
     }
 
     public void testPermissionErrorIncludesSourcePath() {


### PR DESCRIPTION
Classifies retryable S3 resolution/listing failures as 503, retries lazy page fetches, and surfaces hard split-discovery I/O as 400.

Related #158237 
Closes https://github.com/elastic/esql-planning/issues/1831 