### PR TITLE
Build the BBQ merge scorer's query-side records while writing the merged vectors

### DIFF
--- a/docs/changelog/158389.yaml
+++ b/docs/changelog/158389.yaml
@@ -1,0 +1,5 @@
+pr: 158389
+summary: Build the BBQ merge scorer's query-side records while writing the merged vectors
+area: Vector Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/OptimizedScalarQuantizer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/OptimizedScalarQuantizer.java
@@ -76,7 +76,7 @@ public class OptimizedScalarQuantizer {
         byte[] bits,
         float[] centroid
     ) {
-        assert similarityFunction != COSINE || VectorUtil.isUnitVector(vector);
+        assert similarityFunction != COSINE || BQVectorUtils.isUnitVector(vector);
         assert similarityFunction != COSINE || VectorUtil.isUnitVector(centroid);
         assert bits.length == destinations.length;
         if (similarityFunction == EUCLIDEAN) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
@@ -26,7 +26,6 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
@@ -41,11 +40,11 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataAccessHint;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FileDataHint;
 import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.SuppressForbidden;
@@ -60,17 +59,19 @@ import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.elasticsearch.index.codec.vectors.es816.BinaryQuantizer;
 import org.elasticsearch.search.internal.FilterFloatVectorValues;
-import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.Closeable;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readSimilarityFunction;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
-import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.elasticsearch.index.codec.vectors.VectorScoringUtils.scoreAndCollectAll;
 import static org.elasticsearch.index.codec.vectors.es818.ES818BinaryQuantizedVectorsFormat.VECTOR_DATA_EXTENSION;
 
@@ -86,6 +87,10 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
     private final IndexInput quantizedVectorData;
     private final FlatVectorsReader rawVectorsReader;
     private final ES818BinaryFlatVectorsScorer vectorScorer;
+    private final Directory directory;
+    // Query-side temp files the merge's writer may have left for this segment's fields. Only a reader
+    // opened with a MERGE context owns them: the one the graph build opens on the segment being written.
+    private final List<String> mergeQueriesTemps;
 
     @SuppressWarnings("this-escape")
     public ES818BinaryQuantizedVectorsReader(
@@ -96,6 +101,8 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
         this.fields = new HashMap<>();
         this.vectorScorer = vectorsScorer;
         this.rawVectorsReader = rawVectorsReader;
+        this.directory = state.directory;
+        this.mergeQueriesTemps = new ArrayList<>();
         int versionMeta = -1;
         String metaFileName = IndexFileNames.segmentFileName(
             state.segmentInfo.name,
@@ -114,6 +121,17 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
                     state.segmentSuffix
                 );
                 readFields(meta, state.fieldInfos);
+                if (state.context.context() == IOContext.Context.MERGE) {
+                    for (String field : fields.keySet()) {
+                        mergeQueriesTemps.add(
+                            ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName(
+                                state.segmentInfo.name,
+                                state.segmentSuffix,
+                                state.fieldInfos.fieldInfo(field).number
+                            )
+                        );
+                    }
+                }
             } catch (Throwable exception) {
                 priorE = exception;
             } finally {
@@ -137,6 +155,8 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
     private ES818BinaryQuantizedVectorsReader(ES818BinaryQuantizedVectorsReader clone, FlatVectorsReader rawVectorsReader) {
         this.rawVectorsReader = rawVectorsReader;
         this.vectorScorer = clone.vectorScorer;
+        this.directory = clone.directory;
+        this.mergeQueriesTemps = List.of();
         this.quantizedVectorData = clone.quantizedVectorData;
         this.fields = clone.fields;
     }
@@ -273,7 +293,17 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(quantizedVectorData, rawVectorsReader);
+        try {
+            IOUtils.close(quantizedVectorData, rawVectorsReader);
+        } finally {
+            // A query-side temp file the writer produced but no graph build consumed (for example because
+            // the merge stayed below the graph threshold) must not outlive the merge, or Lucene would
+            // register it as a segment file. The list is empty for the source readers a merge also opens
+            // with this context, so this does nothing for them.
+            if (mergeQueriesTemps.isEmpty() == false) {
+                IOUtils.deleteFilesIgnoringExceptions(directory, mergeQueriesTemps);
+            }
+        }
     }
 
     @Override
@@ -393,32 +423,83 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
         if (fi == null) {
             return null;
         }
-        FloatVectorValues floatVectorValues = getFloatVectorValues(fieldInfo.name);
-        if (fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.COSINE) {
-            floatVectorValues = new ES818BinaryQuantizedVectorsWriter.NormalizedFloatVectorValues(floatVectorValues);
+        // The writer of this segment produced the query-side records in its own pass over the merged
+        // vectors, so the merged raw vectors are never read back here. Every writer that can produce a
+        // segment of this format and then build a graph writes that file, so a missing file is a bug:
+        // fail the merge and name the file.
+        String mergeQueries = ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName(
+            segmentWriteState.segmentInfo.name,
+            segmentWriteState.segmentSuffix,
+            fieldInfo.number
+        );
+        IndexInput mergeQueriesInput;
+        try {
+            mergeQueriesInput = segmentWriteState.directory.openInput(mergeQueries, segmentWriteState.context);
+        } catch (NoSuchFileException | FileNotFoundException e) {
+            throw new IllegalStateException(
+                "the writer of segment ["
+                    + segmentWriteState.segmentInfo.name
+                    + "] produced no query-side records for field ["
+                    + fieldInfo.name
+                    + "] (expected ["
+                    + mergeQueries
+                    + "]); only writers that expect to build an HNSW graph produce them",
+                e
+            );
         }
-        OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction());
-        String tempScoreQuantizedVectorName = null;
-        DocsWithFieldSet docsWithField;
-        try (
-            IndexOutput tempScoreQuantizedVector = segmentWriteState.directory.createTempOutput(
-                segmentWriteState.segmentInfo.name,
-                "queries",
-                segmentWriteState.context
-            )
-        ) {
-            tempScoreQuantizedVectorName = tempScoreQuantizedVector.getName();
-            docsWithField = writeBinarizedQueryData(fi.centroid, tempScoreQuantizedVector, floatVectorValues, quantizer);
-            CodecUtil.writeFooter(tempScoreQuantizedVector);
-        } catch (Throwable t) {
-            if (tempScoreQuantizedVectorName != null) {
-                IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, tempScoreQuantizedVectorName);
+        long dataOffset;
+        try {
+            // The file must belong to this segment (the header carries the segment id and suffix) and
+            // hold exactly one record per vector.
+            CodecUtil.checkIndexHeader(
+                mergeQueriesInput,
+                ES818BinaryQuantizedVectorsWriter.MERGE_QUERIES_CODEC_NAME,
+                ES818BinaryQuantizedVectorsFormat.VERSION_START,
+                ES818BinaryQuantizedVectorsFormat.VERSION_CURRENT,
+                segmentWriteState.segmentInfo.getId(),
+                segmentWriteState.segmentSuffix
+            );
+            dataOffset = mergeQueriesInput.getFilePointer();
+            long expectedLength = dataOffset + (long) fi.size * OffHeapBinarizedQueryVectorValues.recordSize(fieldInfo.getVectorDimension())
+                + CodecUtil.footerLength();
+            if (mergeQueriesInput.length() != expectedLength) {
+                throw new CorruptIndexException(
+                    "query-side records for field ["
+                        + fieldInfo.name
+                        + "]: length "
+                        + mergeQueriesInput.length()
+                        + " does not hold "
+                        + fi.size
+                        + " records (expected "
+                        + expectedLength
+                        + ")",
+                    mergeQueriesInput
+                );
             }
+        } catch (Throwable t) {
+            IOUtils.closeWhileSuppressingExceptions(t, mergeQueriesInput);
             throw t;
         }
-        IndexInput quantizedScoreDataInput = segmentWriteState.directory.openInput(tempScoreQuantizedVectorName, segmentWriteState.context);
+        return mergeScorerSupplier(fieldInfo, fi, segmentWriteState, mergeQueries, mergeQueriesInput, dataOffset, fi.size);
+    }
+
+    /**
+     * Builds the merge scorer from the query-side records in {@code queriesInput} (one per vector, in
+     * ordinal order, starting at {@code dataOffset}) and the index-side records in this segment's quantized
+     * vector data. The file {@code queriesName} and the input are released when the supplier is closed,
+     * or here if building it fails.
+     */
+    private CloseableRandomVectorScorerSupplier mergeScorerSupplier(
+        FieldInfo fieldInfo,
+        FieldEntry fi,
+        SegmentWriteState segmentWriteState,
+        String queriesName,
+        IndexInput queriesInput,
+        long dataOffset,
+        int vectorCount
+    ) throws IOException {
+        OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction());
         try {
-            final IndexInput finalBinarizedScoreDataInput = quantizedScoreDataInput;
             // Read the index vectors from their region within the segment data file (sliced to the field
             // offset), mirroring getQuantizedVectorValues. Using the raw, unsliced input would score the
             // graph against bytes at the wrong file offset.
@@ -435,59 +516,26 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
                 fi.vectorDataLength,
                 quantizedVectorData
             );
+            // slice off the header and the footer so the scorer sees only the records
+            IndexInput records = queriesInput.slice(
+                "merge-queries",
+                dataOffset,
+                (long) vectorCount * OffHeapBinarizedQueryVectorValues.recordSize(fieldInfo.getVectorDimension())
+            );
             RandomVectorScorerSupplier scorerSupplier = vectorScorer.getRandomVectorScorerSupplier(
                 fieldInfo.getVectorSimilarityFunction(),
-                new OffHeapBinarizedQueryVectorValues(
-                    finalBinarizedScoreDataInput,
-                    fieldInfo.getVectorDimension(),
-                    docsWithField.cardinality()
-                ),
+                new OffHeapBinarizedQueryVectorValues(records, fieldInfo.getVectorDimension(), vectorCount),
                 vectorValues
             );
-            final String finalTempScoreQuantizedVectorName = tempScoreQuantizedVectorName;
             return new BinarizedCloseableRandomVectorScorerSupplier(scorerSupplier, vectorValues, () -> {
-                IOUtils.close(finalBinarizedScoreDataInput);
-                IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, finalTempScoreQuantizedVectorName);
+                IOUtils.close(queriesInput);
+                IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, queriesName);
             });
         } catch (Throwable t) {
-            IOUtils.closeWhileSuppressingExceptions(t, quantizedScoreDataInput);
-            IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, tempScoreQuantizedVectorName);
+            IOUtils.closeWhileSuppressingExceptions(t, queriesInput);
+            IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, queriesName);
             throw t;
         }
-    }
-
-    static DocsWithFieldSet writeBinarizedQueryData(
-        float[] centroid,
-        IndexOutput binarizedQueryData,
-        FloatVectorValues floatVectorValues,
-        OptimizedScalarQuantizer binaryQuantizer
-    ) throws IOException {
-        DocsWithFieldSet docsWithField = new DocsWithFieldSet();
-        int discretizedDims = BQVectorUtils.discretize(floatVectorValues.dimension(), 64);
-        int[] quantizationScratch = new int[floatVectorValues.dimension()];
-        byte[] toQuery = new byte[(discretizedDims / 8) * BinaryQuantizer.B_QUERY];
-        float[] scratch = new float[floatVectorValues.dimension()];
-        KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
-        for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
-            // write index vector
-            OptimizedScalarQuantizer.QuantizationResult r = binaryQuantizer.scalarQuantize(
-                floatVectorValues.vectorValue(iterator.index()),
-                scratch,
-                quantizationScratch,
-                BinaryQuantizer.B_QUERY,
-                centroid
-            );
-            docsWithField.add(docV);
-            // pack and store the 4bit query vector
-            ESVectorUtil.stride4BitValues(quantizationScratch, toQuery);
-            binarizedQueryData.writeBytes(toQuery, toQuery.length);
-            binarizedQueryData.writeInt(Float.floatToIntBits(r.lowerInterval()));
-            binarizedQueryData.writeInt(Float.floatToIntBits(r.upperInterval()));
-            binarizedQueryData.writeInt(Float.floatToIntBits(r.additionalCorrection()));
-            assert r.quantizedComponentSum() >= 0 && r.quantizedComponentSum() <= 0xffff;
-            binarizedQueryData.writeShort((short) r.quantizedComponentSum());
-        }
-        return docsWithField;
     }
 
     private record FieldEntry(
@@ -587,7 +635,12 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader impleme
             this.binaryValue = byteBuffer.array();
             // + 1 for the quantized sum
             this.correctiveValues = new float[3];
-            this.byteSize = binaryDimensions + Float.BYTES * 3 + Short.BYTES;
+            this.byteSize = recordSize(dimension);
+        }
+
+        /** Bytes per query-side record: the strided 4-bit values, three float corrections and the component sum. */
+        static int recordSize(int dimension) {
+            return (BQVectorUtils.discretize(dimension, 64) / 8) * BinaryQuantizer.B_QUERY + Float.BYTES * 3 + Short.BYTES;
         }
 
         public OptimizedScalarQuantizer.QuantizationResult getCorrectiveTerms(int targetOrd) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsWriter.java
@@ -42,9 +42,11 @@ import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.hnsw.HnswGraphSearcher;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
+import org.elasticsearch.index.codec.vectors.es816.BinaryQuantizer;
 import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.IOException;
@@ -72,6 +74,14 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
     private final IndexOutput meta, binarizedVectorData;
     private final FlatVectorsWriter rawVectorDelegate;
     private final ES818BinaryFlatVectorsScorer vectorsScorer;
+    // Whether an HNSW graph build follows a merge, and the graph threshold it applies. The graph build's
+    // merge scorer consumes the query-side records this writer can produce alongside the index-side ones.
+    private final boolean mergeQueryDataForGraphBuild;
+    private final int mergeQueryDataGraphThreshold;
+    // Query-side files this writer created for the current merge. Once finish() has run they belong to
+    // the reader the graph build opens; if the merge aborts before that, close() deletes them.
+    private final List<String> mergeQueriesWritten = new ArrayList<>();
+    private boolean mergeQueriesHandedOff;
     private boolean finished;
 
     /**
@@ -79,15 +89,35 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
      *
      * @param vectorsScorer the scorer to use for scoring vectors
      */
-    @SuppressWarnings("this-escape")
     public ES818BinaryQuantizedVectorsWriter(
         ES818BinaryFlatVectorsScorer vectorsScorer,
         FlatVectorsWriter rawVectorDelegate,
         SegmentWriteState state
     ) throws IOException {
+        this(vectorsScorer, rawVectorDelegate, state, false, 0);
+    }
+
+    /**
+     * @param mergeQueryDataForGraphBuild whether an HNSW graph build follows a merge. If so, a merge that is
+     *     expected to build a graph also writes the query-side records its merge scorer needs, in the same
+     *     pass as the index-side records, for
+     *     {@link ES818BinaryQuantizedVectorsReader#getRandomVectorScorerSupplierForMerge} to pick up.
+     * @param mergeQueryDataGraphThreshold that build's graph threshold (see {@code hnswGraphThreshold} in
+     *     {@code Lucene99HnswVectorsWriter}), which decides whether a merge of a given size builds a graph
+     */
+    @SuppressWarnings("this-escape")
+    public ES818BinaryQuantizedVectorsWriter(
+        ES818BinaryFlatVectorsScorer vectorsScorer,
+        FlatVectorsWriter rawVectorDelegate,
+        SegmentWriteState state,
+        boolean mergeQueryDataForGraphBuild,
+        int mergeQueryDataGraphThreshold
+    ) throws IOException {
         super(vectorsScorer);
         this.vectorsScorer = vectorsScorer;
         this.segmentWriteState = state;
+        this.mergeQueryDataForGraphBuild = mergeQueryDataForGraphBuild;
+        this.mergeQueryDataGraphThreshold = mergeQueryDataGraphThreshold;
         String metaFileName = IndexFileNames.segmentFileName(
             state.segmentInfo.name,
             state.segmentSuffix,
@@ -310,6 +340,10 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
         if (binarizedVectorData != null) {
             CodecUtil.writeFooter(binarizedVectorData);
         }
+        // From here on the query-side files belong to the reader the graph build opens (Lucene calls
+        // finish() and close() back to back before opening it). A merge that aborts earlier never gets
+        // here, and close() deletes them.
+        mergeQueriesHandedOff = true;
     }
 
     @Override
@@ -328,13 +362,19 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
             if (fieldInfo.getVectorSimilarityFunction() == COSINE) {
                 floatVectorValues = new NormalizedFloatVectorValues(floatVectorValues);
             }
-            BinarizedFloatVectorValues binarizedVectorValues = new BinarizedFloatVectorValues(
-                floatVectorValues,
-                new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction()),
-                centroid
-            );
+            OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction());
             long vectorDataOffset = binarizedVectorData.alignFilePointer(Float.BYTES);
-            DocsWithFieldSet docsWithField = writeBinarizedVectorData(binarizedVectorData, binarizedVectorValues);
+            DocsWithFieldSet docsWithField;
+            if (graphBuildFollows(vectorCount)) {
+                // One pass over the merged vectors writes both the index-side records and the query-side
+                // records the graph build's merge scorer needs, so the merged raw vectors are never read back.
+                docsWithField = writeBinarizedVectorAndMergeQueryData(fieldInfo, floatVectorValues, quantizer, centroid);
+            } else {
+                docsWithField = writeBinarizedVectorData(
+                    binarizedVectorData,
+                    new BinarizedFloatVectorValues(floatVectorValues, quantizer, centroid)
+                );
+            }
             long vectorDataLength = binarizedVectorData.getFilePointer() - vectorDataOffset;
             float centroidDp = docsWithField.cardinality() > 0 ? ESVectorUtil.dotProduct(centroid, centroid) : 0;
             writeMeta(
@@ -357,20 +397,144 @@ public class ES818BinaryQuantizedVectorsWriter extends FlatVectorsWriter {
             // write vector
             byte[] binaryValue = binarizedByteVectorValues.vectorValue(iterator.index());
             output.writeBytes(binaryValue, binaryValue.length);
-            OptimizedScalarQuantizer.QuantizationResult corrections = binarizedByteVectorValues.getCorrectiveTerms(iterator.index());
-            output.writeInt(Float.floatToIntBits(corrections.lowerInterval()));
-            output.writeInt(Float.floatToIntBits(corrections.upperInterval()));
-            output.writeInt(Float.floatToIntBits(corrections.additionalCorrection()));
-            assert corrections.quantizedComponentSum() >= 0 && corrections.quantizedComponentSum() <= 0xffff;
-            output.writeShort((short) corrections.quantizedComponentSum());
+            writeCorrectiveTerms(output, binarizedByteVectorValues.getCorrectiveTerms(iterator.index()));
             docsWithField.add(docV);
         }
         return docsWithField;
     }
 
+    /**
+     * Writes the merged vectors' 1-bit index-side records to the quantized vector data file and, in the same
+     * pass over the same float vectors, their 4-bit query-side records to a file with a fixed name for this
+     * segment, format suffix and field. {@link ES818BinaryQuantizedVectorsReader#getRandomVectorScorerSupplierForMerge}
+     * opens that file to score the graph build instead of reading the merged raw vectors back. Both record
+     * layouts are shared with the flush-time writer and with merges that build no graph.
+     */
+    private DocsWithFieldSet writeBinarizedVectorAndMergeQueryData(
+        FieldInfo fieldInfo,
+        FloatVectorValues floatVectorValues,
+        OptimizedScalarQuantizer quantizer,
+        float[] centroid
+    ) throws IOException {
+        int dimension = floatVectorValues.dimension();
+        int discretizedDims = BQVectorUtils.discretize(dimension, 64);
+        float[] scratch = new float[dimension];
+        int[] indexQuantized = new int[dimension];
+        byte[] indexPacked = new byte[discretizedDims / 8];
+        int[] queryQuantized = new int[dimension];
+        byte[] queryPacked = new byte[(discretizedDims / 8) * BinaryQuantizer.B_QUERY];
+        int[][] quantized = new int[][] { indexQuantized, queryQuantized };
+        byte[] bits = new byte[] { INDEX_BITS, BinaryQuantizer.B_QUERY };
+        DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        // A fixed name, so the reader of this segment can open it without listing the directory. A stale
+        // file of that name is not expected (IndexWriter deletes a failed merge's files); if one exists,
+        // createOutput fails here and the merge fails loudly rather than consuming it.
+        String queriesName = mergeQueriesTempName(segmentWriteState.segmentInfo.name, segmentWriteState.segmentSuffix, fieldInfo.number);
+        IndexOutput queries = segmentWriteState.directory.createOutput(queriesName, segmentWriteState.context);
+        mergeQueriesWritten.add(queriesName);
+        try (queries) {
+            // The header ties the file to this segment: the reader accepts only a file whose segment id and
+            // suffix match, and treats anything else of that name as corrupt.
+            CodecUtil.writeIndexHeader(
+                queries,
+                MERGE_QUERIES_CODEC_NAME,
+                ES818BinaryQuantizedVectorsFormat.VERSION_CURRENT,
+                segmentWriteState.segmentInfo.getId(),
+                segmentWriteState.segmentSuffix
+            );
+            KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
+            for (int docV = iterator.nextDoc(); docV != NO_MORE_DOCS; docV = iterator.nextDoc()) {
+                // one centering pass over the vector serves both quantizations
+                OptimizedScalarQuantizer.QuantizationResult[] results = quantizer.multiScalarQuantize(
+                    floatVectorValues.vectorValue(iterator.index()),
+                    scratch,
+                    quantized,
+                    bits,
+                    centroid
+                );
+                writeIndexRecord(binarizedVectorData, indexQuantized, indexPacked, results[0]);
+                writeQueryRecord(queries, queryQuantized, queryPacked, results[1]);
+                docsWithField.add(docV);
+            }
+            CodecUtil.writeFooter(queries);
+        } catch (Throwable t) {
+            IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, queriesName);
+            throw t;
+        }
+        return docsWithField;
+    }
+
+    /** Whether a merge of {@code vectorCount} vectors goes on to build an HNSW graph, as {@code Lucene99HnswVectorsWriter} decides it. */
+    private boolean graphBuildFollows(int vectorCount) {
+        if (mergeQueryDataForGraphBuild == false || vectorCount <= 0) {
+            return false;
+        }
+        if (mergeQueryDataGraphThreshold <= 0) {
+            return true;
+        }
+        int expectedVisitedNodes = HnswGraphSearcher.expectedVisitedNodes(mergeQueryDataGraphThreshold, vectorCount);
+        return vectorCount > expectedVisitedNodes && expectedVisitedNodes > 0;
+    }
+
+    /** The 1-bit index-side record: packed bits, then the corrective terms. */
+    static void writeIndexRecord(
+        IndexOutput output,
+        int[] quantized,
+        byte[] packed,
+        OptimizedScalarQuantizer.QuantizationResult corrections
+    ) throws IOException {
+        ESVectorUtil.pack1BitValues(quantized, packed);
+        output.writeBytes(packed, packed.length);
+        writeCorrectiveTerms(output, corrections);
+    }
+
+    /** The 4-bit query-side record: strided nibbles, then the corrective terms. */
+    static void writeQueryRecord(
+        IndexOutput output,
+        int[] quantized,
+        byte[] packed,
+        OptimizedScalarQuantizer.QuantizationResult corrections
+    ) throws IOException {
+        ESVectorUtil.stride4BitValues(quantized, packed);
+        output.writeBytes(packed, packed.length);
+        writeCorrectiveTerms(output, corrections);
+    }
+
+    static void writeCorrectiveTerms(IndexOutput output, OptimizedScalarQuantizer.QuantizationResult corrections) throws IOException {
+        output.writeInt(Float.floatToIntBits(corrections.lowerInterval()));
+        output.writeInt(Float.floatToIntBits(corrections.upperInterval()));
+        output.writeInt(Float.floatToIntBits(corrections.additionalCorrection()));
+        assert corrections.quantizedComponentSum() >= 0 && corrections.quantizedComponentSum() <= 0xffff;
+        output.writeShort((short) corrections.quantizedComponentSum());
+    }
+
+    static final byte INDEX_BITS = 1;
+
+    /** Segment-suffix component of the query-side temp file a merge writes: {@code <segment>_<suffix>_bbqmq<field>.tmp}. */
+    static final String MERGE_QUERIES_TEMP_SUFFIX = "bbqmq";
+
+    /** Codec name in the query-side temp file's index header, which also carries the segment id and suffix. */
+    static final String MERGE_QUERIES_CODEC_NAME = "ES818BinaryQuantizedVectorsFormatMergeQueries";
+
+    /** The fixed name of the query-side temp file for a field of a segment being merged. */
+    static String mergeQueriesTempName(String segmentName, String segmentSuffix, int fieldNumber) {
+        String suffix = MERGE_QUERIES_TEMP_SUFFIX + fieldNumber;
+        return IndexFileNames.segmentFileName(segmentName, segmentSuffix.isEmpty() ? suffix : segmentSuffix + "_" + suffix, "tmp");
+    }
+
     @Override
     public void close() throws IOException {
-        IOUtils.close(meta, binarizedVectorData, rawVectorDelegate);
+        try {
+            IOUtils.close(meta, binarizedVectorData, rawVectorDelegate);
+        } finally {
+            // A merge that aborts before finish() (another field's merge failed, or the merge was
+            // cancelled) never opens the reader that would own these files, and IndexWriter only deletes
+            // a failed merge's files once the merge has registered them, which has not happened yet.
+            // Delete them here.
+            if (mergeQueriesHandedOff == false && mergeQueriesWritten.isEmpty() == false) {
+                IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, mergeQueriesWritten);
+            }
+        }
     }
 
     static float[] getCentroid(KnnVectorsReader vectorsReader, String fieldName) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedVectorsFormat.java
@@ -93,14 +93,34 @@ public class ES93BinaryQuantizedVectorsFormat extends AbstractFlatVectorsFormat 
     private static final ES818BinaryFlatVectorsScorer scorer = new ES818BinaryFlatVectorsScorer(ES93GenericFlatVectorScorer.INSTANCE);
 
     private final ES93GenericFlatVectorsFormat rawFormat;
+    private final boolean mergeQueryDataForGraphBuild;
+    private final int mergeQueryDataGraphThreshold;
 
     public ES93BinaryQuantizedVectorsFormat() {
         this(DenseVectorFieldMapper.ElementType.FLOAT, false);
     }
 
     public ES93BinaryQuantizedVectorsFormat(DenseVectorFieldMapper.ElementType elementType, boolean useDirectIO) {
+        this(elementType, useDirectIO, false, 0);
+    }
+
+    /**
+     * @param mergeQueryDataForGraphBuild {@code true} when this flat format backs an HNSW format, whose merges
+     *     build a graph over the merged vectors. The writer then produces the merge scorer's query-side
+     *     records in its own pass, so the graph build does not read the merged raw vectors back.
+     * @param mergeQueryDataGraphThreshold that HNSW format's graph threshold, which decides whether a merge
+     *     of a given size builds a graph at all
+     */
+    public ES93BinaryQuantizedVectorsFormat(
+        DenseVectorFieldMapper.ElementType elementType,
+        boolean useDirectIO,
+        boolean mergeQueryDataForGraphBuild,
+        int mergeQueryDataGraphThreshold
+    ) {
         super(NAME);
         rawFormat = new ES93GenericFlatVectorsFormat(elementType, useDirectIO);
+        this.mergeQueryDataForGraphBuild = mergeQueryDataForGraphBuild;
+        this.mergeQueryDataGraphThreshold = mergeQueryDataGraphThreshold;
     }
 
     @Override
@@ -110,7 +130,13 @@ public class ES93BinaryQuantizedVectorsFormat extends AbstractFlatVectorsFormat 
 
     @Override
     public FlatVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
-        return new ES818BinaryQuantizedVectorsWriter(scorer, rawFormat.fieldsWriter(state), state);
+        return new ES818BinaryQuantizedVectorsWriter(
+            scorer,
+            rawFormat.fieldsWriter(state),
+            state,
+            mergeQueryDataForGraphBuild,
+            mergeQueryDataGraphThreshold
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93HnswBinaryQuantizedVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93HnswBinaryQuantizedVectorsFormat.java
@@ -51,7 +51,7 @@ public class ES93HnswBinaryQuantizedVectorsFormat extends AbstractHnswVectorsFor
     /** Constructs a format using default graph construction parameters */
     public ES93HnswBinaryQuantizedVectorsFormat() {
         super(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null, BBQ_HNSW_GRAPH_THRESHOLD);
-        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat();
+        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(DenseVectorFieldMapper.ElementType.FLOAT, false, true, hnswGraphThreshold);
     }
 
     /**
@@ -61,7 +61,7 @@ public class ES93HnswBinaryQuantizedVectorsFormat extends AbstractHnswVectorsFor
      */
     public ES93HnswBinaryQuantizedVectorsFormat(DenseVectorFieldMapper.ElementType elementType, boolean useDirectIO) {
         super(NAME, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null, BBQ_HNSW_GRAPH_THRESHOLD);
-        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO);
+        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO, true, hnswGraphThreshold);
     }
 
     /**
@@ -78,7 +78,7 @@ public class ES93HnswBinaryQuantizedVectorsFormat extends AbstractHnswVectorsFor
         boolean useDirectIO
     ) {
         super(NAME, maxConn, beamWidth, DEFAULT_NUM_MERGE_WORKER, null, BBQ_HNSW_GRAPH_THRESHOLD);
-        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO);
+        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO, true, hnswGraphThreshold);
     }
 
     /**
@@ -101,7 +101,7 @@ public class ES93HnswBinaryQuantizedVectorsFormat extends AbstractHnswVectorsFor
         ExecutorService mergeExec
     ) {
         super(NAME, maxConn, beamWidth, numMergeWorkers, mergeExec, BBQ_HNSW_GRAPH_THRESHOLD);
-        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO);
+        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO, true, hnswGraphThreshold);
     }
 
     /**
@@ -126,7 +126,9 @@ public class ES93HnswBinaryQuantizedVectorsFormat extends AbstractHnswVectorsFor
         int hnswGraphThreshold
     ) {
         super(NAME, maxConn, beamWidth, numMergeWorkers, mergeExec, resolveThreshold(hnswGraphThreshold, BBQ_HNSW_GRAPH_THRESHOLD));
-        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO);
+        // Pass the resolved threshold (the field), not the parameter: a negative parameter means "use the
+        // default", and the writer must mirror the graph build's decision with the same number.
+        flatVectorsFormat = new ES93BinaryQuantizedVectorsFormat(elementType, useDirectIO, true, this.hnswGraphThreshold);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedRWVectorsFormat.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedRWVectorsFormat.java
@@ -15,8 +15,33 @@ import org.apache.lucene.index.SegmentWriteState;
 import java.io.IOException;
 
 public class ES818BinaryQuantizedRWVectorsFormat extends ES818BinaryQuantizedVectorsFormat {
+
+    private final boolean mergeQueryDataForGraphBuild;
+    private final int hnswGraphThreshold;
+
+    /** A flat-only writer: its merges build no graph and produce no query-side records. */
+    public ES818BinaryQuantizedRWVectorsFormat() {
+        this(false, 0);
+    }
+
+    /**
+     * @param mergeQueryDataForGraphBuild {@code true} when an HNSW format writes through this one, so merges
+     *     that will build a graph also write the query-side records its merge scorer reads
+     * @param hnswGraphThreshold that HNSW format's graph threshold
+     */
+    public ES818BinaryQuantizedRWVectorsFormat(boolean mergeQueryDataForGraphBuild, int hnswGraphThreshold) {
+        this.mergeQueryDataForGraphBuild = mergeQueryDataForGraphBuild;
+        this.hnswGraphThreshold = hnswGraphThreshold;
+    }
+
     @Override
     public FlatVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
-        return new ES818BinaryQuantizedVectorsWriter(scorer, rawVectorFormat.fieldsWriter(state), state);
+        return new ES818BinaryQuantizedVectorsWriter(
+            scorer,
+            rawVectorFormat.fieldsWriter(state),
+            state,
+            mergeQueryDataForGraphBuild,
+            hnswGraphThreshold
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818HnswBinaryQuantizedRWVectorsFormat.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818HnswBinaryQuantizedRWVectorsFormat.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 public class ES818HnswBinaryQuantizedRWVectorsFormat extends ES818HnswBinaryQuantizedVectorsFormat {
-    private static final FlatVectorsFormat flatVectorsFormat = new ES818BinaryQuantizedRWVectorsFormat();
+    // graph threshold 0, matching the writer below: every merge builds a graph and so writes the
+    // query-side records the graph build's merge scorer reads
+    private static final FlatVectorsFormat flatVectorsFormat = new ES818BinaryQuantizedRWVectorsFormat(true, 0);
 
     public ES818HnswBinaryQuantizedRWVectorsFormat() {}
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818MergeQueryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818MergeQueryDataTests.java
@@ -1,0 +1,643 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors.es818;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.MergeInfo;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.VectorUtil;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
+import org.elasticsearch.index.codec.vectors.es816.BinaryQuantizer;
+import org.elasticsearch.index.codec.vectors.es93.ES93BinaryQuantizedVectorsFormat;
+import org.elasticsearch.index.codec.vectors.es93.ES93HnswBinaryQuantizedVectorsFormat;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A BBQ merge writes the merged raw vectors once and must not read them back to build the graph: the
+ * writer produces the query-side records in the same pass that produces the index-side records, and the
+ * merge scorer picks those up. These tests pin that, and that the hand-off file never outlives the merge.
+ */
+public class ES818MergeQueryDataTests extends LuceneTestCase {
+
+    static {
+        LogConfigurator.configureESLogging(); // native vector scoring requires logging to be initialized
+    }
+
+    private static final int DIMS = 64;
+    private static final int DOCS_PER_SEGMENT = 200;
+
+    /** Counts the bytes read from every file, including through clones and slices, and the files created. */
+    private static class ReadCountingDirectory extends FilterDirectory {
+        final Map<String, AtomicLong> bytesRead = new ConcurrentHashMap<>();
+        final Map<String, AtomicLong> created = new ConcurrentHashMap<>();
+
+        ReadCountingDirectory(Directory in) {
+            super(in);
+        }
+
+        @Override
+        public IndexInput openInput(String name, IOContext context) throws IOException {
+            return new CountingIndexInput(name, super.openInput(name, context), bytesRead.computeIfAbsent(name, n -> new AtomicLong()));
+        }
+
+        @Override
+        public IndexOutput createOutput(String name, IOContext context) throws IOException {
+            created.computeIfAbsent(name, n -> new AtomicLong()).incrementAndGet();
+            return super.createOutput(name, context);
+        }
+
+        long bytesRead(String name) {
+            AtomicLong count = bytesRead.get(name);
+            return count == null ? 0 : count.get();
+        }
+
+        /** The hand-off files the writer created, one per field of a merge that builds a graph. */
+        List<String> handOffsCreated() {
+            return created.keySet()
+                .stream()
+                .filter(n -> n.contains(ES818BinaryQuantizedVectorsWriter.MERGE_QUERIES_TEMP_SUFFIX))
+                .sorted()
+                .toList();
+        }
+    }
+
+    private static class CountingIndexInput extends IndexInput {
+        private final IndexInput in;
+        private final AtomicLong counter;
+
+        CountingIndexInput(String description, IndexInput in, AtomicLong counter) {
+            super(description);
+            this.in = in;
+            this.counter = counter;
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            counter.incrementAndGet();
+            return in.readByte();
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            counter.addAndGet(len);
+            in.readBytes(b, offset, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return in.getFilePointer();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            in.seek(pos);
+        }
+
+        @Override
+        public long length() {
+            return in.length();
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            return new CountingIndexInput(sliceDescription, in.slice(sliceDescription, offset, length), counter);
+        }
+
+        @Override
+        public IndexInput clone() {
+            return new CountingIndexInput(toString(), in.clone(), counter);
+        }
+    }
+
+    private static KnnVectorsFormat bbqHnsw(int graphThreshold, DenseVectorFieldMapper.ElementType elementType) {
+        return new ES93HnswBinaryQuantizedVectorsFormat(16, 100, elementType, false, 1, null, graphThreshold);
+    }
+
+    public void testMergeDoesNotReadMergedRawVectorsBack() throws IOException {
+        // threshold 0: the merge always builds a graph, so the merge scorer is always requested
+        runMerge(bbqHnsw(0, DenseVectorFieldMapper.ElementType.FLOAT), true, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    public void testMergeDoesNotReadMergedRawVectorsBackCosine() throws IOException {
+        // cosine normalizes before quantizing on both the writer's and the read-back path
+        runMerge(bbqHnsw(0, DenseVectorFieldMapper.ElementType.FLOAT), true, VectorSimilarityFunction.COSINE);
+    }
+
+    public void testMergeDoesNotReadMergedRawVectorsBackBFloat16() throws IOException {
+        runMerge(bbqHnsw(0, DenseVectorFieldMapper.ElementType.BFLOAT16), true, VectorSimilarityFunction.DOT_PRODUCT);
+    }
+
+    public void testQueryTempIsCleanedWhenNoGraphIsBuilt() throws IOException {
+        // a threshold the merge does not reach: the writer mirrors the graph decision and writes no
+        // hand-off file (asserted), and nothing may outlive the merge; the merge scorer is never requested
+        runMerge(bbqHnsw(Integer.MAX_VALUE, DenseVectorFieldMapper.ElementType.FLOAT), false, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    public void testDefaultThresholdWritesNoHandOffBelowIt() throws IOException {
+        // the production configuration: the mapper passes -1, which the format resolves to its default
+        // (300). Two segments of 200 vectors stay below that threshold's expected search cost, so Lucene
+        // builds no graph and the writer must produce no hand-off either: the mirror has to see the
+        // resolved threshold, not the -1
+        runMerge(bbqHnsw(-1, DenseVectorFieldMapper.ElementType.FLOAT), false, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    /**
+     * The writer mirrors the graph decision, so a leftover hand-off file needs the mirror to disagree with
+     * Lucene; the reader the graph build opens on the segment being merged deletes one regardless.
+     */
+    public void testMergeContextReaderDeletesLeftoverTemp() throws IOException {
+        Path path = createTempDir("bbqLeftoverTemp");
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(
+            TestUtil.alwaysKnnVectorsFormat(bbqHnsw(0, DenseVectorFieldMapper.ElementType.FLOAT))
+        );
+        config.setUseCompoundFile(false);
+        config.getMergePolicy().setNoCFSRatio(0.0);
+        try (Directory dir = new MMapDirectory(path); IndexWriter writer = new IndexWriter(dir, config)) {
+            for (int i = 0; i < 2 * DOCS_PER_SEGMENT; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField("v", randomVector(DIMS), VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+                if (i == DOCS_PER_SEGMENT - 1) {
+                    writer.commit();
+                }
+            }
+            writer.commit();
+            writer.forceMerge(1);
+            writer.commit();
+            SegmentCommitInfo merged = SegmentInfos.readLatestCommit(dir).info(0);
+            // the per-field format suffix, from the quantized data file's name
+            String veb = merged.files().stream().filter(f -> f.endsWith(".veb")).findFirst().orElseThrow();
+            String suffix = veb.substring(merged.info.name.length() + 1, veb.length() - ".veb".length());
+            FieldInfos fieldInfos;
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                fieldInfos = ((SegmentReader) getOnlyLeafReader(reader)).getFieldInfos();
+            }
+            int fieldNumber = fieldInfos.fieldInfo("v").number;
+            String leftover = ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName(merged.info.name, suffix, fieldNumber);
+            String someoneElses = ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName("_zz", suffix, fieldNumber);
+            for (String name : new String[] { leftover, someoneElses }) {
+                try (IndexOutput out = dir.createOutput(name, IOContext.DEFAULT)) {
+                    out.writeInt(42);
+                }
+            }
+            // the flat reader is what owns the hand-off files; open it the two ways a merge and a search do
+            ES93BinaryQuantizedVectorsFormat flat = new ES93BinaryQuantizedVectorsFormat(
+                DenseVectorFieldMapper.ElementType.FLOAT,
+                false,
+                true,
+                0
+            );
+            // a search-time (DEFAULT context) reader must leave both alone
+            flat.fieldsReader(new SegmentReadState(dir, merged.info, fieldInfos, IOContext.DEFAULT, suffix)).close();
+            assertTrue(Arrays.asList(dir.listAll()).containsAll(List.of(leftover, someoneElses)));
+            // the reader a merge opens on the segment it is writing deletes its own fields' leftover, only that
+            flat.fieldsReader(new SegmentReadState(dir, merged.info, fieldInfos, IOContext.merge(new MergeInfo(1, 1, false, -1)), suffix))
+                .close();
+            List<String> after = Arrays.asList(dir.listAll());
+            assertFalse("the leftover hand-off file survived the merge-context reader's close", after.contains(leftover));
+            assertTrue("another segment's file was deleted", after.contains(someoneElses));
+            dir.deleteFile(someoneElses);
+        }
+    }
+
+    /**
+     * There is no read-back path: the merge scorer can only be built from the writer's records. A reader
+     * asked for it without them fails loudly and names the missing file, and a file of that name that is
+     * not this segment's (here: junk) is a corrupt-index error, never something to score a graph from.
+     */
+    public void testMergeScorerWithoutWriterRecordsFailsLoudly() throws IOException {
+        Path path = createTempDir("bbqNoHandOff");
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(
+            TestUtil.alwaysKnnVectorsFormat(bbqHnsw(0, DenseVectorFieldMapper.ElementType.FLOAT))
+        );
+        config.setUseCompoundFile(false);
+        config.getMergePolicy().setNoCFSRatio(0.0);
+        try (Directory dir = new MMapDirectory(path); IndexWriter writer = new IndexWriter(dir, config)) {
+            for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField("v", randomVector(DIMS), VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+            }
+            writer.commit(); // a flushed segment: written without a merge, so without a hand-off
+            SegmentCommitInfo segment = SegmentInfos.readLatestCommit(dir).info(0);
+            String veb = segment.files().stream().filter(f -> f.endsWith(".veb")).findFirst().orElseThrow();
+            String suffix = veb.substring(segment.info.name.length() + 1, veb.length() - ".veb".length());
+            FieldInfos fieldInfos;
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                fieldInfos = ((SegmentReader) getOnlyLeafReader(reader)).getFieldInfos();
+            }
+            FieldInfo field = fieldInfos.fieldInfo("v");
+            String handOff = ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName(segment.info.name, suffix, field.number);
+            ES93BinaryQuantizedVectorsFormat flat = new ES93BinaryQuantizedVectorsFormat(
+                DenseVectorFieldMapper.ElementType.FLOAT,
+                false,
+                true,
+                0
+            );
+            IOContext merge = IOContext.merge(new MergeInfo(1, 1, false, -1));
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.getDefault(),
+                dir,
+                segment.info,
+                fieldInfos,
+                null,
+                merge,
+                suffix
+            );
+
+            try (
+                var reader = (ES818BinaryQuantizedVectorsReader) flat.fieldsReader(
+                    new SegmentReadState(dir, segment.info, fieldInfos, merge, suffix)
+                )
+            ) {
+                IllegalStateException e = expectThrows(
+                    IllegalStateException.class,
+                    () -> reader.getRandomVectorScorerSupplierForMerge(field, writeState)
+                );
+                assertTrue("the error must name the missing file: " + e.getMessage(), e.getMessage().contains(handOff));
+            }
+
+            try (IndexOutput out = dir.createOutput(handOff, IOContext.DEFAULT)) {
+                out.writeInt(42);
+            }
+            try (
+                var reader = (ES818BinaryQuantizedVectorsReader) flat.fieldsReader(
+                    new SegmentReadState(dir, segment.info, fieldInfos, merge, suffix)
+                )
+            ) {
+                expectThrows(CorruptIndexException.class, () -> reader.getRandomVectorScorerSupplierForMerge(field, writeState));
+            }
+            // the merge-context reader's close swept the junk file as a leftover of its own field
+            assertFalse("the junk file outlived the merge-context reader", Arrays.asList(dir.listAll()).contains(handOff));
+        }
+    }
+
+    /**
+     * A merge that fails before the graph build never opens the reader that owns the hand-off files, and
+     * Lucene deletes a failed merge's files only once the merge has registered them, which a merge that
+     * fails this early never does. The writer's close must sweep what it wrote.
+     */
+    public void testPhaseOneAbortLeavesNoHandOff() throws IOException {
+        Path path = createTempDir("bbqPhaseOneAbort");
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(
+            TestUtil.alwaysKnnVectorsFormat(bbqHnsw(0, DenseVectorFieldMapper.ElementType.FLOAT))
+        );
+        config.setUseCompoundFile(false);
+        config.getMergePolicy().setNoCFSRatio(0.0);
+        // merge on the calling thread, so the failure surfaces from forceMerge rather than from a merge thread
+        config.setMergeScheduler(new SerialMergeScheduler());
+        // the second field's hand-off cannot be created: phase 1 aborts after the first field wrote its own
+        FilterDirectory dir = new FilterDirectory(new MMapDirectory(path)) {
+            @Override
+            public IndexOutput createOutput(String name, IOContext context) throws IOException {
+                if (name.contains("_" + ES818BinaryQuantizedVectorsWriter.MERGE_QUERIES_TEMP_SUFFIX)
+                    && name.endsWith("bbqmq0.tmp") == false) {
+                    throw new IOException("simulated failure creating " + name);
+                }
+                return super.createOutput(name, context);
+            }
+        };
+        IndexWriter writer = new IndexWriter(dir, config);
+        try {
+            for (int i = 0; i < 2 * DOCS_PER_SEGMENT; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField("v", randomVector(DIMS), VectorSimilarityFunction.EUCLIDEAN));
+                doc.add(new KnnFloatVectorField("w", randomVector(DIMS), VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+                if (i == DOCS_PER_SEGMENT - 1) {
+                    writer.commit();
+                }
+            }
+            writer.commit();
+            Exception failure = expectThrows(Exception.class, () -> writer.forceMerge(1));
+            // the merge failure surfaces wrapped (IndexWriter marks itself tragic); the cause chain carries it
+            boolean simulated = false;
+            for (Throwable t = failure; t != null && simulated == false; t = t.getCause()) {
+                simulated = String.valueOf(t.getMessage()).contains("simulated failure");
+            }
+            assertTrue("unexpected merge failure: " + failure, simulated);
+        } finally {
+            try {
+                writer.rollback();
+            } catch (Exception e) {
+                // the writer may already be unusable after the merge failure
+            }
+        }
+        for (String file : dir.listAll()) {
+            assertFalse("a hand-off file survived the aborted merge: " + file, file.endsWith(".tmp"));
+        }
+        dir.close();
+    }
+
+    public void testMergeQueriesTempName() {
+        assertEquals("_5_bbqmq7.tmp", ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName("_5", "", 7));
+        assertEquals(
+            "_5_ES93HnswBinaryQuantizedVectorsFormat_0_bbqmq70.tmp",
+            ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName("_5", "ES93HnswBinaryQuantizedVectorsFormat_0", 70)
+        );
+        // never a segment file: Lucene rejects .tmp names in a segment's file set
+        assertTrue(ES818BinaryQuantizedVectorsWriter.mergeQueriesTempName("_5", "x", 1).endsWith(".tmp"));
+    }
+
+    /** The fused pass quantizes both widths from one centering pass; it must equal two independent quantizations. */
+    public void testMultiBitQuantizationMatchesSingleBit() {
+        for (int dims : new int[] { DIMS, 1024, 2048 }) {
+            for (VectorSimilarityFunction similarity : VectorSimilarityFunction.values()) {
+                quantizationMatches(similarity, dims);
+            }
+        }
+    }
+
+    private static void quantizationMatches(VectorSimilarityFunction similarity, int dims) {
+        OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(similarity);
+        float[] centroid = randomVector(dims);
+        for (int i = 0; i < 20; i++) {
+            float[] vector = randomVector(dims);
+            if (similarity == VectorSimilarityFunction.COSINE) {
+                VectorUtil.l2normalize(vector);
+                VectorUtil.l2normalize(centroid);
+            }
+            int[] expectedIndex = new int[dims];
+            int[] expectedQuery = new int[dims];
+            OptimizedScalarQuantizer.QuantizationResult expectedIndexResult = quantizer.scalarQuantize(
+                vector,
+                new float[dims],
+                expectedIndex,
+                ES818BinaryQuantizedVectorsWriter.INDEX_BITS,
+                centroid
+            );
+            OptimizedScalarQuantizer.QuantizationResult expectedQueryResult = quantizer.scalarQuantize(
+                vector,
+                new float[dims],
+                expectedQuery,
+                BinaryQuantizer.B_QUERY,
+                centroid
+            );
+            int[] actualIndex = new int[dims];
+            int[] actualQuery = new int[dims];
+            OptimizedScalarQuantizer.QuantizationResult[] actual = quantizer.multiScalarQuantize(
+                vector,
+                new float[dims],
+                new int[][] { actualIndex, actualQuery },
+                new byte[] { ES818BinaryQuantizedVectorsWriter.INDEX_BITS, BinaryQuantizer.B_QUERY },
+                centroid
+            );
+            // the fused pass runs the same interval optimisation as the single-width call, but the
+            // vectorised loss reduction is not bit-stable across JIT tiers (its lane sums may round
+            // differently once compiled), which moves an optimised interval by an ulp and can flip a
+            // quantised value sitting on a rounding boundary; the comparison allows exactly that much
+            String where = similarity + " dims=" + dims + " vector#" + i;
+            assertQuantizedClose(where + " index side", expectedIndex, actualIndex);
+            assertQuantizedClose(where + " query side", expectedQuery, actualQuery);
+            assertCorrectionsClose(where + " index-side corrections", dims, expectedIndexResult, actual[0]);
+            assertCorrectionsClose(where + " query-side corrections", dims, expectedQueryResult, actual[1]);
+        }
+    }
+
+    private static void assertQuantizedClose(String where, int[] expected, int[] actual) {
+        assertEquals(where, expected.length, actual.length);
+        int flipped = 0;
+        for (int i = 0; i < expected.length; i++) {
+            int diff = Math.abs(expected[i] - actual[i]);
+            assertTrue(where + ": element " + i + " expected " + expected[i] + " but was " + actual[i], diff <= 1);
+            flipped += diff;
+        }
+        assertTrue(where + ": " + flipped + " boundary flips in " + expected.length + " values", flipped <= 1 + expected.length / 100);
+    }
+
+    private static void assertCorrectionsClose(
+        String where,
+        int dims,
+        OptimizedScalarQuantizer.QuantizationResult expected,
+        OptimizedScalarQuantizer.QuantizationResult actual
+    ) {
+        assertClose(where + " lowerInterval", expected.lowerInterval(), actual.lowerInterval());
+        assertClose(where + " upperInterval", expected.upperInterval(), actual.upperInterval());
+        assertClose(where + " additionalCorrection", expected.additionalCorrection(), actual.additionalCorrection());
+        // the component sum moves by one per boundary flip, no more than assertQuantizedClose allows
+        assertTrue(
+            where + " quantizedComponentSum expected " + expected.quantizedComponentSum() + " but was " + actual.quantizedComponentSum(),
+            Math.abs(expected.quantizedComponentSum() - actual.quantizedComponentSum()) <= 1 + dims / 100
+        );
+    }
+
+    private static void assertClose(String where, float expected, float actual) {
+        assertEquals(where, expected, actual, 1e-5f * Math.max(1f, Math.abs(expected)));
+    }
+
+    /**
+     * The query-side records the writer produces read back through the scorer's record reader exactly as
+     * the quantizer produced them: the packed 4-bit values and the corrective terms, by random ordinal.
+     */
+    public void testWriterQueryRecordsRoundTripThroughTheScorerReader() throws IOException {
+        int count = 50;
+        float[] centroid = randomVector(DIMS);
+        OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(VectorSimilarityFunction.EUCLIDEAN);
+        int discretized = org.elasticsearch.index.codec.vectors.BQVectorUtils.discretize(DIMS, 64);
+        int[] indexQuantized = new int[DIMS];
+        int[] queryQuantized = new int[DIMS];
+        byte[] indexPacked = new byte[discretized / 8];
+        byte[] queryPacked = new byte[(discretized / 8) * BinaryQuantizer.B_QUERY];
+        byte[][] expectedPacked = new byte[count][];
+        OptimizedScalarQuantizer.QuantizationResult[] expectedTerms = new OptimizedScalarQuantizer.QuantizationResult[count];
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // the writer's pass, as writeBinarizedVectorAndMergeQueryData does it
+            try (
+                IndexOutput index = dir.createOutput("index", IOContext.DEFAULT);
+                IndexOutput queries = dir.createOutput("queries", IOContext.DEFAULT)
+            ) {
+                for (int i = 0; i < count; i++) {
+                    OptimizedScalarQuantizer.QuantizationResult[] results = quantizer.multiScalarQuantize(
+                        randomVector(DIMS),
+                        new float[DIMS],
+                        new int[][] { indexQuantized, queryQuantized },
+                        new byte[] { ES818BinaryQuantizedVectorsWriter.INDEX_BITS, BinaryQuantizer.B_QUERY },
+                        centroid
+                    );
+                    ES818BinaryQuantizedVectorsWriter.writeIndexRecord(index, indexQuantized, indexPacked, results[0]);
+                    ES818BinaryQuantizedVectorsWriter.writeQueryRecord(queries, queryQuantized, queryPacked, results[1]);
+                    expectedPacked[i] = queryPacked.clone();
+                    expectedTerms[i] = results[1];
+                }
+            }
+            assertEquals(
+                "one record per vector, of the size the reader expects",
+                (long) count * ES818BinaryQuantizedVectorsReader.OffHeapBinarizedQueryVectorValues.recordSize(DIMS),
+                dir.fileLength("queries")
+            );
+            try (IndexInput in = dir.openInput("queries", IOContext.DEFAULT)) {
+                var records = new ES818BinaryQuantizedVectorsReader.OffHeapBinarizedQueryVectorValues(in, DIMS, count);
+                for (int ord : new int[] { 0, count - 1, count / 2, 1, count / 2 }) {
+                    assertArrayEquals("query bits of ordinal " + ord, expectedPacked[ord], records.vectorValue(ord));
+                    assertEquals("corrective terms of ordinal " + ord, expectedTerms[ord], records.getCorrectiveTerms(ord));
+                }
+            }
+        }
+    }
+
+    private void runMerge(KnnVectorsFormat format, boolean expectGraph, VectorSimilarityFunction similarity) throws IOException {
+        float[][] vectors = new float[DOCS_PER_SEGMENT * 2][];
+        for (int i = 0; i < vectors.length; i++) {
+            vectors[i] = randomVector(DIMS);
+        }
+        Path path = createTempDir("bbqMergeQueryData");
+        IndexWriterConfig config = new IndexWriterConfig().setCodec(TestUtil.alwaysKnnVectorsFormat(format));
+        // keep the raw vector file visible as its own file, not hidden inside a .cfs
+        config.setUseCompoundFile(false);
+        config.getMergePolicy().setNoCFSRatio(0.0);
+
+        try (
+            ReadCountingDirectory dir = new ReadCountingDirectory(new MMapDirectory(path));
+            IndexWriter writer = new IndexWriter(dir, config)
+        ) {
+            for (int i = 0; i < vectors.length; i++) {
+                Document doc = new Document();
+                doc.add(new KnnFloatVectorField("v", vectors[i], similarity));
+                // a second vector field of the same format: its own hand-off file, its own cleanup
+                doc.add(new KnnFloatVectorField("w", vectors[vectors.length - 1 - i], similarity));
+                writer.addDocument(doc);
+                if (i == DOCS_PER_SEGMENT - 1) {
+                    writer.commit();
+                }
+            }
+            writer.commit();
+            SegmentInfos before = SegmentInfos.readLatestCommit(dir);
+            assertEquals(2, before.size());
+            long sourceRawBytes = 0;
+            for (SegmentCommitInfo sci : before) {
+                for (String file : sci.files()) {
+                    if (file.endsWith(".vec")) {
+                        sourceRawBytes += dir.fileLength(file);
+                    }
+                }
+            }
+            assertTrue("expected raw vector files for the sources", sourceRawBytes >= 2L * vectors.length * DIMS * Float.BYTES / 2);
+
+            // hold a reader open across the merge, as a serving node does
+            try (DirectoryReader beforeMerge = DirectoryReader.open(writer)) {
+                assertEquals(vectors.length, beforeMerge.numDocs());
+                writer.forceMerge(1);
+            }
+            writer.commit();
+
+            SegmentInfos after = SegmentInfos.readLatestCommit(dir);
+            assertEquals(1, after.size());
+            SegmentCommitInfo merged = after.info(0);
+            String mergedRaw = null;
+            for (String file : merged.files()) {
+                assertFalse("a temp file was registered as a segment file: " + file, file.endsWith(".tmp"));
+                if (file.endsWith(".vec")) {
+                    mergedRaw = file;
+                }
+            }
+            assertNotNull("merged segment has no raw vector file", mergedRaw);
+            for (String file : dir.listAll()) {
+                assertFalse("a temp file outlived the merge: " + file, file.endsWith(".tmp"));
+            }
+            // the writer produces one hand-off per field exactly when the merge builds a graph, and the
+            // merge scorer then reads it; without a graph it produces none rather than one it deletes
+            List<String> handOffs = dir.handOffsCreated();
+            assertEquals("hand-off files created: " + handOffs, expectGraph ? 2 : 0, handOffs.size());
+            for (String handOff : handOffs) {
+                assertTrue("the merge scorer never read the hand-off " + handOff, dir.bytesRead(handOff) > 0);
+            }
+
+            long mergedRawBytes = 2L * vectors.length * DIMS * Float.BYTES; // two fields share the raw vector file
+            long readBack = dir.bytesRead(mergedRaw);
+            // the merge may touch the merged raw file's header, metadata and footer; it must not stream
+            // the vectors back, which would read at least the whole file once
+            assertTrue(
+                "the merge read the merged raw vectors back: " + readBack + " of " + mergedRawBytes + " bytes",
+                readBack < mergedRawBytes / 4
+            );
+            // positive control for the counter: the sources' raw vectors were streamed at least once
+            long sourceReads = 0;
+            for (SegmentCommitInfo sci : before) {
+                for (String file : sci.files()) {
+                    if (file.endsWith(".vec")) {
+                        sourceReads += dir.bytesRead(file);
+                    }
+                }
+            }
+            assertTrue("expected the merge to read the source raw vectors, read " + sourceReads, sourceReads >= sourceRawBytes);
+
+            try (DirectoryReader reader = DirectoryReader.open(writer)) {
+                assertEquals(vectors.length, reader.numDocs());
+                float[] query = vectors[0].clone();
+                if (similarity == VectorSimilarityFunction.COSINE) {
+                    VectorUtil.l2normalize(query); // the field mapper normalizes cosine queries; the scorer asserts it
+                }
+                TopDocs topDocs = new IndexSearcher(reader).search(new KnnFloatVectorQuery("v", query, 5), 5);
+                assertEquals(5, topDocs.scoreDocs.length);
+                // the graph file exists either way; ask the reader whether a graph was actually built
+                KnnVectorsReader vectorsReader = ((CodecReader) getOnlyLeafReader(reader)).getVectorReader();
+                if (vectorsReader instanceof PerFieldKnnVectorsFormat.FieldsReader perField) {
+                    vectorsReader = perField.getFieldReader("v");
+                }
+                HnswGraph graph = ((HnswGraphProvider) vectorsReader).getGraph("v");
+                assertEquals("graph presence", expectGraph, graph != null && graph.size() > 0);
+            }
+        }
+    }
+
+    private static float[] randomVector(int dims) {
+        float[] vector = new float[dims];
+        for (int i = 0; i < dims; i++) {
+            vector[i] = random().nextFloat();
+        }
+        return vector;
+    }
+}


### PR DESCRIPTION
Since Lucene 10.5 (apache/lucene#15732), an HNSW merge writes the merged flat vectors once and then
reopens the segment it is writing to obtain a merge scorer. For `bbq_hnsw` that scorer needs a 4-bit
query-side record for every merged vector, and `ES818BinaryQuantizedVectorsReader` produced them by
reading all the merged raw vectors back from the just-written `.vec` and quantizing them into a temp
file. That is a second full sequential pass over the merged output on every merge, on top of the pass
the writer had already made over the same vectors to produce the 1-bit index-side records.

## How this was noticed

While measuring #155919 (direct I/O for merge-time reads and writes of raw vectors). Merged outputs
written with O_DIRECT, which should not touch the page cache at all, were back at 100 % residency within
seconds of completing. The read-back was the reason: the graph build's scorer streamed every merged
vector back through `mmap`. With it gone, merged outputs stay at 0–0.2 % resident after their write. Even for
a plain page cache user the read-back can cost device I/O, not just cache touches: on a test
node churning a 7 M × 512-dim `bbq_hnsw` index in 20-minute windows, this change alone cut device reads
by about two thirds and page refaults by about the same, with merge throughput unchanged.

## The change

The writer already walks every merged vector once to produce the 1-bit index-side records. Now it
produces the 4-bit query-side records in that same walk (`OptimizedScalarQuantizer.multiScalarQuantize`
does both widths from one centering pass) and writes them to a temp file next to the segment, named
`<segment>_<suffix>_bbqmq<field>.tmp`. When the graph build asks the reader for a merge scorer, the
reader opens that file instead of re-reading the raw vectors. The `.veb` output is what it was before.

The file has a fixed name so the reader can open it without listing the directory. To make sure the
reader only ever scores from its own segment's records, the file starts with an index header carrying
the segment id and suffix, and the reader checks that the length is exactly one record per vector;
anything else is a `CorruptIndexException`. If the file is missing, the reader throws and says which
file it expected. I removed the read-back rather than keeping it as a fallback: every writer that can
precede a graph build now writes the file, and the older `ES818`/`ES816` formats are read-only on main.

Two things keep this cheap. The writer only writes the file when the merge is actually going to build a
graph — it makes the same call Lucene makes (`shouldCreateGraph` with the resolved `hnswGraphThreshold`),
so small merges below the threshold do no extra work. And the file never outlives the merge: the scorer
supplier deletes it when closed, the reader a merge opens on the segment it is writing deletes any it
didn't consume, and if the merge aborts before that, the writer's `close` deletes what it wrote.

The amount of quantization work doesn't change; the 4-bit pass just moves from the reader to the writer.
`int8_hnsw` isn't affected — its merge scorer reads the quantized file, not the raw vectors. Existing
indices get the fix without a reindex, because the mapper picks the current format for every new
segment: a merge of an old index reads old-format sources and writes the merged segment the new way.

Relates to #155919 and #155021. The shape that needs no hand-off file at all is a Lucene one — letting
`mergeOneFlatVectorField` return the scorer supplier it can already build — which would also cover
Lucene's own asymmetric scalar-quantized modes; this is the Elasticsearch-side fix until then.
