### PR TITLE
[9.5] ESQL: Increase ParquetCompressedFormatSpecIT timeout

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -453,9 +453,6 @@ tests:
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=cluster.stats/10_basic/Sparse vector stats}
   issue: https://github.com/elastic/elasticsearch/issues/157110
-- class: org.elasticsearch.xpack.esql.qa.parquet.ParquetCompressedFormatSpecIT
-  method: test {csv-spec:external-basic.renameColumn [gzip/LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/157111
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:dense_vector_aggs.sumDenseVectorOverflow}
   issue: https://github.com/elastic/elasticsearch/issues/155118

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/csvSpecTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
@@ -9,10 +9,13 @@ package org.elasticsearch.xpack.esql.qa.parquet;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
+import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.test.AzureReactorThreadFilter;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 
 import java.util.List;
 
@@ -24,7 +27,10 @@ import java.util.List;
  * The fixtures are generated at build time by {@code ParquetFixtureGenerator} with the
  * corresponding codec and placed into codec-specific directories
  * ({@code standalone-snappy/}, {@code standalone-gzip/}, etc.).
+ * This class runs two csv-spec files across four codecs and exceeds
+ * {@link EsqlSpecTestCase}'s 10-minute suite budget.
  */
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 @ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
 public class ParquetCompressedFormatSpecIT extends AbstractParquetExternalSpecTestCase {
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/157111

Manual 9.5 backport of https://github.com/elastic/elasticsearch/pull/158266