### PR TITLE
Gate tranforms metric test with a flag

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -622,9 +622,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationOrObjectStoreFailures
   issue: https://github.com/elastic/elasticsearch/issues/156569
-- class: org.elasticsearch.xpack.transform.integration.TransformCrossProjectMetricsIT
-  method: testCpsGaugesPublishForRunningTransform
-  issue: https://github.com/elastic/elasticsearch/issues/156575
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlOldCoordinatorSpecLookupJoinExpressionIT
   issue: https://github.com/elastic/elasticsearch/issues/156655
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlCurrentCoordinatorSpecLookupJoinExpressionIT

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformCrossProjectMetricsIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformCrossProjectMetricsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.telemetry.InstrumentType;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 import org.elasticsearch.xpack.transform.telemetry.TransformCrossProjectMetrics;
 
@@ -58,6 +59,7 @@ public class TransformCrossProjectMetricsIT extends TransformSingleNodeTestCase 
     }
 
     public void testCpsGaugesPublishForRunningTransform() throws Exception {
+        assumeTrue("Only relevant when CPS feature flag is on", TransformConfig.TRANSFORM_CROSS_PROJECT.isEnabled());
         var telemetry = getInstanceFromNode(PluginsService.class).filterPlugins(TestTelemetryPlugin.class).findFirst().orElseThrow();
 
         // both gauges are registered at node startup (CPS enabled + transform role)


### PR DESCRIPTION
These metrics are counted only when [this](https://github.com/elastic/elasticsearch/blob/770977b71889566bf2f547298247c9a893231b5a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java#L728-L734) evaluates to true, so I'm adding an equivalent assumption in the test.

This failure happened only when `-Dbuild.snapshot=false` flag was set. Tested it with both `-Dbuild.snapshot=<false/true>` after the fix. Adding a `test-release` label - AFAIR it triggers a suite with `-Dbuild.snapshot=false` set.

The connection between `isSnapshot()` and `TRANSFORM_CROSS_PROJECT.isEnabled()` is that feature flags evaluate to true by default in snapshot builds.

Closes: #156575 