### PR TITLE
[9.5] [ESQL] Increase test boundary to 8192 (#158331)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -20,9 +20,6 @@ tests:
 - class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
   method: testOpenAiEmbeddings {upgradedNodes=3}
   issue: https://github.com/elastic/elasticsearch/issues/144440
-- class: org.elasticsearch.xpack.esql.planner.LocalExecutionPlannerTests
-  method: testLuceneTopNSourceOperator {estimatedRowSizeIsHuge=true}
-  issue: https://github.com/elastic/elasticsearch/issues/152799
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:spatial.convertCartesianFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/144580

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -787,7 +787,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
     }
 
     private int randomEstimatedRowSize(boolean huge) {
-        int hugeBoundary = SourceOperator.MIN_TARGET_PAGE_SIZE * 10;
+        int hugeBoundary = SourceOperator.TARGET_PAGE_SIZE / SourceOperator.MIN_TARGET_PAGE_SIZE;
         return huge ? between(hugeBoundary, Integer.MAX_VALUE) : between(1, hugeBoundary);
     }
 


### PR DESCRIPTION
Backports the following commits to 9.5:
 - [ESQL] Increase test boundary to 8192 (#158331)