### PR TITLE
[9.4] Install tar in the default Docker image (#158361)

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/default/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/default/Dockerfile
@@ -81,7 +81,7 @@ COPY --chmod=664 config/elasticsearch.yml config/log4j2.properties config/
 FROM ${base_image}
 
 RUN microdnf install --setopt=tsflags=nodocs -y \\
-    nc shadow-utils zip unzip findutils procps-ng && \\
+    nc shadow-utils tar zip unzip findutils procps-ng && \\
     microdnf clean all
 
 RUN groupadd -g 1000 elasticsearch && \\

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -588,7 +588,8 @@ public class Docker {
 
         // nc is useful for checking network issues
         // zip/unzip are installed to help users who are working with certificates.
-        Stream.of("nc", "unzip", "zip")
+        // tar is required in some k8s situations: https://github.com/kubernetes/kubernetes/issues/58512
+        Stream.of("nc", "tar", "unzip", "zip")
             .forEach(
                 cliBinary -> assertTrue(
                     cliBinary + " ought to be available.",


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Install tar in the default Docker image (#158361)