### PR TITLE
ES|QL: Stabilize T-Digest bucket count test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -734,21 +734,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.evaluator.command.TestCompoundOutputEvaluatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/154059
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecTdigestIT
-  method: test {csv-spec:tdigest.count with bucket, time, and instance in FROM}
-  issue: https://github.com/elastic/elasticsearch/issues/158011
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecTdigestIT
-  method: test {csv-spec:tdigest.count with bucket, time, and instance in FROM}
-  issue: https://github.com/elastic/elasticsearch/issues/158050
 - class: org.elasticsearch.xpack.ml.inference.ingest.IngestModelMemoryServiceTests
   method: testDuplicateModelAcrossProjectsCountedOnce
   issue: https://github.com/elastic/elasticsearch/issues/158071
 - class: org.elasticsearch.aggregations.bucket.TimeSeriesAggregationsUnlimitedDimensionsIT
   method: testTermsByTsid
   issue: https://github.com/elastic/elasticsearch/issues/158088
-- class: org.elasticsearch.xpack.esql.CsvFlattenedKeywordIT
-  method: test {csv-spec:tdigest.count with bucket, time, and instance in FROM}
-  issue: https://github.com/elastic/elasticsearch/issues/158089
 - class: org.elasticsearch.foreign.processor.BoundsCheckGeneratedClassBehaviorTests
   method: testSlicedSegmentCheckThrowsWhenSliceExceedsSegment
   issue: https://github.com/elastic/elasticsearch/issues/158125

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tdigest.csv-spec
@@ -149,6 +149,8 @@ count:long | bucket:double_range | time:datetime            | instance:keyword |
 count with bucket, time, and instance in FROM
 required_capability: fn_bucket_histogram_types
 
+// The bucket counts depend on how the T-Digests are merged, which varies with the number of shards/nodes the
+// data is spread across. Allow a +-1 tolerance on all counts to make the test independent of the cluster layout.
 FROM tdigest_standard_index
  | WHERE NOT STARTS_WITH(instance, "hand-rolled") AND instance != "multi-row-td"
  | STATS count = COUNT(responseTime, bucket) BY bucket = BUCKET(responseTime, 1), time = BUCKET(@timestamp, 1h), instance
@@ -157,17 +159,17 @@ FROM tdigest_standard_index
  | LIMIT 10
 ;
 
-count:long | bucket:double_range | time:datetime            | instance:keyword | total:long
-5120       | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15470
-61         | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15470
-1          | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15470
-1978       | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15470
-7          | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15470
-0          | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15470
-1          | 3.0..4.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15470
-2149       | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15470
-2          | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15470
-1          | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15470
+count:long   | bucket:double_range | time:datetime            | instance:keyword | total:long
+5119..5121   | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15469..15471
+60..62       | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15469..15471
+0..2         | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-0       | 15469..15471
+1977..1979   | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15469..15471
+6..8         | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15469..15471
+0..1         | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15469..15471
+0..2         | 3.0..4.0            | 2025-09-25T00:00:00.000Z | instance-1       | 15469..15471
+2148..2150   | 0.0..1.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15469..15471
+1..3         | 1.0..2.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15469..15471
+0..2         | 2.0..3.0            | 2025-09-25T00:00:00.000Z | instance-2       | 15469..15471
 ;
 
 // -------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #158011
Fixes #158050
Fixes #158089

Now that we decided against #158000 for now, we need to use other means to fix the flaky test.

## Summary
- allow a one-count tolerance for T-Digest bucket and total counts that vary with shard layout
- unmute the affected single-node, multi-node, and cross-cluster CSV test suites
