### PR TITLE
Build the synthetic vectors loader by lookup

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -90,7 +90,7 @@ public final class LuceneChangesSnapshot extends SearchBasedChangesSnapshot {
         this.lastSeenSeqNo = fromSeqNo - 1;
         final TopDocs topDocs = nextTopDocs();
         this.maxDocIndex = topDocs.scoreDocs.length;
-        this.syntheticVectorPatchLoader = mapperService.mappingLookup().getMapping().syntheticVectorsLoader(null);
+        this.syntheticVectorPatchLoader = mapperService.mappingLookup().syntheticVectorsLoader(null);
         RoutingFieldMapper routingMapper = (RoutingFieldMapper) mapperService.mappingLookup().getMapper(RoutingFieldMapper.NAME);
         boolean routingStoredAsDocValues = routingMapper != null && routingMapper.docValues();
         this.ordinalToRoutingLookup = routingStoredAsDocValues ? new DocValuesOrdinalToRoutingLookup() : null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -158,9 +158,6 @@ public final class Mapping implements ToXContentFragment {
      * @return a {@link SourceLoader.SyntheticVectorsLoader} for extracting synthetic vectors,
      *         potentially using the provided filter
      */
-    public SourceLoader.SyntheticVectorsLoader syntheticVectorsLoader(@Nullable SourceFilter filter) {
-        return root.syntheticVectorsLoader(filter);
-    }
 
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader(@Nullable SourceFilter filter) {
         return syntheticFieldLoader(filter, false);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -518,6 +518,89 @@ public final class MappingLookup {
         return inferenceFields;
     }
 
+    /**
+     * Loader that restores the vector fields excluded from {@code _source}, or {@code null} when there are none to restore. Built from
+     * {@link #syntheticVectorFields()} rather than by walking the mapping. Only nested objects take part: plain objects would just
+     * aggregate their children, and excluding a path already excludes everything below it.
+     */
+    public SourceLoader.SyntheticVectorsLoader syntheticVectorsLoader(@Nullable SourceFilter filter) {
+        if (syntheticVectorFields.isEmpty()) {
+            return null;
+        }
+        // Grouped by the innermost nested object each field sits under, or "" for those under none.
+        Map<String, List<SourceLoader.SyntheticVectorsLoader>> byNestedParent = new LinkedHashMap<>();
+        for (String field : syntheticVectorFields) {
+            if (filter != null && filter.isPathFiltered(field, false)) {
+                continue;
+            }
+            if (getMapper(field) instanceof FieldMapper fieldMapper) {
+                var loader = fieldMapper.syntheticVectorsLoader();
+                if (loader != null) {
+                    groupUnder(byNestedParent, nestedLookup.getNestedParent(field), loader);
+                }
+            }
+        }
+        // Innermost first, so each nested object is wrapped before folding into its own parent's group.
+        for (var nested = deepestNested(byNestedParent); nested != null; nested = deepestNested(byNestedParent)) {
+            var nestedMapper = nestedLookup.getNestedMappers().get(nested);
+            assert nestedMapper != null : "no nested mapper for [" + nested + "]";
+            var inner = combine(byNestedParent.remove(nested));
+            groupUnder(byNestedParent, nestedLookup.getNestedParent(nested), nestedMapper.wrapSyntheticVectorsLoader(inner));
+        }
+        return combine(byNestedParent.get(""));
+    }
+
+    private static void groupUnder(
+        Map<String, List<SourceLoader.SyntheticVectorsLoader>> byNestedParent,
+        @Nullable String nestedParent,
+        SourceLoader.SyntheticVectorsLoader loader
+    ) {
+        byNestedParent.computeIfAbsent(nestedParent == null ? "" : nestedParent, k -> new ArrayList<>()).add(loader);
+    }
+
+    /** The deepest nested path present, or {@code null} once only the ungrouped entries remain. */
+    private static String deepestNested(Map<String, List<SourceLoader.SyntheticVectorsLoader>> byNestedParent) {
+        String deepest = null;
+        int deepestDepth = -1;
+        for (String path : byNestedParent.keySet()) {
+            if (path.isEmpty()) {
+                continue;
+            }
+            int depth = (int) path.chars().filter(c -> c == '.').count();
+            if (depth > deepestDepth) {
+                deepestDepth = depth;
+                deepest = path;
+            }
+        }
+        return deepest;
+    }
+
+    private static SourceLoader.SyntheticVectorsLoader combine(@Nullable List<SourceLoader.SyntheticVectorsLoader> loaders) {
+        if (loaders == null || loaders.isEmpty()) {
+            return null;
+        }
+        if (loaders.size() == 1) {
+            return loaders.get(0);
+        }
+        return context -> {
+            final List<SourceLoader.SyntheticVectorsLoader.Leaf> leaves = new ArrayList<>();
+            for (var loader : loaders) {
+                var leaf = loader.leaf(context);
+                if (leaf != null) {
+                    leaves.add(leaf);
+                }
+            }
+            if (leaves.isEmpty()) {
+                return null;
+            }
+            return (doc, acc) -> {
+                for (var leaf : leaves) {
+                    leaf.load(doc, acc);
+                }
+            };
+        };
+    }
+
     public Set<String> syntheticVectorFields() {
         return syntheticVectorFields;
     }
@@ -671,7 +754,7 @@ public final class MappingLookup {
                 mapping.ignoredSourceFormat()
             );
         }
-        var syntheticVectorsLoader = mapping.syntheticVectorsLoader(filter);
+        var syntheticVectorsLoader = syntheticVectorsLoader(filter);
         if (syntheticVectorsLoader != null) {
             return new SourceLoader.SyntheticVectors(removeExcludedSyntheticVectorFields(filter), syntheticVectorsLoader);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -398,12 +398,8 @@ public class NestedObjectMapper extends ObjectMapper {
         return builder.endObject();
     }
 
-    @Override
-    protected SourceLoader.SyntheticVectorsLoader syntheticVectorsLoader(SourceFilter sourceFilter) {
-        var patchLoader = super.syntheticVectorsLoader(sourceFilter);
-        if (patchLoader == null) {
-            return null;
-        }
+    /** Groups the patches {@code patchLoader} produces per nested document, reported against this object's path. */
+    SourceLoader.SyntheticVectorsLoader wrapSyntheticVectorsLoader(SourceLoader.SyntheticVectorsLoader patchLoader) {
         return context -> {
             var leaf = patchLoader.leaf(context);
             if (leaf == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -44,7 +44,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ObjectMapper extends Mapper {
@@ -1050,47 +1049,6 @@ public class ObjectMapper extends Mapper {
         }
 
         return null;
-    }
-
-    private static SourceLoader.SyntheticVectorsLoader syntheticVectorsLoader(Mapper mapper, SourceFilter sourceFilter) {
-        if (sourceFilter != null && sourceFilter.isPathFiltered(mapper.fullPath(), false)) {
-            return null;
-        }
-        if (mapper instanceof ObjectMapper objMapper) {
-            return objMapper.syntheticVectorsLoader(sourceFilter);
-        } else if (mapper instanceof FieldMapper fieldMapper) {
-            return fieldMapper.syntheticVectorsLoader();
-        } else {
-            return null;
-        }
-    }
-
-    SourceLoader.SyntheticVectorsLoader syntheticVectorsLoader(SourceFilter sourceFilter) {
-        var loaders = mappers.values()
-            .stream()
-            .map(m -> syntheticVectorsLoader(m, sourceFilter))
-            .filter(l -> l != null)
-            .collect(Collectors.toList());
-        if (loaders.isEmpty()) {
-            return null;
-        }
-        return context -> {
-            final List<SourceLoader.SyntheticVectorsLoader.Leaf> leaves = new ArrayList<>();
-            for (var loader : loaders) {
-                var leaf = loader.leaf(context);
-                if (leaf != null) {
-                    leaves.add(leaf);
-                }
-            }
-            if (leaves.isEmpty()) {
-                return null;
-            }
-            return (doc, acc) -> {
-                for (var leaf : leaves) {
-                    leaf.load(doc, acc);
-                }
-            };
-        };
     }
 
     SourceLoader.SyntheticFieldLoader syntheticFieldLoader(

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -29,10 +29,13 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.List;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ObjectMapperTests extends MapperServiceTestCase {
@@ -1489,5 +1492,73 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         );
         MapperParsingException exception = expectThrows(MapperParsingException.class, () -> parentBuilder.build(rootContext));
         assertThat(exception.getMessage(), containsString("the value of [enabled] is [false]"));
+    }
+
+    private static void buildVectorFreeSubtree(XContentBuilder b) throws IOException {
+        for (int i = 0; i < 20; i++) {
+            b.startObject("attr" + i);
+            b.startObject("properties");
+            b.startObject("value").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }
+    }
+
+    private static void buildAttributes(XContentBuilder b, boolean withVector) throws IOException {
+        b.startObject("attributes");
+        b.startObject("properties");
+        buildVectorFreeSubtree(b);
+        if (withVector) {
+            b.startObject("deep");
+            b.startObject("properties");
+            b.startObject("emb");
+            b.field("type", "dense_vector").field("dims", 128).field("index", true).field("similarity", "cosine");
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }
+        b.endObject();
+        b.endObject();
+    }
+
+    public void testSyntheticVectorsLoaderOnlyVisitsBranchesLeadingToVectors() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true).build();
+
+        // No vector anywhere: there is nothing to restore, so no loader is built and the mapping is never walked.
+        MapperService withoutVectors = createMapperService(settings, mapping(b -> buildAttributes(b, false)));
+        assertThat(withoutVectors.mappingLookup().syntheticVectorFields(), empty());
+        assertThat(withoutVectors.mappingLookup().syntheticVectorsLoader(null), nullValue());
+
+        // One vector buried under vector-free siblings: skipping those siblings must not lose it.
+        MapperService withVector = createMapperService(settings, mapping(b -> buildAttributes(b, true)));
+        assertThat(withVector.mappingLookup().syntheticVectorFields(), contains("attributes.deep.emb"));
+        assertThat(withVector.mappingLookup().syntheticVectorsLoader(null), notNullValue());
+
+        // A filter excluding the vector leaves nothing to restore, even though the mapping has one.
+        SourceFilter excluded = new SourceFilter(new String[] {}, new String[] { "attributes.deep.emb" });
+        assertThat(withVector.mappingLookup().syntheticVectorsLoader(excluded), nullValue());
+
+        // Excluding an ancestor covers the field below it, which is why the objects in between are not consulted.
+        SourceFilter excludedParent = new SourceFilter(new String[] {}, new String[] { "attributes" });
+        assertThat(withVector.mappingLookup().syntheticVectorsLoader(excludedParent), nullValue());
+    }
+
+    public void testSyntheticVectorsLoaderWrapsNestedObjects() throws IOException {
+        Settings settings = Settings.builder().put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true).build();
+        MapperService mapperService = createMapperService(settings, mapping(b -> {
+            b.startObject("outer").field("type", "nested").startObject("properties");
+            b.startObject("inner").field("type", "nested").startObject("properties");
+            b.startObject("emb");
+            b.field("type", "dense_vector").field("dims", 128).field("index", true).field("similarity", "cosine");
+            b.endObject();
+            b.endObject().endObject();
+            b.endObject().endObject();
+        }));
+        assertThat(mapperService.mappingLookup().syntheticVectorFields(), contains("outer.inner.emb"));
+        assertThat(mapperService.mappingLookup().syntheticVectorsLoader(null), notNullValue());
+
+        // Excluding the outer nested object covers the vector nested below it.
+        SourceFilter excluded = new SourceFilter(new String[] {}, new String[] { "outer" });
+        assertThat(mapperService.mappingLookup().syntheticVectorsLoader(excluded), nullValue());
     }
 }


### PR DESCRIPTION
`ObjectMapper#syntheticVectorsLoader` recursed through every mapper to find the fields offering a loader, allocating a stream and a list at each object level. It runs once per shard fetch, so a mapping with many fields paid for the whole tree on every request to find a handful of vectors, or none at all.

`MappingLookup` already records which fields have a loader, so the loader is now built from that set: none when it is empty, otherwise one lookup per field. Plain objects drop out entirely — they only aggregate their children, and since `XContentMapValues#compileAutomaton` expands each filter pattern to match subfields too, checking the leaf path already covers every object above it. Nested objects still take part, grouped by their innermost nested ancestor and wrapped inside out so the patches keep the same shape. The cost becomes the number of fields carrying a vector rather than the size of the mapping.

Tests cover a vector under vector-free siblings, one inside a doubly nested object, and filters excluding the field, its parent object, and an enclosing nested object.
