### PR TITLE
SQL: wrap runtime errors when decoding a cursor

### DIFF
--- a/docs/changelog/158437.yaml
+++ b/docs/changelog/158437.yaml
@@ -1,0 +1,6 @@
+area: SQL
+issues:
+ - 157664
+pr: 158437
+summary: Wrap runtime errors when decoding a SQL cursor
+type: bug

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
@@ -110,7 +110,7 @@ public final class Cursors {
         }
         try (SqlStreamInput in = SqlStreamInput.fromString(base64, WRITEABLE_REGISTRY, VERSION)) {
             return in.readOptionalWriteable(BasicFormatter::new);
-        } catch (IOException ex) {
+        } catch (IOException | RuntimeException ex) {
             throw new SqlIllegalArgumentException("Unexpected failure reading cursor", ex);
         }
     }
@@ -151,7 +151,13 @@ public final class Cursors {
             } else {
                 return internalDecodeFromStringWithZone(in.readString(), writeableRegistry);
             }
-        } catch (IOException ex) {
+        } catch (SqlIllegalArgumentException ex) {
+            // thrown by the nested call above, already the right shape
+            throw ex;
+        } catch (IOException | RuntimeException ex) {
+            // the cursor is whatever was in the request, so a broken one fails in ways that are
+            // not IOException: bad base64, a negative or oversized array length, an unknown
+            // writeable name. they all mean the same thing to the caller
             throw new SqlIllegalArgumentException("Unexpected failure reading cursor", ex);
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
@@ -152,7 +152,8 @@ public final class Cursors {
                 return internalDecodeFromStringWithZone(in.readString(), writeableRegistry);
             }
         } catch (SqlIllegalArgumentException ex) {
-            // thrown by the nested call above, already the right shape
+            // already the right type and message, whether it came from the nested call above or
+            // from inside the stream itself, so it must not be wrapped in a second one
             throw ex;
         } catch (IOException | RuntimeException ex) {
             // the cursor is whatever was in the request, so a broken one fails in ways that are

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
 import org.elasticsearch.xpack.sql.proto.formatter.SimpleFormatter;
@@ -42,6 +43,14 @@ public class CursorTests extends ESTestCase {
 
     public static Cursor decodeFromString(String base64) {
         return decodeFromStringWithZone(base64, WRITEABLE_REGISTRY).v1();
+    }
+
+    public void testDecodingGarbageCursorFails() {
+        // the cursor comes straight from the request, so anything can be in it
+        for (String garbage : List.of("not base64 at all!", "///", "AAAA", "AAAAAAAAAAAAAAAAAAAA")) {
+            SqlIllegalArgumentException e = expectThrows(SqlIllegalArgumentException.class, () -> decodeFromString(garbage));
+            assertEquals("Unexpected failure reading cursor", e.getMessage());
+        }
     }
 
     public void testAttachingFormatterToCursor() {


### PR DESCRIPTION
Closes #157664

The cursor in a SQL request is just a base64 string from the caller, so a broken one can fail in ways that are not `IOException`, and only `IOException` was caught:

- bad base64 throws `IllegalArgumentException` from `Base64.getDecoder().decode`
- a negative array length throws `NegativeArraySizeException` from `StreamInput.readArraySize`, which is the one in the stack trace on the issue
- an oversized array length throws `IllegalStateException` from the same place

All three came back raw instead of as `SqlIllegalArgumentException`.

Widened the catch in the two places that decode a cursor string. The nested call in `internalDecodeFromStringWithZone` can throw `SqlIllegalArgumentException` itself, so that is rethrown as is rather than wrapped twice.

The test feeds four broken cursors and checks the error, including plain bad base64 which is the easiest one to hit. Without the change it fails with `Illegal base64 character 20`.

`:x-pack:plugin:sql:test` passes, 3385 tests in 106 classes.
