### PR TITLE
ESQL: Increase ParquetCompressedFormatSpecIT timeout

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -580,9 +580,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.AnalyzerSubqueryTests
   method: testTSSubqueryWithConflictingTypesAndExplicitCast
   issue: https://github.com/elastic/elasticsearch/issues/156229
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetCompressedFormatSpecIT
-  method: test {csv-spec:external-basic.aggregateByGender [lz4raw/HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/156241
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecApproximationIT
   method: test {csv-spec:approximation.Inline stats by}
   issue: https://github.com/elastic/elasticsearch/issues/156264
@@ -674,9 +671,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.TDigestPercentilesIT
   method: testSingleValuedFieldPartiallyUnmapped
   issue: https://github.com/elastic/elasticsearch/issues/156864
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetCompressedFormatSpecIT
-  method: test {csv-spec:external-basic.lookupJoin [lz4raw/GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/156877
 - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=ml/ml_standard_analyze/Test analyze API with the standard 7.16 ML analyzer}
   issue: https://github.com/elastic/elasticsearch/issues/156878
@@ -848,9 +842,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasource.csv.CsvFormatReaderStatusSnapshotTests
   method: testCountersPopulatedAfterDrain
   issue: https://github.com/elastic/elasticsearch/issues/158220
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetCompressedFormatSpecIT
-  method: test {csv-spec:external-multivalue.mvRLikeFromDataset [snappy/GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/158221
 - class: org.elasticsearch.xpack.core.security.authz.accesscontrol.FieldSubsetReaderTests
   method: testSyntheticSourceWithCopyToKeywordDestinationAndFLSDocValues
   issue: https://github.com/elastic/elasticsearch/issues/158222

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
@@ -9,10 +9,13 @@ package org.elasticsearch.xpack.esql.qa.parquet;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.test.AzureReactorThreadFilter;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 
 import java.util.List;
 
@@ -24,7 +27,10 @@ import java.util.List;
  * The fixtures are generated at build time by {@code ParquetFixtureGenerator} with the
  * corresponding codec and placed into codec-specific directories
  * ({@code standalone-snappy/}, {@code standalone-gzip/}, etc.).
+ * This class runs two csv-spec files across four codecs and exceeds
+ * {@link EsqlSpecTestCase}'s 10-minute suite budget.
  */
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class ParquetCompressedFormatSpecIT extends AbstractParquetExternalSpecTestCase {
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/156241
Fixes https://github.com/elastic/elasticsearch/issues/156877
Fixes https://github.com/elastic/elasticsearch/issues/158221
Fixes https://github.com/elastic/elasticsearch/issues/157845

Similar to https://github.com/elastic/elasticsearch/pull/153636


On 9.5 backport, also add https://github.com/elastic/elasticsearch/issues/157111