### PR TITLE
Fix bulk inference requests being left waiting forever

### DIFF
--- a/docs/changelog/158313.yaml
+++ b/docs/changelog/158313.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 156135
+pr: 158313
+summary: Fix bulk inference requests being left waiting forever
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -22,9 +22,6 @@ tests:
 - class: org.elasticsearch.packaging.test.KeystoreManagementTests
   method: test50CreateKeystoreManually
   issue: https://github.com/elastic/elasticsearch/issues/155335
-- class: org.elasticsearch.xpack.esql.inference.completion.CompletionOperatorTests
-  method: testSimpleCircuitBreaking
-  issue: https://github.com/elastic/elasticsearch/issues/156135
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobContainerRetriesTests
   method: testWriteLargeBlob
   issue: https://github.com/elastic/elasticsearch/issues/150356

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutor.java
@@ -169,6 +169,24 @@ public class BulkInferenceExecutor {
         }
 
         /**
+         * Hands the scheduling turn to the next queued bulk request. Any path that stops driving the queue must call this, otherwise a
+         * queued bulk request is left with nobody to resume it.
+         *
+         * @param includeSelf whether this bulk request is itself a valid candidate, which is only the case right after it enqueued itself
+         */
+        private void scheduleNextPendingBulkRequest(boolean includeSelf) {
+            BulkInferenceRequest nextBulkRequest = pendingBulkRequests.poll();
+
+            while (includeSelf == false && nextBulkRequest == this) {
+                nextBulkRequest = pendingBulkRequests.poll();
+            }
+
+            if (nextBulkRequest != null) {
+                executorService.execute(nextBulkRequest::executePendingRequests);
+            }
+        }
+
+        /**
          * Main execution loop that processes inference requests asynchronously with hybrid recursion strategy.
          * <p>
          * This method implements a continuation-based asynchronous pattern with the following features:
@@ -204,6 +222,12 @@ public class BulkInferenceExecutor {
                     if (permits.tryAcquire() == false) {
                         if (requests.hasNext()) {
                             pendingBulkRequests.add(this);
+                            // A parked bulk request is resumed only by whoever releases a permit next, and permit holders look at the
+                            // queue right after releasing. A permit released between the failed tryAcquire() above and this enqueue
+                            // finds the queue still empty and moves on, leaving nobody to resume us.
+                            if (permits.availablePermits() > 0) {
+                                scheduleNextPendingBulkRequest(true);
+                            }
                         }
                         return;
                     } else {
@@ -215,15 +239,7 @@ public class BulkInferenceExecutor {
                             permits.release();
 
                             // Check if another bulk request is pending for execution.
-                            BulkInferenceRequest nexBulkRequest = pendingBulkRequests.poll();
-
-                            while (nexBulkRequest == this) {
-                                nexBulkRequest = pendingBulkRequests.poll();
-                            }
-
-                            if (nexBulkRequest != null) {
-                                executorService.execute(nexBulkRequest::executePendingRequests);
-                            }
+                            scheduleNextPendingBulkRequest(false);
 
                             return;
                         }
@@ -256,10 +272,7 @@ public class BulkInferenceExecutor {
                                         // Response has already been sent
                                         // No need to continue processing this bulk.
                                         // Check if another bulk request is pending for execution.
-                                        BulkInferenceRequest nexBulkRequest = pendingBulkRequests.poll();
-                                        if (nexBulkRequest != null) {
-                                            executorService.execute(nexBulkRequest::executePendingRequests);
-                                        }
+                                        scheduleNextPendingBulkRequest(true);
                                         return;
                                     }
                                     if (executionState.finished() == false) {
@@ -288,6 +301,9 @@ public class BulkInferenceExecutor {
                         inferenceRunner.doInference(bulkRequestItem.request(), inferenceResponseListener);
                     }
                 }
+
+                // This bulk is finished, so it will never look at the queue again: hand the turn over to whoever is still waiting.
+                scheduleNextPendingBulkRequest(false);
             } catch (Exception e) {
                 executionState.addFailure(e);
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/bulk/BulkInferenceExecutorTests.java
@@ -172,6 +172,29 @@ public class BulkInferenceExecutorTests extends ESTestCase {
         latch.await(10, TimeUnit.SECONDS);
     }
 
+    public void testConcurrentBulkExecutionsSharingTheSameExecutor() throws Exception {
+        // Permits and the pending queue are shared per executor, so bulks only contend when they go through the same one. A single
+        // outstanding request makes every bulk but one park on the queue, which is where a lost hand-off would stall the execution.
+        BulkInferenceExecutor bulkExecutor = new BulkInferenceExecutor(mockInferenceRunner(invocation -> {
+            runWithRandomDelay(() -> {
+                ActionListener<InferenceAction.Response> l = invocation.getArgument(1);
+                l.onResponse(mockInferenceResponse());
+            });
+            return null;
+        }), threadPool, new BulkInferenceExecutionConfig(between(1, 10), 1));
+
+        int bulks = between(10, 50);
+        CountDownLatch latch = new CountDownLatch(bulks);
+
+        for (int i = 0; i < bulks; i++) {
+            List<InferenceAction.Request> requests = randomInferenceRequestList(between(1, 50));
+            ActionListener<List<InferenceAction.Response>> listener = ActionListener.wrap(r -> latch.countDown(), ESTestCase::fail);
+            threadPool.generic().execute(() -> bulkExecutor.execute(requestIterator(requests), listener));
+        }
+
+        assertTrue("bulk executions did not complete: a queued bulk request was never resumed", latch.await(30, TimeUnit.SECONDS));
+    }
+
     private BulkInferenceExecutor bulkExecutor(InferenceRunner inferenceRunner) {
         return new BulkInferenceExecutor(inferenceRunner, threadPool, randomBulkExecutionConfig());
     }


### PR DESCRIPTION
Inference work is run in batches, and only a fixed number of batches can be in progress at once. A batch that finds no free slot puts itself on a waiting list and stops, expecting whoever frees a slot next to wake it. Two cases break that.

* If a slot is freed in the moment between a batch checking for one and adding itself to the list, the thread freeing it sees an empty list and moves on, so the batch sleeps with nobody left to wake it. And a batch that finishes its own work leaves without ever checking the list, so anything queued behind it can be stranded too.
* A stranded batch never finishes. In a real query that means it stops making progress and holds onto its worker and memory until something cancels it, which is what most likely showed up as  leftover memory reported  [#156135.](https://github.com/elastic/elasticsearch/issues/156135)

The fix makes every exit path check the waiting list, and has a batch look again for a free slot right after adding itself, so it can restart itself instead of depending on another thread to spot it.

Closes https://github.com/elastic/elasticsearch/issues/156135