### PR TITLE
Allow SystemDataStreamDescriptor to be registered without an owned template

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -260,21 +260,46 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
                 SystemDataStreamDescriptor dataStreamDescriptor = systemIndices.findMatchingDataStreamDescriptor(dataStream.getName());
                 indexTemplate = dataStreamDescriptor != null ? dataStreamDescriptor.getDataStreamName() : null;
                 if (dataStreamDescriptor != null) {
-                    Settings settings = MetadataIndexTemplateService.resolveSettings(
-                        dataStreamDescriptor.getComposableIndexTemplate(),
-                        dataStreamDescriptor.getComponentTemplates()
-                    );
-                    ilmPolicyName = settings.get(IndexMetadata.LIFECYCLE_NAME);
-                    if (indexMode == null) {
-                        indexMode = resolveMode(
-                            state,
-                            indexSettingProviders,
-                            dataStream,
-                            settings,
-                            dataStreamDescriptor.getComposableIndexTemplate()
+                    // When the descriptor owns its template, resolve settings from the embedded template + component templates.
+                    // When the template is managed externally (ownsTemplate() == false), fall back to the cluster-state template
+                    // lookup used for non-system streams so that ILM policy, index mode, and prefer-ILM are still surfaced.
+                    if (dataStreamDescriptor.ownsTemplate()) {
+                        Settings settings = MetadataIndexTemplateService.resolveSettings(
+                            dataStreamDescriptor.getComposableIndexTemplate(),
+                            dataStreamDescriptor.getComponentTemplates()
                         );
+                        ilmPolicyName = settings.get(IndexMetadata.LIFECYCLE_NAME);
+                        if (indexMode == null) {
+                            indexMode = resolveMode(
+                                state,
+                                indexSettingProviders,
+                                dataStream,
+                                settings,
+                                dataStreamDescriptor.getComposableIndexTemplate()
+                            );
+                        }
+                        indexTemplatePreferIlmValue = PREFER_ILM_SETTING.get(settings);
+                    } else {
+                        // Descriptor registered without an owned template: resolve from cluster state, same as non-system streams.
+                        indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);
+                        if (indexTemplate != null) {
+                            ComposableIndexTemplate clusterTemplate = MetadataCreateDataStreamService.lookupTemplateForDataStream(
+                                dataStream.getName(),
+                                state.metadata()
+                            );
+                            if (clusterTemplate != null) {
+                                Settings settings = MetadataIndexTemplateService.resolveSettings(
+                                    clusterTemplate,
+                                    state.metadata().componentTemplates()
+                                );
+                                ilmPolicyName = settings.get(IndexMetadata.LIFECYCLE_NAME);
+                                if (indexMode == null) {
+                                    indexMode = resolveMode(state, indexSettingProviders, dataStream, settings, clusterTemplate);
+                                }
+                                indexTemplatePreferIlmValue = PREFER_ILM_SETTING.get(settings);
+                            }
+                        }
                     }
-                    indexTemplatePreferIlmValue = PREFER_ILM_SETTING.get(settings);
                 }
             } else {
                 indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -331,7 +331,11 @@ public class MetadataRolloverService {
             if (systemDataStreamDescriptor == null) {
                 throw new IllegalArgumentException("no system data stream descriptor found for data stream [" + dataStreamName + "]");
             }
-            templateV2 = systemDataStreamDescriptor.getComposableIndexTemplate();
+            // When the descriptor owns its template, use it directly. When it was registered without one (ownsTemplate() == false),
+            // fall back to the matching template in cluster state — typically applied by the owning plugin at its own startup.
+            templateV2 = systemDataStreamDescriptor.ownsTemplate()
+                ? systemDataStreamDescriptor.getComposableIndexTemplate()
+                : dataStream.getEffectiveIndexTemplate(projectState.metadata());
         }
 
         final DataStream.DataStreamIndices dataStreamIndices = dataStream.getDataStreamIndices(isFailureStoreRollover);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -288,7 +288,10 @@ public class MetadataCreateDataStreamService {
         }
 
         final boolean isSystem = systemDataStreamDescriptor != null;
-        final ComposableIndexTemplate template = isSystem
+        // When the descriptor owns its template, use it directly. When the descriptor was registered without a template
+        // (ownsTemplate() == false), fall back to the matching template in cluster state — typically one applied by the
+        // owning plugin (e.g. Kibana) at its own startup. Non-system streams always use the cluster-state lookup.
+        final ComposableIndexTemplate template = (isSystem && systemDataStreamDescriptor.ownsTemplate())
             ? systemDataStreamDescriptor.getComposableIndexTemplate()
             : lookupTemplateForDataStream(dataStreamName, currentProject);
         // The initial backing index and the initial failure store index will have the same initial generation.
@@ -573,7 +576,10 @@ public class MetadataCreateDataStreamService {
         ComposableIndexTemplate template,
         boolean isSystem
     ) {
-        DataStreamOptions.Builder builder = isSystem
+        // Use the descriptor's embedded component templates only when it also owns the composable template.
+        // When the template comes from cluster state, use the project-level component templates instead.
+        final boolean useDescriptorComponents = isSystem && systemDataStreamDescriptor.ownsTemplate();
+        DataStreamOptions.Builder builder = useDescriptorComponents
             ? MetadataIndexTemplateService.resolveDataStreamOptions(template, systemDataStreamDescriptor.getComponentTemplates())
             : MetadataIndexTemplateService.resolveDataStreamOptions(template, project.componentTemplates());
         return builder == null ? null : builder.build();
@@ -585,7 +591,10 @@ public class MetadataCreateDataStreamService {
         ComposableIndexTemplate template,
         boolean isSystem
     ) {
-        DataStreamLifecycle.Builder builder = isSystem
+        // Use the descriptor's embedded component templates only when it also owns the composable template.
+        // When the template comes from cluster state, use the project-level component templates instead.
+        final boolean useDescriptorComponents = isSystem && systemDataStreamDescriptor.ownsTemplate();
+        DataStreamLifecycle.Builder builder = useDescriptorComponents
             ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
             : MetadataIndexTemplateService.resolveLifecycle(template, project.componentTemplates());
         return builder == null ? null : builder.build();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1104,14 +1104,22 @@ public class MetadataCreateIndexService {
         Objects.requireNonNull(request.systemDataStreamDescriptor());
         logger.debug("applying create index request for system data stream [{}]", request.systemDataStreamDescriptor());
 
+        // The descriptor may not own its template (ownsTemplate() == false). In that case the template was already resolved from
+        // cluster state upstream (in MetadataCreateDataStreamService) and passed via CreateIndexClusterStateUpdateRequest; use it.
         ComposableIndexTemplate template = request.systemDataStreamDescriptor().getComposableIndexTemplate();
-        if (request.dataStreamName() == null && template.getDataStreamTemplate() != null) {
+        if (template == null) {
+            template = request.matchingTemplate();
+        }
+        if (request.dataStreamName() == null && template != null && template.getDataStreamTemplate() != null) {
             throw new IllegalArgumentException(
                 "cannot create index with name [" + request.index() + "], because it matches with a system data stream"
             );
         }
 
-        final Map<String, ComponentTemplate> componentTemplates = request.systemDataStreamDescriptor().getComponentTemplates();
+        // Use embedded component templates only when the descriptor owns the composable template.
+        final Map<String, ComponentTemplate> componentTemplates = request.systemDataStreamDescriptor().ownsTemplate()
+            ? request.systemDataStreamDescriptor().getComponentTemplates()
+            : Map.of();
         final List<CompressedXContent> mappings = collectSystemV2Mappings(template, componentTemplates, xContentRegistry, request.index());
 
         final Metadata metadata = currentState.getMetadata();

--- a/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
@@ -89,8 +89,17 @@ public class SystemDataStreamDescriptor implements SystemResourceDescriptor {
         String origin,
         ExecutorNames executorNames
     ) {
-        this(dataStreamName, description, type, composableIndexTemplate, componentTemplates, allowedElasticProductOrigins, origin,
-            executorNames, true);
+        this(
+            dataStreamName,
+            description,
+            type,
+            composableIndexTemplate,
+            componentTemplates,
+            allowedElasticProductOrigins,
+            origin,
+            executorNames,
+            true
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemDataStreamDescriptor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.system.SystemResourceDescriptor;
 
@@ -34,14 +35,17 @@ import java.util.stream.Stream;
  *
  * <p>A SystemDataStreamDescriptor defines a list of allowed product origins. If that list is empty, only system operations can read,
  * write to, or modify the system data stream. If there are entries in the list, then a special request header must be used in any
- * request that accesses the system data stream, either through plugin-provided APIs or through data stream APIs.
+ * request that accesses the system data stream, either through plugin-derived APIs or through data stream APIs.
  *
  * <p>A SystemDataStreamDescriptor may be internal or external. If internal, the system feature must define APIs for interacting with
  * the system data stream. If external, the system feature will allow use of the data stream API, assuming the correct permissions
  * and product origin flag.
  *
- * <p>One interesting implementation detail is that the SystemDataStreamDescriptor manages its own templates for the data stream, so
- * although they have names, they are never listed in the index template or component template APIs.
+ * <p>A descriptor may optionally carry a {@link ComposableIndexTemplate} that provides the mappings, settings, and lifecycle for the
+ * stream’s backing indices. When a template is provided, ES uses it directly and never exposes it through the index-template APIs.
+ * When no template is provided ({@code composableIndexTemplate == null}), ES falls back to the matching template already present in
+ * cluster state — typically one that the owning plugin applied at its own startup. This decoupled mode allows ES to register the
+ * descriptor (and therefore enforce system-stream access controls) without needing to own or duplicate the template body.
  *
  * <p>The descriptor also provides names for the thread pools that Elasticsearch should use to read, search, or modify the descriptor’s
  * indices.
@@ -58,7 +62,11 @@ public class SystemDataStreamDescriptor implements SystemResourceDescriptor {
     private final ExecutorNames executorNames;
 
     /**
-     * Creates a new descriptor for a system data descriptor
+     * Creates a new descriptor for a system data stream that owns and manages its own index template.
+     *
+     * <p>Use this constructor when the ES plugin is the authoritative owner of the template. The template is embedded in the descriptor
+     * and never surfaced through the index-template APIs.
+     *
      * @param dataStreamName the name of the data stream. Must not be {@code null}
      * @param description a brief description of what the data stream is used for. Must not be {@code null}
      * @param type the {@link Type} of the data stream which determines how the data stream can be accessed. Must not be {@code null}
@@ -81,6 +89,50 @@ public class SystemDataStreamDescriptor implements SystemResourceDescriptor {
         String origin,
         ExecutorNames executorNames
     ) {
+        this(dataStreamName, description, type, composableIndexTemplate, componentTemplates, allowedElasticProductOrigins, origin,
+            executorNames, true);
+    }
+
+    /**
+     * Creates a new descriptor for a system data stream whose index template is managed externally (e.g. by Kibana at its own startup).
+     *
+     * <p>Use this constructor when another plugin or application owns the template. ES will register the descriptor — enforcing
+     * system-stream access controls and protection — without needing to own or duplicate the template body. At stream-creation or
+     * rollover time, ES falls back to the matching template already present in cluster state.
+     *
+     * <p>Note: {@code componentTemplates} is ignored when {@code composableIndexTemplate} is {@code null}; pass {@code null} or
+     * {@code Map.of()}.
+     *
+     * @param dataStreamName the name of the data stream. Must not be {@code null}
+     * @param description a brief description of what the data stream is used for. Must not be {@code null}
+     * @param type the {@link Type} of the data stream which determines how the data stream can be accessed. Must not be {@code null}
+     * @param allowedElasticProductOrigins a list of product origin values that are allowed to access this data stream if the
+     *                                     type is {@link Type#EXTERNAL}. Must not be {@code null}
+     * @param origin specifies the origin to use when creating or updating the data stream
+     * @param executorNames thread pools that should be used for operations on the system data stream
+     */
+    public SystemDataStreamDescriptor(
+        String dataStreamName,
+        String description,
+        Type type,
+        List<String> allowedElasticProductOrigins,
+        String origin,
+        ExecutorNames executorNames
+    ) {
+        this(dataStreamName, description, type, null, null, allowedElasticProductOrigins, origin, executorNames, false);
+    }
+
+    private SystemDataStreamDescriptor(
+        String dataStreamName,
+        String description,
+        Type type,
+        @Nullable ComposableIndexTemplate composableIndexTemplate,
+        @Nullable Map<String, ComponentTemplate> componentTemplates,
+        List<String> allowedElasticProductOrigins,
+        String origin,
+        ExecutorNames executorNames,
+        boolean requireTemplate
+    ) {
         this.dataStreamName = Objects.requireNonNull(dataStreamName, "dataStreamName must be specified");
         if (dataStreamName.length() < 2) {
             throw new IllegalArgumentException("system data stream name [" + dataStreamName + "] but must at least 2 characters in length");
@@ -90,7 +142,10 @@ public class SystemDataStreamDescriptor implements SystemResourceDescriptor {
         }
         this.description = Objects.requireNonNull(description, "description must be specified");
         this.type = Objects.requireNonNull(type, "type must be specified");
-        this.composableIndexTemplate = Objects.requireNonNull(composableIndexTemplate, "composableIndexTemplate must be provided");
+        if (requireTemplate) {
+            Objects.requireNonNull(composableIndexTemplate, "composableIndexTemplate must be provided");
+        }
+        this.composableIndexTemplate = composableIndexTemplate;
         this.componentTemplates = componentTemplates == null ? Map.of() : Map.copyOf(componentTemplates);
         this.allowedElasticProductOrigins = Objects.requireNonNull(
             allowedElasticProductOrigins,
@@ -139,8 +194,22 @@ public class SystemDataStreamDescriptor implements SystemResourceDescriptor {
         return description;
     }
 
+    /**
+     * Returns the index template embedded in this descriptor, or {@code null} when the descriptor was created without one.
+     * Callers that create a data stream or roll over a system stream must fall back to the matching template in cluster state when
+     * this method returns {@code null}.
+     */
+    @Nullable
     public ComposableIndexTemplate getComposableIndexTemplate() {
         return composableIndexTemplate;
+    }
+
+    /**
+     * Returns {@code true} when this descriptor owns its index template (i.e. {@link #getComposableIndexTemplate()} is non-null).
+     * Returns {@code false} when the template is managed externally and looked up from cluster state at creation/rollover time.
+     */
+    public boolean ownsTemplate() {
+        return composableIndexTemplate != null;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexSettingsUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexSettingsUpdateService.java
@@ -160,9 +160,13 @@ public class SystemIndexSettingsUpdateService implements ClusterStateListener {
                     continue;
                 }
                 Settings dsSettings = Settings.EMPTY;
-                Template template = dsDescriptor.getComposableIndexTemplate().template();
-                if (template != null && template.settings() != null) {
-                    dsSettings = template.settings();
+                // Descriptors registered without an owned template (ownsTemplate() == false) have no embedded settings to check.
+                ComposableIndexTemplate composableTemplate = dsDescriptor.getComposableIndexTemplate();
+                if (composableTemplate != null) {
+                    Template template = composableTemplate.template();
+                    if (template != null && template.settings() != null) {
+                        dsSettings = template.settings();
+                    }
                 }
                 for (Index idx : ds.getIndices()) {
                     backingIndexToDescriptorSettings.put(idx.getName(), dsSettings);


### PR DESCRIPTION
Closes #149309

`SystemDataStreamDescriptor` currently requires a `ComposableIndexTemplate` at construction, which forces the ES Kibana plugin to duplicate and maintain every template that Kibana already manages. Each new system data stream needs a coordinated cross repo PR: ES merges the template copy first, Kibana second.

i think we can fix this by making the template optional. This adds a second constructor that takes just teh stream name, type, access rules, and executor names (no template body). When a stream is created or rolled over, ES falls back to the matching template already in cluster state. The existing constructor is unchanged. `ownsTemplate()` is a small helper the call sites use to pick the right path. Marking as draft, happy to add tests once we agree on the shape.