### PR TITLE
Add release notes for v9.5.3 release

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,13 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
+## 9.5.3 [elasticsearch-9.5.3-breaking-changes]
+```{applies_to}
+stack: ga 9.5.3
+```
+
+There are no breaking changes associated with this release.
+
 ## 9.4.6 [elasticsearch-9.4.6-breaking-changes]
 
 There are no breaking changes associated with this release.

--- a/docs/release-notes/changelog-bundles/9.5.3.yml
+++ b/docs/release-notes/changelog-bundles/9.5.3.yml
@@ -66,12 +66,12 @@ changelogs:
     issues:
       - 157103
   - pr: 157214
-    summary: Allow rotating secrets with the inference `_update` API
+    summary: Fix secret rotation in the inference `_update` API
     area: Inference
     type: bug
     issues: []
   - pr: 157229
-    summary: Restore shared score accumulation across segments for IVF search
+    summary: Restore early-exit scoring across segments for IVF search
     area: Vector Search
     type: bug
     issues: []

--- a/docs/release-notes/changelog-bundles/9.5.3.yml
+++ b/docs/release-notes/changelog-bundles/9.5.3.yml
@@ -1,0 +1,190 @@
+version: 9.5.3
+released: false
+generated: 2026-09-03T08:04:39.081731Z
+changelogs:
+  - pr: 149429
+    summary: Fixing `StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest()`
+    area: Engine
+    type: bug
+    issues:
+      - 149343
+  - pr: 150342
+    summary: Eagerly fail reindexes that are unable to be relocated
+    area: Reindex
+    type: bug
+    issues:
+      - 150294
+      - 150295
+  - pr: 152269
+    summary: Deprecate legacy monitoring REST apis.
+    area: Monitoring
+    type: deprecation
+    issues: []
+    deprecation:
+      area: REST API
+      title: Deprecate legacy monitoring REST apis.
+      details: "The `_monitoring/bulk` and `_monitoring/migrate/alerts` REST APIs, used by the legacy internal collection method for Stack Monitoring, are deprecated and will be removed in Elasticsearch 10.0."
+      impact: Users relying on internal collection for Stack Monitoring should migrate to Metricbeat or Elastic Agent based monitoring. Calling either endpoint now returns a deprecation warning.
+      notable: false
+      essSettingChange: false
+  - pr: 153577
+    summary: Unified and faster calibration path
+    area: Vector Search
+    type: enhancement
+    issues: []
+  - pr: 154480
+    summary: Bound `min_hash` filter params to prevent OOM
+    area: Analysis
+    type: bug
+    issues: []
+  - pr: 156326
+    summary: Fix ES|QL query failures when a multi-field sub-field has conflicting types across indices
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 156412
+    summary: Fix ROUND of an integer with a negative precision silently overflowing to a negative value
+    area: ES|QL
+    type: bug
+    issues:
+      - 156411
+  - pr: 156980
+    summary: Decouple type-check exactness from pushdown exactness for fused block-loader functions
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 157044
+    summary: Honor pruning in the `_shard_doc` sort comparator
+    area: Search
+    type: bug
+    issues:
+      - 155559
+  - pr: 157148
+    summary: Fix TS STATS literal aggregates dropped by optimizer
+    area: ES|QL
+    type: bug
+    issues:
+      - 157103
+  - pr: 157214
+    summary: "[Inference API] Fix inference/_update to allow rotating secrets"
+    area: Inference
+    type: bug
+    issues: []
+  - pr: 157229
+    summary: Fix shared score accumulator amongst segments for ivf search
+    area: Vector Search
+    type: bug
+    issues: []
+  - pr: 157567
+    summary: Surface CCS skipped-cluster stats on datafeed extraction failure
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 157630
+    summary: Fix empty `collectRange` crash in doc-values queries (lucene#16546)
+    area: Mapping
+    type: bug
+    issues: []
+  - pr: 157634
+    summary: "`DataStreamAutoShardingService.calculate()` works on stale data [#134505]"
+    area: Data streams
+    type: bug
+    issues:
+      - 134505
+  - pr: 157730
+    summary: Fix bfloat16 reading from old index versions with endianness mismatches
+    area: Vector Search
+    type: bug
+    issues:
+      - 157696
+  - pr: 157752
+    summary: Fix result size limit check on INSERT
+    area: SQL
+    type: bug
+    issues: []
+  - pr: 157760
+    summary: "Audit: reject oversized request bodies"
+    area: Audit
+    type: enhancement
+    issues: []
+  - pr: 157790
+    summary: Fix mv_min/mv_max on columnar ip fields
+    area: ES|QL
+    type: bug
+    issues:
+      - 157521
+  - pr: 157798
+    summary: Fix backwards read of `_ignored_source` doc values
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 157857
+    summary: Fix `ArrayOrder` block loaders falsely claiming SORTED_ASCENDING
+    area: Columnar
+    type: bug
+    issues:
+      - 157817
+  - pr: 157858
+    summary: Fix BYTE_LENGTH returning 0 for keywords in columnar mode
+    area: Columnar
+    type: bug
+    issues: []
+  - pr: 157889
+    summary: Fix FLS field names term state filtering
+    area: Authorization
+    type: bug
+    issues: []
+  - pr: 157929
+    summary: Reject blank datafeed ID in stop datafeed request
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 158020
+    summary: Reject blank job id on close request
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 158060
+    summary: Fix composite agg on doc values skipper fields
+    area: Mapping
+    type: bug
+    issues:
+      - 158008
+  - pr: 158108
+    summary: Fix leaking bulk cancellation task in `IncrementalBulkService`
+    area: Task Management
+    type: bug
+    issues:
+      - 158018
+  - pr: 158143
+    summary: "Audit: emit `request.raw_body` for protobuf bodies"
+    area: Audit
+    type: enhancement
+    issues: []
+  - pr: 158175
+    summary: Reduce memory usage during serialization when retrieving component and composable templates via the GET APIs
+    area: Templates
+    type: bug
+    issues: []
+  - pr: 158187
+    summary: "Fix(mapper): handle missing counts in contains query"
+    area: Mapping
+    type: bug
+    issues: []
+  - pr: 158211
+    summary: Cap `min_hash` filter params
+    area: Analysis
+    type: bug
+    issues: []
+  - pr: 158235
+    summary: Do not abort shard bulk on expansion rejection
+    area: CRUD
+    type: bug
+    issues:
+      - 158212
+  - pr: 158296
+    summary: Update knn query automatic pre-filtering to handle exists queries on inference fields
+    area: Search
+    type: bug
+    issues:
+      - 157951

--- a/docs/release-notes/changelog-bundles/9.5.3.yml
+++ b/docs/release-notes/changelog-bundles/9.5.3.yml
@@ -3,187 +3,187 @@ released: false
 generated: 2026-09-03T08:04:39.081731Z
 changelogs:
   - pr: 149429
-    summary: Fixing `StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest()`
+    summary: Fix translog resource leaks and leftover upload tasks on node shutdown
     area: Engine
     type: bug
     issues:
       - 149343
   - pr: 150342
-    summary: Eagerly fail reindexes that are unable to be relocated
+    summary: Fail reindex tasks that cannot relocate during node shutdown
     area: Reindex
     type: bug
     issues:
       - 150294
       - 150295
   - pr: 152269
-    summary: Deprecate legacy monitoring REST apis.
+    summary: Deprecate the legacy monitoring REST APIs
     area: Monitoring
     type: deprecation
     issues: []
     deprecation:
       area: REST API
-      title: Deprecate legacy monitoring REST apis.
+      title: Deprecate the legacy monitoring REST APIs
       details: "The `_monitoring/bulk` and `_monitoring/migrate/alerts` REST APIs, used by the legacy internal collection method for Stack Monitoring, are deprecated and will be removed in Elasticsearch 10.0."
-      impact: Users relying on internal collection for Stack Monitoring should migrate to Metricbeat or Elastic Agent based monitoring. Calling either endpoint now returns a deprecation warning.
+      impact: If you use internal collection for Stack Monitoring, migrate to AutoOps, Elastic Agent, or Metricbeat. Calling either endpoint returns a deprecation warning.
       notable: false
       essSettingChange: false
   - pr: 153577
-    summary: Unified and faster calibration path
+    summary: Speed up vector quantization calibration during index merge
     area: Vector Search
     type: enhancement
     issues: []
   - pr: 154480
-    summary: Bound `min_hash` filter params to prevent OOM
+    summary: Prevent out-of-memory errors from extreme `min_hash` filter settings
     area: Analysis
     type: bug
     issues: []
   - pr: 156326
-    summary: Fix ES|QL query failures when a multi-field sub-field has conflicting types across indices
+    summary: Fix query failures when a multi-field sub-field has conflicting types across indices
     area: ES|QL
     type: bug
     issues: []
   - pr: 156412
-    summary: Fix ROUND of an integer with a negative precision silently overflowing to a negative value
+    summary: Fix `ROUND` overflowing integer values when used with negative precision
     area: ES|QL
     type: bug
     issues:
       - 156411
   - pr: 156980
-    summary: Decouple type-check exactness from pushdown exactness for fused block-loader functions
+    summary: Fix query failures after fusing field extraction into exact-string functions
     area: ES|QL
     type: bug
     issues: []
   - pr: 157044
-    summary: Honor pruning in the `_shard_doc` sort comparator
+    summary: Speed up `_shard_doc` `search_after` pagination by applying sort pruning
     area: Search
     type: bug
     issues:
       - 155559
   - pr: 157148
-    summary: Fix TS STATS literal aggregates dropped by optimizer
+    summary: Fix `TS` `STATS` dropping constant literal aggregates
     area: ES|QL
     type: bug
     issues:
       - 157103
   - pr: 157214
-    summary: "[Inference API] Fix inference/_update to allow rotating secrets"
+    summary: Allow rotating secrets with the inference `_update` API
     area: Inference
     type: bug
     issues: []
   - pr: 157229
-    summary: Fix shared score accumulator amongst segments for ivf search
+    summary: Restore shared score accumulation across segments for IVF search
     area: Vector Search
     type: bug
     issues: []
   - pr: 157567
-    summary: Surface CCS skipped-cluster stats on datafeed extraction failure
+    summary: Report skipped clusters in datafeed stats after a cross-cluster search failure
     area: Machine Learning
     type: bug
     issues: []
   - pr: 157630
-    summary: Fix empty `collectRange` crash in doc-values queries (lucene#16546)
+    summary: Fix search crashes from empty collect ranges in doc-values queries
     area: Mapping
     type: bug
     issues: []
   - pr: 157634
-    summary: "`DataStreamAutoShardingService.calculate()` works on stale data [#134505]"
+    summary: Fix data stream auto-sharding using stale index settings
     area: Data streams
     type: bug
     issues:
       - 134505
   - pr: 157730
-    summary: Fix bfloat16 reading from old index versions with endianness mismatches
+    summary: Fix reading `bfloat16` values from older index formats with different endianness
     area: Vector Search
     type: bug
     issues:
       - 157696
   - pr: 157752
-    summary: Fix result size limit check on INSERT
+    summary: Fix the SQL `INSERT` function ignoring the result size limit
     area: SQL
     type: bug
     issues: []
   - pr: 157760
-    summary: "Audit: reject oversized request bodies"
+    summary: Reject oversized request bodies when request-body auditing is enabled
     area: Audit
     type: enhancement
     issues: []
   - pr: 157790
-    summary: Fix mv_min/mv_max on columnar ip fields
+    summary: Fix `MV_MIN` and `MV_MAX` on `ip` fields in columnar mode
     area: ES|QL
     type: bug
     issues:
       - 157521
   - pr: 157798
-    summary: Fix backwards read of `_ignored_source` doc values
+    summary: Fix failures when reading `_ignored_source` out of document order
     area: ES|QL
     type: bug
     issues: []
   - pr: 157857
-    summary: Fix `ArrayOrder` block loaders falsely claiming SORTED_ASCENDING
+    summary: Fix incorrect `MV_MIN` and `MV_PERCENTILE` results in columnar mode
     area: Columnar
     type: bug
     issues:
       - 157817
   - pr: 157858
-    summary: Fix BYTE_LENGTH returning 0 for keywords in columnar mode
+    summary: Fix `BYTE_LENGTH` returning 0 for `keyword` fields in columnar mode
     area: Columnar
     type: bug
     issues: []
   - pr: 157889
-    summary: Fix FLS field names term state filtering
+    summary: Fix field-level security filtering for `_field_names` terms
     area: Authorization
     type: bug
     issues: []
   - pr: 157929
-    summary: Reject blank datafeed ID in stop datafeed request
+    summary: Reject a blank datafeed ID in stop datafeed requests
     area: Machine Learning
     type: bug
     issues: []
   - pr: 158020
-    summary: Reject blank job id on close request
+    summary: Reject a blank job ID in close job requests
     area: Machine Learning
     type: bug
     issues: []
   - pr: 158060
-    summary: Fix composite agg on doc values skipper fields
+    summary: Fix composite aggregations returning no buckets on logsdb timestamp fields
     area: Mapping
     type: bug
     issues:
       - 158008
   - pr: 158108
-    summary: Fix leaking bulk cancellation task in `IncrementalBulkService`
+    summary: Fix leaking cancellation tasks in incremental bulk indexing
     area: Task Management
     type: bug
     issues:
       - 158018
   - pr: 158143
-    summary: "Audit: emit `request.raw_body` for protobuf bodies"
+    summary: Add `request.raw_body` to audit events for protobuf request bodies
     area: Audit
     type: enhancement
     issues: []
   - pr: 158175
-    summary: Reduce memory usage during serialization when retrieving component and composable templates via the GET APIs
+    summary: Reduce memory usage when retrieving component and composable templates
     area: Templates
     type: bug
     issues: []
   - pr: 158187
-    summary: "Fix(mapper): handle missing counts in contains query"
+    summary: Fix contains queries failing on single-valued keyword fields
     area: Mapping
     type: bug
     issues: []
   - pr: 158211
-    summary: Cap `min_hash` filter params
+    summary: Limit `min_hash` filter parameters to prevent integer overflow
     area: Analysis
     type: bug
     issues: []
   - pr: 158235
-    summary: Do not abort shard bulk on expansion rejection
+    summary: Prevent indexing-pressure rejections from stopping an entire bulk shard request
     area: CRUD
     type: bug
     issues:
       - 158212
   - pr: 158296
-    summary: Update knn query automatic pre-filtering to handle exists queries on inference fields
+    summary: Fix kNN automatic pre-filtering for `exists` queries on inference fields
     area: Search
     type: bug
     issues:

--- a/docs/release-notes/changelog-bundles/9.5.3.yml
+++ b/docs/release-notes/changelog-bundles/9.5.3.yml
@@ -49,7 +49,7 @@ changelogs:
     issues:
       - 156411
   - pr: 156980
-    summary: Fix query failures after fusing field extraction into exact-string functions
+    summary: Fix failures in string functions that use extracted fields
     area: ES|QL
     type: bug
     issues: []

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -16,6 +16,16 @@ To give you insight into what deprecated features you’re using, {{es}}:
 
 % ## Next version [elasticsearch-nextversion-deprecations]
 
+## 9.5.3 [elasticsearch-9.5.3-deprecations]
+```{applies_to}
+stack: ga 9.5.3
+```
+
+Monitoring:
+* Deprecate legacy monitoring REST apis. [#152269](https://github.com/elastic/elasticsearch/pull/152269)
+
+
+
 ## 9.4.6 [elasticsearch-9.4.6-deprecations]
 
 There are no deprecations associated with this release.

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -22,7 +22,7 @@ stack: ga 9.5.3
 ```
 
 Monitoring:
-* Deprecate legacy monitoring REST apis. [#152269](https://github.com/elastic/elasticsearch/pull/152269)
+* Deprecate the legacy monitoring REST APIs [#152269](https://github.com/elastic/elasticsearch/pull/152269)
 
 
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -55,7 +55,7 @@ Data streams:
 * Fix data stream auto-sharding using stale index settings [#157634](https://github.com/elastic/elasticsearch/pull/157634) (issue: [#134505](https://github.com/elastic/elasticsearch/issues/134505))
 
 ES|QL:
-* Fix query failures after fusing field extraction into exact-string functions [#156980](https://github.com/elastic/elasticsearch/pull/156980)
+* Fix failures in string functions that use extracted fields [#156980](https://github.com/elastic/elasticsearch/pull/156980)
 * Fix query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
 * Fix `ROUND` overflowing integer values when used with negative precision [#156412](https://github.com/elastic/elasticsearch/pull/156412) (issue: [#156411](https://github.com/elastic/elasticsearch/issues/156411))
 * Fix `TS` `STATS` dropping constant literal aggregates [#157148](https://github.com/elastic/elasticsearch/pull/157148) (issue: [#157103](https://github.com/elastic/elasticsearch/issues/157103))

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,86 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+## 9.5.3 [elasticsearch-9.5.3-release-notes]
+```{applies_to}
+stack: ga 9.5.3
+```
+
+### Features and enhancements [elasticsearch-9.5.3-features-enhancements]
+
+Audit:
+* Audit: emit `request.raw_body` for protobuf bodies [#158143](https://github.com/elastic/elasticsearch/pull/158143)
+* Audit: reject oversized request bodies [#157760](https://github.com/elastic/elasticsearch/pull/157760)
+
+Vector Search:
+* Unified and faster calibration path [#153577](https://github.com/elastic/elasticsearch/pull/153577)
+
+
+### Fixes [elasticsearch-9.5.3-fixes]
+
+Analysis:
+* Bound `min_hash` filter params to prevent OOM [#154480](https://github.com/elastic/elasticsearch/pull/154480)
+* Cap `min_hash` filter params [#158211](https://github.com/elastic/elasticsearch/pull/158211)
+
+Authorization:
+* Fix FLS field names term state filtering [#157889](https://github.com/elastic/elasticsearch/pull/157889)
+
+CRUD:
+* Do not abort shard bulk on expansion rejection [#158235](https://github.com/elastic/elasticsearch/pull/158235) (issue: [#158212](https://github.com/elastic/elasticsearch/issues/158212))
+
+Columnar:
+* Fix BYTE_LENGTH returning 0 for keywords in columnar mode [#157858](https://github.com/elastic/elasticsearch/pull/157858)
+* Fix `ArrayOrder` block loaders falsely claiming SORTED_ASCENDING [#157857](https://github.com/elastic/elasticsearch/pull/157857) (issue: [#157817](https://github.com/elastic/elasticsearch/issues/157817))
+
+Data streams:
+* `DataStreamAutoShardingService.calculate()` works on stale data [#134505] [#157634](https://github.com/elastic/elasticsearch/pull/157634) (issue: [#134505](https://github.com/elastic/elasticsearch/issues/134505))
+
+ES|QL:
+* Decouple type-check exactness from pushdown exactness for fused block-loader functions [#156980](https://github.com/elastic/elasticsearch/pull/156980)
+* Fix ES|QL query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
+* Fix ROUND of an integer with a negative precision silently overflowing to a negative value [#156412](https://github.com/elastic/elasticsearch/pull/156412) (issue: [#156411](https://github.com/elastic/elasticsearch/issues/156411))
+* Fix TS STATS literal aggregates dropped by optimizer [#157148](https://github.com/elastic/elasticsearch/pull/157148) (issue: [#157103](https://github.com/elastic/elasticsearch/issues/157103))
+* Fix backwards read of `_ignored_source` doc values [#157798](https://github.com/elastic/elasticsearch/pull/157798)
+* Fix mv_min/mv_max on columnar ip fields [#157790](https://github.com/elastic/elasticsearch/pull/157790) (issue: [#157521](https://github.com/elastic/elasticsearch/issues/157521))
+
+Engine:
+* Fixing `StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest()` [#149429](https://github.com/elastic/elasticsearch/pull/149429) (issue: [#149343](https://github.com/elastic/elasticsearch/issues/149343))
+
+Inference:
+* [Inference API] Fix inference/_update to allow rotating secrets [#157214](https://github.com/elastic/elasticsearch/pull/157214)
+
+Machine Learning:
+* Reject blank datafeed ID in stop datafeed request [#157929](https://github.com/elastic/elasticsearch/pull/157929)
+* Reject blank job id on close request [#158020](https://github.com/elastic/elasticsearch/pull/158020)
+* Surface CCS skipped-cluster stats on datafeed extraction failure [#157567](https://github.com/elastic/elasticsearch/pull/157567)
+
+Mapping:
+* Fix composite agg on doc values skipper fields [#158060](https://github.com/elastic/elasticsearch/pull/158060) (issue: [#158008](https://github.com/elastic/elasticsearch/issues/158008))
+* Fix empty `collectRange` crash in doc-values queries (lucene#16546) [#157630](https://github.com/elastic/elasticsearch/pull/157630)
+* Fix(mapper): handle missing counts in contains query [#158187](https://github.com/elastic/elasticsearch/pull/158187)
+
+Reindex:
+* Eagerly fail reindexes that are unable to be relocated [#150342](https://github.com/elastic/elasticsearch/pull/150342) (issues: [#150294](https://github.com/elastic/elasticsearch/issues/150294), [#150295](https://github.com/elastic/elasticsearch/issues/150295))
+
+SQL:
+* Fix result size limit check on INSERT [#157752](https://github.com/elastic/elasticsearch/pull/157752)
+
+Search:
+* Honor pruning in the `_shard_doc` sort comparator [#157044](https://github.com/elastic/elasticsearch/pull/157044) (issue: [#155559](https://github.com/elastic/elasticsearch/issues/155559))
+* Update knn query automatic pre-filtering to handle exists queries on inference fields [#158296](https://github.com/elastic/elasticsearch/pull/158296) (issue: [#157951](https://github.com/elastic/elasticsearch/issues/157951))
+
+Task Management:
+* Fix leaking bulk cancellation task in `IncrementalBulkService` [#158108](https://github.com/elastic/elasticsearch/pull/158108) (issue: [#158018](https://github.com/elastic/elasticsearch/issues/158018))
+
+Templates:
+* Reduce memory usage during serialization when retrieving component and composable templates via the GET APIs [#158175](https://github.com/elastic/elasticsearch/pull/158175)
+
+Vector Search:
+* Fix bfloat16 reading from old index versions with endianness mismatches [#157730](https://github.com/elastic/elasticsearch/pull/157730) (issue: [#157696](https://github.com/elastic/elasticsearch/issues/157696))
+* Fix shared score accumulator amongst segments for ivf search [#157229](https://github.com/elastic/elasticsearch/pull/157229)
+
+
+
 ## 9.4.6 [elasticsearch-9.4.6-release-notes]
 
 ### Features and enhancements [elasticsearch-9.4.6-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -66,7 +66,7 @@ Engine:
 * Fix translog resource leaks and leftover upload tasks on node shutdown [#149429](https://github.com/elastic/elasticsearch/pull/149429) (issue: [#149343](https://github.com/elastic/elasticsearch/issues/149343))
 
 Inference:
-* Allow rotating secrets with the inference `_update` API [#157214](https://github.com/elastic/elasticsearch/pull/157214)
+* Fix secret rotation in the inference `_update` API [#157214](https://github.com/elastic/elasticsearch/pull/157214)
 
 Machine Learning:
 * Reject a blank datafeed ID in stop datafeed requests [#157929](https://github.com/elastic/elasticsearch/pull/157929)
@@ -96,7 +96,7 @@ Templates:
 
 Vector Search:
 * Fix reading `bfloat16` values from older index formats with different endianness [#157730](https://github.com/elastic/elasticsearch/pull/157730) (issue: [#157696](https://github.com/elastic/elasticsearch/issues/157696))
-* Restore shared score accumulation across segments for IVF search [#157229](https://github.com/elastic/elasticsearch/pull/157229)
+* Restore early-exit scoring across segments for IVF search [#157229](https://github.com/elastic/elasticsearch/pull/157229)
 
 
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -28,75 +28,75 @@ stack: ga 9.5.3
 ### Features and enhancements [elasticsearch-9.5.3-features-enhancements]
 
 Audit:
-* Audit: emit `request.raw_body` for protobuf bodies [#158143](https://github.com/elastic/elasticsearch/pull/158143)
-* Audit: reject oversized request bodies [#157760](https://github.com/elastic/elasticsearch/pull/157760)
+* Add `request.raw_body` to audit events for protobuf request bodies [#158143](https://github.com/elastic/elasticsearch/pull/158143)
+* Reject oversized request bodies when request-body auditing is enabled [#157760](https://github.com/elastic/elasticsearch/pull/157760)
 
 Vector Search:
-* Unified and faster calibration path [#153577](https://github.com/elastic/elasticsearch/pull/153577)
+* Speed up vector quantization calibration during index merge [#153577](https://github.com/elastic/elasticsearch/pull/153577)
 
 
 ### Fixes [elasticsearch-9.5.3-fixes]
 
 Analysis:
-* Bound `min_hash` filter params to prevent OOM [#154480](https://github.com/elastic/elasticsearch/pull/154480)
-* Cap `min_hash` filter params [#158211](https://github.com/elastic/elasticsearch/pull/158211)
+* Prevent out-of-memory errors from extreme `min_hash` filter settings [#154480](https://github.com/elastic/elasticsearch/pull/154480)
+* Limit `min_hash` filter parameters to prevent integer overflow [#158211](https://github.com/elastic/elasticsearch/pull/158211)
 
 Authorization:
-* Fix FLS field names term state filtering [#157889](https://github.com/elastic/elasticsearch/pull/157889)
+* Fix field-level security filtering for `_field_names` terms [#157889](https://github.com/elastic/elasticsearch/pull/157889)
 
 CRUD:
-* Do not abort shard bulk on expansion rejection [#158235](https://github.com/elastic/elasticsearch/pull/158235) (issue: [#158212](https://github.com/elastic/elasticsearch/issues/158212))
+* Prevent indexing-pressure rejections from stopping an entire bulk shard request [#158235](https://github.com/elastic/elasticsearch/pull/158235) (issue: [#158212](https://github.com/elastic/elasticsearch/issues/158212))
 
 Columnar:
-* Fix BYTE_LENGTH returning 0 for keywords in columnar mode [#157858](https://github.com/elastic/elasticsearch/pull/157858)
-* Fix `ArrayOrder` block loaders falsely claiming SORTED_ASCENDING [#157857](https://github.com/elastic/elasticsearch/pull/157857) (issue: [#157817](https://github.com/elastic/elasticsearch/issues/157817))
+* Fix `BYTE_LENGTH` returning 0 for `keyword` fields in columnar mode [#157858](https://github.com/elastic/elasticsearch/pull/157858)
+* Fix incorrect `MV_MIN` and `MV_PERCENTILE` results in columnar mode [#157857](https://github.com/elastic/elasticsearch/pull/157857) (issue: [#157817](https://github.com/elastic/elasticsearch/issues/157817))
 
 Data streams:
-* `DataStreamAutoShardingService.calculate()` works on stale data [#134505] [#157634](https://github.com/elastic/elasticsearch/pull/157634) (issue: [#134505](https://github.com/elastic/elasticsearch/issues/134505))
+* Fix data stream auto-sharding using stale index settings [#157634](https://github.com/elastic/elasticsearch/pull/157634) (issue: [#134505](https://github.com/elastic/elasticsearch/issues/134505))
 
 ES|QL:
-* Decouple type-check exactness from pushdown exactness for fused block-loader functions [#156980](https://github.com/elastic/elasticsearch/pull/156980)
-* Fix ES|QL query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
-* Fix ROUND of an integer with a negative precision silently overflowing to a negative value [#156412](https://github.com/elastic/elasticsearch/pull/156412) (issue: [#156411](https://github.com/elastic/elasticsearch/issues/156411))
-* Fix TS STATS literal aggregates dropped by optimizer [#157148](https://github.com/elastic/elasticsearch/pull/157148) (issue: [#157103](https://github.com/elastic/elasticsearch/issues/157103))
-* Fix backwards read of `_ignored_source` doc values [#157798](https://github.com/elastic/elasticsearch/pull/157798)
-* Fix mv_min/mv_max on columnar ip fields [#157790](https://github.com/elastic/elasticsearch/pull/157790) (issue: [#157521](https://github.com/elastic/elasticsearch/issues/157521))
+* Fix query failures after fusing field extraction into exact-string functions [#156980](https://github.com/elastic/elasticsearch/pull/156980)
+* Fix query failures when a multi-field sub-field has conflicting types across indices [#156326](https://github.com/elastic/elasticsearch/pull/156326)
+* Fix `ROUND` overflowing integer values when used with negative precision [#156412](https://github.com/elastic/elasticsearch/pull/156412) (issue: [#156411](https://github.com/elastic/elasticsearch/issues/156411))
+* Fix `TS` `STATS` dropping constant literal aggregates [#157148](https://github.com/elastic/elasticsearch/pull/157148) (issue: [#157103](https://github.com/elastic/elasticsearch/issues/157103))
+* Fix failures when reading `_ignored_source` out of document order [#157798](https://github.com/elastic/elasticsearch/pull/157798)
+* Fix `MV_MIN` and `MV_MAX` on `ip` fields in columnar mode [#157790](https://github.com/elastic/elasticsearch/pull/157790) (issue: [#157521](https://github.com/elastic/elasticsearch/issues/157521))
 
 Engine:
-* Fixing `StatelessTranslogIT.testTranslogLocalFailureOnlyStressRecoveryTest()` [#149429](https://github.com/elastic/elasticsearch/pull/149429) (issue: [#149343](https://github.com/elastic/elasticsearch/issues/149343))
+* Fix translog resource leaks and leftover upload tasks on node shutdown [#149429](https://github.com/elastic/elasticsearch/pull/149429) (issue: [#149343](https://github.com/elastic/elasticsearch/issues/149343))
 
 Inference:
-* [Inference API] Fix inference/_update to allow rotating secrets [#157214](https://github.com/elastic/elasticsearch/pull/157214)
+* Allow rotating secrets with the inference `_update` API [#157214](https://github.com/elastic/elasticsearch/pull/157214)
 
 Machine Learning:
-* Reject blank datafeed ID in stop datafeed request [#157929](https://github.com/elastic/elasticsearch/pull/157929)
-* Reject blank job id on close request [#158020](https://github.com/elastic/elasticsearch/pull/158020)
-* Surface CCS skipped-cluster stats on datafeed extraction failure [#157567](https://github.com/elastic/elasticsearch/pull/157567)
+* Reject a blank datafeed ID in stop datafeed requests [#157929](https://github.com/elastic/elasticsearch/pull/157929)
+* Reject a blank job ID in close job requests [#158020](https://github.com/elastic/elasticsearch/pull/158020)
+* Report skipped clusters in datafeed stats after a cross-cluster search failure [#157567](https://github.com/elastic/elasticsearch/pull/157567)
 
 Mapping:
-* Fix composite agg on doc values skipper fields [#158060](https://github.com/elastic/elasticsearch/pull/158060) (issue: [#158008](https://github.com/elastic/elasticsearch/issues/158008))
-* Fix empty `collectRange` crash in doc-values queries (lucene#16546) [#157630](https://github.com/elastic/elasticsearch/pull/157630)
-* Fix(mapper): handle missing counts in contains query [#158187](https://github.com/elastic/elasticsearch/pull/158187)
+* Fix composite aggregations returning no buckets on logsdb timestamp fields [#158060](https://github.com/elastic/elasticsearch/pull/158060) (issue: [#158008](https://github.com/elastic/elasticsearch/issues/158008))
+* Fix search crashes from empty collect ranges in doc-values queries [#157630](https://github.com/elastic/elasticsearch/pull/157630)
+* Fix contains queries failing on single-valued keyword fields [#158187](https://github.com/elastic/elasticsearch/pull/158187)
 
 Reindex:
-* Eagerly fail reindexes that are unable to be relocated [#150342](https://github.com/elastic/elasticsearch/pull/150342) (issues: [#150294](https://github.com/elastic/elasticsearch/issues/150294), [#150295](https://github.com/elastic/elasticsearch/issues/150295))
+* Fail reindex tasks that cannot relocate during node shutdown [#150342](https://github.com/elastic/elasticsearch/pull/150342) (issues: [#150294](https://github.com/elastic/elasticsearch/issues/150294), [#150295](https://github.com/elastic/elasticsearch/issues/150295))
 
 SQL:
-* Fix result size limit check on INSERT [#157752](https://github.com/elastic/elasticsearch/pull/157752)
+* Fix the SQL `INSERT` function ignoring the result size limit [#157752](https://github.com/elastic/elasticsearch/pull/157752)
 
 Search:
-* Honor pruning in the `_shard_doc` sort comparator [#157044](https://github.com/elastic/elasticsearch/pull/157044) (issue: [#155559](https://github.com/elastic/elasticsearch/issues/155559))
-* Update knn query automatic pre-filtering to handle exists queries on inference fields [#158296](https://github.com/elastic/elasticsearch/pull/158296) (issue: [#157951](https://github.com/elastic/elasticsearch/issues/157951))
+* Speed up `_shard_doc` `search_after` pagination by applying sort pruning [#157044](https://github.com/elastic/elasticsearch/pull/157044) (issue: [#155559](https://github.com/elastic/elasticsearch/issues/155559))
+* Fix kNN automatic pre-filtering for `exists` queries on inference fields [#158296](https://github.com/elastic/elasticsearch/pull/158296) (issue: [#157951](https://github.com/elastic/elasticsearch/issues/157951))
 
 Task Management:
-* Fix leaking bulk cancellation task in `IncrementalBulkService` [#158108](https://github.com/elastic/elasticsearch/pull/158108) (issue: [#158018](https://github.com/elastic/elasticsearch/issues/158018))
+* Fix leaking cancellation tasks in incremental bulk indexing [#158108](https://github.com/elastic/elasticsearch/pull/158108) (issue: [#158018](https://github.com/elastic/elasticsearch/issues/158018))
 
 Templates:
-* Reduce memory usage during serialization when retrieving component and composable templates via the GET APIs [#158175](https://github.com/elastic/elasticsearch/pull/158175)
+* Reduce memory usage when retrieving component and composable templates [#158175](https://github.com/elastic/elasticsearch/pull/158175)
 
 Vector Search:
-* Fix bfloat16 reading from old index versions with endianness mismatches [#157730](https://github.com/elastic/elasticsearch/pull/157730) (issue: [#157696](https://github.com/elastic/elasticsearch/issues/157696))
-* Fix shared score accumulator amongst segments for ivf search [#157229](https://github.com/elastic/elasticsearch/pull/157229)
+* Fix reading `bfloat16` values from older index formats with different endianness [#157730](https://github.com/elastic/elasticsearch/pull/157730) (issue: [#157696](https://github.com/elastic/elasticsearch/issues/157696))
+* Restore shared score accumulation across segments for IVF search [#157229](https://github.com/elastic/elasticsearch/pull/157229)
 
 
 


### PR DESCRIPTION
Generated manually from build candidate `9.5.3-f681d916` (elasticsearch commit d89b36a3bd00f4a74f4ceb2e64356d9336cc37d2 on `9.5`)