### PR TITLE
[9.5] Update knn query automatic pre-filtering to handle exists queries on inference fields (#158296)

### DIFF
--- a/docs/changelog/158296.yaml
+++ b/docs/changelog/158296.yaml
@@ -1,0 +1,7 @@
+area: Search
+issues:
+ - 157951
+pr: 158296
+summary: Update knn query automatic pre-filtering to handle exists queries on inference
+  fields
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -336,7 +336,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     ) throws IOException {
         for (QueryBuilder query : clauses) {
             try (AutoPrefilteringScope autoPrefilteringScope = context.autoPrefilteringScope()) {
-                autoPrefilteringScope.push(collectPrefilters(query));
+                autoPrefilteringScope.push(collectPrefilters(query), context.nestedScope().getObjectMapper());
                 Query luceneQuery = query.toQuery(context, queryVisitor);
                 booleanQueryBuilder.add(new BooleanClause(luceneQuery, occurs));
             }
@@ -363,7 +363,7 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         Set<Query> deduplicate = new HashSet<>();
         for (QueryBuilder query : clauses) {
             try (AutoPrefilteringScope autoPrefilteringScope = context.autoPrefilteringScope()) {
-                autoPrefilteringScope.push(collectPrefilters(query));
+                autoPrefilteringScope.push(collectPrefilters(query), context.nestedScope().getObjectMapper());
                 Query luceneQuery = query.toQuery(context, clauseVisitor);
                 if (deduplicate.add(luceneQuery)) {
                     queryVisitor.merge(clauseVisitor);

--- a/server/src/main/java/org/elasticsearch/index/query/support/AutoPrefilteringScope.java
+++ b/server/src/main/java/org/elasticsearch/index/query/support/AutoPrefilteringScope.java
@@ -9,7 +9,9 @@
 
 package org.elasticsearch.index.query.support;
 
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
@@ -28,16 +30,29 @@ import java.util.List;
  * A query that consumes prefilters fetches a flattened list of all prefilters in scope via {@link #getPrefilters()}.
  * When the query leaves the scope, {@link #pop()} should be called to remove the latest list of prefilters from the stack.
  * This way queries in other query tree branches will not fetch irrelevant prefilters.
+ *
+ * Each list of prefilters is tagged with the nested level of the query that pushed it. A consumer sits at its own
+ * nested level, which may be deeper than the level a prefilter was collected at, so it needs to know which document
+ * space a prefilter is meant to be evaluated in before converting it to a lucene query.
  */
 public final class AutoPrefilteringScope implements Releasable {
 
-    private final Deque<List<QueryBuilder>> prefiltersStack = new LinkedList<>();
+    /**
+     * A prefilter together with the nested level of the query that collected it. A {@code null} level means the
+     * prefilter was collected outside of any nested scope, so it applies to root documents.
+     */
+    public record ScopedPrefilter(QueryBuilder query, @Nullable NestedObjectMapper nestedLevel) {}
+
+    private final Deque<List<ScopedPrefilter>> prefiltersStack = new LinkedList<>();
 
     /**
      * Pushes a list of prefilters to the scope.
+     *
+     * @param prefilters the prefilters collected by the pushing query
+     * @param nestedLevel the nested level the pushing query sits at, or {@code null} if it is not in a nested scope
      */
-    public void push(List<QueryBuilder> prefilters) {
-        prefiltersStack.push(prefilters);
+    public void push(List<QueryBuilder> prefilters, @Nullable NestedObjectMapper nestedLevel) {
+        prefiltersStack.push(prefilters.stream().map(q -> new ScopedPrefilter(q, nestedLevel)).toList());
     }
 
     /**
@@ -50,7 +65,7 @@ public final class AutoPrefilteringScope implements Releasable {
     /**
      * Returns all prefilters in scope.
      */
-    public List<QueryBuilder> getPrefilters() {
+    public List<ScopedPrefilter> getPrefilters() {
         return prefiltersStack.stream().flatMap(List::stream).toList();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/support/NestedScope.java
+++ b/server/src/main/java/org/elasticsearch/index/query/support/NestedScope.java
@@ -9,9 +9,12 @@
 
 package org.elasticsearch.index.query.support;
 
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -43,6 +46,29 @@ public final class NestedScope {
      */
     public ObjectMapper previousLevel() {
         return levelStack.pop();
+    }
+
+    /**
+     * Temporarily makes {@code level} the current nested level.
+     *
+     * @param level an ancestor of the current level, or {@code null} for the root document space
+     * @return a {@link Releasable} that restores the levels that were unwound
+     */
+    public Releasable unwindTo(@Nullable NestedObjectMapper level) {
+        if (levelStack.peek() == level) {
+            return () -> {};
+        }
+
+        Deque<NestedObjectMapper> unwound = new ArrayDeque<>();
+        while (levelStack.isEmpty() == false && levelStack.peek() != level) {
+            unwound.push(levelStack.pop());
+        }
+        assert levelStack.peek() == level : "[" + level + "] is not an ancestor of the current nested level";
+        return () -> {
+            while (unwound.isEmpty() == false) {
+                levelStack.push(unwound.pop());
+            }
+        };
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -34,6 +35,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.ToChildBlockJoinQueryBuilder;
+import org.elasticsearch.index.query.support.AutoPrefilteringScope.ScopedPrefilter;
 import org.elasticsearch.index.query.support.AutoPrefilteringUtils;
 import org.elasticsearch.index.search.NestedHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -619,11 +621,22 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             return List.of();
         }
         final List<Query> autoPrefilters = new ArrayList<>();
-        for (QueryBuilder queryBuilder : context.autoPrefilteringScope().getPrefilters().stream().filter(f -> this != f).toList()) {
-            Optional<QueryBuilder> pruned = AutoPrefilteringUtils.pruneQuery(queryBuilder, UNSUPPORTED_AUTO_PREFILTERING_QUERY_TYPES);
+        for (ScopedPrefilter scopedPrefilter : context.autoPrefilteringScope().getPrefilters()) {
+            if (this == scopedPrefilter.query()) {
+                continue;
+            }
+            Optional<QueryBuilder> pruned = AutoPrefilteringUtils.pruneQuery(
+                scopedPrefilter.query(),
+                UNSUPPORTED_AUTO_PREFILTERING_QUERY_TYPES
+            );
             if (pruned.isPresent()) {
-                Query query = pruned.get().toQuery(context);
-                autoPrefilters.add(query);
+                // A prefilter is meant to be evaluated in the document space of the query that collected it, which may
+                // sit above this knn query's nested level. Building it here without unwinding would give block join
+                // queries - such as an exists query on a semantic_text field - a child level as their parent filter,
+                // leaving the prefilter matching nothing. The filters are joined down to child documents in doToQuery.
+                try (Releasable ignored = context.nestedScope().unwindTo(scopedPrefilter.nestedLevel())) {
+                    autoPrefilters.add(pruned.get().toQuery(context));
+                }
             }
         }
         return autoPrefilters;

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.query.support.AutoPrefilteringScope.ScopedPrefilter;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -879,7 +880,10 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
 
         @Override
         protected Query doToQuery(SearchExecutionContext context) {
-            prefiltersToQueryNameMap.put(queryName(), context.autoPrefilteringScope().getPrefilters().stream().collect(Collectors.toSet()));
+            prefiltersToQueryNameMap.put(
+                queryName(),
+                context.autoPrefilteringScope().getPrefilters().stream().map(ScopedPrefilter::query).collect(Collectors.toSet())
+            );
             return new Query() {
                 @Override
                 public String toString(String field) {

--- a/server/src/test/java/org/elasticsearch/index/query/support/AutoPrefilteringScopeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/support/AutoPrefilteringScopeTests.java
@@ -9,8 +9,12 @@
 
 package org.elasticsearch.index.query.support;
 
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RandomQueryBuilder;
+import org.elasticsearch.index.query.support.AutoPrefilteringScope.ScopedPrefilter;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collection;
@@ -33,6 +37,10 @@ public class AutoPrefilteringScopeTests extends ESTestCase {
         List<QueryBuilder> prefilters_2_2 = randomList(0, 5, () -> RandomQueryBuilder.createQuery(random()));
         List<QueryBuilder> prefilters_3_1 = randomList(0, 5, () -> RandomQueryBuilder.createQuery(random()));
 
+        NestedObjectMapper level_1 = null;
+        NestedObjectMapper level_2 = buildNestedMapper("a");
+        NestedObjectMapper level_3 = buildNestedMapper("a.b");
+
         // Given + increases level and - decreases level, we add scope as follows:
         // + 1_1 + 2_1 + 3_1
         // - 3_1 + 2_2
@@ -41,42 +49,50 @@ public class AutoPrefilteringScopeTests extends ESTestCase {
         // - 1_1
         // and we check current prefilters after each operation.
 
-        autoPrefilteringScope.push(prefilters_1_1);
-        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(prefilters_1_1));
-        autoPrefilteringScope.push(prefilters_2_1);
+        autoPrefilteringScope.push(prefilters_1_1, level_1);
+        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(scoped(prefilters_1_1, level_1)));
+        autoPrefilteringScope.push(prefilters_2_1, level_2);
         assertThat(
             autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_2_1, prefilters_1_1).flatMap(Collection::stream).toList())
+            equalTo(Stream.of(scoped(prefilters_2_1, level_2), scoped(prefilters_1_1, level_1)).flatMap(Collection::stream).toList())
         );
-        autoPrefilteringScope.push(prefilters_3_1);
+        autoPrefilteringScope.push(prefilters_3_1, level_3);
         assertThat(
             autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_3_1, prefilters_2_1, prefilters_1_1).flatMap(Collection::stream).toList())
-        );
-        autoPrefilteringScope.pop();
-        assertThat(
-            autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_2_1, prefilters_1_1).flatMap(Collection::stream).toList())
-        );
-        autoPrefilteringScope.push(prefilters_2_2);
-        assertThat(
-            autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_2_2, prefilters_2_1, prefilters_1_1).flatMap(Collection::stream).toList())
+            equalTo(
+                Stream.of(scoped(prefilters_3_1, level_3), scoped(prefilters_2_1, level_2), scoped(prefilters_1_1, level_1))
+                    .flatMap(Collection::stream)
+                    .toList()
+            )
         );
         autoPrefilteringScope.pop();
         assertThat(
             autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_2_1, prefilters_1_1).flatMap(Collection::stream).toList())
+            equalTo(Stream.of(scoped(prefilters_2_1, level_2), scoped(prefilters_1_1, level_1)).flatMap(Collection::stream).toList())
         );
-        autoPrefilteringScope.pop();
-        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(prefilters_1_1));
-        autoPrefilteringScope.push(prefilters_1_2);
+        autoPrefilteringScope.push(prefilters_2_2, level_2);
         assertThat(
             autoPrefilteringScope.getPrefilters(),
-            equalTo(Stream.of(prefilters_1_2, prefilters_1_1).flatMap(Collection::stream).toList())
+            equalTo(
+                Stream.of(scoped(prefilters_2_2, level_2), scoped(prefilters_2_1, level_2), scoped(prefilters_1_1, level_1))
+                    .flatMap(Collection::stream)
+                    .toList()
+            )
         );
         autoPrefilteringScope.pop();
-        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(prefilters_1_1));
+        assertThat(
+            autoPrefilteringScope.getPrefilters(),
+            equalTo(Stream.of(scoped(prefilters_2_1, level_2), scoped(prefilters_1_1, level_1)).flatMap(Collection::stream).toList())
+        );
+        autoPrefilteringScope.pop();
+        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(scoped(prefilters_1_1, level_1)));
+        autoPrefilteringScope.push(prefilters_1_2, level_1);
+        assertThat(
+            autoPrefilteringScope.getPrefilters(),
+            equalTo(Stream.of(scoped(prefilters_1_2, level_1), scoped(prefilters_1_1, level_1)).flatMap(Collection::stream).toList())
+        );
+        autoPrefilteringScope.pop();
+        assertThat(autoPrefilteringScope.getPrefilters(), equalTo(scoped(prefilters_1_1, level_1)));
         autoPrefilteringScope.pop();
         assertThat(autoPrefilteringScope.getPrefilters(), empty());
     }
@@ -87,17 +103,26 @@ public class AutoPrefilteringScopeTests extends ESTestCase {
         List<QueryBuilder> prefilters_2 = randomList(0, 5, () -> RandomQueryBuilder.createQuery(random()));
 
         try (autoPrefilteringScope) {
-            autoPrefilteringScope.push(prefilters_1);
+            autoPrefilteringScope.push(prefilters_1, null);
 
             try (autoPrefilteringScope) {
-                autoPrefilteringScope.push(prefilters_2);
+                autoPrefilteringScope.push(prefilters_2, null);
                 assertThat(
                     autoPrefilteringScope.getPrefilters(),
-                    equalTo(Stream.of(prefilters_2, prefilters_1).flatMap(Collection::stream).toList())
+                    equalTo(Stream.of(scoped(prefilters_2, null), scoped(prefilters_1, null)).flatMap(Collection::stream).toList())
                 );
             }
-            assertThat(autoPrefilteringScope.getPrefilters(), equalTo(prefilters_1));
+            assertThat(autoPrefilteringScope.getPrefilters(), equalTo(scoped(prefilters_1, null)));
         }
         assertThat(autoPrefilteringScope.getPrefilters(), is(empty()));
+    }
+
+    private static List<ScopedPrefilter> scoped(List<QueryBuilder> prefilters, NestedObjectMapper nestedLevel) {
+        return prefilters.stream().map(q -> new ScopedPrefilter(q, nestedLevel)).toList();
+    }
+
+    private static NestedObjectMapper buildNestedMapper(String path) {
+        return new NestedObjectMapper.Builder(path, IndexVersion.current(), query -> { throw new UnsupportedOperationException(); }, null)
+            .build(MapperBuilderContext.root(false, false));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/support/NestedScopeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/support/NestedScopeTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.query.support;
+
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.NestedObjectMapper;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class NestedScopeTests extends ESTestCase {
+
+    public void testUnwindToAncestorLevel() {
+        NestedScope nestedScope = new NestedScope();
+        NestedObjectMapper outer = buildNestedMapper("a");
+        NestedObjectMapper inner = buildNestedMapper("a.b");
+        nestedScope.nextLevel(outer);
+        nestedScope.nextLevel(inner);
+
+        try (Releasable ignored = nestedScope.unwindTo(outer)) {
+            assertThat(nestedScope.getObjectMapper(), sameInstance(outer));
+        }
+        assertThat(nestedScope.getObjectMapper(), sameInstance(inner));
+    }
+
+    public void testUnwindToRoot() {
+        NestedScope nestedScope = new NestedScope();
+        NestedObjectMapper outer = buildNestedMapper("a");
+        NestedObjectMapper inner = buildNestedMapper("a.b");
+        nestedScope.nextLevel(outer);
+        nestedScope.nextLevel(inner);
+
+        try (Releasable ignored = nestedScope.unwindTo(null)) {
+            assertThat(nestedScope.getObjectMapper(), nullValue());
+        }
+        assertThat(nestedScope.getObjectMapper(), sameInstance(inner));
+        nestedScope.previousLevel();
+        assertThat(nestedScope.getObjectMapper(), sameInstance(outer));
+    }
+
+    public void testUnwindToCurrentLevelIsANoOp() {
+        NestedScope nestedScope = new NestedScope();
+        NestedObjectMapper level = buildNestedMapper("a");
+        nestedScope.nextLevel(level);
+
+        try (Releasable ignored = nestedScope.unwindTo(level)) {
+            assertThat(nestedScope.getObjectMapper(), sameInstance(level));
+        }
+        assertThat(nestedScope.getObjectMapper(), sameInstance(level));
+    }
+
+    private static NestedObjectMapper buildNestedMapper(String path) {
+        return new NestedObjectMapper.Builder(path, IndexVersion.current(), query -> { throw new UnsupportedOperationException(); }, null)
+            .build(MapperBuilderContext.root(false, false));
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -66,6 +66,7 @@ public class InferenceFeatures implements FeatureSpecification {
     private static final NodeFeature COHERE_V2_API = new NodeFeature("inference.cohere.v2");
     public static final NodeFeature SEMANTIC_TEXT_HIGHLIGHTING_FLAT = new NodeFeature("semantic_text.highlighter.flat_index_options");
     private static final NodeFeature SEMANTIC_TEXT_FIELDS_CHUNKS_FORMAT = new NodeFeature("semantic_text.fields_chunks_format");
+    private static final NodeFeature SEMANTIC_EXISTS_QUERY_AUTO_PREFILTER_FIX = new NodeFeature("semantic.exists_query_auto_prefilter_fix");
 
     public static final NodeFeature INFERENCE_ENDPOINT_CACHE = new NodeFeature("inference.endpoint.cache");
     public static final NodeFeature INFERENCE_CCM_CACHE = new NodeFeature("inference.ccm.cache");
@@ -165,7 +166,8 @@ public class InferenceFeatures implements FeatureSpecification {
                 SEMANTIC_TEXT_EMBEDDING_TASK,
                 SemanticTextFieldMapper.SEMANTIC_TEXT_ORIGINAL_VALUES_DOC_VALUES,
                 SemanticFieldMapper.SEMANTIC_FIELD_MAPPER,
-                TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_EMPTY_RESULT_FIX
+                TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_EMPTY_RESULT_FIX,
+                SEMANTIC_EXISTS_QUERY_AUTO_PREFILTER_FIX
             )
         );
         testFeatures.addAll(getFeatures());

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/100_semantic_text_auto_prefiltering.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/100_semantic_text_auto_prefiltering.yml
@@ -945,3 +945,50 @@ setup:
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._source.dense_field_1: "violins" }
   - match: { hits.hits.1._source.dense_field_1: "pianos" }
+
+---
+"Test exists on a semantic_text field is used as a prefilter to a semantic match on the same field":
+
+  - requires:
+      cluster_features: "semantic.exists_query_auto_prefilter_fix"
+      reason: auto prefiltering tracks the nested level a prefilter was collected at
+
+  - do:
+      search:
+        index: test-index
+        body: >
+          {
+            "query": {
+              "bool": {
+                "must": [
+                  { "match": { "dense_field_2": { "query": "cats" } } },
+                  { "exists": { "field": "dense_field_2" } }
+                ]
+              }
+            }
+          }
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "11" }
+
+  - do:
+      search:
+        index: test-index
+        body: >
+          {
+            "query": {
+              "bool": {
+                "must": [
+                  { "match": { "dense_field_2": { "query": "cats" } } }
+                ],
+                "filter": [
+                  { "exists": { "field": "dense_field_2" } }
+                ]
+              }
+            }
+          }
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "11" }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/190_semantic_field_auto_prefiltering.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/190_semantic_field_auto_prefiltering.yml
@@ -1,0 +1,93 @@
+setup:
+  - requires:
+      cluster_features: [ "semantic_field.semantic_field_mapper", "semantic.exists_query_auto_prefilter_fix" ]
+      reason: auto prefiltering tracks the nested level a prefilter was collected at
+
+  - do:
+      inference.put:
+        task_type: embedding
+        inference_id: embedding-inference-id
+        body: >
+          {
+            "service": "text_embedding_test_service",
+            "service_settings": {
+              "model": "my_model",
+              "dimensions": 4,
+              "similarity": "cosine",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      indices.create:
+        index: test-index
+        body:
+          mappings:
+            properties:
+              id:
+                type: keyword
+              semantic_field_1:
+                type: semantic
+                inference_id: embedding-inference-id
+              semantic_field_2:
+                type: semantic
+                inference_id: embedding-inference-id
+
+  - do:
+      bulk:
+        index: test-index
+        refresh: true
+        body: |
+          {"index": {"_id": "1"}}
+          {"id": "1", "semantic_field_1": "violins", "semantic_field_2": "cats"}
+          {"index": {"_id": "2"}}
+          {"id": "2", "semantic_field_1": "violins"}
+          {"index": {"_id": "3"}}
+          {"id": "3", "semantic_field_1": "pianos", "semantic_field_2": "cats"}
+
+---
+"Test exists on a semantic field is used as a prefilter to a semantic match on the same field":
+
+  - do:
+      search:
+        index: test-index
+        body: >
+          {
+            "query": {
+              "bool": {
+                "must": [
+                  { "match": { "semantic_field_2": { "query": "cats" } } },
+                  { "exists": { "field": "semantic_field_2" } }
+                ]
+              }
+            },
+            "sort": [ { "id": "asc" } ]
+          }
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "3" }
+
+  - do:
+      search:
+        index: test-index
+        body: >
+          {
+            "query": {
+              "bool": {
+                "must": [
+                  { "match": { "semantic_field_2": { "query": "cats" } } }
+                ],
+                "filter": [
+                  { "exists": { "field": "semantic_field_2" } }
+                ]
+              }
+            },
+            "sort": [ { "id": "asc" } ]
+          }
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "3" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Update knn query automatic pre-filtering to handle exists queries on inference fields (#158296)](https://github.com/elastic/elasticsearch/pull/158296)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)