### PR TITLE
[9.5] Fix leaking bulk cancellation task in IncrementalBulkService (#158108)

### DIFF
--- a/docs/changelog/158108.yaml
+++ b/docs/changelog/158108.yaml
@@ -1,0 +1,6 @@
+area: Task Management
+issues:
+ - 158018
+pr: 158108
+summary: Fix leaking bulk cancellation task in `IncrementalBulkService`
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.bulk;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -128,9 +129,9 @@ public class IncrementalBulkService {
     }
 
     public Handler newBulkRequest(
-        @Nullable String waitForActiveShards,
+        @Nullable ActiveShardCount waitForActiveShards,
         @Nullable TimeValue timeout,
-        @Nullable String refresh,
+        @Nullable WriteRequest.RefreshPolicy refreshPolicy,
         Set<String> paramsUsed
     ) {
         ensureEnabled();
@@ -139,7 +140,7 @@ public class IncrementalBulkService {
             indexingPressure,
             waitForActiveShards,
             timeout,
-            refresh,
+            refreshPolicy,
             chunkWaitTimeMillisHistogram,
             paramsUsed,
             taskManager,
@@ -187,7 +188,7 @@ public class IncrementalBulkService {
         private final ActiveShardCount waitForActiveShards;
         private final TimeValue timeout;
         private final Set<String> paramsUsed;
-        private final String refresh;
+        private final WriteRequest.RefreshPolicy refreshPolicy;
 
         private final ArrayList<Releasable> releasables = new ArrayList<>(4);
         private final ArrayList<BulkResponse> responses = new ArrayList<>(2);
@@ -209,15 +210,24 @@ public class IncrementalBulkService {
         protected Handler(
             Client client,
             IndexingPressure indexingPressure,
-            @Nullable String waitForActiveShards,
+            @Nullable ActiveShardCount waitForActiveShards,
             @Nullable TimeValue timeout,
-            @Nullable String refresh,
+            @Nullable WriteRequest.RefreshPolicy refreshPolicy,
             LongHistogram chunkWaitTimeMillisHistogram,
             Set<String> paramsUsed,
             TaskManager taskManager,
             ThreadPool threadPool
         ) {
+            this.client = client;
+            this.threadPool = threadPool;
             this.taskManager = taskManager;
+            this.waitForActiveShards = waitForActiveShards;
+            this.timeout = timeout;
+            this.refreshPolicy = refreshPolicy;
+            this.paramsUsed = paramsUsed;
+            this.chunkWaitTimeMillisHistogram = chunkWaitTimeMillisHistogram;
+            this.incrementalOperation = indexingPressure.startIncrementalCoordinating(0, 0, false);
+
             try (var ignored = threadPool.getThreadContext().newTraceContext()) {
                 bulkSessionTask = (CancellableTask) taskManager.register(
                     BULK_SESSION_TASK_TYPE,
@@ -240,17 +250,12 @@ public class IncrementalBulkService {
                         }
                     }
                 );
+                createNewBulkRequest(EMPTY_STATE);
+            } catch (Exception e) {
+                // The caller never receives this Handler, so nothing would be left to release the reservation.
+                incrementalOperation.close();
+                throw e;
             }
-
-            this.client = client;
-            this.threadPool = threadPool;
-            this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
-            this.timeout = timeout;
-            this.refresh = refresh;
-            this.paramsUsed = paramsUsed;
-            this.incrementalOperation = indexingPressure.startIncrementalCoordinating(0, 0, false);
-            this.chunkWaitTimeMillisHistogram = chunkWaitTimeMillisHistogram;
-            createNewBulkRequest(EMPTY_STATE);
         }
 
         /**
@@ -261,11 +266,16 @@ public class IncrementalBulkService {
             // Guard on millis(), not nanos(): ThreadPool#schedule floors the delay to whole milliseconds, so a
             // sub-millisecond timeout would otherwise arm a zero-delay task that cancels the request immediately.
             if (requestTimeout != null && requestTimeout.millis() > 0) {
-                pendingTimeout = threadPool.schedule(
-                    () -> cancel("request timed out after [" + requestTimeout + "]", () -> {}),
-                    requestTimeout,
-                    threadPool.generic()
-                );
+                try {
+                    pendingTimeout = threadPool.schedule(
+                        () -> cancel("request timed out after [" + requestTimeout + "]", () -> {}),
+                        requestTimeout,
+                        threadPool.generic()
+                    );
+                } catch (EsRejectedExecutionException e) {
+                    // Failing to arm cancellation tracking is not a reason to reject the bulk request: the timeout is best effort.
+                    assert e.isExecutorShutdown() : e;
+                }
             }
         }
 
@@ -485,8 +495,8 @@ public class IncrementalBulkService {
             if (timeout != null) {
                 bulkRequest.timeout(timeout);
             }
-            if (refresh != null) {
-                bulkRequest.setRefreshPolicy(refresh);
+            if (refreshPolicy != null) {
+                bulkRequest.setRefreshPolicy(refreshPolicy);
             }
             bulkRequest.requestParamsUsed(paramsUsed);
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.bulk.BulkRequestParser;
 import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
@@ -143,12 +144,14 @@ public class RestBulkAction extends BaseRestHandler {
         } else {
             request.ensureContent();
             String waitForActiveShards = request.param("wait_for_active_shards");
+            ActiveShardCount activeShardCount = waitForActiveShards == null ? null : ActiveShardCount.parseString(waitForActiveShards);
             TimeValue timeout = request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT);
             String refresh = request.param("refresh");
+            WriteRequest.RefreshPolicy refreshPolicy = refresh == null ? null : WriteRequest.RefreshPolicy.parse(refresh);
             return new ChunkHandler(
                 allowExplicitIndex,
                 request,
-                () -> bulkHandler.newBulkRequest(waitForActiveShards, timeout, refresh, request.params().keySet())
+                () -> bulkHandler.newBulkRequest(activeShardCount, timeout, refreshPolicy, request.params().keySet())
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/IncrementalBulkServiceTests.java
@@ -12,11 +12,15 @@ package org.elasticsearch.action.bulk;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -26,6 +30,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.Matchers.empty;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -37,12 +42,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Tests the {@link IncrementalBulkService#REQUEST_TIMEOUT} scheduling that this service adds on top of
- * the bulk-session cancellation machinery. The downstream effect of cancellation (the next chunk failing
- * with a {@code TaskCancelledException}) is covered by {@code IncrementalBulkIT}; here we only assert that
- * the timeout reliably triggers cancellation and is cancelled itself once the request finishes.
- */
 public class IncrementalBulkServiceTests extends ESTestCase {
 
     /**
@@ -153,5 +152,37 @@ public class IncrementalBulkServiceTests extends ESTestCase {
         // close() cancelled the scheduled task, so advancing past the deadline must not fire the timeout
         taskQueue.runAllTasksInTimeOrder();
         verify(taskManager, never()).cancelTaskAndDescendants(any(), startsWith("request timed out"), anyBoolean(), any());
+    }
+
+    /**
+     * The admission check must run before the session task is registered. A node that is over its coordinating
+     * limit rejects every incoming request, so registering first and unwinding afterwards would leak a task per
+     * rejected request for as long as the overload lasts.
+     */
+    public void testIndexingPressureRejectionRegistersNoTask() {
+        DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
+        ThreadPool threadPool = taskQueue.getThreadPool();
+        TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Task.HEADERS_TO_COPY);
+        IndexingPressure indexingPressure = new IndexingPressure(
+            Settings.builder().put(IndexingPressure.MAX_COORDINATING_BYTES.getKey(), ByteSizeValue.ofKb(1)).build()
+        );
+        IncrementalBulkService service = new IncrementalBulkService(
+            mock(Client.class),
+            indexingPressure,
+            MeterRegistry.NOOP,
+            taskManager,
+            threadPool,
+            ClusterSettings.createBuiltInClusterSettings(
+                Settings.builder().put(IncrementalBulkService.REQUEST_TIMEOUT.getKey(), TimeValue.timeValueSeconds(30)).build()
+            )
+        );
+
+        // forceExecution so this operation itself is admitted, leaving the node over its coordinating limit
+        try (Releasable ignored = indexingPressure.markCoordinatingOperationStarted(1, ByteSizeValue.ofKb(2).getBytes(), true)) {
+            expectThrows(EsRejectedExecutionException.class, service::newBulkRequest);
+        }
+
+        assertThat(taskManager.getTasks().values(), empty());
+        assertFalse("no timeout task should be scheduled for a rejected request", taskQueue.hasDeferredTasks());
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -451,6 +452,37 @@ public class RestBulkActionTests extends ESTestCase {
             );
             assertThat(ex.getMessage(), containsString("invalid [_slice] value"));
         }
+    }
+
+    public void testInvalidParamsDoNotRegisterBulkSessionTask() {
+        var param = randomFrom(
+            Map.entry("wait_for_active_shards", Set.of("all")),
+            Map.entry("refresh", Set.of("false", "true", "wait_for", ""))
+        );
+        // Alphabetic, so it is also never a valid shard count.
+        String value = randomValueOtherThanMany(param.getValue()::contains, () -> randomAlphaOfLengthBetween(1, 10));
+        TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Task.HEADERS_TO_COPY);
+        NoOpNodeClient client = new NoOpNodeClient(threadPool);
+        RestBulkAction action = new RestBulkAction(
+            Settings.EMPTY,
+            ClusterSettings.createBuiltInClusterSettings(),
+            new IncrementalBulkService(client, new IndexingPressure(Settings.EMPTY), MeterRegistry.NOOP, taskManager, threadPool)
+        );
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
+            .withMethod(RestRequest.Method.POST)
+            .withParams(Map.of(param.getKey(), value))
+            .withBody(new FakeHttpBodyStream())
+            .withHeaders(
+                Map.of("Content-Type", List.of(XContentType.JSON.mediaType()), "Content-Length", List.of(String.valueOf(between(1, 1024))))
+            )
+            .build();
+
+        var e = expectThrows(
+            IllegalArgumentException.class,
+            () -> action.handleRequest(request, new FakeRestChannel(request, randomBoolean()), client)
+        );
+        assertThat(e.getMessage(), containsString("[" + value + "]"));
+        assertThat(taskManager.getTasks().values(), empty());
     }
 
     public void testIncrementalParsing() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.5`:
 - [Fix leaking bulk cancellation task in IncrementalBulkService (#158108)](https://github.com/elastic/elasticsearch/pull/158108)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)