### PR TITLE
Fix backwards read of `shape` doc values in block loaders

### DIFF
--- a/docs/changelog/158341.yaml
+++ b/docs/changelog/158341.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 158341
+summary: Fix backwards read of `shape` doc values in block loaders
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -105,11 +105,17 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
         private static class BoundsReader implements BlockLoader.ColumnAtATimeReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
             private final CircuitBreaker breaker;
+            /**
+             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             */
             private final BinaryDocValues binaryDocValues;
+            private final Thread creationThread;
+            private int docId = -1;
 
             private BoundsReader(CircuitBreaker breaker, BinaryDocValues binaryDocValues) {
                 this.breaker = breaker;
                 this.binaryDocValues = binaryDocValues;
+                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -124,6 +130,8 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.IntBuilder builder) throws IOException {
+                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
+                docId = doc;
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -134,7 +142,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
 
             @Override
             public boolean canReuse(int startingDocID) {
-                return true;
+                return creationThread == Thread.currentThread() && docId <= startingDocID;
             }
 
             private void writeExtent(BlockLoader.IntBuilder builder, Extent extent) {
@@ -188,13 +196,19 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
         private static class CentroidReader implements BlockLoader.ColumnAtATimeReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
             private final CircuitBreaker breaker;
+            /**
+             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             */
             private final BinaryDocValues binaryDocValues;
             private final CoordinateEncoder encoder;
+            private final Thread creationThread;
+            private int docId = -1;
 
             private CentroidReader(CircuitBreaker breaker, BinaryDocValues binaryDocValues, CoordinateEncoder encoder) {
                 this.breaker = breaker;
                 this.binaryDocValues = binaryDocValues;
                 this.encoder = encoder;
+                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -209,6 +223,8 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
+                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
+                docId = doc;
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -219,7 +235,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
 
             @Override
             public boolean canReuse(int startingDocID) {
-                return true;
+                return creationThread == Thread.currentThread() && docId <= startingDocID;
             }
 
             private void writeCentroid(BlockLoader.DoubleBuilder builder) throws IOException {
@@ -287,9 +303,14 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
         private static class BoundsAndCentroidReader implements BlockLoader.ColumnAtATimeReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
             private final CircuitBreaker breaker;
+            /**
+             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             */
             private final BinaryDocValues binaryDocValues;
             private final CoordinateEncoder encoder;
             private final BoundsAndCentroidBlockLoader loader;
+            private final Thread creationThread;
+            private int docId = -1;
 
             private BoundsAndCentroidReader(
                 CircuitBreaker breaker,
@@ -301,6 +322,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                 this.binaryDocValues = binaryDocValues;
                 this.encoder = encoder;
                 this.loader = loader;
+                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -315,6 +337,8 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
+                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
+                docId = doc;
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -325,7 +349,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
 
             @Override
             public boolean canReuse(int startingDocID) {
-                return true;
+                return creationThread == Thread.currentThread() && docId <= startingDocID;
             }
 
             private void writeBoundsAndCentroid(BlockLoader.DoubleBuilder builder, Extent extent) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -102,20 +102,16 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
         }
 
-        private static class BoundsReader implements BlockLoader.ColumnAtATimeReader {
+        private static class BoundsReader extends BlockDocValuesReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
-            private final CircuitBreaker breaker;
             /**
-             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             * Forward-only, so this reader cannot revisit a document. See {@link #canReuse}.
              */
             private final BinaryDocValues binaryDocValues;
-            private final Thread creationThread;
-            private int docId = -1;
 
             private BoundsReader(CircuitBreaker breaker, BinaryDocValues binaryDocValues) {
-                this.breaker = breaker;
+                super(breaker);
                 this.binaryDocValues = binaryDocValues;
-                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -130,8 +126,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.IntBuilder builder) throws IOException {
-                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
-                docId = doc;
+                assert doc >= docId() : "docs must be read in order, got [" + doc + "] after [" + docId() + "]";
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -141,8 +136,13 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             @Override
-            public boolean canReuse(int startingDocID) {
-                return creationThread == Thread.currentThread() && docId <= startingDocID;
+            protected int docId() {
+                return binaryDocValues.docID();
+            }
+
+            @Override
+            public String toString() {
+                return "ShapeBounds";
             }
 
             private void writeExtent(BlockLoader.IntBuilder builder, Extent extent) {
@@ -193,22 +193,18 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
         }
 
-        private static class CentroidReader implements BlockLoader.ColumnAtATimeReader {
+        private static class CentroidReader extends BlockDocValuesReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
-            private final CircuitBreaker breaker;
             /**
-             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             * Forward-only, so this reader cannot revisit a document. See {@link #canReuse}.
              */
             private final BinaryDocValues binaryDocValues;
             private final CoordinateEncoder encoder;
-            private final Thread creationThread;
-            private int docId = -1;
 
             private CentroidReader(CircuitBreaker breaker, BinaryDocValues binaryDocValues, CoordinateEncoder encoder) {
-                this.breaker = breaker;
+                super(breaker);
                 this.binaryDocValues = binaryDocValues;
                 this.encoder = encoder;
-                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -223,8 +219,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
-                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
-                docId = doc;
+                assert doc >= docId() : "docs must be read in order, got [" + doc + "] after [" + docId() + "]";
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -234,8 +229,13 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             @Override
-            public boolean canReuse(int startingDocID) {
-                return creationThread == Thread.currentThread() && docId <= startingDocID;
+            protected int docId() {
+                return binaryDocValues.docID();
+            }
+
+            @Override
+            public String toString() {
+                return "ShapeCentroid";
             }
 
             private void writeCentroid(BlockLoader.DoubleBuilder builder) throws IOException {
@@ -300,17 +300,14 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
         }
 
-        private static class BoundsAndCentroidReader implements BlockLoader.ColumnAtATimeReader {
+        private static class BoundsAndCentroidReader extends BlockDocValuesReader {
             private final GeometryDocValueReader reader = new GeometryDocValueReader();
-            private final CircuitBreaker breaker;
             /**
-             * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+             * Forward-only, so this reader cannot revisit a document. See {@link #canReuse}.
              */
             private final BinaryDocValues binaryDocValues;
             private final CoordinateEncoder encoder;
             private final BoundsAndCentroidBlockLoader loader;
-            private final Thread creationThread;
-            private int docId = -1;
 
             private BoundsAndCentroidReader(
                 CircuitBreaker breaker,
@@ -318,11 +315,10 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                 CoordinateEncoder encoder,
                 BoundsAndCentroidBlockLoader loader
             ) {
-                this.breaker = breaker;
+                super(breaker);
                 this.binaryDocValues = binaryDocValues;
                 this.encoder = encoder;
                 this.loader = loader;
-                this.creationThread = Thread.currentThread();
             }
 
             @Override
@@ -337,8 +333,7 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             private void read(int doc, BlockLoader.DoubleBuilder builder) throws IOException {
-                assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
-                docId = doc;
+                assert doc >= docId() : "docs must be read in order, got [" + doc + "] after [" + docId() + "]";
                 if (binaryDocValues.advanceExact(doc) == false) {
                     builder.appendNull();
                     return;
@@ -348,8 +343,13 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             }
 
             @Override
-            public boolean canReuse(int startingDocID) {
-                return creationThread == Thread.currentThread() && docId <= startingDocID;
+            protected int docId() {
+                return binaryDocValues.docID();
+            }
+
+            @Override
+            public String toString() {
+                return "ShapeBoundsAndCentroid";
             }
 
             private void writeBoundsAndCentroid(BlockLoader.DoubleBuilder builder, Extent extent) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.SpatialEnvelopeVisitor;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.lucene.spatial.BinaryShapeDocValuesField;
 import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
@@ -229,5 +230,49 @@ public class AbstractShapeGeometryFieldMapperTests extends ESTestCase {
 
     private static int[] evenArray(int maxIndex) {
         return IntStream.range(0, maxIndex / 2).map(x -> x * 2).toArray();
+    }
+
+    /**
+     * The shape readers wrap a forward-only binary doc values iterator, so {@code canReuse} has to track the last document read.
+     * Reporting {@code true} for an earlier document lets {@code ValuesSourceReaderOperator} hand a retained reader a document it has
+     * already passed, which resolves against whichever binary doc values block is still loaded.
+     */
+    public void testCanReuseTracksLastReadDoc() throws IOException {
+        testCanReuseTracksLastReadDoc(new AbstractShapeGeometryFieldMapper.AbstractShapeGeometryFieldType.BoundsBlockLoader("field"));
+        testCanReuseTracksLastReadDoc(
+            new AbstractShapeGeometryFieldMapper.AbstractShapeGeometryFieldType.CentroidBlockLoader("field", CoordinateEncoder.CARTESIAN)
+        );
+        testCanReuseTracksLastReadDoc(
+            new AbstractShapeGeometryFieldMapper.AbstractShapeGeometryFieldType.BoundsAndCentroidBlockLoader(
+                "field",
+                CoordinateEncoder.CARTESIAN
+            )
+        );
+    }
+
+    private void testCanReuseTracksLastReadDoc(BlockDocValuesReader.DocValuesBlockLoader loader) throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (var iw = new IndexWriter(directory, new IndexWriterConfig(null /* analyzer */))) {
+                for (int i = 0; i < 5; i++) {
+                    var geometry = new Rectangle(i, i + 1, i + 1, i);
+                    var shape = new BinaryShapeDocValuesField("field", CoordinateEncoder.CARTESIAN);
+                    shape.add(new CartesianShapeIndexer("field").indexShape(geometry), geometry);
+                    var doc = new Document();
+                    doc.add(shape);
+                    iw.addDocument(doc);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                var leaf = getOnlyLeafReader(reader).getContext();
+                CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+                try (BlockLoader.ColumnAtATimeReader allReader = loader.reader(breaker, leaf)) {
+                    allReader.read(TestBlock.factory(), TestBlock.docs(3), 0, false).close();
+
+                    assertFalse(loader + " must not be reused for an earlier doc", allReader.canReuse(2));
+                    assertTrue(loader + " may be reused for the doc it just read", allReader.canReuse(3));
+                    assertTrue(loader + " may be reused for a later doc", allReader.canReuse(4));
+                }
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/ShapeBackwardsReadIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/ShapeBackwardsReadIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.spatial;
+
+import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlPluginWithEnterpriseOrTrialLicense;
+import org.elasticsearch.xpack.esql.datasources.datasource.TestEncryptionServicePlugin;
+import org.elasticsearch.xpack.spatial.SpatialPlugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * A {@code SORT}/{@code LIMIT} makes {@code LuceneTopNSourceOperator} emit pages in sort order, so a later page can start behind a
+ * document an earlier page already read. {@code ValuesSourceReaderOperator} keeps a column reader across those pages unless
+ * {@link org.elasticsearch.index.mapper.BlockLoader.ColumnAtATimeReader#canReuse} says otherwise, and the {@code shape} readers hold a
+ * forward-only binary doc values iterator. When the field is stored in the TSDB doc values format its values are chopped into
+ * compressed blocks, so revisiting an earlier document resolved against the still-loaded later block and threw
+ * {@link ArrayIndexOutOfBoundsException} for a negative block-relative index.
+ * <p>
+ * {@code @SuppressCodecs("*")} matters: {@link org.elasticsearch.test.ESIntegTestCase} otherwise forces
+ * {@code index.codec=lucene_default} through its random index template, which bypasses {@code PerFieldFormatSupplier} and therefore
+ * never selects the TSDB doc values format these readers need in order to reproduce the failure.
+ */
+@SuppressCodecs("*")
+public class ShapeBackwardsReadIT extends AbstractEsqlIntegTestCase {
+
+    /** Enough documents, with fat enough geometries, to spill the binary doc values across several compressed blocks. */
+    private static final int NUM_DOCS = 6000;
+    private static final int VERTICES = 60;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(SpatialPlugin.class, TestEncryptionServicePlugin.class, EsqlPluginWithEnterpriseOrTrialLicense.class);
+    }
+
+    /**
+     * {@code columnar} index mode enables the TSDB doc values format by default and routes {@code shape} value reads through
+     * {@code GeometrySourceBlockLoader}, so a plain {@code KEEP} after a {@code SORT} is enough.
+     */
+    public void testShapeReadsAfterTopNOnColumnarIndex() throws Exception {
+        String index = "shape_columnar";
+        createShapeIndex(index, Settings.builder().put("index.mode", "columnar").put("index.codec", "default"));
+
+        assertQueriesSucceed(
+            index,
+            "SORT sort_key | LIMIT 5000 | KEEP location",
+            "SORT sort_key DESC | LIMIT 5000 | KEEP location",
+            "SORT sort_key | LIMIT 5000 | EVAL wkt = TO_STRING(location) | KEEP wkt",
+            "SORT sort_key | LIMIT 5000 | STATS extent = ST_EXTENT_AGG(location)",
+            "SORT sort_key | LIMIT 5000 | STATS centroid = ST_CENTROID_AGG(location)",
+            "SORT sort_key | LIMIT 5000 | STATS e = ST_EXTENT_AGG(location), c = ST_CENTROID_AGG(location)"
+        );
+    }
+
+    /**
+     * Runs every query and reports all of them, rather than stopping at the first, so a partial regression cannot hide behind an
+     * earlier failure.
+     */
+    private void assertQueriesSucceed(String index, String... tails) {
+        List<String> failures = new ArrayList<>();
+        for (String tail : tails) {
+            String query = "FROM " + index + " | " + tail;
+            try (var resp = run(query)) {
+                assertThat(resp.columns(), not(empty()));
+            } catch (Exception e) {
+                Throwable root = e;
+                while (root.getCause() != null) {
+                    root = root.getCause();
+                }
+                failures.add(tail + " -> " + root.getClass().getSimpleName() + ": " + root.getMessage());
+            }
+        }
+        assertThat("queries must not fail on a reused reader", failures, empty());
+    }
+
+    private void createShapeIndex(String index, Settings.Builder settings) throws Exception {
+        assertAcked(prepareCreate(index).setSettings(settings.put("index.number_of_shards", 1).build()).setMapping("""
+            {
+              "properties" : {
+                "location": { "type" : "shape" },
+                "sort_key": { "type" : "long" }
+              }
+            }
+            """));
+
+        List<IndexRequest> batch = new ArrayList<>();
+        for (int i = 0; i < NUM_DOCS; i++) {
+            batch.add(new IndexRequest(index).id(Integer.toString(i)).source("location", polygon(i), "sort_key", scrambled(i)));
+            if (batch.size() == 500) {
+                indexBatch(batch);
+                batch = new ArrayList<>();
+            }
+        }
+        if (batch.isEmpty() == false) {
+            indexBatch(batch);
+        }
+        // One segment, so the reader is retained across pages instead of being dropped at a segment boundary.
+        client().admin().indices().prepareForceMerge(index).setMaxNumSegments(1).get();
+        client().admin().indices().prepareRefresh(index).get();
+        ensureYellow(index);
+    }
+
+    private void indexBatch(List<IndexRequest> batch) {
+        BulkRequestBuilder bulk = client().prepareBulk();
+        batch.forEach(bulk::add);
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.NONE).get();
+    }
+
+    /** Uncorrelated with the document id, so sorting on it genuinely shuffles documents across pages. */
+    private static long scrambled(int i) {
+        return (i * 2654435761L) % 1000003L;
+    }
+
+    private static String polygon(int i) {
+        double cx = i % 100;
+        double cy = i % 50;
+        double r = 0.4;
+        StringBuilder sb = new StringBuilder("POLYGON((");
+        for (int v = 0; v <= VERTICES; v++) {
+            double angle = 2 * Math.PI * (v % VERTICES) / VERTICES;
+            if (v > 0) {
+                sb.append(", ");
+            }
+            sb.append(String.format(Locale.ROOT, "%.6f %.6f", cx + r * Math.cos(angle), cy + r * Math.sin(angle)));
+        }
+        return sb.append("))").toString();
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/ShapeBackwardsReadIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/ShapeBackwardsReadIT.java
@@ -7,25 +7,25 @@
 
 package org.elasticsearch.xpack.esql.spatial;
 
-import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
 import org.elasticsearch.xpack.esql.action.EsqlPluginWithEnterpriseOrTrialLicense;
 import org.elasticsearch.xpack.esql.datasources.datasource.TestEncryptionServicePlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
+import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * A {@code SORT}/{@code LIMIT} makes {@code LuceneTopNSourceOperator} emit pages in sort order, so a later page can start behind a
@@ -35,15 +35,30 @@ import static org.hamcrest.Matchers.not;
  * compressed blocks, so revisiting an earlier document resolved against the still-loaded later block and threw
  * {@link ArrayIndexOutOfBoundsException} for a negative block-relative index.
  * <p>
- * {@code @SuppressCodecs("*")} matters: {@link org.elasticsearch.test.ESIntegTestCase} otherwise forces
- * {@code index.codec=lucene_default} through its random index template, which bypasses {@code PerFieldFormatSupplier} and therefore
- * never selects the TSDB doc values format these readers need in order to reproduce the failure.
+ * Three preconditions are load-bearing and each is asserted rather than assumed, because if any silently fails the queries all pass
+ * while never reaching {@code canReuse}:
+ * <ul>
+ *     <li>{@code index.codec} must be a real Elasticsearch codec. {@link org.elasticsearch.test.ESIntegTestCase} puts
+ *     {@code index.codec=lucene_default} on its random index template, which bypasses {@code PerFieldFormatSupplier} and so never
+ *     selects the TSDB doc values format. The create-request setting below overrides the template
+ *     ({@code MetadataCreateIndexService} applies request settings last).</li>
+ *     <li>{@code page_size} must be well below the query {@code LIMIT}, or the whole TopN result arrives as one page and no reader is
+ *     ever handed a document it has passed. {@link #getPragmas()} pins it; {@code randomPragmas()} can otherwise pick a page size
+ *     larger than the limit.</li>
+ *     <li>The index must be one segment, or {@code ValuesSourceReaderOperator} takes the many-segments path, which consults
+ *     {@code positionFieldWorkDocGuaranteedAscending} and never calls {@code canReuse} at all.</li>
+ * </ul>
+ * <p>
+ * If this test fails, expect the unhelpful message {@code AssertionError: timeout} rather than a description of the backwards read.
+ * Assertions are enabled on test nodes, so the reader's order assert (or the one in {@code AbstractTSDBDocValuesProducer}) fires first,
+ * and an {@link AssertionError} is an {@link Error}: nothing in {@code compute/operator} catches {@link Throwable}, so it escapes to the
+ * thread pool's uncaught handler and the query's listener never completes. Re-run with {@code -Dtests.asserts=false} to see the
+ * underlying {@link ArrayIndexOutOfBoundsException} and its negative index, which names the block and the document.
  */
-@SuppressCodecs("*")
 public class ShapeBackwardsReadIT extends AbstractEsqlIntegTestCase {
 
-    /** Enough documents, with fat enough geometries, to spill the binary doc values across several compressed blocks. */
     private static final int NUM_DOCS = 6000;
+    private static final int LIMIT = 5000;
     private static final int VERTICES = 60;
 
     @Override
@@ -51,77 +66,85 @@ public class ShapeBackwardsReadIT extends AbstractEsqlIntegTestCase {
         return List.of(SpatialPlugin.class, TestEncryptionServicePlugin.class, EsqlPluginWithEnterpriseOrTrialLicense.class);
     }
 
+    @Override
+    protected QueryPragmas getPragmas() {
+        // Must stay well under LIMIT so the TopN result spans several pages; that is what lets a reader be reused for an earlier doc.
+        return new QueryPragmas(Settings.builder().put(QueryPragmas.PAGE_SIZE.getKey(), 512).build());
+    }
+
     /**
-     * {@code columnar} index mode enables the TSDB doc values format by default and routes {@code shape} value reads through
-     * {@code GeometrySourceBlockLoader}, so a plain {@code KEEP} after a {@code SORT} is enough.
+     * One query per affected reader. {@code columnar} index mode enables the TSDB doc values format by default and routes {@code shape}
+     * value reads through {@code GeometrySourceBlockLoader}, so a plain {@code KEEP} after a {@code SORT} reaches it.
      */
     public void testShapeReadsAfterTopNOnColumnarIndex() throws Exception {
         String index = "shape_columnar";
-        createShapeIndex(index, Settings.builder().put("index.mode", "columnar").put("index.codec", "default"));
+        createShapeIndex(index);
 
-        assertQueriesSucceed(
-            index,
-            "SORT sort_key | LIMIT 5000 | KEEP location",
-            "SORT sort_key DESC | LIMIT 5000 | KEEP location",
-            "SORT sort_key | LIMIT 5000 | EVAL wkt = TO_STRING(location) | KEEP wkt",
-            "SORT sort_key | LIMIT 5000 | STATS extent = ST_EXTENT_AGG(location)",
-            "SORT sort_key | LIMIT 5000 | STATS centroid = ST_CENTROID_AGG(location)",
-            "SORT sort_key | LIMIT 5000 | STATS e = ST_EXTENT_AGG(location), c = ST_CENTROID_AGG(location)"
-        );
+        // GeometrySourceReader: also checks the values, so a silent wrong-document read cannot pass.
+        assertDistinctGeometries(index, "SORT sort_key | LIMIT " + LIMIT + " | KEEP location");
+        // BoundsReader, CentroidReader, BoundsAndCentroidReader.
+        assertRows(index, "SORT sort_key | LIMIT " + LIMIT + " | STATS extent = ST_EXTENT_AGG(location)", 1);
+        assertRows(index, "SORT sort_key | LIMIT " + LIMIT + " | STATS centroid = ST_CENTROID_AGG(location)", 1);
+        assertRows(index, "SORT sort_key | LIMIT " + LIMIT + " | STATS e = ST_EXTENT_AGG(location), c = ST_CENTROID_AGG(location)", 1);
+    }
+
+    private void assertRows(String index, String tail, int expectedRows) {
+        String query = "FROM " + index + " | " + tail;
+        List<List<Object>> values;
+        try (var resp = run(query)) {
+            values = getValuesList(resp.values());
+        }
+        assertThat(query, values.size(), equalTo(expectedRows));
     }
 
     /**
-     * Runs every query and reports all of them, rather than stopping at the first, so a partial regression cannot hide behind an
-     * earlier failure.
+     * Every document carries a distinct geometry, so reading the wrong document shows up as a duplicate even when nothing throws --
+     * the silent manifestation of a backwards read, which is what happens on formats that address binary doc values randomly.
      */
-    private void assertQueriesSucceed(String index, String... tails) {
-        List<String> failures = new ArrayList<>();
-        for (String tail : tails) {
-            String query = "FROM " + index + " | " + tail;
-            try (var resp = run(query)) {
-                assertThat(resp.columns(), not(empty()));
-            } catch (Exception e) {
-                Throwable root = e;
-                while (root.getCause() != null) {
-                    root = root.getCause();
+    private void assertDistinctGeometries(String index, String tail) {
+        String query = "FROM " + index + " | " + tail;
+        List<List<Object>> values;
+        try (var resp = run(query)) {
+            values = getValuesList(resp.values());
+        }
+        assertThat(query, values.size(), equalTo(LIMIT));
+        Set<Object> distinct = new HashSet<>();
+        for (List<Object> row : values) {
+            distinct.add(row.getFirst());
+        }
+        assertThat(query + " returned a document's geometry more than once", distinct.size(), equalTo(LIMIT));
+    }
+
+    private void createShapeIndex(String index) throws Exception {
+        assertAcked(
+            prepareCreate(index).setSettings(
+                Settings.builder()
+                    .put("index.mode", "columnar")
+                    // See the class javadoc: the random index template would otherwise pin lucene_default.
+                    .put("index.codec", "default")
+                    .put("index.number_of_shards", 1)
+                    .build()
+            ).setMapping("""
+                {
+                  "properties" : {
+                    "location": { "type" : "shape" },
+                    "sort_key": { "type" : "long" }
+                  }
                 }
-                failures.add(tail + " -> " + root.getClass().getSimpleName() + ": " + root.getMessage());
-            }
-        }
-        assertThat("queries must not fail on a reused reader", failures, empty());
-    }
+                """)
+        );
 
-    private void createShapeIndex(String index, Settings.Builder settings) throws Exception {
-        assertAcked(prepareCreate(index).setSettings(settings.put("index.number_of_shards", 1).build()).setMapping("""
-            {
-              "properties" : {
-                "location": { "type" : "shape" },
-                "sort_key": { "type" : "long" }
-              }
-            }
-            """));
-
-        List<IndexRequest> batch = new ArrayList<>();
+        List<IndexRequestBuilder> docs = new ArrayList<>(NUM_DOCS);
         for (int i = 0; i < NUM_DOCS; i++) {
-            batch.add(new IndexRequest(index).id(Integer.toString(i)).source("location", polygon(i), "sort_key", scrambled(i)));
-            if (batch.size() == 500) {
-                indexBatch(batch);
-                batch = new ArrayList<>();
-            }
+            docs.add(prepareIndex(index).setId(Integer.toString(i)).setSource("location", polygon(i), "sort_key", scrambled(i)));
         }
-        if (batch.isEmpty() == false) {
-            indexBatch(batch);
-        }
-        // One segment, so the reader is retained across pages instead of being dropped at a segment boundary.
-        client().admin().indices().prepareForceMerge(index).setMaxNumSegments(1).get();
-        client().admin().indices().prepareRefresh(index).get();
-        ensureYellow(index);
-    }
+        // indexRandom asserts that no document failed to index; a mapping rejection would otherwise leave an empty index on which
+        // every query below trivially passes.
+        indexRandom(true, false, docs);
+        assertHitCount(prepareSearch(index).setSize(0), NUM_DOCS);
 
-    private void indexBatch(List<IndexRequest> batch) {
-        BulkRequestBuilder bulk = client().prepareBulk();
-        batch.forEach(bulk::add);
-        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.NONE).get();
+        // Asserts no shard failed and that each shard really ended up with a single segment.
+        forceMerge(true);
     }
 
     /** Uncorrelated with the document id, so sorting on it genuinely shuffles documents across pages. */
@@ -129,8 +152,9 @@ public class ShapeBackwardsReadIT extends AbstractEsqlIntegTestCase {
         return (i * 2654435761L) % 1000003L;
     }
 
+    /** A regular {@link #VERTICES}-gon whose centre is unique per document, so no two documents share a geometry. */
     private static String polygon(int i) {
-        double cx = i % 100;
+        double cx = (i % 100) + (i / 100) * 0.001;
         double cy = i % 50;
         double r = 0.4;
         StringBuilder sb = new StringBuilder("POLYGON((");
@@ -139,7 +163,7 @@ public class ShapeBackwardsReadIT extends AbstractEsqlIntegTestCase {
             if (v > 0) {
                 sb.append(", ");
             }
-            sb.append(String.format(Locale.ROOT, "%.6f %.6f", cx + r * Math.cos(angle), cy + r * Math.sin(angle)));
+            sb.append(cx + r * Math.cos(angle)).append(' ').append(cy + r * Math.sin(angle));
         }
         return sb.append("))").toString();
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoader.java
@@ -44,10 +44,16 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
     }
 
     private static class GeometrySourceReader implements BlockLoader.ColumnAtATimeReader {
+        /**
+         * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+         */
         private final BinaryDocValues docValues;
+        private final Thread creationThread;
+        private int docId = -1;
 
         GeometrySourceReader(BinaryDocValues docValues) {
             this.docValues = docValues;
+            this.creationThread = Thread.currentThread();
         }
 
         @Override
@@ -62,6 +68,8 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
         }
 
         private void read(int doc, BlockLoader.BytesRefBuilder builder) throws IOException {
+            assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
+            docId = doc;
             if (docValues.advanceExact(doc) == false) {
                 builder.appendNull();
                 return;
@@ -80,7 +88,7 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
 
         @Override
         public boolean canReuse(int startingDocID) {
-            return true;
+            return creationThread == Thread.currentThread() && docId <= startingDocID;
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoader.java
@@ -40,20 +40,23 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
         if (docValues == null) {
             return ConstantNull.COLUMN_READER;
         }
-        return new GeometrySourceReader(docValues);
+        return new GeometrySourceReader(breaker, docValues);
     }
 
-    private static class GeometrySourceReader implements BlockLoader.ColumnAtATimeReader {
+    private static class GeometrySourceReader extends BlockDocValuesReader {
         /**
-         * Forward-only iterator, so it is what makes this reader unable to revisit a document. See {@link #canReuse}.
+         * Forward-only, so this reader cannot revisit a document. See {@link #canReuse}.
          */
         private final BinaryDocValues docValues;
-        private final Thread creationThread;
-        private int docId = -1;
 
-        GeometrySourceReader(BinaryDocValues docValues) {
+        GeometrySourceReader(CircuitBreaker breaker, BinaryDocValues docValues) {
+            super(breaker);
             this.docValues = docValues;
-            this.creationThread = Thread.currentThread();
+        }
+
+        @Override
+        protected int docId() {
+            return docValues.docID();
         }
 
         @Override
@@ -68,8 +71,7 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
         }
 
         private void read(int doc, BlockLoader.BytesRefBuilder builder) throws IOException {
-            assert doc >= docId : "docs must be read in order, got [" + doc + "] after [" + docId + "]";
-            docId = doc;
+            assert doc >= docId() : "docs must be read in order, got [" + doc + "] after [" + docId() + "]";
             if (docValues.advanceExact(doc) == false) {
                 builder.appendNull();
                 return;
@@ -84,11 +86,6 @@ public class GeometrySourceBlockLoader extends BlockDocValuesReader.DocValuesBlo
                 builder.appendBytesRef(wkb);
             }
             builder.endPositionEntry();
-        }
-
-        @Override
-        public boolean canReuse(int startingDocID) {
-            return creationThread == Thread.currentThread() && docId <= startingDocID;
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoaderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeometrySourceBlockLoaderTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.TestBlock;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class GeometrySourceBlockLoaderTests extends ESTestCase {
+
+    /**
+     * The reader wraps a forward-only binary doc values iterator, so {@code canReuse} has to track the last document read. Reporting
+     * {@code true} for an earlier document lets {@code ValuesSourceReaderOperator} hand a retained reader a document it has already
+     * passed, which resolves against whichever binary doc values block is still loaded.
+     */
+    public void testCanReuseTracksLastReadDoc() throws IOException {
+        String field = GeometrySourceDocValuesField.fieldName("location");
+        var loader = new GeometrySourceBlockLoader(field);
+        try (Directory directory = newDirectory()) {
+            try (var iw = new IndexWriter(directory, new IndexWriterConfig(null /* analyzer */))) {
+                for (int i = 0; i < 5; i++) {
+                    var dv = new GeometrySourceDocValuesField(field);
+                    dv.add(new Point(i, i + 1));
+                    var doc = new Document();
+                    doc.add(dv);
+                    iw.addDocument(doc);
+                }
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                var leaf = getOnlyLeafReader(reader).getContext();
+                CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
+                try (BlockLoader.ColumnAtATimeReader allReader = loader.reader(breaker, leaf)) {
+                    allReader.read(TestBlock.factory(), TestBlock.docs(3), 0, false).close();
+
+                    assertFalse("must not be reused for an earlier doc", allReader.canReuse(2));
+                    assertTrue("may be reused for the doc it just read", allReader.canReuse(3));
+                    assertTrue("may be reused for a later doc", allReader.canReuse(4));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Four `shape` block loader readers return `true` from `canReuse` unconditionally while holding a forward only binary doc values iterator. `canReuse` is the only thing stopping `ValuesSourceReaderOperator` from handing a cached reader a document it has already passed, so after a `SORT` the decoder resolves an earlier document against the block it still has loaded and the block relative index goes negative.

| Reader | Location |
|---|---|
| `BoundsReader` | `AbstractShapeGeometryFieldMapper.java:136` |
| `CentroidReader` | `AbstractShapeGeometryFieldMapper.java:221` |
| `BoundsAndCentroidReader` | `AbstractShapeGeometryFieldMapper.java:327` |
| `GeometrySourceReader` | `GeometrySourceBlockLoader.java:82` |

`FROM index | SORT sort_key | LIMIT 5000 | KEEP location` on a `columnar` index with a `shape` field, with enough documents to span several binary blocks:

```
java.lang.ArrayIndexOutOfBoundsException: Index -5816 out of bounds for length 530
	at AbstractTSDBDocValuesProducer$BinaryDecoder.decode(AbstractTSDBDocValuesProducer.java:736)
	at GeometrySourceBlockLoader$GeometrySourceReader.read(GeometrySourceBlockLoader.java:69)
	at ValuesFromManyReader$ForwardSequenceRun.loadForwardSequence(ValuesFromManyReader.java:159)
	at Driver.runSingleLoopIteration(Driver.java:335)
```

Scope: the same query without `SORT` passes. `ST_EXTENT_AGG` and `ST_CENTROID_AGG` after a `SORT` fail the same
way. `geo_shape` is safe, since `PerFieldFormatSupplier` keeps it off the TSDB doc values format. It fails the query rather than returning wrong values, because a backwards read inside the loaded block still resolves correctly.

### Fix

All four extend `BlockDocValuesReader`, which already declares this check `final`. That drops four hand written copies and their `creationThread`, `docId` and `breaker` fields, and forces the `toString()` three of them were missing. 21 other readers already extend it. #157798 had to hand write the check because `IgnoredSourceRowStrideReader` needs a conditional answer a `final` method cannot give, which does not apply here.

### Tests

One integration test with a query per affected reader, plus contract tests for all four. I ran each against the unfixed code to confirm it fails there.

`ESIntegTestCase` puts `index.codec: lucene_default` on its random index template, which never selects the TSDB doc values format. That is why no existing test caught this, and why the new test pins `index.codec`. It also pins `page_size`, since `randomPragmas` can exceed the `LIMIT` and collapse the TopN result into one page. Before pinning, the test passed against unfixed code in about one run in four.

### Backport

`canReuse` was correct in #118802, where the iterator was built inside every `read()` call. #140034 moved it into a field and the check was carried over unchanged, so the range should follow #140034 rather than the age of the readers. #157798 went to 9.5 and 9.4.
