### PR TITLE
ESQL: parallelize limited doc-values-only scans

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -200,37 +200,38 @@ public class LuceneSourceOperator extends LuceneOperator {
         }
 
         /**
-         * Cost-aware {@link DataPartitioning#AUTO} strategy for the unsorted source. A no-limit scan (e.g. {@code STATS})
-         * visits every matching doc, so it shares the {@link #autoPartitioning} rule with count and TopN: costly →
-         * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
+         * Cost-aware {@link DataPartitioning#AUTO} strategy for the unsorted source.
          * <p>
-         * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} unless it is a guaranteed full scan:
-         * costly-to-build clauses (BKD point ranges, multi-term) keep {@code SHARD} because a single shard-level walk
-         * beats rebuilding scorers per segment when the limit fires early; {@link org.apache.lucene.search.MatchAllDocsQuery}
-         * and {@link org.apache.lucene.search.MatchNoDocsQuery} keep {@code SHARD}; cheap filters (cost below
-         * {@code minCostForDoc}) keep {@code SHARD}. Only a scan-heavy filter with {@code cost ≥ minCostForDoc} (e.g. a
-         * doc-values-only field with no BKD index) is promoted to {@link PartitioningStrategy#DOC}, because those scans
-         * visit {@code ~maxDoc} regardless of match density and the limit is never reached early.
+         * Decision table (both branches share the same cost signal):
+         * <ul>
+         *     <li>{@link org.apache.lucene.search.MatchAllDocsQuery}: no-limit → DOC; limited → SHARD.</li>
+         *     <li>{@link org.apache.lucene.search.MatchNoDocsQuery} or costly clause (BKD / multi-term): no-limit → SEGMENT; limited → SHARD.</li>
+         *     <li>cheap filter ({@code cost < minCostForDoc}): no-limit → SEGMENT; limited → SHARD.</li>
+         *     <li>scan-heavy filter ({@code cost ≥ minCostForDoc}, e.g. doc-values-only with no BKD): → DOC in both cases,
+         *         because the scan visits {@code ~maxDoc} regardless of match density and the limit is never reached early.</li>
+         * </ul>
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
-            return limit -> limit == NO_LIMIT
-                ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
-                : (ctx, query) -> limitedScanAutoStrategy(ctx, query, minCostForDoc);
-        }
-
-        private static PartitioningStrategy limitedScanAutoStrategy(ShardContext ctx, Query query, long minCostForDoc) {
-            if (containsCostlyClause(query)) {
-                return SHARD;
-            }
-            Query unwrapped = unwrapQuery(query);
-            if (unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
-                return SHARD;
-            }
-            try {
-                return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SHARD : DOC;
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            return limit -> (ctx, query) -> {
+                Query unwrapped = unwrapQuery(query);
+                if (limit != NO_LIMIT) {
+                    if (containsCostlyClause(query) || unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
+                        return SHARD;
+                    }
+                    try {
+                        return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SHARD : DOC;
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+                if (unwrapped instanceof MatchAllDocsQuery) return DOC;
+                if (unwrapped instanceof MatchNoDocsQuery || containsCostlyClause(query)) return SEGMENT;
+                try {
+                    return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SEGMENT : DOC;
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            };
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -202,14 +202,20 @@ public class LuceneSourceOperator extends LuceneOperator {
         /**
          * Cost-aware {@link DataPartitioning#AUTO} strategy for the unsorted source. A no-limit scan (e.g. {@code STATS})
          * visits every matching doc, so it shares the {@link #autoPartitioning} rule with count and TopN: costly →
-         * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC. A query with a {@code limit} early-terminates
-         * after matching {@code N} docs — whether DOC pays off then depends on match density, which the cost can't see —
-         * so that case is deferred and keeps the low-overhead {@link PartitioningStrategy#SHARD}.
+         * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
+         * <p>
+         * A query with a {@code limit} uses the same cost-aware rule but with {@link PartitioningStrategy#SHARD} as the
+         * {@code cheap} outcome. This keeps low-overhead {@code SHARD} for cases where the limit genuinely helps — a cheap
+         * indexed (BKD) lookup skips to its matches and early-terminates cheaply — but promotes scan-heavy queries
+         * ({@code cost ≥ minCostForDoc}, e.g. a doc-values-only filter with no BKD index) to
+         * {@link PartitioningStrategy#DOC}, because those scans visit {@code ~maxDoc} regardless of match density and the
+         * limit is never reached early. {@link org.apache.lucene.search.MatchAllDocsQuery} also gets
+         * {@link PartitioningStrategy#DOC} because its cost is {@code maxDoc}.
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
             return limit -> limit == NO_LIMIT
                 ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
-                : Factory::lowOverheadAutoStrategy;
+                : (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SHARD);
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -205,19 +205,18 @@ public class LuceneSourceOperator extends LuceneOperator {
          * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
          * <p>
          * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} for costly-to-build clauses (point ranges,
-         * multi-term) because: (a) a single shard-level BKD walk is more efficient than one scorer rebuild per segment when
-         * the limit fires early, and (b) the costly-clause concern in {@link #autoPartitioning} is specifically about
-         * DOC sub-segment slices rebuilding scorers, which does not apply to SHARD. For non-costly queries the same
-         * cost-aware rule as the no-limit branch applies with {@link PartitioningStrategy#SHARD} as the {@code cheap}
-         * outcome: a scan-heavy query (e.g. a doc-values-only filter with no BKD index, or {@link
-         * org.apache.lucene.search.MatchAllDocsQuery}) has cost {@code ≥ minCostForDoc} and is promoted to
-         * {@link PartitioningStrategy#DOC} because those scans visit {@code ~maxDoc} regardless of match density and the
-         * limit is never reached early.
+         * multi-term) because a single shard-level BKD walk is more efficient than rebuilding scorers per segment when
+         * the limit fires early. For non-costly queries, {@link #autoPartitioning} is used with {@link
+         * PartitioningStrategy#SHARD} as both the {@code matchAll} and {@code cheap} outcomes: {@code MatchAll} with a
+         * limit (e.g. {@code FROM idx | LIMIT 1000}) keeps {@code SHARD} because it trivially early-terminates; a
+         * cheap low-cost filter keeps {@code SHARD} for the same reason; only a scan-heavy query (e.g. a doc-values-only
+         * filter with no BKD index, cost {@code ≥ minCostForDoc}) is promoted to {@link PartitioningStrategy#DOC}
+         * because those scans visit {@code ~maxDoc} regardless of match density and the limit is never reached early.
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
             return limit -> limit == NO_LIMIT
                 ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
-                : (ctx, query) -> containsCostlyClause(query) ? SHARD : autoPartitioning(ctx, query, DOC, minCostForDoc, SHARD);
+                : (ctx, query) -> containsCostlyClause(query) ? SHARD : autoPartitioning(ctx, query, SHARD, minCostForDoc, SHARD);
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -204,19 +204,33 @@ public class LuceneSourceOperator extends LuceneOperator {
          * visits every matching doc, so it shares the {@link #autoPartitioning} rule with count and TopN: costly →
          * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
          * <p>
-         * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} for costly-to-build clauses (point ranges,
-         * multi-term) because a single shard-level BKD walk is more efficient than rebuilding scorers per segment when
-         * the limit fires early. For non-costly queries, {@link #autoPartitioning} is used with {@link
-         * PartitioningStrategy#SHARD} as both the {@code matchAll} and {@code cheap} outcomes: {@code MatchAll} with a
-         * limit (e.g. {@code FROM idx | LIMIT 1000}) keeps {@code SHARD} because it trivially early-terminates; a
-         * cheap low-cost filter keeps {@code SHARD} for the same reason; only a scan-heavy query (e.g. a doc-values-only
-         * filter with no BKD index, cost {@code ≥ minCostForDoc}) is promoted to {@link PartitioningStrategy#DOC}
-         * because those scans visit {@code ~maxDoc} regardless of match density and the limit is never reached early.
+         * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} unless it is a guaranteed full scan:
+         * costly-to-build clauses (BKD point ranges, multi-term) keep {@code SHARD} because a single shard-level walk
+         * beats rebuilding scorers per segment when the limit fires early; {@link org.apache.lucene.search.MatchAllDocsQuery}
+         * and {@link org.apache.lucene.search.MatchNoDocsQuery} keep {@code SHARD}; cheap filters (cost below
+         * {@code minCostForDoc}) keep {@code SHARD}. Only a scan-heavy filter with {@code cost ≥ minCostForDoc} (e.g. a
+         * doc-values-only field with no BKD index) is promoted to {@link PartitioningStrategy#DOC}, because those scans
+         * visit {@code ~maxDoc} regardless of match density and the limit is never reached early.
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
             return limit -> limit == NO_LIMIT
                 ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
-                : (ctx, query) -> containsCostlyClause(query) ? SHARD : autoPartitioning(ctx, query, SHARD, minCostForDoc, SHARD);
+                : (ctx, query) -> limitedScanAutoStrategy(ctx, query, minCostForDoc);
+        }
+
+        private static PartitioningStrategy limitedScanAutoStrategy(ShardContext ctx, Query query, long minCostForDoc) {
+            if (containsCostlyClause(query)) {
+                return SHARD;
+            }
+            Query unwrapped = unwrapQuery(query);
+            if (unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
+                return SHARD;
+            }
+            try {
+                return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SHARD : DOC;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -200,38 +200,37 @@ public class LuceneSourceOperator extends LuceneOperator {
         }
 
         /**
-         * Cost-aware {@link DataPartitioning#AUTO} strategy for the unsorted source.
+         * Cost-aware {@link DataPartitioning#AUTO} strategy for the unsorted source. A no-limit scan (e.g. {@code STATS})
+         * visits every matching doc, so it shares the {@link #autoPartitioning} rule with count and TopN: costly →
+         * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
          * <p>
-         * Decision table (both branches share the same cost signal):
-         * <ul>
-         *     <li>{@link org.apache.lucene.search.MatchAllDocsQuery}: no-limit → DOC; limited → SHARD.</li>
-         *     <li>{@link org.apache.lucene.search.MatchNoDocsQuery} or costly clause (BKD / multi-term): no-limit → SEGMENT; limited → SHARD.</li>
-         *     <li>cheap filter ({@code cost < minCostForDoc}): no-limit → SEGMENT; limited → SHARD.</li>
-         *     <li>scan-heavy filter ({@code cost ≥ minCostForDoc}, e.g. doc-values-only with no BKD): → DOC in both cases,
-         *         because the scan visits {@code ~maxDoc} regardless of match density and the limit is never reached early.</li>
-         * </ul>
+         * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} unless it is a guaranteed full scan:
+         * costly-to-build clauses (BKD point ranges, multi-term) keep {@code SHARD} because a single shard-level walk
+         * beats rebuilding scorers per segment when the limit fires early; {@link org.apache.lucene.search.MatchAllDocsQuery}
+         * and {@link org.apache.lucene.search.MatchNoDocsQuery} keep {@code SHARD}; cheap filters (cost below
+         * {@code minCostForDoc}) keep {@code SHARD}. Only a scan-heavy filter with {@code cost ≥ minCostForDoc} (e.g. a
+         * doc-values-only field with no BKD index) is promoted to {@link PartitioningStrategy#DOC}, because those scans
+         * visit {@code ~maxDoc} regardless of match density and the limit is never reached early.
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
-            return limit -> (ctx, query) -> {
-                Query unwrapped = unwrapQuery(query);
-                if (limit != NO_LIMIT) {
-                    if (containsCostlyClause(query) || unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
-                        return SHARD;
-                    }
-                    try {
-                        return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SHARD : DOC;
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
-                if (unwrapped instanceof MatchAllDocsQuery) return DOC;
-                if (unwrapped instanceof MatchNoDocsQuery || containsCostlyClause(query)) return SEGMENT;
-                try {
-                    return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SEGMENT : DOC;
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            };
+            return limit -> limit == NO_LIMIT
+                ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
+                : (ctx, query) -> limitedScanAutoStrategy(ctx, query, minCostForDoc);
+        }
+
+        private static PartitioningStrategy limitedScanAutoStrategy(ShardContext ctx, Query query, long minCostForDoc) {
+            if (containsCostlyClause(query)) {
+                return SHARD;
+            }
+            Query unwrapped = unwrapQuery(query);
+            if (unwrapped instanceof MatchAllDocsQuery || unwrapped instanceof MatchNoDocsQuery) {
+                return SHARD;
+            }
+            try {
+                return queryCost(ctx, query, minCostForDoc) < minCostForDoc ? SHARD : DOC;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperator.java
@@ -204,18 +204,20 @@ public class LuceneSourceOperator extends LuceneOperator {
          * visits every matching doc, so it shares the {@link #autoPartitioning} rule with count and TopN: costly →
          * SEGMENT, cheap ({@code cost < minCostForDoc}) → SEGMENT, else DOC.
          * <p>
-         * A query with a {@code limit} uses the same cost-aware rule but with {@link PartitioningStrategy#SHARD} as the
-         * {@code cheap} outcome. This keeps low-overhead {@code SHARD} for cases where the limit genuinely helps — a cheap
-         * indexed (BKD) lookup skips to its matches and early-terminates cheaply — but promotes scan-heavy queries
-         * ({@code cost ≥ minCostForDoc}, e.g. a doc-values-only filter with no BKD index) to
-         * {@link PartitioningStrategy#DOC}, because those scans visit {@code ~maxDoc} regardless of match density and the
-         * limit is never reached early. {@link org.apache.lucene.search.MatchAllDocsQuery} also gets
-         * {@link PartitioningStrategy#DOC} because its cost is {@code maxDoc}.
+         * A query with a {@code limit} keeps {@link PartitioningStrategy#SHARD} for costly-to-build clauses (point ranges,
+         * multi-term) because: (a) a single shard-level BKD walk is more efficient than one scorer rebuild per segment when
+         * the limit fires early, and (b) the costly-clause concern in {@link #autoPartitioning} is specifically about
+         * DOC sub-segment slices rebuilding scorers, which does not apply to SHARD. For non-costly queries the same
+         * cost-aware rule as the no-limit branch applies with {@link PartitioningStrategy#SHARD} as the {@code cheap}
+         * outcome: a scan-heavy query (e.g. a doc-values-only filter with no BKD index, or {@link
+         * org.apache.lucene.search.MatchAllDocsQuery}) has cost {@code ≥ minCostForDoc} and is promoted to
+         * {@link PartitioningStrategy#DOC} because those scans visit {@code ~maxDoc} regardless of match density and the
+         * limit is never reached early.
          */
         public static DataPartitioning.AutoStrategy autoStrategy(long minCostForDoc) {
             return limit -> limit == NO_LIMIT
                 ? (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SEGMENT)
-                : (ctx, query) -> autoPartitioning(ctx, query, DOC, minCostForDoc, SHARD);
+                : (ctx, query) -> containsCostlyClause(query) ? SHARD : autoPartitioning(ctx, query, DOC, minCostForDoc, SHARD);
         }
 
         /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
@@ -44,8 +44,10 @@ import static org.hamcrest.Matchers.equalTo;
  * lookup, an empty result, or the low-cost side of the threshold → {@link LuceneSliceQueue.PartitioningStrategy#SEGMENT};
  * a costly point/multi-term clause → SEGMENT; {@code MatchAll} → DOC.
  *
- * <p>A <b>limited</b> scan (implicit {@code LIMIT}) early-terminates after matching N docs, so it is deferred and keeps
- * the low-overhead {@link LuceneSliceQueue.PartitioningStrategy#SHARD} regardless of the query.
+ * <p>A <b>limited</b> scan (implicit {@code LIMIT}) uses the same cost-aware rule with
+ * {@link LuceneSliceQueue.PartitioningStrategy#SHARD} as only the cheap outcome: a cheap indexed lookup (cost below
+ * threshold) keeps {@code SHARD}, while scan-heavy queries — doc-values-only filters or {@code MatchAll} (both cost
+ * ≈ maxDoc) — are promoted to {@link LuceneSliceQueue.PartitioningStrategy#DOC} because the limit rarely fires early.
  */
 public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
 
@@ -99,11 +101,22 @@ public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
         assertThat(pick(LongPoint.newRangeQuery("pt", 0, NUM_DOCS / 2), NO_LIMIT), equalTo(SEGMENT));
     }
 
-    // --- implicit limit: deferred, always SHARD ---
+    // --- implicit limit: cost-aware, not always SHARD ---
 
-    public void testLimitedScanPicksShard() throws IOException {
-        assertThat(pick(SortedNumericDocValuesField.newSlowRangeQuery("dv", 0, NUM_DOCS / 2), between(1, 1000)), equalTo(SHARD));
-        assertThat(pick(Queries.ALL_DOCS_INSTANCE, between(1, 1000)), equalTo(SHARD));
+    public void testLimitedDocValuesScanPicksDoc() throws IOException {
+        // Doc-values-only filter (no BKD): cost ≈ maxDoc, so SHARD would scan ~maxDoc single-threaded.
+        // The limit is unlikely to fire (very few matches), so parallelise with DOC instead.
+        assertThat(pick(SortedNumericDocValuesField.newSlowRangeQuery("dv", 0, NUM_DOCS / 2), between(1, 1000)), equalTo(DOC));
+    }
+
+    public void testLimitedMatchAllPicksDoc() throws IOException {
+        // FROM foo | LIMIT N: cost = maxDoc, so parallelize with DOC even though the limit might fire early.
+        assertThat(pick(Queries.ALL_DOCS_INSTANCE, between(1, 1000)), equalTo(DOC));
+    }
+
+    public void testLimitedCheapTermPicksShard() throws IOException {
+        // Term query: cost = one matching doc, well below MIN_COST_FOR_DOC threshold, keep SHARD.
+        assertThat(pick(new TermQuery(new Term("kw", "v7")), between(1, 1000)), equalTo(SHARD));
     }
 
     private static final int NO_LIMIT = LuceneOperator.NO_LIMIT;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
@@ -44,10 +44,12 @@ import static org.hamcrest.Matchers.equalTo;
  * lookup, an empty result, or the low-cost side of the threshold → {@link LuceneSliceQueue.PartitioningStrategy#SEGMENT};
  * a costly point/multi-term clause → SEGMENT; {@code MatchAll} → DOC.
  *
- * <p>A <b>limited</b> scan (implicit {@code LIMIT}) uses the same cost-aware rule with
- * {@link LuceneSliceQueue.PartitioningStrategy#SHARD} as only the cheap outcome: a cheap indexed lookup (cost below
- * threshold) keeps {@code SHARD}, while scan-heavy queries — doc-values-only filters or {@code MatchAll} (both cost
- * ≈ maxDoc) — are promoted to {@link LuceneSliceQueue.PartitioningStrategy#DOC} because the limit rarely fires early.
+ * <p>A <b>limited</b> scan (implicit {@code LIMIT}) has three outcomes: (1) a costly-to-build clause (BKD point range,
+ * multi-term) keeps {@link LuceneSliceQueue.PartitioningStrategy#SHARD} — a single shard-level walk beats rebuilding
+ * per-segment scorers when the limit fires early; (2) a non-costly cheap query (cost below threshold) keeps
+ * {@code SHARD}; (3) a non-costly scan-heavy query (doc-values-only filter or {@code MatchAll}, cost ≈ maxDoc) is
+ * promoted to {@link LuceneSliceQueue.PartitioningStrategy#DOC} because those scans visit ~maxDoc and the limit
+ * rarely fires early.
  */
 public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
 
@@ -110,13 +112,19 @@ public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
     }
 
     public void testLimitedMatchAllPicksDoc() throws IOException {
-        // FROM foo | LIMIT N: cost = maxDoc, so parallelize with DOC even though the limit might fire early.
+        // FROM foo | LIMIT N: cost = maxDoc, not a costly clause — parallelize with DOC.
         assertThat(pick(Queries.ALL_DOCS_INSTANCE, between(1, 1000)), equalTo(DOC));
     }
 
     public void testLimitedCheapTermPicksShard() throws IOException {
-        // Term query: cost = one matching doc, well below MIN_COST_FOR_DOC threshold, keep SHARD.
+        // Term query: not costly to build, cost = 1 (below threshold) → SHARD.
         assertThat(pick(new TermQuery(new Term("kw", "v7")), between(1, 1000)), equalTo(SHARD));
+    }
+
+    public void testLimitedPointRangePicksShard() throws IOException {
+        // BKD point range: costly to build, so keep SHARD — single shard-level BKD walk beats
+        // one scorer-rebuild per segment when the limit fires early.
+        assertThat(pick(LongPoint.newRangeQuery("pt", 0, NUM_DOCS / 2), between(1, 1000)), equalTo(SHARD));
     }
 
     private static final int NO_LIMIT = LuceneOperator.NO_LIMIT;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/query/LuceneSourceOperatorCostAwareStrategyTests.java
@@ -44,12 +44,10 @@ import static org.hamcrest.Matchers.equalTo;
  * lookup, an empty result, or the low-cost side of the threshold → {@link LuceneSliceQueue.PartitioningStrategy#SEGMENT};
  * a costly point/multi-term clause → SEGMENT; {@code MatchAll} → DOC.
  *
- * <p>A <b>limited</b> scan (implicit {@code LIMIT}) has three outcomes: (1) a costly-to-build clause (BKD point range,
- * multi-term) keeps {@link LuceneSliceQueue.PartitioningStrategy#SHARD} — a single shard-level walk beats rebuilding
- * per-segment scorers when the limit fires early; (2) a non-costly cheap query (cost below threshold) keeps
- * {@code SHARD}; (3) a non-costly scan-heavy query (doc-values-only filter or {@code MatchAll}, cost ≈ maxDoc) is
- * promoted to {@link LuceneSliceQueue.PartitioningStrategy#DOC} because those scans visit ~maxDoc and the limit
- * rarely fires early.
+ * <p>A <b>limited</b> scan (implicit {@code LIMIT}) keeps {@link LuceneSliceQueue.PartitioningStrategy#SHARD} for
+ * costly-to-build clauses (BKD point ranges, multi-term) and for cheap / {@code MatchAll} queries that trivially
+ * early-terminate. Only a scan-heavy non-costly filter (doc-values-only, cost ≥ threshold) is promoted to
+ * {@link LuceneSliceQueue.PartitioningStrategy#DOC} because it visits ~maxDoc regardless of match density.
  */
 public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
 
@@ -111,9 +109,9 @@ public class LuceneSourceOperatorCostAwareStrategyTests extends ESTestCase {
         assertThat(pick(SortedNumericDocValuesField.newSlowRangeQuery("dv", 0, NUM_DOCS / 2), between(1, 1000)), equalTo(DOC));
     }
 
-    public void testLimitedMatchAllPicksDoc() throws IOException {
-        // FROM foo | LIMIT N: cost = maxDoc, not a costly clause — parallelize with DOC.
-        assertThat(pick(Queries.ALL_DOCS_INSTANCE, between(1, 1000)), equalTo(DOC));
+    public void testLimitedMatchAllPicksShard() throws IOException {
+        // FROM foo | LIMIT N: MatchAll early-terminates immediately, keep low-overhead SHARD.
+        assertThat(pick(Queries.ALL_DOCS_INSTANCE, between(1, 1000)), equalTo(SHARD));
     }
 
     public void testLimitedCheapTermPicksShard() throws IOException {


### PR DESCRIPTION
## Summary

- `autoStrategy(long)` — the production cost-aware AUTO strategy — previously returned `SHARD` for **any** query carrying a limit, assuming a pushed `WHERE` clause would early-terminate quickly.
- That assumption holds for BKD-backed filters (cheap, skip to matches) but is inverted for **doc-values-only** filters (columnar mode / `index: false`): those scans visit `~maxDoc` regardless of match density, the limit rarely fires early, and 15 of 16 `task_concurrency` drivers sit idle.
- Fix: route the limit branch through the existing `autoPartitioning` with `DOC` as the `MatchAll` outcome and `SHARD` as the cheap (below-threshold cost) outcome.
  - DV-only filter (cost ≈ maxDoc) → **DOC** — parallelises across `task_concurrency` drivers
  - `MatchAllDocsQuery` (cost = maxDoc) → **DOC**
  - Cheap BKD lookup (cost < threshold) → **SHARD** — unchanged, low overhead wins

The practical trigger: `FROM hits | WHERE <columnar_long_field> == const | KEEP …` with the implicit `LIMIT 1000` picks `SHARD` today; after this fix it picks `DOC`.

## Test plan

- Updated `LuceneSourceOperatorCostAwareStrategyTests` to assert the new per-query outcomes for the limit branch (DV scan → DOC, MatchAll → DOC, cheap term → SHARD).
- Existing `LuceneSourceOperatorAutoStrategyTests` (tests the `int`-overload `AutoStrategy.DEFAULT`, unchanged) still passes.
- Quick manual verification with `"pragma": {"data_partitioning": "doc"}` against a ClickBench columnar index shows the expected speedup on Q20 (`WHERE UserID == <const>`).