### PR TITLE
[9.5] Fix LIKE/RLIKE list of patterns on non-indexed keyword and wildcard fields

### DIFF
--- a/docs/changelog/158251.yaml
+++ b/docs/changelog/158251.yaml
@@ -1,0 +1,5 @@
+area: Mapping
+issues: []
+pr: 158228
+summary: Fix LIKE/RLIKE list of patterns returning wrong results on non-indexed keyword fields and errors on wildcard fields
+type: bug

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -91,11 +91,11 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryM
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
@@ -766,7 +766,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return ScanningBinaryDocValuesAutomatonQuery.forWildcard(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
             }
             if (caseInsensitive == false) {
                 Term term = new Term(name(), value);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -61,9 +61,9 @@ import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper.MatchOnlyTextFieldType;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
@@ -627,10 +627,10 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         // SortedSet DV, case-insensitive: script-backed query
         assertThat(sortedSet.wildcardQuery("foo*", null, true, MOCK_CONTEXT), Matchers.instanceOf(StringScriptFieldWildcardQuery.class));
 
-        // Binary DV: ScanningBinaryDocValuesWildcardQuery
+        // Binary DV: ScanningBinaryDocValuesAutomatonQuery
         assertThat(
             binary.wildcardQuery("foo*", null, false, MOCK_CONTEXT),
-            Matchers.instanceOf(ScanningBinaryDocValuesWildcardQuery.class)
+            Matchers.instanceOf(ScanningBinaryDocValuesAutomatonQuery.class)
         );
 
         // Doc-values only, expensive queries disabled

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1373,7 +1373,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return new AutomatonQueryWithDescription(new Term(name()), automatonSupplier.get(), description);
             } else if (usesBinaryDocValues()) {
-                return new ScanningBinaryDocValuesAutomatonQuery(name(), automatonSupplier.get(), useArrayOrderBinaryDocValues, description);
+                return new ScanningBinaryDocValuesAutomatonQuery(
+                    name(),
+                    automatonSupplier.get(),
+                    useArrayOrderBinaryDocValues,
+                    description
+                );
             } else {
                 return new AutomatonQueryWithDescription(
                     new Term(name()),

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -75,12 +75,12 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.Utf8CodePointsFro
 import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
@@ -1234,8 +1234,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                     value = indexedValueForSearch(value).utf8ToString();
                 }
 
-                if (usesBinaryDocValues) {
-                    return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                if (usesBinaryDocValues()) {
+                    return ScanningBinaryDocValuesAutomatonQuery.forWildcard(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
                 }
 
                 if (caseInsensitive == false) {
@@ -1369,7 +1369,19 @@ public final class KeywordFieldMapper extends FieldMapper {
             SearchExecutionContext context,
             String description
         ) {
-            return new AutomatonQueryWithDescription(new Term(name()), automatonSupplier.get(), description);
+            failIfNotIndexedNorDocValuesFallback(context);
+            if (indexType.hasTerms()) {
+                return new AutomatonQueryWithDescription(new Term(name()), automatonSupplier.get(), description);
+            } else if (usesBinaryDocValues()) {
+                return new ScanningBinaryDocValuesAutomatonQuery(name(), automatonSupplier.get(), useArrayOrderBinaryDocValues, description);
+            } else {
+                return new AutomatonQueryWithDescription(
+                    new Term(name()),
+                    automatonSupplier.get(),
+                    description,
+                    MultiTermQuery.DOC_VALUES_REWRITE
+                );
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -85,11 +85,11 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomB
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermInSetQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.lucene.search.FuzzyQueries;
 import org.elasticsearch.script.Script;
@@ -1049,7 +1049,7 @@ public final class TextFieldMapper extends FieldMapper {
             }
             failIfNotIndexedNorDocValuesFallback(context);
             if (usesBinaryDocValues) {
-                return new ScanningBinaryDocValuesWildcardQuery(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
+                return ScanningBinaryDocValuesAutomatonQuery.forWildcard(name(), value, caseInsensitive, useArrayOrderBinaryDocValues);
             }
             if (caseInsensitive == false) {
                 Term term = new Term(name(), value);

--- a/server/src/main/java/org/elasticsearch/index/query/AutomatonQueryWithDescription.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AutomatonQueryWithDescription.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.AutomatonQuery;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.util.automaton.Automaton;
 
 /**
@@ -23,6 +24,15 @@ public class AutomatonQueryWithDescription extends AutomatonQuery {
 
     public AutomatonQueryWithDescription(Term term, Automaton automaton, String description) {
         super(term, automaton);
+        this.description = description;
+    }
+
+    /**
+     * Creates a query using a specific rewrite method (e.g. {@link MultiTermQuery#DOC_VALUES_REWRITE}
+     * for doc-values-only keyword fields that have no inverted index).
+     */
+    public AutomatonQueryWithDescription(Term term, Automaton automaton, String description, MultiTermQuery.RewriteMethod rewriteMethod) {
+        super(term, automaton, false, rewriteMethod);
         this.description = description;
     }
 

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQuery.java
@@ -31,12 +31,7 @@ public final class ScanningBinaryDocValuesAutomatonQuery extends AbstractBinaryD
 
     private final String description;
 
-    public ScanningBinaryDocValuesAutomatonQuery(
-        String fieldName,
-        Automaton automaton,
-        boolean arrayOrderInlineNull,
-        String description
-    ) {
+    public ScanningBinaryDocValuesAutomatonQuery(String fieldName, Automaton automaton, boolean arrayOrderInlineNull, String description) {
         super(fieldName, new ByteRunAutomaton(automaton), arrayOrderInlineNull);
         this.description = Objects.requireNonNull(description);
     }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQuery.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
@@ -19,28 +18,46 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 
-import java.io.IOException;
 import java.util.Objects;
 
 /**
- * A query for matching an exact BytesRef value for a specific field.
+ * A query that matches documents where a binary doc values field contains a value matching the given automaton.
  * The equivalent of {@link org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery}, but then without the scripting overhead and
  * just for binary doc values.
  * <p>
  * This implementation is slow, because it potentially scans binary doc values for each document.
  */
-public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDocValuesAutomatonQuery {
+public final class ScanningBinaryDocValuesAutomatonQuery extends AbstractBinaryDocValuesAutomatonQuery {
 
-    private final String pattern;
-    private final boolean caseInsensitive;
+    private final String description;
 
-    public ScanningBinaryDocValuesWildcardQuery(String fieldName, String pattern, boolean caseInsensitive, boolean arrayOrderInlineNull) {
-        super(fieldName, buildByteRunAutomaton(fieldName, pattern, caseInsensitive), arrayOrderInlineNull);
-        this.pattern = Objects.requireNonNull(pattern);
-        this.caseInsensitive = caseInsensitive;
+    public ScanningBinaryDocValuesAutomatonQuery(
+        String fieldName,
+        Automaton automaton,
+        boolean arrayOrderInlineNull,
+        String description
+    ) {
+        super(fieldName, new ByteRunAutomaton(automaton), arrayOrderInlineNull);
+        this.description = Objects.requireNonNull(description);
     }
 
-    private static ByteRunAutomaton buildByteRunAutomaton(String fieldName, String pattern, boolean caseInsensitive) {
+    /** Creates a query matching a wildcard pattern, rewriting {@code *literal*} patterns to a faster contains query. */
+    public static Query forWildcard(String fieldName, String pattern, boolean caseInsensitive, boolean arrayOrderInlineNull) {
+        if (caseInsensitive == false) {
+            var innerPattern = getContainsPattern(pattern);
+            if (innerPattern != null) {
+                return new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(innerPattern), arrayOrderInlineNull);
+            }
+        }
+        return new ScanningBinaryDocValuesAutomatonQuery(
+            fieldName,
+            buildAutomaton(fieldName, pattern, caseInsensitive),
+            arrayOrderInlineNull,
+            "pattern=" + pattern + ",caseInsensitive=" + caseInsensitive
+        );
+    }
+
+    private static Automaton buildAutomaton(String fieldName, String pattern, boolean caseInsensitive) {
         Term term = new Term(Objects.requireNonNull(fieldName), Objects.requireNonNull(pattern));
         Automaton automaton;
         if (caseInsensitive) {
@@ -48,18 +65,7 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
         } else {
             automaton = WildcardQuery.toAutomaton(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
         }
-        return new ByteRunAutomaton(automaton);
-    }
-
-    @Override
-    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-        if (caseInsensitive == false) {
-            var innerPattern = getContainsPattern(pattern);
-            if (innerPattern != null) {
-                return new BinaryDocValuesContainsTermQuery(fieldName, new BytesRef(innerPattern), arrayOrderInlineNull);
-            }
-        }
-        return super.rewrite(indexSearcher);
+        return automaton;
     }
 
     /**
@@ -84,13 +90,7 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
 
     @Override
     public String toString(String field) {
-        return "ScanningBinaryDocValuesWildcardQuery(fieldName="
-            + fieldName
-            + ",pattern="
-            + pattern
-            + ",caseInsensitive="
-            + caseInsensitive
-            + ")";
+        return "ScanningBinaryDocValuesAutomatonQuery(fieldName=" + fieldName + "," + description + ")";
     }
 
     @Override
@@ -101,14 +101,14 @@ public final class ScanningBinaryDocValuesWildcardQuery extends AbstractBinaryDo
         if (sameClassAs(o) == false) {
             return false;
         }
-        ScanningBinaryDocValuesWildcardQuery that = (ScanningBinaryDocValuesWildcardQuery) o;
+        ScanningBinaryDocValuesAutomatonQuery that = (ScanningBinaryDocValuesAutomatonQuery) o;
         return Objects.equals(fieldName, that.fieldName)
-            && Objects.equals(pattern, that.pattern)
-            && caseInsensitive == that.caseInsensitive;
+            && Objects.equals(automaton, that.automaton)
+            && arrayOrderInlineNull == that.arrayOrderInlineNull;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classHash(), fieldName, pattern, caseInsensitive);
+        return Objects.hash(classHash(), fieldName, automaton, arrayOrderInlineNull);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -38,6 +38,9 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -58,11 +61,12 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
+import org.elasticsearch.index.query.AutomatonQueryWithDescription;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesTermQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.lucene.queries.XSortedSetDocValuesRangeQuery;
 import org.elasticsearch.script.ScriptCompiler;
 
@@ -372,7 +376,10 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             builder,
             true
         );
-        assertEquals(new ScanningBinaryDocValuesWildcardQuery("field", "foo*", false, false), ft.wildcardQuery("foo*", null, MOCK_CONTEXT));
+        assertEquals(
+            ScanningBinaryDocValuesAutomatonQuery.forWildcard("field", "foo*", false, false),
+            ft.wildcardQuery("foo*", null, MOCK_CONTEXT)
+        );
     }
 
     public void testRegexpQueryHighCardinality() {
@@ -448,6 +455,62 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType binaryFt = new KeywordFieldType("field", false, true, true, Map.of());
         q = binaryFt.regexpQuery("foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, null, MOCK_CONTEXT);
         assertEquals(new ScanningBinaryDocValuesRegexpQuery("field", "foo.*", 0, RegExp.ASCII_CASE_INSENSITIVE, 10, false, null), q);
+    }
+
+    public void testAutomatonQuery() {
+        // Indexed field → AutomatonQueryWithDescription with the default (terms-dictionary) rewrite
+        MappedFieldType ft = new KeywordFieldType("field");
+        Automaton automaton = Automata.makeString("foo");
+        Query q = ft.automatonQuery(() -> automaton, () -> new CharacterRunAutomaton(automaton), null, MOCK_CONTEXT, "test");
+        assertThat(q, instanceOf(AutomatonQueryWithDescription.class));
+
+        // Unsearchable (no index, no doc values) → IAE
+        MappedFieldType unsearchable = new KeywordFieldType("field", false, false, Collections.emptyMap());
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> unsearchable.automatonQuery(() -> automaton, () -> new CharacterRunAutomaton(automaton), null, MOCK_CONTEXT, "test")
+        );
+        assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
+
+        // Doc-values-only + disallow expensive queries → ElasticsearchException
+        MappedFieldType dvOnly = new KeywordFieldType("field", false, true, Map.of());
+        ElasticsearchException ee = expectThrows(
+            ElasticsearchException.class,
+            () -> dvOnly.automatonQuery(
+                () -> automaton,
+                () -> new CharacterRunAutomaton(automaton),
+                null,
+                MOCK_CONTEXT_DISALLOW_EXPENSIVE,
+                "test"
+            )
+        );
+        assertTrue(ee.getMessage().contains("search.allow_expensive_queries"));
+    }
+
+    public void testAutomatonQueryDocValuesOnly() {
+        // Sorted-set doc-values-only keyword → DOC_VALUES_REWRITE
+        MappedFieldType ft = new KeywordFieldType("field", false, true, Map.of());
+        Automaton automaton = Automata.makeString("foo");
+        Query q = ft.automatonQuery(() -> automaton, () -> new CharacterRunAutomaton(automaton), null, MOCK_CONTEXT, "test");
+        assertThat(q, instanceOf(AutomatonQueryWithDescription.class));
+        assertEquals(MultiTermQuery.DOC_VALUES_REWRITE, ((AutomatonQueryWithDescription) q).getRewriteMethod());
+    }
+
+    public void testAutomatonQueryHighCardinality() {
+        // Binary doc values (cardinality: high) → ScanningBinaryDocValuesAutomatonQuery
+        KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("field", defaultIndexSettings());
+        builder.docValues(FieldMapper.DocValuesParameter.Values.Cardinality.HIGH);
+        MappedFieldType ft = new KeywordFieldType(
+            "field",
+            IndexType.docValuesOnly(),
+            TextSearchInfo.SIMPLE_MATCH_ONLY,
+            null,
+            builder,
+            true
+        );
+        Automaton automaton = Automata.makeString("foo");
+        Query q = ft.automatonQuery(() -> automaton, () -> new CharacterRunAutomaton(automaton), null, MOCK_CONTEXT, "testdesc");
+        assertEquals(new ScanningBinaryDocValuesAutomatonQuery("field", automaton, false, "testdesc"), q);
     }
 
     public void testFuzzyQuery() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -49,9 +49,9 @@ import org.elasticsearch.index.mapper.blockloader.DelegatingBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryMultiSeparateCountBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromOrdsBlockLoader;
+import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesPrefixQuery;
 import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesRegexpQuery;
-import org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.StringScriptFieldPrefixQuery;
@@ -822,12 +822,12 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         q = ft.wildcardQuery("foo*", null, true, MOCK_CONTEXT);
         assertThat(q, instanceOf(StringScriptFieldWildcardQuery.class));
 
-        // Binary DV → ScanningBinaryDocValuesWildcardQuery (both cases)
+        // Binary DV → ScanningBinaryDocValuesAutomatonQuery (both cases)
         TextFieldType binaryFt = binaryDocValuesOnly();
         q = binaryFt.wildcardQuery("foo*", null, false, MOCK_CONTEXT);
-        assertThat(q, instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
+        assertThat(q, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
         q = binaryFt.wildcardQuery("foo*", null, true, MOCK_CONTEXT);
-        assertThat(q, instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
+        assertThat(q, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
 
         // Neither indexed nor doc values → error
         TextFieldType neither = new TextFieldType("field", false, false, Collections.emptyMap());

--- a/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesScanningQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/BinaryDocValuesScanningQueryTests.java
@@ -66,7 +66,7 @@ public class BinaryDocValuesScanningQueryTests extends ESTestCase {
     }
 
     public void testWildcardQuery() throws IOException {
-        assertMatchCount(new ScanningBinaryDocValuesWildcardQuery(FIELD, "resea*", false, false), 1);
+        assertMatchCount(ScanningBinaryDocValuesAutomatonQuery.forWildcard(FIELD, "resea*", false, false), 1);
     }
 
     public void testRegexpQuery() throws IOException {

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQueryTests.java
@@ -17,12 +17,16 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.index.codec.tsdb.es819.ES819Version3TSDBDocValuesFormat;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
@@ -30,17 +34,22 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.elasticsearch.lucene.queries.ScanningBinaryDocValuesWildcardQuery.getContainsPattern;
+import static org.elasticsearch.lucene.queries.ScanningBinaryDocValuesAutomatonQuery.getContainsPattern;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
-public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
+public class ScanningBinaryDocValuesAutomatonQueryTests extends ESTestCase {
 
     public void testArrayOrderInlineNull() throws Exception {
         String fieldName = "field";
@@ -54,12 +63,21 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // Automaton wildcard "be*" matches "beta" and "best"; the all-null doc preceding "best" must not be matched.
-                    assertEquals(2, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "be*", false, true)));
-                    // "*et*" rewrites to a contains query: with a multi-valued doc present in the segment the contains fast path is gated
-                    // off and the per-value decode fallback runs, so only "beta" (which contains "et") matches — not "best".
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*et*", false, true)));
+                    assertEquals(
+                        2,
+                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "be*", false, true))
+                    );
+                    // "*et*" short-circuits to a contains query: with a multi-valued doc present in the segment the contains fast path is
+                    // gated off and the per-value decode fallback runs, so only "beta" (which contains "et") matches — not "best".
+                    assertEquals(
+                        1,
+                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*et*", false, true))
+                    );
                     // "*ph*" contains-matches "alpha" only.
-                    assertEquals(1, searcher.count(new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ph*", false, true)));
+                    assertEquals(
+                        1,
+                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*ph*", false, true))
+                    );
                 }
             }
         }
@@ -101,10 +119,41 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
                         long count = searcher.count(
-                            new ScanningBinaryDocValuesWildcardQuery(fieldName, entry.getKey() + "*", false, false)
+                            ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, entry.getKey() + "*", false, false)
                         );
                         assertEquals(entry.getValue().longValue(), count);
                     }
+                }
+            }
+        }
+    }
+
+    /** Exercises the primary constructor with a union automaton — the shape ESQL's LIKE-list pushdown produces. */
+    public void testBasicsUnionAutomaton() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                addDoc(writer, fieldName, "alpha");
+                addDoc(writer, fieldName, "beta");
+                addDoc(writer, fieldName, "gamma");
+                addDoc(writer, fieldName, "delta");
+                addDoc(writer, fieldName, "alpha", "gamma"); // multi-valued: both arms match, count as 1 doc
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+
+                    // union of "alpha" and "beta" — matches first, second, and fifth docs
+                    Automaton automaton = Operations.determinize(
+                        Operations.union(Arrays.asList(Automata.makeString("alpha"), Automata.makeString("beta"))),
+                        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+                    );
+                    Query query = new ScanningBinaryDocValuesAutomatonQuery(
+                        fieldName,
+                        automaton,
+                        false,
+                        "LIKE(\"alpha\", \"beta\"), caseInsensitive=false"
+                    );
+                    assertEquals(3, searcher.count(query));
                 }
             }
         }
@@ -119,7 +168,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, false);
+                    Query query = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "a*", false, false);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -144,7 +193,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "a*", false, false);
+                    Query query = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "a*", false, false);
                     assertEquals(1, searcher.count(query));
                 }
             }
@@ -188,7 +237,12 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                     );
                     TopDocs baselineResults = searcher.search(baselineQuery, 32);
 
-                    Query contenderQuery = new ScanningBinaryDocValuesWildcardQuery("contender_field", randomWildcard, false, false);
+                    Query contenderQuery = ScanningBinaryDocValuesAutomatonQuery.forWildcard(
+                        "contender_field",
+                        randomWildcard,
+                        false,
+                        false
+                    );
                     TopDocs contenderResults = searcher.search(contenderQuery, 32);
 
                     assertThat(contenderResults.totalHits, equalTo(baselineResults.totalHits));
@@ -219,7 +273,7 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
         assertThat(getContainsPattern("*fo\\**"), nullValue());
     }
 
-    public void testRewriteToContainsQuery() throws IOException {
+    public void testForWildcardReturnsContainsQueryForStarLiteralStar() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -231,16 +285,15 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", false, false);
-                    Query rewritten = query.rewrite(searcher);
-                    assertThat(rewritten, instanceOf(BinaryDocValuesContainsTermQuery.class));
-                    assertEquals(3, searcher.count(rewritten));
+                    Query query = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*search*", false, false);
+                    assertThat(query, instanceOf(BinaryDocValuesContainsTermQuery.class));
+                    assertEquals(3, searcher.count(query));
                 }
             }
         }
     }
 
-    public void testRewriteToContainsQueryMultiValued() throws IOException {
+    public void testForWildcardReturnsContainsQueryMultiValued() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -251,16 +304,15 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*ell*", false, false);
-                    Query rewritten = query.rewrite(searcher);
-                    assertThat(rewritten, instanceOf(BinaryDocValuesContainsTermQuery.class));
-                    assertEquals(2, searcher.count(rewritten));
+                    Query query = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*ell*", false, false);
+                    assertThat(query, instanceOf(BinaryDocValuesContainsTermQuery.class));
+                    assertEquals(2, searcher.count(query));
                 }
             }
         }
     }
 
-    public void testCaseInsensitiveNotRewrittenToContains() throws IOException {
+    public void testCaseInsensitiveNotOptimizedToContains() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -268,16 +320,15 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
 
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*search*", true, false);
-                    Query rewritten = query.rewrite(searcher);
-                    assertThat(rewritten, instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
-                    assertEquals(1, searcher.count(rewritten));
+                    Query query = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*search*", true, false);
+                    assertThat(query, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
+                    assertEquals(1, searcher.count(query));
                 }
             }
         }
     }
 
-    public void testNonContainsPatternNotRewritten() throws IOException {
+    public void testNonContainsPatternNotOptimized() throws IOException {
         String fieldName = "field";
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
@@ -286,14 +337,160 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
 
-                    Query prefixQuery = new ScanningBinaryDocValuesWildcardQuery(fieldName, "foo*", false, false);
-                    assertThat(prefixQuery.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
+                    Query prefixQuery = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "foo*", false, false);
+                    assertThat(prefixQuery, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
+                    assertThat(prefixQuery, sameInstance(prefixQuery.rewrite(searcher)));
 
-                    Query multiWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*foo*bar*", false, false);
-                    assertThat(multiWildcard.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
+                    Query multiWildcard = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*foo*bar*", false, false);
+                    assertThat(multiWildcard, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
 
-                    Query singleCharWildcard = new ScanningBinaryDocValuesWildcardQuery(fieldName, "*fo?*", false, false);
-                    assertThat(singleCharWildcard.rewrite(searcher), instanceOf(ScanningBinaryDocValuesWildcardQuery.class));
+                    Query singleCharWildcard = ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*fo?*", false, false);
+                    assertThat(singleCharWildcard, instanceOf(ScanningBinaryDocValuesAutomatonQuery.class));
+                }
+            }
+        }
+    }
+
+    public void testToString() {
+        // wildcard factory — description contains the pattern and caseInsensitive flag
+        Query q1 = ScanningBinaryDocValuesAutomatonQuery.forWildcard("my_field", "foo*", false, false);
+        String str1 = q1.toString("other_field");
+        assertThat(str1, containsString("my_field")); // stored fieldName, not the Lucene context param
+        assertThat(str1, containsString("foo*"));
+        assertThat(str1, not(containsString("other_field")));
+
+        // primary ctor — description is caller-supplied
+        Automaton automaton = Automata.makeString("hello");
+        Query q2 = new ScanningBinaryDocValuesAutomatonQuery("my_field", automaton, false, "custom desc");
+        assertThat(q2.toString("other_field"), containsString("my_field"));
+        assertThat(q2.toString("other_field"), containsString("custom desc"));
+    }
+
+    public void testVisitor() {
+        Automaton automaton = Automata.makeString("hello");
+        ScanningBinaryDocValuesAutomatonQuery query = new ScanningBinaryDocValuesAutomatonQuery(
+            "my_field",
+            automaton,
+            false,
+            "desc"
+        );
+
+        AtomicBoolean called = new AtomicBoolean(false);
+        query.visit(new QueryVisitor() {
+            @Override
+            public boolean acceptField(String field) {
+                return "my_field".equals(field);
+            }
+
+            @Override
+            public void consumeTermsMatching(Query query, String field, java.util.function.Supplier<ByteRunAutomaton> automaton) {
+                called.set(true);
+                assertEquals("my_field", field);
+                // the automaton supplier returns a functional ByteRunAutomaton
+                ByteRunAutomaton bra = automaton.get();
+                BytesRef hello = new BytesRef("hello");
+                assertTrue(bra.run(hello.bytes, hello.offset, hello.length));
+                BytesRef world = new BytesRef("world");
+                assertFalse(bra.run(world.bytes, world.offset, world.length));
+            }
+        });
+        assertTrue("consumeTermsMatching should have been called", called.get());
+
+        // acceptField == false → consumeTermsMatching not called
+        AtomicBoolean notCalled = new AtomicBoolean(false);
+        query.visit(new QueryVisitor() {
+            @Override
+            public boolean acceptField(String field) {
+                return false;
+            }
+
+            @Override
+            public void consumeTermsMatching(Query q, String field, java.util.function.Supplier<ByteRunAutomaton> automaton) {
+                notCalled.set(true);
+            }
+        });
+        assertFalse("consumeTermsMatching should NOT have been called when acceptField returns false", notCalled.get());
+    }
+
+    public void testEqualsAndHashCode() {
+        Automaton automaton1 = Automata.makeString("hello");
+        Automaton automaton2 = Automata.makeString("hello"); // same language, built independently
+        Automaton automaton3 = Automata.makeString("world"); // different language
+
+        // Instances with structurally equal automatons are equal regardless of description.
+        // Description is display-only and does not participate in equals/hashCode.
+        ScanningBinaryDocValuesAutomatonQuery q1 = new ScanningBinaryDocValuesAutomatonQuery("field", automaton1, false, "desc-a");
+        ScanningBinaryDocValuesAutomatonQuery q2 = new ScanningBinaryDocValuesAutomatonQuery(
+            "field",
+            automaton2,
+            false,
+            "desc-b" // different description, same automaton
+        );
+        assertEquals(q1, q2);
+        assertEquals(q1.hashCode(), q2.hashCode());
+
+        // Different automaton → not equal.
+        ScanningBinaryDocValuesAutomatonQuery q3 = new ScanningBinaryDocValuesAutomatonQuery("field", automaton3, false, "desc-a");
+        assertNotEquals(q1, q3);
+
+        // Different field → not equal.
+        ScanningBinaryDocValuesAutomatonQuery q4 = new ScanningBinaryDocValuesAutomatonQuery(
+            "other_field",
+            automaton1,
+            false,
+            "desc-a"
+        );
+        assertNotEquals(q1, q4);
+
+        // Different arrayOrderInlineNull → not equal.
+        ScanningBinaryDocValuesAutomatonQuery q5 = new ScanningBinaryDocValuesAutomatonQuery(
+            "field",
+            automaton1,
+            true,
+            "desc-a"
+        );
+        assertNotEquals(q1, q5);
+
+        // forWildcard with the same inputs produces equal instances.
+        Query fw1 = ScanningBinaryDocValuesAutomatonQuery.forWildcard("field", "foo*", false, false);
+        Query fw2 = ScanningBinaryDocValuesAutomatonQuery.forWildcard("field", "foo*", false, false);
+        assertEquals(fw1, fw2);
+        assertEquals(fw1.hashCode(), fw2.hashCode());
+
+        // forWildcard differs with different caseInsensitive (different automaton).
+        Query fw3 = ScanningBinaryDocValuesAutomatonQuery.forWildcard("field", "foo*", true, false);
+        assertNotEquals(fw1, fw3);
+
+        // Instances of different types are never equal (sameClassAs check).
+        assertNotEquals(q1, new ScanningBinaryDocValuesRegexpQuery("field", "hello", 0, 0, 10, false, null));
+    }
+
+    public void testUnionMatchesAllPatterns() throws IOException {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = newRandomIndexWriter(dir)) {
+                addDoc(writer, fieldName, "apple");
+                addDoc(writer, fieldName, "banana");
+                addDoc(writer, fieldName, "cherry");
+                addDoc(writer, fieldName, "date"); // should not match
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+
+                    // Three-pattern union: apple | banana | cherry
+                    Automaton automaton = Operations.determinize(
+                        Operations.union(
+                            Arrays.asList(Automata.makeString("apple"), Automata.makeString("banana"), Automata.makeString("cherry"))
+                        ),
+                        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+                    );
+                    Query query = new ScanningBinaryDocValuesAutomatonQuery(
+                        fieldName,
+                        automaton,
+                        false,
+                        "LIKE(\"apple\", \"banana\", \"cherry\"), caseInsensitive=false"
+                    );
+                    assertEquals(3, searcher.count(query));
                 }
             }
         }
@@ -321,5 +518,4 @@ public class ScanningBinaryDocValuesWildcardQueryTests extends ESTestCase {
         }
         return new RandomIndexWriter(random(), dir, iwc);
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/ScanningBinaryDocValuesAutomatonQueryTests.java
@@ -63,21 +63,12 @@ public class ScanningBinaryDocValuesAutomatonQueryTests extends ESTestCase {
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     // Automaton wildcard "be*" matches "beta" and "best"; the all-null doc preceding "best" must not be matched.
-                    assertEquals(
-                        2,
-                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "be*", false, true))
-                    );
+                    assertEquals(2, searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "be*", false, true)));
                     // "*et*" short-circuits to a contains query: with a multi-valued doc present in the segment the contains fast path is
                     // gated off and the per-value decode fallback runs, so only "beta" (which contains "et") matches — not "best".
-                    assertEquals(
-                        1,
-                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*et*", false, true))
-                    );
+                    assertEquals(1, searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*et*", false, true)));
                     // "*ph*" contains-matches "alpha" only.
-                    assertEquals(
-                        1,
-                        searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*ph*", false, true))
-                    );
+                    assertEquals(1, searcher.count(ScanningBinaryDocValuesAutomatonQuery.forWildcard(fieldName, "*ph*", false, true)));
                 }
             }
         }
@@ -368,12 +359,7 @@ public class ScanningBinaryDocValuesAutomatonQueryTests extends ESTestCase {
 
     public void testVisitor() {
         Automaton automaton = Automata.makeString("hello");
-        ScanningBinaryDocValuesAutomatonQuery query = new ScanningBinaryDocValuesAutomatonQuery(
-            "my_field",
-            automaton,
-            false,
-            "desc"
-        );
+        ScanningBinaryDocValuesAutomatonQuery query = new ScanningBinaryDocValuesAutomatonQuery("my_field", automaton, false, "desc");
 
         AtomicBoolean called = new AtomicBoolean(false);
         query.visit(new QueryVisitor() {
@@ -434,21 +420,11 @@ public class ScanningBinaryDocValuesAutomatonQueryTests extends ESTestCase {
         assertNotEquals(q1, q3);
 
         // Different field → not equal.
-        ScanningBinaryDocValuesAutomatonQuery q4 = new ScanningBinaryDocValuesAutomatonQuery(
-            "other_field",
-            automaton1,
-            false,
-            "desc-a"
-        );
+        ScanningBinaryDocValuesAutomatonQuery q4 = new ScanningBinaryDocValuesAutomatonQuery("other_field", automaton1, false, "desc-a");
         assertNotEquals(q1, q4);
 
         // Different arrayOrderInlineNull → not equal.
-        ScanningBinaryDocValuesAutomatonQuery q5 = new ScanningBinaryDocValuesAutomatonQuery(
-            "field",
-            automaton1,
-            true,
-            "desc-a"
-        );
+        ScanningBinaryDocValuesAutomatonQuery q5 = new ScanningBinaryDocValuesAutomatonQuery("field", automaton1, true, "desc-a");
         assertNotEquals(q1, q5);
 
         // forWildcard with the same inputs produces equal instances.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -102,7 +102,6 @@ emp_no:integer | first_name:keyword
 
 likeListTwoArgWildcard
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("Eberhardt*", "testString*") 
 | KEEP emp_no, first_name;
@@ -125,7 +124,6 @@ foobar
 
 likeListThreeArgWildcard
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("Eberhardt*", "Ot*", "Part?") 
 | KEEP emp_no, first_name  
@@ -140,7 +138,6 @@ emp_no:integer | first_name:keyword
 
 likeListMultipleWhere
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("Eberhardt*", "Ot*", "Part?") 
 | WHERE first_name like ("Eberhard?", "Otm*")
@@ -167,7 +164,6 @@ emp_no:integer | first_name:keyword
 
 likeListOverlappingPatterns
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("Eber*", "Eberhardt") 
 | KEEP emp_no, first_name;
@@ -187,7 +183,6 @@ emp_no:integer | first_name:keyword
 
 likeListSpecialCharacters
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("*ar*", "?eor*") 
 | KEEP emp_no, first_name 
@@ -240,7 +235,6 @@ emp_no:integer | first_name:keyword
 
 notLikeListThreeArgWildcardNotOtherFilter
 required_capability: like_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name not like ("Eberhardt*", "Ot*", "Part?") and emp_no < 10010 
 | KEEP emp_no, first_name
@@ -259,7 +253,6 @@ emp_no:integer | first_name:keyword
 
 likeListBeginningWithWildcard
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name like ("A*", "B*", "C*") 
 | KEEP emp_no, first_name 
@@ -286,7 +279,6 @@ emp_no:integer | first_name:keyword
 
 notLikeListThreeArgWildcardOtherFirst
 required_capability: like_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE emp_no < 10010 and first_name not like ("Eberhardt*", "Ot*", "Part?") 
 | KEEP emp_no, first_name  
@@ -340,7 +332,6 @@ emp_no:integer | first_name:keyword
 
 notLikeListMultipleWhere
 required_capability: like_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name not like ("Eberhardt*", "Ot*", "Part?", "A*", "B*", "C*", "D*") 
 | WHERE first_name not like ("Eberhard?", "Otm*", "F*", "G*", "H*", "I*", "J*", "K*", "L*")
@@ -396,7 +387,6 @@ emp_no:integer | first_name:keyword
 
 notLikeListNotField
 required_capability: like_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE not first_name like ("Eberhardt*", "Ot*", "Part?", "A*", "B*", "C*", "D*") 
 | WHERE first_name not like ("Eberhard?", "Otm*", "F*", "G*", "H*", "I*", "J*", "K*", "L*")
@@ -465,7 +455,6 @@ emp_no:integer | first_name:keyword
 
 notLikeListWildcard
 required_capability: like_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name not like ("A*","B*", "C*", "D*","E*", "F*", "G*", "H*", "I*", "J*", "K*") 
 | KEEP emp_no, first_name  
@@ -534,7 +523,6 @@ emp_no:integer | first_name:keyword
 
 likeListWithUpperTurnedInsensitiveMult
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) LIKE ("GEOR*", "WE*")  
 | KEEP emp_no, first_name 
@@ -558,7 +546,6 @@ emp_no:integer | first_name:keyword
 
 likeListWithUpperAllUpper
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) LIKE ("GEOR*", "WEI*")
 | KEEP emp_no, first_name 
@@ -582,7 +569,6 @@ emp_no:integer | first_name:keyword
 
 likeListWithUpperMultiplePatternsMixedCase
 required_capability: like_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) LIKE ("geor*", "WEIYI*", "bErnI*") 
 | KEEP emp_no, first_name 
@@ -614,7 +600,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListWithUpperAllUpper
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) RLIKE ("GEOR.*", "WEI.*")
 | KEEP emp_no, first_name 
@@ -638,7 +623,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListWithUpperMultiplePatternsMixedCase
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) RLIKE ("geor*", "WEIYI.*", "bErnI.*") 
 | KEEP emp_no, first_name 
@@ -679,7 +663,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListTwoArgWildcard
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name rlike ("Eberhardt.*", "testString.*") 
 | KEEP emp_no, first_name;
@@ -702,7 +685,6 @@ foobar
 
 rlikeListThreeArgWildcard
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name rlike ("Eberhardt.*", "Ot.*", "Part.") 
 | KEEP emp_no, first_name  
@@ -716,7 +698,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListMultipleWhere
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name RLIKE ("Eberhardt.*", "Ot.*", "Part.") 
 | WHERE first_name RLIKE ("Eberhard.", "Otm.*")
@@ -743,7 +724,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListOverlappingPatterns
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name rlike ("Eber.*", "Eberhardt") 
 | KEEP emp_no, first_name;
@@ -763,7 +743,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListSpecialCharacters
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name rlike (".*ar.*", ".*eor.*") 
 | KEEP emp_no, first_name 
@@ -816,7 +795,6 @@ emp_no:integer | first_name:keyword
 
 notRlikeListThreeArgWildcardNotOtherFilter
 required_capability: rlike_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name not rlike ("Eberhardt.*", "Ot.*", "Part.") and emp_no < 10010 
 | KEEP emp_no, first_name
@@ -835,7 +813,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListBeginningWithWildcard
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE first_name rlike ("A.*", "B.*", "C.*") 
 | KEEP emp_no, first_name 
@@ -862,7 +839,6 @@ emp_no:integer | first_name:keyword
 
 notRlikeListThreeArgWildcardOtherFirst
 required_capability: rlike_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE emp_no < 10010 and first_name not rlike ("Eberhardt.*", "Ot.*", "Part.") 
 | KEEP emp_no, first_name  
@@ -916,7 +892,6 @@ emp_no:integer | first_name:keyword
 
 notRlikeListMultipleWhere
 required_capability: rlike_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name NOT RLIKE ("Eberhardt.*", "Ot.*", "Part.", "A.*", "B.*", "C.*", "D.*") 
 | WHERE first_name NOT RLIKE ("Eberhard.", "Otm.*", "F.*", "G.*", "H.*", "I.*", "J.*", "K.*", "L.*")
@@ -972,7 +947,6 @@ emp_no:integer | first_name:keyword
 
 notRlikeListNotField
 required_capability: rlike_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE NOT first_name RLIKE ("Eberhardt.*", "Ot.*", "Part.", "A.*", "B.*", "C.*", "D.*") 
 | WHERE first_name NOT RLIKE ("Eberhard.", "Otm.*", "F.*", "G.*", "H.*", "I.*", "J.*", "K.*", "L.*")
@@ -1041,7 +1015,6 @@ emp_no:integer | first_name:keyword
 
 notRlikeListWildcard
 required_capability: rlike_with_list_of_patterns
-skip_columnar: NOT LIKE/RLIKE with list of patterns returns incorrect results in columnar mode
 FROM employees 
 | WHERE first_name NOT RLIKE ("A.*","B.*", "C.*", "D.*","E.*", "F.*", "G.*", "H.*", "I.*", "J.*", "K.*") 
 | KEEP emp_no, first_name  
@@ -1110,7 +1083,6 @@ emp_no:integer | first_name:keyword
 
 rlikeListWithUpperTurnedInsensitiveMult
 required_capability: rlike_with_list_of_patterns
-skip_columnar: LIKE/RLIKE with list of patterns returns empty results in columnar mode
 FROM employees 
 | WHERE TO_UPPER(first_name) RLIKE ("GEOR.*", "WE.*")  
 | KEEP emp_no, first_name 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.fielddata.SortingArrayOrderBinaryDocValues;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Query that provided an arbitrary match across all binary doc values (but only for docs that also
@@ -138,6 +139,31 @@ abstract class BinaryDvConfirmedQuery extends Query {
             approximation,
             field,
             new FuzzyQueryAutomatonProvider(searchTerm, fuzzyQuery),
+            arrayOrder
+        );
+    }
+
+    /**
+     * Returns a query that runs the provided supplier-based automaton across all binary doc values
+     * (but only for docs that also match a provided approximation query which is key to getting good
+     * performance). Reads the field's binary doc values using the in-order
+     * {@link org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ArrayOrderInlineNull ArrayOrderInlineNull} format when
+     * {@code arrayOrder} is {@code true} (high-cardinality columnar fields in strictly columnar index mode).
+     * <p>
+     * The {@code description} is used as the equality proxy for query-cache identity; it must be derived
+     * deterministically from the pattern list and case-sensitivity flag that produced the automaton.
+     */
+    public static Query fromAutomaton(
+        Query approximation,
+        String field,
+        Supplier<Automaton> automatonSupplier,
+        String description,
+        boolean arrayOrder
+    ) {
+        return new BinaryDvConfirmedAutomatonQuery(
+            approximation,
+            field,
+            new SuppliedAutomatonProvider(automatonSupplier, description),
             arrayOrder
         );
     }
@@ -407,6 +433,44 @@ abstract class BinaryDvConfirmedQuery extends Query {
         @Override
         public Automaton getAutomaton(String field) {
             return fuzzyQuery.getAutomata().automaton;
+        }
+    }
+
+    /**
+     * Wraps an already-built automaton supplier. Equality keys on {@code description} only because
+     * {@link Supplier} has no value-based equality; the description must be derived deterministically
+     * from the pattern list and case-sensitivity flag that produced the automaton.
+     */
+    private static final class SuppliedAutomatonProvider implements AutomatonProvider {
+        private final Supplier<Automaton> supplier;
+        private final String description;
+
+        SuppliedAutomatonProvider(Supplier<Automaton> supplier, String description) {
+            this.supplier = Objects.requireNonNull(supplier);
+            this.description = Objects.requireNonNull(description);
+        }
+
+        @Override
+        public Automaton getAutomaton(String field) {
+            return supplier.get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SuppliedAutomatonProvider that = (SuppliedAutomatonProvider) o;
+            return Objects.equals(description, that.description);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(description);
+        }
+
+        @Override
+        public String toString() {
+            return description;
         }
     }
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ElasticsearchParseException;
@@ -94,6 +95,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.index.IndexSettings.IGNORE_ABOVE_SETTING;
 import static org.elasticsearch.index.mapper.Mapper.IgnoreAbove.getIgnoreAboveDefaultValue;
@@ -437,6 +439,29 @@ public class WildcardFieldMapper extends FieldMapper {
                 getNgramTokens(tokens, sequence.toString());
             }
             return tokens.isEmpty() && (numWildcardChars == 0 || numWildcardStrings > 0);
+        }
+
+        @Override
+        public Query automatonQuery(
+            Supplier<Automaton> automatonSupplier,
+            Supplier<CharacterRunAutomaton> characterRunAutomatonSupplier,
+            @Nullable MultiTermQuery.RewriteMethod method,
+            SearchExecutionContext context,
+            String description
+        ) {
+            Automaton automaton = automatonSupplier.get();
+            if (Operations.isTotal(automaton)) {
+                return existsQuery(context);
+            }
+            // No ngram acceleration is possible for an opaque union automaton, so use existsQuery
+            // as the approximation and let the doc-values scan do the real filtering.
+            return BinaryDvConfirmedQuery.fromAutomaton(
+                existsQuery(context),
+                name(),
+                automatonSupplier,
+                description,
+                arrayOrderBinaryDocValues
+            );
         }
 
         @Override


### PR DESCRIPTION
Backporting #158251 to 9.5 branch.

- `KeywordFieldType.automatonQuery` had no doc-values fallback, causing multi-pattern `LIKE`/`RLIKE` pushdown to silently return empty results on keyword fields with `index: false` (including columnar mode, where indexing is disabled by default).
- `WildcardFieldType` had no `automatonQuery` override at all, causing a 400 error on any `LIKE`/`RLIKE` list query against a `wildcard` field.
- `WildcardLikeList` and `RLikeList` are the only callers of `MappedFieldType.automatonQuery`. Single-pattern `LIKE`/`RLIKE` goes through `normalizedWildcardQuery`, which already has a doc-values fallback — so only multi-pattern queries were affected.
- **Fixes:** the 28 `skip_columnar:` directives in `where-like.csv-spec` added by #157378 are removed.
- Generalise `ScanningBinaryDocValuesWildcardQuery` into `ScanningBinaryDocValuesAutomatonQuery` to serve both the wildcard factory path and the new general automaton path.