### PR TITLE
Add OTLP metric exemplar ingestion

### DIFF
--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPIndexingRestIT.java
@@ -66,6 +66,7 @@ public abstract class AbstractOTLPIndexingRestIT extends ESRestTestCase {
     @Before
     public void waitForOtlpTemplates() throws Exception {
         assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/metrics-otel@template"))));
+        assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/exemplars-otel@template"))));
         assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/traces-otel@template"))));
         assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/logs-otel@template"))));
     }

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -10,16 +10,21 @@ package org.elasticsearch.xpack.oteldata.otlp;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoubleExemplarData;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
 import io.opentelemetry.sdk.metrics.data.HistogramData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoubleExemplarData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableExponentialHistogramPointData;
@@ -31,6 +36,7 @@ import io.opentelemetry.sdk.resources.Resource;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.junit.After;
 import org.junit.Before;
@@ -51,13 +57,17 @@ import static org.elasticsearch.xpack.oteldata.otlp.OTLPMetricsIndexingRestIT.Mo
 import static org.elasticsearch.xpack.oteldata.otlp.OTLPMetricsIndexingRestIT.Monotonicity.NON_MONOTONIC;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
+
+    private static final FeatureFlag METRIC_EXEMPLARS_FEATURE_FLAG = new FeatureFlag("metric_exemplars");
 
     private OtlpHttpMetricExporter exporter;
     private SdkMeterProvider meterProvider;
@@ -71,7 +81,7 @@ public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
     public void initMetricExporter() throws Exception {
         exporter = OtlpHttpMetricExporter.builder()
             .setEndpoint(getClusterHosts().getFirst().toURI() + "/_otlp/v1/metrics")
-            .addHeader("Authorization", "ApiKey " + createApiKey("metrics-*"))
+            .addHeader("Authorization", "ApiKey " + createApiKey("metrics-*", "exemplars-*"))
             .build();
         meterProvider = SdkMeterProvider.builder()
             .registerMetricReader(
@@ -192,6 +202,65 @@ public class OTLPMetricsIndexingRestIT extends AbstractOTLPIndexingRestIT {
         assertThat(evaluate(metrics, "long_gauge.type"), equalTo("long"));
         assertThat(evaluate(metrics, "long_gauge.meta.unit"), equalTo("By"));
         assertThat(evaluate(metrics, "long_gauge.time_series_metric"), equalTo("gauge"));
+    }
+
+    public void testExemplars() throws Exception {
+        assumeTrue("requires metric exemplar ingestion", METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled());
+        long dataPointTimestamp = Clock.getDefault().now();
+        long exemplarTimestamp = dataPointTimestamp - TimeUnit.MILLISECONDS.toNanos(1);
+        SpanContext spanContext = SpanContext.create(
+            "00112233445566778899aabbccddeeff",
+            "0011223344556677",
+            TraceFlags.getSampled(),
+            TraceState.getDefault()
+        );
+        DoubleExemplarData exemplar = ImmutableDoubleExemplarData.create(
+            Attributes.of(AttributeKey.longKey("thread.id"), 42L),
+            exemplarTimestamp,
+            spanContext,
+            0.42
+        );
+        MetricData metric = ImmutableMetricData.createDoubleGauge(
+            Resource.create(Attributes.of(stringKey("service.name"), "checkout-service")),
+            io.opentelemetry.sdk.common.InstrumentationScopeInfo.create("io.opentelemetry.http"),
+            "request.duration",
+            "",
+            "s",
+            ImmutableGaugeData.create(
+                List.of(
+                    ImmutableDoublePointData.create(
+                        dataPointTimestamp,
+                        dataPointTimestamp,
+                        Attributes.of(stringKey("route"), "/checkout"),
+                        1.0,
+                        List.of(exemplar, ImmutableDoubleExemplarData.create(Attributes.empty(), exemplarTimestamp, spanContext, 0.43))
+                    )
+                )
+            )
+        );
+
+        export(List.of(metric));
+        assertOK(client().performRequest(new Request("GET", "metrics-*,exemplars-*/_refresh")));
+
+        ObjectPath metricSearch = search("metrics-generic.otel-default");
+        ObjectPath exemplarSearch = search("exemplars-generic.otel-default");
+        assertThat(metricSearch.evaluate("hits.total.value"), equalTo(1));
+        assertThat(exemplarSearch.evaluate("hits.total.value"), equalTo(1));
+        Map<String, Object> metricSource = metricSearch.evaluate("hits.hits.0._source");
+        Map<String, Object> exemplarSource = exemplarSearch.evaluate("hits.hits.0._source");
+        assertThat(evaluate(exemplarSource, "data_stream.type"), equalTo("exemplars"));
+        assertThat(evaluate(exemplarSource, "resource.attributes.service\\.name"), equalTo("checkout-service"));
+        assertThat(evaluate(exemplarSource, "scope.name"), equalTo("io.opentelemetry.http"));
+        assertThat(evaluate(exemplarSource, "attributes.route"), equalTo("/checkout"));
+        assertThat(evaluate(exemplarSource, "filtered_attributes.thread\\.id"), equalTo(42));
+        assertThat(evaluate(exemplarSource, "trace_id"), equalTo("00112233445566778899aabbccddeeff"));
+        assertThat(evaluate(exemplarSource, "span_id"), equalTo("0011223344556677"));
+        assertThat(ObjectPath.<Number>evaluate(exemplarSource, "metrics.request\\.duration").doubleValue(), closeTo(0.42, 0.000001));
+        assertThat(evaluate(exemplarSource, "_metric_names_hash"), equalTo(evaluate(metricSource, "_metric_names_hash")));
+
+        Map<String, Object> exemplarMetrics = evaluate(getMapping("exemplars-generic.otel-default"), "properties.metrics.properties");
+        assertThat(evaluate(exemplarMetrics, "request\\.duration.type"), equalTo("double"));
+        assertThat(evaluate(exemplarMetrics, "request\\.duration.time_series_metric"), nullValue());
     }
 
     public void testCounterTemporality() throws Exception {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.index.IndexingPressure;
@@ -35,6 +36,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class OTelPlugin extends Plugin implements ActionPlugin {
+
+    public static final FeatureFlag METRIC_EXEMPLARS_FEATURE_FLAG = new FeatureFlag("metric_exemplars");
 
     // OTEL_DATA_REGISTRY_ENABLED controls enabling the index template registry.
     //

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
@@ -72,7 +72,9 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
 
             ProcessingContext finalContext = context;
             bulkRequestBuilder.execute(listener.delegateFailure((delegate, bulkResponse) -> {
-                if (bulkResponse.hasFailures() || finalContext.getIgnoredItems() > 0) {
+                if (bulkResponse.hasFailures()
+                    || finalContext.getIgnoredItems() > 0
+                    || finalContext.getWarningMessage().isEmpty() == false) {
                     handlePartialSuccess(bulkResponse, finalContext, delegate);
                 } else {
                     delegate.onResponse(new OTLPActionResponse(BytesArray.EMPTY));
@@ -118,6 +120,13 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
         }
 
         default String getIgnoredItemsMessage(int limit) {
+            return "";
+        }
+
+        /**
+         * Returns a warning that should produce a partial-success response without increasing the rejected-item count.
+         */
+        default String getWarningMessage() {
             return "";
         }
 
@@ -192,6 +201,7 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
             }
         }
         failureMessageBuilder.append(context.getIgnoredItemsMessage(10));
+        failureMessageBuilder.append(context.getWarningMessage());
         String message = failureMessageBuilder.toString();
         if (status == RestStatus.TOO_MANY_REQUESTS) {
             listener.onFailure(new ElasticsearchStatusException(message, RestStatus.TOO_MANY_REQUESTS));

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.oteldata.otlp;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsPartialSuccess;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionType;
@@ -34,14 +35,20 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.oteldata.OTelPlugin;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.ExemplarDocumentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Transport action for handling OpenTelemetry Protocol (OTLP) Metrics requests.
@@ -88,11 +95,26 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
             return context;
         }
         MetricDocumentBuilder metricDocumentBuilder = new MetricDocumentBuilder(byteStringAccessor, defaultMappingHints);
+        ExemplarDocumentBuilder exemplarDocumentBuilder = OTelPlugin.METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled()
+            ? new ExemplarDocumentBuilder(byteStringAccessor)
+            : null;
+        Set<ExemplarIdentity> exemplarIdentities = new HashSet<>();
         ProjectMetadata projectMetadata = clusterService.state().projectState(ProjectId.DEFAULT).metadata();
         Map<String, IndexVersion> indexVersions = new HashMap<>();
-        context.consume(
-            dataPointGroup -> addIndexRequest(bulkRequestBuilder, metricDocumentBuilder, dataPointGroup, projectMetadata, indexVersions)
-        );
+        context.consume(dataPointGroup -> {
+            addMetricIndexRequest(bulkRequestBuilder, metricDocumentBuilder, dataPointGroup, projectMetadata, indexVersions);
+            if (exemplarDocumentBuilder != null) {
+                addExemplarIndexRequests(
+                    bulkRequestBuilder,
+                    exemplarDocumentBuilder,
+                    dataPointGroup,
+                    context,
+                    projectMetadata,
+                    indexVersions,
+                    exemplarIdentities
+                );
+            }
+        });
         return context;
     }
 
@@ -120,7 +142,7 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
         return IndexVersion.current();
     }
 
-    private void addIndexRequest(
+    private void addMetricIndexRequest(
         BulkRequestBuilder bulkRequestBuilder,
         MetricDocumentBuilder metricDocumentBuilder,
         DataPointGroupingContext.DataPointGroup dataPointGroup,
@@ -152,4 +174,66 @@ public class OTLPMetricsTransportAction extends AbstractOTLPTransportAction {
             bulkRequestBuilder.add(indexRequest);
         }
     }
+
+    private void addExemplarIndexRequests(
+        BulkRequestBuilder bulkRequestBuilder,
+        ExemplarDocumentBuilder exemplarDocumentBuilder,
+        DataPointGroupingContext.DataPointGroup dataPointGroup,
+        DataPointGroupingContext context,
+        ProjectMetadata projectMetadata,
+        Map<String, IndexVersion> indexVersions,
+        Set<ExemplarIdentity> exemplarIdentities
+    ) throws IOException {
+        TargetIndex targetIndex = dataPointGroup.targetIndex().exemplarsTarget();
+        if (targetIndex == null) {
+            return;
+        }
+        for (DataPoint dataPoint : dataPointGroup.dataPoints()) {
+            for (var exemplar : dataPoint.getExemplars()) {
+                if (exemplar.getValueCase() == Exemplar.ValueCase.VALUE_NOT_SET) {
+                    continue;
+                }
+                try (XContentBuilder xContentBuilder = XContentFactory.cborBuilder(new BytesStreamOutput())) {
+                    Map<String, String> dynamicTemplates = new HashMap<>();
+                    Map<String, Map<String, String>> dynamicTemplateParams = new HashMap<>();
+                    String dataStreamName = targetIndex.index();
+                    IndexVersion indexVersion = indexVersions.computeIfAbsent(
+                        dataStreamName,
+                        name -> resolveIndexVersion(projectMetadata, name)
+                    );
+                    BytesRef tsid = exemplarDocumentBuilder.buildExemplarDocument(
+                        xContentBuilder,
+                        dataPointGroup,
+                        dataPoint,
+                        exemplar,
+                        targetIndex,
+                        dynamicTemplates,
+                        dynamicTemplateParams,
+                        indexVersion
+                    );
+                    ExemplarIdentity identity = new ExemplarIdentity(
+                        targetIndex.index(),
+                        tsid,
+                        TimeUnit.NANOSECONDS.toMillis(exemplar.getTimeUnixNano())
+                    );
+                    if (exemplarIdentities.add(identity) == false) {
+                        context.recordDuplicateExemplar();
+                        continue;
+                    }
+                    var indexRequest = new IndexRequest(targetIndex.index()).opType(DocWriteRequest.OpType.CREATE)
+                        .setRequireDataStream(true)
+                        .source(xContentBuilder)
+                        .setIncludeSourceOnError(false)
+                        .setDynamicTemplates(dynamicTemplates)
+                        .setDynamicTemplateParams(dynamicTemplateParams);
+                    if (indexVersion.onOrAfter(IndexVersions.TSID_SINGLE_PREFIX_BYTE_FEATURE_FLAG)) {
+                        indexRequest.tsid(tsid);
+                    }
+                    bulkRequestBuilder.add(indexRequest);
+                }
+            }
+        }
+    }
+
+    private record ExemplarIdentity(String index, BytesRef tsid, long timestamp) {}
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPoint.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPoint.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.oteldata.otlp.datapoint;
 
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
@@ -61,6 +62,13 @@ public interface DataPoint {
      * @return a list of key-value pairs representing the attributes
      */
     List<KeyValue> getAttributes();
+
+    /**
+     * Returns the exemplars associated with the data point.
+     */
+    default List<Exemplar> getExemplars() {
+        return List.of();
+    }
 
     /**
      * Returns the unit of measurement for the data point.
@@ -133,6 +141,11 @@ public interface DataPoint {
         @Override
         public List<KeyValue> getAttributes() {
             return dataPoint.getAttributesList();
+        }
+
+        @Override
+        public List<Exemplar> getExemplars() {
+            return dataPoint.getExemplarsList();
         }
 
         @Override
@@ -219,6 +232,11 @@ public interface DataPoint {
         @Override
         public List<KeyValue> getAttributes() {
             return dataPoint.getAttributesList();
+        }
+
+        @Override
+        public List<Exemplar> getExemplars() {
+            return dataPoint.getExemplarsList();
         }
 
         @Override
@@ -311,6 +329,11 @@ public interface DataPoint {
         @Override
         public List<KeyValue> getAttributes() {
             return dataPoint.getAttributesList();
+        }
+
+        @Override
+        public List<Exemplar> getExemplars() {
+            return dataPoint.getExemplarsList();
         }
 
         @Override

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
@@ -18,11 +18,13 @@ import io.opentelemetry.proto.resource.v1.Resource;
 
 import com.google.protobuf.ByteString;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
 import org.elasticsearch.common.hash.MurmurHash3.Hash128;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.xpack.oteldata.otlp.AbstractOTLPTransportAction;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
@@ -48,6 +50,7 @@ public class DataPointGroupingContext implements AbstractOTLPTransportAction.Pro
 
     private int totalDataPoints = 0;
     private int ignoredDataPoints = 0;
+    private int duplicateExemplars = 0;
 
     public DataPointGroupingContext(BufferedByteStringAccessor byteStringAccessor, MappingHints defaultMappingHints) {
         this.byteStringAccessor = byteStringAccessor;
@@ -143,6 +146,19 @@ public class DataPointGroupingContext implements AbstractOTLPTransportAction.Pro
             }
         }
         return sb.toString();
+    }
+
+    /** Records an exemplar dropped without rejecting its parent data point. */
+    public void recordDuplicateExemplar() {
+        duplicateExemplars++;
+    }
+
+    @Override
+    public String getWarningMessage() {
+        if (duplicateExemplars == 0) {
+            return "";
+        }
+        return duplicateExemplars + " exemplars were dropped due to duplicate timestamps";
     }
 
     private ResourceGroup getOrCreateResourceGroup(ResourceMetrics resourceMetrics) {
@@ -287,7 +303,9 @@ public class DataPointGroupingContext implements AbstractOTLPTransportAction.Pro
         private final Set<String> metricNames = new HashSet<>();
         private final List<DataPoint> dataPoints = new ArrayList<>();
         private final TargetIndex targetIndex;
+        private final Map<String, TsidBuilder> tsidBuildersByMetricNamesHash = new HashMap<>();
         private String metricNamesHash;
+        private boolean buildTsidCalled = false;
 
         public DataPointGroup(
             Resource resource,
@@ -330,7 +348,29 @@ public class DataPointGroupingContext implements AbstractOTLPTransportAction.Pro
             return metricNamesHash;
         }
 
+        /**
+         * Computes the metric names hash for a single metric.
+         */
+        public String getMetricNameHash(BufferedMurmur3Hasher hasher, String metricName) {
+            hasher.reset();
+            hasher.addString(metricName);
+            return Integer.toHexString(hasher.digestHash().hashCode());
+        }
+
+        /**
+         * Builds a TSID using the supplied metric names hash in addition to the shared data point dimensions.
+         */
+        public BytesRef buildTsid(String metricNamesHash, IndexVersion indexVersion) {
+            buildTsidCalled = true;
+            TsidBuilder finalTsidBuilder = tsidBuildersByMetricNamesHash.computeIfAbsent(
+                metricNamesHash,
+                hash -> new TsidBuilder(tsidBuilder.size() + 1).addAll(tsidBuilder).addStringDimension("_metric_names_hash", hash)
+            );
+            return finalTsidBuilder.buildTsid(indexVersion);
+        }
+
         public boolean addDataPoint(Set<String> ignoredDataPointMessages, DataPoint dataPoint) {
+            assert buildTsidCalled == false : "cannot add a data point after a TSID has been built";
             metricNamesHash = null; // reset the hash when adding a new data point
             if (metricNames.add(dataPoint.getMetricName()) == false) {
                 ignoredDataPointMessages.add(
@@ -357,10 +397,6 @@ public class DataPointGroupingContext implements AbstractOTLPTransportAction.Pro
 
         public ByteString scopeSchemaUrl() {
             return scopeSchemaUrl;
-        }
-
-        public TsidBuilder tsidBuilder() {
-            return tsidBuilder;
         }
 
         public List<KeyValue> dataPointAttributes() {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
@@ -24,6 +24,7 @@ public final class TargetIndex {
 
     public static final String TYPE_LOGS = "logs";
     public static final String TYPE_METRICS = "metrics";
+    public static final String TYPE_EXEMPLARS = "exemplars";
 
     private static final String RECEIVER = "/receiver/";
     private static final String CONNECTOR = "/connector/";
@@ -54,6 +55,22 @@ public final class TargetIndex {
 
     public static TargetIndex defaultMetrics() {
         return DEFAULT_METRICS_TARGET;
+    }
+
+    /**
+     * Returns the exemplar data stream corresponding to this metrics data stream.
+     * Explicit non-data-stream targets do not have an automatically derived exemplar target.
+     */
+    public @Nullable TargetIndex exemplarsTarget() {
+        if (TYPE_METRICS.equals(type) == false) {
+            return null;
+        }
+        TargetIndex target = new TargetIndex();
+        target.type = TYPE_EXEMPLARS;
+        target.dataset = dataset;
+        target.namespace = namespace;
+        target.index = TYPE_EXEMPLARS + index.substring(TYPE_METRICS.length());
+        return target;
     }
 
     public static boolean isTargetIndexAttribute(String attributeKey) {

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/ExemplarDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/ExemplarDocumentBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
+import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Keeps exemplar observations independently queryable while preserving the dimensions of their parent metric series.
+ */
+public class ExemplarDocumentBuilder extends OtelTsdbDocumentBuilder {
+
+    public ExemplarDocumentBuilder(BufferedByteStringAccessor byteStringAccessor) {
+        super(byteStringAccessor);
+    }
+
+    /**
+     * Builds one exemplar document and returns the TSID shared with its grouped parent metric document.
+     */
+    public BytesRef buildExemplarDocument(
+        XContentBuilder builder,
+        DataPointGroupingContext.DataPointGroup dataPointGroup,
+        DataPoint dataPoint,
+        Exemplar exemplar,
+        TargetIndex targetIndex,
+        Map<String, String> dynamicTemplates,
+        Map<String, Map<String, String>> dynamicTemplateParams,
+        IndexVersion indexVersion
+    ) throws IOException {
+        builder.startObject();
+        builder.field("@timestamp", TimeUnit.NANOSECONDS.toMillis(exemplar.getTimeUnixNano()));
+        String metricNameHash = dataPointGroup.getMetricNameHash(hasher, dataPoint.getMetricName());
+        buildDimensionFields(builder, dataPointGroup, targetIndex, metricNameHash);
+        buildFilteredAttributes(builder, exemplar.getFilteredAttributesList());
+        addHexFieldIfNotEmpty(builder, "trace_id", exemplar.getTraceId());
+        addHexFieldIfNotEmpty(builder, "span_id", exemplar.getSpanId());
+
+        String metricFieldPath = "metrics." + dataPoint.getMetricName();
+        builder.startObject("metrics");
+        builder.field(dataPoint.getMetricName());
+        switch (exemplar.getValueCase()) {
+            case AS_DOUBLE -> {
+                builder.value(exemplar.getAsDouble());
+                dynamicTemplates.put(metricFieldPath, "exemplar_value_double");
+            }
+            case AS_INT -> {
+                builder.value(exemplar.getAsInt());
+                dynamicTemplates.put(metricFieldPath, "exemplar_value_long");
+            }
+            case VALUE_NOT_SET -> throw new IllegalArgumentException("exemplar has no value");
+        }
+        builder.endObject();
+        if (Strings.hasLength(dataPointGroup.unit())) {
+            dynamicTemplateParams.put(metricFieldPath, Map.of(UNIT_FIELD, dataPointGroup.unit()));
+        }
+        builder.endObject();
+
+        return buildTsid(dataPointGroup, metricNameHash, indexVersion);
+    }
+
+    private void buildFilteredAttributes(XContentBuilder builder, List<KeyValue> filteredAttributes) throws IOException {
+        if (filteredAttributes.isEmpty()) {
+            return;
+        }
+        builder.startObject("filtered_attributes");
+        for (int i = 0; i < filteredAttributes.size(); i++) {
+            KeyValue attribute = filteredAttributes.get(i);
+            builder.field(attribute.getKey());
+            buildAnyValue(builder, attribute.getValue());
+        }
+        builder.endObject();
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -7,13 +7,7 @@
 
 package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
 
-import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
-
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.cluster.routing.TsidBuilder;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
@@ -30,12 +24,8 @@ import java.util.concurrent.TimeUnit;
  * This class constructs an Elasticsearch document representation of a metric data point group.
  * It also handles dynamic templates for metrics based on their attributes.
  */
-public class MetricDocumentBuilder extends OTelDocumentBuilder {
+public class MetricDocumentBuilder extends OtelTsdbDocumentBuilder {
 
-    public static final String UNIT_FIELD = "unit";
-    public static final String TEMPORALITY_FIELD = "temporality";
-
-    private final BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
     private final MappingHints defaultMappingHints;
     private final ExponentialHistogramConverter.BucketBuffer scratch = new ExponentialHistogramConverter.BucketBuffer();
 
@@ -57,22 +47,8 @@ public class MetricDocumentBuilder extends OTelDocumentBuilder {
         if (dataPointGroup.getStartTimestampUnixNano() != 0) {
             builder.field("start_timestamp", TimeUnit.NANOSECONDS.toMillis(dataPointGroup.getStartTimestampUnixNano()));
         }
-        // Metrics intentionally skip merging paired *.geo.location.lat/.lon into a [lon, lat] array:
-        // The *.geo.location dynamic template doesn't apply to metrics because geo_point isn't a supported dimension type.
-        // That would mean the merged value would land as a plain [lon, lat] array with no guaranteed element order.
-        buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
-        buildDataStream(builder, dataPointGroup.targetIndex());
-        buildScope(builder, dataPointGroup.scope(), dataPointGroup.scopeSchemaUrl());
-        buildAttributes(builder, dataPointGroup.dataPointAttributes(), 0);
-        if (Strings.hasLength(dataPointGroup.unit())) {
-            builder.field(UNIT_FIELD, dataPointGroup.unit());
-        }
-        String temporality = temporalityToString(dataPointGroup.temporality());
-        if (temporality != null) {
-            builder.field(TEMPORALITY_FIELD, temporality);
-        }
         String metricNamesHash = dataPointGroup.getMetricNamesHash(hasher);
-        builder.field("_metric_names_hash", metricNamesHash);
+        buildDimensionFields(builder, dataPointGroup, dataPointGroup.targetIndex(), metricNamesHash);
 
         long docCount = 0;
         builder.startObject("metrics");
@@ -99,23 +75,7 @@ public class MetricDocumentBuilder extends OTelDocumentBuilder {
             builder.field("_doc_count", docCount);
         }
         builder.endObject();
-        TsidBuilder tsidBuilder = dataPointGroup.tsidBuilder();
-        tsidBuilder.addStringDimension("_metric_names_hash", metricNamesHash);
-        return tsidBuilder.buildTsid(indexVersion);
-    }
-
-    /**
-     * Converts an {@link AggregationTemporality} to the string value stored in the temporality dimension field.
-     */
-    public static @Nullable String temporalityToString(@Nullable AggregationTemporality temporality) {
-        if (temporality == null) {
-            return null;
-        }
-        return switch (temporality) {
-            case AGGREGATION_TEMPORALITY_CUMULATIVE -> "cumulative";
-            case AGGREGATION_TEMPORALITY_DELTA -> "delta";
-            default -> null;
-        };
+        return buildTsid(dataPointGroup, metricNamesHash, indexVersion);
     }
 
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OtelTsdbDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/OtelTsdbDocumentBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.TargetIndex;
+import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
+
+import java.io.IOException;
+
+/**
+ * Keeps the shared dimension fields and TSID construction identical for metric and exemplar documents.
+ */
+public abstract class OtelTsdbDocumentBuilder extends OTelDocumentBuilder {
+
+    public static final String UNIT_FIELD = "unit";
+    public static final String TEMPORALITY_FIELD = "temporality";
+
+    protected final BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
+
+    protected OtelTsdbDocumentBuilder(BufferedByteStringAccessor byteStringAccessor) {
+        super(byteStringAccessor);
+    }
+
+    protected void buildDimensionFields(
+        XContentBuilder builder,
+        DataPointGroupingContext.DataPointGroup dataPointGroup,
+        TargetIndex targetIndex,
+        String metricNamesHash
+    ) throws IOException {
+        // Metric dimensions intentionally skip merging paired *.geo.location.lat/.lon into a [lon, lat] array:
+        // The *.geo.location dynamic template doesn't apply because geo_point isn't a supported dimension type.
+        // That would mean the merged value would land as a plain [lon, lat] array with no guaranteed element order.
+        buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
+        buildDataStream(builder, targetIndex);
+        buildScope(builder, dataPointGroup.scope(), dataPointGroup.scopeSchemaUrl());
+        buildAttributes(builder, dataPointGroup.dataPointAttributes(), 0);
+        if (Strings.hasLength(dataPointGroup.unit())) {
+            builder.field(UNIT_FIELD, dataPointGroup.unit());
+        }
+        String temporality = temporalityToString(dataPointGroup.temporality());
+        if (temporality != null) {
+            builder.field(TEMPORALITY_FIELD, temporality);
+        }
+        builder.field("_metric_names_hash", metricNamesHash);
+    }
+
+    protected BytesRef buildTsid(
+        DataPointGroupingContext.DataPointGroup dataPointGroup,
+        String metricNamesHash,
+        IndexVersion indexVersion
+    ) {
+        return dataPointGroup.buildTsid(metricNamesHash, indexVersion);
+    }
+
+    /**
+     * Converts an {@link AggregationTemporality} to the string value stored in the temporality dimension field.
+     */
+    public static @Nullable String temporalityToString(@Nullable AggregationTemporality temporality) {
+        if (temporality == null) {
+            return null;
+        }
+        return switch (temporality) {
+            case AGGREGATION_TEMPORALITY_CUMULATIVE -> "cumulative";
+            case AGGREGATION_TEMPORALITY_DELTA -> "delta";
+            default -> null;
+        };
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/DataPointTsidFunnel.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/DataPointTsidFunnel.java
@@ -12,13 +12,13 @@ import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.cluster.routing.TsidBuilder.TsidFunnel;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
-import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilder;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.OtelTsdbDocumentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 public class DataPointTsidFunnel implements TsidFunnel<DataPoint> {
 
     // for "unit", "temporality", and "_metric_names_hash" that will be added in
-    // MetricDocumentBuilder once the data point group is complete
+    // DataPointGroup once the group is complete
     private static final int EXTRA_DIMENSIONS_SIZE = 3;
     private final BufferedByteStringAccessor byteStringAccessor;
 
@@ -35,10 +35,13 @@ public class DataPointTsidFunnel implements TsidFunnel<DataPoint> {
     @Override
     public void add(DataPoint dataPoint, TsidBuilder tsidBuilder) {
         tsidBuilder.add(dataPoint.getAttributes(), AttributeListTsidFunnel.get(byteStringAccessor, "attributes."));
-        tsidBuilder.addStringDimension(MetricDocumentBuilder.UNIT_FIELD, dataPoint.getUnit());
+        tsidBuilder.addStringDimension(OtelTsdbDocumentBuilder.UNIT_FIELD, dataPoint.getUnit());
         AggregationTemporality temporality = dataPoint.getTemporality();
         if (temporality != null) {
-            tsidBuilder.addStringDimension(MetricDocumentBuilder.TEMPORALITY_FIELD, MetricDocumentBuilder.temporalityToString(temporality));
+            tsidBuilder.addStringDimension(
+                OtelTsdbDocumentBuilder.TEMPORALITY_FIELD,
+                OtelTsdbDocumentBuilder.temporalityToString(temporality)
+            );
         }
     }
 }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
@@ -9,10 +9,15 @@ package org.elasticsearch.xpack.oteldata.otlp;
 
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
 import io.opentelemetry.proto.metrics.v1.Metric;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -34,6 +39,7 @@ import java.util.Set;
 
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +111,71 @@ public class OTLPMetricsTransportActionTests extends AbstractOTLPTransportAction
             Settings.builder().put(OTelPlugin.HISTOGRAM_FIELD_TYPE_SETTING.getKey(), "exponential_histogram").build()
         );
         assertThat(metricsAction.defaultMappingHints, equalTo(MappingHints.DEFAULT_EXPONENTIAL_HISTOGRAM));
+    }
+
+    public void testExemplarIngestionFollowsFeatureFlag() throws Exception {
+        Exemplar exemplar = OtlpUtils.createLongExemplar(1_000_000L, 42L);
+        Metric metric = OtlpUtils.createGaugeMetric(
+            "test.metric",
+            "ms",
+            List.of(OtlpUtils.createDoubleDataPoint(2_000_000L, 0, List.of(), List.of(exemplar)))
+        );
+        BulkRequestBuilder bulkRequestBuilder = new BulkRequestBuilder(client);
+
+        metricsAction.prepareBulkRequest(createMetricsRequest(metric), bulkRequestBuilder);
+
+        int expectedActions = OTelPlugin.METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled() ? 2 : 1;
+        var requests = bulkRequestBuilder.request().requests();
+        assertThat(requests, hasSize(expectedActions));
+        if (OTelPlugin.METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled()) {
+            IndexRequest exemplarRequest = (IndexRequest) requests.get(1);
+            assertThat(exemplarRequest.index(), equalTo("exemplars-generic.otel-default"));
+            assertThat(exemplarRequest.getDynamicTemplates(), equalTo(Map.of("metrics.test.metric", "exemplar_value_long")));
+            assertThat(exemplarRequest.getDynamicTemplateParams(), equalTo(Map.of("metrics.test.metric", Map.of("unit", "ms"))));
+        }
+    }
+
+    public void testDuplicateExemplarWarning() throws Exception {
+        assumeTrue("requires metric exemplar ingestion", OTelPlugin.METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled());
+        Exemplar exemplar = OtlpUtils.createLongExemplar(1_000_000L, 42L);
+        Metric metric = OtlpUtils.createGaugeMetric(
+            "test.metric",
+            "",
+            List.of(OtlpUtils.createDoubleDataPoint(2_000_000L, 0, List.of(), List.of(exemplar, exemplar)))
+        );
+
+        OTLPActionResponse response = executeRequest(
+            createMetricsRequest(metric),
+            new BulkResponse(new BulkItemResponse[] { successResponse(), successResponse() }, 0)
+        );
+
+        byte[] responseBytes = response.getResponse().array();
+        assertThat(parseRejectedCount(responseBytes), equalTo(0L));
+        assertThat(parseErrorMessage(responseBytes), equalTo("1 exemplars were dropped due to duplicate timestamps"));
+    }
+
+    public void testSameTimestampExemplarsForDifferentMetricsAreNotDuplicates() throws Exception {
+        assumeTrue("requires metric exemplar ingestion", OTelPlugin.METRIC_EXEMPLARS_FEATURE_FLAG.isEnabled());
+        Exemplar exemplar = OtlpUtils.createLongExemplar(1_000_000L, 42L);
+        Metric firstMetric = OtlpUtils.createGaugeMetric(
+            "first.metric",
+            "",
+            List.of(OtlpUtils.createDoubleDataPoint(2_000_000L, 0, List.of(), List.of(exemplar)))
+        );
+        Metric secondMetric = OtlpUtils.createGaugeMetric(
+            "second.metric",
+            "",
+            List.of(OtlpUtils.createDoubleDataPoint(2_000_000L, 0, List.of(), List.of(exemplar)))
+        );
+        BulkRequestBuilder bulkRequestBuilder = new BulkRequestBuilder(client);
+
+        metricsAction.prepareBulkRequest(createMetricsRequest(firstMetric, secondMetric), bulkRequestBuilder);
+
+        var requests = bulkRequestBuilder.request().requests();
+        assertThat(requests, hasSize(3));
+        IndexRequest firstExemplarRequest = (IndexRequest) requests.get(1);
+        IndexRequest secondExemplarRequest = (IndexRequest) requests.get(2);
+        assertNotEquals(firstExemplarRequest.tsid(), secondExemplarRequest.tsid());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OtlpUtils.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OtlpUtils.java
@@ -13,6 +13,7 @@ import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.common.v1.KeyValueList;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogram;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Gauge;
@@ -26,6 +27,8 @@ import io.opentelemetry.proto.metrics.v1.Sum;
 import io.opentelemetry.proto.metrics.v1.Summary;
 import io.opentelemetry.proto.metrics.v1.SummaryDataPoint;
 import io.opentelemetry.proto.resource.v1.Resource;
+
+import com.google.protobuf.ByteString;
 
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 
@@ -158,10 +161,20 @@ public class OtlpUtils {
     }
 
     public static NumberDataPoint createDoubleDataPoint(long timeUnixNano, long startTimeUnixNano, List<KeyValue> attributes) {
+        return createDoubleDataPoint(timeUnixNano, startTimeUnixNano, attributes, List.of());
+    }
+
+    public static NumberDataPoint createDoubleDataPoint(
+        long timeUnixNano,
+        long startTimeUnixNano,
+        List<KeyValue> attributes,
+        List<Exemplar> exemplars
+    ) {
         return NumberDataPoint.newBuilder()
             .setTimeUnixNano(timeUnixNano)
             .setStartTimeUnixNano(startTimeUnixNano)
             .addAllAttributes(attributes)
+            .addAllExemplars(exemplars)
             .setAsDouble(randomDouble())
             .build();
     }
@@ -171,12 +184,42 @@ public class OtlpUtils {
     }
 
     public static NumberDataPoint createLongDataPoint(long timeUnixNano, long startTimeUnixNano, List<KeyValue> attributes) {
+        return createLongDataPoint(timeUnixNano, startTimeUnixNano, attributes, List.of());
+    }
+
+    public static NumberDataPoint createLongDataPoint(
+        long timeUnixNano,
+        long startTimeUnixNano,
+        List<KeyValue> attributes,
+        List<Exemplar> exemplars
+    ) {
         return NumberDataPoint.newBuilder()
             .setTimeUnixNano(timeUnixNano)
             .setStartTimeUnixNano(startTimeUnixNano)
             .addAllAttributes(attributes)
+            .addAllExemplars(exemplars)
             .setAsInt(randomLong())
             .build();
+    }
+
+    public static Exemplar createDoubleExemplar(
+        long timeUnixNano,
+        double value,
+        List<KeyValue> filteredAttributes,
+        ByteString traceId,
+        ByteString spanId
+    ) {
+        return Exemplar.newBuilder()
+            .setTimeUnixNano(timeUnixNano)
+            .setAsDouble(value)
+            .addAllFilteredAttributes(filteredAttributes)
+            .setTraceId(traceId)
+            .setSpanId(spanId)
+            .build();
+    }
+
+    public static Exemplar createLongExemplar(long timeUnixNano, long value) {
+        return Exemplar.newBuilder().setTimeUnixNano(timeUnixNano).setAsInt(value).build();
     }
 
     public static NumberDataPoint createNoValueDataPoint(long timestamp) {

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndexTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndexTests.java
@@ -148,6 +148,29 @@ public class TargetIndexTests extends ESTestCase {
         assertThat(index.namespace(), equalTo("default"));
     }
 
+    public void testExemplarsTarget() {
+        TargetIndex metrics = TargetIndex.evaluate("metrics", List.of(), null, List.of(), List.of());
+
+        TargetIndex exemplars = metrics.exemplarsTarget();
+
+        assertThat(exemplars.index(), equalTo("exemplars-generic.otel-default"));
+        assertThat(exemplars.type(), equalTo("exemplars"));
+        assertThat(exemplars.dataset(), equalTo("generic.otel"));
+        assertThat(exemplars.namespace(), equalTo("default"));
+    }
+
+    public void testExplicitIndexHasNoExemplarsTarget() {
+        TargetIndex index = TargetIndex.evaluate(
+            "metrics",
+            List.of(createStringAttribute("elasticsearch.index", "custom-index")),
+            null,
+            List.of(),
+            List.of()
+        );
+
+        assertThat(index.exemplarsTarget(), nullValue());
+    }
+
     public void testDataStreamSanitization() {
         List<KeyValue> attributes = List.of(
             createStringAttribute("data_stream.dataset", "Some-Dataset"),

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/ExemplarDocumentBuilderTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/ExemplarDocumentBuilderTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
+import io.opentelemetry.proto.metrics.v1.Metric;
+
+import com.google.protobuf.ByteString;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.oteldata.otlp.OtlpUtils;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
+import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
+import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createDoubleDataPoint;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createDoubleExemplar;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createGaugeMetric;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createLongDataPoint;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.createLongExemplar;
+import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class ExemplarDocumentBuilderTests extends ESTestCase {
+
+    private static final IndexVersion INDEX_VERSION = IndexVersion.current();
+    private final BufferedByteStringAccessor byteStringAccessor = new BufferedByteStringAccessor();
+    private final ExemplarDocumentBuilder exemplarDocumentBuilder = new ExemplarDocumentBuilder(byteStringAccessor);
+
+    public void testBuildDoubleExemplarDocument() throws Exception {
+        String traceId = "00112233445566778899aabbccddeeff";
+        String spanId = "0011223344556677";
+        Exemplar exemplar = createDoubleExemplar(
+            1_234_567_890L,
+            0.42,
+            List.of(keyValue("thread.id", 42L)),
+            ByteString.copyFrom(HexFormat.of().parseHex(traceId)),
+            ByteString.copyFrom(HexFormat.of().parseHex(spanId))
+        );
+        Metric metric = createGaugeMetric(
+            "request.duration",
+            "s",
+            List.of(createDoubleDataPoint(2_000_000_000L, 1_000_000_000L, List.of(keyValue("route", "/checkout")), List.of(exemplar)))
+        );
+        DataPointGroupingContext.DataPointGroup group = group(metric);
+        DataPoint dataPoint = group.dataPoints().getFirst();
+        Map<String, String> dynamicTemplates = new HashMap<>();
+        Map<String, Map<String, String>> dynamicTemplateParams = new HashMap<>();
+
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
+            exemplarDocumentBuilder.buildExemplarDocument(
+                builder,
+                group,
+                dataPoint,
+                exemplar,
+                group.targetIndex().exemplarsTarget(),
+                dynamicTemplates,
+                dynamicTemplateParams,
+                INDEX_VERSION
+            );
+            ObjectPath doc = ObjectPath.createFromXContent(JsonXContent.jsonXContent, BytesReference.bytes(builder));
+            assertThat(doc.evaluate("@timestamp"), equalTo(1234));
+            assertThat(doc.evaluate("data_stream.type"), equalTo("exemplars"));
+            assertThat(doc.evaluate("data_stream.dataset"), equalTo("generic.otel"));
+            assertThat(doc.evaluate("resource.attributes.service\\.name"), equalTo("test-service"));
+            assertThat(doc.evaluate("scope.name"), equalTo("test"));
+            assertThat(doc.evaluate("attributes.route"), equalTo("/checkout"));
+            assertThat(doc.evaluate("unit"), equalTo("s"));
+            assertThat(doc.evaluate("filtered_attributes.thread\\.id"), equalTo(42));
+            assertThat(doc.evaluate("trace_id"), equalTo(traceId));
+            assertThat(doc.evaluate("span_id"), equalTo(spanId));
+            assertThat(doc.evaluate("metrics.request\\.duration"), equalTo(0.42));
+        }
+        assertThat(dynamicTemplates, hasEntry("metrics.request.duration", "exemplar_value_double"));
+        assertThat(dynamicTemplateParams, hasEntry("metrics.request.duration", Map.of("unit", "s")));
+    }
+
+    public void testExemplarsUseMetricSpecificTsid() throws Exception {
+        Exemplar doubleExemplar = createDoubleExemplar(1_000_000L, 0.42, List.of(), ByteString.EMPTY, ByteString.EMPTY);
+        Exemplar longExemplar = createLongExemplar(1_000_000L, 42L);
+        List<Metric> metrics = List.of(
+            createGaugeMetric(
+                "request.duration",
+                "s",
+                List.of(createDoubleDataPoint(3_000_000L, 0, List.of(keyValue("route", "/checkout")), List.of(doubleExemplar)))
+            ),
+            createGaugeMetric(
+                "request.size",
+                "s",
+                List.of(createLongDataPoint(3_000_000L, 0, List.of(keyValue("route", "/checkout")), List.of(longExemplar)))
+            )
+        );
+        DataPointGroupingContext.DataPointGroup group = group(metrics);
+        MetricDocumentBuilder metricDocumentBuilder = new MetricDocumentBuilder(byteStringAccessor, MappingHints.DEFAULT_TDIGEST);
+        BytesRef metricTsid;
+        String metricNamesHash;
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
+            metricTsid = metricDocumentBuilder.buildMetricDocument(builder, group, new HashMap<>(), new HashMap<>(), INDEX_VERSION);
+            ObjectPath doc = ObjectPath.createFromXContent(JsonXContent.jsonXContent, BytesReference.bytes(builder));
+            metricNamesHash = doc.evaluate("_metric_names_hash");
+        }
+
+        Set<BytesRef> exemplarTsids = new HashSet<>();
+        Set<String> exemplarMetricNamesHashes = new HashSet<>();
+        for (DataPoint dataPoint : group.dataPoints()) {
+            Exemplar exemplar = dataPoint.getExemplars().getFirst();
+            Map<String, String> dynamicTemplates = new HashMap<>();
+            try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
+                BytesRef exemplarTsid = exemplarDocumentBuilder.buildExemplarDocument(
+                    builder,
+                    group,
+                    dataPoint,
+                    exemplar,
+                    group.targetIndex().exemplarsTarget(),
+                    dynamicTemplates,
+                    new HashMap<>(),
+                    INDEX_VERSION
+                );
+                assertNotEquals(metricTsid, exemplarTsid);
+                assertTrue(exemplarTsids.add(exemplarTsid));
+                ObjectPath doc = ObjectPath.createFromXContent(JsonXContent.jsonXContent, BytesReference.bytes(builder));
+                String exemplarMetricNamesHash = doc.evaluate("_metric_names_hash");
+                assertNotEquals(metricNamesHash, exemplarMetricNamesHash);
+                assertTrue(exemplarMetricNamesHashes.add(exemplarMetricNamesHash));
+            }
+            String expectedTemplate = exemplar.getValueCase() == Exemplar.ValueCase.AS_INT
+                ? "exemplar_value_long"
+                : "exemplar_value_double";
+            assertThat(dynamicTemplates, hasEntry("metrics." + dataPoint.getMetricName(), expectedTemplate));
+        }
+        assertThat(exemplarTsids.size(), equalTo(2));
+        assertThat(exemplarMetricNamesHashes.size(), equalTo(2));
+    }
+
+    private DataPointGroupingContext.DataPointGroup group(Metric metric) throws IOException {
+        return group(List.of(metric));
+    }
+
+    private DataPointGroupingContext.DataPointGroup group(List<Metric> metrics) throws IOException {
+        DataPointGroupingContext context = new DataPointGroupingContext(byteStringAccessor, MappingHints.DEFAULT_TDIGEST);
+        ExportMetricsServiceRequest request = ExportMetricsServiceRequest.newBuilder()
+            .addResourceMetrics(
+                OtlpUtils.createResourceMetrics(
+                    List.of(keyValue("service.name", "test-service")),
+                    List.of(OtlpUtils.createScopeMetrics("test", "1.0.0", metrics))
+                )
+            )
+            .build();
+        context.groupDataPoints(request);
+        AtomicReference<DataPointGroupingContext.DataPointGroup> group = new AtomicReference<>();
+        context.consume(dataPointGroup -> assertTrue(group.compareAndSet(null, dataPointGroup)));
+        return group.get();
+    }
+}


### PR DESCRIPTION
Part of #154786

Adds ingestion for exemplars into the `exemplars-*` datastream for the OTLP endpoint behind a feature flag.

The exemplar documents will use the exact same set of dimension keys and values as the corresponding metric documents with one exception: The `_metric_names_hash` dimension is omitted, as we never group multiple exemplars into a single document. Instead the `metric_name` dimension is added to identify the exemplar metric.

If there are duplicate exemplars in the same request (same metric, timestamp and dimension values) we detect them, drop them and emit a warning via the OTLP partial success response. The OTLP partial success explicitly supports 0 dropped metrics with additional warnings as a pattern according to the spec.