### PR TITLE
ESQL:DS: Detach closed datasource read buffers

### DIFF
--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
@@ -299,7 +299,7 @@ public final class AzureStorageObject extends AbstractMeteredStorageObject {
         int len = Math.toIntExact(length);
         final DirectReadBuffer drb;
         try {
-            drb = factory.allocate(len);
+            drb = factory.allocateWritableWindow(len);
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObject.java
@@ -307,7 +307,7 @@ public final class AzureStorageObject extends AbstractMeteredStorageObject {
 
         BlobRange range = new BlobRange(position, length);
         long startNanos = System.nanoTime();
-        final CompletableFuture<ByteBuffer> future;
+        final CompletableFuture<Void> future;
         try {
             future = blobAsyncClient.downloadWithResponse(range, null, null, false)
                 .flatMapMany(response -> response.getValue())
@@ -318,10 +318,9 @@ public final class AzureStorageObject extends AbstractMeteredStorageObject {
                     acc.put(chunk);
                     return acc;
                 })
-                .map(buffer -> {
-                    buffer.flip();
-                    return buffer;
-                })
+                .doOnNext(ByteBuffer::flip)
+                // Do not complete the SDK-retained future with an alias of drb's payload.
+                .then()
                 .toFuture();
         } catch (RuntimeException e) {
             // Assembly-time throw from Reactor operator construction. No request was issued,
@@ -330,7 +329,7 @@ public final class AzureStorageObject extends AbstractMeteredStorageObject {
             listener.onFailure(mapReadFailure("Failed to read bytes from", e));
             return;
         }
-        onReadComplete(future, (buffer, error) -> {
+        onReadComplete(future, (ignored, error) -> {
             if (error != null) {
                 counters.addRequest(System.nanoTime() - startNanos, 0L);
                 // Release eagerly on the failure path so the breaker charge does not outlive

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageObjectTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.azure;
 
+import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.common.policy.RequestRetryOptions;
@@ -15,10 +16,13 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.sun.net.httpserver.HttpServer;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.test.AzureReactorThreadFilter;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObjectMetrics;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -26,7 +30,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Unit tests for AzureStorageObject.
@@ -106,6 +115,59 @@ public class AzureStorageObjectTests extends ESTestCase {
         }
     }
 
+    public void testReadBytesAsyncConstrainsOverAllocatedDestination() throws Exception {
+        byte[] payload = randomByteArrayOfLength(between(32, 512));
+        HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+            exchange.getResponseHeaders().add("Content-Range", "bytes 0-" + (payload.length - 1) + "/" + payload.length);
+            exchange.getResponseHeaders().add("ETag", "\"0x1\"");
+            exchange.getResponseHeaders().add("x-ms-creation-time", "Wed, 01 Jan 2026 00:00:00 GMT");
+            exchange.sendResponseHeaders(206, payload.length);
+            exchange.getResponseBody().write(payload);
+            exchange.close();
+        });
+        server.start();
+        try {
+            BlobClient blobClient = newBlobClient(server, "container", "blob.parquet");
+            BlobAsyncClient blobAsyncClient = newBlobAsyncClient(server, "container", "blob.parquet");
+            StoragePath path = StoragePath.of("wasbs://devstoreaccount1.blob.core.windows.net/container/blob.parquet");
+            AzureStorageObject obj = new AzureStorageObject(blobClient, blobAsyncClient, "container", "blob.parquet", path);
+
+            AtomicInteger closeCalls = new AtomicInteger();
+            DirectBufferFactory factory = length -> {
+                ByteBuffer buffer = ByteBuffer.allocate(length + 17);
+                buffer.limit(1);
+                return new DirectReadBuffer(buffer, closeCalls::incrementAndGet);
+            };
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<DirectReadBuffer> result = new AtomicReference<>();
+            AtomicReference<Exception> error = new AtomicReference<>();
+
+            obj.readBytesAsync(0, payload.length, factory, Runnable::run, ActionListener.wrap(buffer -> {
+                result.set(buffer);
+                latch.countDown();
+            }, e -> {
+                error.set(e);
+                latch.countDown();
+            }));
+
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertNull(error.get());
+            assertNotNull(result.get());
+            try (DirectReadBuffer drb = result.get()) {
+                assertEquals(payload.length + 17, drb.buffer().capacity());
+                assertEquals(payload.length, drb.buffer().remaining());
+                byte[] actual = new byte[payload.length];
+                drb.buffer().get(actual);
+                assertArrayEquals(payload, actual);
+            }
+            assertEquals(1, closeCalls.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
     /**
      * Metadata-probe paths (length(), exists(), lastModified()) are intentionally NOT counted in
      * metrics() — they are not data reads. Even when fetchMetadata fails, requestCount stays at 0.
@@ -143,6 +205,14 @@ public class AzureStorageObjectTests extends ESTestCase {
      * disabled so unit tests stay fast and deterministic.
      */
     private static BlobClient newBlobClient(HttpServer server, String container, String blobName) {
+        return newBlobServiceClientBuilder(server).buildClient().getBlobContainerClient(container).getBlobClient(blobName);
+    }
+
+    private static BlobAsyncClient newBlobAsyncClient(HttpServer server, String container, String blobName) {
+        return newBlobServiceClientBuilder(server).buildAsyncClient().getBlobContainerAsyncClient(container).getBlobAsyncClient(blobName);
+    }
+
+    private static BlobServiceClientBuilder newBlobServiceClientBuilder(HttpServer server) {
         String endpoint = "http://" + server.getAddress().getHostString() + ":" + server.getAddress().getPort() + "/devstoreaccount1";
         // Azurite's well-known dev-storage shared key — value comes from public Azure SDK docs.
         // Used here only to satisfy the SDK's auth-header-signing pipeline against our local server.
@@ -160,10 +230,6 @@ public class AzureStorageObjectTests extends ESTestCase {
             1L,
             null
         );
-        return new BlobServiceClientBuilder().connectionString(connectionString)
-            .retryOptions(noRetries)
-            .buildClient()
-            .getBlobContainerClient(container)
-            .getBlobClient(blobName);
+        return new BlobServiceClientBuilder().connectionString(connectionString).retryOptions(noRetries);
     }
 }

--- a/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/main/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObject.java
@@ -219,7 +219,7 @@ public final class GcsStorageObject extends AbstractMeteredStorageObject {
         int len = Math.toIntExact(length);
         final DirectReadBuffer drb;
         try {
-            drb = factory.allocate(len);
+            drb = factory.allocateWritableWindow(len);
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-gcs/src/test/java/org/elasticsearch/xpack/esql/datasource/gcs/GcsStorageObjectTests.java
@@ -31,6 +31,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -494,6 +495,45 @@ public class GcsStorageObjectTests extends ESTestCase {
         }
         verify(mockReader).seek(10);
         verify(mockReader).limit(15);
+    }
+
+    public void testReadBytesAsyncConstrainsOverAllocatedDestination() throws Exception {
+        byte[] payload = "async".getBytes(StandardCharsets.UTF_8);
+        ReadChannel mockReader = mock(ReadChannel.class);
+        when(mockStorage.reader(any(BlobId.class))).thenReturn(mockReader);
+        doAnswer(invocation -> {
+            ByteBuffer buffer = invocation.getArgument(0);
+            buffer.put(payload);
+            return payload.length;
+        }).when(mockReader).read(any(ByteBuffer.class));
+
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory overAllocatingFactory = length -> {
+            ByteBuffer buffer = ByteBuffer.allocate(length + 17);
+            buffer.limit(1);
+            return new DirectReadBuffer(buffer, closeCalls::incrementAndGet);
+        };
+        GcsStorageObject obj = new GcsStorageObject(
+            mockStorage,
+            "my-bucket",
+            "data/file.parquet",
+            StoragePath.of("gs://my-bucket/data/file.parquet")
+        );
+        AtomicReference<DirectReadBuffer> result = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        obj.readBytesAsync(10, payload.length, overAllocatingFactory, Runnable::run, ActionListener.wrap(result::set, error::set));
+
+        assertNull(error.get());
+        assertNotNull(result.get());
+        try (DirectReadBuffer drb = result.get()) {
+            assertEquals(payload.length + 17, drb.buffer().capacity());
+            assertEquals(payload.length, drb.buffer().remaining());
+            byte[] actual = new byte[payload.length];
+            drb.buffer().get(actual);
+            assertArrayEquals(payload, actual);
+        }
+        assertEquals(1, closeCalls.get());
     }
 
     public void testReadBytesAsyncNegativePositionFails() throws Exception {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
@@ -63,8 +63,13 @@ final class DirectByteBufferBodyHandlers {
         // Cross-callback fields are volatile as defense-in-depth. The Reactive Streams contract
         // guarantees serial signals with happens-before, but making the visibility explicit avoids
         // depending on each publisher implementation honoring that subtlety correctly.
+        //
+        // Volatile is sufficient here, unlike the destinationLock that KnownLengthAsyncResponseTransformer
+        // needs on the S3 path: every signal that can release this destination is a Flow.Subscriber
+        // callback, and those are serialized by the publisher. There is no out-of-band failure
+        // callback, and cancelling the body future never re-enters the subscriber. Do not "restore
+        // symmetry" by adding a lock that would guard against nothing.
         private volatile DirectReadBuffer destinationBuf;
-        private volatile ByteBuffer destination;
         private int offset;
         private volatile Flow.Subscription subscription;
         private volatile boolean failed;
@@ -84,13 +89,22 @@ final class DirectByteBufferBodyHandlers {
                 return;
             }
             this.subscription = subscription;
+            DirectReadBuffer allocated;
             try {
-                this.destinationBuf = factory.allocate(expectedLength);
-                this.destination = destinationBuf.buffer();
+                allocated = allocateIfBodyOpen(factory, expectedLength, body, subscription);
             } catch (Exception e) {
                 failed = true;
                 subscription.cancel();
                 body.completeExceptionally(e);
+                return;
+            }
+            if (allocated == null) {
+                return;
+            }
+            this.destinationBuf = allocated;
+            if (body.isDone() || failed) {
+                releaseOnFailure();
+                subscription.cancel();
                 return;
             }
             try {
@@ -104,10 +118,11 @@ final class DirectByteBufferBodyHandlers {
 
         @Override
         public void onNext(List<ByteBuffer> items) {
-            if (failed) {
-                return;
-            }
             for (ByteBuffer chunk : items) {
+                DirectReadBuffer drb = destinationBuf;
+                if (drb == null || failed) {
+                    return;
+                }
                 int remaining = chunk.remaining();
                 if (remaining > expectedLength - offset) {
                     fail(
@@ -120,7 +135,7 @@ final class DirectByteBufferBodyHandlers {
                     );
                     return;
                 }
-                DirectByteBufferCopies.copyChunkIntoDestination(destination, offset, chunk);
+                DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), offset, chunk);
                 offset += remaining;
             }
         }
@@ -148,14 +163,15 @@ final class DirectByteBufferBodyHandlers {
                 );
                 return;
             }
-            destination.position(0).limit(offset);
-            // Transfer ownership of the buffer to the caller.
-            // Null out the field so releaseOnFailure (if ever invoked after this point) does not
-            // double-close it. The destination ByteBuffer's position/limit set above is observable
-            // through transferred.buffer() since they share the same NIO view.
             DirectReadBuffer transferred = destinationBuf;
             destinationBuf = null;
-            body.complete(transferred);
+            if (transferred == null) {
+                return;
+            }
+            transferred.buffer().position(0).limit(offset);
+            if (body.complete(transferred) == false) {
+                transferred.close();
+            }
         }
 
         @Override
@@ -188,9 +204,8 @@ final class DirectByteBufferBodyHandlers {
         private final int length;
         private final DirectBufferFactory factory;
         private final CompletableFuture<DirectReadBuffer> body = new CompletableFuture<>();
-        // See FixedLengthDirectSubscriber for the volatility rationale.
+        // See FixedLengthDirectSubscriber for the volatility rationale and for why no lock is needed.
         private volatile DirectReadBuffer destinationBuf;
-        private volatile ByteBuffer destination;
         private long skipRemaining;
         private int fillOffset;
         private volatile Flow.Subscription subscription;
@@ -216,13 +231,22 @@ final class DirectByteBufferBodyHandlers {
                 return;
             }
             this.subscription = subscription;
+            DirectReadBuffer allocated;
             try {
-                this.destinationBuf = factory.allocate(length);
-                this.destination = destinationBuf.buffer();
+                allocated = allocateIfBodyOpen(factory, length, body, subscription);
             } catch (Exception e) {
                 failed = true;
                 subscription.cancel();
                 body.completeExceptionally(e);
+                return;
+            }
+            if (allocated == null) {
+                return;
+            }
+            this.destinationBuf = allocated;
+            if (body.isDone() || failed) {
+                releaseOnFailure();
+                subscription.cancel();
                 return;
             }
             try {
@@ -236,10 +260,11 @@ final class DirectByteBufferBodyHandlers {
 
         @Override
         public void onNext(List<ByteBuffer> items) {
-            if (failed) {
-                return;
-            }
             for (ByteBuffer chunk : items) {
+                DirectReadBuffer drb = destinationBuf;
+                if (drb == null || failed) {
+                    return;
+                }
                 if (skipRemaining > 0) {
                     long toSkip = Math.min(skipRemaining, chunk.remaining());
                     chunk.position(chunk.position() + (int) toSkip);
@@ -249,7 +274,7 @@ final class DirectByteBufferBodyHandlers {
                     int toCopy = Math.min(chunk.remaining(), length - fillOffset);
                     ByteBuffer slice = chunk.slice();
                     slice.limit(toCopy);
-                    DirectByteBufferCopies.copyChunkIntoDestination(destination, fillOffset, slice);
+                    DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), fillOffset, slice);
                     chunk.position(chunk.position() + toCopy);
                     fillOffset += toCopy;
                 }
@@ -289,11 +314,15 @@ final class DirectByteBufferBodyHandlers {
                 );
                 return;
             }
-            destination.position(0).limit(fillOffset);
-            // Transfer ownership of the buffer to the caller; see FixedLengthDirectSubscriber.
             DirectReadBuffer transferred = destinationBuf;
             destinationBuf = null;
-            body.complete(transferred);
+            if (transferred == null) {
+                return;
+            }
+            transferred.buffer().position(0).limit(fillOffset);
+            if (body.complete(transferred) == false) {
+                transferred.close();
+            }
         }
 
         @Override
@@ -308,6 +337,29 @@ final class DirectByteBufferBodyHandlers {
                 drb.close();
             }
         }
+    }
+
+    /**
+     * Allocates a writable destination only if {@code body} is still open. Returns {@code null}
+     * when the body was already cancelled or completed, after closing any unused allocation.
+     */
+    private static DirectReadBuffer allocateIfBodyOpen(
+        DirectBufferFactory factory,
+        int length,
+        CompletableFuture<DirectReadBuffer> body,
+        Flow.Subscription subscription
+    ) throws IOException {
+        if (body.isDone()) {
+            subscription.cancel();
+            return null;
+        }
+        DirectReadBuffer allocated = factory.allocateWritableWindow(length);
+        if (body.isDone()) {
+            allocated.close();
+            subscription.cancel();
+            return null;
+        }
+        return allocated;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlers.java
@@ -60,19 +60,13 @@ final class DirectByteBufferBodyHandlers {
         private final int expectedLength;
         private final DirectBufferFactory factory;
         private final CompletableFuture<DirectReadBuffer> body = new CompletableFuture<>();
-        // Cross-callback fields are volatile as defense-in-depth. The Reactive Streams contract
-        // guarantees serial signals with happens-before, but making the visibility explicit avoids
-        // depending on each publisher implementation honoring that subtlety correctly.
-        //
-        // Volatile is sufficient here, unlike the destinationLock that KnownLengthAsyncResponseTransformer
-        // needs on the S3 path: every signal that can release this destination is a Flow.Subscriber
-        // callback, and those are serialized by the publisher. There is no out-of-band failure
-        // callback, and cancelling the body future never re-enters the subscriber. Do not "restore
-        // symmetry" by adding a lock that would guard against nothing.
-        private volatile DirectReadBuffer destinationBuf;
+        // Subscriber signals are serialized, but cancellation of body can arrive from another
+        // thread and must not close the destination while onNext is copying into it.
+        private final Object destinationLock = new Object();
+        private DirectReadBuffer destinationBuf;
         private int offset;
         private volatile Flow.Subscription subscription;
-        private volatile boolean failed;
+        private boolean failed;
 
         FixedLengthDirectSubscriber(int expectedLength, DirectBufferFactory factory) {
             if (expectedLength < 0) {
@@ -80,6 +74,15 @@ final class DirectByteBufferBodyHandlers {
             }
             this.expectedLength = expectedLength;
             this.factory = factory;
+            body.whenComplete((ignored, error) -> {
+                if (body.isCancelled()) {
+                    releaseOnFailure();
+                    Flow.Subscription current = subscription;
+                    if (current != null) {
+                        current.cancel();
+                    }
+                }
+            });
         }
 
         @Override
@@ -93,16 +96,27 @@ final class DirectByteBufferBodyHandlers {
             try {
                 allocated = allocateIfBodyOpen(factory, expectedLength, body, subscription);
             } catch (Exception e) {
-                failed = true;
-                subscription.cancel();
-                body.completeExceptionally(e);
+                fail(e, true);
                 return;
             }
             if (allocated == null) {
                 return;
             }
-            this.destinationBuf = allocated;
-            if (body.isDone() || failed) {
+            boolean published;
+            synchronized (destinationLock) {
+                if (body.isDone() || failed) {
+                    published = false;
+                } else {
+                    destinationBuf = allocated;
+                    published = true;
+                }
+            }
+            if (published == false) {
+                allocated.close();
+                subscription.cancel();
+                return;
+            }
+            if (body.isDone()) {
                 releaseOnFailure();
                 subscription.cancel();
                 return;
@@ -110,61 +124,66 @@ final class DirectByteBufferBodyHandlers {
             try {
                 subscription.request(Long.MAX_VALUE);
             } catch (RuntimeException e) {
-                failed = true;
-                releaseOnFailure();
-                body.completeExceptionally(e);
+                fail(e, true);
             }
         }
 
         @Override
         public void onNext(List<ByteBuffer> items) {
-            for (ByteBuffer chunk : items) {
-                DirectReadBuffer drb = destinationBuf;
-                if (drb == null || failed) {
-                    return;
-                }
-                int remaining = chunk.remaining();
-                if (remaining > expectedLength - offset) {
-                    fail(
-                        new IOException(
+            IOException overflow = null;
+            synchronized (destinationLock) {
+                for (ByteBuffer chunk : items) {
+                    DirectReadBuffer drb = destinationBuf;
+                    if (drb == null || failed) {
+                        return;
+                    }
+                    int remaining = chunk.remaining();
+                    if (remaining > expectedLength - offset) {
+                        overflow = new IOException(
                             "HTTP response body exceeded expected length: cumulative="
                                 + ((long) offset + remaining)
                                 + ", expected="
                                 + expectedLength
-                        )
-                    );
-                    return;
+                        );
+                        break;
+                    }
+                    DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), offset, chunk);
+                    offset += remaining;
                 }
-                DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), offset, chunk);
-                offset += remaining;
+            }
+            if (overflow != null) {
+                fail(overflow, true);
             }
         }
 
         @Override
         public void onError(Throwable throwable) {
-            if (failed) {
-                return;
-            }
-            failed = true;
-            releaseOnFailure();
-            body.completeExceptionally(throwable);
+            fail(throwable, false);
         }
 
         @Override
         public void onComplete() {
-            if (failed) {
+            DirectReadBuffer transferred;
+            IOException shortRead;
+            synchronized (destinationLock) {
+                if (failed) {
+                    return;
+                }
+                if (offset != expectedLength) {
+                    transferred = null;
+                    shortRead = new IOException(
+                        "HTTP response body shorter than expected: received=" + offset + ", expected=" + expectedLength
+                    );
+                } else {
+                    transferred = destinationBuf;
+                    destinationBuf = null;
+                    shortRead = null;
+                }
+            }
+            if (shortRead != null) {
+                fail(shortRead, false);
                 return;
             }
-            if (offset != expectedLength) {
-                failed = true;
-                releaseOnFailure();
-                body.completeExceptionally(
-                    new IOException("HTTP response body shorter than expected: received=" + offset + ", expected=" + expectedLength)
-                );
-                return;
-            }
-            DirectReadBuffer transferred = destinationBuf;
-            destinationBuf = null;
             if (transferred == null) {
                 return;
             }
@@ -179,17 +198,35 @@ final class DirectByteBufferBodyHandlers {
             return body;
         }
 
-        private void fail(IOException error) {
-            failed = true;
-            subscription.cancel();
-            releaseOnFailure();
+        private void fail(Throwable error, boolean cancelSubscription) {
+            DirectReadBuffer drb;
+            synchronized (destinationLock) {
+                if (failed) {
+                    return;
+                }
+                failed = true;
+                drb = destinationBuf;
+                destinationBuf = null;
+            }
+            if (cancelSubscription) {
+                Flow.Subscription current = subscription;
+                if (current != null) {
+                    current.cancel();
+                }
+            }
+            if (drb != null) {
+                drb.close();
+            }
             body.completeExceptionally(error);
         }
 
         private void releaseOnFailure() {
-            DirectReadBuffer drb = destinationBuf;
-            if (drb != null) {
+            DirectReadBuffer drb;
+            synchronized (destinationLock) {
+                drb = destinationBuf;
                 destinationBuf = null;
+            }
+            if (drb != null) {
                 drb.close();
             }
         }
@@ -204,12 +241,12 @@ final class DirectByteBufferBodyHandlers {
         private final int length;
         private final DirectBufferFactory factory;
         private final CompletableFuture<DirectReadBuffer> body = new CompletableFuture<>();
-        // See FixedLengthDirectSubscriber for the volatility rationale and for why no lock is needed.
-        private volatile DirectReadBuffer destinationBuf;
+        private final Object destinationLock = new Object();
+        private DirectReadBuffer destinationBuf;
         private long skipRemaining;
         private int fillOffset;
         private volatile Flow.Subscription subscription;
-        private volatile boolean failed;
+        private boolean failed;
 
         SkipThenFillDirectSubscriber(long skip, int length, DirectBufferFactory factory) {
             if (skip < 0) {
@@ -222,6 +259,15 @@ final class DirectByteBufferBodyHandlers {
             this.length = length;
             this.skipRemaining = skip;
             this.factory = factory;
+            body.whenComplete((ignored, error) -> {
+                if (body.isCancelled()) {
+                    releaseOnFailure();
+                    Flow.Subscription current = subscription;
+                    if (current != null) {
+                        current.cancel();
+                    }
+                }
+            });
         }
 
         @Override
@@ -235,16 +281,28 @@ final class DirectByteBufferBodyHandlers {
             try {
                 allocated = allocateIfBodyOpen(factory, length, body, subscription);
             } catch (Exception e) {
-                failed = true;
                 subscription.cancel();
-                body.completeExceptionally(e);
+                fail(e);
                 return;
             }
             if (allocated == null) {
                 return;
             }
-            this.destinationBuf = allocated;
-            if (body.isDone() || failed) {
+            boolean published;
+            synchronized (destinationLock) {
+                if (body.isDone() || failed) {
+                    published = false;
+                } else {
+                    destinationBuf = allocated;
+                    published = true;
+                }
+            }
+            if (published == false) {
+                allocated.close();
+                subscription.cancel();
+                return;
+            }
+            if (body.isDone()) {
                 releaseOnFailure();
                 subscription.cancel();
                 return;
@@ -252,70 +310,67 @@ final class DirectByteBufferBodyHandlers {
             try {
                 subscription.request(Long.MAX_VALUE);
             } catch (RuntimeException e) {
-                failed = true;
-                releaseOnFailure();
-                body.completeExceptionally(e);
+                fail(e);
             }
         }
 
         @Override
         public void onNext(List<ByteBuffer> items) {
-            for (ByteBuffer chunk : items) {
-                DirectReadBuffer drb = destinationBuf;
-                if (drb == null || failed) {
-                    return;
-                }
-                if (skipRemaining > 0) {
-                    long toSkip = Math.min(skipRemaining, chunk.remaining());
-                    chunk.position(chunk.position() + (int) toSkip);
-                    skipRemaining -= toSkip;
-                }
-                if (fillOffset < length && chunk.hasRemaining()) {
-                    int toCopy = Math.min(chunk.remaining(), length - fillOffset);
-                    ByteBuffer slice = chunk.slice();
-                    slice.limit(toCopy);
-                    DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), fillOffset, slice);
-                    chunk.position(chunk.position() + toCopy);
-                    fillOffset += toCopy;
+            synchronized (destinationLock) {
+                for (ByteBuffer chunk : items) {
+                    DirectReadBuffer drb = destinationBuf;
+                    if (drb == null || failed) {
+                        return;
+                    }
+                    if (skipRemaining > 0) {
+                        long toSkip = Math.min(skipRemaining, chunk.remaining());
+                        chunk.position(chunk.position() + (int) toSkip);
+                        skipRemaining -= toSkip;
+                    }
+                    if (fillOffset < length && chunk.hasRemaining()) {
+                        int toCopy = Math.min(chunk.remaining(), length - fillOffset);
+                        ByteBuffer slice = chunk.slice();
+                        slice.limit(toCopy);
+                        DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), fillOffset, slice);
+                        chunk.position(chunk.position() + toCopy);
+                        fillOffset += toCopy;
+                    }
                 }
             }
         }
 
         @Override
         public void onError(Throwable throwable) {
-            if (failed) {
-                return;
-            }
-            failed = true;
-            releaseOnFailure();
-            body.completeExceptionally(throwable);
+            fail(throwable);
         }
 
         @Override
         public void onComplete() {
-            if (failed) {
+            DirectReadBuffer transferred;
+            IOException readFailure;
+            synchronized (destinationLock) {
+                if (failed) {
+                    return;
+                }
+                if (skipRemaining > 0) {
+                    transferred = null;
+                    readFailure = new IOException("Position " + skip + " is beyond content length for HTTP response body");
+                } else if (fillOffset != length) {
+                    // Downstream consumers trust the requested length when slicing the returned buffer.
+                    transferred = null;
+                    readFailure = new IOException(
+                        "HTTP response body shorter than expected: received=" + fillOffset + ", expected=" + length
+                    );
+                } else {
+                    transferred = destinationBuf;
+                    destinationBuf = null;
+                    readFailure = null;
+                }
+            }
+            if (readFailure != null) {
+                fail(readFailure);
                 return;
             }
-            if (skipRemaining > 0) {
-                failed = true;
-                releaseOnFailure();
-                body.completeExceptionally(new IOException("Position " + skip + " is beyond content length for HTTP response body"));
-                return;
-            }
-            // Strict contract: a range read must deliver exactly {@code length} bytes after the skip.
-            // Matches FixedLengthDirectSubscriber (206 path) and KnownLengthAsyncResponseTransformer (S3).
-            // Downstream consumers like CoalescedRangeReader trust the requested length when slicing,
-            // so returning a short buffer here would surface as an IllegalArgumentException at slice time.
-            if (fillOffset != length) {
-                failed = true;
-                releaseOnFailure();
-                body.completeExceptionally(
-                    new IOException("HTTP response body shorter than expected: received=" + fillOffset + ", expected=" + length)
-                );
-                return;
-            }
-            DirectReadBuffer transferred = destinationBuf;
-            destinationBuf = null;
             if (transferred == null) {
                 return;
             }
@@ -330,19 +385,34 @@ final class DirectByteBufferBodyHandlers {
             return body;
         }
 
-        private void releaseOnFailure() {
-            DirectReadBuffer drb = destinationBuf;
-            if (drb != null) {
+        private void fail(Throwable error) {
+            DirectReadBuffer drb;
+            synchronized (destinationLock) {
+                if (failed) {
+                    return;
+                }
+                failed = true;
+                drb = destinationBuf;
                 destinationBuf = null;
+            }
+            if (drb != null) {
+                drb.close();
+            }
+            body.completeExceptionally(error);
+        }
+
+        private void releaseOnFailure() {
+            DirectReadBuffer drb;
+            synchronized (destinationLock) {
+                drb = destinationBuf;
+                destinationBuf = null;
+            }
+            if (drb != null) {
                 drb.close();
             }
         }
     }
 
-    /**
-     * Allocates a writable destination only if {@code body} is still open. Returns {@code null}
-     * when the body was already cancelled or completed, after closing any unused allocation.
-     */
     private static DirectReadBuffer allocateIfBodyOpen(
         DirectBufferFactory factory,
         int length,

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
@@ -14,12 +14,18 @@ import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 
 import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -29,6 +35,9 @@ import static org.mockito.Mockito.when;
 public class DirectByteBufferBodyHandlersTests extends ESTestCase {
 
     private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
+
+    /** Arbitrary non-zero slack, so a factory buffer that is larger than requested is not a rounding coincidence. */
+    private static final int EXTRA_CAPACITY = 17;
 
     public void testFixedLengthSingleChunk() throws Exception {
         byte[] payload = randomByteArrayOfLength(between(1, 4096));
@@ -61,6 +70,33 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
             assertFalse(result.buffer().isDirect());
             assertArrayEquals(payload, toByteArray(result.buffer()));
         }
+    }
+
+    public void testFixedLengthOverAllocatedDestinationUsesExpectedLength() throws Exception {
+        byte[] payload = randomByteArrayOfLength(between(32, 512));
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            payload.length,
+            overAllocatingFactory(closeCalls)
+        );
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+        subscriber.onComplete();
+
+        try (DirectReadBuffer result = subscriber.getBody().get()) {
+            assertEquals(payload.length + EXTRA_CAPACITY, result.buffer().capacity());
+            assertEquals(payload.length, result.buffer().remaining());
+            assertArrayEquals(payload, toByteArray(result.buffer()));
+        }
+        assertEquals(1, closeCalls.get());
+    }
+
+    public void testFixedLengthRejectsUndersizedFactoryBufferAndCancels() {
+        assertFixedLengthInvalidFactoryBufferRejected(ByteBuffer.allocate(15), 16);
+    }
+
+    public void testFixedLengthRejectsReadOnlyFactoryBufferAndCancels() {
+        assertFixedLengthInvalidFactoryBufferRejected(ByteBuffer.allocateDirect(16).asReadOnlyBuffer(), 16);
     }
 
     public void testFixedLengthShortBodyFails() {
@@ -98,6 +134,80 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         assertThat(ex.getCause().getMessage(), containsString("exceeded expected length"));
     }
 
+    public void testFixedLengthLateOnNextAfterCompleteIsIgnored() throws Exception {
+        byte[] payload = randomByteArrayOfLength(32);
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            payload.length,
+            FACTORY
+        );
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+        subscriber.onComplete();
+        subscriber.onNext(List.of(ByteBuffer.wrap(new byte[] { 1 })));
+
+        try (DirectReadBuffer result = subscriber.getBody().get()) {
+            assertArrayEquals(payload, toByteArray(result.buffer()));
+        }
+    }
+
+    public void testFixedLengthCancelledBodyReleasesCompletedDestination() {
+        byte[] payload = randomByteArrayOfLength(32);
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            payload.length,
+            factory
+        );
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+        assertTrue(subscriber.getBody().cancel(false));
+
+        subscriber.onComplete();
+
+        assertEquals(1, closeCalls.get());
+    }
+
+    public void testFixedLengthCancelBeforeSubscribeDoesNotAllocate() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            32,
+            factory
+        );
+        assertTrue(subscriber.getBody().cancel(false));
+        RecordingSubscription subscription = new RecordingSubscription();
+
+        subscriber.onSubscribe(subscription);
+
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+        assertEquals(0, closeCalls.get());
+        assertTrue(subscriber.getBody().isCancelled());
+    }
+
+    public void testFixedLengthClosedResultIsNotRetainedBySubscriber() throws Exception {
+        byte[] payload = randomByteArrayOfLength(1 << 20);
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            payload.length,
+            FACTORY
+        );
+        CompletableFuture<DirectReadBuffer> body = subscriber.getBody();
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+        subscriber.onComplete();
+
+        WeakReference<byte[]> destination = closeAndForgetDestination(body);
+        try {
+            assertBusy(() -> {
+                System.gc();
+                assertTrue("the completed body future must remain strongly reachable", body.isDone());
+                assertNull("a closed fixed-length destination must be collectable", destination.get());
+            });
+        } finally {
+            Reference.reachabilityFence(subscriber);
+        }
+    }
+
     public void testSkipThenFillAcrossChunks() throws Exception {
         byte[] fullBody = "0123456789ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
         byte[] expected = "56789".getBytes(StandardCharsets.UTF_8);
@@ -110,6 +220,101 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         try (DirectReadBuffer result = subscriber.getBody().toCompletableFuture().get()) {
             assertFalse(result.buffer().isDirect());
             assertArrayEquals(expected, toByteArray(result.buffer()));
+        }
+    }
+
+    public void testSkipThenFillOverAllocatedDestinationUsesExpectedLength() throws Exception {
+        byte[] fullBody = "0123456789ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = "56789".getBytes(StandardCharsets.UTF_8);
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(5, expected.length, overAllocatingFactory(closeCalls));
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(fullBody)));
+        subscriber.onComplete();
+
+        try (DirectReadBuffer result = subscriber.getBody().get()) {
+            assertEquals(expected.length + EXTRA_CAPACITY, result.buffer().capacity());
+            assertEquals(expected.length, result.buffer().remaining());
+            assertArrayEquals(expected, toByteArray(result.buffer()));
+        }
+        assertEquals(1, closeCalls.get());
+    }
+
+    public void testSkipThenFillRejectsUndersizedFactoryBufferAndCancels() {
+        assertSkipThenFillInvalidFactoryBufferRejected(ByteBuffer.allocate(15), 16);
+    }
+
+    public void testSkipThenFillRejectsReadOnlyFactoryBufferAndCancels() {
+        assertSkipThenFillInvalidFactoryBufferRejected(ByteBuffer.allocateDirect(16).asReadOnlyBuffer(), 16);
+    }
+
+    public void testSkipThenFillLateOnNextAfterCompleteIsIgnored() throws Exception {
+        byte[] fullBody = "0123456789".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = "345".getBytes(StandardCharsets.UTF_8);
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(3, expected.length, FACTORY);
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(fullBody)));
+        subscriber.onComplete();
+        subscriber.onNext(List.of(ByteBuffer.wrap(new byte[] { 1 })));
+
+        try (DirectReadBuffer result = subscriber.getBody().get()) {
+            assertArrayEquals(expected, toByteArray(result.buffer()));
+        }
+    }
+
+    public void testSkipThenFillCancelledBodyReleasesCompletedDestination() {
+        byte[] fullBody = "0123456789".getBytes(StandardCharsets.UTF_8);
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(3, 3, factory);
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(fullBody)));
+        assertTrue(subscriber.getBody().cancel(false));
+
+        subscriber.onComplete();
+
+        assertEquals(1, closeCalls.get());
+    }
+
+    public void testSkipThenFillCancelBeforeSubscribeDoesNotAllocate() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(3, 3, factory);
+        assertTrue(subscriber.getBody().cancel(false));
+        RecordingSubscription subscription = new RecordingSubscription();
+
+        subscriber.onSubscribe(subscription);
+
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+        assertEquals(0, closeCalls.get());
+        assertTrue(subscriber.getBody().isCancelled());
+    }
+
+    public void testSkipThenFillClosedResultIsNotRetainedBySubscriber() throws Exception {
+        int skip = 3;
+        int length = 1 << 20;
+        byte[] fullBody = randomByteArrayOfLength(skip + length);
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(skip, length, FACTORY);
+        CompletableFuture<DirectReadBuffer> body = subscriber.getBody();
+        subscriber.onSubscribe(new TestSubscription());
+        subscriber.onNext(List.of(ByteBuffer.wrap(fullBody)));
+        subscriber.onComplete();
+
+        WeakReference<byte[]> destination = closeAndForgetDestination(body);
+        try {
+            assertBusy(() -> {
+                System.gc();
+                assertTrue("the completed body future must remain strongly reachable", body.isDone());
+                assertNull("a closed skip-then-fill destination must be collectable", destination.get());
+            });
+        } finally {
+            Reference.reachabilityFence(subscriber);
         }
     }
 
@@ -236,6 +441,58 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         }
     }
 
+    private void assertFixedLengthInvalidFactoryBufferRejected(ByteBuffer invalidBuffer, int expectedLength) {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = ignored -> new DirectReadBuffer(invalidBuffer, closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber subscriber = new DirectByteBufferBodyHandlers.FixedLengthDirectSubscriber(
+            expectedLength,
+            factory
+        );
+        RecordingSubscription subscription = new RecordingSubscription();
+
+        subscriber.onSubscribe(subscription);
+
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> subscriber.getBody().get());
+        assertThat(ex.getCause(), instanceOf(IOException.class));
+        assertThat(ex.getCause().getMessage(), containsString("DirectBufferFactory"));
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+    }
+
+    private void assertSkipThenFillInvalidFactoryBufferRejected(ByteBuffer invalidBuffer, int length) {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = ignored -> new DirectReadBuffer(invalidBuffer, closeCalls::incrementAndGet);
+        DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
+            new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(0, length, factory);
+        RecordingSubscription subscription = new RecordingSubscription();
+
+        subscriber.onSubscribe(subscription);
+
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> subscriber.getBody().get());
+        assertThat(ex.getCause(), instanceOf(IOException.class));
+        assertThat(ex.getCause().getMessage(), containsString("DirectBufferFactory"));
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+    }
+
+    /** Hands back a destination that is both larger and more narrowly limited than the request. */
+    private static DirectBufferFactory overAllocatingFactory(AtomicInteger closeCalls) {
+        return length -> {
+            ByteBuffer destination = ByteBuffer.allocate(length + EXTRA_CAPACITY);
+            destination.limit(1);
+            return new DirectReadBuffer(destination, closeCalls::incrementAndGet);
+        };
+    }
+
+    private static WeakReference<byte[]> closeAndForgetDestination(CompletableFuture<DirectReadBuffer> body) throws Exception {
+        DirectReadBuffer result = body.get();
+        WeakReference<byte[]> destination = new WeakReference<>(result.buffer().array());
+        result.close();
+        return destination;
+    }
+
     private static byte[] toByteArray(ByteBuffer buffer) {
         byte[] bytes = new byte[buffer.remaining()];
         buffer.get(bytes);
@@ -248,5 +505,20 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
 
         @Override
         public void cancel() {}
+    }
+
+    private static final class RecordingSubscription implements Flow.Subscription {
+        private final AtomicLong requested = new AtomicLong();
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        @Override
+        public void request(long n) {
+            requested.addAndGet(n);
+        }
+
+        @Override
+        public void cancel() {
+            cancelled.set(true);
+        }
     }
 }

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/DirectByteBufferBodyHandlersTests.java
@@ -150,7 +150,7 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         }
     }
 
-    public void testFixedLengthCancelledBodyReleasesCompletedDestination() {
+    public void testFixedLengthCancellationReleasesDestinationImmediately() {
         byte[] payload = randomByteArrayOfLength(32);
         AtomicInteger closeCalls = new AtomicInteger();
         DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
@@ -158,12 +158,14 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
             payload.length,
             factory
         );
-        subscriber.onSubscribe(new TestSubscription());
+        RecordingSubscription subscription = new RecordingSubscription();
+        subscriber.onSubscribe(subscription);
         subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
         assertTrue(subscriber.getBody().cancel(false));
 
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
         subscriber.onComplete();
-
         assertEquals(1, closeCalls.get());
     }
 
@@ -264,18 +266,20 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         }
     }
 
-    public void testSkipThenFillCancelledBodyReleasesCompletedDestination() {
+    public void testSkipThenFillCancellationReleasesDestinationImmediately() {
         byte[] fullBody = "0123456789".getBytes(StandardCharsets.UTF_8);
         AtomicInteger closeCalls = new AtomicInteger();
         DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
         DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber subscriber =
             new DirectByteBufferBodyHandlers.SkipThenFillDirectSubscriber(3, 3, factory);
-        subscriber.onSubscribe(new TestSubscription());
+        RecordingSubscription subscription = new RecordingSubscription();
+        subscriber.onSubscribe(subscription);
         subscriber.onNext(List.of(ByteBuffer.wrap(fullBody)));
         assertTrue(subscriber.getBody().cancel(false));
 
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
         subscriber.onComplete();
-
         assertEquals(1, closeCalls.get());
     }
 
@@ -477,7 +481,6 @@ public class DirectByteBufferBodyHandlersTests extends ESTestCase {
         assertEquals(0L, subscription.requested.get());
     }
 
-    /** Hands back a destination that is both larger and more narrowly limited than the request. */
     private static DirectBufferFactory overAllocatingFactory(AtomicInteger closeCalls) {
         return length -> {
             ByteBuffer destination = ByteBuffer.allocate(length + EXTRA_CAPACITY);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReader.java
@@ -215,15 +215,9 @@ final class CoalescedRangeReader {
         try {
             for (MergedRange mr : merged) {
                 int length = (int) mr.length();
-                DirectReadBuffer result = factory.allocate(length);
+                DirectReadBuffer result = factory.allocateWritableWindow(length);
                 buffers.add(result);
                 ByteBuffer buffer = result.buffer();
-                if (buffer.capacity() < length) {
-                    throw new IllegalArgumentException(
-                        "Allocated buffer capacity [" + buffer.capacity() + "] is smaller than merged range length [" + length + "]"
-                    );
-                }
-                buffer.position(0).limit(length);
                 int read = 0;
                 while (read < length) {
                     int currentRead = storageObject.readBytes(mr.offset() + read, buffer);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/CoalescedRangeReaderTests.java
@@ -325,8 +325,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
             ) {
                 requestLengths.add(length);
                 try {
-                    DirectReadBuffer buffer = factory.allocate((int) length);
-                    buffer.buffer().position(0).limit((int) length);
+                    DirectReadBuffer buffer = factory.allocateWritableWindow((int) length);
                     listener.onResponse(buffer);
                 } catch (Exception e) {
                     listener.onFailure(e);
@@ -520,7 +519,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
                 executor.execute(() -> {
                     final DirectReadBuffer drb;
                     try {
-                        drb = factory.allocate((int) length);
+                        drb = factory.allocateWritableWindow((int) length);
                     } catch (IOException e) {
                         listener.onFailure(e);
                         return;
@@ -635,7 +634,7 @@ public class CoalescedRangeReaderTests extends ESTestCase {
                             }
                             final DirectReadBuffer drb;
                             try {
-                                drb = factory.allocate((int) length);
+                                drb = factory.allocateWritableWindow((int) length);
                             } catch (IOException e) {
                                 listener.onFailure(e);
                                 return;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
@@ -986,7 +986,7 @@ public class OptimizedFilteredReaderTests extends ESTestCase {
                 try {
                     int offset = Math.toIntExact(position);
                     int bytes = Math.toIntExact(Math.min(length, data.length - position));
-                    allocated = factory.allocate(bytes);
+                    allocated = factory.allocateWritableWindow(bytes);
                     ByteBuffer buffer = allocated.buffer();
                     buffer.put(data, offset, bytes);
                     buffer.flip();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetLimitIoClipTests.java
@@ -771,7 +771,7 @@ public class ParquetLimitIoClipTests extends ESTestCase {
                 try {
                     int pos = (int) position;
                     int len = (int) Math.min(length, data.length - position);
-                    DirectReadBuffer allocated = factory.allocate(len);
+                    DirectReadBuffer allocated = factory.allocateWritableWindow(len);
                     ByteBuffer buffer = allocated.buffer();
                     buffer.put(data, pos, len);
                     buffer.flip();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -808,7 +808,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         private DirectReadBuffer allocateAndFill(long position, long length, DirectBufferFactory factory) throws IOException {
             int offset = Math.toIntExact(position);
             int bytes = Math.toIntExact(Math.min(length, data.length - position));
-            DirectReadBuffer allocated = factory.allocate(bytes);
+            DirectReadBuffer allocated = factory.allocateWritableWindow(bytes);
             try {
                 allocated.buffer().put(data, offset, bytes).flip();
                 return allocated;
@@ -977,7 +977,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         private DirectReadBuffer allocateAndFill(long position, long length, DirectBufferFactory factory) throws IOException {
             int offset = Math.toIntExact(position);
             int bytes = Math.toIntExact(Math.min(length, data.length - position));
-            DirectReadBuffer allocated = factory.allocate(bytes);
+            DirectReadBuffer allocated = factory.allocateWritableWindow(bytes);
             try {
                 allocated.buffer().put(data, offset, bytes).flip();
                 return allocated;

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
@@ -104,6 +104,7 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
         // Allocated lazily here (not in the constructor) because prepare() is invoked again on each
         // retry; the previous attempt's buffer, if any, must be discarded.
         CompletableFuture<DirectReadBuffer> bufferFuture = new CompletableFuture<>();
+        this.currentSubscriber = null;
         this.resultFuture = bufferFuture;
         return bufferFuture;
     }
@@ -204,14 +205,9 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
             }
         }
 
-        /**
-         * Installs {@code allocated} as the destination unless a terminal callback already ran or
-         * the result future is no longer open. Returns {@code false} when the owner was not
-         * published and therefore remains the caller's to close.
-         */
         private boolean publishDestination(DirectReadBuffer allocated) {
             synchronized (destinationLock) {
-                if (failed || successClaimed || resultFuture.isDone()) {
+                if (destinationUnavailable()) {
                     return false;
                 }
                 destinationBuf = allocated;
@@ -219,11 +215,15 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
             }
         }
 
-        /** Whether a terminal callback has claimed the destination, or the result future is no longer open. */
         private boolean destinationAbandoned() {
             synchronized (destinationLock) {
-                return failed || successClaimed || resultFuture.isDone();
+                return destinationUnavailable();
             }
+        }
+
+        private boolean destinationUnavailable() {
+            assert Thread.holdsLock(destinationLock);
+            return failed || successClaimed || resultFuture.isDone();
         }
 
         @Override
@@ -297,14 +297,6 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
             }
         }
 
-        /**
-         * Claims the destination for failure, releases it, and fails the result future.
-         *
-         * @return {@code false} when a terminal signal already claimed the destination, in which
-         *         case {@code error} is dropped. Dropping it after {@link #onComplete()} claimed a
-         *         success is deliberate: the body had already been received in full, so a late
-         *         {@code exceptionOccurred} must not retract a result the consumer may hold.
-         */
         boolean fail(Throwable error) {
             synchronized (destinationLock) {
                 if (failed || successClaimed) {

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformer.java
@@ -20,7 +20,6 @@ import org.reactivestreams.Subscription;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An {@link AsyncResponseTransformer} that accumulates the response body into a single, pre-sized
@@ -45,14 +44,15 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>This transformer takes the expected payload length up front (which we always know for
  * range-read requests, and which the S3 service confirms in {@code Content-Length}), allocates
- * one destination buffer of exactly that size in {@link #prepare()}, and copies each
+ * one destination buffer with at least that capacity for each subscription, and copies each
  * {@code onNext(ByteBuffer)} chunk into the destination at the running offset. That
  * collapses three SDK-internal copies into a single chunk-to-destination copy.
  *
  * <p><b>Synchronization:</b> Reactive Streams serializes the {@link Subscriber}'s own signals, but
  * {@link #exceptionOccurred} is a transformer-level callback outside that ordering and can race the
- * terminal subscriber signal (e.g. the SDK drops the publisher on a transport error). The shared
- * destination buffer is therefore an {@link AtomicReference} and the terminal-state fields {@code volatile}.
+ * terminal subscriber signal (e.g. the SDK drops the publisher on a transport error). The
+ * subscriber therefore serializes destination-buffer copies and ownership transitions under a
+ * private lock.
  *
  * <p><b>Retries:</b> the SDK calls {@link #prepare()} again on each retry, so a fresh destination
  * buffer is allocated for every attempt. Stale state from a previous attempt is not reused.
@@ -122,19 +122,14 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
 
     @Override
     public void exceptionOccurred(Throwable error) {
-        // Release the buffer if it was allocated in onSubscribe but onError was never
-        // delivered to the subscriber (e.g. SDK abandons the publisher after a transport
-        // error). releaseOnFailure() is idempotent — if onError already fired it is a no-op.
-        ChunkCopyingSubscriber subscriber = currentSubscriber;
-        if (subscriber != null) {
-            // Mark failed before releasing so any in-flight onNext that slips past the
-            // AWS SDK's cancellation guarantee sees the flag and returns early instead of
-            // writing into the already-released buffer.
-            subscriber.failed = true;
-            subscriber.releaseOnFailure();
-        }
         CompletableFuture<DirectReadBuffer> f = resultFuture;
-        if (f != null) {
+        ChunkCopyingSubscriber subscriber = currentSubscriber;
+        if (subscriber != null && subscriber.resultFuture == f) {
+            // The subscriber arbitrates this callback with its own terminal signals and closes
+            // any published owner before delivering failure.
+            subscriber.fail(error);
+        } else if (f != null) {
+            // No subscriber belongs to this prepared attempt yet.
             f.completeExceptionally(error);
         }
     }
@@ -149,16 +144,18 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
         private final CompletableFuture<DirectReadBuffer> resultFuture;
         private final int expectedLength;
         private final DirectBufferFactory factory;
-        // Cross-callback fields are volatile as defense-in-depth. The Reactive Streams contract
-        // guarantees serial signals with happens-before, but making the visibility explicit avoids
-        // depending on each publisher implementation honoring that subtlety correctly.
-        // destinationBuf uses AtomicReference so releaseOnFailure() is safe when called
-        // concurrently from exceptionOccurred() on the transformer and onError() on the subscriber.
-        private final AtomicReference<DirectReadBuffer> destinationBuf = new AtomicReference<>();
-        private volatile ByteBuffer destination;
+        private final Object destinationLock = new Object();
+        // All four fields below are guarded by destinationLock, with no unsynchronized reads. A
+        // published owner may leave destinationBuf only through a claim under that lock. Failure
+        // claimants close before unlocking and completing failure; a successful claimant either
+        // transfers ownership or closes if completion loses. An unpublished owner belongs to
+        // onSubscribe, and a successfully transferred owner belongs to the consumer.
+        private DirectReadBuffer destinationBuf;
         private int offset;
+        private boolean failed;
+        private boolean successClaimed;
+
         private volatile Subscription subscription;
-        private volatile boolean failed;
 
         ChunkCopyingSubscriber(CompletableFuture<DirectReadBuffer> resultFuture, int expectedLength, DirectBufferFactory factory) {
             this.resultFuture = resultFuture;
@@ -174,105 +171,156 @@ final class KnownLengthAsyncResponseTransformer<R extends SdkResponse> implement
                 return;
             }
             this.subscription = s;
-            // Allocate here (rather than the constructor) so an allocator OOM/breaker trip is
-            // routed through the result future instead of escaping publisher.subscribe(...) as
-            // an Error.
+            // Allocate outside destinationLock, and here rather than in the constructor, so an
+            // allocator OOM/breaker trip is routed through the result future instead of escaping
+            // publisher.subscribe(...) as an Error.
+            final DirectReadBuffer allocated;
             try {
-                DirectReadBuffer drb = factory.allocate(expectedLength);
-                this.destinationBuf.set(drb);
-                this.destination = drb.buffer();
-                // Guard against exceptionOccurred racing the window between allocate() and set()
-                // above: if it fired first it saw null in destinationBuf and could not release,
-                // so we must release now if the future was already completed exceptionally.
-                if (resultFuture.isDone()) {
-                    releaseOnFailure();
-                    return;
-                }
+                allocated = factory.allocateWritableWindow(expectedLength);
             } catch (Exception e) {
-                failed = true;
-                releaseOnFailure();
                 s.cancel();
-                resultFuture.completeExceptionally(e);
+                fail(e);
+                return;
+            }
+            if (publishDestination(allocated) == false) {
+                // This owner was never visible to another thread, so closing it here cannot race
+                // a terminal callback. The claimant that beat us owns the failure completion.
+                allocated.close();
+                s.cancel();
+                return;
+            }
+            if (destinationAbandoned()) {
+                // Something terminated between publication and demand. fail() is a no-op when a
+                // terminal callback already claimed the owner; otherwise it releases the owner
+                // that nobody else will.
+                fail(new IOException("S3 destination was abandoned before demand was requested"));
+                s.cancel();
                 return;
             }
             try {
                 s.request(Long.MAX_VALUE);
             } catch (RuntimeException e) {
-                failed = true;
-                releaseOnFailure();
-                resultFuture.completeExceptionally(e);
+                fail(e);
+            }
+        }
+
+        /**
+         * Installs {@code allocated} as the destination unless a terminal callback already ran or
+         * the result future is no longer open. Returns {@code false} when the owner was not
+         * published and therefore remains the caller's to close.
+         */
+        private boolean publishDestination(DirectReadBuffer allocated) {
+            synchronized (destinationLock) {
+                if (failed || successClaimed || resultFuture.isDone()) {
+                    return false;
+                }
+                destinationBuf = allocated;
+                return true;
+            }
+        }
+
+        /** Whether a terminal callback has claimed the destination, or the result future is no longer open. */
+        private boolean destinationAbandoned() {
+            synchronized (destinationLock) {
+                return failed || successClaimed || resultFuture.isDone();
             }
         }
 
         @Override
         public void onNext(ByteBuffer chunk) {
-            if (failed) {
-                return;
-            }
             int remaining = chunk.remaining();
-            // Overflow-safe form of `offset + remaining > destination.capacity()`. `offset` is always
-            // in [0, destination.capacity()] thanks to this same guard on prior iterations, so the
-            // subtraction never underflows.
-            if (remaining > destination.capacity() - offset) {
-                failed = true;
-                IOException error = new IOException(
-                    "S3 response body exceeded expected length: cumulative="
-                        + ((long) offset + remaining)
-                        + ", expected="
-                        + destination.capacity()
-                );
-                subscription.cancel();
-                releaseOnFailure();
-                resultFuture.completeExceptionally(error);
-                return;
+            IOException overflow = null;
+            synchronized (destinationLock) {
+                DirectReadBuffer drb = destinationBuf;
+                if (drb == null || failed || successClaimed) {
+                    return;
+                }
+                // Overflow-safe because offset remains in [0, expectedLength].
+                if (remaining > expectedLength - offset) {
+                    failed = true;
+                    overflow = new IOException(
+                        "S3 response body exceeded expected length: cumulative="
+                            + ((long) offset + remaining)
+                            + ", expected="
+                            + expectedLength
+                    );
+                    destinationBuf = null;
+                    drb.close();
+                } else {
+                    DirectByteBufferCopies.copyChunkIntoDestination(drb.buffer(), offset, chunk);
+                    offset += remaining;
+                }
             }
-            DirectByteBufferCopies.copyChunkIntoDestination(destination, offset, chunk);
-            offset += remaining;
+            if (overflow != null) {
+                subscription.cancel();
+                resultFuture.completeExceptionally(overflow);
+            }
         }
 
         @Override
         public void onError(Throwable error) {
-            if (failed) {
-                return;
-            }
-            failed = true;
-            releaseOnFailure();
-            resultFuture.completeExceptionally(error);
+            fail(error);
         }
 
         @Override
         public void onComplete() {
-            if (failed) {
+            DirectReadBuffer transferred;
+            IOException shortRead = null;
+            synchronized (destinationLock) {
+                if (failed || successClaimed) {
+                    return;
+                }
+                transferred = destinationBuf;
+                if (transferred == null) {
+                    return;
+                }
+                destinationBuf = null;
+                if (offset != expectedLength) {
+                    failed = true;
+                    shortRead = new IOException(
+                        "S3 response body shorter than expected: received=" + offset + ", expected=" + expectedLength
+                    );
+                    transferred.close();
+                } else {
+                    successClaimed = true;
+                }
+            }
+            if (shortRead != null) {
+                resultFuture.completeExceptionally(shortRead);
                 return;
             }
-            if (offset != destination.capacity()) {
-                int capacity = destination.capacity();
-                failed = true;
-                releaseOnFailure();
-                resultFuture.completeExceptionally(
-                    new IOException("S3 response body shorter than expected: received=" + offset + ", expected=" + capacity)
-                );
-                return;
-            }
-            destination.position(0).limit(offset);
-            // Transfer ownership of the buffer to the caller; getAndSet(null) ensures any
-            // concurrent releaseOnFailure (e.g. exceptionOccurred) sees null and does not
-            // double-close. The destination ByteBuffer's position/limit set above is observable
-            // through drb.buffer() since they share the same NIO view.
-            DirectReadBuffer transferred = destinationBuf.getAndSet(null);
-            // If exceptionOccurred raced ahead and already failed the future, complete() returns false and we
-            // hold the buffer's only reference — release it rather than orphan its memory. A null transferred
-            // means releaseOnFailure won that race and already failed the future, so there is nothing to do.
-            if (transferred != null && resultFuture.complete(transferred) == false) {
+            transferred.buffer().position(0).limit(offset);
+            // Completion can run downstream listeners, so keep it outside destinationLock. If the
+            // future was independently completed or cancelled, retain ownership and close here.
+            if (resultFuture.complete(transferred) == false) {
                 transferred.close();
             }
         }
 
-        void releaseOnFailure() {
-            DirectReadBuffer drb = destinationBuf.getAndSet(null);
-            if (drb != null) {
-                drb.close();
+        /**
+         * Claims the destination for failure, releases it, and fails the result future.
+         *
+         * @return {@code false} when a terminal signal already claimed the destination, in which
+         *         case {@code error} is dropped. Dropping it after {@link #onComplete()} claimed a
+         *         success is deliberate: the body had already been received in full, so a late
+         *         {@code exceptionOccurred} must not retract a result the consumer may hold.
+         */
+        boolean fail(Throwable error) {
+            synchronized (destinationLock) {
+                if (failed || successClaimed) {
+                    return false;
+                }
+                failed = true;
+                DirectReadBuffer drb = destinationBuf;
+                if (drb != null) {
+                    // Close while holding the lock so another terminal callback cannot return
+                    // before the published owner has been released.
+                    destinationBuf = null;
+                    drb.close();
+                }
             }
+            resultFuture.completeExceptionally(error);
+            return true;
         }
     }
 

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
@@ -21,13 +21,17 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -44,6 +48,9 @@ import static org.hamcrest.Matchers.instanceOf;
 public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
 
     private static final DirectBufferFactory FACTORY = DirectBufferFactory.forBreaker(new NoopCircuitBreaker("test"));
+
+    /** Arbitrary non-zero slack, so a factory buffer that is larger than requested is not a rounding coincidence. */
+    private static final int EXTRA_CAPACITY = 17;
 
     public void testRejectsNegativeExpectedLength() {
         IllegalArgumentException ex = expectThrows(
@@ -100,6 +107,30 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
             assertFalse(result.buffer().isDirect());
             assertEquals(0, result.buffer().remaining());
         }
+    }
+
+    public void testOverAllocatedDestinationUsesExpectedLength() throws Exception {
+        byte[] payload = randomByteArrayOfLength(between(32, 512));
+        AtomicInteger closeCalls = new AtomicInteger();
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            payload.length,
+            overAllocatingFactory(closeCalls)
+        );
+
+        try (DirectReadBuffer result = runTransformer(transformer, response(payload.length), List.of(ByteBuffer.wrap(payload)))) {
+            assertEquals(payload.length + EXTRA_CAPACITY, result.buffer().capacity());
+            assertEquals(payload.length, result.buffer().remaining());
+            assertArrayEquals(payload, toByteArray(result.buffer()));
+        }
+        assertEquals(1, closeCalls.get());
+    }
+
+    public void testRejectsUndersizedFactoryBufferAndCancels() {
+        assertInvalidFactoryBufferRejected(ByteBuffer.allocate(15), 16);
+    }
+
+    public void testRejectsReadOnlyFactoryBufferAndCancels() {
+        assertInvalidFactoryBufferRejected(ByteBuffer.allocateDirect(16).asReadOnlyBuffer(), 16);
     }
 
     public void testOverflowFailsFastAndCancelsSubscription() {
@@ -193,6 +224,79 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         assertSame(error, ex.getCause());
     }
 
+    public void testStreamAfterPreparedFutureFailedClosesAllocationAndCancels() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> new DirectReadBuffer(ByteBuffer.allocate(length), closeCalls::incrementAndGet);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(16, factory);
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        RuntimeException error = new RuntimeException("failed before stream");
+        transformer.exceptionOccurred(error);
+        RecordingSubscription subscription = new RecordingSubscription();
+
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(subscription);
+            }
+        });
+
+        ExecutionException ex = expectThrows(ExecutionException.class, future::get);
+        assertSame(error, ex.getCause());
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+    }
+
+    public void testExceptionOccurredAfterSuccessfulTransferDoesNotCloseResult() throws Exception {
+        CircuitBreaker breaker = new LimitedBreaker("successful-transfer-race", ByteSizeValue.ofMb(16));
+        byte[] payload = randomByteArrayOfLength(256);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            payload.length,
+            DirectBufferFactory.forBreaker(breaker)
+        );
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        transformer.onResponse(response(payload.length));
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new TestSubscription());
+                subscriber.onNext(ByteBuffer.wrap(payload));
+                subscriber.onComplete();
+            }
+        });
+
+        DirectReadBuffer result = future.get();
+        transformer.exceptionOccurred(new IOException("late transport failure"));
+        assertArrayEquals(payload, toByteArray(result.buffer()));
+        assertEquals(payload.length, breaker.getUsed());
+        result.close();
+        assertEquals(0L, breaker.getUsed());
+    }
+
+    public void testLateOnNextAfterCompletionIsIgnored() throws Exception {
+        byte[] payload = randomByteArrayOfLength(32);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            payload.length,
+            FACTORY
+        );
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        transformer.onResponse(response(payload.length));
+
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new TestSubscription());
+                subscriber.onNext(ByteBuffer.wrap(payload));
+                subscriber.onComplete();
+                subscriber.onNext(ByteBuffer.wrap(new byte[] { 1 }));
+            }
+        });
+
+        try (DirectReadBuffer result = future.get()) {
+            assertArrayEquals(payload, toByteArray(result.buffer()));
+        }
+    }
+
     public void testRetryAllocatesFreshDestination() throws Exception {
         // The SDK invokes prepare() for every retry attempt; the result of the first attempt must
         // not contaminate the second.
@@ -258,6 +362,52 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         assertEquals("onComplete must release the buffer it could not hand off", 0L, breaker.getUsed());
     }
 
+    /**
+     * Reproduces the pooled-channel retention seen in the OOM heap dump. The AWS SDK keeps the
+     * future returned by {@link KnownLengthAsyncResponseTransformer#prepare()} in an
+     * {@code IdempotentAsyncResponseHandler} attached to an idle channel. Closing the delivered
+     * buffer returns its breaker charge, but the completed future and subscriber must not keep
+     * the backing bytes strongly reachable.
+     */
+    public void testClosedResultDoesNotRemainReachableThroughCompletedFuture() throws Exception {
+        CircuitBreaker breaker = new LimitedBreaker("completed-future-retention", ByteSizeValue.ofMb(16));
+        DirectBufferFactory factory = DirectBufferFactory.forBreaker(breaker);
+        byte[] payload = randomByteArrayOfLength(1 << 20);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            payload.length,
+            factory
+        );
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        transformer.onResponse(response(payload.length));
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new TestSubscription());
+                s.onNext(ByteBuffer.wrap(payload));
+                s.onComplete();
+            }
+        });
+
+        WeakReference<byte[]> destination = closeAndForgetDestination(future);
+        assertEquals("close must return the destination's breaker charge", 0L, breaker.getUsed());
+
+        // Models IdempotentAsyncResponseHandler.cachedPreparedFuture on a pooled channel.
+        AtomicReference<CompletableFuture<DirectReadBuffer>> cachedPreparedFuture = new AtomicReference<>(future);
+        try {
+            assertBusy(() -> {
+                System.gc();
+                assertTrue("the simulated channel must keep the completed future alive", cachedPreparedFuture.get().isDone());
+                assertNotNull("the retained transformer must remain usable", transformer.response());
+                assertNull(
+                    "a closed S3 destination must be collectable while the SDK retains the future and transformer",
+                    destination.get()
+                );
+            });
+        } finally {
+            Reference.reachabilityFence(transformer);
+        }
+    }
+
     public void testResponseObjectExposedViaGetter() throws Exception {
         byte[] payload = randomByteArrayOfLength(between(8, 256));
         GetObjectResponse expectedResponse = response(payload.length);
@@ -306,6 +456,46 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         return result;
     }
 
+    private void assertInvalidFactoryBufferRejected(ByteBuffer invalidBuffer, int expectedLength) {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = ignored -> new DirectReadBuffer(invalidBuffer, closeCalls::incrementAndGet);
+        KnownLengthAsyncResponseTransformer<GetObjectResponse> transformer = new KnownLengthAsyncResponseTransformer<>(
+            expectedLength,
+            factory
+        );
+        CompletableFuture<DirectReadBuffer> future = transformer.prepare();
+        RecordingSubscription subscription = new RecordingSubscription();
+        transformer.onStream(new SdkPublisher<>() {
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(subscription);
+            }
+        });
+
+        ExecutionException ex = expectThrows(ExecutionException.class, future::get);
+        assertThat(ex.getCause(), instanceOf(IOException.class));
+        assertThat(ex.getCause().getMessage(), containsString("DirectBufferFactory"));
+        assertEquals(1, closeCalls.get());
+        assertTrue(subscription.cancelled.get());
+        assertEquals(0L, subscription.requested.get());
+    }
+
+    /** Hands back a destination that is both larger and more narrowly limited than the request. */
+    private static DirectBufferFactory overAllocatingFactory(AtomicInteger closeCalls) {
+        return length -> {
+            ByteBuffer destination = ByteBuffer.allocate(length + EXTRA_CAPACITY);
+            destination.limit(1);
+            return new DirectReadBuffer(destination, closeCalls::incrementAndGet);
+        };
+    }
+
+    private static WeakReference<byte[]> closeAndForgetDestination(CompletableFuture<DirectReadBuffer> future) throws Exception {
+        DirectReadBuffer result = future.get();
+        WeakReference<byte[]> destination = new WeakReference<>(result.buffer().array());
+        result.close();
+        return destination;
+    }
+
     private static byte[] toByteArray(ByteBuffer buffer) {
         byte[] bytes = new byte[buffer.remaining()];
         buffer.get(bytes);
@@ -347,5 +537,20 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
 
         @Override
         public void cancel() {}
+    }
+
+    private static final class RecordingSubscription implements Subscription {
+        private final AtomicLong requested = new AtomicLong();
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        @Override
+        public void request(long n) {
+            requested.addAndGet(n);
+        }
+
+        @Override
+        public void cancel() {
+            cancelled.set(true);
+        }
     }
 }

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/KnownLengthAsyncResponseTransformerTests.java
@@ -480,7 +480,6 @@ public class KnownLengthAsyncResponseTransformerTests extends ESTestCase {
         assertEquals(0L, subscription.requested.get());
     }
 
-    /** Hands back a destination that is both larger and more narrowly limited than the request. */
     private static DirectBufferFactory overAllocatingFactory(AtomicInteger closeCalls) {
         return length -> {
             ByteBuffer destination = ByteBuffer.allocate(length + EXTRA_CAPACITY);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RangeStorageObject.java
@@ -130,7 +130,7 @@ class RangeStorageObject implements StorageObject {
             // is direct and allocator-owned, consistent with the StorageObject.readBytesAsync
             // contract.
             try {
-                listener.onResponse(factory.allocate(0));
+                listener.onResponse(factory.allocateWritableWindow(0));
             } catch (IOException e) {
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectBufferFactory.java
@@ -24,12 +24,39 @@ import java.io.IOException;
  * production path.
  *
  * <p>{@link #allocate(int)} may throw {@link IOException} when the underlying allocator refuses
- * the allocation (circuit-breaker trip, OOM, etc.). On success the returned buffer is uninitialized
- * and the caller is responsible for closing it once consumption is complete or on the failure path.
+ * the allocation (circuit-breaker trip, OOM, etc.). On success the returned buffer is
+ * uninitialized, writable, and has capacity at least {@code length}; callers must not assume its
+ * capacity is exactly {@code length}. Callers that fill by {@code remaining()} should use
+ * {@link #allocateWritableWindow(int)} so an over-sized or oddly-limited factory buffer cannot be
+ * filled past the request. The caller is responsible for closing the owner once consumption is
+ * complete or on the failure path.
  */
 @FunctionalInterface
 public interface DirectBufferFactory {
     DirectReadBuffer allocate(int length) throws IOException;
+
+    /**
+     * Allocates a destination and constrains it to a writable window of {@code length} bytes.
+     * Closes the owner if the window cannot be established so a rejected factory buffer does not
+     * leak its charge.
+     */
+    default DirectReadBuffer allocateWritableWindow(int length) throws IOException {
+        DirectReadBuffer allocated = allocate(length);
+        try {
+            allocated.requireWritableWindow(length);
+            return allocated;
+        } catch (Throwable t) {
+            // Throwable, not IOException: a factory that hands back an already-closed owner throws
+            // IllegalStateException, and close() itself throws AssertionError on a double free.
+            // Either way the charge must be refunded and the original failure must survive.
+            try {
+                allocated.close();
+            } catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
+            throw t;
+        }
+    }
 
     /**
      * Returns a factory that allocates a heap {@code byte[]} of {@code length} bytes and charges

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectMemoryDebug.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectMemoryDebug.java
@@ -40,10 +40,13 @@ import java.nio.ByteBuffer;
  *   <li><b>{@code es.arrow.debug_buffers}</b> (default: on when assertions are enabled) — the
  *       thorough, opt-in mode for a correctness-validation pass. Poisons the <em>whole</em> buffer
  *       and enables {@link DirectReadBuffer}'s allocation/free stack-trace capture plus its
- *       double-free / use-after-close throws (see {@link #trackingEnabled()}). It is an explicit
- *       check rather than a Java {@code assert}, so it can be turned on with {@code -Des.arrow.debug_buffers=true}
- *       on a node that is <em>not</em> running with {@code -ea}. Slower (an extra write-pass over
- *       freed bytes, plus a stack walk per allocation), so not for headline timing runs.</li>
+ *       double-free {@link AssertionError} and stack-rich post-close
+ *       {@link IllegalStateException} (see {@link #trackingEnabled()}). Post-close access is
+ *       rejected with an {@link IllegalStateException} even when this mode is off. It is an
+ *       explicit check rather than a Java {@code assert}, so it can be turned on with
+ *       {@code -Des.arrow.debug_buffers=true} on a node that is <em>not</em> running with
+ *       {@code -ea}. Slower (an extra write-pass over freed bytes, plus a stack walk per
+ *       allocation), so not for headline timing runs.</li>
  * </ul>
  *
  * <p>The Arrow debug allocator (enabled via {@code arrow.memory.debug.allocator} in test builds) is
@@ -73,7 +76,8 @@ public final class DirectMemoryDebug {
 
     /**
      * Whether the thorough debug mode ({@code es.arrow.debug_buffers}) is on. {@link DirectReadBuffer}
-     * gates its allocation/free stack-trace capture and its double-free / use-after-close checks on this.
+     * gates its allocation/free stack-trace capture, double-free check, and stack-rich
+     * use-after-close {@link IllegalStateException} on this.
      */
     static boolean trackingEnabled() {
         return DEBUG_TRACKING;
@@ -82,14 +86,15 @@ public final class DirectMemoryDebug {
     /**
      * Overwrite the direct memory backing {@code buffer} with the poison sentinel, just before the
      * buffer is released — the whole buffer under {@code es.arrow.debug_buffers}, otherwise only the
-     * header under {@code es.arrow.poison_freed_buffers}. No-op when both knobs are off, on heap-backed
-     * buffers (test stubs), and does not mutate the caller's {@code position}/{@code limit}.
+     * header under {@code es.arrow.poison_freed_buffers}. No-op when both knobs are off, on
+     * heap-backed or read-only buffers, and does not mutate the caller's
+     * {@code position}/{@code limit}.
      */
     public static void poison(ByteBuffer buffer) {
         if (DEBUG_TRACKING == false && POISON_FREED == false) {
             return;
         }
-        if (buffer == null || buffer.isDirect() == false) {
+        if (buffer == null || buffer.isDirect() == false || buffer.isReadOnly()) {
             return;
         }
         ByteBuffer view = buffer.duplicate();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
@@ -17,6 +17,7 @@ import org.elasticsearch.core.Releasable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Result of {@link StorageObject#readBytesAsync(long, long, DirectBufferFactory, java.util.concurrent.Executor,
@@ -61,16 +62,15 @@ public final class DirectReadBuffer implements Releasable {
 
     private static final String STORAGE_READ_BREAKER_LABEL = "storage read buffer";
 
-    private volatile ByteBuffer buffer;
+    private final AtomicReference<ByteBuffer> buffer;
     private final Releasable onClose;
 
-    // Lifecycle tracking; gated by es.arrow.debug_buffers (defaults to -ea). All null/false when off.
+    // Lifecycle tracking; gated by es.arrow.debug_buffers (defaults to -ea). Both are null when off.
     private final Throwable allocSite;
-    private volatile boolean released;
     private volatile Throwable freeSite;
 
     public DirectReadBuffer(ByteBuffer buffer, Releasable onClose) {
-        this.buffer = buffer;
+        this.buffer = new AtomicReference<>(buffer);
         this.onClose = onClose;
         this.allocSite = DirectMemoryDebug.trackingEnabled() ? new Throwable("DirectReadBuffer allocated here") : null;
     }
@@ -176,8 +176,8 @@ public final class DirectReadBuffer implements Releasable {
      * and free stack traces are attached as suppressed exceptions.
      */
     public ByteBuffer buffer() {
-        ByteBuffer current = buffer;
-        if (current == null || (DirectMemoryDebug.trackingEnabled() && released)) {
+        ByteBuffer current = buffer.get();
+        if (current == null) {
             throw useAfterFree();
         }
         return current;
@@ -185,18 +185,19 @@ public final class DirectReadBuffer implements Releasable {
 
     @Override
     public void close() {
-        ByteBuffer toRelease = buffer;
-        if (DirectMemoryDebug.trackingEnabled()) {
+        ByteBuffer toRelease = buffer.getAndSet(null);
+        if (toRelease == null) {
             // A second close would double-free an ArrowBuf or double-release a breaker charge.
             // Surface it here with both stacks rather than letting the backing store throw a
             // context-free exception.
-            if (released) {
+            if (DirectMemoryDebug.trackingEnabled()) {
                 throw doubleFree();
             }
-            freeSite = new Throwable("DirectReadBuffer freed here");
-            released = true;
+            return;
         }
-        buffer = null;
+        if (DirectMemoryDebug.trackingEnabled()) {
+            freeSite = new Throwable("DirectReadBuffer freed here");
+        }
         try {
             // Poison before releasing (self-gated by es.arrow.* knobs; no-op for heap buffers) so any
             // surviving alias that reads this region after free fails deterministically instead of flakily.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBuffer.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.UninitializedArrays;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,10 +30,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * buffer is not required to be direct. The caller must invoke {@link #close()} once the bytes
  * have been consumed.
  *
- * <p>Using {@link #buffer()} after {@link #close()} is undefined: a heap array may still be
- * reachable, but an Arrow-backed view reads dangling memory that may have been recycled.
+ * <p>{@link #close()} drops this owner's reference to the backing buffer. Any aliases obtained
+ * from {@link #buffer()} before close remain the consumer's responsibility and are not tracked by
+ * this owner. Calling {@link #buffer()} after close always throws {@link IllegalStateException}.
  *
- * <h2>Use-after-free / double-free detection (assertions only)</h2>
+ * <h2>Use-after-free / double-free detection</h2>
  * <p>When the buffer is a detached {@link ByteBuffer} view of an {@link ArrowBuf} (the
  * {@link DirectBufferFactory#forAllocator(BufferAllocator)} path), reads through that view
  * <em>bypass Arrow's reference-count tracking entirely</em> — the Arrow debug allocator can
@@ -42,36 +44,34 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * slice handed out before close is read after the backing {@link ArrowBuf} was returned to the
  * allocator and recycled.
  *
- * <p>To make that class of bug deterministic and self-locating, when assertions are enabled this
- * type:
+ * <p>Detachment and rejection of post-close {@link #buffer()} access are production behavior.
+ * When debug tracking is on (default under {@code -ea}) this type additionally:
  * <ul>
  *   <li>captures the <b>allocation</b> stack trace at construction and the <b>free</b> stack trace
- *       at {@link #close()} ("who deallocated this"),</li>
- *   <li>throws on a second {@link #close()} (double-free) and on any {@link #buffer()} access after
- *       close (use-after-free), attaching both stack traces, and</li>
+ *       at {@link #close()} ("who deallocated this") and attaches both to the post-close
+ *       {@link IllegalStateException},</li>
+ *   <li>throws {@link AssertionError} on a second {@link #close()} (double-free), and</li>
  *   <li><b>poisons</b> direct memory with a recognizable pattern immediately before releasing it,
  *       so any surviving alias that reads the freed region fails the same way on every run instead
  *       of occasionally seeing still-intact bytes. Heap buffers skip poisoning ({@link
  *       DirectMemoryDebug#poison(ByteBuffer)} is a no-op when {@code isDirect()} is false).</li>
  * </ul>
- * All of this compiles out (no allocation, no poisoning) when assertions are disabled, so the
- * production read path is unchanged.
  */
 public final class DirectReadBuffer implements Releasable {
 
     private static final String STORAGE_READ_BREAKER_LABEL = "storage read buffer";
 
-    private final ByteBuffer buffer;
-    private final Releasable release;
+    private volatile ByteBuffer buffer;
+    private final Releasable onClose;
 
     // Lifecycle tracking; gated by es.arrow.debug_buffers (defaults to -ea). All null/false when off.
     private final Throwable allocSite;
     private volatile boolean released;
     private volatile Throwable freeSite;
 
-    public DirectReadBuffer(ByteBuffer buffer, Releasable release) {
+    public DirectReadBuffer(ByteBuffer buffer, Releasable onClose) {
         this.buffer = buffer;
-        this.release = release;
+        this.onClose = onClose;
         this.allocSite = DirectMemoryDebug.trackingEnabled() ? new Throwable("DirectReadBuffer allocated here") : null;
     }
 
@@ -143,24 +143,49 @@ public final class DirectReadBuffer implements Releasable {
     }
 
     /**
-     * The bytes. Must not be accessed after {@link #close()}; doing so is undefined for Arrow-backed
-     * buffers (freed, possibly recycled native memory). When {@code es.arrow.debug_buffers} is on,
-     * a post-close access throws with the allocation and free stack traces attached.
+     * Constrains this owner's buffer to a writable window of {@code length} bytes starting at
+     * position 0. {@link DirectBufferFactory#allocate(int)} may return a larger or oddly-limited
+     * buffer; callers that fill by {@code remaining()} must invoke this before I/O so they cannot
+     * read past the requested length.
+     *
+     * <p>Deliberately not public: this is an allocation-time normalization for
+     * {@link DirectBufferFactory#allocateWritableWindow(int)}. Applying it to a buffer that has
+     * already been filled would widen the window back to the requested length and expose the
+     * uninitialized tail of a short read.
+     *
+     * @throws IOException if the buffer is read-only or {@code capacity() < length}
      */
-    public ByteBuffer buffer() {
-        if (DirectMemoryDebug.trackingEnabled() && released) {
-            throw useAfterFree();
+    void requireWritableWindow(int length) throws IOException {
+        ByteBuffer destination = buffer();
+        if (destination.isReadOnly()) {
+            throw new IOException("DirectBufferFactory returned a read-only buffer for requested length [" + length + "]");
         }
-        return buffer;
+        if (destination.capacity() < length) {
+            throw new IOException(
+                "DirectBufferFactory returned buffer capacity [" + destination.capacity() + "] for requested length [" + length + "]"
+            );
+        }
+        // Copies and channel reads use remaining() / relative puts, so restore the complete
+        // requested window even if a custom factory returned a buffer with a smaller limit.
+        destination.position(0).limit(length);
     }
 
-    /** The underlying {@link Releasable}. Prefer {@link #close()}, which adds lifecycle checks. */
-    public Releasable release() {
-        return release;
+    /**
+     * The bytes. Must not be accessed after {@link #close()}. A post-close access throws an
+     * {@link IllegalStateException}. When {@code es.arrow.debug_buffers} is on, the allocation
+     * and free stack traces are attached as suppressed exceptions.
+     */
+    public ByteBuffer buffer() {
+        ByteBuffer current = buffer;
+        if (current == null || (DirectMemoryDebug.trackingEnabled() && released)) {
+            throw useAfterFree();
+        }
+        return current;
     }
 
     @Override
     public void close() {
+        ByteBuffer toRelease = buffer;
         if (DirectMemoryDebug.trackingEnabled()) {
             // A second close would double-free an ArrowBuf or double-release a breaker charge.
             // Surface it here with both stacks rather than letting the backing store throw a
@@ -171,14 +196,19 @@ public final class DirectReadBuffer implements Releasable {
             freeSite = new Throwable("DirectReadBuffer freed here");
             released = true;
         }
-        // Poison before releasing (self-gated by es.arrow.* knobs; no-op for heap buffers) so any
-        // surviving alias that reads this region after free fails deterministically instead of flakily.
-        DirectMemoryDebug.poison(buffer);
-        release.close();
+        buffer = null;
+        try {
+            // Poison before releasing (self-gated by es.arrow.* knobs; no-op for heap buffers) so any
+            // surviving alias that reads this region after free fails deterministically instead of flakily.
+            DirectMemoryDebug.poison(toRelease);
+        } finally {
+            // Unconditional: a buffer this owner cannot poison is still a charge it must refund.
+            onClose.close();
+        }
     }
 
-    private AssertionError useAfterFree() {
-        AssertionError e = new AssertionError("DirectReadBuffer.buffer() accessed after close() (use-after-free)");
+    private IllegalStateException useAfterFree() {
+        IllegalStateException e = new IllegalStateException("DirectReadBuffer buffer was closed");
         if (allocSite != null) {
             e.addSuppressed(allocSite);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageObject.java
@@ -116,11 +116,12 @@ public interface StorageObject {
      * {@link #supportsNativeAsync()} returns true.
      * <p>
      * <b>Returned buffer contract:</b> the {@link DirectReadBuffer#buffer()} delivered to the
-     * listener has {@code capacity() == length} (the requested length) and {@code remaining()}
-     * equal to the number of bytes actually read. On a short read these differ — consumers must
-     * use {@code remaining()} (or {@code limit() - position()}) to size their work, never
-     * {@code capacity()}. The buffer is not required to be direct; production factories
-     * return a heap {@code byte[]} view.
+     * listener has {@code remaining()} equal to the number of bytes actually read, and
+     * {@code capacity()} of at least {@code length}. Callers must not assume exact capacity —
+     * consumers must use {@code remaining()} (or {@code limit() - position()}) to size their
+     * work. Implementations call {@link DirectBufferFactory#allocateWritableWindow(int)} so an
+     * over-sized factory buffer cannot be filled past the request. The buffer is not required
+     * to be direct; production factories return a heap {@code byte[]} view.
      * <p>
      * On end-of-content at {@code position} the buffer is delivered with {@code remaining() == 0}.
      *
@@ -139,8 +140,8 @@ public interface StorageObject {
      * @param position the starting byte position
      * @param length the number of bytes to read
      * @param factory produces the {@link DirectReadBuffer} the bytes are read into; the storage
-     *            object calls {@link DirectBufferFactory#allocate(int)} exactly once with
-     *            {@code length}
+     *            object allocates from it exactly once, through
+     *            {@link DirectBufferFactory#allocateWritableWindow(int)} with {@code length}
      * @param executor executor for running the async operation
      * @param listener callback for the result or failure
      */
@@ -165,7 +166,7 @@ public interface StorageObject {
         final DirectReadBuffer drb;
         boolean submitted = false;
         try {
-            drb = factory.allocate((int) length);
+            drb = factory.allocateWritableWindow((int) length);
         } catch (Exception e) {
             listener.onFailure(e);
             return;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
@@ -7,15 +7,22 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectBufferFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.DirectReadBuffer;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ByteArrayStorageObjectTests extends ESTestCase {
+
+    /** Arbitrary non-zero slack, so a factory buffer that is larger than requested is not a rounding coincidence. */
+    private static final int EXTRA_CAPACITY = 17;
 
     public void testNewStreamReadsFullContent() throws IOException {
         byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
@@ -48,6 +55,31 @@ public class ByteArrayStorageObjectTests extends ESTestCase {
         byte[] data = new byte[42];
         ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 10, 20);
         assertEquals(20, obj.length());
+    }
+
+    public void testReadBytesAsyncOverAllocatedFactoryUsesRequestedLength() {
+        int requestedLength = 3;
+        byte[] data = "abcdef".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory factory = length -> {
+            ByteBuffer destination = ByteBuffer.allocate(length + EXTRA_CAPACITY);
+            destination.limit(1);
+            return new DirectReadBuffer(destination, closeCalls::incrementAndGet);
+        };
+        // Runnable::run keeps the read on this thread, so the listener has already fired on return.
+        PlainActionFuture<DirectReadBuffer> delivered = new PlainActionFuture<>();
+
+        obj.readBytesAsync(0, requestedLength, factory, Runnable::run, delivered);
+
+        try (DirectReadBuffer result = delivered.actionGet()) {
+            assertEquals(requestedLength + EXTRA_CAPACITY, result.buffer().capacity());
+            assertEquals(requestedLength, result.buffer().remaining());
+            byte[] out = new byte[requestedLength];
+            result.buffer().get(out);
+            assertEquals("abc", new String(out, StandardCharsets.UTF_8));
+        }
+        assertEquals(1, closeCalls.get());
     }
 
     public void testReadBytesIntoHeapBuffer() throws IOException {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBufferTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies that closing a {@link DirectReadBuffer} severs ownership of its payload while retaining
+ * deterministic diagnostics for invalid lifecycle use.
+ */
+public class DirectReadBufferTests extends ESTestCase {
+
+    public void testCloseDetachesBackingBuffer() throws Exception {
+        DirectReadBuffer owner = new DirectReadBuffer(ByteBuffer.allocate(1 << 20), () -> {});
+        WeakReference<byte[]> backing = closeAndForgetBacking(owner);
+
+        try {
+            assertBusy(() -> {
+                System.gc();
+                assertNull("a closed owner must not retain its backing array", backing.get());
+            });
+        } finally {
+            Reference.reachabilityFence(owner);
+        }
+    }
+
+    public void testBufferAfterClose() {
+        DirectReadBuffer owner = new DirectReadBuffer(ByteBuffer.allocate(8), () -> {});
+        owner.close();
+
+        IllegalStateException error = expectThrows(IllegalStateException.class, owner::buffer);
+        assertThat(error.getMessage(), containsString("DirectReadBuffer"));
+        assertThat(error.getMessage(), containsString("closed"));
+        if (DirectMemoryDebug.trackingEnabled()) {
+            assertEquals(2, error.getSuppressed().length);
+            assertThat(error.getSuppressed()[0].getMessage(), containsString("allocated here"));
+            assertThat(error.getSuppressed()[1].getMessage(), containsString("freed here"));
+        }
+    }
+
+    public void testRequireWritableWindowNormalizesOverAllocatedBuffer() throws Exception {
+        ByteBuffer destination = ByteBuffer.allocate(32);
+        destination.limit(1);
+        DirectReadBuffer owner = new DirectReadBuffer(destination, () -> {});
+        owner.requireWritableWindow(8);
+        assertEquals(8, owner.buffer().remaining());
+        assertEquals(32, owner.buffer().capacity());
+    }
+
+    public void testAllocateWritableWindowRejectsInvalidFactoryBuffers() {
+        AtomicInteger closeCalls = new AtomicInteger();
+        DirectBufferFactory undersized = ignored -> new DirectReadBuffer(ByteBuffer.allocate(15), closeCalls::incrementAndGet);
+        IOException undersizedError = expectThrows(IOException.class, () -> undersized.allocateWritableWindow(16));
+        assertThat(undersizedError.getMessage(), containsString("DirectBufferFactory"));
+        assertEquals(1, closeCalls.get());
+
+        DirectBufferFactory readOnly = ignored -> new DirectReadBuffer(
+            ByteBuffer.allocateDirect(16).asReadOnlyBuffer(),
+            closeCalls::incrementAndGet
+        );
+        IOException readOnlyError = expectThrows(IOException.class, () -> readOnly.allocateWritableWindow(16));
+        assertThat(readOnlyError.getMessage(), containsString("DirectBufferFactory"));
+        assertEquals(2, closeCalls.get());
+    }
+
+    public void testDoubleCloseWithTracking() {
+        assumeTrue("requires debug tracking", DirectMemoryDebug.trackingEnabled());
+        DirectReadBuffer owner = new DirectReadBuffer(ByteBuffer.allocate(8), () -> {});
+        owner.close();
+
+        AssertionError error = expectThrows(AssertionError.class, owner::close);
+        assertThat(error.getMessage(), containsString("called twice"));
+        assertEquals(2, error.getSuppressed().length);
+    }
+
+    public void testClosePoisonsDetachedDirectBufferSnapshot() {
+        // Header poisoning also runs without tracking, but tracking poisons the whole buffer and
+        // therefore verifies that close retained a snapshot before detaching the owner.
+        assumeTrue("requires full-buffer poison", DirectMemoryDebug.trackingEnabled());
+        ByteBuffer buffer = ByteBuffer.allocateDirect(257);
+        ByteBuffer alias = buffer.duplicate();
+        DirectReadBuffer owner = new DirectReadBuffer(buffer, () -> {});
+
+        owner.close();
+
+        alias.clear();
+        while (alias.remaining() >= Integer.BYTES) {
+            assertEquals(0xBADBADBA, alias.getInt());
+        }
+        while (alias.hasRemaining()) {
+            assertEquals((byte) 0xDE, alias.get());
+        }
+    }
+
+    private static WeakReference<byte[]> closeAndForgetBacking(DirectReadBuffer owner) {
+        WeakReference<byte[]> backing = new WeakReference<>(owner.buffer().array());
+        owner.close();
+        return backing;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/DirectReadBufferTests.java
@@ -14,6 +14,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -84,6 +85,30 @@ public class DirectReadBufferTests extends ESTestCase {
         AssertionError error = expectThrows(AssertionError.class, owner::close);
         assertThat(error.getMessage(), containsString("called twice"));
         assertEquals(2, error.getSuppressed().length);
+    }
+
+    public void testConcurrentCloseReleasesBackingBufferOnce() throws InterruptedException {
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicReference<AssertionError> doubleClose = new AtomicReference<>();
+        DirectReadBuffer owner = new DirectReadBuffer(ByteBuffer.allocate(8), closeCalls::incrementAndGet);
+
+        startInParallel(2, ignored -> {
+            try {
+                owner.close();
+            } catch (AssertionError e) {
+                if (doubleClose.compareAndSet(null, e) == false) {
+                    throw e;
+                }
+            }
+        });
+
+        assertEquals(1, closeCalls.get());
+        if (DirectMemoryDebug.trackingEnabled()) {
+            assertNotNull(doubleClose.get());
+            assertThat(doubleClose.get().getMessage(), containsString("called twice"));
+        } else {
+            assertNull(doubleClose.get());
+        }
     }
 
     public void testClosePoisonsDetachedDirectBufferSnapshot() {


### PR DESCRIPTION
Detach released payloads and remove S3/HTTP subscriber aliases to prevent backing-array retention. Harden ownership races and add regression coverage.

Closes https://github.com/elastic/esql-planning/issues/1848
