### PR TITLE
Fix `testRelocationWithPITReferencingPinnedGenFiles`

### DIFF
--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/PointInTimeRelocationIT.java
@@ -1310,7 +1310,7 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
         blobReadBlocked.countDown();
     }
 
-    public void testRelocationWithPITReferencingPinnedGenFiles() {
+    public void testRelocationWithPITReferencingPinnedGenFiles() throws Exception {
         var indexNode = startMasterAndIndexNode(nodeSettings);
         var searchNodeA = startSearchNode(nodeSettings);
 
@@ -1379,16 +1379,20 @@ public class PointInTimeRelocationIT extends AbstractStatelessPluginIntegTestCas
         ensureGreen(indexName);
         assertThat(internalCluster().nodesInclude(indexName), hasItem(newSearchNode));
 
+        // ensureGreen is not enough, the source node serves this PIT with the old id until its PIT contexts are gone.
+        waitForNoPITContextOnNode(searchNodeA, 5);
+
         // PIT search should still work after relocation, with an updated PIT id
         var updatedPitId = new AtomicReference<BytesReference>();
         assertResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
             // We index two new documents together with the updates
             assertHitCount(resp, initialDocs + 2);
+            assertFalse("PIT id should have changed after relocation.", isEquivalentId(resp.pointInTimeId(), pitId));
             updatedPitId.set(resp.pointInTimeId());
         });
 
         // Close the PIT with the updated id
-        closePointInTime(updatedPitId.get());
+        assertClosePit(updatedPitId.get(), 1);
     }
 
     /**


### PR DESCRIPTION
Noticed failure: [bpzkxa7np5wm4](https://gradle-enterprise.elastic.co/s/bpzkxa7np5wm4/tests/task/:x-pack:plugin:stateless:internalClusterTest/details/org.elasticsearch.xpack.stateless.recovery.PointInTimeRelocationIT/testRelocationWithPITReferencingPinnedGenFiles?top-execution=1) while running tests on VM for a different PR.

My understanding is that the same root cause as https://github.com/elastic/elasticsearch/pull/156880 could also cause the linked failure if both `ensureGreen` and `closePointInTime` race with the source node applying the updating cluster state, we could end up with a leftover PIT context on the target shard during cleanup.



