### PR TITLE
[9.4] Bump QueryLoggingTemplateRegistry version (#158294)

### DIFF
--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/QueryLoggingTemplateRegistry.java
@@ -36,7 +36,10 @@ public class QueryLoggingTemplateRegistry extends IndexTemplateRegistry {
     // version 4: move filter to main body
     // version 5: add esql.profile longs mapping (broken — two templates merged into one array entry)
     // version 6: fix dynamic_templates to use one array entry per template
-    public static final int INDEX_TEMPLATE_VERSION = 6;
+    // version 7: params support
+    // version 8: params is indexable
+    // version 9: lower priority
+    public static final int INDEX_TEMPLATE_VERSION = 9;
 
     public static final String QUERY_LOGGING_TEMPLATE_VERSION_VARIABLE = "xpack.stack.querylog.template.version";
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Bump QueryLoggingTemplateRegistry version (#158294)](https://github.com/elastic/elasticsearch/pull/158294)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)