### PR TITLE
Test fix: increase the timeout when waiting for index rollover by ILM

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -57,9 +57,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.ManyRequestsIT
   method: testManyRequests
   issue: https://github.com/elastic/elasticsearch/issues/151627
-- class: org.elasticsearch.xpack.ilm.actions.RolloverActionIT
-  method: testILMRolloverRetriesOnReadOnlyBlock
-  issue: https://github.com/elastic/elasticsearch/issues/157832
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
   issue: https://github.com/elastic/elasticsearch/issues/157941

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
@@ -338,7 +338,11 @@ public class RolloverActionIT extends IlmESRestTestCase {
         client().performRequest(allowWritesOnIndexSettingUpdate);
 
         // index is not readonly so the ILM should complete successfully
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), firstIndex), equalTo(PhaseCompleteStep.finalStep("hot").getKey())));
+        assertBusy(
+            () -> assertThat(getStepKeyForIndex(client(), firstIndex), equalTo(PhaseCompleteStep.finalStep("hot").getKey())),
+            30,
+            TimeUnit.SECONDS
+        );
     }
 
     public void testILMRolloverOnManuallyRolledIndex() throws Exception {


### PR DESCRIPTION
Increase the timeout when waiting for the rollover to happen because there is a timing when it's a few milliseconds too late. We have confirmed through the logs that the rollover did happen shortly after.

Fixes #157832