### PR TITLE
ESQL:DS: Preserve ES|QL datasource failure status

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -60,6 +60,7 @@ public final class AsyncExternalSourceBuffer {
     private final SubscribableListener<Void> completionFuture = new SubscribableListener<>();
 
     private final AtomicBoolean noMoreInputs = new AtomicBoolean(false);
+    private final Object failureLock = new Object();
     private volatile Throwable failure = null;
 
     /**
@@ -455,7 +456,15 @@ public final class AsyncExternalSourceBuffer {
      * surfaces the failure via {@link org.elasticsearch.compute.operator.SourceOperator#getOutput()}.
      */
     public void onFailure(Throwable t) {
-        this.failure = t;
+        synchronized (failureLock) {
+            if (failure != null) {
+                if (failure != t) {
+                    failure.addSuppressed(t);
+                }
+                return;
+            }
+            failure = t;
+        }
         noMoreInputs.set(true);
         notifyNotEmpty();
         notifyNotFull();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ColumnMapping.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -388,6 +389,9 @@ public final class ColumnMapping implements Writeable {
                 }
             }
             return new Page(positions, blocks);
+        } catch (ElasticsearchException e) {
+            Releasables.closeExpectNoException(blocks);
+            throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
             throw new RuntimeException("Failed to map page", e);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -281,6 +283,57 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         assertEquals("finish(true) must discard the page finish(false) left queued", 0, buffer.size());
         assertEquals(0, buffer.bytesInBuffer());
         assertTrue("the page's blocks must be released, not leaked", block.isReleased());
+    }
+
+    public void testOnFailurePreservesFirstFailureAndSuppressesLaterFailures() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        CircuitBreakingException first = new CircuitBreakingException("breaker", CircuitBreaker.Durability.TRANSIENT);
+        IllegalStateException late = new IllegalStateException("late");
+
+        buffer.onFailure(first);
+        buffer.onFailure(late);
+        buffer.onFailure(first);
+
+        assertSame(first, buffer.failure());
+        assertArrayEquals(new Throwable[] { late }, first.getSuppressed());
+    }
+
+    public void testConcurrentOnFailureSelectsExactlyOneFirstFailure() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024);
+        int failureCount = 10;
+        List<RuntimeException> reported = new ArrayList<>(failureCount);
+        CyclicBarrier start = new CyclicBarrier(failureCount);
+        AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+        Thread[] reporters = new Thread[failureCount];
+
+        for (int i = 0; i < failureCount; i++) {
+            RuntimeException failure = new RuntimeException("failure-" + i);
+            reported.add(failure);
+            reporters[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    buffer.onFailure(failure);
+                } catch (Throwable t) {
+                    threadFailure.compareAndSet(null, t);
+                }
+            }, "async-buffer-failure-" + i);
+            reporters[i].setDaemon(true);
+            reporters[i].start();
+        }
+        for (Thread reporter : reporters) {
+            reporter.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse("failure reporter should have exited", reporter.isAlive());
+        }
+        assertNull("failure reporter threw", threadFailure.get());
+
+        Throwable retained = buffer.failure();
+        assertTrue("the retained failure must be one of the reports", reported.contains(retained));
+        List<Throwable> suppressed = List.of(retained.getSuppressed());
+        assertEquals(failureCount - 1, suppressed.size());
+        for (RuntimeException failure : reported) {
+            long occurrences = suppressed.stream().filter(candidate -> candidate == failure).count();
+            assertEquals(failure == retained ? 0L : 1L, occurrences);
+        }
     }
 
     public void testFormatReaderStatusGetterMatchesLastRecorded() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ColumnMappingTests.java
@@ -7,8 +7,12 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -19,7 +23,9 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -431,6 +437,29 @@ public class ColumnMappingTests extends ESTestCase {
 
     // ===== mapPage failure-cleanup =====
 
+    public void testMapPagePreservesCircuitBreakingException() {
+        BigArrays limitedBigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(0))
+            .withCircuitBreaking();
+        BlockFactory limitedBlockFactory = BlockFactory.builder(limitedBigArrays).build();
+        ColumnMapping mapping = new ColumnMapping(new int[] { 0, -1 }, null);
+        IntBlock passThrough = blockFactory.newConstantIntBlockWith(1, 1);
+        Page filePage = new Page(1, new Block[] { passThrough });
+
+        try {
+            CircuitBreakingException failure = expectThrows(
+                CircuitBreakingException.class,
+                () -> mapping.mapPage(filePage, limitedBlockFactory)
+            );
+            assertEquals(RestStatus.TOO_MANY_REQUESTS, failure.status());
+            assertFalse("cleanup must leave the input page's reference intact", passThrough.isReleased());
+        } finally {
+            filePage.releaseBlocks();
+        }
+
+        assertTrue("cleanup must undo the temporary pass-through reference", passThrough.isReleased());
+        assertEquals(0L, limitedBlockFactory.breaker().getUsed());
+    }
+
     public void testReconciliationCastMatchesDeclaredCoercion() {
         // THE one-coercion-path equivalence: casting a physical block through the reconciliation
         // route (mapPage with a cast slot) and through the declared route (DeclaredTypeCoercions
@@ -500,17 +529,18 @@ public class ColumnMappingTests extends ESTestCase {
 
     public void testCastDatetimeToDateNanosOutOfRangeIsStrictWithoutSink() {
         // Without a warnings sink the cast is strict: the unrepresentable instant fails the page
-        // (wrapped by mapPage) instead of nulling. Previously this pair silently multiplied into
-        // an overflowed long; the range rule now matches TO_DATE_NANOS (DateUtils.toNanoSeconds).
+        // with its client-error status intact instead of nulling. Previously this pair silently
+        // multiplied into an overflowed long; the range rule now matches TO_DATE_NANOS
+        // (DateUtils.toNanoSeconds).
         ColumnMapping mapping = new ColumnMapping(new int[] { 0 }, new DataType[] { DataType.DATE_NANOS });
         LongBlock src = blockFactory.newConstantLongBlockWith(-5L, 1);
         Page filePage = new Page(1, new Block[] { src });
         try {
-            RuntimeException e = expectThrows(
-                RuntimeException.class,
+            InvalidArgumentException e = expectThrows(
+                InvalidArgumentException.class,
                 () -> mapping.mapPage(filePage, blockFactory, new DataType[] { DataType.DATETIME })
             );
-            assertTrue("wrapped under mapPage's catch", e.getMessage() != null && e.getMessage().contains("Failed to map page"));
+            assertEquals(RestStatus.BAD_REQUEST, e.status());
         } finally {
             filePage.releaseBlocks();
         }


### PR DESCRIPTION
Preserves status-bearing mapping failures and atomically retains the first async failure.

Closes https://github.com/elastic/esql-planning/issues/1827