### PR TITLE
ESQL:DS: Drain buffered Parquet rows after TopN early-stop

### DIFF
--- a/docs/changelog/158391.yaml
+++ b/docs/changelog/158391.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 152038
+pr: 158391
+summary: "ESQL:DS: Drain buffered Parquet rows after TopN early-stop"
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1182,23 +1182,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
             releaseHeldIo();
             return false;
         }
-        // Under two-phase, drain leading fully-filtered batches before deciding: the source-row
-        // counter would otherwise claim there is data when every remaining batch is empty.
-        if (twoPhase != null) {
-            long startNanos = System.nanoTime();
-            long startCpuNanos = ThreadCpuTimer.currentNanos();
-            try {
-                drainEmptyTwoPhaseBatches();
-            } finally {
-                if (startCpuNanos >= 0) {
-                    counters.addTotalReadCpuNanos(ThreadCpuTimer.elapsedNanos(startCpuNanos));
-                }
-                counters.addTotalReadNanos(System.nanoTime() - startNanos);
-            }
-            if (twoPhase != null && twoPhase.hasMoreBatches() == false) {
-                rowsRemainingInGroup = 0;
-            }
-        }
         // Serve rows already materialized for the current row group before consulting the
         // early-termination side channel. dynamicThreshold.noFurtherCandidates() is a volatile flag
         // that a concurrent TopN worker can flip at any moment (e.g. once a NULLS FIRST top-K
@@ -1208,7 +1191,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
         // Early termination still takes effect below, where it stops us from advancing to (and
         // prefetching) any further row groups; the only extra work is draining the already-decoded,
         // in-memory current group, which the TopN simply discards.
-        if (rowsRemainingInGroup > 0) {
+        if (hasBufferedRows()) {
             return true;
         }
         if (dynamicThreshold != null && dynamicThreshold.noFurtherCandidates()) {
@@ -1224,6 +1207,36 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                 "Failed to read Parquet row group [" + (rowGroupOrdinal + 1) + "] in file [" + fileLocation + "]"
             );
         }
+    }
+
+    /**
+     * Whether the current row group already has an emit-ready batch. Drains leading fully-filtered
+     * two-phase batches and zeros {@link #rowsRemainingInGroup} when no batches remain, so a leftover
+     * source-row count (LIMIT-truncated two-phase) cannot look like data. Mutates the two-phase
+     * cursor. Must not read {@link DynamicThreshold#noFurtherCandidates()}: that volatile flag can
+     * flip between a caller's {@link #hasNext()} and {@link #next()}, and buffered rows must still
+     * be served.
+     */
+    private boolean hasBufferedRows() {
+        if (exhausted) {
+            return false;
+        }
+        if (twoPhase != null) {
+            long startNanos = System.nanoTime();
+            long startCpuNanos = ThreadCpuTimer.currentNanos();
+            try {
+                drainEmptyTwoPhaseBatches();
+            } finally {
+                if (startCpuNanos >= 0) {
+                    counters.addTotalReadCpuNanos(ThreadCpuTimer.elapsedNanos(startCpuNanos));
+                }
+                counters.addTotalReadNanos(System.nanoTime() - startNanos);
+            }
+            if (twoPhase != null && twoPhase.hasMoreBatches() == false) {
+                rowsRemainingInGroup = 0;
+            }
+        }
+        return rowsRemainingInGroup > 0;
     }
 
     /**
@@ -1603,7 +1616,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
                     // LIMIT can stop Phase-1 without decoding the tail. sourceRowsPerBatch then
                     // sums to less than rowGroupRowCount; rowsRemainingInGroup is still set to the
                     // full group below so per-batch bookkeeping stays in source-row units.
-                    // hasNext() zeroes it when hasMoreBatches() is false after the last emitted batch.
+                    // hasBufferedRows() zeroes it when hasMoreBatches() is false after the last emitted batch.
                     break;
                 }
                 int rowsToRead = (int) Math.min(batchSize, rowGroupRowCount - rowsConsumed);
@@ -2446,8 +2459,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
 
     @Override
     public Page next() {
-        if (hasNext() == false) {
-            throw new NoSuchElementException();
+        // Drain any already-decoded batch without re-reading noFurtherCandidates. After
+        // advanceRowGroup() a new two-phase group may still have leading empty batches, so a true
+        // hasNext() is not enough to emit: loop until hasBufferedRows() or the iterator is done.
+        while (hasBufferedRows() == false) {
+            if (hasNext() == false) {
+                throw new NoSuchElementException("Parquet iterator exhausted");
+            }
         }
         long startNanos = System.nanoTime();
         long startCpuNanos = ThreadCpuTimer.currentNanos();
@@ -2519,11 +2537,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page>, C
      */
     private Page nextTwoPhaseBatch(int firstRowOfBatchInRG) {
         TwoPhaseRowGroup state = twoPhase;
-        // hasNext() drains any leading fully-filtered batches before returning true, so the
+        // hasBufferedRows() drains any leading fully-filtered batches before next() emits, so the
         // current cursor must point at a batch with at least one survivor by the time we get
-        // here. An assertion guards against an unexpected entry from a buggy hasNext path.
+        // here. An assertion guards against an unexpected entry from a buggy next/hasNext path.
         assert state.hasMoreBatches() && state.currentSurvivorCount() > 0
-            : "nextTwoPhaseBatch invoked on empty/missing batch (hasNext should have advanced or returned false)";
+            : "nextTwoPhaseBatch invoked on empty/missing batch (hasBufferedRows should have advanced or next returned false)";
         int sourceRows = state.currentSourceRows();
         int survivorCount = state.currentSurvivorCount();
         int[] survivorPositions = state.currentSurvivorPositions();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetDynamicThresholdTests.java
@@ -262,6 +262,29 @@ public class OptimizedParquetDynamicThresholdTests extends ESTestCase {
         }
     }
 
+    public void testBufferedStringRowsSurviveNoFurtherCandidatesFlipBetweenHasNextAndNext() throws Exception {
+        // BYTES_REF counterpart of the numeric flip test above: the CI failure was
+        // ExternalParquetStringTopNSideChannelIT.testNullsFirstEarlyTermination. Do not use
+        // bytesRefThreshold() — it hides the channel, so markNoFurtherCandidates() cannot be called.
+        byte[] data = writeStringParquet(REQUIRED_STRING_SCHEMA, 64L * 1024 * 1024, 1024, 500, OptimizedParquetDynamicThresholdTests::key);
+        SharedMinCompetitive.KeyConfig keyConfig = new SharedMinCompetitive.KeyConfig(ElementType.BYTES_REF, TopNEncoder.UTF8, true, false);
+        SharedMinCompetitive channel = new SharedMinCompetitive.Supplier(blockFactory.breaker(), List.of(keyConfig)).get();
+        DynamicThreshold threshold = new DynamicThreshold("name", true, false, channel);
+        try (
+            threshold;
+            CloseableIterator<Page> iterator = reader(threshold).read(storageObject(data), FormatReadContext.of(List.of("name"), 128))
+        ) {
+            assertTrue("first hasNext() must materialize the row group", iterator.hasNext());
+            channel.markNoFurtherCandidates();
+            Page page = iterator.next();
+            try {
+                assertThat(page.getPositionCount(), greaterThan(0));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
     public void testNullsLastCanSkipNullAndDominatedRowGroups() throws Exception {
         byte[] data = writeLongParquet(OPTIONAL_LONG_SCHEMA, 1L, 2 * 1024 * 1024, 300, i -> i < 100 ? null : (long) i);
 


### PR DESCRIPTION
OptimizedParquetColumnIterator.next() no longer re-enters the full hasNext() path, so a concurrent NULLS FIRST noFurtherCandidates flip cannot turn an already-decoded batch into NoSuchElementException. Adds a BYTES_REF flip test.

Fixes #152038 (follow-up to #152838).
