### PR TITLE
Gate frozen_after serialization on GA transport version

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -58,7 +58,6 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
     // Versions over the wire
     private static final TransportVersion INTRODUCE_LIFECYCLE_TEMPLATE = TransportVersion.fromName("introduce_lifecycle_template");
     public static final TransportVersion ADD_SAMPLE_METHOD_DOWNSAMPLE_DLM = TransportVersion.fromName("add_sample_method_downsample_dlm");
-    public static final TransportVersion SEARCHABLE_SNAPSHOTS_DLM_TV = TransportVersion.fromName("searchable_snapshots_dlm");
     public static final TransportVersion DLM_FROZEN_TIER_GA_TV = TransportVersion.fromName("dlm_frozen_tier_ga");
     public static final String EFFECTIVE_RETENTION_REST_API_CAPABILITY = "data_stream_lifecycle_effective_retention";
 
@@ -385,8 +384,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         if (out.getTransportVersion().supports(ADD_SAMPLE_METHOD_DOWNSAMPLE_DLM)) {
             out.writeOptionalWriteable(downsamplingMethod);
         }
-        if (out.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV)
-            || (DLM_SEARCHABLE_SNAPSHOTS_FEATURE_FLAG.isEnabled() && out.getTransportVersion().supports(SEARCHABLE_SNAPSHOTS_DLM_TV))) {
+        if (out.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV)) {
             out.writeOptionalTimeValue(frozenAfter);
         }
     }
@@ -407,8 +405,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         downsamplingMethod = in.getTransportVersion().supports(ADD_SAMPLE_METHOD_DOWNSAMPLE_DLM)
             ? in.readOptionalWriteable(DownsampleConfig.SamplingMethod::read)
             : null;
-        frozenAfter = ((DLM_SEARCHABLE_SNAPSHOTS_FEATURE_FLAG.isEnabled() && in.getTransportVersion().supports(SEARCHABLE_SNAPSHOTS_DLM_TV))
-            || in.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV)) ? in.readOptionalTimeValue() : null;
+        frozenAfter = in.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV) ? in.readOptionalTimeValue() : null;
     }
 
     /**
@@ -792,8 +789,7 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             if (out.getTransportVersion().supports(ADD_SAMPLE_METHOD_DOWNSAMPLE_DLM)) {
                 ResettableValue.write(out, downsamplingMethod, StreamOutput::writeWriteable);
             }
-            if ((DLM_SEARCHABLE_SNAPSHOTS_FEATURE_FLAG.isEnabled() && out.getTransportVersion().supports(SEARCHABLE_SNAPSHOTS_DLM_TV)
-                || out.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV))) {
+            if (out.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV)) {
                 ResettableValue.write(out, frozenAfter, StreamOutput::writeTimeValue);
             }
         }
@@ -856,11 +852,9 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
                 .supports(ADD_SAMPLE_METHOD_DOWNSAMPLE_DLM)
                     ? ResettableValue.read(in, DownsampleConfig.SamplingMethod::read)
                     : ResettableValue.undefined();
-            ResettableValue<TimeValue> frozenAfter = (DLM_SEARCHABLE_SNAPSHOTS_FEATURE_FLAG.isEnabled()
-                && in.getTransportVersion().supports(SEARCHABLE_SNAPSHOTS_DLM_TV)
-                || in.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV))
-                    ? ResettableValue.read(in, StreamInput::readTimeValue)
-                    : ResettableValue.undefined();
+            ResettableValue<TimeValue> frozenAfter = in.getTransportVersion().supports(DLM_FROZEN_TIER_GA_TV)
+                ? ResettableValue.read(in, StreamInput::readTimeValue)
+                : ResettableValue.undefined();
             return new Template(lifecycleTarget, enabled, dataRetention, downsamplingRounds, downsamplingMethod, frozenAfter);
         }
 


### PR DESCRIPTION
frozen_after serialization was gated on a feature flag plus an intermediate transport version, in addition to the GA transport version. Feature flags are on in snapshot builds and off in release builds, so a snapshot node and a release node at the same transport version disagreed on whether frozen_after was on the wire. The stream misaligned and the receiving node crashed, taking down mixed-version test clusters such as the EqlSearchIT BWC suite.

Gate frozen_after purely on the GA transport version and drop the flag branch. Release-to-release upgrades are unaffected since released builds never wrote the field through the flag path. Remove the now-unused intermediate version.

Relates to #154835