### PR TITLE
Do not abort shard bulk on expansion rejection

### DIFF
--- a/docs/changelog/158235.yaml
+++ b/docs/changelog/158235.yaml
@@ -1,0 +1,6 @@
+area: CRUD
+issues:
+ - 158212
+pr: 158235
+summary: Do not abort shard bulk on expansion rejection
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -37,9 +37,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.ShardId;
@@ -65,11 +67,14 @@ import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -732,10 +737,84 @@ public class IndexingPressureIT extends ESIntegTestCase {
 
         final BulkResponse responses = client(coordinatingOnlyNode).bulk(clientBulk).actionGet();
         assertTrue(responses.hasFailures());
-        assertThat(responses.getItems()[0].getFailure().getCause().getCause().getCause(), instanceOf(EsRejectedExecutionException.class));
+        assertThat(responses.getItems()[0].getFailure().getCause(), instanceOf(EsRejectedExecutionException.class));
 
         IndexingPressure primaryWriteLimits = internalCluster().getInstance(IndexingPressure.class, primaryName);
         assertEquals(1L, primaryWriteLimits.stats().getPrimaryRejections());
+    }
+
+    /**
+     * An update rejected midway through a bulk because its translation goes over the primary limit must
+     * fail alone; the surrounding operations must succeed and replicate.
+     */
+    public void testUpdateExpansionRejectedMidBulkOnlyFailsThatUpdate() throws Exception {
+        // High enough to admit the bulk; the listener below trips the limit right before the update translates
+        final long primaryLimitBytes = ByteSizeValue.ofMb(10).getBytes();
+        restartNodesWithSettings(
+            Settings.builder()
+                .put(IndexingPressure.MAX_PRIMARY_BYTES.getKey(), ByteSizeValue.ofBytes(primaryLimitBytes).getStringRep())
+                .build()
+        );
+        assertAcked(prepareCreate(INDEX_NAME, indexSettings(1, 1)));
+        ensureGreen(INDEX_NAME);
+
+        // Large existing doc: translating the update into a full index request expands tracked bytes
+        final String docId = "update-doc";
+        client().prepareIndex(INDEX_NAME).setId(docId).setSource(Collections.singletonMap("big", randomAlphaOfLength(4096))).get();
+
+        final int itemsBeforeUpdate = randomIntBetween(1, 5);
+        final String lastDocBeforeUpdate = "before-" + (itemsBeforeUpdate - 1);
+        final BulkRequest bulk = new BulkRequest();
+        for (int i = 0; i < itemsBeforeUpdate; i++) {
+            bulk.add(
+                client().prepareIndex(INDEX_NAME)
+                    .setId("before-" + i)
+                    .setSource(Collections.singletonMap("key", randomAlphaOfLength(50)))
+                    .request()
+            );
+        }
+        bulk.add(client().prepareUpdate(INDEX_NAME, docId).setDoc(Collections.singletonMap("patch", randomAlphaOfLength(8))).request());
+        for (int i = 0; i < randomIntBetween(1, 5); i++) {
+            bulk.add(
+                client().prepareIndex(INDEX_NAME)
+                    .setId("after-" + i)
+                    .setSource(Collections.singletonMap("key", randomAlphaOfLength(50)))
+                    .request()
+            );
+        }
+
+        final IndexingPressure primaryPressure = internalCluster().getInstance(IndexingPressure.class, getPrimaryReplicaNodeNames().v1());
+        final AtomicReference<Releasable> heldReplicaBytes = new AtomicReference<>();
+        final BulkResponse response;
+        try {
+            PreIndexListenerInstallerPlugin.installPreIndexListener((shardId, index) -> {
+                if (index.origin() == Engine.Operation.Origin.PRIMARY
+                    && index.id().equals(lastDocBeforeUpdate)
+                    && heldReplicaBytes.get() == null) {
+                    // Replica bytes count against the primary limit (the coordinating limit is 1.5 x primary limit)
+                    heldReplicaBytes.set(primaryPressure.markReplicaOperationStarted(1, primaryLimitBytes * 2, true));
+                }
+            });
+
+            response = client(getCoordinatingOnlyNode()).bulk(bulk).actionGet();
+        } finally {
+            PreIndexListenerInstallerPlugin.resetPreIndexListener();
+            Releasables.close(heldReplicaBytes.get());
+        }
+        assertThat("the limit must trip before the update translates", heldReplicaBytes.get(), notNullValue());
+
+        assertTrue(response.hasFailures());
+        for (BulkItemResponse item : response.getItems()) {
+            if (item.getOpType() == DocWriteRequest.OpType.UPDATE) {
+                assertTrue("the update must be rejected", item.isFailed());
+                assertThat(item.getFailure().getCause(), instanceOf(EsRejectedExecutionException.class));
+            } else {
+                assertFalse("only the update must fail: " + item.getFailure(), item.isFailed());
+            }
+        }
+        assertEquals(1L, primaryPressure.stats().getPrimaryRejections());
+
+        assertLocalCheckpointsReachMaxSeqNo();
     }
 
     public void testWriteCanRejectOnReplicaBasedOnMaxDocumentSize() throws Exception {
@@ -827,6 +906,67 @@ public class IndexingPressureIT extends ESIntegTestCase {
         assertEquals(1L, primaryWriteLimits.stats().getPrimaryRejections());
         assertEquals(1L, primaryWriteLimits.stats().getLargeOpsRejections());
         assertThat(primaryWriteLimits.stats().getTotalLargeRejectedOpsBytes(), is(greaterThanOrEqualTo(50L)));
+    }
+
+    /**
+     * Going over the primary limit midway through a bulk of index requests must not abort the bulk:
+     * already-applied operations would never replicate, stranding the replica's local checkpoint.
+     */
+    public void testPrimaryRejectionMidBulkDoesNotStrandReplicaCheckpoint() throws Exception {
+        // High enough to admit the bulk; the listener below trips the limit mid-bulk
+        final long primaryLimitBytes = ByteSizeValue.ofMb(10).getBytes();
+        restartNodesWithSettings(
+            Settings.builder()
+                .put(IndexingPressure.MAX_PRIMARY_BYTES.getKey(), ByteSizeValue.ofBytes(primaryLimitBytes).getStringRep())
+                .build()
+        );
+        assertAcked(prepareCreate(INDEX_NAME, indexSettings(1, 1)));
+        ensureGreen(INDEX_NAME);
+
+        final BulkRequest bulk = new BulkRequest();
+        for (int i = 0; i < 20; i++) {
+            bulk.add(
+                client().prepareIndex(INDEX_NAME)
+                    .setId("doc-" + i)
+                    .setSource(Collections.singletonMap("f", randomAlphaOfLength(64)))
+                    .request()
+            );
+        }
+
+        final int tripAfterItems = 5;
+        final IndexingPressure primaryPressure = internalCluster().getInstance(IndexingPressure.class, getPrimaryReplicaNodeNames().v1());
+        final AtomicInteger appliedOnPrimary = new AtomicInteger();
+        final AtomicReference<Releasable> heldReplicaBytes = new AtomicReference<>();
+        try {
+            PreIndexListenerInstallerPlugin.installPreIndexListener((shardId, index) -> {
+                if (index.origin() == Engine.Operation.Origin.PRIMARY && appliedOnPrimary.incrementAndGet() == tripAfterItems) {
+                    // Replica bytes count against the primary limit (the replica limit is 1.5 x primary limit)
+                    heldReplicaBytes.set(primaryPressure.markReplicaOperationStarted(1, primaryLimitBytes * 2, true));
+                }
+            });
+
+            assertNoFailures(client(getCoordinatingOnlyNode()).bulk(bulk).actionGet());
+        } finally {
+            PreIndexListenerInstallerPlugin.resetPreIndexListener();
+            Releasables.close(heldReplicaBytes.get());
+        }
+
+        assertThat("the limit must trip mid-bulk", appliedOnPrimary.get(), greaterThanOrEqualTo(tripAfterItems));
+
+        assertLocalCheckpointsReachMaxSeqNo();
+    }
+
+    private void assertLocalCheckpointsReachMaxSeqNo() throws Exception {
+        assertBusy(() -> {
+            for (ShardStats shardStats : indicesAdmin().prepareStats(INDEX_NAME).get().getShards()) {
+                final SeqNoStats seqNoStats = shardStats.getSeqNoStats();
+                assertThat(
+                    "copy is missing operations: " + shardStats.getShardRouting() + " " + seqNoStats,
+                    seqNoStats.getLocalCheckpoint(),
+                    equalTo(seqNoStats.getMaxSeqNo())
+                );
+            }
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void restartNodesWithSettings(Settings settings) throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
@@ -176,8 +176,15 @@ class BulkPrimaryExecutionContext {
         assert assertInvariants(ItemProcessingState.INITIAL);
         requestToExecute = writeRequest;
         currentItemState = ItemProcessingState.TRANSLATED;
-        pressureExpansionTracker.addExpandedBytes(expansionDeltaBytes(getCurrent(), writeRequest));
         assert assertInvariants(ItemProcessingState.TRANSLATED);
+    }
+
+    public void trackMemoryConsumptionForTranslatedUpdateRequest(DocWriteRequest<?> translatedRequest) {
+        assert assertInvariants(ItemProcessingState.INITIAL);
+        long expandedBytes = expansionDeltaBytes(getCurrent(), translatedRequest);
+        if (expandedBytes > 0) {
+            pressureExpansionTracker.addExpandedBytes(expandedBytes);
+        }
     }
 
     /**
@@ -368,6 +375,8 @@ class BulkPrimaryExecutionContext {
         // anymore.
         if (primary.routingEntry().isSearchable() == false) {
             if (requestToExecute != null) {
+                // In the failure path (i.e. after a memory pressure rejection) getCurrent() == requestToExecute
+                // and thus the expansionDeltaBytes == 0 and this will be a no-op
                 pressureExpansionTracker.removeExpandedBytes(expansionDeltaBytes(getCurrent(), requestToExecute));
             }
             requestToExecute = null;

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -470,6 +470,9 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                     // Include inference fields so that partial updates can still retrieve embeddings for fields that weren't updated.
                     FetchSourceContext.FETCH_ALL_SOURCE
                 );
+                if (updateResult.getResponseResult() != DocWriteResponse.Result.NOOP) {
+                    context.trackMemoryConsumptionForTranslatedUpdateRequest(updateResult.action());
+                }
             } catch (Exception failure) {
                 // we may fail translating a update to index or delete operation
                 // we use index result to communicate failure while translating update request

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -86,6 +86,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -891,6 +892,8 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         when(shard.applyIndexOperationOnPrimary(anyLong(), any(), any(), anyLong(), anyLong(), anyLong(), anyBoolean())).thenReturn(
             indexResult
         );
+        ShardRouting shardRouting = newShardRouting(ShardRouting.Role.DEFAULT);
+        when(shard.routingEntry()).thenReturn(shardRouting);
 
         UpdateHelper updateHelper = mock(UpdateHelper.class);
         when(updateHelper.prepare(any(), eq(shard), any(), any())).thenReturn(
@@ -934,20 +937,104 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             ) {
                 BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard, tracker);
                 assertEquals(indexingBytes + maxMemoryOverhead, indexingPressure.stats().getCurrentCombinedCoordinatingAndPrimaryBytes());
-                expectThrows(
-                    EsRejectedExecutionException.class,
-                    () -> TransportShardBulkAction.executeBulkItemRequest(
-                        context,
-                        updateHelper,
-                        threadPool::absoluteTimeInMillis,
-                        new NoopMappingUpdatePerformer(),
-                        (listener, mappingVersion) -> {},
-                        ASSERTING_DONE_LISTENER,
-                        documentParsingProvider
-                    )
+
+                TransportShardBulkAction.executeBulkItemRequest(
+                    context,
+                    updateHelper,
+                    threadPool::absoluteTimeInMillis,
+                    new NoopMappingUpdatePerformer(),
+                    (listener, mappingVersion) -> {},
+                    ASSERTING_DONE_LISTENER,
+                    documentParsingProvider
                 );
+
+                assertFalse(context.hasMoreOperationsToExecute());
+                verify(shard, never()).applyIndexOperationOnPrimary(anyLong(), any(), any(), anyLong(), anyLong(), anyLong(), anyBoolean());
+                assertEquals(indexingBytes + maxMemoryOverhead, indexingPressure.stats().getCurrentCombinedCoordinatingAndPrimaryBytes());
+                assertEquals(1L, indexingPressure.stats().getPrimaryRejections());
+
+                BulkItemResponse primaryResponse = bulkShardRequest.items()[0].getPrimaryResponse();
+                assertThat(primaryResponse.getItemId(), equalTo(0));
+                assertThat(primaryResponse.getId(), equalTo("id"));
+                assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.UPDATE));
+                assertTrue(primaryResponse.isFailed());
+                assertEquals(RestStatus.TOO_MANY_REQUESTS, primaryResponse.status());
+                assertThat(primaryResponse.getFailure().getCause(), instanceOf(EsRejectedExecutionException.class));
             }
         }
+    }
+
+    public void testRejectedUpdateExpansionDoesNotOverReleaseWhenRunningInServerless() throws Exception {
+        IndexSettings indexSettings = new IndexSettings(indexMetadata(), Settings.EMPTY);
+        DocWriteRequest<UpdateRequest> writeRequest = new UpdateRequest("index", "id").doc(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        BulkItemRequest primaryRequest = new BulkItemRequest(0, writeRequest);
+
+        String value = randomAlphanumericOfLength(4096);
+        IndexRequest updateResponse = new IndexRequest("index").id("id").source(Requests.INDEX_CONTENT_TYPE, "field", value);
+        DocumentParsingProvider documentParsingProvider = mock(DocumentParsingProvider.class);
+
+        IndexShard shard = mockShard(indexSettings, null);
+        ShardRouting shardRouting = newShardRouting(ShardRouting.Role.INDEX_ONLY);
+        when(shard.routingEntry()).thenReturn(shardRouting);
+
+        UpdateHelper updateHelper = mock(UpdateHelper.class);
+        when(updateHelper.prepare(any(), eq(shard), any(), any(), any())).thenReturn(
+            new UpdateHelper.Result(
+                updateResponse,
+                DocWriteResponse.Result.UPDATED,
+                Collections.singletonMap("field", randomAlphanumericOfLength(value.length())),
+                Requests.INDEX_CONTENT_TYPE
+            )
+        );
+
+        BulkItemRequest[] items = new BulkItemRequest[] { primaryRequest };
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, SplitShardCountSummary.IRRELEVANT, RefreshPolicy.NONE, items);
+
+        randomlySetIgnoredPrimaryResponse(primaryRequest);
+
+        final long indexingBytes = bulkShardRequest.ramBytesUsed();
+        final long maxMemoryOverhead = TransportShardBulkAction.getMaxOperationMemoryOverhead(bulkShardRequest);
+        final long maxPrimaryBytes = maxMemoryOverhead + indexingBytes + 1024;
+
+        Settings pressureSettings = Settings.builder()
+            .put(IndexingPressure.MAX_PRIMARY_BYTES.getKey(), maxPrimaryBytes + "B")
+            .put(IndexingPressure.MAX_OPERATION_SIZE.getKey(), "128B")
+            .build();
+
+        IndexingPressure indexingPressure = new IndexingPressure(pressureSettings);
+
+        try (Releasable coordinating = indexingPressure.markCoordinatingOperationStarted(1, indexingBytes, false)) {
+            try (
+                IndexingPressure.PrimaryExpansionTracker tracker = indexingPressure.trackPrimaryOperationExpansion(
+                    1,
+                    maxMemoryOverhead,
+                    false
+                )
+            ) {
+                BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard, tracker);
+                assertEquals(indexingBytes + maxMemoryOverhead, indexingPressure.stats().getCurrentCombinedCoordinatingAndPrimaryBytes());
+                assertEquals(maxMemoryOverhead, indexingPressure.stats().getCurrentPrimaryBytes());
+
+                TransportShardBulkAction.executeBulkItemRequest(
+                    context,
+                    updateHelper,
+                    threadPool::absoluteTimeInMillis,
+                    new NoopMappingUpdatePerformer(),
+                    (listener, mappingVersion) -> {},
+                    ASSERTING_DONE_LISTENER,
+                    documentParsingProvider
+                );
+
+                assertFalse(context.hasMoreOperationsToExecute());
+                assertTrue(bulkShardRequest.items()[0].getPrimaryResponse().isFailed());
+                assertEquals(1L, indexingPressure.stats().getPrimaryRejections());
+
+                assertEquals(indexingBytes + maxMemoryOverhead, indexingPressure.stats().getCurrentCombinedCoordinatingAndPrimaryBytes());
+                assertEquals(maxMemoryOverhead, indexingPressure.stats().getCurrentPrimaryBytes());
+            }
+        }
+        assertEquals(0L, indexingPressure.stats().getCurrentCombinedCoordinatingAndPrimaryBytes());
+        assertEquals(0L, indexingPressure.stats().getCurrentPrimaryBytes());
     }
 
     public void testUpdateWithDelete() throws Exception {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -978,7 +978,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         when(shard.routingEntry()).thenReturn(shardRouting);
 
         UpdateHelper updateHelper = mock(UpdateHelper.class);
-        when(updateHelper.prepare(any(), eq(shard), any(), any(), any())).thenReturn(
+        when(updateHelper.prepare(any(), eq(shard), any(), any())).thenReturn(
             new UpdateHelper.Result(
                 updateResponse,
                 DocWriteResponse.Result.UPDATED,


### PR DESCRIPTION
An indexing pressure rejection could be thrown from the middle of
the primary bulk item loop, since setRequestToExecute tracked
expanded bytes for every item. The exception escaped
performOnPrimary and aborted the whole BulkShardRequest before
replication, so operations already applied to the primary were
never replicated, permanently stranding the replica local
checkpoint below max_seq_no and pinning the global checkpoint.

Track the expansion only for translated updates, within the item
try/catch, so a rejection fails just that update and the remaining
operations execute and replicate normally.

Closes #158212
Backport of #158235
