### PR TITLE
[8.19] Fix testInvalidMaxAnalyzedOffset to exclude now-valid -1

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -543,7 +543,7 @@ public class HighlightBuilderTests extends ESTestCase {
     public void testInvalidMaxAnalyzedOffset() throws IOException {
         XContentParseException e = expectParseThrows(
             XContentParseException.class,
-            "{ \"max_analyzed_offset\" : " + randomIntBetween(-100, -1) + "}"
+            "{ \"max_analyzed_offset\" : " + randomIntBetween(-100, -2) + "}"
         );
         assertThat(e.getMessage(), containsString("[highlight] failed to parse field [" + MAX_ANALYZED_OFFSET_FIELD.toString() + "]"));
         assertThat(e.getCause().getMessage(), containsString("[max_analyzed_offset] must be a positive integer, or -1"));


### PR DESCRIPTION
## Summary

- #157381 backported the `max_analyzed_offset = -1` feature to 8.19, correctly updating the validation to accept `-1` as a valid value.
- However, the test range in `testInvalidMaxAnalyzedOffset` was changed from `randomIntBetween(-100, 0)` to `randomIntBetween(-100, -1)`, which still includes `-1`.
- When the random seed produces `-1`, the validation no longer throws, causing the test to fail intermittently.
- Fix: change the upper bound to `-2` (matching the equivalent fix on `main` from #120001).

Closes #158105