### PR TITLE
[ESQL] [Data federation] Clarify that datasets should use a single file format (and ideally schema)

### DIFF
--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -22,7 +22,7 @@ Federated data sources can read the following file formats:
 :::{include} _snippets/data-federation/supported-file-formats.md
 :::
 
-The format is detected automatically from the file extension. You can override this in the [dataset settings](#common-settings).
+Datasets must be scoped to a single file format. Most buckets contain a mix of file types, so use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
 
 ### Text formats
 

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -22,7 +22,7 @@ Federated data sources can read the following file formats:
 :::{include} _snippets/data-federation/supported-file-formats.md
 :::
 
-Datasets must be scoped to a single file format. Most buckets contain a mix of file types, so use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
+Datasets must be scoped to a single file format. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
 
 ### Text formats
 

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -24,6 +24,10 @@ Federated data sources can read the following file formats:
 
 Datasets must be scoped to a single file format. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
 
+:::{important}
+When set, the `format` setting forces every file the resource pattern matches through the same reader, regardless of file extension. If the pattern matches files of a different format, this can lead to errors or, worse, returning garbled data without error.
+:::
+
 ### Text formats
 
 The following text formats are recognized by file extension:

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -22,7 +22,9 @@ Federated data sources can read the following file formats:
 :::{include} _snippets/data-federation/supported-file-formats.md
 :::
 
-Datasets should be scoped to a single file format. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
+Datasets should be scoped to a single file format. The format is detected from each file's extension, or you can set it explicitly with the [`format`](#common-settings) setting. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`.
+
+If you need to query files of different formats from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
 
 :::{important}
 When set, the `format` setting forces every file the resource pattern matches through the same reader, regardless of file extension. If the pattern matches files of a different format, this can lead to errors or, worse, returning garbled data without error.

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -22,7 +22,7 @@ Federated data sources can read the following file formats:
 :::{include} _snippets/data-federation/supported-file-formats.md
 :::
 
-Datasets must be scoped to a single file format. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
+Datasets should be scoped to a single file format. If your bucket contains a mix of file types, use the [resource pattern](esql-data-federation-patterns.md) to narrow the dataset to one, for example `**/*.parquet`. If you need to query both CSV and Parquet files from the same bucket, create a separate dataset for each. Ideally, all files in a dataset also share the same schema. When they differ, the [`schema_resolution`](#schema-merge-strategies) setting controls how differences are reconciled.
 
 :::{important}
 When set, the `format` setting forces every file the resource pattern matches through the same reader, regardless of file extension. If the pattern matches files of a different format, this can lead to errors or, worse, returning garbled data without error.

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -426,7 +426,9 @@ Because federated data does not live in {{es}}, the system discovers schemas bef
 When a dataset spans multiple files, the files might have different schemas. Set `schema_resolution` in the dataset's `settings` object to choose a strategy:
 
 - `union_by_name` (default): Merges schemas from all files by column name. Columns that exist in some files but not others are filled with nulls. Types are widened where possible: when two files define the same column with incompatible types, the column type defaults to `keyword`. If you want type conflicts to produce an error, use `strict` instead. This is safer when files can vary, at the cost of reading and merging more file metadata.
-- `first_file_wins`: After files are discovered, they are ordered and the schema is taken from **the first file in that order**. Later files are assumed to match. This is typically faster, but schema differences in later files can cause query errors or values to be read under the wrong assumptions. Use [`file_sort_by`](#first-file-wins-file-order) and [`file_order`](#first-file-wins-file-order) to choose that first file. Those settings are rejected on `union_by_name` and `strict`.
+- `first_file_wins`: After files are discovered, they are ordered and the schema is taken from **the first file in that order**. Later files are assumed to match. This is typically faster, but schema differences in later files can cause query errors or values to be read under the wrong assumptions.
+Use [`file_sort_by`](#first-file-wins-file-order) and [`file_order`](#first-file-wins-file-order) to choose that first file. {applies_to}`stack: experimental 9.6+`
+Those settings are rejected on `union_by_name` and `strict`.
 - `strict`: Requires every file to have the same schema, apart from nullability, and returns an error when they differ. Use this when schema drift must fail explicitly.
 
 ### First-file-wins file order

--- a/docs/reference/query-languages/esql/esql-data-federation-datasets.md
+++ b/docs/reference/query-languages/esql/esql-data-federation-datasets.md
@@ -423,7 +423,7 @@ Because federated data does not live in {{es}}, the system discovers schemas bef
 
 When a dataset spans multiple files, the files might have different schemas. Set `schema_resolution` in the dataset's `settings` object to choose a strategy:
 
-- `union_by_name` (default): Merges schemas from all files by column name. Types are widened where possible: when two files disagree with no common type, the column falls back to `keyword` and the response carries a warning suggesting `strict` if you want the conflict to fail instead. `union_by_name` never fails on a type conflict. This is safer when files can vary, at the cost of reading and merging more file metadata.
+- `union_by_name` (default): Merges schemas from all files by column name. Columns that exist in some files but not others are filled with nulls. Types are widened where possible: when two files define the same column with incompatible types, the column type defaults to `keyword`. If you want type conflicts to produce an error, use `strict` instead. This is safer when files can vary, at the cost of reading and merging more file metadata.
 - `first_file_wins`: After files are discovered, they are ordered and the schema is taken from **the first file in that order**. Later files are assumed to match. This is typically faster, but schema differences in later files can cause query errors or values to be read under the wrong assumptions. Use [`file_sort_by`](#first-file-wins-file-order) and [`file_order`](#first-file-wins-file-order) to choose that first file. Those settings are rejected on `union_by_name` and `strict`.
 - `strict`: Requires every file to have the same schema, apart from nullability, and returns an error when they differ. Use this when schema drift must fail explicitly.
 

--- a/docs/reference/query-languages/esql/esql-data-federation.md
+++ b/docs/reference/query-languages/esql/esql-data-federation.md
@@ -68,7 +68,7 @@ A [data source](esql-data-federation-sources.md) tells {{es}} where the storage 
 ::::::
 
 ::::::{step} You create datasets (what to read)
-Each [dataset](esql-data-federation-datasets.md) points at specific files in that storage and makes them queryable. Datasets must be scoped to a single [file format](esql-data-federation-datasets.md#supported-file-formats) and ideally share one schema. One data source can serve many datasets.
+Each [dataset](esql-data-federation-datasets.md) points at specific files in that storage and makes them queryable. Datasets should be scoped to a single [file format](esql-data-federation-datasets.md#supported-file-formats) and ideally share one schema. One data source can serve many datasets.
 
 Datasets are designed to work like indices for queries. They share the same namespace as indices, data streams, aliases, and [{{esql}} views](esql-views.md), so a dataset cannot have the same name as any of them.
 ::::::

--- a/docs/reference/query-languages/esql/esql-data-federation.md
+++ b/docs/reference/query-languages/esql/esql-data-federation.md
@@ -68,7 +68,7 @@ A [data source](esql-data-federation-sources.md) tells {{es}} where the storage 
 ::::::
 
 ::::::{step} You create datasets (what to read)
-Each [dataset](esql-data-federation-datasets.md) points at specific files in that storage and makes them queryable. One data source can serve many datasets.
+Each [dataset](esql-data-federation-datasets.md) points at specific files in that storage and makes them queryable. Datasets must be scoped to a single [file format](esql-data-federation-datasets.md#supported-file-formats) and ideally share one schema. One data source can serve many datasets.
 
 Datasets are designed to work like indices for queries. They share the same namespace as indices, data streams, aliases, and [{{esql}} views](esql-views.md), so a dataset cannot have the same name as any of them.
 ::::::


### PR DESCRIPTION
Adds guidance that datasets must be scoped to a single file format. If a bucket contains both CSV and Parquet files, users should create a separate dataset for each.

**Changes:**
- **esql-data-federation-datasets.md**: Added the constraint in the "Supported file formats" section, before the auto-detection sentence.
- **esql-data-federation.md**: Added the same guidance in step 3 of "How it works", so it's surfaced early for readers going top-down.