### PR TITLE
[9.5] Abort the msearch instead of force-adding failure items on a breaker trip (#156934)

### DIFF
--- a/qa/ccs-common-rest/build.gradle
+++ b/qa/ccs-common-rest/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 tasks.named("yamlRestTest") {
   ArrayList<String> blacklist = [
-    'msearch/50_circuit_breaker/msearch circuit breaker trips and returns failure item without aborting the request', // cluster.put_settings applies to the indexing cluster but msearch runs on the query cluster, so the REQUEST breaker limit is never lowered on the coordinator that buffers sub-responses
+    'msearch/50_circuit_breaker/msearch circuit breaker trip aborts the whole request with a top-level 429', // cluster.put_settings applies to the indexing cluster but msearch runs on the query cluster, so the REQUEST breaker limit is never lowered on the coordinator that buffers sub-responses
     'search/150_rewrite_on_coordinator/Ensure that we fetch the document only once', // terms lookup query with index
     'search/170_terms_query/Terms Query with No.of terms exceeding index.max_terms_count should FAIL', // terms lookup query with index
     'search.aggregation/220_filters_bucket/cache busting', // node_selector?

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -86,8 +86,9 @@ excludeList.add('aggregations/percentiles_hdr_metric/Negative values test')
 excludeList.add("cat.shards/10_basic/Help")
 
 // Pre-9.5 coordinators do not reserve REQUEST breaker bytes for buffered msearch sub-responses,
-// so the circuit breaker limit is never enforced and sub-search 1 succeeds instead of returning 429.
-excludeList.add('msearch/50_circuit_breaker/msearch circuit breaker trips and returns failure item without aborting the request')
+// so the circuit breaker limit is never enforced and the whole request succeeds instead of
+// aborting with a top-level 429.
+excludeList.add('msearch/50_circuit_breaker/msearch circuit breaker trip aborts the whole request with a top-level 429')
 
 excludeList.add('search.highlight/70_number_of_fragments/number_of_fragments above the maximum should FAIL')
 excludeList.add('search.highlight/70_number_of_fragments/negative number_of_fragments should FAIL')

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/50_circuit_breaker.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/50_circuit_breaker.yml
@@ -15,7 +15,7 @@ teardown:
             indices.breaker.request.limit: null
 
 ---
-"msearch circuit breaker trips and returns failure item without aborting the request":
+"msearch circuit breaker trip aborts the whole request with a top-level 429":
   - do:
       indices.create:
         index: msearch-cb-test
@@ -208,9 +208,8 @@ teardown:
           persistent:
             indices.breaker.request.limit: "63000b"
 
-  # max_concurrent_searches=1 forces sequential execution so sub-search 0 completes and
-  # its estimate is reserved before sub-search 1 starts.
   - do:
+      catch: /circuit_breaking_exception/
       msearch:
         max_concurrent_searches: 1
         body:
@@ -221,12 +220,6 @@ teardown:
           - index: msearch-cb-test-missing
           - { query: { match_all: {} } }
 
-  # Sub-search 0 completes normally.
-  - match: { responses.0.status: 200 }
-  - match: { responses.0.hits.total.value: 80 }
-  # Sub-search 1 is rejected by the circuit breaker; the overall request still returns HTTP 200.
-  - match: { responses.1.status: 429 }
-  - match: { responses.1.error.type: circuit_breaking_exception }
-  # Sub-search 2 fails independently (missing index) and is still returned correctly.
-  - match: { responses.2.status: 404 }
-  - match: { responses.2.error.type: index_not_found_exception }
+  # The whole request is rejected with a single top-level 429; there is no per-sub-search responses array.
+  - match: { status: 429 }
+  - match: { error.type: circuit_breaking_exception }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
@@ -18,13 +18,16 @@ import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse.Item;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.SliceIndexing;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.search.DummyQueryBuilder;
 import org.elasticsearch.search.SearchService;
@@ -192,6 +195,53 @@ public class MultiSearchIT extends ESIntegTestCase {
         assertBusy(
             () -> assertThat(
                 "request breaker should return to baseline after an all-failure msearch completes",
+                requestBreakerEstimated(coordinatorNode),
+                equalTo(baseline)
+            )
+        );
+    }
+
+    public void testBreakerTripAbortsMsearchWithTopLevel429() throws Exception {
+        String coordinatorNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        assumeFalse("coordinator uses a noop request breaker, skipping test", noopBreakerUsed(coordinatorNode));
+
+        String index = "msearch-breaker-abort-it";
+        int numDocs = 50;
+        createIndex(index, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build());
+        List<IndexRequestBuilder> indexRequests = new ArrayList<>(numDocs);
+        for (int i = 0; i < numDocs; i++) {
+            indexRequests.add(prepareIndex(index).setId(Integer.toString(i)).setSource("payload", "x".repeat(2_000)));
+        }
+        indexRandom(true, indexRequests);
+        ensureGreen(index);
+
+        assertBusy(
+            () -> assertThat("request breaker should be at baseline before msearch", requestBreakerEstimated(coordinatorNode), equalTo(0L))
+        );
+        long baseline = requestBreakerEstimated(coordinatorNode);
+
+        var coordinatorClient = internalCluster().client(coordinatorNode);
+        updateClusterSettings(Settings.builder().put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "1b"));
+        try {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.maxConcurrentSearchRequests(1);
+            for (int i = 0; i < 10; i++) {
+                request.add(coordinatorClient.prepareSearch(index).setSize(numDocs).setQuery(QueryBuilders.matchAllQuery()).request());
+            }
+            CircuitBreakingException e = expectThrows(
+                CircuitBreakingException.class,
+                () -> coordinatorClient.multiSearch(request).actionGet()
+            );
+            assertThat(e.status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+        } finally {
+            updateClusterSettings(
+                Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey())
+            );
+        }
+
+        assertBusy(
+            () -> assertThat(
+                "request breaker should return to baseline after an aborted msearch completes",
                 requestBreakerEstimated(coordinatorNode),
                 equalTo(baseline)
             )

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -51,6 +52,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 
 import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
@@ -237,7 +239,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         // Each completed sub-search stays in {@code responses} until the last one finishes. Incremental bytes (hits,
         // suggest, etc.) and failure-item bytes are reserved here; query-phase aggregation bytes are handed off from
         // {@link QueryPhaseResultConsumer} and released together when the combined {@link MultiSearchResponse} is delivered.
-        final MultiSearchBreakerAccounting breakerAccounting = new MultiSearchBreakerAccounting();
+        final MultiSearchBreakerAccounting breakerAccounting = new MultiSearchBreakerAccounting((CancellableTask) task);
         final ActionListener<MultiSearchResponse> breakerReleasingListener = ActionListener.runAfter(
             listener,
             breakerAccounting::releaseAll
@@ -601,6 +603,12 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         // responseCounter. CircuitBreakingException is caught below and returned as a failure item without throwing.
         client.search(request.request, subscribeListener.map(searchResponse -> {
             long queryPhaseAggHandoff = searchResponse.getQueryPhaseAggregationBreakerBytes();
+            if (breakerAccounting.isAborting()) {
+                if (queryPhaseAggHandoff > 0) {
+                    circuitBreaker.addWithoutBreaking(-queryPhaseAggHandoff);
+                }
+                return new MultiSearchResponse.Item(null, breakerAccounting.abortCause());
+            }
             long bytes = 0;
             // addedToAccounting: breakerAccounting.add() was called — releaseAll() owns the release
             // of both incremental bytes and the handoff. If false, the outer catch releases the
@@ -616,7 +624,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
                     if (queryPhaseAggHandoff > 0) {
                         circuitBreaker.addWithoutBreaking(-queryPhaseAggHandoff);
                     }
-                    // No mustIncRef() yet — respondAndRelease on the search path will decRef the response.
+                    breakerAccounting.triggerAbort(e);
                     return new MultiSearchResponse.Item(null, e);
                 }
                 breakerAccounting.add(bytes, queryPhaseAggHandoff);
@@ -648,7 +656,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
 
             private void handleResponse(final int responseSlot, MultiSearchResponse.Item item) {
                 if (item.isFailure()) {
-                    item = accountOrSubstituteFailureItem(breakerAccounting, item);
+                    item = accountFailureItemOrAbort(breakerAccounting, item);
                 }
                 responses.set(responseSlot, item);
                 if (responseCounter.decrementAndGet() == 0) {
@@ -658,10 +666,25 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             }
 
             private void finish() {
+                CircuitBreakingException abortCause = breakerAccounting.abortCause();
+                if (abortCause != null) {
+                    releaseBufferedResponses();
+                    listener.onFailure(abortCause);
+                    return;
+                }
                 ActionListener.respondAndRelease(
                     listener,
                     new MultiSearchResponse(responses.toArray(new MultiSearchResponse.Item[responses.length()]), buildTookInMillis())
                 );
+            }
+
+            private void releaseBufferedResponses() {
+                for (int i = 0; i < responses.length(); i++) {
+                    MultiSearchResponse.Item item = responses.get(i);
+                    if (item != null && item.getResponse() != null) {
+                        item.getResponse().decRef();
+                    }
+                }
             }
 
             /**
@@ -686,23 +709,23 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
     }
 
     /**
-     * Reserves breaker bytes for a failure item. A failure item can't simply be discarded like an
-     * over-sized response can, but its size (e.g. a {@link SearchPhaseExecutionException} with many
-     * {@link ShardSearchFailure} entries) is unbounded, so a genuine trip is handled by substituting the
-     * small, bounded {@link CircuitBreakingException} itself via {@link #accountBoundedFailureSubstitute}
-     * instead of force-adding the original. Any other exception is treated as a breaker bug rather than a
-     * legitimate trip: it's logged, and the original bytes are force-added so a defect here can't hang
-     * the msearch.
+     * Reserves breaker bytes for a failure item. A failure item's size is unbounded, so a genuine trip aborts the whole
+     * msearch rather than being force-added. Any other exception is a breaker bug, not a legitimate trip: it's logged
+     * and the bytes are force-added so a defect here can't hang the msearch.
      */
-    private MultiSearchResponse.Item accountOrSubstituteFailureItem(
+    private MultiSearchResponse.Item accountFailureItemOrAbort(
         MultiSearchBreakerAccounting breakerAccounting,
         MultiSearchResponse.Item item
     ) {
+        if (breakerAccounting.isAborting()) {
+            return item;
+        }
         long bytes = estimateFailureBytes(item.getFailure());
         try {
             circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, "<msearch_failure>");
         } catch (CircuitBreakingException tripped) {
-            return accountBoundedFailureSubstitute(breakerAccounting, tripped);
+            breakerAccounting.triggerAbort(tripped);
+            return item;
         } catch (Exception unexpected) {
             logger.warn("msearch circuit breaker: failed to reserve bytes for failure item", unexpected);
             circuitBreaker.addWithoutBreaking(bytes);
@@ -713,25 +736,6 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         return item;
     }
 
-    /**
-     * Accounts for a small, bounded {@link CircuitBreakingException} substituted for a failure item that
-     * didn't fit. If even this substitute doesn't fit, it's force-added rather than dropped: not risk-free,
-     * but its size is capped, unlike the original's, so forcing it through risks far less overshoot.
-     */
-    private MultiSearchResponse.Item accountBoundedFailureSubstitute(
-        MultiSearchBreakerAccounting breakerAccounting,
-        CircuitBreakingException substitute
-    ) {
-        long substituteBytes = estimateFailureBytes(substitute);
-        try {
-            circuitBreaker.addEstimateBytesAndMaybeBreak(substituteBytes, "<msearch_failure>");
-        } catch (CircuitBreakingException stillTripped) {
-            circuitBreaker.addWithoutBreaking(substituteBytes);
-        }
-        breakerAccounting.add(substituteBytes, 0);
-        return new MultiSearchResponse.Item(null, substitute);
-    }
-
     record SearchRequestSlot(SearchRequest request, int responseSlot) {
 
     }
@@ -739,12 +743,18 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
     /**
      * Tracks REQUEST breaker bytes reserved while sub-search responses are buffered: incremental estimates from
      * {@link #estimateActualBytes} plus query-phase aggregation bytes handed off from {@link QueryPhaseResultConsumer}.
-     * Also tracks bytes reserved for failure items via {@link #accountOrSubstituteFailureItem}, whether from a genuine
-     * sub-search failure or from a {@link CircuitBreakingException} substituted for an over-sized item.
+     * Also owns the abort state: when a reservation genuinely trips the breaker the whole msearch is aborted rather than
+     * force-adding unbounded bytes, ultimately failing with a single top-level 429 ({@link CircuitBreakingException}).
      */
     final class MultiSearchBreakerAccounting {
         private final AtomicLong incrementalBytes = new AtomicLong();
         private final AtomicLong queryPhaseAggregationHandoffBytes = new AtomicLong();
+        private final AtomicReference<CircuitBreakingException> abortCause = new AtomicReference<>();
+        private final CancellableTask task;
+
+        MultiSearchBreakerAccounting(CancellableTask task) {
+            this.task = task;
+        }
 
         void add(long incremental, long queryPhaseAggregationHandoff) {
             incrementalBytes.addAndGet(incremental);
@@ -756,6 +766,20 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             if (release > 0) {
                 circuitBreaker.addWithoutBreaking(-release);
             }
+        }
+
+        void triggerAbort(CircuitBreakingException cause) {
+            if (abortCause.compareAndSet(null, cause)) {
+                taskManager.cancelTaskAndDescendants(task, "msearch circuit breaker tripped", false, ActionListener.noop());
+            }
+        }
+
+        boolean isAborting() {
+            return abortCause.get() != null;
+        }
+
+        CircuitBreakingException abortCause() {
+            return abortCause.get();
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
@@ -23,7 +23,8 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.SearchResponseUtils;
-import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -36,6 +37,7 @@ import org.junit.BeforeClass;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -93,7 +95,8 @@ public class MultiSearchActionTookTests extends ESTestCase {
 
         TransportMultiSearchAction action = createTransportMultiSearchAction(controlledClock, expected);
 
-        action.doExecute(mock(Task.class), multiSearchRequest, new ActionListener<>() {
+        CancellableTask task = new CancellableTask(1, "test", "test", "", TaskId.EMPTY_TASK_ID, Map.of());
+        action.doExecute(task, multiSearchRequest, new ActionListener<>() {
             @Override
             public void onResponse(MultiSearchResponse multiSearchResponse) {
                 if (controlledClock) {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -51,9 +52,12 @@ import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.suggest.SortBy;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.DefaultBuiltInExecutorBuilders;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
@@ -77,12 +81,9 @@ import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -813,14 +814,15 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         // Simulate query-phase agg bytes already on the breaker before the response arrives.
         breaker.addWithoutBreaking(handoffBytes);
 
-        runMsearchWithBreaker(breaker, 1, () -> {
+        AtomicReference<CancellableTask> msearchTask = new AtomicReference<>();
+        expectThrows(CircuitBreakingException.class, () -> runMsearchWithBreaker(breaker, 1, () -> {
             SearchResponse r = SearchResponse.emptyResponseBuilder().tookInMillis(1L).build();
             r.setQueryPhaseAggregationBreakerBytes(handoffBytes);
             return r;
-        });
+        }, null, null, null, msearchTask::set));
 
-        // The CBE path must release the pre-reserved handoff bytes; releaseAll() is a no-op (nothing accumulated).
         assertThat(breaker.getUsed(), equalTo(0L));
+        assertTrue(msearchTask.get().isCancelled());
     }
 
     public void testBreakerReleasesHandoffOnUnexpectedException() throws Exception {
@@ -841,37 +843,25 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         assertThat(breaker.getUsed(), equalTo(0L));
     }
 
-    public void testBreakerTripDuringExecution() throws Exception {
+    public void testBreakerTripDuringExecutionAbortsMsearch() throws Exception {
         int tripOn = 2;
         int numRequests = 3;
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(tripOn);
-        // The mock client completes searches synchronously, so all three sub-searches run sequentially
-        // via the recursive executeSearch chain (not the outer concurrent for-loop). Reservation call 1
-        // succeeds (slot 0), call 2 trips (slot 1), call 3 succeeds (slot 2).
-        boolean[] failures = new boolean[numRequests];
-        Exception[] failureExceptions = new Exception[numRequests];
-        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
-        runMsearchWithBreaker(
-            breaker,
-            numRequests,
-            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
-            null,
-            (captured) -> {
-                for (int i = 0; i < captured.length; i++) {
-                    items[i] = captured[i];
-                    failures[i] = captured[i].isFailure();
-                    failureExceptions[i] = captured[i].getFailure();
-                }
-            }
+        AtomicReference<CancellableTask> msearchTask = new AtomicReference<>();
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> runMsearchWithBreaker(
+                breaker,
+                numRequests,
+                () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+                null,
+                null,
+                null,
+                msearchTask::set
+            )
         );
-        assertFalse(failures[0]);
-        assertThat(items[0].getResponse(), not(nullValue()));
-        assertTrue(failures[1]);
-        assertThat(items[1].getResponse(), nullValue());
-        assertThat(failureExceptions[1], instanceOf(CircuitBreakingException.class));
-        assertFalse(failures[2]);
-        assertThat(items[2].getResponse(), not(nullValue()));
         assertThat(breaker.getUsed(), equalTo(0L));
+        assertTrue(msearchTask.get().isCancelled());
     }
 
     public void testBreakerAccountsFailureItems() throws Exception {
@@ -900,100 +890,47 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         assertThat(breaker.totalReserved(), equalTo(expectedTotal));
     }
 
-    public void testBreakerAccountsCircuitBreakingFailureItem() throws Exception {
-        int tripOn = 2;
-        int numRequests = 3;
-        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(tripOn);
-        SearchResponse emptyResponse = SearchResponse.emptyResponseBuilder().tookInMillis(1L).build();
-        long perResponseBytes;
-        try {
-            perResponseBytes = TransportMultiSearchAction.estimateActualBytes(emptyResponse);
-        } finally {
-            emptyResponse.decRef();
-        }
-        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
-        AtomicLong usedWhilePending = new AtomicLong(-1);
-        runMsearchWithBreaker(
-            breaker,
-            numRequests,
-            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
-            null,
-            null,
-            captured -> {
-                System.arraycopy(captured, 0, items, 0, numRequests);
-                usedWhilePending.set(breaker.getUsed());
-            }
-        );
-        assertTrue(items[1].isFailure());
-        assertThat(items[1].getFailure(), instanceOf(CircuitBreakingException.class));
-        long cbeItemBytes = TransportMultiSearchAction.estimateFailureBytes(items[1].getFailure());
-
-        assertThat(usedWhilePending.get(), equalTo(2 * perResponseBytes + cbeItemBytes));
-        assertThat(breaker.getUsed(), equalTo(0L));
-    }
-
-    public void testAllSubSearchesFailStillTripsBreaker() throws Exception {
+    public void testFailureItemTripAbortsMsearch() throws Exception {
         int numRequests = 20;
-        int numOriginalFailuresKept = 2;
-
-        MultiSearchResponse.Item[] uncappedItems = new MultiSearchResponse.Item[numRequests];
-        runMsearchWithBreaker(
-            new TrackingCircuitBreaker(-1),
-            numRequests,
-            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
-            index -> true,
-            () -> searchPhaseExecutionExceptionWithShardFailures(10),
-            captured -> System.arraycopy(captured, 0, uncappedItems, 0, numRequests)
-        );
-        long originalFailureBytes = TransportMultiSearchAction.estimateFailureBytes(uncappedItems[0].getFailure());
-
-        long byteLimit = numOriginalFailuresKept * originalFailureBytes;
+        int numFailuresThatFit = 2;
+        long originalFailureBytes = TransportMultiSearchAction.estimateFailureBytes(searchPhaseExecutionExceptionWithShardFailures(10));
+        long byteLimit = numFailuresThatFit * originalFailureBytes;
         TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(byteLimit);
-        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[numRequests];
-        runMsearchWithBreaker(
-            breaker,
-            numRequests,
-            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
-            index -> true,
-            () -> searchPhaseExecutionExceptionWithShardFailures(10),
-            captured -> System.arraycopy(captured, 0, items, 0, numRequests)
+        AtomicReference<CancellableTask> msearchTask = new AtomicReference<>();
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> runMsearchWithBreaker(
+                breaker,
+                numRequests,
+                () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+                index -> true,
+                () -> searchPhaseExecutionExceptionWithShardFailures(10),
+                null,
+                msearchTask::set
+            )
         );
-
-        for (int i = 0; i < items.length; i++) {
-            assertTrue(items[i].isFailure());
-            if (i < numOriginalFailuresKept) {
-                assertThat(items[i].getFailure(), instanceOf(SearchPhaseExecutionException.class));
-            } else {
-                assertThat(items[i].getFailure(), instanceOf(CircuitBreakingException.class));
-            }
-        }
-        assertThat(breaker.largestAddWithoutBreaking(), allOf(greaterThan(0L), lessThan(originalFailureBytes)));
         assertThat(breaker.getUsed(), equalTo(0L));
+        assertTrue(msearchTask.get().isCancelled());
     }
 
-    public void testAccountFailureItemSubstitutesBoundedExceptionWhenTripped() throws Exception {
-        // The failure that actually reaches accountOrSubstituteFailureItem() is somewhat bigger than this,
-        // since it's thrown from deeper inside the real action execution chain than the one built here, which
-        // adds more stack trace frames. That's fine here: we only need the limit to sit below the real failure's
-        // size to trip the breaker, not to match it exactly.
+    public void testOversizedFailureItemAbortsMsearch() throws Exception {
         long largeFailureBytes = TransportMultiSearchAction.estimateFailureBytes(searchPhaseExecutionExceptionWithShardFailures(50));
-        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(largeFailureBytes);
-
-        MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[1];
-        runMsearchWithBreaker(
-            breaker,
-            1,
-            () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
-            index -> true,
-            () -> searchPhaseExecutionExceptionWithShardFailures(50),
-            captured -> items[0] = captured[0]
+        TrackingCircuitBreaker breaker = new TrackingCircuitBreaker(largeFailureBytes - 1);
+        AtomicReference<CancellableTask> msearchTask = new AtomicReference<>();
+        expectThrows(
+            CircuitBreakingException.class,
+            () -> runMsearchWithBreaker(
+                breaker,
+                1,
+                () -> SearchResponse.emptyResponseBuilder().tookInMillis(1L).build(),
+                index -> true,
+                () -> searchPhaseExecutionExceptionWithShardFailures(50),
+                null,
+                msearchTask::set
+            )
         );
-
-        assertTrue(items[0].isFailure());
-        assertThat(items[0].getFailure(), instanceOf(CircuitBreakingException.class));
-        assertThat(items[0].getFailure(), not(instanceOf(SearchPhaseExecutionException.class)));
-        assertThat(breaker.largestAddWithoutBreaking(), equalTo(0L));
         assertThat(breaker.getUsed(), equalTo(0L));
+        assertTrue(msearchTask.get().isCancelled());
     }
 
     private static SearchPhaseExecutionException searchPhaseExecutionExceptionWithShardFailures(int numShardFailures) {
@@ -1034,23 +971,32 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         Supplier<Exception> failureSupplier,
         Consumer<MultiSearchResponse.Item[]> responseItemsConsumer
     ) throws Exception {
+        runMsearchWithBreaker(breaker, numRequests, responseSupplier, failSearch, failureSupplier, responseItemsConsumer, null);
+    }
+
+    private void runMsearchWithBreaker(
+        TrackingCircuitBreaker breaker,
+        int numRequests,
+        Supplier<SearchResponse> responseSupplier,
+        IntPredicate failSearch,
+        Supplier<Exception> failureSupplier,
+        Consumer<MultiSearchResponse.Item[]> responseItemsConsumer,
+        Consumer<CancellableTask> onTaskRegistered
+    ) {
         Settings settings = Settings.builder().put("node.name", "msearch-breaker-test").build();
         ActionFilters actionFilters = mock(ActionFilters.class);
         when(actionFilters.filters()).thenReturn(new ActionFilter[0]);
         ThreadPool threadPool = new ThreadPool(settings, MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders());
+        MockTransportService transportService = MockTransportService.createNewService(
+            Settings.EMPTY,
+            VersionInformation.CURRENT,
+            TransportVersion.current(),
+            threadPool
+        );
         try {
-            TransportService transportService = new TransportService(
-                Settings.EMPTY,
-                mock(Transport.class),
-                threadPool,
-                TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-                boundAddress -> DiscoveryNodeUtils.builder(UUIDs.randomBase64UUID())
-                    .applySettings(settings)
-                    .address(boundAddress.publishAddress())
-                    .build(),
-                null,
-                Collections.emptySet()
-            );
+            transportService.getTaskManager().setTaskCancellationService(new TaskCancellationService(transportService));
+            transportService.start();
+            transportService.acceptIncomingRequests();
             ClusterService clusterService = mock(ClusterService.class);
             when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test")).build());
             MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
@@ -1076,7 +1022,7 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
                 @Override
                 public String getLocalNodeId() {
-                    return "local";
+                    return transportService.getLocalNode().getId();
                 }
             };
             TransportMultiSearchAction action = new TransportMultiSearchAction(
@@ -1089,17 +1035,27 @@ public class TransportMultiSearchActionTests extends ESTestCase {
                 DefaultProjectResolver.INSTANCE,
                 breaker
             );
+            CancellableTask task = (CancellableTask) transportService.getTaskManager()
+                .register("transport", TransportMultiSearchAction.TYPE.name(), multiSearchRequest);
+            if (onTaskRegistered != null) {
+                onTaskRegistered.accept(task);
+            }
             PlainActionFuture<MultiSearchResponse> future = new PlainActionFuture<>();
-            action.execute(
-                multiSearchRequest.createTask(0, "type", "action", null, Map.of()),
-                multiSearchRequest,
-                responseItemsConsumer == null ? future : future.delegateFailureAndWrap((l, response) -> {
-                    responseItemsConsumer.accept(response.getResponses());
-                    l.onResponse(response);
-                })
-            );
-            future.get();
+            try {
+                action.execute(
+                    task,
+                    multiSearchRequest,
+                    responseItemsConsumer == null ? future : future.delegateFailureAndWrap((l, response) -> {
+                        responseItemsConsumer.accept(response.getResponses());
+                        l.onResponse(response);
+                    })
+                );
+                future.actionGet();
+            } finally {
+                transportService.getTaskManager().unregister(task);
+            }
         } finally {
+            transportService.close();
             assertTrue(ESTestCase.terminate(threadPool));
         }
     }
@@ -1107,7 +1063,6 @@ public class TransportMultiSearchActionTests extends ESTestCase {
     private static final class TrackingCircuitBreaker implements CircuitBreaker {
         private final AtomicLong used = new AtomicLong();
         private final AtomicLong totalReserved = new AtomicLong();
-        private final AtomicLong largestAddWithoutBreaking = new AtomicLong();
         private final AtomicInteger reservationCalls = new AtomicInteger();
         private final int tripOnCall;
         private final long byteLimit;
@@ -1153,9 +1108,6 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         @Override
         public void addWithoutBreaking(long bytes) {
             used.addAndGet(bytes);
-            if (bytes > 0) {
-                largestAddWithoutBreaking.updateAndGet(current -> Math.max(current, bytes));
-            }
         }
 
         @Override
@@ -1193,10 +1145,6 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
         long totalReserved() {
             return totalReserved.get();
-        }
-
-        long largestAddWithoutBreaking() {
-            return largestAddWithoutBreaking.get();
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Abort the msearch instead of force-adding failure items on a breaker trip (#156934)](https://github.com/elastic/elasticsearch/pull/156934)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)