### PR TITLE
[Inference API] Add proper closing to the existing HttpClientManager instances

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -307,6 +307,8 @@ public class InferencePlugin extends Plugin
     private final SetOnce<HttpRequestSender.Factory> httpFactory = new SetOnce<>();
     private final SetOnce<AmazonBedrockRequestSender.Factory> amazonBedrockFactory = new SetOnce<>();
     private final SetOnce<HttpRequestSender.Factory> elasticInferenceServiceFactory = new SetOnce<>();
+    private final SetOnce<HttpClientManager> httpClientManagerRef = new SetOnce<>();
+    private final SetOnce<HttpClientManager> eisHttpClientManagerRef = new SetOnce<>();
     private final SetOnce<ServiceComponents> serviceComponents = new SetOnce<>();
     private final SetOnce<TokenCache> oauth2TokenCache = new SetOnce<>();
     private final SetOnce<ProjectResolver> projectResolver = new SetOnce<>();
@@ -419,6 +421,7 @@ public class InferencePlugin extends Plugin
             throttlerManager,
             circuitBreaker
         );
+        httpClientManagerRef.set(httpClientManager);
         var httpRequestSenderFactory = new HttpRequestSender.Factory(serviceComponents.get(), httpClientManager, services.clusterService());
         httpFactory.set(httpRequestSenderFactory);
 
@@ -446,6 +449,7 @@ public class InferencePlugin extends Plugin
             circuitBreaker
         );
         var elasticInferenceServiceHttpClientManager = eisRequestSenderFactoryComponents.httpClientManager();
+        eisHttpClientManagerRef.set(elasticInferenceServiceHttpClientManager);
         elasticInferenceServiceFactory.set(eisRequestSenderFactoryComponents.factory());
 
         var inferencePreferencesCache = new InferencePreferencesCache(
@@ -930,7 +934,12 @@ public class InferencePlugin extends Plugin
         var serviceComponentsRef = serviceComponents.get();
         var throttlerToClose = serviceComponentsRef != null ? serviceComponentsRef.throttlerManager() : null;
 
-        IOUtils.closeWhileHandlingException(inferenceServiceRegistry.get(), throttlerToClose);
+        IOUtils.closeWhileHandlingException(
+            inferenceServiceRegistry.get(),
+            throttlerToClose,
+            httpClientManagerRef.get(),
+            eisHttpClientManagerRef.get()
+        );
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpClientManager.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpClientManager.java
@@ -35,6 +35,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSettings.ELASTIC_INFERENCE_SERVICE_SSL_CONFIGURATION_PREFIX;
@@ -96,6 +97,7 @@ public class HttpClientManager implements Closeable {
     private final PoolingNHttpClientConnectionManager connectionManager;
     private IdleConnectionEvictor connectionEvictor;
     private final HttpClient httpClient;
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
     private volatile TimeValue evictionInterval;
     private volatile TimeValue connectionMaxIdle;
@@ -251,6 +253,10 @@ public class HttpClientManager implements Closeable {
     }
 
     public void start() {
+        // Never start, if the client manager was closed
+        if (isClosed.get()) {
+            return;
+        }
         httpClient.start();
         connectionEvictor.start();
     }
@@ -265,8 +271,11 @@ public class HttpClientManager implements Closeable {
 
     @Override
     public void close() throws IOException {
-        httpClient.close();
-        connectionEvictor.close();
+        // Make sure closing the client manager is idempotent
+        if (isClosed.compareAndSet(false, true)) {
+            httpClient.close();
+            connectionEvictor.close();
+        }
     }
 
     private void setMaxConnections(int maxConnections) {


### PR DESCRIPTION
Should fix flaky authorization tests due to a race, where `close` was called before `start`