### PR TITLE
`PeerRecoverySourceService` throttling at parity with stateless

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -223,7 +223,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     ) {
         this.settings = settings;
         this.buildInIndexListener = Arrays.asList(
-            peerRecoverySourceService,
+            peerRecoverySourceService.indexEventListener(),
             recoveryTargetService,
             searchService,
             snapshotShardsService,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -46,6 +45,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -132,30 +132,25 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         if (DiscoveryNode.canContainData(clusterService.getSettings())) {
             clusterService.addListener(this);
         }
-        this.addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void beforeStop() {
-                ongoingRecoveries.cancelAllPendingRecoveries();
-            }
-        });
     }
 
     @Override
     protected void doStop() {
+        // Stop accepting new source-side recovery requests and drain the queue of not-yet-started recoveries.
+        ongoingRecoveries.close();
+        ongoingRecoveries.cancelAllPendingRecoveries();
         final ClusterService clusterService = indicesService.clusterService();
         if (DiscoveryNode.canContainData(clusterService.getSettings())) {
-            // Drained by the `beforeStop()` listener registered in `doStart()`, which runs before the lifecycle
-            // transitions to STOPPED, preventing `onRecoveryComplete()` from racing to promote a queued recovery
-            // against a stopped lifecycle. Any new incoming recovery would also fail at `indexServiceSafe()` since
-            // `IndicesService.stop()` runs before this service closes.
-            assert ongoingRecoveries.queuedRecoveryCount() == 0 : "pending recoveries queue should already be drained";
-            ongoingRecoveries.awaitEmpty();
-            indicesService.clusterService().removeListener(this);
+            clusterService.removeListener(this);
         }
     }
 
     @Override
-    protected void doClose() {}
+    protected void doClose() {
+        // Waits for any recoveries that were still active when doStop() drained the queue.
+        assert ongoingRecoveries.queuedRecoveryCount() == 0 : "pending recoveries queue should already be drained";
+        ongoingRecoveries.awaitEmpty();
+    }
 
     @Override
     public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
@@ -243,8 +238,20 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
         private int activeRecoveryHandlerCount = 0;
 
+        private boolean closed = false;
+
         OngoingRecoveries(CompositeRecoverySchedulingListener schedulingListeners) {
             this.schedulingListeners = schedulingListeners;
+        }
+
+        /// Rejects all subsequent [enqueueRecovery] calls. Called when the service stops, before draining the queue.
+        synchronized void close() {
+            this.closed = true;
+        }
+
+        // visible for testing
+        synchronized boolean closed() {
+            return this.closed;
         }
 
         // visible for testing
@@ -260,22 +267,36 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         /// Always enqueues first to preserve FIFO ordering across all recoveries.
         /// Attempts recoveries for pending items (if slots are available) after enqueuing.
         void enqueueRecovery(StartRecoveryRequest request, Task task, IndexShard shard, ActionListener<RecoveryResponse> listener) {
+            final boolean alreadyClosed;
             synchronized (this) {
-                assert lifecycle.started();
-                ensureNoDuplicateAllocationId(request.targetAllocationId());
-                // TODO: consider capping the queue depth and rejecting with DelayRecoveryException once exceeded.
-                final var subscribableListener = new SubscribableListener<RecoveryResponse>();
-                subscribableListener.addListener(listener);
-                pendingRecoveries.add(new PendingRecovery(request, task, shard, subscribableListener));
-                shard.recoveryStats().sourceRecoveryQueued();
+                alreadyClosed = this.closed;
+                if (alreadyClosed == false) {
+                    ensureNoDuplicateAllocationId(request.targetAllocationId());
+                    // TODO: consider capping the queue depth and rejecting with DelayRecoveryException once exceeded.
+                    final var subscribableListener = new SubscribableListener<RecoveryResponse>();
+                    subscribableListener.addListener(listener);
+                    pendingRecoveries.add(new PendingRecovery(request, task, shard, subscribableListener));
+                    shard.recoveryStats().sourceRecoveryQueued();
+                }
             }
-            schedulingListeners.onPeerRecoveryQueuedOnSource();
-            startRecoveriesUpToLimit();
+            if (alreadyClosed) {
+                listener.onFailure(
+                    new DelayRecoveryException(
+                        Strings.format(
+                            "cannot start recovery for shard %s, with target node %s: source node is closing",
+                            shard.shardId(),
+                            request.targetNode()
+                        )
+                    )
+                );
+            } else {
+                schedulingListeners.onPeerRecoveryQueuedOnSource();
+                startRecoveriesUpToLimit();
+            }
         }
 
         private RecoverySourceHandler addNewRecovery(StartRecoveryRequest request, Task task, IndexShard shard) {
             assert Thread.holdsLock(this);
-            assert lifecycle.started();
             assert activeRecoveryHandlerCount < maxConcurrentOutgoingRecoveries;
             final ShardRecoveryContext shardContext = activeRecoveries.computeIfAbsent(shard, s -> new ShardRecoveryContext());
             final Tuple<RecoverySourceHandler, RemoteRecoveryTargetHandler> handlers = shardContext.addNewRecovery(request, task, shard);
@@ -295,9 +316,6 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                     }
                 }
                 cancelled = removePendingRecoveries(pendingRecovery -> pendingRecovery.request().targetNode().equals(node));
-                for (PendingRecovery cancelledRecovery : cancelled) {
-                    cancelledRecovery.shard().recoveryStats().sourceQueuedRecoveryDiscarded();
-                }
             }
             for (PendingRecovery cancelledRecovery : cancelled) {
                 cancelledRecovery.listener()
@@ -319,7 +337,6 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             IndexShard shard,
             ActionListener<RecoveryResponse> listener
         ) {
-            assert lifecycle.started();
             final ShardRecoveryContext shardContext = activeRecoveries.get(shard);
             if (shardContext != null && shardContext.reestablishRecovery(request, listener)) {
                 return;
@@ -402,9 +419,6 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             final List<PendingRecovery> cancelled;
             synchronized (this) {
                 cancelled = removePendingRecoveries(ignored -> true);
-                for (PendingRecovery cancelledRecovery : cancelled) {
-                    cancelledRecovery.shard().recoveryStats().sourceQueuedRecoveryDiscarded();
-                }
             }
             for (PendingRecovery cancelledRecovery : cancelled) {
                 cancelledRecovery.listener()
@@ -460,9 +474,6 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                     ExceptionsHelper.maybeThrowRuntimeAndSuppress(failures);
                 }
                 cancelled = removePendingRecoveries(pendingRecovery -> pendingRecovery.shard() == shard);
-                for (PendingRecovery cancelledRecovery : cancelled) {
-                    cancelledRecovery.shard().recoveryStats().sourceQueuedRecoveryDiscarded();
-                }
             }
             for (PendingRecovery cancelledRecovery : cancelled) {
                 cancelledRecovery.listener()
@@ -480,7 +491,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         }
 
         private void awaitEmpty() {
-            assert lifecycle.stoppedOrClosed();
+            assert closed();
             if (isEmpty()) {
                 return;
             }
@@ -546,13 +557,15 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         private List<PendingRecovery> removePendingRecoveries(Predicate<PendingRecovery> predicate) {
             assert Thread.holdsLock(this);
             final List<PendingRecovery> cancelled = new ArrayList<>();
-            pendingRecoveries.removeIf(pendingRecovery -> {
-                if (predicate.test(pendingRecovery)) {
-                    cancelled.add(pendingRecovery);
-                    return true;
+            final Iterator<PendingRecovery> it = pendingRecoveries.iterator();
+            while (it.hasNext()) {
+                final PendingRecovery pending = it.next();
+                if (predicate.test(pending)) {
+                    cancelled.add(pending);
+                    it.remove();
+                    pending.shard().recoveryStats().sourceQueuedRecoveryDiscarded();
                 }
-                return false;
-            });
+            }
             // immutable
             return List.copyOf(cancelled);
         }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -56,7 +56,7 @@ import java.util.function.Predicate;
  * The source recovery accepts recovery requests from other peer shards and start the recovery process from this
  * source shard to the target shard.
  */
-public class PeerRecoverySourceService extends AbstractLifecycleComponent implements IndexEventListener, ClusterStateListener {
+public class PeerRecoverySourceService extends AbstractLifecycleComponent {
 
     private static final Logger logger = LogManager.getLogger(PeerRecoverySourceService.class);
 
@@ -85,7 +85,8 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
     private final RecoveryPlannerService recoveryPlannerService;
 
     // visible for testing
-    final OngoingRecoveries ongoingRecoveries;
+    @Nullable
+    final ThrottledRecoveries throttledRecoveries;
 
     public PeerRecoverySourceService(
         TransportService transportService,
@@ -100,12 +101,9 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         this.clusterService = clusterService;
         this.recoverySettings = recoverySettings;
         this.recoveryPlannerService = recoveryPlannerService;
-        this.ongoingRecoveries = new OngoingRecoveries(schedulingListeners);
-        clusterService.getClusterSettings()
-            .initializeAndWatchIfRegistered(
-                INDICES_RECOVERY_MAX_CONCURRENT_OUTGOING_RECOVERIES_SETTING,
-                ongoingRecoveries::updateMaxConcurrentOutgoingRecoveries
-            );
+        this.throttledRecoveries = DiscoveryNode.canContainData(clusterService.getSettings())
+            ? new ThrottledRecoveries(clusterService, schedulingListeners)
+            : null;
         // When the target node wants to start a peer recovery it sends a START_RECOVERY request to the source
         // node. Upon receiving START_RECOVERY, the source node will initiate the peer recovery.
         transportService.registerRequestHandler(
@@ -128,44 +126,32 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
     @Override
     protected void doStart() {
-        final ClusterService clusterService = indicesService.clusterService();
-        if (DiscoveryNode.canContainData(clusterService.getSettings())) {
-            clusterService.addListener(this);
+        if (throttledRecoveries != null) {
+            clusterService.addListener(throttledRecoveries);
         }
     }
 
     @Override
     protected void doStop() {
-        // Stop accepting new source-side recovery requests and drain the queue of not-yet-started recoveries.
-        ongoingRecoveries.close();
-        ongoingRecoveries.cancelAllPendingRecoveries();
-        final ClusterService clusterService = indicesService.clusterService();
-        if (DiscoveryNode.canContainData(clusterService.getSettings())) {
-            clusterService.removeListener(this);
+        if (throttledRecoveries != null) {
+            // Stop accepting new source-side recovery requests and drain the queue of not-yet-started recoveries.
+            throttledRecoveries.close();
+            throttledRecoveries.cancelAllPendingRecoveries();
+            clusterService.removeListener(throttledRecoveries);
         }
     }
 
     @Override
     protected void doClose() {
-        // Waits for any recoveries that were still active when doStop() drained the queue.
-        assert ongoingRecoveries.queuedRecoveryCount() == 0 : "pending recoveries queue should already be drained";
-        ongoingRecoveries.awaitEmpty();
-    }
-
-    @Override
-    public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
-        if (indexShard != null) {
-            ongoingRecoveries.cancel(indexShard);
+        if (throttledRecoveries != null) {
+            // Waits for any recoveries that were still active when doStop() drained the queue.
+            assert throttledRecoveries.queuedRecoveryCount() == 0 : "pending recoveries queue should already be drained";
+            throttledRecoveries.awaitEmpty();
         }
     }
 
-    @Override
-    public void clusterChanged(ClusterChangedEvent event) {
-        if (event.nodesRemoved()) {
-            for (DiscoveryNode removedNode : event.nodesDelta().removedNodes()) {
-                ongoingRecoveries.cancelOnNodeLeft(removedNode);
-            }
-        }
+    public IndexEventListener indexEventListener() {
+        return throttledRecoveries != null ? throttledRecoveries : new IndexEventListener() {};
     }
 
     private void recover(StartRecoveryRequest request, Task task, ActionListener<RecoveryResponse> listener) {
@@ -208,7 +194,8 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             );
             throw new DelayRecoveryException("source shard is not marked yet as relocating to [" + request.targetNode() + "]");
         }
-        ongoingRecoveries.enqueueRecovery(request, task, shard, listener);
+        assert throttledRecoveries != null : "recovery request received on non-data node";
+        throttledRecoveries.enqueueRecovery(request, task, shard, listener);
     }
 
     private void reestablish(ReestablishRecoveryRequest request, ActionListener<RecoveryResponse> listener) {
@@ -221,10 +208,11 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             request.shardId().id(),
             request.recoveryId()
         );
-        ongoingRecoveries.reestablishRecovery(request, shard, listener);
+        assert throttledRecoveries != null : "reestablish request received on non-data node";
+        throttledRecoveries.reestablishRecovery(request, shard, listener);
     }
 
-    final class OngoingRecoveries {
+    final class ThrottledRecoveries implements IndexEventListener, ClusterStateListener {
 
         private int maxConcurrentOutgoingRecoveries;
 
@@ -240,8 +228,29 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
         private boolean closed = false;
 
-        OngoingRecoveries(CompositeRecoverySchedulingListener schedulingListeners) {
+        ThrottledRecoveries(ClusterService clusterService, CompositeRecoverySchedulingListener schedulingListeners) {
             this.schedulingListeners = schedulingListeners;
+            clusterService.getClusterSettings()
+                .initializeAndWatchIfRegistered(
+                    INDICES_RECOVERY_MAX_CONCURRENT_OUTGOING_RECOVERIES_SETTING,
+                    this::updateMaxConcurrentOutgoingRecoveries
+                );
+        }
+
+        @Override
+        public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
+            if (indexShard != null) {
+                cancelRecoveriesOnShardClosed(indexShard);
+            }
+        }
+
+        @Override
+        public void clusterChanged(ClusterChangedEvent event) {
+            if (event.nodesRemoved()) {
+                for (DiscoveryNode removedNode : event.nodesDelta().removedNodes()) {
+                    cancelRecoveriesOnNodeLeft(removedNode);
+                }
+            }
         }
 
         /// Rejects all subsequent [enqueueRecovery] calls. Called when the service stops, before draining the queue.
@@ -306,7 +315,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             return handlers.v1();
         }
 
-        void cancelOnNodeLeft(DiscoveryNode node) {
+        void cancelRecoveriesOnNodeLeft(DiscoveryNode node) {
             final List<PendingRecovery> cancelled;
             synchronized (this) {
                 final Collection<RemoteRecoveryTargetHandler> handlers = nodeToHandlers.get(node);
@@ -458,7 +467,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
             }
         }
 
-        private void cancel(IndexShard shard) {
+        private void cancelRecoveriesOnShardClosed(IndexShard shard) {
             final List<PendingRecovery> cancelled;
             synchronized (this) {
                 final ShardRecoveryContext shardRecoveryContext = activeRecoveries.get(shard);
@@ -586,7 +595,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                 Task task,
                 IndexShard shard
             ) {
-                assert Thread.holdsLock(OngoingRecoveries.this);
+                assert Thread.holdsLock(ThrottledRecoveries.this);
                 final Tuple<RecoverySourceHandler, RemoteRecoveryTargetHandler> handlers = createRecoverySourceHandler(
                     request,
                     task,
@@ -598,7 +607,7 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
             /// Attaches `listener` to the active handler matching `request`. Returns `false` if no handler matches.
             boolean reestablishRecovery(ReestablishRecoveryRequest request, ActionListener<RecoveryResponse> listener) {
-                assert Thread.holdsLock(OngoingRecoveries.this);
+                assert Thread.holdsLock(ThrottledRecoveries.this);
                 RecoverySourceHandler handler = null;
                 for (RecoverySourceHandler existingHandler : recoveryHandlers.keySet()) {
                     if (existingHandler.getRequest().recoveryId() == request.recoveryId()

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
@@ -65,16 +65,16 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertThat(primary1.recoveryStats().currentAsSource(), equalTo(1));
             assertThat(primary2.recoveryStats().currentAsSource(), equalTo(1));
 
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
             closeShards(primary1, primary2, primary3);
@@ -98,9 +98,9 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1, schedulingListeners); var block1 = blockShardRecovery(primary1)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
             // The recovery will fail immediately because the fake target allocation ID is not in the shard's routing table
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary2),
                 task,
                 primary2,
@@ -109,8 +109,8 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                     exception -> assertThat(exception, instanceOf(DelayRecoveryException.class))
                 )
             );
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
             assertThat(primary1.recoveryStats().currentAsSource(), equalTo(1));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
@@ -118,7 +118,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             block1.close();
             safeAwait(completedListener);
 
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(0));
             assertTrue(primary1.recoveryStats().noCurrentRecoveries());
             assertTrue(primary2.recoveryStats().noCurrentRecoveries());
@@ -148,13 +148,13 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1, schedulingListeners); var block = blockShardRecovery(primary1)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
             assertThat(new ArrayList<>(callOrder), equalTo(List.of("queued", "dequeued")));
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
 
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
             assertThat(new ArrayList<>(callOrder), equalTo(List.of("queued", "dequeued", "queued")));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
             block.close();
             safeAwait(allRecoveriesStarted);
             closeShards(primary1, primary2);
@@ -186,27 +186,27 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = blockShardRecovery(primary2)
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary3),
                 task,
                 primary3,
                 ActionListener.wrap(r -> fail("unexpected success"), e -> callOrder.add(3))
             );
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary4),
                 task,
                 primary4,
                 ActionListener.wrap(r -> fail("unexpected success"), e -> callOrder.add(4))
             );
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary5),
                 task,
                 primary5,
                 ActionListener.wrap(r -> fail("unexpected success"), e -> callOrder.add(5))
             );
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(3));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(3));
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(1));
             assertThat(primary4.recoveryStats().currentAsSourceQueued(), equalTo(1));
             assertThat(primary5.recoveryStats().currentAsSourceQueued(), equalTo(1));
@@ -229,14 +229,14 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         // Two handlers for the same shard each consume one slot.
         try (var service = newPeerRecoverySourceService(2); var ignored = blockShardRecovery(primary)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary), task, primary, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary), task, primary, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary), task, primary, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary), task, primary, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
             assertThat(primary.recoveryStats().currentAsSource(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
             closeShards(primary, primary2);
@@ -251,22 +251,22 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1); var ignored = blockShardRecovery(primary1)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
             // Queue two recoveries for different shards.
             final AtomicReference<Exception> primary2Response = new AtomicReference<>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary2),
                 task,
                 primary2,
                 ActionListener.wrap(r -> fail("unexpected success"), primary2Response::set)
             );
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(2));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(2));
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
-            service.beforeIndexShardClosed(primary2.shardId(), primary2, Settings.EMPTY);
+            service.throttledRecoveries.beforeIndexShardClosed(primary2.shardId(), primary2, Settings.EMPTY);
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(0));
             assertThat(primary2.recoveryStats().currentAsSource(), equalTo(0));
             assertNotNull(primary2Response.get());
@@ -274,7 +274,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             assertThat(primary2Response.get().getMessage(), containsString("index shard closed"));
 
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             closeShards(primary1, primary2, primary3);
         }
@@ -287,7 +287,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1); var ignored = blockShardRecovery(primary1)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
             // Queue a recovery targeting a specific node.
             final DiscoveryNode departedNode = getFakeDiscoNode("departing");
@@ -304,18 +304,18 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 true
             );
             final AtomicReference<Exception> primary2Response = new AtomicReference<>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 requestToDepartingNode,
                 task,
                 primary2,
                 ActionListener.wrap(r -> fail("unexpected success"), primary2Response::set)
             );
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             // Simulate node departure, the pending entry should fail.
-            service.ongoingRecoveries.cancelOnNodeLeft(departedNode);
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.cancelRecoveriesOnNodeLeft(departedNode);
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(0));
             assertNotNull(primary2Response.get());
             assertThat(primary2Response.get(), instanceOf(DelayRecoveryException.class));
@@ -336,21 +336,21 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
 
             final AtomicReference<Exception> primary3Response = new AtomicReference<>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary3),
                 task,
                 primary3,
                 ActionListener.wrap(r -> fail("unexpected success"), primary3Response::set)
             );
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
-            service.ongoingRecoveries.cancelAllPendingRecoveries();
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.cancelAllPendingRecoveries();
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(0));
             assertNotNull(primary3Response.get());
             assertThat(primary3Response.get().getMessage(), containsString("node is closing"));
@@ -379,7 +379,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
             // Block so the first recovery stays active long enough to test duplicate rejection.
             try (var ignored = blockShardRecovery(primary)) {
-                service.ongoingRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
+                service.throttledRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
 
                 // Same target allocation ID should be rejected while the recovery is active.
                 final var duplicate = new StartRecoveryRequest(
@@ -396,7 +396,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 );
                 final var exception = expectThrows(
                     DelayRecoveryException.class,
-                    () -> service.ongoingRecoveries.enqueueRecovery(duplicate, task, primary, ActionListener.noop())
+                    () -> service.throttledRecoveries.enqueueRecovery(duplicate, task, primary, ActionListener.noop())
                 );
                 assertThat(exception.getMessage(), containsString("recovery with same target already registered"));
             }
@@ -412,7 +412,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                     secondComplete.countDown();
                 }
             });
-            service.ongoingRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
             safeAwait(secondComplete);
 
             closeShards(primary);
@@ -426,12 +426,12 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1); var ignored = Releasables.wrap(blockShardRecovery(primary1))) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
             final var queuedRequest = newStartRecoveryRequest(primary2);
-            service.ongoingRecoveries.enqueueRecovery(queuedRequest, task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            service.throttledRecoveries.enqueueRecovery(queuedRequest, task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             // Request for the same target allocation ID should be rejected.
             final var duplicateRequest = new StartRecoveryRequest(
@@ -448,7 +448,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             );
             final var exception = expectThrows(
                 DelayRecoveryException.class,
-                () -> service.ongoingRecoveries.enqueueRecovery(duplicateRequest, task, primary2, ActionListener.noop())
+                () -> service.throttledRecoveries.enqueueRecovery(duplicateRequest, task, primary2, ActionListener.noop())
             );
             assertThat(exception.getMessage(), containsString("recovery with same target already registered"));
 
@@ -468,8 +468,8 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         ) {
             service.start();
             final var activeRequest = newStartRecoveryRequest(primary1);
-            service.ongoingRecoveries.enqueueRecovery(activeRequest, task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(activeRequest, task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
 
             final var duplicateOfActive = new StartRecoveryRequest(
                 primary3.shardId(),
@@ -485,10 +485,10 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             );
             final var exception = expectThrows(
                 DelayRecoveryException.class,
-                () -> service.ongoingRecoveries.enqueueRecovery(duplicateOfActive, task, primary3, ActionListener.noop())
+                () -> service.throttledRecoveries.enqueueRecovery(duplicateOfActive, task, primary3, ActionListener.noop())
             );
             assertThat(exception.getMessage(), containsString("recovery with same target already registered"));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             closeShards(primary1, primary2, primary3);
         }
@@ -501,7 +501,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(Integer.MAX_VALUE); var ignored = blockShardRecovery(primary)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(request, task, primary, ActionListener.noop());
 
             // Reestablish with the correct recovery ID and allocation ID succeeds.
             final var reestablishRequest = new ReestablishRecoveryRequest(
@@ -509,7 +509,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 request.shardId(),
                 request.targetAllocationId()
             );
-            service.ongoingRecoveries.reestablishRecovery(reestablishRequest, primary, ActionListener.noop());
+            service.throttledRecoveries.reestablishRecovery(reestablishRequest, primary, ActionListener.noop());
 
             // Wrong recovery ID throws ResourceNotFoundException.
             final var wrongIdRequest = new ReestablishRecoveryRequest(
@@ -519,7 +519,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             );
             expectThrows(
                 ResourceNotFoundException.class,
-                () -> service.ongoingRecoveries.reestablishRecovery(wrongIdRequest, primary, ActionListener.noop())
+                () -> service.throttledRecoveries.reestablishRecovery(wrongIdRequest, primary, ActionListener.noop())
             );
 
             closeShards(primary);
@@ -533,18 +533,18 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
 
         try (var service = newPeerRecoverySourceService(1); var ignored = blockShardRecovery(primary1)) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
             // Capture the original listener to verify it is never called prematurely.
             final var request2 = newStartRecoveryRequest(primary2);
             final var oldListenerResponse = new AtomicReference<Exception>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 request2,
                 task,
                 primary2,
                 ActionListener.wrap(r -> fail("unexpected success"), oldListenerResponse::set)
             );
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
             // Reestablish the pending recovery with a fresh listener.
@@ -554,21 +554,21 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 request2.shardId(),
                 request2.targetAllocationId()
             );
-            service.ongoingRecoveries.reestablishRecovery(
+            service.throttledRecoveries.reestablishRecovery(
                 reestablishRequest,
                 primary2,
                 ActionListener.wrap(r -> fail("unexpected success"), newListenerResponse::set)
             );
 
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(1));
 
             assertNull(oldListenerResponse.get());
             assertNull(newListenerResponse.get());
 
             // Both the old and new listener are notified on completion (here cancellation).
-            service.ongoingRecoveries.cancelAllPendingRecoveries();
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.cancelAllPendingRecoveries();
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertThat(primary2.recoveryStats().currentAsSourceQueued(), equalTo(0));
             assertNotNull("old listener must have been called on cancel", oldListenerResponse.get());
             assertThat(oldListenerResponse.get(), instanceOf(DelayRecoveryException.class));
@@ -579,7 +579,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             // Reestablishing when no matching entry exists throws PeerRecoveryNotFound.
             expectThrows(
                 PeerRecoveryNotFound.class,
-                () -> service.ongoingRecoveries.reestablishRecovery(reestablishRequest, primary2, ActionListener.noop())
+                () -> service.throttledRecoveries.reestablishRecovery(reestablishRequest, primary2, ActionListener.noop())
             );
 
             closeShards(primary1, primary2);
@@ -598,21 +598,21 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         ) {
             service.start();
             // Slot 1: primary1 with allocation ID A (active)
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
             // Slot 2: primary2 fills the remaining slot
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
 
             // Queue a second recovery for primary1 with a different allocation ID.
             final var queuedRequest = newStartRecoveryRequest(primary1);
             final var oldListenerResponse = new AtomicReference<Exception>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 queuedRequest,
                 task,
                 primary1,
                 ActionListener.wrap(r -> fail("unexpected success"), oldListenerResponse::set)
             );
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             final var reestablishRequest = new ReestablishRecoveryRequest(
                 queuedRequest.recoveryId(),
@@ -620,15 +620,15 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 queuedRequest.targetAllocationId()
             );
             final var newListenerResponse = new AtomicReference<Exception>();
-            service.ongoingRecoveries.reestablishRecovery(
+            service.throttledRecoveries.reestablishRecovery(
                 reestablishRequest,
                 primary1,
                 ActionListener.wrap(r -> fail("unexpected success"), newListenerResponse::set)
             );
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             // Both the old and new listener are notified on completion (here cancellation).
-            service.ongoingRecoveries.cancelAllPendingRecoveries();
+            service.throttledRecoveries.cancelAllPendingRecoveries();
             assertNotNull("old listener must be called on cancel", oldListenerResponse.get());
             assertThat(oldListenerResponse.get(), instanceOf(DelayRecoveryException.class));
             assertNotNull("new listener must be called on cancel", newListenerResponse.get());
@@ -645,17 +645,17 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         try (var service = newPeerRecoverySourceService(1)) {
             service.start();
             service.stop();
-            assertTrue(service.ongoingRecoveries.closed());
+            assertTrue(service.throttledRecoveries.closed());
 
             final AtomicReference<Exception> response = new AtomicReference<>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary),
                 task,
                 primary,
                 ActionListener.wrap(r -> fail("unexpected success"), response::set)
             );
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(0));
             assertThat(response.get(), instanceOf(DelayRecoveryException.class));
             assertThat(response.get().getMessage(), containsString("source node is closing"));
             assertTrue(primary.recoveryStats().noCurrentRecoveries());
@@ -673,28 +673,28 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         final var service = newPeerRecoverySourceService(1);
         try {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
             final AtomicReference<Exception> queuedResponse = new AtomicReference<>();
-            service.ongoingRecoveries.enqueueRecovery(
+            service.throttledRecoveries.enqueueRecovery(
                 newStartRecoveryRequest(primary2),
                 task,
                 primary2,
                 ActionListener.wrap(r -> fail("unexpected success"), queuedResponse::set)
             );
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             // stop() cancels the queued recovery but returns without waiting for the active one.
             service.stop();
             assertThat(queuedResponse.get(), instanceOf(DelayRecoveryException.class));
             assertThat(queuedResponse.get().getMessage(), containsString("source node is closing"));
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             // close() waits for the active recovery, which completes once its permit block is released.
             runInParallel(service::close, block::close);
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(0));
         } finally {
             closeShards(primary1, primary2);
         }
@@ -716,13 +716,13 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             );
 
             // First request starts immediately under the new lower limit.
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             // Second request queues because the new limit (1) is already reached.
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             closeShards(primary1, primary2);
         }
@@ -742,23 +742,23 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2), blockShardRecovery(primary3))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(3));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(3));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             // Decreasing the limit below the current active count must not cancel or disturb the in-flight recoveries
             clusterSettings.applySettings(
                 Settings.builder().put(INDICES_RECOVERY_MAX_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(), 1).build()
             );
 
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(3));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(3));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             // New requests queue because active count (3) exceeds the new limit (1)
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             closeShards(primary1, primary2, primary3, primary4);
         }
@@ -780,12 +780,12 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         ) {
             service.start();
             // Fill all 3 active slots, then queue primary4
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(3));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(3));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             final var dequeuedCount = new AtomicInteger();
             schedulingListeners.addListener(new RecoverySchedulingListener() {
@@ -801,7 +801,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             );
 
             assertThat(dequeuedCount.get(), equalTo(0));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(1));
 
             closeShards(primary1, primary2, primary3, primary4);
         }
@@ -820,10 +820,10 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             final var dequeuedCount = new AtomicInteger();
             schedulingListeners.addListener(new RecoverySchedulingListener() {
@@ -862,20 +862,20 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             )
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             clusterSettings.applySettings(
                 Settings.builder().put(INDICES_RECOVERY_MAX_CONCURRENT_OUTGOING_RECOVERIES_SETTING.getKey(), 4).build()
             );
 
             // Both new requests must start immediately because active count (2) is below the new higher limit (4)
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(4));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(4));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
 
             closeShards(primary1, primary2, primary3, primary4);
         }
@@ -906,13 +906,13 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary5), task, primary5, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(3));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary5), task, primary5, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(3));
 
             // Raising the limit high enough to fit everything drains the entire queue at once
             clusterSettings.applySettings(
@@ -924,8 +924,8 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             // primary1 and primary2 are blocked waiting for their shard's primary operation permits, so
             // recoverToTarget for those two hangs and onRecoveryComplete never fires. They remain active.
             // For the other 3 dequeued requests, recoverToTarget runs and completes immediately.
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertTrue(primary3.recoveryStats().noCurrentRecoveries());
             assertTrue(primary4.recoveryStats().noCurrentRecoveries());
             assertTrue(primary5.recoveryStats().noCurrentRecoveries());
@@ -962,14 +962,14 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             var ignored = Releasables.wrap(blockShardRecovery(primary1), blockShardRecovery(primary2))
         ) {
             service.start();
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
             // Queue 3 items. The limit increase opens only 2 initial slots, so the 3rd drains via cascade.
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary5), task, primary5, ActionListener.noop());
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(3));
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary3), task, primary3, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary4), task, primary4, ActionListener.noop());
+            service.throttledRecoveries.enqueueRecovery(newStartRecoveryRequest(primary5), task, primary5, ActionListener.noop());
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(3));
             assertThat(primary3.recoveryStats().currentAsSourceQueued(), equalTo(1));
             assertThat(primary4.recoveryStats().currentAsSourceQueued(), equalTo(1));
             assertThat(primary5.recoveryStats().currentAsSourceQueued(), equalTo(1));
@@ -984,8 +984,8 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             // primary1 and primary2 are blocked waiting for their shard's primary operation permits, so
             // recoverToTarget for those two hangs and onRecoveryComplete never fires. They remain active.
             // For the other 3 dequeued requests, recoverToTarget runs and completes immediately.
-            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(2));
-            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.throttledRecoveries.activeRecoveryCount(), equalTo(2));
+            assertThat(service.throttledRecoveries.queuedRecoveryCount(), equalTo(0));
             assertTrue(primary3.recoveryStats().noCurrentRecoveries());
             assertTrue(primary4.recoveryStats().noCurrentRecoveries());
             assertTrue(primary5.recoveryStats().noCurrentRecoveries());
@@ -1020,11 +1020,16 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
             ) {
                 service.start();
 
-                service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(runningShard), task, runningShard, ActionListener.noop());
-                assertEquals(1, service.ongoingRecoveries.activeRecoveryCount());
+                service.throttledRecoveries.enqueueRecovery(
+                    newStartRecoveryRequest(runningShard),
+                    task,
+                    runningShard,
+                    ActionListener.noop()
+                );
+                assertEquals(1, service.throttledRecoveries.activeRecoveryCount());
 
                 for (int i = 0; i < queuedRecoveryCount; i++) {
-                    service.ongoingRecoveries.enqueueRecovery(
+                    service.throttledRecoveries.enqueueRecovery(
                         newStartRecoveryRequest(enqueuedShard),
                         task,
                         enqueuedShard,
@@ -1032,8 +1037,8 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                     );
                 }
 
-                assertEquals(1, service.ongoingRecoveries.activeRecoveryCount());
-                assertEquals(queuedRecoveryCount, service.ongoingRecoveries.queuedRecoveryCount());
+                assertEquals(1, service.throttledRecoveries.activeRecoveryCount());
+                assertEquals(queuedRecoveryCount, service.throttledRecoveries.queuedRecoveryCount());
 
                 // Close queued shard so recoveries fail synchronously in recoverToTarget
                 closeShards(enqueuedShard);
@@ -1042,7 +1047,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
                 block.close();
 
                 safeAwait(recoveriesCompleted);
-                assertEquals(0, service.ongoingRecoveries.queuedRecoveryCount());
+                assertEquals(0, service.throttledRecoveries.queuedRecoveryCount());
                 closeShards(runningShard);
             }
         }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
@@ -638,28 +638,64 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         }
     }
 
-    /// Regression test for the race where an active recovery completes during service shutdown and would cause
-    /// a new pending recovery to be started after the lifecycle already moved to `State.STOPPED`.
-    /// The queue is now drained before the lifecycle state changes.
-    public void testCompletingRecoveryWhileStopping() throws Exception {
+    public void testEnqueueAfterStopFails() throws Exception {
+        final IndexShard primary = newStartedShard(true);
+        final var task = newRecoveryTask();
+
+        try (var service = newPeerRecoverySourceService(1)) {
+            service.start();
+            service.stop();
+            assertTrue(service.ongoingRecoveries.closed());
+
+            final AtomicReference<Exception> response = new AtomicReference<>();
+            service.ongoingRecoveries.enqueueRecovery(
+                newStartRecoveryRequest(primary),
+                task,
+                primary,
+                ActionListener.wrap(r -> fail("unexpected success"), response::set)
+            );
+            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(0));
+            assertThat(response.get(), instanceOf(DelayRecoveryException.class));
+            assertThat(response.get().getMessage(), containsString("source node is closing"));
+            assertTrue(primary.recoveryStats().noCurrentRecoveries());
+
+            closeShards(primary);
+        }
+    }
+
+    public void testStopDrainsQueueAndCloseAwaitsActiveRecoveries() throws Exception {
         final IndexShard primary1 = newStartedShard(true);
         final IndexShard primary2 = newStartedShard(true);
         final var task = newRecoveryTask();
         final var block = blockShardRecovery(primary1);
 
-        try (var service = newPeerRecoverySourceService(1)) {
+        final var service = newPeerRecoverySourceService(1);
+        try {
             service.start();
-
-            // Fill slot
             service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary1), task, primary1, ActionListener.noop());
 
-            // Queue another recovery
-            service.ongoingRecoveries.enqueueRecovery(newStartRecoveryRequest(primary2), task, primary2, ActionListener.noop());
+            final AtomicReference<Exception> queuedResponse = new AtomicReference<>();
+            service.ongoingRecoveries.enqueueRecovery(
+                newStartRecoveryRequest(primary2),
+                task,
+                primary2,
+                ActionListener.wrap(r -> fail("unexpected success"), queuedResponse::set)
+            );
+            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
             assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(1));
 
-            // Stop the service and complete listener. Lifecycle assertions in the production code must hold.
-            // The pending recovery should never start after the service moved to `State.STOPPED`.
-            runInParallel(service::stop, block::close);
+            // stop() cancels the queued recovery but returns without waiting for the active one.
+            service.stop();
+            assertThat(queuedResponse.get(), instanceOf(DelayRecoveryException.class));
+            assertThat(queuedResponse.get().getMessage(), containsString("source node is closing"));
+            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(1));
+            assertThat(service.ongoingRecoveries.queuedRecoveryCount(), equalTo(0));
+
+            // close() waits for the active recovery, which completes once its permit block is released.
+            runInParallel(service::close, block::close);
+            assertThat(service.ongoingRecoveries.activeRecoveryCount(), equalTo(0));
+        } finally {
             closeShards(primary1, primary2);
         }
     }


### PR DESCRIPTION
Follows: https://github.com/elastic/elasticsearch/pull/157465b 

Brings `PeerRecoverySourceService` to structural parity with `StatelessPrimaryRelocationSourceService`, applying the same design improvements that were introduced there.

🚧  WIP

Relates to https://github.com/elastic/elasticsearch-team/issues/2800
